### PR TITLE
add WebSocket transport (ZWS/2.0, RFC 45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 *.so
 *.html
 /*.log
+omq-tokio/tests/helpers/zmq_ws_peer

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -174,10 +174,19 @@ transport cell on each backend) and `omq-tokio/tests/interop_compio.rs`
 | `udp://host:port` | UDP datagram (`RADIO` / `DISH` only) | both |
 | `lz4+tcp://host:port` | TCP + LZ4 transform | both, feature `lz4` |
 | `zstd+tcp://host:port` | TCP + zstd transform with optional dict training | both, feature `zstd` |
+| `ws://host:port/path` | ZeroMQ over WebSocket (ZWS/2.0, RFC 45) | both, feature `ws` |
+| `wss://host:port/path` | ZeroMQ over WebSocket with TLS | both, feature `ws` |
 
 Compression-style schemes are runtime layers stacked on top of the TCP
 transport, not separate transports. The encoder/decoder live in
 `omq-proto` and are wired in by the backend after the ZMTP handshake.
+
+WebSocket (`ws://`, `wss://`) is a separate transport with its own
+driver loop (`ws_driver`). ZWS replaces ZMTP's byte-stream framing
+with WebSocket binary messages: each message is one ZMTP frame
+prefixed by a 1-byte flag (`0x00` final, `0x01` more, `0x02`
+command). The 64-byte ZMTP greeting is skipped; mechanism negotiation
+happens via `Sec-WebSocket-Protocol` header during the HTTP upgrade.
 
 ## Transport type dispatch
 
@@ -250,7 +259,8 @@ behind).
 | `src/proto/chunked_buf.rs` | `ChunkedInputBuf` -- zero-copy multi-chunk input buffer |
 | `src/proto/mechanism/` | Mechanism dispatch + handshakes (NULL / PLAIN / CURVE / BLAKE3ZMQ) |
 | `src/proto/transform/` | LZ4 and Zstd per-part encoder/decoder |
-| `src/endpoint.rs` | URI parsing (`tcp://`, `ipc://`, `lz4+tcp://`, etc.) |
+| `src/proto/zws.rs` | ZWS/2.0 frame codec (feature `ws`) |
+| `src/endpoint.rs` | URI parsing (`tcp://`, `ipc://`, `lz4+tcp://`, `ws://`, etc.) |
 | `src/options.rs` | `Options` builder (HWM, identity, keepalive, mechanism) |
 | `src/subscription.rs` | Patricia-trie prefix matcher for SUB/XSUB |
 
@@ -268,6 +278,8 @@ behind).
 | `src/transport/tcp.rs` | TCP bind/connect/accept |
 | `src/transport/ipc.rs` | IPC bind/connect |
 | `src/transport/inproc.rs` | In-process transport (no ZMTP; blume MPSC for fan-in, yring SPSC for eligible cross-thread pairs) |
+| `src/transport/ws.rs` | WS bind/connect/accept (feature `ws`) |
+| `src/transport/ws_driver.rs` | WS connection driver (feature `ws`) |
 | `src/monitor.rs` | `MonitorPublisher` + `MonitorStream` |
 
 ### omq-tokio
@@ -284,6 +296,7 @@ behind).
 | `src/routing/identity.rs` | ROUTER/REP/SERVER identity routing |
 | `src/routing/fair_queue.rs` | PULL/SUB fair-queue recv |
 | `src/transport/tcp.rs` | TCP bind/connect with reconnect |
+| `src/transport/ws.rs` | WS bind/connect/accept + WS connection driver (feature `ws`) |
 
 ## Adding a new socket type / transport / mechanism
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -630,3 +630,34 @@ patterns without deadlock or ordering violations. Same-thread
 throughput is bounded by blume's Mutex + VecDeque path and compio's
 per-task-poll overhead (~39% of cycles).
 
+## WebSocket transport (ZWS/2.0)
+
+PUSH/PULL over `ws://127.0.0.1`, 1 peer, 2 s rounds, same machine.
+libzmq 4.3.5 built with `ENABLE_DRAFTS=ON`.
+
+```
+                    128 B              2 KiB              8 KiB
+                msg/s    MB/s     msg/s    MB/s     msg/s    MB/s
+libzmq 4.3.5   1,911K    245      289K     592       69K     569
+omq-tokio        955K    122      666K   1,364      193K   1,581
+omq-compio       112K     14       93K     190       85K     693
+```
+
+At small messages libzmq leads 2x over omq-tokio: it uses a custom
+WS codec with no tungstenite overhead and batches frames into fewer
+syscalls. At 8 KiB omq-tokio is 2.8x faster because the batched
+feed-then-flush path amortizes per-frame WS overhead across the
+batch, and tokio's multi-threaded runtime overlaps send and recv.
+
+omq-compio is single-threaded (one io_uring thread per socket).
+The sender and receiver take turns on the same thread, so there is
+no batching window: each message is one feed + flush round-trip
+through tungstenite, which is ~8 µs. That per-message latency
+dominates at every size.
+
+**What WS costs vs TCP.** On the same box, omq-tokio over
+`tcp://` does 5.9M msg/s at 128 B and 4.5 GB/s at 8 KiB. The WS
+overhead comes from: (1) per-frame WS header + client-side XOR
+masking, (2) no gather I/O (each WS message is an independent
+tungstenite write), (3) the HTTP upgrade handshake at connect time.
+

--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -23,6 +23,7 @@ blake3zmq = ["omq-proto/blake3zmq"]
 plain = ["omq-proto/plain"]
 lz4 = ["omq-proto/lz4"]
 zstd = ["omq-proto/zstd"]
+ws = ["omq-proto/ws", "dep:compio-ws"]
 priority = ["omq-proto/priority"]
 # Enables the fuzz test suites (`tests/fuzz_*.rs`). Off by default -
 # those targets do ~1 M iterations each and dominate runtime of
@@ -44,6 +45,7 @@ async-lock = "3"
 socket2 = "0.6"
 smallvec = { version = "1", features = ["const_generics", "union"] }
 libc = "0.2"
+compio-ws = { version = "0.4.0-rc.2", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/omq-compio/benches/common/mod.rs
+++ b/omq-compio/benches/common/mod.rs
@@ -124,7 +124,7 @@ pub(crate) fn endpoint(transport: &str, seq: usize) -> Endpoint {
             let _ = std::fs::remove_file(&dir);
             Endpoint::Ipc(IpcPath::Filesystem(dir))
         }
-        "tcp" | "lz4+tcp" | "zstd+tcp" => {
+        "tcp" | "lz4+tcp" | "zstd+tcp" | "ws" => {
             let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
                 .expect("bench: failed to allocate a tcp port");
             let port = l.local_addr().unwrap().port();
@@ -136,10 +136,16 @@ pub(crate) fn endpoint(transport: &str, seq: usize) -> Endpoint {
                 "lz4+tcp" => Endpoint::Lz4Tcp { host, port },
                 #[cfg(feature = "zstd")]
                 "zstd+tcp" => Endpoint::ZstdTcp { host, port },
+                #[cfg(feature = "ws")]
+                "ws" => Endpoint::Ws {
+                    host,
+                    port,
+                    path: "/".into(),
+                },
                 _ => panic!(
                     "bench: transport '{transport}' requires its feature; \
                      rerun with `--features {}`",
-                    transport.trim_end_matches("tcp").trim_end_matches('+')
+                    transport.replace("+tcp", "")
                 ),
             }
         }

--- a/omq-compio/src/socket/bind.rs
+++ b/omq-compio/src/socket/bind.rs
@@ -35,6 +35,10 @@ impl Socket {
         if endpoint.is_tcp_family() {
             return self.bind_tcp(endpoint).await;
         }
+        #[cfg(feature = "ws")]
+        if endpoint.is_ws_family() {
+            return self.bind_ws(endpoint).await;
+        }
         #[allow(unreachable_patterns, clippy::match_wildcard_for_single_variants)]
         match endpoint {
             Endpoint::Inproc { name } => self.bind_inproc(name).await,
@@ -319,6 +323,68 @@ impl Socket {
                 if inner.in_tx.send_async(frame).await.is_err() {
                     break;
                 }
+            }
+        });
+        let ret = resolved.clone();
+        self.inner()
+            .listeners
+            .write()
+            .expect("listeners lock")
+            .push(ListenerEntry {
+                endpoint: resolved,
+                _task: task,
+            });
+        Ok(ret)
+    }
+
+    #[cfg(feature = "ws")]
+    async fn bind_ws(&self, endpoint: Endpoint) -> Result<Endpoint> {
+        use crate::transport::ws as ws_transport;
+
+        let ws_listener = ws_transport::bind(&endpoint).await?;
+        let local = ws_listener.local_addr;
+        let resolved = match &endpoint {
+            Endpoint::Ws { path, .. } => Endpoint::Ws {
+                host: omq_proto::endpoint::Host::Ip(local.ip()),
+                port: local.port(),
+                path: path.clone(),
+            },
+            Endpoint::Wss { path, .. } => Endpoint::Wss {
+                host: omq_proto::endpoint::Host::Ip(local.ip()),
+                port: local.port(),
+                path: path.clone(),
+            },
+            _ => unreachable!("checked above"),
+        };
+        self.inner().monitor.listening(resolved.clone());
+        let inner = self.inner().clone();
+        let ep_for_task = resolved.clone();
+        let task = compio::runtime::spawn(async move {
+            while let Ok((stream, addr)) = ws_listener.inner.accept().await {
+                let inner = inner.clone();
+                let ep = ep_for_task.clone();
+                compio::runtime::spawn(async move {
+                    let Ok(ws) = ws_transport::accept(stream).await else {
+                        return;
+                    };
+                    let conn_id = inner
+                        .next_connection_id
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    inner.monitor.accepted(
+                        ep.clone(),
+                        crate::monitor::PeerIdent::Socket(addr),
+                        conn_id,
+                    );
+                    crate::socket::install::install_ws_peer(
+                        &inner,
+                        ws,
+                        omq_proto::proto::connection::Role::Server,
+                        ep,
+                        conn_id,
+                        Some(addr),
+                    );
+                })
+                .detach();
             }
         });
         let ret = resolved.clone();

--- a/omq-compio/src/socket/connect.rs
+++ b/omq-compio/src/socket/connect.rs
@@ -42,6 +42,7 @@ impl Socket {
         self.connect_inner(endpoint, opts.priority.get()).await
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn connect_inner(
         &self,
         endpoint: Endpoint,
@@ -65,6 +66,34 @@ impl Socket {
                 #[cfg(feature = "priority")]
                 priority,
             );
+            return Ok(());
+        }
+        #[cfg(feature = "ws")]
+        if endpoint.is_ws_family() {
+            let inner = self.inner().clone();
+            let ep = endpoint.clone();
+            compio::runtime::spawn(async move {
+                let Ok(ws) = crate::transport::ws::connect(&ep).await else {
+                    return;
+                };
+                let conn_id = inner
+                    .next_connection_id
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                inner.monitor.connected(
+                    ep.clone(),
+                    crate::monitor::PeerIdent::Path(ep.to_string()),
+                    conn_id,
+                );
+                crate::socket::install::install_ws_peer(
+                    &inner,
+                    ws,
+                    omq_proto::proto::connection::Role::Client,
+                    ep,
+                    conn_id,
+                    None,
+                );
+            })
+            .detach();
             return Ok(());
         }
         #[allow(unreachable_patterns, clippy::match_wildcard_for_single_variants)]

--- a/omq-compio/src/socket/install.rs
+++ b/omq-compio/src/socket/install.rs
@@ -349,6 +349,101 @@ fn handle_driver_exit(
     }
 }
 
+#[cfg(feature = "ws")]
+pub(super) fn install_ws_peer(
+    inner: &std::sync::Arc<SocketInner>,
+    ws: crate::transport::ws::WsStream,
+    role: omq_proto::proto::connection::Role,
+    endpoint: Endpoint,
+    connection_id: u64,
+    peer_addr: Option<std::net::SocketAddr>,
+) {
+    let cap = cmd_channel_capacity(&inner.options);
+    let (cmd_tx, cmd_rx) = flume::bounded::<DriverCommand>(cap);
+    let handle: WirePeerHandle = std::sync::Arc::new(RwLock::new(cmd_tx));
+    let info_holder: std::sync::Arc<RwLock<Option<PeerInfo>>> =
+        std::sync::Arc::new(RwLock::new(None));
+    let peer_sub = pub_side_peer_sub(inner.socket_type);
+    let peer_groups = radio_side_peer_groups(inner.socket_type);
+
+    let out = PeerOut::Wire(handle);
+    let slot_idx = {
+        let mut peers = inner.out_peers.write().expect("peers lock");
+        let idx = peers.insert(PeerSlot {
+            out,
+            direct_io: None,
+            peer: std::sync::Arc::new(RwLock::new(None)),
+            connection_id,
+            endpoint: endpoint.clone(),
+            info: info_holder.clone(),
+            peer_sub: peer_sub.clone(),
+            peer_groups: peer_groups.clone(),
+            #[cfg(feature = "priority")]
+            priority: omq_proto::DEFAULT_PRIORITY,
+        });
+        inner
+            .peers_gen
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        idx
+    };
+    {
+        let pipes = unsafe { &mut *inner.inproc_send_pipes.get() };
+        while pipes.len() <= slot_idx {
+            pipes.push(None);
+        }
+    }
+    inner.rebuild_peer_keys();
+    inner.on_peer_ready.notify(usize::MAX);
+
+    let (snap_tx, snap_rx) = flume::bounded::<InprocPeerSnapshot>(1);
+    spawn_snap_listener(inner.clone(), snap_rx, slot_idx, connection_id);
+
+    let socket_type = inner.socket_type;
+    let options = inner.options.clone();
+    let peer_in_tx = inner.in_tx.clone();
+    let shared_msg_rx = if is_round_robin_send(socket_type) {
+        inner.shared_send_rx.clone()
+    } else {
+        None
+    };
+    let monitor_ctx = MonitorCtx {
+        monitor: inner.monitor.clone(),
+        endpoint: endpoint.clone(),
+        connection_id,
+        peer_info: info_holder.clone(),
+        peer_address: peer_addr,
+        peer_sub,
+        peer_groups,
+    };
+    let inner_for_exit = inner.clone();
+    let endpoint_for_exit = endpoint;
+    compio::runtime::spawn(async move {
+        let res = crate::transport::ws_driver::run_ws_connection(
+            ws,
+            role,
+            socket_type,
+            options,
+            cmd_rx,
+            shared_msg_rx,
+            peer_in_tx,
+            snap_tx,
+            Some(monitor_ctx),
+        )
+        .await;
+        handle_driver_exit(
+            &inner_for_exit,
+            &res,
+            &info_holder,
+            &endpoint_for_exit,
+            connection_id,
+            socket_type,
+            peer_addr,
+        );
+        inner_for_exit.release_slot(slot_idx);
+    })
+    .detach();
+}
+
 pub(super) fn spawn_wire_driver(cfg: WireDriverConfig) -> compio::runtime::JoinHandle<()> {
     let WireDriverConfig {
         inner,

--- a/omq-compio/src/transport/mod.rs
+++ b/omq-compio/src/transport/mod.rs
@@ -10,3 +10,7 @@ mod recv_stream;
 pub(crate) mod stream_raw;
 pub mod tcp;
 pub mod udp;
+#[cfg(feature = "ws")]
+pub mod ws;
+#[cfg(feature = "ws")]
+pub mod ws_driver;

--- a/omq-compio/src/transport/ws.rs
+++ b/omq-compio/src/transport/ws.rs
@@ -1,0 +1,137 @@
+//! WebSocket bind/connect glue (ZWS/2.0, RFC 45).
+
+use std::net::SocketAddr;
+
+use compio::net::{TcpListener, TcpStream};
+use compio_ws::tungstenite::client::IntoClientRequest;
+use compio_ws::tungstenite::http::{HeaderValue, Request, Response, StatusCode};
+
+use omq_proto::endpoint::{Endpoint, Host};
+use omq_proto::error::{Error, Result};
+
+pub(crate) type WsStream = compio_ws::WebSocketStream<TcpStream>;
+
+const SUBPROTOCOL: &str = "ZWS2.0";
+const SUBPROTOCOL_NULL: &str = "ZWS2.0/NULL";
+
+fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
+    use std::net::{IpAddr, Ipv4Addr};
+    match host {
+        Host::Wildcard => Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)),
+        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
+        Host::Name(_) => Err(Error::InvalidEndpoint(
+            "DNS resolution not yet supported on omq-compio WS".into(),
+        )),
+    }
+}
+
+fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
+    match host {
+        Host::Wildcard => Err(Error::InvalidEndpoint(
+            "cannot connect to wildcard host".into(),
+        )),
+        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
+        Host::Name(_) => Err(Error::InvalidEndpoint(
+            "DNS resolution not yet supported on omq-compio WS".into(),
+        )),
+    }
+}
+
+fn ws_config() -> compio_ws::Config {
+    compio_ws::Config::new().disable_nagle(true)
+}
+
+pub(crate) struct WsListener {
+    pub(crate) inner: TcpListener,
+    pub(crate) local_addr: SocketAddr,
+}
+
+pub(crate) async fn bind(endpoint: &Endpoint) -> Result<WsListener> {
+    let (host, port) = match endpoint {
+        Endpoint::Ws { host, port, .. } | Endpoint::Wss { host, port, .. } => (host, *port),
+        _ => {
+            return Err(Error::InvalidEndpoint(format!(
+                "ws transport got non-ws endpoint: {endpoint}"
+            )));
+        }
+    };
+    let addr = resolve_bind(host, port)?;
+    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let local = listener.local_addr().map_err(Error::Io)?;
+    Ok(WsListener {
+        inner: listener,
+        local_addr: local,
+    })
+}
+
+fn ws_io_err(e: impl std::fmt::Display) -> Error {
+    Error::Io(std::io::Error::other(e.to_string()))
+}
+
+#[allow(clippy::result_large_err)]
+pub(crate) async fn accept(stream: TcpStream) -> Result<WsStream> {
+    let _ = stream.set_nodelay(true);
+    let ws = compio_ws::accept_hdr_with_config_async(
+        stream,
+        |req: &Request<()>,
+         mut resp: Response<()>|
+         -> std::result::Result<Response<()>, Response<Option<String>>> {
+            let protocols = req
+                .headers()
+                .get("Sec-WebSocket-Protocol")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            let chosen = protocols
+                .split(',')
+                .map(str::trim)
+                .find(|p| *p == SUBPROTOCOL_NULL || *p == SUBPROTOCOL);
+            if let Some(proto) = chosen {
+                resp.headers_mut().insert(
+                    "Sec-WebSocket-Protocol",
+                    HeaderValue::from_str(proto).expect("valid header"),
+                );
+                Ok(resp)
+            } else {
+                let mut err_resp: Response<Option<String>> =
+                    Response::new(Some("no supported ZWS subprotocol".into()));
+                *err_resp.status_mut() = StatusCode::BAD_REQUEST;
+                Err(err_resp)
+            }
+        },
+        ws_config(),
+    )
+    .await
+    .map_err(ws_io_err)?;
+    Ok(ws)
+}
+
+pub(crate) async fn connect(endpoint: &Endpoint) -> Result<WsStream> {
+    let (host, port, path) = match endpoint {
+        Endpoint::Ws {
+            host, port, path, ..
+        }
+        | Endpoint::Wss {
+            host, port, path, ..
+        } => (host, *port, path.as_str()),
+        _ => {
+            return Err(Error::InvalidEndpoint(format!(
+                "ws transport got non-ws endpoint: {endpoint}"
+            )));
+        }
+    };
+    let addr = resolve_connect(host, port)?;
+    let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
+    let _ = stream.set_nodelay(true);
+
+    let url = format!("ws://{host}:{port}{path}");
+    let mut request = url.into_client_request().map_err(ws_io_err)?;
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_static(SUBPROTOCOL_NULL),
+    );
+
+    let (ws, _response) = compio_ws::client_async_with_config(request, stream, ws_config())
+        .await
+        .map_err(ws_io_err)?;
+    Ok(ws)
+}

--- a/omq-compio/src/transport/ws_driver.rs
+++ b/omq-compio/src/transport/ws_driver.rs
@@ -1,0 +1,269 @@
+//! WebSocket connection driver (ZWS/2.0, RFC 45).
+//!
+//! Message-oriented driver parallel to `driver.rs`. Much simpler: no
+//! multi-shot recv, no `DirectIoState`, no `begin_supplied_payload`.
+//! Each inbound WS binary message is one ZMTP frame.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use flume::Receiver;
+use futures::{FutureExt, StreamExt};
+use smallvec::SmallVec;
+
+use omq_proto::error::{Error, Result};
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+use omq_proto::proto::connection::{Connection, ConnectionConfig, Role, TransportMode};
+use omq_proto::proto::{Command, Event, SocketType};
+
+use crate::transport::dispatch::{Drained, MonitorCtx, dispatch_drained_events};
+use crate::transport::inproc::{InprocFrame, InprocPeerSnapshot};
+use crate::transport::ws::WsStream;
+
+fn ws_io_err(e: impl std::fmt::Display) -> Error {
+    Error::Io(std::io::Error::other(e.to_string()))
+}
+
+pub use crate::transport::driver::DriverCommand;
+
+fn generated_identity(connection_id: u64) -> Bytes {
+    let mut buf = Vec::with_capacity(9);
+    buf.push(0);
+    buf.extend_from_slice(&connection_id.to_be_bytes());
+    Bytes::from(buf)
+}
+
+async fn maybe_sleep_until(deadline: Option<Instant>) {
+    match deadline {
+        Some(t) => compio::time::sleep_until(t).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(crate) async fn run_ws_connection(
+    mut ws: WsStream,
+    role: Role,
+    socket_type: SocketType,
+    options: Options,
+    inbox: Receiver<DriverCommand>,
+    shared_msg_rx: Option<Receiver<Message>>,
+    peer_in_tx: blume::Sender<InprocFrame>,
+    peer_snapshot_tx: flume::Sender<InprocPeerSnapshot>,
+    monitor_ctx: Option<MonitorCtx>,
+) -> Result<()> {
+    let mut cfg = ConnectionConfig::new(role, socket_type)
+        .identity(options.identity.clone())
+        .mechanism(options.mechanism.to_setup())
+        .transport_mode(TransportMode::WebSocket);
+    if let Some(n) = options.max_message_size {
+        cfg = cfg.max_message_size(n);
+    }
+    let mut codec = Connection::new(cfg);
+
+    let hb_interval = options.heartbeat_interval;
+    let hb_timeout = options
+        .heartbeat_timeout
+        .or(options.heartbeat_interval)
+        .unwrap_or(Duration::MAX);
+    let hb_ttl_deciseconds = options
+        .heartbeat_ttl
+        .and_then(|d| u16::try_from(d.as_millis() / 100).ok())
+        .unwrap_or(0);
+
+    let mut closing = false;
+    let mut deadline: Option<Instant> = options.handshake_timeout.map(|t| Instant::now() + t);
+    let mut hb_next: Option<Instant> = None;
+    let mut hb_last_input = Instant::now();
+    let mut peer_identity = Bytes::new();
+    let mut handshake_done = false;
+    let mut pending_cmds: VecDeque<DriverCommand> = VecDeque::new();
+    let mut shared_closed = false;
+
+    flush_ws_frames(&mut codec, &mut ws).await?;
+
+    loop {
+        if closing && handshake_done && pending_cmds.is_empty() && !codec.has_pending_ws_frames() {
+            return Ok(());
+        }
+
+        {
+            let drained = drain_events(
+                &mut codec,
+                &mut handshake_done,
+                &mut deadline,
+                &mut hb_next,
+                hb_interval,
+                &mut peer_identity,
+                monitor_ctx.as_ref(),
+                &mut pending_cmds,
+            );
+            if dispatch_drained_events(
+                drained,
+                socket_type,
+                &peer_in_tx,
+                &peer_snapshot_tx,
+                monitor_ctx.as_ref(),
+                &peer_identity,
+            )
+            .await?
+            {
+                return Ok(());
+            }
+        }
+
+        flush_ws_frames(&mut codec, &mut ws).await?;
+
+        let timeout_fut = maybe_sleep_until(deadline);
+        let hb_fut = maybe_sleep_until(hb_next);
+        let cmd_fut = inbox.recv_async();
+        let shared_active = shared_msg_rx.as_ref().filter(|_| !shared_closed);
+        let shared_fut = async {
+            match shared_active {
+                Some(rx) => rx.recv_async().await.ok(),
+                None => std::future::pending::<Option<Message>>().await,
+            }
+        };
+
+        let ws_next = ws.next();
+        futures::pin_mut!(timeout_fut);
+        futures::pin_mut!(hb_fut);
+        futures::pin_mut!(cmd_fut);
+        futures::pin_mut!(shared_fut);
+        futures::pin_mut!(ws_next);
+        futures::select_biased! {
+            () = timeout_fut.fuse() => {
+                return Err(Error::HandshakeFailed("handshake timeout".into()));
+            }
+            () = hb_fut.fuse() => {
+                let elapsed = hb_last_input.elapsed();
+                if elapsed > hb_timeout {
+                    return Err(Error::Timeout);
+                }
+                let ping = Command::Ping {
+                    ttl_deciseconds: hb_ttl_deciseconds,
+                    context: Bytes::new(),
+                };
+                codec.send_command(&ping)?;
+                if let Some(iv) = hb_interval {
+                    hb_next = Some(Instant::now() + iv);
+                }
+            }
+            msg = ws_next.fuse() => {
+                let Some(msg) = msg else { return Ok(()); };
+                let msg = msg.map_err(ws_io_err)?;
+                match msg {
+                    compio_ws::tungstenite::Message::Binary(data) => {
+                        hb_last_input = Instant::now();
+                        codec.handle_ws_message(data)?;
+                    }
+                    compio_ws::tungstenite::Message::Close(_) => return Ok(()),
+                    _ => {}
+                }
+            }
+            cmd = cmd_fut.fuse() => {
+                let Ok(cmd) = cmd else { return Ok(()); };
+                if handshake_done {
+                    handle_outbound_cmd(&mut codec, cmd, &mut closing)?;
+                } else {
+                    pending_cmds.push_back(cmd);
+                }
+            }
+            msg = shared_fut.fuse() => {
+                let Some(m) = msg else {
+                    shared_closed = true;
+                    continue;
+                };
+                if handshake_done {
+                    codec.send_message(&m)?;
+                    if let Some(rx) = shared_msg_rx.as_ref() {
+                        while let Ok(extra) = rx.try_recv() {
+                            codec.send_message(&extra)?;
+                        }
+                    }
+                    flush_ws_frames(&mut codec, &mut ws).await?;
+                } else {
+                    pending_cmds.push_back(DriverCommand::SendMessage(m));
+                }
+            }
+        }
+    }
+}
+
+fn handle_outbound_cmd(
+    codec: &mut Connection,
+    cmd: DriverCommand,
+    closing: &mut bool,
+) -> Result<()> {
+    match cmd {
+        DriverCommand::SendMessage(m) => codec.send_message(&m)?,
+        DriverCommand::SendCommand(c) => codec.send_command(&c)?,
+        DriverCommand::Close => *closing = true,
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn drain_events(
+    codec: &mut Connection,
+    handshake_done: &mut bool,
+    deadline: &mut Option<Instant>,
+    hb_next: &mut Option<Instant>,
+    hb_interval: Option<Duration>,
+    peer_identity: &mut Bytes,
+    monitor_ctx: Option<&MonitorCtx>,
+    pending_cmds: &mut VecDeque<DriverCommand>,
+) -> SmallVec<[Drained; 8]> {
+    let mut out: SmallVec<[Drained; 8]> = SmallVec::new();
+    while let Some(ev) = codec.poll_event() {
+        match ev {
+            Event::HandshakeSucceeded {
+                peer_minor,
+                peer_properties,
+            } => {
+                if !*handshake_done {
+                    *handshake_done = true;
+                    *deadline = None;
+                    if let Some(iv) = hb_interval {
+                        *hb_next = Some(Instant::now() + iv);
+                    }
+                    *peer_identity = peer_properties.identity.clone().unwrap_or_else(|| {
+                        monitor_ctx
+                            .as_ref()
+                            .map_or_else(Bytes::new, |ctx| generated_identity(ctx.connection_id))
+                    });
+                    while let Some(cmd) = pending_cmds.pop_front() {
+                        let _ = handle_outbound_cmd(codec, cmd, &mut false);
+                    }
+                    out.push(Drained::Handshake {
+                        peer_minor,
+                        peer_properties,
+                    });
+                }
+            }
+            Event::Message(_) => unreachable!("messages use poll_message"),
+            Event::Command(c) => out.push(Drained::Cmd(c)),
+        }
+    }
+    while let Some(m) = codec.poll_message() {
+        out.push(Drained::Msg(m));
+    }
+    out
+}
+
+async fn flush_ws_frames(codec: &mut Connection, ws: &mut WsStream) -> Result<()> {
+    use futures::SinkExt;
+    let mut any = false;
+    while let Some(frame) = codec.poll_ws_frame() {
+        ws.feed(compio_ws::tungstenite::Message::Binary(frame))
+            .await
+            .map_err(ws_io_err)?;
+        any = true;
+    }
+    if any {
+        ws.flush().await.map_err(ws_io_err)?;
+    }
+    Ok(())
+}

--- a/omq-compio/tests/ws_basic.rs
+++ b/omq-compio/tests/ws_basic.rs
@@ -1,0 +1,103 @@
+#![cfg(feature = "ws")]
+
+use bytes::Bytes;
+use omq_compio::Socket;
+use omq_proto::endpoint::Endpoint;
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+use omq_proto::proto::SocketType;
+
+fn ws_endpoint(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+#[compio::test]
+async fn push_pull_one_message() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+
+    let port = match &bound {
+        Endpoint::Ws { port, .. } => *port,
+        other => panic!("expected Ws endpoint, got {other:?}"),
+    };
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    compio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    push.send(Message::from(Bytes::from_static(b"hello ws")))
+        .await
+        .unwrap();
+
+    let msg = compio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello ws"[..]);
+}
+
+#[compio::test]
+async fn push_pull_multipart() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+
+    let port = match &bound {
+        Endpoint::Ws { port, .. } => *port,
+        other => panic!("expected Ws endpoint, got {other:?}"),
+    };
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    compio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let msg = Message::multipart([
+        Bytes::from_static(b"frame1"),
+        Bytes::from_static(b"frame2"),
+        Bytes::from_static(b"frame3"),
+    ]);
+    push.send(msg).await.unwrap();
+
+    let received = compio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(received.len(), 3);
+    assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
+    assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
+    assert_eq!(received.part_bytes(2).unwrap(), &b"frame3"[..]);
+}
+
+#[compio::test]
+async fn push_pull_many_messages() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+
+    let port = match &bound {
+        Endpoint::Ws { port, .. } => *port,
+        other => panic!("expected Ws endpoint, got {other:?}"),
+    };
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    compio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let count = 100;
+    for i in 0..count {
+        push.send(Message::from(Bytes::from(format!("msg-{i}"))))
+            .await
+            .unwrap();
+    }
+
+    for i in 0..count {
+        let msg = compio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+            .await
+            .expect("recv timed out")
+            .unwrap();
+        assert_eq!(msg.part_bytes(0).unwrap(), format!("msg-{i}").as_bytes(),);
+    }
+}

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -30,6 +30,7 @@ blake3zmq = [
 plain = []
 lz4 = ["dep:lz4-sys"]
 zstd = ["dep:zstd-safe"]
+ws = []
 priority = []
 
 [dependencies]

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -37,6 +37,14 @@ pub enum Endpoint {
     /// `zstd` feature.
     #[cfg(feature = "zstd")]
     ZstdTcp { host: Host, port: u16 },
+    /// `ws://host:port/path` ZeroMQ over WebSocket (RFC 45). Requires the
+    /// `ws` feature.
+    #[cfg(feature = "ws")]
+    Ws { host: Host, port: u16, path: String },
+    /// `wss://host:port/path` ZeroMQ over WebSocket with TLS. Requires the
+    /// `ws` feature.
+    #[cfg(feature = "ws")]
+    Wss { host: Host, port: u16, path: String },
 }
 
 /// TCP / UDP host specification: either an IP address or a DNS name.
@@ -106,6 +114,10 @@ impl FromStr for Endpoint {
             "zstd+tcp" => {
                 parse_host_port(rest).map(|(host, port)| Endpoint::ZstdTcp { host, port })
             }
+            #[cfg(feature = "ws")]
+            "ws" => parse_ws(rest, false),
+            #[cfg(feature = "ws")]
+            "wss" => parse_ws(rest, true),
             _ => Err(Error::UnsupportedScheme(scheme.to_string())),
         }
     }
@@ -125,6 +137,10 @@ impl fmt::Display for Endpoint {
             Self::Lz4Tcp { host, port } => write!(f, "lz4+tcp://{host}:{port}"),
             #[cfg(feature = "zstd")]
             Self::ZstdTcp { host, port } => write!(f, "zstd+tcp://{host}:{port}"),
+            #[cfg(feature = "ws")]
+            Self::Ws { host, port, path } => write!(f, "ws://{host}:{port}{path}"),
+            #[cfg(feature = "ws")]
+            Self::Wss { host, port, path } => write!(f, "wss://{host}:{port}{path}"),
         }
     }
 }
@@ -183,6 +199,12 @@ impl Endpoint {
         }
     }
 
+    /// Whether this endpoint uses the WebSocket transport.
+    #[cfg(feature = "ws")]
+    pub fn is_ws_family(&self) -> bool {
+        matches!(self, Endpoint::Ws { .. } | Endpoint::Wss { .. })
+    }
+
     /// Short scheme tag suitable for monitor / log output.
     pub fn scheme(&self) -> &'static str {
         match self {
@@ -194,6 +216,10 @@ impl Endpoint {
             Endpoint::Lz4Tcp { .. } => "lz4+tcp",
             #[cfg(feature = "zstd")]
             Endpoint::ZstdTcp { .. } => "zstd+tcp",
+            #[cfg(feature = "ws")]
+            Endpoint::Ws { .. } => "ws",
+            #[cfg(feature = "ws")]
+            Endpoint::Wss { .. } => "wss",
         }
     }
 }
@@ -331,6 +357,21 @@ fn parse_ipc(rest: &str) -> Result<IpcPath> {
         return Ok(IpcPath::Abstract(name.to_string()));
     }
     Ok(IpcPath::Filesystem(PathBuf::from(rest)))
+}
+
+#[cfg(feature = "ws")]
+fn parse_ws(rest: &str, tls: bool) -> Result<Endpoint> {
+    let (hp, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+    let (host, port) = parse_host_port(hp)?;
+    let path = path.to_string();
+    if tls {
+        Ok(Endpoint::Wss { host, port, path })
+    } else {
+        Ok(Endpoint::Ws { host, port, path })
+    }
 }
 
 fn parse_udp(rest: &str) -> Result<Endpoint> {

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -131,6 +131,23 @@ pub struct Options {
     /// path that reads large payloads into a single pre-sized buffer
     /// instead of accumulating fixed-size reads through the codec.
     pub large_message_threshold: Option<usize>,
+
+    /// TLS configuration for `wss://` endpoints. Ignored for non-WSS
+    /// transports. Requires the `ws` feature.
+    #[cfg(feature = "ws")]
+    pub wss_tls: WssTls,
+}
+
+/// TLS configuration for WSS endpoints.
+#[cfg(feature = "ws")]
+#[derive(Clone, Debug, Default)]
+pub struct WssTls {
+    /// PEM-encoded server certificate chain for WSS bind.
+    pub server_cert_pem: Option<Vec<u8>>,
+    /// PEM-encoded server private key for WSS bind.
+    pub server_key_pem: Option<Vec<u8>>,
+    /// Accept invalid server certificates on connect (for testing).
+    pub accept_invalid_certs: bool,
 }
 
 /// Security-mechanism configuration. NULL is the default; CURVE is
@@ -325,6 +342,8 @@ impl Default for Options {
             compression_auto_train: true,
             compression_level: -3,
             large_message_threshold: Some(128 * 1024),
+            #[cfg(feature = "ws")]
+            wss_tls: WssTls::default(),
         }
     }
 }

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -474,4 +474,59 @@ impl Connection {
         // pushed before deciding to switch back to direct-recv.
         self.drive()
     }
+
+    /// Feed one complete ZWS binary message (flag byte + body) received
+    /// from a WebSocket. Each WS binary message is one ZMTP frame.
+    #[cfg(feature = "ws")]
+    pub fn handle_ws_message(&mut self, msg: Bytes) -> Result<()> {
+        let decoded = super::super::zws::decode_frame(msg)?;
+        match self.state {
+            State::Closed => return Err(Error::Closed),
+            State::AwaitingGreeting => {
+                return Err(Error::Protocol(
+                    "WS message in AwaitingGreeting state".into(),
+                ));
+            }
+            State::AwaitingSuppliedPayload { .. } => {
+                return Err(Error::Protocol(
+                    "WS message while awaiting supplied payload".into(),
+                ));
+            }
+            State::MechanismHandshake => {
+                if !decoded.flags.command {
+                    return Err(Error::HandshakeFailed(
+                        "peer sent data frame during handshake".into(),
+                    ));
+                }
+                let cmd = decode_command_raw(decoded.payload.as_bytes())?;
+                let mut cmds = Vec::new();
+                let step = self.mechanism.on_command(cmd, &mut cmds)?;
+                self.write_outbound_commands(&cmds);
+                if let MechanismStep::Complete { peer_properties } = step {
+                    let peer_type = peer_properties.socket_type.ok_or_else(|| {
+                        Error::HandshakeFailed("peer did not declare socket type".into())
+                    })?;
+                    if !is_compatible(self.config.socket_type, peer_type) {
+                        return Err(Error::HandshakeFailed(format!(
+                            "incompatible socket types: ours={:?} peer={:?}",
+                            self.config.socket_type, peer_type
+                        )));
+                    }
+                    #[cfg(any(feature = "curve", feature = "blake3zmq"))]
+                    {
+                        self.transform = self.mechanism.build_transform()?;
+                    }
+                    self.state = State::Ready;
+                    self.events.push_back(Event::HandshakeSucceeded {
+                        peer_minor: self.peer_minor,
+                        peer_properties: Arc::new(peer_properties),
+                    });
+                }
+            }
+            State::Ready => {
+                self.decode_assembled_frame(decoded.flags, decoded.payload)?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -67,6 +67,21 @@ pub enum Role {
     Client,
 }
 
+/// Transport framing mode. Determines whether the connection uses standard
+/// ZMTP byte-stream framing (with 64-byte greeting + length-prefixed frames)
+/// or ZWS message-oriented framing (RFC 45).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TransportMode {
+    /// Standard ZMTP byte-stream framing with 64-byte greeting.
+    #[default]
+    Zmtp,
+    /// ZWS/2.0 (RFC 45): no greeting, 1-byte flag prefix per WebSocket
+    /// binary message. Mechanism is negotiated via `Sec-WebSocket-Protocol`
+    /// header during the HTTP upgrade.
+    #[cfg(feature = "ws")]
+    WebSocket,
+}
+
 /// Configuration for a new [`Connection`].
 #[derive(Clone, Debug)]
 pub struct ConnectionConfig {
@@ -80,6 +95,8 @@ pub struct ConnectionConfig {
     pub max_message_size: Option<usize>,
     /// Security mechanism to negotiate during the handshake.
     pub mechanism: MechanismSetup,
+    /// Transport framing mode.
+    pub transport_mode: TransportMode,
 }
 
 impl ConnectionConfig {
@@ -91,6 +108,7 @@ impl ConnectionConfig {
             identity: bytes::Bytes::new(),
             max_message_size: None,
             mechanism: MechanismSetup::Null,
+            transport_mode: TransportMode::default(),
         }
     }
 
@@ -109,6 +127,12 @@ impl ConnectionConfig {
     #[must_use]
     pub fn mechanism(mut self, m: MechanismSetup) -> Self {
         self.mechanism = m;
+        self
+    }
+
+    #[must_use]
+    pub fn transport_mode(mut self, mode: TransportMode) -> Self {
+        self.transport_mode = mode;
         self
     }
 
@@ -213,6 +237,11 @@ pub struct Connection {
     messages: VecDeque<Message>,
     pending_parts: Vec<Payload>,
     pending_size: usize,
+    /// ZWS outbound queue: each entry is one complete ZWS binary message
+    /// (flag byte + payload). Used only when `transport_mode == WebSocket`;
+    /// the byte-stream `out_chunks` queue is unused in WS mode.
+    #[cfg(feature = "ws")]
+    ws_out_frames: VecDeque<Bytes>,
 }
 
 impl Connection {
@@ -220,6 +249,8 @@ impl Connection {
     /// Supports the NULL, CURVE, and BLAKE3ZMQ mechanisms.
     pub fn new(config: ConnectionConfig) -> Self {
         let mechanism = config.mechanism.clone().build();
+        #[cfg(feature = "ws")]
+        let ws_mode = config.transport_mode == TransportMode::WebSocket;
         let mut conn = Self {
             state: State::AwaitingGreeting,
             peer_minor: greeting::ZMTP_MINOR,
@@ -237,10 +268,40 @@ impl Connection {
             messages: VecDeque::new(),
             pending_parts: Vec::new(),
             pending_size: 0,
+            #[cfg(feature = "ws")]
+            ws_out_frames: VecDeque::new(),
             config,
         };
+        #[cfg(feature = "ws")]
+        if ws_mode {
+            conn.init_ws_mode();
+            return conn;
+        }
         conn.queue_greeting();
         conn
+    }
+
+    /// Initialize the connection in ZWS mode: skip the greeting,
+    /// start mechanism handshake immediately, and queue outbound
+    /// mechanism commands as ZWS frames.
+    #[cfg(feature = "ws")]
+    fn init_ws_mode(&mut self) {
+        use super::command::PeerProperties;
+        self.state = State::MechanismHandshake;
+        let mut our_props = PeerProperties::default().with_socket_type(self.config.socket_type);
+        if !self.config.identity.is_empty() {
+            our_props = our_props.with_identity(self.config.identity.clone());
+        }
+        let mut cmds = Vec::new();
+        self.mechanism
+            .start(
+                &mut cmds,
+                our_props,
+                &self.our_greeting,
+                &self.peer_greeting,
+            )
+            .expect("mechanism start failed");
+        self.write_outbound_commands(&cmds);
     }
 
     fn queue_greeting(&mut self) {

--- a/omq-proto/src/proto/connection/outbound.rs
+++ b/omq-proto/src/proto/connection/outbound.rs
@@ -72,6 +72,12 @@ impl Connection {
 
     pub(super) fn emit_frame(&mut self, flags: crate::message::FrameFlags, payload: Payload) {
         let f = crate::message::Frame { flags, payload };
+        #[cfg(feature = "ws")]
+        if self.config.transport_mode == super::TransportMode::WebSocket {
+            self.ws_out_frames
+                .push_back(super::super::zws::encode_frame(&f));
+            return;
+        }
         let plen = f.payload.len();
         self.out_bytes_total += frame::header_len_for(plen) + plen;
         frame::encode_frame_into(&f, &mut self.out_chunks, &mut self.header_scratch);
@@ -131,6 +137,20 @@ impl Connection {
         }
         self.write_outbound_commands(std::slice::from_ref(cmd));
         Ok(())
+    }
+
+    /// Pop one outbound ZWS frame. Each frame is a complete WebSocket
+    /// binary message (flag byte + payload). Returns `None` when the
+    /// queue is empty.
+    #[cfg(feature = "ws")]
+    pub fn poll_ws_frame(&mut self) -> Option<Bytes> {
+        self.ws_out_frames.pop_front()
+    }
+
+    /// Whether any ZWS frames are pending transmit.
+    #[cfg(feature = "ws")]
+    pub fn has_pending_ws_frames(&self) -> bool {
+        !self.ws_out_frames.is_empty()
     }
 
     /// CURVE-encrypted part: wrap the plaintext per RFC 26 (`"\x07"

--- a/omq-proto/src/proto/mod.rs
+++ b/omq-proto/src/proto/mod.rs
@@ -22,6 +22,8 @@ pub mod greeting;
 pub mod mechanism;
 pub mod transform;
 pub mod z85;
+#[cfg(feature = "ws")]
+pub mod zws;
 
 pub use command::{Command, CommandKind, PeerProperties};
 pub use connection::{Connection, ConnectionConfig, Event, Role};

--- a/omq-proto/src/proto/zws.rs
+++ b/omq-proto/src/proto/zws.rs
@@ -1,0 +1,162 @@
+//! ZWS/2.0 frame codec (RFC 45).
+//!
+//! Each ZWS frame is one WebSocket binary message: a 1-byte flag followed by
+//! the frame body. No length prefix; WebSocket message boundaries delimit
+//! frames.
+
+use bytes::{BufMut, Bytes, BytesMut};
+use smallvec::SmallVec;
+
+use crate::error::{Error, Result};
+use crate::message::{Frame, FrameFlags, Message, Payload};
+
+pub const FLAG_FINAL: u8 = 0x00;
+pub const FLAG_MORE: u8 = 0x01;
+pub const FLAG_COMMAND: u8 = 0x02;
+
+/// Encode a single ZMTP frame as a ZWS binary message: `[flag][body]`.
+pub fn encode_frame(frame: &Frame) -> Bytes {
+    let flag = if frame.flags.command {
+        FLAG_COMMAND
+    } else if frame.flags.more {
+        FLAG_MORE
+    } else {
+        FLAG_FINAL
+    };
+    let payload = frame.payload.as_bytes();
+    let mut buf = BytesMut::with_capacity(1 + payload.len());
+    buf.put_u8(flag);
+    buf.extend_from_slice(&payload);
+    buf.freeze()
+}
+
+/// Decode a ZWS binary message into a ZMTP frame.
+pub fn decode_frame(mut msg: Bytes) -> Result<Frame> {
+    if msg.is_empty() {
+        return Err(Error::Protocol("empty ZWS frame".into()));
+    }
+    let flag = msg[0];
+    let flags = match flag {
+        FLAG_FINAL => FrameFlags::LAST,
+        FLAG_MORE => FrameFlags::MORE,
+        FLAG_COMMAND => FrameFlags::COMMAND,
+        _ => {
+            return Err(Error::Protocol(format!(
+                "invalid ZWS flag byte: 0x{flag:02x}"
+            )));
+        }
+    };
+    let _ = msg.split_to(1);
+    Ok(Frame {
+        flags,
+        payload: Payload::from_bytes(msg),
+    })
+}
+
+/// Encode an application message as a sequence of ZWS binary messages (one
+/// per frame part). Multi-part messages produce multiple entries; the last
+/// has flag `0x00`, all preceding have flag `0x01`.
+pub fn encode_message(msg: &Message) -> SmallVec<[Bytes; 4]> {
+    let parts = msg.parts_payload();
+    let n = parts.len();
+    let mut out = SmallVec::with_capacity(n);
+    for (i, part) in parts.iter().enumerate() {
+        let flag = if i + 1 < n { FLAG_MORE } else { FLAG_FINAL };
+        let payload = part.as_bytes();
+        let mut buf = BytesMut::with_capacity(1 + payload.len());
+        buf.put_u8(flag);
+        buf.extend_from_slice(&payload);
+        out.push(buf.freeze());
+    }
+    out
+}
+
+/// Encode a ZMTP command as a single ZWS binary message with flag `0x02`.
+pub fn encode_command(body: &Bytes) -> Bytes {
+    let mut buf = BytesMut::with_capacity(1 + body.len());
+    buf.put_u8(FLAG_COMMAND);
+    buf.extend_from_slice(body);
+    buf.freeze()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_final() {
+        let frame = Frame::data(Bytes::from_static(b"hello"), false);
+        let wire = encode_frame(&frame);
+        assert_eq!(wire[0], FLAG_FINAL);
+        assert_eq!(&wire[1..], b"hello");
+        let decoded = decode_frame(wire).unwrap();
+        assert_eq!(decoded.flags, FrameFlags::LAST);
+        assert_eq!(decoded.payload.as_bytes(), &b"hello"[..]);
+    }
+
+    #[test]
+    fn encode_decode_more() {
+        let frame = Frame::data(Bytes::from_static(b"part1"), true);
+        let wire = encode_frame(&frame);
+        assert_eq!(wire[0], FLAG_MORE);
+        let decoded = decode_frame(wire).unwrap();
+        assert_eq!(decoded.flags, FrameFlags::MORE);
+    }
+
+    #[test]
+    fn encode_decode_command() {
+        let frame = Frame::command(Bytes::from_static(b"\x05READYstuff"));
+        let wire = encode_frame(&frame);
+        assert_eq!(wire[0], FLAG_COMMAND);
+        let decoded = decode_frame(wire).unwrap();
+        assert_eq!(decoded.flags, FrameFlags::COMMAND);
+        assert_eq!(decoded.payload.as_bytes(), &b"\x05READYstuff"[..]);
+    }
+
+    #[test]
+    fn decode_empty_fails() {
+        assert!(decode_frame(Bytes::new()).is_err());
+    }
+
+    #[test]
+    fn decode_invalid_flag_fails() {
+        assert!(decode_frame(Bytes::from_static(&[0x03, b'x'])).is_err());
+        assert!(decode_frame(Bytes::from_static(&[0xFF])).is_err());
+    }
+
+    #[test]
+    fn encode_message_single_part() {
+        let msg = Message::from(Bytes::from_static(b"payload"));
+        let frames = encode_message(&msg);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0][0], FLAG_FINAL);
+        assert_eq!(&frames[0][1..], b"payload");
+    }
+
+    #[test]
+    fn encode_message_multi_part() {
+        let msg = Message::multipart([
+            Bytes::from_static(b"a"),
+            Bytes::from_static(b"b"),
+            Bytes::from_static(b"c"),
+        ]);
+        let frames = encode_message(&msg);
+        assert_eq!(frames.len(), 3);
+        assert_eq!(frames[0][0], FLAG_MORE);
+        assert_eq!(frames[1][0], FLAG_MORE);
+        assert_eq!(frames[2][0], FLAG_FINAL);
+        assert_eq!(&frames[0][1..], b"a");
+        assert_eq!(&frames[1][1..], b"b");
+        assert_eq!(&frames[2][1..], b"c");
+    }
+
+    #[test]
+    fn encode_empty_payload() {
+        let frame = Frame::data(Bytes::new(), false);
+        let wire = encode_frame(&frame);
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0], FLAG_FINAL);
+        let decoded = decode_frame(wire).unwrap();
+        assert!(decoded.payload.as_bytes().is_empty());
+    }
+}

--- a/omq-proto/tests/connection.rs
+++ b/omq-proto/tests/connection.rs
@@ -551,3 +551,122 @@ fn bad_signature_rejected() {
         Err(Error::Protocol(_))
     ));
 }
+
+// ---- ZWS (WebSocket mode) tests ----
+
+#[cfg(feature = "ws")]
+mod ws {
+    use super::*;
+    use omq_proto::proto::connection::TransportMode;
+
+    fn ws_push_pull_pair() -> (Connection, Connection) {
+        let push = Connection::new(
+            ConnectionConfig::new(Role::Client, SocketType::Push)
+                .identity(Bytes::from_static(b"p"))
+                .transport_mode(TransportMode::WebSocket),
+        );
+        let pull = Connection::new(
+            ConnectionConfig::new(Role::Server, SocketType::Pull)
+                .transport_mode(TransportMode::WebSocket),
+        );
+        (push, pull)
+    }
+
+    fn pump_ws(a: &mut Connection, b: &mut Connection) {
+        loop {
+            let mut progress = false;
+            while let Some(frame) = a.poll_ws_frame() {
+                b.handle_ws_message(frame).expect("b accepts");
+                progress = true;
+            }
+            while let Some(frame) = b.poll_ws_frame() {
+                a.handle_ws_message(frame).expect("a accepts");
+                progress = true;
+            }
+            if !progress {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn ws_null_handshake() {
+        let (mut push, mut pull) = ws_push_pull_pair();
+        assert!(push.has_pending_ws_frames(), "mechanism start queues READY");
+        pump_ws(&mut push, &mut pull);
+        assert!(push.is_ready());
+        assert!(pull.is_ready());
+        let pev = push.poll_event().unwrap();
+        let lev = pull.poll_event().unwrap();
+        match (pev, lev) {
+            (
+                Event::HandshakeSucceeded {
+                    peer_properties: p, ..
+                },
+                Event::HandshakeSucceeded {
+                    peer_properties: l, ..
+                },
+            ) => {
+                assert_eq!(p.socket_type, Some(SocketType::Pull));
+                assert_eq!(l.socket_type, Some(SocketType::Push));
+                assert_eq!(l.identity, Some(Bytes::from_static(b"p")));
+            }
+            other => panic!("expected HandshakeSucceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ws_message_roundtrip() {
+        let (mut push, mut pull) = ws_push_pull_pair();
+        pump_ws(&mut push, &mut pull);
+        assert!(push.is_ready());
+
+        push.send_message(&Message::from(Bytes::from_static(b"hello")))
+            .unwrap();
+        pump_ws(&mut push, &mut pull);
+        let msg = pull.poll_message().unwrap();
+        assert_eq!(msg.part_bytes(0).unwrap(), &b"hello"[..]);
+    }
+
+    #[test]
+    fn ws_multipart_roundtrip() {
+        let (mut push, mut pull) = ws_push_pull_pair();
+        pump_ws(&mut push, &mut pull);
+
+        let msg = Message::multipart([
+            Bytes::from_static(b"frame1"),
+            Bytes::from_static(b"frame2"),
+            Bytes::from_static(b"frame3"),
+        ]);
+        push.send_message(&msg).unwrap();
+        pump_ws(&mut push, &mut pull);
+        let received = pull.poll_message().unwrap();
+        assert_eq!(received.len(), 3);
+        assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
+        assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
+        assert_eq!(received.part_bytes(2).unwrap(), &b"frame3"[..]);
+    }
+
+    #[test]
+    fn ws_incompatible_types_rejected() {
+        let mut a = Connection::new(
+            ConnectionConfig::new(Role::Client, SocketType::Push)
+                .transport_mode(TransportMode::WebSocket),
+        );
+        let mut b = Connection::new(
+            ConnectionConfig::new(Role::Server, SocketType::Push)
+                .transport_mode(TransportMode::WebSocket),
+        );
+        while let Some(frame) = a.poll_ws_frame() {
+            let _ = b.handle_ws_message(frame);
+        }
+        while let Some(frame) = b.poll_ws_frame() {
+            let result = a.handle_ws_message(frame);
+            if let Err(Error::HandshakeFailed(msg)) = result {
+                assert!(msg.contains("incompatible"));
+                return;
+            }
+        }
+        panic!("expected incompatible socket type rejection");
+    }
+}

--- a/omq-proto/tests/endpoint.rs
+++ b/omq-proto/tests/endpoint.rs
@@ -127,8 +127,8 @@ fn zstd_tcp() {
 #[test]
 fn unsupported_scheme() {
     assert!(matches!(
-        "ws://host:80".parse::<Endpoint>().unwrap_err(),
-        Error::UnsupportedScheme(s) if s == "ws"
+        "quic://host:80".parse::<Endpoint>().unwrap_err(),
+        Error::UnsupportedScheme(s) if s == "quic"
     ));
 }
 
@@ -217,4 +217,77 @@ fn spec_connect_prefix() {
 fn spec_no_prefix_is_default() {
     let s: EndpointSpec = "tcp://host:5555".parse().unwrap();
     assert_eq!(s.role, EndpointRole::Default);
+}
+
+// ---- WebSocket endpoint tests (ws feature) ----
+
+#[test]
+#[cfg(feature = "ws")]
+fn ws_basic() {
+    let ep = parse("ws://host:8080/zeromq");
+    assert!(matches!(
+        &ep,
+        Endpoint::Ws { host: Host::Name(h), port: 8080, path }
+            if h == "host" && path == "/zeromq"
+    ));
+    assert_eq!(ep.to_string(), "ws://host:8080/zeromq");
+    assert_eq!(ep.scheme(), "ws");
+    assert!(ep.is_ws_family());
+    assert!(!ep.is_tcp_family());
+}
+
+#[test]
+#[cfg(feature = "ws")]
+fn wss_basic() {
+    let ep = parse("wss://example.com:443/ws");
+    assert!(matches!(
+        &ep,
+        Endpoint::Wss { host: Host::Name(h), port: 443, path }
+            if h == "example.com" && path == "/ws"
+    ));
+    assert_eq!(ep.to_string(), "wss://example.com:443/ws");
+    assert_eq!(ep.scheme(), "wss");
+    assert!(ep.is_ws_family());
+}
+
+#[test]
+#[cfg(feature = "ws")]
+fn ws_default_path() {
+    let ep = parse("ws://127.0.0.1:9000");
+    assert!(matches!(
+        &ep,
+        Endpoint::Ws { host: Host::Ip(_), port: 9000, path }
+            if path == "/"
+    ));
+    assert_eq!(ep.to_string(), "ws://127.0.0.1:9000/");
+}
+
+#[test]
+#[cfg(feature = "ws")]
+fn ws_wildcard_port() {
+    let ep = parse("ws://*:*");
+    assert!(matches!(
+        &ep,
+        Endpoint::Ws { host: Host::Wildcard, port: 0, path }
+            if path == "/"
+    ));
+}
+
+#[test]
+#[cfg(feature = "ws")]
+fn ws_ipv6() {
+    let ep = parse("ws://[::1]:8080/zmq");
+    assert!(matches!(
+        &ep,
+        Endpoint::Ws { host: Host::Ip(_), port: 8080, path }
+            if path == "/zmq"
+    ));
+}
+
+#[test]
+#[cfg(feature = "ws")]
+fn ws_roundtrip() {
+    let original = "ws://myhost:5555/path/to/endpoint";
+    let ep = parse(original);
+    assert_eq!(ep.to_string(), original);
 }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -21,6 +21,7 @@ blake3zmq = ["omq-proto/blake3zmq"]
 plain = ["omq-proto/plain"]
 lz4 = ["omq-proto/lz4"]
 zstd = ["omq-proto/zstd"]
+ws = ["omq-proto/ws", "dep:tokio-tungstenite", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls"]
 priority = ["omq-proto/priority"]
 # Enables the fuzz test suites (`tests/fuzz_*.rs`). Off by default -
 # those targets do ~1 M iterations each and dominate runtime of
@@ -42,13 +43,20 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "io-util", 
 tokio-util = { version = "0.7", features = ["rt"] }
 socket2 = "0.6"
 libc = "0.2"
+tokio-tungstenite = { version = "0.29", optional = true, features = ["rustls-tls-native-roots"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "std"] }
+rustls-native-certs = { version = "0.8", optional = true }
+rustls-pemfile = { version = "2", optional = true }
+rustls-pki-types = { version = "1", optional = true }
+tokio-rustls = { version = "0.26", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }
+rcgen = "0.14"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 # Cross-runtime interop tests drive a compio backend on a dedicated
 # thread while the tokio backend runs in the test's own runtime.
-omq-compio = { path = "../omq-compio", default-features = false }
+omq-compio = { path = "../omq-compio", default-features = false, features = ["ws"] }
 compio = { version = "0.19.0-rc.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 
 [[bin]]

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -146,7 +146,7 @@ pub(crate) fn endpoint(transport: &str, seq: usize) -> Endpoint {
             let _ = std::fs::remove_file(&dir);
             Endpoint::Ipc(IpcPath::Filesystem(dir))
         }
-        "tcp" | "lz4+tcp" | "zstd+tcp" => {
+        "tcp" | "lz4+tcp" | "zstd+tcp" | "ws" => {
             let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
                 .expect("bench: failed to allocate a tcp port");
             let port = l.local_addr().unwrap().port();
@@ -158,9 +158,15 @@ pub(crate) fn endpoint(transport: &str, seq: usize) -> Endpoint {
                 "lz4+tcp" => Endpoint::Lz4Tcp { host, port },
                 #[cfg(feature = "zstd")]
                 "zstd+tcp" => Endpoint::ZstdTcp { host, port },
+                #[cfg(feature = "ws")]
+                "ws" => Endpoint::Ws {
+                    host,
+                    port,
+                    path: "/".into(),
+                },
                 _ => panic!(
                     "bench: transport '{transport}' requires its feature; \
-                            rebuild with `--features lz4` and/or `--features zstd`"
+                            rebuild with the required feature flag"
                 ),
             }
         }

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ws")]
+use super::AnyListener;
 use super::{
     Canceled, ConnectionStatus, DialerEntry, Duration, Endpoint, Error, InternalEvent,
     ListenerEntry, MonitorEvent, PeerIdent, Result, SocketDriver, SocketType, UdpDialerEntry,
@@ -259,8 +261,33 @@ impl SocketDriver {
             &snapshot,
             &self.recv_notify,
             self.options.max_message_size,
+            #[cfg(feature = "ws")]
+            &self.options.wss_tls,
         )
         .await?;
+        #[cfg(feature = "ws")]
+        let resolved = if endpoint.is_ws_family() {
+            let local = match &listener {
+                AnyListener::Ws(l) => l.local_addr,
+                _ => unreachable!(),
+            };
+            match &endpoint {
+                Endpoint::Ws { path, .. } => Endpoint::Ws {
+                    host: omq_proto::endpoint::Host::Ip(local.ip()),
+                    port: local.port(),
+                    path: path.clone(),
+                },
+                Endpoint::Wss { path, .. } => Endpoint::Wss {
+                    host: omq_proto::endpoint::Host::Ip(local.ip()),
+                    port: local.port(),
+                    path: path.clone(),
+                },
+                _ => unreachable!(),
+            }
+        } else {
+            endpoint.rewrap_tcp(listener.local_endpoint().clone())
+        };
+        #[cfg(not(feature = "ws"))]
         let resolved = endpoint.rewrap_tcp(listener.local_endpoint().clone());
         self.monitor.publish(MonitorEvent::Listening {
             endpoint: resolved.clone(),
@@ -318,10 +345,20 @@ impl SocketDriver {
         let tx_for_delay = tx.clone();
         let snapshot = self.inproc_snapshot();
         let recv_notify = self.recv_notify.clone();
+        #[cfg(feature = "ws")]
+        let accept_invalid_certs = self.options.wss_tls.accept_invalid_certs;
         let task = tokio::spawn(async move {
             let ep_for_dial = dialer_ep.clone();
             let result = dial_with_backoff(
-                || connect_any(&ep_for_dial, &snapshot, &recv_notify),
+                || {
+                    connect_any(
+                        &ep_for_dial,
+                        &snapshot,
+                        &recv_notify,
+                        #[cfg(feature = "ws")]
+                        accept_invalid_certs,
+                    )
+                },
                 policy,
                 &child_cancel,
                 |delay, attempt| {

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -13,6 +13,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "ws")]
+use super::dispatch::AnyListener;
 use super::dispatch::{
     AnyConn, AnyStream, bind_any, connect_any, generated_identity, peer_ident_socket_addr,
 };

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -188,6 +188,17 @@ impl SocketDriver {
                     priority,
                 );
             }
+            #[cfg(feature = "ws")]
+            AnyConn::WebSocket { ws, peer_ident } => {
+                self.spawn_ws_connection(
+                    ws,
+                    peer_ident,
+                    endpoint,
+                    is_server,
+                    #[cfg(feature = "priority")]
+                    priority,
+                );
+            }
         }
     }
 
@@ -349,6 +360,95 @@ impl SocketDriver {
         self.send_strategy
             .connection_added(peer_id, handle, identity.clone(), false);
         self.recv_strategy.connection_added(peer_id, identity);
+    }
+
+    #[cfg(feature = "ws")]
+    fn spawn_ws_connection(
+        &mut self,
+        ws: crate::transport::ws::WsStream,
+        peer_ident: PeerIdent,
+        endpoint: Endpoint,
+        is_server: bool,
+        #[cfg(feature = "priority")] priority: u8,
+    ) {
+        if let Some(max) = max_peer_count(self.socket_type)
+            && self.peers.len() >= max
+        {
+            return;
+        }
+        let peer_id = self.next_peer_id;
+        self.next_peer_id += 1;
+
+        let role = if is_server {
+            Role::Server
+        } else {
+            Role::Client
+        };
+
+        let inbox_cap = 64usize;
+        let (inbox_tx, inbox_rx) = mpsc::channel(inbox_cap);
+        let child_cancel = self.cancel.child_token();
+
+        let driver_cfg = DriverConfig {
+            handshake_timeout: self.options.handshake_timeout,
+            heartbeat_interval: self.options.heartbeat_interval,
+            heartbeat_timeout: self.options.heartbeat_timeout,
+            heartbeat_ttl: self.options.heartbeat_ttl,
+            large_message_threshold: 0,
+        };
+
+        let peer_out_tx = self.peer_out_tx.clone();
+        let options = self.options.clone();
+        let socket_type = self.socket_type;
+        let cancel_clone = child_cancel.clone();
+        #[cfg(not(feature = "priority"))]
+        let shared_rx = self.send_strategy.shared_rx();
+        let recv_direct = if can_bypass_actor_recv(socket_type) {
+            Some(self.recv_tx.clone())
+        } else {
+            None
+        };
+
+        self.peers.insert(
+            peer_id,
+            PeerEntry {
+                ident: peer_ident,
+                handle: DriverHandle {
+                    inbox: inbox_tx,
+                    cancel: child_cancel,
+                },
+                identity: bytes::Bytes::new(),
+                info: None,
+                endpoint,
+                is_client: !is_server,
+                #[cfg(feature = "priority")]
+                priority,
+            },
+        );
+
+        if self.peers.len() > 1 {
+            *self.send_ring.write().unwrap() = None;
+        }
+
+        tokio::spawn(async move {
+            crate::transport::ws::run_ws_driver(
+                ws,
+                role,
+                socket_type,
+                &options,
+                inbox_rx,
+                peer_out_tx,
+                peer_id,
+                cancel_clone,
+                driver_cfg,
+                #[cfg(not(feature = "priority"))]
+                shared_rx,
+                #[cfg(feature = "priority")]
+                None,
+                recv_direct,
+            )
+            .await;
+        });
     }
 
     /// Inproc fast path: skip the ZMTP codec entirely. The peer's

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -100,6 +100,11 @@ pub(crate) enum AnyConn {
         conn: InprocConn,
         peer_ident: PeerIdent,
     },
+    #[cfg(feature = "ws")]
+    WebSocket {
+        ws: crate::transport::ws::WsStream,
+        peer_ident: PeerIdent,
+    },
 }
 
 impl std::fmt::Debug for AnyConn {
@@ -113,6 +118,11 @@ impl std::fmt::Debug for AnyConn {
                 .debug_struct("AnyConn::Inproc")
                 .field("peer_ident", peer_ident)
                 .finish(),
+            #[cfg(feature = "ws")]
+            Self::WebSocket { peer_ident, .. } => f
+                .debug_struct("AnyConn::WebSocket")
+                .field("peer_ident", peer_ident)
+                .finish(),
         }
     }
 }
@@ -121,6 +131,8 @@ impl AnyConn {
     pub(crate) fn peer_ident(&self) -> &PeerIdent {
         match self {
             Self::ByteStream { peer_ident, .. } | Self::Inproc { peer_ident, .. } => peer_ident,
+            #[cfg(feature = "ws")]
+            Self::WebSocket { peer_ident, .. } => peer_ident,
         }
     }
 }
@@ -129,6 +141,8 @@ pub(super) enum AnyListener {
     Tcp(crate::transport::tcp::TcpListener),
     Inproc(crate::transport::InprocListener),
     Ipc(crate::transport::ipc::IpcListener),
+    #[cfg(feature = "ws")]
+    Ws(crate::transport::ws::WsListener),
 }
 
 impl AnyListener {
@@ -137,6 +151,14 @@ impl AnyListener {
             Self::Tcp(l) => l.local_endpoint(),
             Self::Inproc(l) => l.local_endpoint(),
             Self::Ipc(l) => l.local_endpoint(),
+            #[cfg(feature = "ws")]
+            Self::Ws(_) => {
+                static DUMMY: Endpoint = Endpoint::Tcp {
+                    host: omq_proto::endpoint::Host::Wildcard,
+                    port: 0,
+                };
+                &DUMMY
+            }
         }
     }
 
@@ -155,6 +177,15 @@ impl AnyListener {
                 stream: AnyStream::Ipc(s),
                 peer_ident,
             }),
+            #[cfg(feature = "ws")]
+            Self::Ws(l) => {
+                let (stream, addr) = l.inner.accept().await.map_err(Error::Io)?;
+                let ws = crate::transport::ws::accept(stream, l.tls_acceptor.as_ref()).await?;
+                Ok(AnyConn::WebSocket {
+                    ws,
+                    peer_ident: PeerIdent::Socket(addr),
+                })
+            }
         }
     }
 }
@@ -168,11 +199,32 @@ pub(super) async fn bind_any(
     snapshot: &InprocPeerSnapshot,
     recv_notify: &std::sync::Arc<tokio::sync::Notify>,
     max_message_size: Option<usize>,
+    #[cfg(feature = "ws")] wss_tls: &omq_proto::options::WssTls,
 ) -> Result<AnyListener> {
     if endpoint.is_tcp_family() {
         return Ok(AnyListener::Tcp(
             TcpTransport::bind(&endpoint.underlying_tcp()).await?,
         ));
+    }
+    #[cfg(feature = "ws")]
+    if endpoint.is_ws_family() {
+        let (host, port) = match endpoint {
+            Endpoint::Ws { host, port, .. } | Endpoint::Wss { host, port, .. } => (host, *port),
+            _ => unreachable!(),
+        };
+        let tls_acc = if matches!(endpoint, Endpoint::Wss { .. }) {
+            let cert = wss_tls.server_cert_pem.as_deref().ok_or_else(|| {
+                Error::Protocol("wss:// bind requires server_cert_pem in WssTls options".into())
+            })?;
+            let key = wss_tls.server_key_pem.as_deref().ok_or_else(|| {
+                Error::Protocol("wss:// bind requires server_key_pem in WssTls options".into())
+            })?;
+            Some(crate::transport::ws::build_tls_acceptor(cert, key)?)
+        } else {
+            None
+        };
+        let l = crate::transport::ws::bind(host, port, tls_acc).await?;
+        return Ok(AnyListener::Ws(l));
     }
     match endpoint {
         Endpoint::Inproc { name } => Ok(AnyListener::Inproc(inproc_transport::bind(
@@ -191,6 +243,7 @@ pub(super) async fn connect_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    #[cfg(feature = "ws")] accept_invalid_certs: bool,
 ) -> Result<AnyConn> {
     if endpoint.is_tcp_family() {
         let s = TcpTransport::connect(&endpoint.underlying_tcp()).await?;
@@ -199,6 +252,28 @@ pub(super) async fn connect_any(
             stream: AnyStream::Tcp(s),
             peer_ident,
         });
+    }
+    #[cfg(feature = "ws")]
+    if endpoint.is_ws_family() {
+        let (host, port, path) = match endpoint {
+            Endpoint::Ws {
+                host, port, path, ..
+            }
+            | Endpoint::Wss {
+                host, port, path, ..
+            } => (host, *port, path.as_str()),
+            _ => unreachable!(),
+        };
+        let ws = crate::transport::ws::connect(
+            host,
+            port,
+            path,
+            matches!(endpoint, Endpoint::Wss { .. }),
+            accept_invalid_certs,
+        )
+        .await?;
+        let peer_ident = peer_ident_for_endpoint(endpoint);
+        return Ok(AnyConn::WebSocket { ws, peer_ident });
     }
     match endpoint {
         Endpoint::Inproc { name } => {

--- a/omq-tokio/src/transport/mod.rs
+++ b/omq-tokio/src/transport/mod.rs
@@ -28,6 +28,8 @@ pub use backoff::{Canceled, dial_with_backoff};
 pub use inproc::{InprocConn, InprocFrame, InprocListener, InprocPeerSnapshot};
 pub use ipc::IpcTransport;
 pub use tcp::TcpTransport;
+#[cfg(feature = "ws")]
+pub mod ws;
 
 /// A transport scheme.
 ///

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -1,0 +1,524 @@
+//! WebSocket bind/connect glue and WS connection driver (ZWS/2.0, RFC 45).
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{HeaderValue, Request, Response, StatusCode};
+use tokio_util::sync::CancellationToken;
+
+use omq_proto::error::{Error, Result};
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+use omq_proto::proto::connection::{Connection, ConnectionConfig, Role, TransportMode};
+use omq_proto::proto::{Command, Event, SocketType};
+
+use crate::engine::driver::{DriverCommand, DriverConfig, PeerOut};
+use crate::routing::drop_queue::QueueReceiver;
+
+pub(crate) type WsStream = tokio_tungstenite::WebSocketStream<WsTransport>;
+
+pub(crate) enum WsTransport {
+    Plain(TcpStream),
+    Tls(tokio_rustls::client::TlsStream<TcpStream>),
+    TlsServer(tokio_rustls::server::TlsStream<TcpStream>),
+}
+
+impl tokio::io::AsyncRead for WsTransport {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Plain(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+            Self::Tls(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+            Self::TlsServer(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl tokio::io::AsyncWrite for WsTransport {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Self::Plain(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            Self::Tls(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            Self::TlsServer(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Plain(s) => std::pin::Pin::new(s).poll_flush(cx),
+            Self::Tls(s) => std::pin::Pin::new(s).poll_flush(cx),
+            Self::TlsServer(s) => std::pin::Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Plain(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            Self::Tls(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            Self::TlsServer(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+const SUBPROTOCOL: &str = "ZWS2.0";
+const SUBPROTOCOL_NULL: &str = "ZWS2.0/NULL";
+
+fn ws_err(e: impl std::fmt::Display) -> Error {
+    Error::Io(std::io::Error::other(e.to_string()))
+}
+
+// ---- Bind / Accept / Connect ----
+
+pub(crate) struct WsListener {
+    pub(crate) inner: TcpListener,
+    pub(crate) local_addr: SocketAddr,
+    pub(crate) tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
+}
+
+pub(crate) async fn bind(
+    host: &omq_proto::endpoint::Host,
+    port: u16,
+    tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
+) -> Result<WsListener> {
+    use std::net::{IpAddr, Ipv4Addr};
+    let addr = match host {
+        omq_proto::endpoint::Host::Wildcard => {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+        }
+        omq_proto::endpoint::Host::Ip(ip) => SocketAddr::new(*ip, port),
+        omq_proto::endpoint::Host::Name(name) => tokio::net::lookup_host(format!("{name}:{port}"))
+            .await
+            .map_err(Error::Io)?
+            .next()
+            .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
+    };
+    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let local = listener.local_addr().map_err(Error::Io)?;
+    Ok(WsListener {
+        inner: listener,
+        local_addr: local,
+        tls_acceptor,
+    })
+}
+
+#[allow(clippy::result_large_err)]
+pub(crate) async fn accept(
+    stream: TcpStream,
+    tls_acceptor: Option<&tokio_rustls::TlsAcceptor>,
+) -> Result<WsStream> {
+    let _ = stream.set_nodelay(true);
+    let transport = if let Some(acc) = tls_acceptor {
+        let tls = acc.accept(stream).await.map_err(Error::Io)?;
+        WsTransport::TlsServer(tls)
+    } else {
+        WsTransport::Plain(stream)
+    };
+    let ws = tokio_tungstenite::accept_hdr_async(
+        transport,
+        |req: &Request<()>,
+         mut resp: Response<()>|
+         -> std::result::Result<Response<()>, Response<Option<String>>> {
+            let protocols = req
+                .headers()
+                .get("Sec-WebSocket-Protocol")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            let chosen = protocols
+                .split(',')
+                .map(str::trim)
+                .find(|p| *p == SUBPROTOCOL_NULL || *p == SUBPROTOCOL);
+            if let Some(proto) = chosen {
+                resp.headers_mut().insert(
+                    "Sec-WebSocket-Protocol",
+                    HeaderValue::from_str(proto).expect("valid header"),
+                );
+                Ok(resp)
+            } else {
+                let mut err_resp: Response<Option<String>> =
+                    Response::new(Some("no supported ZWS subprotocol".into()));
+                *err_resp.status_mut() = StatusCode::BAD_REQUEST;
+                Err(err_resp)
+            }
+        },
+    )
+    .await
+    .map_err(ws_err)?;
+    Ok(ws)
+}
+
+pub(crate) async fn connect(
+    host: &omq_proto::endpoint::Host,
+    port: u16,
+    path: &str,
+    tls: bool,
+    accept_invalid_certs: bool,
+) -> Result<WsStream> {
+    let addr = match host {
+        omq_proto::endpoint::Host::Wildcard => {
+            return Err(Error::InvalidEndpoint(
+                "cannot connect to wildcard host".into(),
+            ));
+        }
+        omq_proto::endpoint::Host::Ip(ip) => SocketAddr::new(*ip, port),
+        omq_proto::endpoint::Host::Name(name) => tokio::net::lookup_host(format!("{name}:{port}"))
+            .await
+            .map_err(Error::Io)?
+            .next()
+            .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
+    };
+    let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
+    let _ = stream.set_nodelay(true);
+
+    let scheme = if tls { "wss" } else { "ws" };
+    let url = format!("{scheme}://{host}:{port}{path}");
+    let mut request = url.into_client_request().map_err(ws_err)?;
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_static(SUBPROTOCOL_NULL),
+    );
+
+    let transport = if tls {
+        let connector = build_tls_connector(accept_invalid_certs)?;
+        let host_str = match host {
+            omq_proto::endpoint::Host::Name(n) => n.clone(),
+            omq_proto::endpoint::Host::Ip(ip) => ip.to_string(),
+            omq_proto::endpoint::Host::Wildcard => "localhost".into(),
+        };
+        let domain = rustls_pki_types::ServerName::try_from(host_str).map_err(ws_err)?;
+        let tls_stream = connector.connect(domain, stream).await.map_err(Error::Io)?;
+        WsTransport::Tls(tls_stream)
+    } else {
+        WsTransport::Plain(stream)
+    };
+
+    let (ws, _response) = tokio_tungstenite::client_async(request, transport)
+        .await
+        .map_err(ws_err)?;
+    Ok(ws)
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn build_tls_connector(accept_invalid_certs: bool) -> Result<tokio_rustls::TlsConnector> {
+    use std::sync::Arc;
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth();
+    if accept_invalid_certs {
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NoVerify));
+    } else {
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in rustls_native_certs::load_native_certs().expect("load system certs") {
+            let _ = roots.add(cert);
+        }
+        config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+    }
+    Ok(tokio_rustls::TlsConnector::from(Arc::new(config)))
+}
+
+pub(crate) fn build_tls_acceptor(
+    cert_pem: &[u8],
+    key_pem: &[u8],
+) -> Result<tokio_rustls::TlsAcceptor> {
+    use std::sync::Arc;
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let certs: Vec<_> = rustls_pemfile::certs(&mut &*cert_pem)
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| Error::Protocol(format!("invalid cert PEM: {e}")))?;
+    let key = rustls_pemfile::private_key(&mut &*key_pem)
+        .map_err(|e| Error::Protocol(format!("invalid key PEM: {e}")))?
+        .ok_or_else(|| Error::Protocol("no private key in PEM".into()))?;
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| Error::Protocol(format!("TLS config: {e}")))?;
+    Ok(tokio_rustls::TlsAcceptor::from(Arc::new(config)))
+}
+
+#[derive(Debug)]
+struct NoVerify;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _: &rustls_pki_types::CertificateDer<'_>,
+        _: &[rustls_pki_types::CertificateDer<'_>],
+        _: &rustls_pki_types::ServerName<'_>,
+        _: &[u8],
+        _: rustls_pki_types::UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &rustls_pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &rustls_pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::CryptoProvider::get_default()
+            .map(|p| p.signature_verification_algorithms.supported_schemes())
+            .unwrap_or_default()
+    }
+}
+
+// ---- WS Connection Driver ----
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_ws_driver(
+    mut ws: WsStream,
+    role: Role,
+    socket_type: SocketType,
+    options: &Options,
+    mut inbox: mpsc::Receiver<DriverCommand>,
+    peer_out: mpsc::Sender<(u64, PeerOut)>,
+    peer_id: u64,
+    cancel: CancellationToken,
+    config: DriverConfig,
+    shared_rx: Option<QueueReceiver>,
+    recv_direct: Option<async_channel::Sender<Message>>,
+) {
+    let res = run_ws_inner(
+        &mut ws,
+        role,
+        socket_type,
+        options,
+        &mut inbox,
+        &peer_out,
+        peer_id,
+        &cancel,
+        &config,
+        shared_rx.as_ref(),
+        recv_direct.as_ref(),
+    )
+    .await;
+    if let Err(e) = &res {
+        let ev = Event::Command(Command::Error {
+            reason: format!("{e}"),
+        });
+        let _ = peer_out.send((peer_id, PeerOut::Event(ev))).await;
+    }
+    let _ = peer_out.send((peer_id, PeerOut::Closed)).await;
+    let _ = ws.close(None).await;
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn run_ws_inner(
+    ws: &mut WsStream,
+    role: Role,
+    socket_type: SocketType,
+    options: &Options,
+    inbox: &mut mpsc::Receiver<DriverCommand>,
+    peer_out: &mpsc::Sender<(u64, PeerOut)>,
+    peer_id: u64,
+    cancel: &CancellationToken,
+    config: &DriverConfig,
+    shared_rx: Option<&QueueReceiver>,
+    recv_direct: Option<&async_channel::Sender<Message>>,
+) -> Result<()> {
+    let mut cfg = ConnectionConfig::new(role, socket_type)
+        .identity(options.identity.clone())
+        .mechanism(options.mechanism.to_setup())
+        .transport_mode(TransportMode::WebSocket);
+    if let Some(n) = options.max_message_size {
+        cfg = cfg.max_message_size(n);
+    }
+    let mut codec = Connection::new(cfg);
+
+    let hb_interval = config.heartbeat_interval;
+    let hb_timeout = config
+        .heartbeat_timeout
+        .or(config.heartbeat_interval)
+        .unwrap_or(Duration::MAX);
+    let hb_ttl_deciseconds = config
+        .heartbeat_ttl
+        .and_then(|d| u16::try_from(d.as_millis() / 100).ok())
+        .unwrap_or(0);
+
+    let mut handshake_done = false;
+    let mut deadline: Option<Instant> = config.handshake_timeout.map(|t| Instant::now() + t);
+    let mut hb_next: Option<Instant> = None;
+    let mut hb_last_input = Instant::now();
+
+    flush_ws_frames(&mut codec, ws).await?;
+
+    loop {
+        drain_events(
+            &mut codec,
+            &mut handshake_done,
+            &mut deadline,
+            &mut hb_next,
+            hb_interval,
+            peer_out,
+            peer_id,
+            recv_direct,
+        )
+        .await?;
+        flush_ws_frames(&mut codec, ws).await?;
+
+        let sleep_deadline = match (deadline, hb_next) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        };
+        let timeout = async {
+            match sleep_deadline {
+                Some(t) => tokio::time::sleep_until(t.into()).await,
+                None => std::future::pending::<()>().await,
+            }
+        };
+
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Ok(()),
+            () = timeout => {
+                if let Some(dl) = deadline
+                    && Instant::now() >= dl
+                {
+                    return Err(Error::HandshakeFailed("handshake timeout".into()));
+                }
+                if hb_next.is_some() {
+                    if hb_last_input.elapsed() > hb_timeout {
+                        return Err(Error::Timeout);
+                    }
+                    let ping = Command::Ping {
+                        ttl_deciseconds: hb_ttl_deciseconds,
+                        context: Bytes::new(),
+                    };
+                    codec.send_command(&ping)?;
+                    if let Some(iv) = hb_interval {
+                        hb_next = Some(Instant::now() + iv);
+                    }
+                }
+            }
+            msg = ws.next() => {
+                let Some(msg) = msg else { return Ok(()); };
+                let msg = msg.map_err(ws_err)?;
+                match msg {
+                    tokio_tungstenite::tungstenite::Message::Binary(data) => {
+                        hb_last_input = Instant::now();
+                        codec.handle_ws_message(data)?;
+                    }
+                    tokio_tungstenite::tungstenite::Message::Close(_) => return Ok(()),
+                    _ => {}
+                }
+            }
+            cmd = inbox.recv() => {
+                let Some(cmd) = cmd else { return Ok(()); };
+                match cmd {
+                    DriverCommand::SendMessage(m) => {
+                        codec.send_message(&m)?;
+                        flush_ws_frames(&mut codec, ws).await?;
+                    }
+                    DriverCommand::SendCommand(c) => {
+                        codec.send_command(&c)?;
+                        flush_ws_frames(&mut codec, ws).await?;
+                    }
+                    DriverCommand::Close => return Ok(()),
+                }
+            }
+            msg = async {
+                match shared_rx {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending::<Option<Message>>().await,
+                }
+            } => {
+                if let Some(m) = msg {
+                    codec.send_message(&m)?;
+                    let mut drained = 1usize;
+                    if let Some(rx) = shared_rx {
+                        while let Some(extra) = rx.try_pop() {
+                            codec.send_message(&extra)?;
+                            drained += 1;
+                        }
+                        rx.release_permits(drained);
+                    }
+                    flush_ws_frames(&mut codec, ws).await?;
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drain_events(
+    codec: &mut Connection,
+    handshake_done: &mut bool,
+    deadline: &mut Option<Instant>,
+    hb_next: &mut Option<Instant>,
+    hb_interval: Option<Duration>,
+    peer_out: &mpsc::Sender<(u64, PeerOut)>,
+    peer_id: u64,
+    recv_direct: Option<&async_channel::Sender<Message>>,
+) -> Result<()> {
+    while let Some(ev) = codec.poll_event() {
+        match ev {
+            Event::HandshakeSucceeded { .. } if !*handshake_done => {
+                *handshake_done = true;
+                *deadline = None;
+                if let Some(iv) = hb_interval {
+                    *hb_next = Some(Instant::now() + iv);
+                }
+            }
+            _ => {}
+        }
+        let _ = peer_out.send((peer_id, PeerOut::Event(ev))).await;
+    }
+    while let Some(m) = codec.poll_message() {
+        if let Some(direct) = recv_direct {
+            let _ = direct.send(m).await;
+            continue;
+        }
+        let ev = Event::Message(m);
+        let _ = peer_out.send((peer_id, PeerOut::Event(ev))).await;
+    }
+    Ok(())
+}
+
+async fn flush_ws_frames(codec: &mut Connection, ws: &mut WsStream) -> Result<()> {
+    let mut any = false;
+    while let Some(frame) = codec.poll_ws_frame() {
+        ws.feed(tokio_tungstenite::tungstenite::Message::Binary(frame))
+            .await
+            .map_err(ws_err)?;
+        any = true;
+    }
+    if any {
+        ws.flush().await.map_err(ws_err)?;
+    }
+    Ok(())
+}

--- a/omq-tokio/tests/helpers/zmq_ws_peer.c
+++ b/omq-tokio/tests/helpers/zmq_ws_peer.c
@@ -1,0 +1,69 @@
+// Helper for libzmq WS interop tests.
+// Usage: zmq_ws_peer push ws://host:port COUNT SIZE
+//        zmq_ws_peer pull ws://host:port COUNT SIZE
+#include <zmq.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc < 5) {
+        fprintf(stderr, "usage: %s push|pull ENDPOINT COUNT SIZE\n", argv[0]);
+        return 1;
+    }
+    const char *role = argv[1];
+    const char *endpoint = argv[2];
+    int count = atoi(argv[3]);
+    int size = atoi(argv[4]);
+
+    void *ctx = zmq_ctx_new();
+    if (!ctx) { perror("zmq_ctx_new"); return 1; }
+
+    int is_push = strcmp(role, "push") == 0;
+    void *sock = zmq_socket(ctx, is_push ? ZMQ_PUSH : ZMQ_PULL);
+    if (!sock) { perror("zmq_socket"); return 1; }
+
+    int linger = 1000;
+    zmq_setsockopt(sock, ZMQ_LINGER, &linger, sizeof(linger));
+
+    int rc;
+    if (is_push) {
+        rc = zmq_connect(sock, endpoint);
+    } else {
+        rc = zmq_bind(sock, endpoint);
+    }
+    if (rc != 0) {
+        fprintf(stderr, "%s failed: %s\n", is_push ? "connect" : "bind", zmq_strerror(zmq_errno()));
+        return 1;
+    }
+
+    char *buf = calloc(1, size);
+    if (is_push) {
+        // Wait for connection to establish
+        zmq_sleep(1);
+        for (int i = 0; i < count; i++) {
+            snprintf(buf, size, "msg-%d", i);
+            rc = zmq_send(sock, buf, size, 0);
+            if (rc < 0) {
+                fprintf(stderr, "send[%d] failed: %s\n", i, zmq_strerror(zmq_errno()));
+                break;
+            }
+        }
+    } else {
+        for (int i = 0; i < count; i++) {
+            rc = zmq_recv(sock, buf, size, 0);
+            if (rc < 0) {
+                fprintf(stderr, "recv[%d] failed: %s\n", i, zmq_strerror(zmq_errno()));
+                break;
+            }
+        }
+        // Print success marker
+        printf("OK %d\n", count);
+        fflush(stdout);
+    }
+
+    free(buf);
+    zmq_close(sock);
+    zmq_ctx_destroy(ctx);
+    return 0;
+}

--- a/omq-tokio/tests/interop_compio_ws.rs
+++ b/omq-tokio/tests/interop_compio_ws.rs
@@ -1,0 +1,124 @@
+//! Cross-runtime WS interop: tokio backend <-> compio backend over
+//! ws://. Drives compio on a dedicated thread while tokio runs in the
+//! test's own runtime.
+
+#![cfg(feature = "ws")]
+
+use std::net::{IpAddr, Ipv4Addr, TcpListener as StdTcpListener};
+use std::thread;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_proto::endpoint::Host;
+
+fn free_tcp_port() -> u16 {
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+fn ws_tokio(port: u16) -> omq_tokio::Endpoint {
+    omq_tokio::Endpoint::Ws {
+        host: Host::Ip(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        port,
+        path: "/".into(),
+    }
+}
+
+fn ws_compio(port: u16) -> omq_compio::Endpoint {
+    omq_compio::Endpoint::Ws {
+        host: Host::Ip(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        port,
+        path: "/".into(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tokio_push_to_compio_pull_ws() {
+    let port = free_tcp_port();
+    let (bound_tx, bound_rx) = std::sync::mpsc::channel();
+
+    let pull_thread = thread::spawn(move || {
+        let rt = compio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            use omq_compio::{Options, Socket, SocketType};
+            let pull = Socket::new(SocketType::Pull, Options::default());
+            pull.bind(ws_compio(port)).await.unwrap();
+            let _ = bound_tx.send(());
+            let mut got = Vec::new();
+            for _ in 0..3 {
+                let msg = compio::time::timeout(Duration::from_secs(5), pull.recv())
+                    .await
+                    .expect("recv timed out")
+                    .unwrap();
+                got.push(msg.part_bytes(0).unwrap().to_vec());
+            }
+            got
+        })
+    });
+
+    tokio::task::spawn_blocking(move || bound_rx.recv().unwrap())
+        .await
+        .unwrap();
+
+    let push = omq_tokio::Socket::new(omq_tokio::SocketType::Push, omq_tokio::Options::default());
+    push.connect(ws_tokio(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    for i in 0..3u32 {
+        push.send(omq_proto::message::Message::from(Bytes::from(format!(
+            "ws-msg-{i}"
+        ))))
+        .await
+        .unwrap();
+    }
+
+    let got = pull_thread.join().expect("compio thread panicked");
+    assert_eq!(got.len(), 3);
+    for (i, data) in got.iter().enumerate() {
+        assert_eq!(data, format!("ws-msg-{i}").as_bytes());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compio_push_to_tokio_pull_ws() {
+    let port = free_tcp_port();
+
+    let pull = omq_tokio::Socket::new(omq_tokio::SocketType::Pull, omq_tokio::Options::default());
+    pull.bind(ws_tokio(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let push_thread = thread::spawn(move || {
+        let rt = compio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            use omq_compio::{Options, Socket, SocketType};
+            let push = Socket::new(SocketType::Push, Options::default());
+            push.connect(ws_compio(port)).await.unwrap();
+            compio::time::sleep(Duration::from_millis(300)).await;
+            for i in 0..3u32 {
+                push.send(omq_proto::message::Message::from(Bytes::from(format!(
+                    "ws-rev-{i}"
+                ))))
+                .await
+                .unwrap();
+            }
+            compio::time::sleep(Duration::from_millis(500)).await;
+        });
+    });
+
+    let mut got = Vec::new();
+    for _ in 0..3 {
+        let msg = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+            .await
+            .expect("recv timed out")
+            .unwrap();
+        got.push(msg.part_bytes(0).unwrap().to_vec());
+    }
+
+    push_thread.join().expect("compio thread panicked");
+    assert_eq!(got.len(), 3);
+    for (i, data) in got.iter().enumerate() {
+        assert_eq!(data, format!("ws-rev-{i}").as_bytes());
+    }
+}

--- a/omq-tokio/tests/interop_libzmq_ws.rs
+++ b/omq-tokio/tests/interop_libzmq_ws.rs
@@ -1,0 +1,125 @@
+//! Interop: omq-tokio <-> libzmq 4.3.5 (draft) over ws://.
+//! Requires the `zmq_ws_peer` helper binary built against libzmq
+//! with `ENABLE_DRAFTS=ON`.
+
+#![cfg(feature = "ws")]
+
+use bytes::Bytes;
+use omq_proto::endpoint::Endpoint;
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+use omq_proto::proto::SocketType;
+use omq_tokio::Socket;
+use std::process::Command;
+use std::time::Duration;
+
+const HELPER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/helpers/zmq_ws_peer");
+
+fn helper_exists() -> bool {
+    std::path::Path::new(HELPER).exists()
+}
+
+fn ws_ep(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+fn get_port(ep: &Endpoint) -> u16 {
+    match ep {
+        Endpoint::Ws { port, .. } => *port,
+        _ => panic!("expected ws"),
+    }
+}
+
+/// omq PULL (bind) <- libzmq PUSH (connect)
+#[tokio::test]
+async fn libzmq_push_to_omq_pull() {
+    if !helper_exists() {
+        eprintln!("SKIP: zmq_ws_peer helper not found at {HELPER}");
+        return;
+    }
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_ep(0)).await.unwrap();
+    let port = get_port(&bound);
+
+    let count = 10;
+    let size = 64;
+    let mut child = Command::new(HELPER)
+        .args([
+            "push",
+            &format!("ws://127.0.0.1:{port}"),
+            &count.to_string(),
+            &size.to_string(),
+        ])
+        .spawn()
+        .expect("spawn zmq_ws_peer");
+
+    for i in 0..count {
+        let msg = tokio::time::timeout(Duration::from_secs(10), pull.recv())
+            .await
+            .unwrap_or_else(|_| panic!("recv timed out at {i}/{count}"))
+            .unwrap();
+        let data = msg.part_bytes(0).unwrap();
+        let expected = format!("msg-{i}");
+        assert!(
+            data.starts_with(expected.as_bytes()),
+            "msg {i}: expected prefix {expected:?}, got {:?}",
+            String::from_utf8_lossy(&data[..expected.len().min(data.len())])
+        );
+    }
+    let status = child.wait().unwrap();
+    assert!(status.success(), "zmq_ws_peer exited with {status}");
+}
+
+/// omq PUSH (connect) -> libzmq PULL (bind)
+#[tokio::test]
+async fn omq_push_to_libzmq_pull() {
+    if !helper_exists() {
+        eprintln!("SKIP: zmq_ws_peer helper not found at {HELPER}");
+        return;
+    }
+    let port = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    };
+
+    let count = 10;
+    let size = 64;
+    let child = Command::new(HELPER)
+        .args([
+            "pull",
+            &format!("ws://127.0.0.1:{port}"),
+            &count.to_string(),
+            &size.to_string(),
+        ])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn zmq_ws_peer");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_ep(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    for i in 0..count {
+        let mut buf = vec![0u8; size];
+        let s = format!("msg-{i}");
+        buf[..s.len()].copy_from_slice(s.as_bytes());
+        push.send(Message::from(Bytes::from(buf))).await.unwrap();
+    }
+
+    let output =
+        tokio::task::spawn_blocking(move || child.wait_with_output().expect("wait zmq_ws_peer"))
+            .await
+            .unwrap();
+    assert!(
+        output.status.success(),
+        "zmq_ws_peer: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("OK {count}")),
+        "expected OK {count}, got: {stdout}"
+    );
+}

--- a/omq-tokio/tests/ws_basic.rs
+++ b/omq-tokio/tests/ws_basic.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "ws")]
+
+use bytes::Bytes;
+use omq_proto::endpoint::Endpoint;
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+use omq_proto::proto::SocketType;
+use omq_tokio::Socket;
+
+fn ws_endpoint(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+fn get_ws_port(ep: &Endpoint) -> u16 {
+    match ep {
+        Endpoint::Ws { port, .. } => *port,
+        other => panic!("expected Ws endpoint, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn push_pull_one_message() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+    let port = get_ws_port(&bound);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    push.send(Message::from(Bytes::from_static(b"hello ws")))
+        .await
+        .unwrap();
+
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello ws"[..]);
+}
+
+#[tokio::test]
+async fn push_pull_multipart() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+    let port = get_ws_port(&bound);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let msg = Message::multipart([
+        Bytes::from_static(b"frame1"),
+        Bytes::from_static(b"frame2"),
+        Bytes::from_static(b"frame3"),
+    ]);
+    push.send(msg).await.unwrap();
+
+    let received = tokio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(received.len(), 3);
+    assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
+    assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
+    assert_eq!(received.part_bytes(2).unwrap(), &b"frame3"[..]);
+}
+
+#[tokio::test]
+async fn push_pull_many_messages() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let bound = pull.bind(ws_endpoint(0)).await.unwrap();
+    let port = get_ws_port(&bound);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ws_endpoint(port)).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let count = 100;
+    for i in 0..count {
+        push.send(Message::from(Bytes::from(format!("msg-{i}"))))
+            .await
+            .unwrap();
+    }
+
+    for i in 0..count {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), pull.recv())
+            .await
+            .expect("recv timed out")
+            .unwrap();
+        assert_eq!(msg.part_bytes(0).unwrap(), format!("msg-{i}").as_bytes(),);
+    }
+}

--- a/omq-tokio/tests/wss_basic.rs
+++ b/omq-tokio/tests/wss_basic.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "ws")]
+
+use bytes::Bytes;
+use omq_proto::endpoint::Endpoint;
+use omq_proto::message::Message;
+use omq_proto::options::{Options, WssTls};
+use omq_proto::proto::SocketType;
+use omq_tokio::Socket;
+use std::time::Duration;
+
+fn self_signed_tls() -> (Vec<u8>, Vec<u8>) {
+    let certified = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    let cert_pem = certified.cert.pem().into_bytes();
+    let key_pem = certified.signing_key.serialize_pem().into_bytes();
+    (cert_pem, key_pem)
+}
+
+fn wss_endpoint(port: u16) -> Endpoint {
+    format!("wss://127.0.0.1:{port}/").parse().unwrap()
+}
+
+fn get_port(ep: &Endpoint) -> u16 {
+    match ep {
+        Endpoint::Wss { port, .. } => *port,
+        other => panic!("expected Wss, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn wss_push_pull() {
+    let (cert_pem, key_pem) = self_signed_tls();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let bound = pull.bind(wss_endpoint(0)).await.unwrap();
+    let port = get_port(&bound);
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(wss_endpoint(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::from(Bytes::from_static(b"hello wss")))
+        .await
+        .unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello wss"[..]);
+}
+
+#[tokio::test]
+async fn wss_multipart() {
+    let (cert_pem, key_pem) = self_signed_tls();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let bound = pull.bind(wss_endpoint(0)).await.unwrap();
+    let port = get_port(&bound);
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(wss_endpoint(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let msg = Message::multipart([Bytes::from_static(b"frame1"), Bytes::from_static(b"frame2")]);
+    push.send(msg).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+
+    assert_eq!(received.len(), 2);
+    assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
+    assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
+}

--- a/omq/Cargo.toml
+++ b/omq/Cargo.toml
@@ -41,6 +41,10 @@ zstd = [
   "omq-compio?/zstd",
   "omq-tokio?/zstd",
 ]
+ws = [
+  "omq-compio?/ws",
+  "omq-tokio?/ws",
+]
 priority = [
   "omq-compio?/priority",
   "omq-tokio?/priority",


### PR DESCRIPTION
Feature-gated behind `ws`. Each ZMTP frame maps to one WebSocket binary message with a 1-byte flag prefix (0x00 final, 0x01 more, 0x02 command); no 64-byte greeting, no length-prefixed framing. Mechanism negotiation via Sec-WebSocket-Protocol header (ZWS2.0/NULL).

omq-proto:
- Endpoint::Ws / Endpoint::Wss with user-configurable path
- TransportMode::WebSocket on ConnectionConfig (skips greeting, starts in MechanismHandshake, encodes frames as ZWS)
- Connection::handle_ws_message() / poll_ws_frame() APIs
- proto::zws module: encode/decode ZWS flag-byte frames

omq-compio:
- compio-ws (tungstenite) for WS handshake + message I/O
- ws_driver: message-oriented connection driver (no multi-shot recv, no DirectIoState)
- Bind/connect dispatch in Socket::bind / Socket::connect

omq-tokio:
- tokio-tungstenite for WS handshake + message I/O
- WS driver in transport::ws::run_ws_driver
- AnyConn::WebSocket / AnyListener::Ws dispatch
- DNS resolution support on connect + bind

omq facade:
- ws feature passthrough with weak-dependency syntax