### PR TITLE
release: pyomq 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-05-25
+
+### pyomq 0.10.2
+
+- Fix: `pyproject.toml` version was not bumped in 0.10.1.
+
 ## [0.2.12] - 2026-05-25
 
 ### pyomq 0.10.1

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-05-25
+
+### Fixed
+
+- `pyproject.toml` version was not bumped in 0.10.1.
+
+## [0.10.1] - 2026-05-25
+
+### Fixed
+
+- Suppress `dead_code` warnings from PyO3 proc-macro call sites.
+
 ## [0.10.0] - 2026-05-25
 
 ### Changed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bytes",
  "compio",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- `pyomq 0.10.2`: fix `pyproject.toml` version not bumped in 0.10.1