### PR TITLE
Problem: interop_compio tests flake with AddrInUse due to TOCTOU race

### DIFF
--- a/omq-tokio/tests/interop_compio.rs
+++ b/omq-tokio/tests/interop_compio.rs
@@ -4,19 +4,14 @@
 //! test's own runtime. Catches drift between the two backends'
 //! framing, handshake, and per-socket-type send/recv contracts.
 
-use std::net::{IpAddr, Ipv4Addr, TcpListener as StdTcpListener};
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
 use bytes::Bytes;
 use omq_proto::endpoint::Host;
-
-fn free_tcp_port() -> u16 {
-    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
-    let port = listener.local_addr().unwrap().port();
-    drop(listener);
-    port
-}
 
 fn loopback_tokio(port: u16) -> omq_tokio::Endpoint {
     omq_tokio::Endpoint::Tcp {
@@ -37,7 +32,7 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         let rt = compio::runtime::Runtime::new().unwrap();
         let out = rt.block_on(async move { f() });
@@ -46,16 +41,31 @@ where
     rx.recv().expect("compio thread panicked")
 }
 
+fn compio_port(ep: omq_compio::Endpoint) -> u16 {
+    match ep {
+        omq_compio::Endpoint::Tcp { port, .. } => port,
+        other => panic!("expected TCP endpoint, got {other:?}"),
+    }
+}
+
+fn tokio_port(ep: omq_tokio::Endpoint) -> u16 {
+    match ep {
+        omq_tokio::Endpoint::Tcp { port, .. } => port,
+        other => panic!("expected TCP endpoint, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn tokio_push_to_compio_pull_tcp() {
-    let port = free_tcp_port();
+    let (port_tx, port_rx) = mpsc::channel::<u16>();
 
     let pull_thread = thread::spawn(move || {
         let rt = compio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
             use omq_compio::{Options, Socket, SocketType};
             let pull = Socket::new(SocketType::Pull, Options::default());
-            pull.bind(loopback_compio(port)).await.unwrap();
+            let bound = pull.bind(loopback_compio(0)).await.unwrap();
+            port_tx.send(compio_port(bound)).unwrap();
             let mut got = Vec::new();
             for _ in 0..3 {
                 let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
@@ -68,7 +78,7 @@ async fn tokio_push_to_compio_pull_tcp() {
         })
     });
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let port = port_rx.recv().unwrap();
     {
         use omq_tokio::{Message, Options, Socket, SocketType};
         let push = Socket::new(SocketType::Push, Options::default());
@@ -76,8 +86,6 @@ async fn tokio_push_to_compio_pull_tcp() {
         for i in 0..3 {
             push.send(Message::single(format!("m{i}"))).await.unwrap();
         }
-        // Hold push alive long enough for its driver to flush before
-        // the socket drops.
         tokio::time::sleep(Duration::from_millis(150)).await;
     }
 
@@ -87,12 +95,12 @@ async fn tokio_push_to_compio_pull_tcp() {
 
 #[tokio::test]
 async fn compio_push_to_tokio_pull_tcp() {
-    let port = free_tcp_port();
-    let pull = {
+    let (pull, port) = {
         use omq_tokio::{Options, Socket, SocketType};
         let s = Socket::new(SocketType::Pull, Options::default());
-        s.bind(loopback_tokio(port)).await.unwrap();
-        s
+        let bound = s.bind(loopback_tokio(0)).await.unwrap();
+        let port = tokio_port(bound);
+        (s, port)
     };
 
     let push_thread = thread::spawn(move || {
@@ -104,7 +112,6 @@ async fn compio_push_to_tokio_pull_tcp() {
             for i in 0..3 {
                 push.send(Message::single(format!("m{i}"))).await.unwrap();
             }
-            // Let the wire driver flush before the runtime tears down.
             compio::time::sleep(Duration::from_millis(150)).await;
         });
     });
@@ -123,14 +130,15 @@ async fn compio_push_to_tokio_pull_tcp() {
 
 #[tokio::test]
 async fn tokio_dealer_to_compio_router_tcp() {
-    let port = free_tcp_port();
+    let (port_tx, port_rx) = mpsc::channel::<u16>();
 
     let router_thread = thread::spawn(move || {
         let rt = compio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
             use omq_compio::{Options, Socket, SocketType};
             let router = Socket::new(SocketType::Router, Options::default());
-            router.bind(loopback_compio(port)).await.unwrap();
+            let bound = router.bind(loopback_compio(0)).await.unwrap();
+            port_tx.send(compio_port(bound)).unwrap();
             let m = compio::time::timeout(Duration::from_secs(2), router.recv())
                 .await
                 .expect("compio router timed out")
@@ -142,7 +150,7 @@ async fn tokio_dealer_to_compio_router_tcp() {
         })
     });
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let port = port_rx.recv().unwrap();
     {
         use omq_tokio::{Message, Options, Socket, SocketType};
         let dealer = Socket::new(
@@ -161,7 +169,23 @@ async fn tokio_dealer_to_compio_router_tcp() {
 
 #[tokio::test]
 async fn compio_pub_to_tokio_sub_tcp() {
-    let port = free_tcp_port();
+    let (port_tx, port_rx) = mpsc::channel::<u16>();
+
+    let pub_thread = thread::spawn(move || {
+        let rt = compio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            use omq_compio::{Message, Options, Socket, SocketType};
+            let p = Socket::new(SocketType::Pub, Options::default());
+            let bound = p.bind(loopback_compio(0)).await.unwrap();
+            port_tx.send(compio_port(bound)).unwrap();
+            for _ in 0..30 {
+                let _ = p.send(Message::single("topic.hello")).await;
+                compio::time::sleep(Duration::from_millis(20)).await;
+            }
+        });
+    });
+
+    let port = port_rx.recv().unwrap();
     let sub = {
         use omq_tokio::{Options, Socket, SocketType};
         let s = Socket::new(SocketType::Sub, Options::default());
@@ -169,20 +193,6 @@ async fn compio_pub_to_tokio_sub_tcp() {
         s.connect(loopback_tokio(port)).await.unwrap();
         s
     };
-
-    let pub_thread = thread::spawn(move || {
-        let rt = compio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            use omq_compio::{Message, Options, Socket, SocketType};
-            let p = Socket::new(SocketType::Pub, Options::default());
-            p.bind(loopback_compio(port)).await.unwrap();
-            // Drive a few publishes so the SUBSCRIBE has time to land.
-            for _ in 0..30 {
-                let _ = p.send(Message::single("topic.hello")).await;
-                compio::time::sleep(Duration::from_millis(20)).await;
-            }
-        });
-    });
 
     let m = tokio::time::timeout(Duration::from_secs(3), sub.recv())
         .await


### PR DESCRIPTION
Solution:

- replace `free_tcp_port()` (bind :0, drop, return port) with bind-to-0 + channel: the binding side sends the resolved port over an `mpsc` channel before the connecting side runs, eliminating the window between drop and re-bind
- `compio_pub_to_tokio_sub_tcp` reordered so PUB binds first (gets port via channel), SUB connects after