### PR TITLE
fix(tokio): copy read buffer on compression transports

### DIFF
--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -348,10 +348,17 @@ where
                         inbox.close();
                         return Ok(());
                     }
-                    let chunk = read_buf.split().freeze();
-                    if read_buf.capacity() < READ_BUF_SIZE {
-                        read_buf.reserve(READ_BUF_SIZE);
-                    }
+                    let chunk = if decoder.is_some() {
+                        let b = Bytes::copy_from_slice(&read_buf);
+                        read_buf.clear();
+                        b
+                    } else {
+                        let chunk = read_buf.split().freeze();
+                        if read_buf.capacity() < READ_BUF_SIZE {
+                            read_buf.reserve(READ_BUF_SIZE);
+                        }
+                        chunk
+                    };
                     if let Err(e) = codec.handle_input(chunk) {
                         while let Some(ev) = codec.poll_event() {
                             let _ = peer_out


### PR DESCRIPTION
## Summary

- The zero-copy read path (`split().freeze()`) pins the full 128 KiB `BytesMut` backing via refcount. On compression transports, the lz4/zstd decoder's plaintext-passthrough path keeps sub-slices in the recv channel — each small message holds 128 KiB alive until consumed.
- This pushed the lz4 soak heap slope to 601 KiB/s on CI (threshold: 500), introduced by `4801385`.
- Use `Bytes::copy_from_slice` when a decoder is present so sub-slices pin only the actual bytes read. Non-compression transports keep the zero-copy path.

## Test plan

- [x] `soak_compression_lz4` at 60s: 179 → 131 KiB/s
- [x] `soak_compression` (zstd) at 60s: -390 KiB/s (no regression)
- [x] `soak_large_throughput` (no compression): -66 KiB/s (zero-copy preserved)
- [x] `lz4_tcp` integration tests pass
- [x] clippy clean
- [ ] CI soak workflow