### PR TITLE
release: omq-tokio 0.12.1, omq-libzmq 0.4.1, omq 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,26 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
-### omq-libzmq 0.2.0 (was omq-zmq)
+## [0.2.11] - 2026-05-25
 
+### omq-tokio 0.12.1
+
+- Fix: copy read buffer on compression transports to prevent buffer retention across reads.
+
+### omq-libzmq 0.4.1
+
+- Fix: eliminate TOCTOU race in IPv6 test port allocation (bind to `:0`, read actual endpoint).
 - Package renamed from `omq-zmq` to `omq-libzmq`. Library name (`omq_zmq`) unchanged.
 - 7 formerly-ENOTSUP socket options now store and round-trip values. 13 rarely-used options explicitly accepted as no-ops.
-- `zmq_msg_get`/`zmq_msg_gets` improved for libzmq compatibility. Context options expanded.
+- `zmq_msg_get`/`zmq_msg_sets` improved for libzmq compatibility. Context options expanded.
 
-### omq-zeromq 0.4.0
+### omq-zeromq 0.7.0
 
 - `Socket::disconnect()` method.
+
+### omq 0.12.1
+
+- Dependency version bumps.
 
 ## [0.2.10] - 2026-05-20
 

--- a/examples/zguide-compio/01_req_rep/Cargo.toml
+++ b/examples/zguide-compio/01_req_rep/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/02_pub_sub/Cargo.toml
+++ b/examples/zguide-compio/02_pub_sub/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/03_pipeline/Cargo.toml
+++ b/examples/zguide-compio/03_pipeline/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/04_lazy_pirate/Cargo.toml
+++ b/examples/zguide-compio/04_lazy_pirate/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/05_heartbeat/Cargo.toml
+++ b/examples/zguide-compio/05_heartbeat/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/06_last_value_cache/Cargo.toml
+++ b/examples/zguide-compio/06_last_value_cache/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/07_clone/Cargo.toml
+++ b/examples/zguide-compio/07_clone/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/08_majordomo/Cargo.toml
+++ b/examples/zguide-compio/08_majordomo/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/09_titanic/Cargo.toml
+++ b/examples/zguide-compio/09_titanic/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/10_binary_star/Cargo.toml
+++ b/examples/zguide-compio/10_binary_star/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/11_freelance/Cargo.toml
+++ b/examples/zguide-compio/11_freelance/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq" }
+omq = { version = "0.12.1", path = "../../../omq" }
 compio = { git = "https://github.com/compio-rs/compio.git", rev = "453ed63", features = ["macros", "runtime", "time"] }
 bytes = "1"
 

--- a/examples/zguide-compio/Cargo.lock
+++ b/examples/zguide-compio/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -690,9 +690,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom"
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "omq"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "omq-compio",
 ]
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/examples/zguide-tokio/01_req_rep/Cargo.toml
+++ b/examples/zguide-tokio/01_req_rep/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/02_pub_sub/Cargo.toml
+++ b/examples/zguide-tokio/02_pub_sub/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/03_pipeline/Cargo.toml
+++ b/examples/zguide-tokio/03_pipeline/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
+++ b/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/05_heartbeat/Cargo.toml
+++ b/examples/zguide-tokio/05_heartbeat/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/06_last_value_cache/Cargo.toml
+++ b/examples/zguide-tokio/06_last_value_cache/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/07_clone/Cargo.toml
+++ b/examples/zguide-tokio/07_clone/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/08_majordomo/Cargo.toml
+++ b/examples/zguide-tokio/08_majordomo/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/09_titanic/Cargo.toml
+++ b/examples/zguide-tokio/09_titanic/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/10_binary_star/Cargo.toml
+++ b/examples/zguide-tokio/10_binary_star/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/11_freelance/Cargo.toml
+++ b/examples/zguide-tokio/11_freelance/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq = { version = "0.12.0", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
+omq = { version = "0.12.1", path = "../../../omq", default-features = false, features = ["tokio-backend"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/Cargo.lock
+++ b/examples/zguide-tokio/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "omq"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "omq-tokio",
 ]
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-channel",
  "bytes",

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-libzmq"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-tokio"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/omq/Cargo.toml
+++ b/omq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -55,7 +55,7 @@ priority = [
 
 [dependencies]
 omq-compio = { path = "../omq-compio", version = "0.11.0", default-features = false, optional = true }
-omq-tokio  = { path = "../omq-tokio",  version = "0.12.0", default-features = false, optional = true }
+omq-tokio  = { path = "../omq-tokio",  version = "0.12.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 features = ["compio-backend", "curve", "blake3zmq", "plain", "lz4", "zstd", "ws", "priority"]


### PR DESCRIPTION
- `omq-tokio 0.12.1`: fix buffer retention on compression transports — copy read buffer instead of split when a decoder is active
- `omq-libzmq 0.4.1`: fix TOCTOU race in IPv6 tests; document rename from `omq-zmq`, socket option improvements, and `zmq_msg_get`/`zmq_msg_sets` compatibility
- `omq-zeromq 0.7.0`: document `Socket::disconnect()` (was undocumented in CHANGELOG)
- `omq 0.12.1`: dep bump for omq-tokio
- zguide examples: bump `omq` dep to `0.12.1`, regenerate lock files