### PR TITLE
release: pyomq 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-05-25
+
+### pyomq 0.10.3
+
+- Fix: `destroy_socket()` now cancels its pump tasks before attempting `Rc::try_unwrap`, releasing the `Rc<InnerSocket>` clones the pumps held. Previously sockets lingered as zombies, retaining queue memory until `ctx.term()`.
+- Fix (omq-compio): evict stale `identity_to_slot` entries when a dialer reconnects. Each reconnect previously leaked one map entry, producing steady RSS growth under high reconnect rates.
+
 ## [0.2.13] - 2026-05-25
 
 ### pyomq 0.10.2

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "bytes",
  "compio",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.10.2"
+version = "0.10.3"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
Solution:

- Bump `pyomq` to 0.10.3 (Cargo.toml, pyproject.toml, Cargo.lock).
- CHANGELOG entry for [0.2.14] covering the two fixes that landed in #17: `destroy_socket` now cancels pump tasks (no more zombie sockets), and `omq-compio` evicts stale `identity_to_slot` entries on dialer reconnect.