### PR TITLE
Problem: CI runs wastefully on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: ci
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Solution:

- add `paths-ignore` for `**/*.md` and `doc/**` to both `push` and `pull_request` triggers in `ci.yml`