### PR TITLE
Document omq-zeromq compatibility gaps

### DIFF
--- a/omq-zeromq/Cargo.toml
+++ b/omq-zeromq/Cargo.toml
@@ -22,7 +22,9 @@ libc = "0.2"
 tokio = { version = "1", features = ["sync", "time", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
+futures-channel = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+trybuild = "1"
 
 [[bin]]
 name = "bench_peer_zeromq"

--- a/omq-zeromq/tests/compatibility_gaps.rs
+++ b/omq-zeromq/tests/compatibility_gaps.rs
@@ -1,0 +1,17 @@
+//! Compile-time compatibility checks against common zmq.rs API shapes.
+//!
+//! Passing cases are API patterns currently supported by `omq-zeromq`.
+//! Compile-fail cases document places where `omq-zeromq` intentionally or
+//! accidentally diverges from the `zeromq` crate API.
+
+#[test]
+fn supported_zmqrs_patterns_compile() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/trybuild/compat-pass/*.rs");
+}
+
+#[test]
+fn known_zmqrs_api_gaps_are_documented() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/trybuild/compat-fail/*.rs");
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vec_bytes.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vec_bytes.rs
@@ -1,0 +1,7 @@
+use bytes::Bytes;
+use std::convert::TryFrom;
+use zeromq::ZmqMessage;
+
+fn main() {
+    let _msg = ZmqMessage::try_from(vec![Bytes::from_static(b"body")]).unwrap();
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vec_bytes.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vec_bytes.stderr
@@ -1,0 +1,45 @@
+error[E0277]: the trait bound `ZmqMessage: TryFrom<Vec<bytes::Bytes>>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_from_vec_bytes.rs:6:16
+  |
+6 |     let _msg = ZmqMessage::try_from(vec![Bytes::from_static(b"body")]).unwrap();
+  |                ^^^^^^^^^^ the trait `From<Vec<bytes::Bytes>>` is not implemented for `ZmqMessage`
+  |
+help: the following other types implement trait `From<T>`
+ --> src/message.rs
+  |
+  | impl From<String> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<String>`
+...
+  | impl From<&str> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<&str>`
+...
+  | impl From<Vec<u8>> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<Vec<u8>>`
+...
+  | impl From<Bytes> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<bytes::Bytes>`
+  = note: required for `Vec<bytes::Bytes>` to implement `Into<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryFrom<Vec<bytes::Bytes>>`
+
+error[E0277]: the trait bound `ZmqMessage: From<Vec<bytes::Bytes>>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_from_vec_bytes.rs:6:16
+  |
+6 |     let _msg = ZmqMessage::try_from(vec![Bytes::from_static(b"body")]).unwrap();
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Vec<bytes::Bytes>>` is not implemented for `ZmqMessage`
+  |
+help: the following other types implement trait `From<T>`
+ --> src/message.rs
+  |
+  | impl From<String> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<String>`
+...
+  | impl From<&str> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<&str>`
+...
+  | impl From<Vec<u8>> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<Vec<u8>>`
+...
+  | impl From<Bytes> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<bytes::Bytes>`
+  = note: required for `Vec<bytes::Bytes>` to implement `Into<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryFrom<Vec<bytes::Bytes>>`

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.rs
@@ -1,0 +1,10 @@
+use bytes::Bytes;
+use std::collections::VecDeque;
+use std::convert::TryFrom;
+use zeromq::ZmqMessage;
+
+fn main() {
+    let mut frames = VecDeque::new();
+    frames.push_back(Bytes::from_static(b"body"));
+    let _msg = ZmqMessage::try_from(frames).unwrap();
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.stderr
@@ -1,0 +1,45 @@
+error[E0277]: the trait bound `ZmqMessage: TryFrom<VecDeque<bytes::Bytes>>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.rs:9:16
+  |
+9 |     let _msg = ZmqMessage::try_from(frames).unwrap();
+  |                ^^^^^^^^^^ the trait `From<VecDeque<bytes::Bytes>>` is not implemented for `ZmqMessage`
+  |
+help: the following other types implement trait `From<T>`
+ --> src/message.rs
+  |
+  | impl From<String> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<String>`
+...
+  | impl From<&str> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<&str>`
+...
+  | impl From<Vec<u8>> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<Vec<u8>>`
+...
+  | impl From<Bytes> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<bytes::Bytes>`
+  = note: required for `VecDeque<bytes::Bytes>` to implement `Into<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryFrom<VecDeque<bytes::Bytes>>`
+
+error[E0277]: the trait bound `ZmqMessage: From<VecDeque<bytes::Bytes>>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_from_vecdeque_bytes.rs:9:16
+  |
+9 |     let _msg = ZmqMessage::try_from(frames).unwrap();
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<VecDeque<bytes::Bytes>>` is not implemented for `ZmqMessage`
+  |
+help: the following other types implement trait `From<T>`
+ --> src/message.rs
+  |
+  | impl From<String> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<String>`
+...
+  | impl From<&str> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<&str>`
+...
+  | impl From<Vec<u8>> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<Vec<u8>>`
+...
+  | impl From<Bytes> for ZmqMessage {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ZmqMessage` implements `From<bytes::Bytes>`
+  = note: required for `VecDeque<bytes::Bytes>` to implement `Into<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryFrom<VecDeque<bytes::Bytes>>`

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_into_string.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_into_string.rs
@@ -1,0 +1,7 @@
+use std::convert::TryInto;
+use zeromq::ZmqMessage;
+
+fn main() {
+    let msg = ZmqMessage::from("body");
+    let _body: String = msg.try_into().unwrap();
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_into_string.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_into_string.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `String: TryFrom<ZmqMessage>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_into_string.rs:6:29
+  |
+6 |     let _body: String = msg.try_into().unwrap();
+  |                             ^^^^^^^^ the trait `From<ZmqMessage>` is not implemented for `String`
+  |
+  = help: the following other types implement trait `From<T>`:
+            `String` implements `From<&String>`
+            `String` implements `From<&mut str>`
+            `String` implements `From<&str>`
+            `String` implements `From<Box<str>>`
+            `String` implements `From<Cow<'_, str>>`
+            `String` implements `From<char>`
+  = note: required for `ZmqMessage` to implement `Into<String>`
+  = note: required for `String` to implement `TryFrom<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryInto<String>`

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_into_vec_u8.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_into_vec_u8.rs
@@ -1,0 +1,7 @@
+use std::convert::TryInto;
+use zeromq::ZmqMessage;
+
+fn main() {
+    let msg = ZmqMessage::from("body");
+    let _body: Vec<u8> = msg.try_into().unwrap();
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/message_try_into_vec_u8.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/message_try_into_vec_u8.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `Vec<u8>: TryFrom<ZmqMessage>` is not satisfied
+ --> tests/trybuild/compat-fail/message_try_into_vec_u8.rs:6:30
+  |
+6 |     let _body: Vec<u8> = msg.try_into().unwrap();
+  |                              ^^^^^^^^ the trait `From<ZmqMessage>` is not implemented for `Vec<u8>`
+  |
+  = help: the following other types implement trait `From<T>`:
+            `Vec<u8>` implements `From<&str>`
+            `Vec<u8>` implements `From<ByteString>`
+            `Vec<u8>` implements `From<CString>`
+            `Vec<u8>` implements `From<String>`
+            `Vec<u8>` implements `From<bytes::bytes::Bytes>`
+            `Vec<u8>` implements `From<bytes::bytes_mut::BytesMut>`
+  = note: required for `ZmqMessage` to implement `Into<Vec<u8>>`
+  = note: required for `Vec<u8>` to implement `TryFrom<ZmqMessage>`
+  = note: required for `ZmqMessage` to implement `TryInto<Vec<u8>>`

--- a/omq-zeromq/tests/trybuild/compat-fail/monitor_receiver_type.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/monitor_receiver_type.rs
@@ -1,0 +1,8 @@
+use futures_channel::mpsc;
+use zeromq::{PushSocket, Socket, SocketEvent};
+
+fn zmqrs_monitor_type(mut socket: PushSocket) -> mpsc::Receiver<SocketEvent> {
+    socket.monitor()
+}
+
+fn main() {}

--- a/omq-zeromq/tests/trybuild/compat-fail/monitor_receiver_type.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/monitor_receiver_type.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+ --> tests/trybuild/compat-fail/monitor_receiver_type.rs:5:5
+  |
+4 | fn zmqrs_monitor_type(mut socket: PushSocket) -> mpsc::Receiver<SocketEvent> {
+  |                                                  --------------------------- expected `futures_channel::mpsc::Receiver<SocketEvent>` because of return type
+5 |     socket.monitor()
+  |     ^^^^^^^^^^^^^^^^ expected `Receiver<SocketEvent>`, found `MonitorStream`
+  |
+  = note: expected struct `futures_channel::mpsc::Receiver<SocketEvent>`
+             found struct `MonitorStream`

--- a/omq-zeromq/tests/trybuild/compat-fail/peer_identity_util_path.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/peer_identity_util_path.rs
@@ -1,0 +1,5 @@
+use zeromq::util::PeerIdentity;
+
+fn main() {
+    let _identity = PeerIdentity::new();
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/peer_identity_util_path.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/peer_identity_util_path.stderr
@@ -1,0 +1,5 @@
+error[E0432]: unresolved import `zeromq::util`
+ --> tests/trybuild/compat-fail/peer_identity_util_path.rs:1:13
+  |
+1 | use zeromq::util::PeerIdentity;
+  |             ^^^^ could not find `util` in `zeromq`

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_close_return.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_close_return.rs
@@ -1,0 +1,7 @@
+use zeromq::{PushSocket, Socket, ZmqError};
+
+async fn zmqrs_close_shape(socket: PushSocket) -> Vec<ZmqError> {
+    socket.close().await
+}
+
+fn main() {}

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_close_return.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_close_return.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+ --> tests/trybuild/compat-fail/socket_close_return.rs:4:5
+  |
+4 |     socket.close().await
+  |     ^^^^^^^^^^^^^^^^^^^^ expected `Vec<ZmqError>`, found `Result<(), ZmqError>`
+  |
+  = note: expected struct `Vec<ZmqError>`
+               found enum `Result<(), ZmqError>`

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_options_mutating_builder.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_options_mutating_builder.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+use zeromq::SocketOptions;
+
+fn main() {
+    let mut options = SocketOptions::default();
+    options.no_connect_timeout();
+    options.connect_timeout(Duration::from_secs(5));
+}

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_options_mutating_builder.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_options_mutating_builder.stderr
@@ -1,0 +1,29 @@
+warning: variable does not need to be mutable
+ --> tests/trybuild/compat-fail/socket_options_mutating_builder.rs:5:9
+  |
+5 |     let mut options = SocketOptions::default();
+  |         ----^^^^^^^
+  |         |
+  |         help: remove this `mut`
+  |
+  = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+error[E0382]: use of moved value: `options`
+ --> tests/trybuild/compat-fail/socket_options_mutating_builder.rs:7:5
+  |
+5 |     let mut options = SocketOptions::default();
+  |         ----------- move occurs because `options` has type `SocketOptions`, which does not implement the `Copy` trait
+6 |     options.no_connect_timeout();
+  |             -------------------- `options` moved due to this method call
+7 |     options.connect_timeout(Duration::from_secs(5));
+  |     ^^^^^^^ value used here after move
+  |
+note: `SocketOptions::no_connect_timeout` takes ownership of the receiver `self`, which moves `options`
+ --> src/options.rs
+  |
+  |     pub fn no_connect_timeout(mut self) -> Self {
+  |                                   ^^^^
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+  |
+6 |     options.clone().no_connect_timeout();
+  |            ++++++++

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_trait_backend.rs
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_trait_backend.rs
@@ -1,0 +1,7 @@
+use zeromq::{PushSocket, Socket};
+
+fn needs_zmqrs_backend(socket: &PushSocket) {
+    let _ = socket.backend();
+}
+
+fn main() {}

--- a/omq-zeromq/tests/trybuild/compat-fail/socket_trait_backend.stderr
+++ b/omq-zeromq/tests/trybuild/compat-fail/socket_trait_backend.stderr
@@ -1,0 +1,13 @@
+warning: unused import: `Socket`
+ --> tests/trybuild/compat-fail/socket_trait_backend.rs:1:26
+  |
+1 | use zeromq::{PushSocket, Socket};
+  |                          ^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0599]: no method named `backend` found for reference `&PushSocket` in the current scope
+ --> tests/trybuild/compat-fail/socket_trait_backend.rs:4:20
+  |
+4 |     let _ = socket.backend();
+  |                    ^^^^^^^ method not found in `&PushSocket`

--- a/omq-zeromq/tests/trybuild/compat-pass/common_socket_patterns.rs
+++ b/omq-zeromq/tests/trybuild/compat-pass/common_socket_patterns.rs
@@ -1,0 +1,31 @@
+use bytes::Bytes;
+use zeromq::{
+    PullSocket, PushSocket, Socket, SocketRecv, SocketSend, SubSocket, ZmqMessage, ZmqResult,
+};
+
+async fn push_pull_shape() -> ZmqResult<()> {
+    let mut push = PushSocket::new();
+    let mut pull = PullSocket::new();
+
+    let ep = push.bind("tcp://127.0.0.1:0").await?;
+    pull.connect(&ep.to_string()).await?;
+
+    push.send(ZmqMessage::from(Bytes::from_static(b"hello")))
+        .await?;
+    let msg = pull.recv().await?;
+    let _ = msg.get(0);
+    let _ = msg.iter();
+
+    Ok(())
+}
+
+async fn subscription_shape(mut sub: SubSocket) -> ZmqResult<()> {
+    sub.subscribe("topic").await?;
+    sub.unsubscribe("topic").await?;
+    Ok(())
+}
+
+fn main() {
+    let _ = push_pull_shape;
+    let _ = subscription_shape;
+}


### PR DESCRIPTION
## Summary

Adds a small `trybuild` compatibility suite for `omq-zeromq`.

The suite has two purposes:

- keep a known-good common `zeromq` socket usage pattern compiling
- document current places where `omq-zeromq` differs from the `zeromq` crate API

The compile-fail fixtures cover:

- `ZmqMessage::try_from(Vec<Bytes>)`
- `ZmqMessage::try_from(VecDeque<Bytes>)`
- `TryInto<String>` and `TryInto<Vec<u8>>` for `ZmqMessage`
- `Socket::monitor()` returning the zmq.rs monitor receiver type
- `zeromq::util::PeerIdentity`
- `Socket::close(self) -> Vec<ZmqError>`
- mutating `SocketOptions` builder calls
- the zmq.rs-specific `Socket::backend()` hook

This is not asserting that every gap should be closed. It makes the current
compatibility boundary executable so future API-compat work has a checklist.

## Verification

Before opening this PR, I also checked the fixture intent both ways:

- every compile-fail fixture compiles against local `zeromq` 0.6.0
- the shared pass fixture compiles against `omq-zeromq`
- every compile-fail fixture fails against `omq-zeromq`

Validation run on this branch:

```sh
RUSTC_WRAPPER= cargo fmt --all -- --check
RUSTC_WRAPPER= cargo test -p omq-zeromq --test compatibility_gaps
RUSTC_WRAPPER= cargo test -p omq-zeromq
RUSTC_WRAPPER= cargo clippy -p omq-zeromq --all-targets -- --deny warnings
```
