### PR TITLE
feat(pyomq): expose on_mute and compression options

### DIFF
--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -87,6 +87,14 @@ from ._native import (  # type: ignore[attr-defined]
     BLAKE3ZMQ_PUBLICKEY,
     BLAKE3ZMQ_SECRETKEY,
     BLAKE3ZMQ_SERVERKEY,
+    # omq-specific options
+    OMQ_ON_MUTE,
+    OMQ_COMPRESSION_LEVEL,
+    OMQ_COMPRESSION_DICT,
+    OMQ_COMPRESSION_AUTO_TRAIN,
+    OMQ_ON_MUTE_BLOCK,
+    OMQ_ON_MUTE_DROP_NEWEST,
+    OMQ_ON_MUTE_DROP_OLDEST,
 )
 
 from .error import (  # noqa: F401  re-exports
@@ -245,6 +253,10 @@ _SOCKOPT_NAMES = {
     "blake3zmq_publickey": BLAKE3ZMQ_PUBLICKEY,
     "blake3zmq_secretkey": BLAKE3ZMQ_SECRETKEY,
     "blake3zmq_serverkey": BLAKE3ZMQ_SERVERKEY,
+    "on_mute": OMQ_ON_MUTE,
+    "compression_level": OMQ_COMPRESSION_LEVEL,
+    "compression_dict": OMQ_COMPRESSION_DICT,
+    "compression_auto_train": OMQ_COMPRESSION_AUTO_TRAIN,
     "sndbuf": SNDBUF,
     "rcvbuf": RCVBUF,
     "mechanism": MECHANISM,
@@ -710,6 +722,9 @@ __all__ = [
     "SNDMORE", "NOBLOCK", "DONTWAIT",
     "CURVE_SERVER", "CURVE_PUBLICKEY", "CURVE_SECRETKEY", "CURVE_SERVERKEY",
     "BLAKE3ZMQ_SERVER", "BLAKE3ZMQ_PUBLICKEY", "BLAKE3ZMQ_SECRETKEY", "BLAKE3ZMQ_SERVERKEY",
+    "OMQ_ON_MUTE", "OMQ_COMPRESSION_LEVEL", "OMQ_COMPRESSION_DICT",
+    "OMQ_COMPRESSION_AUTO_TRAIN",
+    "OMQ_ON_MUTE_BLOCK", "OMQ_ON_MUTE_DROP_NEWEST", "OMQ_ON_MUTE_DROP_OLDEST",
     # poll / compat constants
     "POLLIN", "POLLOUT", "POLLERR", "POLLPRI", "STREAM", "HWM",
     # additional compat constants

--- a/bindings/pyomq/src/constants.rs
+++ b/bindings/pyomq/src/constants.rs
@@ -67,6 +67,17 @@ pub const BLAKE3ZMQ_PUBLICKEY: i32 = 1001;
 pub const BLAKE3ZMQ_SECRETKEY: i32 = 1002;
 pub const BLAKE3ZMQ_SERVERKEY: i32 = 1003;
 
+// omq-specific options (no libzmq equivalent):
+pub const OMQ_ON_MUTE: i32 = 1004;
+pub const OMQ_COMPRESSION_LEVEL: i32 = 1005;
+pub const OMQ_COMPRESSION_DICT: i32 = 1006;
+pub const OMQ_COMPRESSION_AUTO_TRAIN: i32 = 1007;
+
+// OnMute enum values:
+pub const OMQ_ON_MUTE_BLOCK: i32 = 0;
+pub const OMQ_ON_MUTE_DROP_NEWEST: i32 = 1;
+pub const OMQ_ON_MUTE_DROP_OLDEST: i32 = 2;
+
 // Additional compat constants (used in options.rs match arms):
 pub const RATE: i32 = 8;
 pub const SNDBUF: i32 = 11;
@@ -158,6 +169,13 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
         BLAKE3ZMQ_PUBLICKEY,
         BLAKE3ZMQ_SECRETKEY,
         BLAKE3ZMQ_SERVERKEY,
+        OMQ_ON_MUTE,
+        OMQ_COMPRESSION_LEVEL,
+        OMQ_COMPRESSION_DICT,
+        OMQ_COMPRESSION_AUTO_TRAIN,
+        OMQ_ON_MUTE_BLOCK,
+        OMQ_ON_MUTE_DROP_NEWEST,
+        OMQ_ON_MUTE_DROP_OLDEST,
         SNDMORE,
         NOBLOCK,
         DONTWAIT

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -9,7 +9,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use omq_proto::options::{KeepAlive, ReconnectPolicy};
+use omq_proto::options::{KeepAlive, OnMute, ReconnectPolicy};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
@@ -24,7 +24,7 @@ use omq_compio as backend;
 // SocketInner accessed via fully-qualified path; no top-level import.
 
 /// Wrapper-only state that doesn't live on `Options`.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Overlay {
     pub rcvtimeo: Option<Duration>,
     pub sndtimeo: Option<Duration>,
@@ -62,6 +62,57 @@ pub struct Overlay {
     pub blake3zmq_serverkey: Option<Vec<u8>>,
     #[cfg(feature = "blake3zmq")]
     pub blake3zmq_authenticator: Option<crate::blake3zmq_auth::Blake3ZmqAuthenticator>,
+    pub on_mute: OnMute,
+    pub compression_level: i32,
+    pub compression_dict: Option<Bytes>,
+    pub compression_auto_train: bool,
+}
+
+impl Default for Overlay {
+    fn default() -> Self {
+        Self {
+            rcvtimeo: None,
+            sndtimeo: None,
+            linger: None,
+            send_hwm: None,
+            recv_hwm: None,
+            identity: Bytes::new(),
+            keepalive: KeepAlive::Default,
+            keepalive_idle: None,
+            keepalive_intvl: None,
+            keepalive_cnt: None,
+            max_message_size: None,
+            router_mandatory: false,
+            heartbeat_ivl: None,
+            heartbeat_ttl: None,
+            heartbeat_timeout: None,
+            handshake_ivl: None,
+            conflate: false,
+            reconnect_ivl: None,
+            reconnect_ivl_max: None,
+            send_buffer_size: None,
+            recv_buffer_size: None,
+            plain_server: false,
+            plain_username: None,
+            plain_password: None,
+            curve_server: false,
+            curve_publickey: None,
+            curve_secretkey: None,
+            curve_serverkey: None,
+            #[cfg(feature = "curve")]
+            curve_authenticator: None,
+            blake3zmq_server: false,
+            blake3zmq_publickey: None,
+            blake3zmq_secretkey: None,
+            blake3zmq_serverkey: None,
+            #[cfg(feature = "blake3zmq")]
+            blake3zmq_authenticator: None,
+            on_mute: OnMute::Block,
+            compression_level: -3,
+            compression_dict: None,
+            compression_auto_train: true,
+        }
+    }
 }
 
 impl Overlay {
@@ -89,6 +140,10 @@ impl Overlay {
                 (Some(min), None) => ReconnectPolicy::Fixed(min),
                 (Some(min), Some(max)) => ReconnectPolicy::Exponential { min, max },
             },
+            on_mute: self.on_mute,
+            compression_level: self.compression_level,
+            compression_dict: self.compression_dict.clone(),
+            compression_auto_train: self.compression_auto_train,
             ..Default::default()
         };
         #[cfg(feature = "plain")]
@@ -234,6 +289,10 @@ impl Overlay {
             blake3zmq_serverkey: None,
             #[cfg(feature = "blake3zmq")]
             blake3zmq_authenticator: None,
+            on_mute: o.on_mute,
+            compression_level: o.compression_level,
+            compression_dict: o.compression_dict.clone(),
+            compression_auto_train: o.compression_auto_train,
         }
     }
 }
@@ -426,6 +485,40 @@ pub fn setsockopt(
         constants::BLAKE3ZMQ_SERVERKEY => {
             let v: &[u8] = value.extract()?;
             ov.blake3zmq_serverkey = Some(v.to_vec());
+        }
+        constants::OMQ_ON_MUTE => {
+            ov.on_mute = match value.extract::<i64>()? {
+                0 => OnMute::Block,
+                1 => OnMute::DropNewest,
+                2 => OnMute::DropOldest,
+                v => {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "OMQ_ON_MUTE must be 0 (Block), 1 (DropNewest), or 2 (DropOldest), \
+                         got {v}"
+                    )));
+                }
+            };
+        }
+        constants::OMQ_COMPRESSION_LEVEL => {
+            ov.compression_level = value.extract::<i32>()?;
+        }
+        constants::OMQ_COMPRESSION_DICT => {
+            let v: &[u8] = value.extract()?;
+            if v.is_empty() {
+                ov.compression_dict = None;
+            } else {
+                const DICT_MAX: usize = 64 * 1024 - 4;
+                if v.len() > DICT_MAX {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "compression dict must be at most {DICT_MAX} bytes, got {}",
+                        v.len()
+                    )));
+                }
+                ov.compression_dict = Some(Bytes::copy_from_slice(v));
+            }
+        }
+        constants::OMQ_COMPRESSION_AUTO_TRAIN => {
+            ov.compression_auto_train = value.extract::<i64>()? != 0;
         }
         // No-ops accepted for source-compat with pyzmq:
         constants::IMMEDIATE
@@ -699,6 +792,32 @@ pub fn getsockopt<'py>(
                 .clone()
                 .unwrap_or_default();
             Ok(PyBytes::new_bound(py, &v).into_any())
+        }
+        constants::OMQ_ON_MUTE => {
+            let v: i64 = match sock.overlay.lock().unwrap().on_mute {
+                OnMute::Block => 0,
+                OnMute::DropNewest => 1,
+                OnMute::DropOldest => 2,
+            };
+            Ok(int_to_bound(py, v))
+        }
+        constants::OMQ_COMPRESSION_LEVEL => {
+            let v = sock.overlay.lock().unwrap().compression_level as i64;
+            Ok(int_to_bound(py, v))
+        }
+        constants::OMQ_COMPRESSION_DICT => {
+            let v = sock
+                .overlay
+                .lock()
+                .unwrap()
+                .compression_dict
+                .clone()
+                .unwrap_or_default();
+            Ok(PyBytes::new_bound(py, &v).into_any())
+        }
+        constants::OMQ_COMPRESSION_AUTO_TRAIN => {
+            let v = sock.overlay.lock().unwrap().compression_auto_train as i64;
+            Ok(int_to_bound(py, v))
         }
         // Compat no-ops: return sensible defaults.
         constants::MECHANISM => Ok(int_to_bound(py, 0_i64)),

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -253,3 +253,82 @@ def test_has_feature():
     assert isinstance(zmq.has("plain"), bool)
     assert zmq.has("gssapi") is False
     assert zmq.has("INPROC") is True
+
+
+# Group H: omq-specific options.
+
+
+def test_on_mute_round_trip():
+    ctx, s = _push()
+    try:
+        assert s.getsockopt(zmq.OMQ_ON_MUTE) == zmq.OMQ_ON_MUTE_BLOCK
+        s.setsockopt(zmq.OMQ_ON_MUTE, zmq.OMQ_ON_MUTE_DROP_NEWEST)
+        assert s.getsockopt(zmq.OMQ_ON_MUTE) == zmq.OMQ_ON_MUTE_DROP_NEWEST
+        s.setsockopt(zmq.OMQ_ON_MUTE, zmq.OMQ_ON_MUTE_DROP_OLDEST)
+        assert s.getsockopt(zmq.OMQ_ON_MUTE) == zmq.OMQ_ON_MUTE_DROP_OLDEST
+        s.setsockopt(zmq.OMQ_ON_MUTE, zmq.OMQ_ON_MUTE_BLOCK)
+        assert s.getsockopt(zmq.OMQ_ON_MUTE) == zmq.OMQ_ON_MUTE_BLOCK
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_on_mute_rejects_invalid():
+    ctx, s = _push()
+    try:
+        with pytest.raises((zmq.ZMQError, ValueError)):
+            s.setsockopt(zmq.OMQ_ON_MUTE, 99)
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_compression_level_round_trip():
+    ctx, s = _push()
+    try:
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_LEVEL) == -3
+        s.setsockopt(zmq.OMQ_COMPRESSION_LEVEL, 5)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_LEVEL) == 5
+        s.setsockopt(zmq.OMQ_COMPRESSION_LEVEL, -1)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_LEVEL) == -1
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_compression_dict_round_trip():
+    ctx, s = _push()
+    try:
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_DICT) == b""
+        d = b"my-dict-bytes-1234"
+        s.setsockopt(zmq.OMQ_COMPRESSION_DICT, d)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_DICT) == d
+        s.setsockopt(zmq.OMQ_COMPRESSION_DICT, b"")
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_DICT) == b""
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_compression_dict_rejects_oversize():
+    ctx, s = _push()
+    try:
+        oversize = b"\x00" * (64 * 1024)
+        with pytest.raises((zmq.ZMQError, ValueError)):
+            s.setsockopt(zmq.OMQ_COMPRESSION_DICT, oversize)
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_compression_auto_train_round_trip():
+    ctx, s = _push()
+    try:
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 1
+        s.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 0)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 0
+        s.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 1)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 1
+    finally:
+        s.close()
+        ctx.term()


### PR DESCRIPTION
- Expose `OMQ_ON_MUTE` (Block/DropNewest/DropOldest), `OMQ_COMPRESSION_LEVEL`, `OMQ_COMPRESSION_DICT`, and `OMQ_COMPRESSION_AUTO_TRAIN` via setsockopt/getsockopt
- Constants use IDs 1004-1007; OnMute enum values exported as `OMQ_ON_MUTE_BLOCK` (0), `OMQ_ON_MUTE_DROP_NEWEST` (1), `OMQ_ON_MUTE_DROP_OLDEST` (2)
- Manual `Default` impl for `Overlay` to get correct non-zero defaults (`compression_level: -3`, `compression_auto_train: true`)
- Attribute-style access wired via `_SOCKOPT_NAMES` (e.g. `socket.on_mute`)
- 6 new round-trip + validation tests in `test_options.py`