### PR TITLE
fix(pyomq): improve bindings chart layout and drop redundant tables

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -69,59 +69,16 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/pyomq/doc/charts/bindings.svg" alt="pyomq vs pyzmq performance" width="850">
 </p>
 
-Loopback PUSH/PULL throughput vs pyzmq, on a Linux 6.12 (Debian 13) VM on an
-Intel Mac Mini 2018 (i7-8700B, 3.2 GHz), Rust 1.95.0, default features:
-
-<!-- PERF:START -->
-| Size    | inproc pyomq | inproc pyzmq | ratio     | tcp pyomq | tcp pyzmq | ratio     |
-|---------|-------------:|-------------:|----------:|----------:|----------:|----------:|
-| 8 B     |     1.61 M/s |      567 k/s | **2.84×** |  1.47 M/s |   563 k/s | **2.62×** |
-| 16 B    |     1.63 M/s |      581 k/s | **2.80×** |  1.48 M/s |   530 k/s | **2.80×** |
-| 32 B    |     1.62 M/s |      566 k/s | **2.85×** |  1.45 M/s |   543 k/s | **2.67×** |
-| 64 B    |     1.63 M/s |      511 k/s | **3.19×** |  1.46 M/s |   511 k/s | **2.86×** |
-| 128 B   |     1.61 M/s |      487 k/s | **3.31×** |  1.44 M/s |   468 k/s | **3.08×** |
-| 256 B   |     1.62 M/s |      491 k/s | **3.29×** |  1.44 M/s |   472 k/s | **3.04×** |
-| 512 B   |     1.59 M/s |      495 k/s | **3.21×** |  1.35 M/s |   458 k/s | **2.94×** |
-| 1 KiB   |     1.51 M/s |      457 k/s | **3.31×** |  1.28 M/s |   450 k/s | **2.84×** |
-| 2 KiB   |     1.50 M/s |      431 k/s | **3.48×** |   904 k/s |   344 k/s | **2.63×** |
-| 4 KiB   |     1.45 M/s |      408 k/s | **3.55×** |   596 k/s |   199 k/s | **3.00×** |
-| 8 KiB   |     1.31 M/s |      353 k/s | **3.73×** |   340 k/s |   106 k/s | **3.22×** |
-| 16 KiB  |      985 k/s |      262 k/s | **3.76×** |   170 k/s |    56 k/s | **3.01×** |
-| 32 KiB  |      726 k/s |      200 k/s | **3.63×** |   107 k/s |    47 k/s | **2.29×** |
-| 64 KiB  |      480 k/s |      120 k/s | **3.99×** |    53 k/s |    37 k/s | **1.44×** |
-<!-- PERF:END -->
-
-### REQ/REP latency (TCP loopback)
-
-Serial ping-pong: 1000 warmup + 10000 measured iterations per cell. Lower is better;
-ratio = pyzmq / pyomq.
-
-<!-- LATENCY_PERF:START -->
-| Size    | pyomq p50 | pyzmq p50 | ratio     | pyomq p99 | pyzmq p99 | ratio     |
-|---------|----------:|----------:|----------:|----------:|----------:|----------:|
-| 8 B     |   64.0 µs |   69.6 µs |     1.09× |   81.6 µs |   88.8 µs |     1.09× |
-| 16 B    |   63.7 µs |   70.2 µs | **1.10×** |   85.2 µs |   91.9 µs |     1.08× |
-| 32 B    |   63.5 µs |   69.9 µs | **1.10×** |   80.5 µs |    104 µs | **1.30×** |
-| 64 B    |   62.5 µs |   71.5 µs | **1.14×** |   94.1 µs |   92.1 µs |     0.98× |
-| 128 B   |   60.1 µs |   72.8 µs | **1.21×** |   88.0 µs |   88.9 µs |     1.01× |
-| 256 B   |   62.9 µs |   72.9 µs | **1.16×** |   81.8 µs |   89.9 µs |     1.10× |
-| 512 B   |   65.2 µs |   71.4 µs |     1.10× |   85.6 µs |   89.1 µs |     1.04× |
-| 1 KiB   |   67.1 µs |   73.0 µs |     1.09× |   83.4 µs |   90.1 µs |     1.08× |
-| 2 KiB   |   68.4 µs |   73.7 µs |     1.08× |   88.3 µs |   90.2 µs |     1.02× |
-| 4 KiB   |   67.9 µs |   75.1 µs | **1.11×** |   86.4 µs |   92.4 µs |     1.07× |
-| 8 KiB   |   70.2 µs |   91.0 µs | **1.30×** |   90.5 µs |    122 µs | **1.35×** |
-| 16 KiB  |   75.0 µs |   95.2 µs | **1.27×** |   94.8 µs |    110 µs | **1.16×** |
-| 32 KiB  |   80.5 µs |    106 µs | **1.32×** |    102 µs |    123 µs | **1.21×** |
-| 64 KiB  |    111 µs |    116 µs |     1.05× |    132 µs |    140 µs |     1.06× |
-<!-- LATENCY_PERF:END -->
+2-process loopback throughput and latency vs pyzmq, measured on Linux 6.12
+(Debian 13), Intel i7-8700B 3.2 GHz, Rust 1.95.0.
 
 ### `zmq.proxy()` forwarding (128 B, TCP)
 
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |   886 k/s |   501 k/s | **1.77×** |
-| REQ/REP rt/s       |  11,576/s |   6,259/s | **1.85×** |
+| PUSH/PULL msg/s    |   903 k/s |   505 k/s | **1.79×** |
+| REQ/REP rt/s       |  11,508/s |   6,616/s | **1.74×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the compio thread —
@@ -130,7 +87,7 @@ C-level `zmq_proxy`. PUSH/PULL forwarding is throughput-bound and pyomq is ~2.5�
 faster. REQ/REP proxy is latency-bound (4 TCP hops per round-trip); pyomq is
 ~1.7× faster thanks to direct socket forwarding.
 
-Run `scripts/update_perf.py` (after `maturin develop --release`) to re-measure and update the tables above.
+Run `scripts/update_perf.py` (after `maturin develop --release`) to re-measure, regenerate the chart, and update the proxy table.
 
 ## Compression transports
 

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -1,249 +1,247 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 520" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="520" fill="white"/>
-  <text x="425.0" y="18" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — TCP loopback (higher is better)</text>
-  <line x1="90" y1="248.0" x2="760" y2="248.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="248.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">0</text>
-  <line x1="90" y1="205.4" x2="760" y2="205.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="205.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400k</text>
-  <line x1="90" y1="162.8" x2="760" y2="162.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="162.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">800k</text>
-  <line x1="90" y1="120.2" x2="760" y2="120.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="120.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.2M</text>
-  <line x1="90" y1="77.6" x2="760" y2="77.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="77.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.6M</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 600" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="600" fill="white"/>
+  <text x="425.0" y="18" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — 2-process, TCP loopback (higher is better)</text>
+  <line x1="90" y1="280.0" x2="760" y2="280.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="280.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">0</text>
+  <line x1="90" y1="218.8" x2="760" y2="218.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="218.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
+  <line x1="90" y1="157.5" x2="760" y2="157.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="157.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
+  <line x1="90" y1="96.2" x2="760" y2="96.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="96.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
   <line x1="90" y1="35.0" x2="760" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90" y1="248.0" x2="760" y2="248.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="248.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.0 MB/s</text>
-  <line x1="90" y1="205.4" x2="760" y2="205.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="205.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.0 GB/s</text>
-  <line x1="90" y1="162.8" x2="760" y2="162.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="162.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.0 GB/s</text>
-  <line x1="90" y1="120.2" x2="760" y2="120.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="120.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.0 GB/s</text>
-  <line x1="90" y1="77.6" x2="760" y2="77.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="77.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.0 GB/s</text>
+  <line x1="90" y1="280.0" x2="760" y2="280.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="280.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.0 MB/s</text>
+  <line x1="90" y1="231.0" x2="760" y2="231.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="231.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.0 GB/s</text>
+  <line x1="90" y1="182.0" x2="760" y2="182.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="182.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.0 GB/s</text>
+  <line x1="90" y1="133.0" x2="760" y2="133.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="133.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.0 GB/s</text>
+  <line x1="90" y1="84.0" x2="760" y2="84.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="84.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.0 GB/s</text>
   <line x1="90" y1="35.0" x2="760" y2="35.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="35.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5.0 GB/s</text>
-  <line x1="90.0" y1="35" x2="90.0" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="141.5" y1="35" x2="141.5" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="193.1" y1="35" x2="193.1" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="244.6" y1="35" x2="244.6" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="296.2" y1="35" x2="296.2" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="347.7" y1="35" x2="347.7" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="399.2" y1="35" x2="399.2" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="450.8" y1="35" x2="450.8" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="502.3" y1="35" x2="502.3" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="553.8" y1="35" x2="553.8" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="605.4" y1="35" x2="605.4" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="656.9" y1="35" x2="656.9" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="708.5" y1="35" x2="708.5" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="35" x2="760.0" y2="248" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="90" y1="35" x2="90" y2="248" stroke="#9ca3af" stroke-width="1.5"/>
-  <line x1="760" y1="35" x2="760" y2="248" stroke="#9ca3af" stroke-width="1.5"/>
-  <line x1="90" y1="248" x2="760" y2="248" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="142" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,142)">msg/s</text>
-  <text x="835" y="142" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,835,142)">throughput</text>
-  <polyline points="90.0,91.0 141.5,90.2 193.1,93.7 244.6,92.6 296.2,94.4 347.7,95.2 399.2,104.5 450.8,112.0 502.3,151.7 553.8,184.5 605.4,211.8 656.9,229.9 708.5,236.6 760.0,242.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,143.1 141.5,143.7 193.1,142.2 244.6,148.2 296.2,150.0 347.7,154.4 399.2,158.3 450.8,171.0 502.3,184.5 553.8,202.1 605.4,216.5 656.9,230.3 708.5,236.5 760.0,242.2" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,188.0 141.5,191.6 193.1,190.1 244.6,193.6 296.2,198.1 347.7,197.8 399.2,199.2 450.8,200.1 502.3,211.4 553.8,226.8 605.4,236.7 656.9,242.0 708.5,243.0 760.0,244.1" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,240.5 141.5,240.6 193.1,240.6 244.6,240.5 296.2,240.7 347.7,240.6 399.2,240.7 450.8,240.8 502.3,240.9 553.8,241.1 605.4,241.4 656.9,241.8 708.5,242.2 760.0,242.8" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,247.5 141.5,247.0 193.1,246.0 244.6,244.0 296.2,240.1 347.7,232.3 399.2,218.6 450.8,192.3 502.3,169.1 553.8,143.9 605.4,129.3 656.9,129.5 708.5,98.4 760.0,100.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="247.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="247.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="246.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="244.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="240.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="232.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="218.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="192.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="169.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="143.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="129.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="129.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="98.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="100.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,247.7 141.5,247.3 193.1,246.6 244.6,245.4 296.2,243.0 347.7,238.4 399.2,229.6 450.8,216.5 502.3,196.0 553.8,172.8 605.4,144.8 656.9,132.3 708.5,97.0 760.0,96.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="247.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="247.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="246.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="245.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="243.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="238.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="229.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="216.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="196.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="172.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="144.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="132.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="97.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="96.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,247.8 141.5,247.6 193.1,247.3 244.6,246.6 296.2,245.4 347.7,242.9 399.2,238.0 450.8,228.4 502.3,218.0 553.8,213.3 605.4,211.1 656.9,208.6 708.5,182.8 760.0,145.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="247.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="247.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="247.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="246.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="245.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="242.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="238.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="228.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="218.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="213.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="211.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="208.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="182.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="145.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,248.0 141.5,248.0 193.1,247.9 244.6,247.8 296.2,247.6 347.7,247.2 399.2,246.5 450.8,245.1 502.3,242.2 553.8,236.7 605.4,226.3 656.9,207.6 708.5,171.6 760.0,110.8" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="248.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="248.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="247.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="247.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="247.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="247.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="246.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="245.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="242.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="236.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="226.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="207.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="171.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="110.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="262" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="141.5" y="262" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="193.1" y="262" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="244.6" y="262" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="296.2" y="262" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="347.7" y="262" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="399.2" y="262" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="450.8" y="262" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="502.3" y="262" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="553.8" y="262" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="605.4" y="262" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="656.9" y="262" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="708.5" y="262" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <text x="760.0" y="262" text-anchor="middle" fill="#374151" font-size="8.5">64 KiB</text>
-  <text x="425.0" y="288" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency — TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90.0" y1="35" x2="90.0" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="141.5" y1="35" x2="141.5" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="193.1" y1="35" x2="193.1" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="244.6" y1="35" x2="244.6" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="296.2" y1="35" x2="296.2" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="347.7" y1="35" x2="347.7" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="399.2" y1="35" x2="399.2" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="450.8" y1="35" x2="450.8" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="502.3" y1="35" x2="502.3" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="553.8" y1="35" x2="553.8" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="605.4" y1="35" x2="605.4" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="656.9" y1="35" x2="656.9" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="708.5" y1="35" x2="708.5" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="35" x2="760.0" y2="280" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="35" x2="90" y2="280" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="760" y1="35" x2="760" y2="280" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="280" x2="760" y2="280" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="158" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,158)">msg/s</text>
+  <text x="835" y="158" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,835,158)">throughput</text>
+  <polyline points="90.0,98.7 141.5,100.5 193.1,98.8 244.6,105.2 296.2,103.1 347.7,105.6 399.2,113.0 450.8,135.2 502.3,166.6 553.8,207.3 605.4,237.3 656.9,258.7 708.5,266.6 760.0,273.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,158.4 141.5,158.4 193.1,162.8 244.6,163.7 296.2,169.0 347.7,170.3 399.2,175.1 450.8,190.7 502.3,207.1 553.8,224.6 605.4,243.4 656.9,259.7 708.5,266.7 760.0,273.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,211.9 141.5,212.2 193.1,212.9 244.6,217.6 296.2,220.3 347.7,221.2 399.2,223.6 450.8,224.9 502.3,235.9 553.8,254.7 605.4,266.7 656.9,273.0 708.5,274.4 760.0,275.4" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,273.5 141.5,273.7 193.1,273.5 244.6,273.5 296.2,273.6 347.7,273.8 399.2,273.7 450.8,273.8 502.3,274.0 553.8,273.9 605.4,274.4 656.9,275.1 708.5,275.6 760.0,276.7" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,279.4 141.5,278.9 193.1,277.7 244.6,275.5 296.2,270.9 347.7,262.1 399.2,245.8 450.8,220.7 502.3,187.1 553.8,160.9 605.4,139.9 656.9,140.3 708.5,104.4 760.0,102.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="279.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="278.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="277.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="275.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="270.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="262.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="245.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="220.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="187.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="160.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="139.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="140.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="104.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="102.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,279.6 141.5,279.2 193.1,278.5 244.6,277.0 296.2,274.3 347.7,268.8 399.2,258.5 450.8,243.4 502.3,220.3 553.8,189.3 605.4,160.2 656.9,146.7 708.5,105.7 760.0,97.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="279.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="279.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="278.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="277.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="274.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="268.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="258.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="243.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="220.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="189.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="160.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="146.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="105.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="97.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,279.8 141.5,279.6 193.1,279.1 244.6,278.4 296.2,276.9 347.7,274.0 399.2,268.5 450.8,257.4 502.3,243.9 553.8,238.6 605.4,236.5 656.9,234.4 708.5,206.0 760.0,158.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="279.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="279.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="279.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="278.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="276.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="274.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="268.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="257.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="243.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="238.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="236.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="234.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="206.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="158.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,280.0 141.5,280.0 193.1,279.9 244.6,279.8 296.2,279.7 347.7,279.4 399.2,278.7 450.8,277.5 502.3,275.1 553.8,270.1 605.4,261.8 656.9,248.0 708.5,221.9 760.0,193.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="280.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="280.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="279.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="279.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="279.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="279.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="278.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="277.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="275.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="270.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="261.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="248.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="221.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="193.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="294" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
+  <text x="141.5" y="294" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="193.1" y="294" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="244.6" y="294" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="296.2" y="294" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="347.7" y="294" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="399.2" y="294" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="450.8" y="294" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="502.3" y="294" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="553.8" y="294" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="605.4" y="294" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="656.9" y="294" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="708.5" y="294" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <text x="760.0" y="294" text-anchor="middle" fill="#374151" font-size="8.5">64 KiB</text>
+  <text x="425.0" y="320" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency — 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90" y1="502.0" x2="760" y2="502.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="502.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
+  <line x1="90" y1="484.0" x2="760" y2="484.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="484.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
+  <line x1="90" y1="466.0" x2="760" y2="466.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="466.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
   <line x1="90" y1="448.0" x2="760" y2="448.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="448.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
-  <line x1="90" y1="432.0" x2="760" y2="432.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="432.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
-  <line x1="90" y1="416.0" x2="760" y2="416.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="416.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
-  <line x1="90" y1="400.0" x2="760" y2="400.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="400.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
-  <line x1="90" y1="384.0" x2="760" y2="384.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="384.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
-  <line x1="90" y1="368.0" x2="760" y2="368.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="368.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
-  <line x1="90" y1="352.0" x2="760" y2="352.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="352.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 µs</text>
-  <line x1="90" y1="336.0" x2="760" y2="336.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="336.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 µs</text>
-  <line x1="90" y1="320.0" x2="760" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="320.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 µs</text>
-  <line x1="90" y1="304.0" x2="760" y2="304.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="304.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 µs</text>
-  <line x1="90.0" y1="304" x2="90.0" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="141.5" y1="304" x2="141.5" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="193.1" y1="304" x2="193.1" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="244.6" y1="304" x2="244.6" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="296.2" y1="304" x2="296.2" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="347.7" y1="304" x2="347.7" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="399.2" y1="304" x2="399.2" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="450.8" y1="304" x2="450.8" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="502.3" y1="304" x2="502.3" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="553.8" y1="304" x2="553.8" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="605.4" y1="304" x2="605.4" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="656.9" y1="304" x2="656.9" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="708.5" y1="304" x2="708.5" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="304" x2="760.0" y2="464" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="90" y1="304" x2="90" y2="464" stroke="#9ca3af" stroke-width="1.5"/>
-  <line x1="90" y1="464" x2="760" y2="464" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="384" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,384)">p50 latency (µs)</text>
-  <polyline points="90.0,412.8 141.5,413.0 193.1,413.2 244.6,414.0 296.2,415.9 347.7,413.7 399.2,411.8 450.8,410.3 502.3,409.3 553.8,409.7 605.4,407.8 656.9,404.0 708.5,399.6 760.0,375.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="412.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="413.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="413.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="414.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="415.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="413.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="411.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="410.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="409.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="409.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="407.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="404.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="399.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="375.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,394.6 141.5,393.5 193.1,394.3 244.6,395.4 296.2,394.6 347.7,396.0 399.2,392.7 450.8,396.1 502.3,393.3 553.8,394.1 605.4,389.3 656.9,388.2 708.5,381.2 760.0,359.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="394.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="393.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="394.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="395.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="394.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="396.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="392.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="396.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="393.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="394.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="389.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="388.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="381.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="359.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,408.3 141.5,407.9 193.1,408.1 244.6,406.8 296.2,405.7 347.7,405.7 399.2,406.9 450.8,405.6 502.3,405.0 553.8,403.9 605.4,391.2 656.9,387.9 708.5,379.3 760.0,371.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="408.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="407.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="408.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="406.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="405.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="405.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="406.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="405.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="405.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="403.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="391.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="387.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="379.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="371.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,369.4 141.5,368.8 193.1,368.7 244.6,371.7 296.2,367.4 347.7,370.7 399.2,366.6 450.8,371.2 502.3,370.8 553.8,372.5 605.4,338.5 656.9,335.7 708.5,328.4 760.0,317.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="369.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="141.5" cy="368.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="193.1" cy="368.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="244.6" cy="371.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="296.2" cy="367.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="347.7" cy="370.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="399.2" cy="366.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="450.8" cy="371.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="502.3" cy="370.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="553.8" cy="372.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="605.4" cy="338.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="656.9" cy="335.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="708.5" cy="328.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="317.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="478" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="141.5" y="478" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="193.1" y="478" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="244.6" y="478" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="296.2" y="478" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="347.7" y="478" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="399.2" y="478" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="450.8" y="478" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="502.3" y="478" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="553.8" y="478" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="605.4" y="478" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="656.9" y="478" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="708.5" y="478" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <text x="760.0" y="478" text-anchor="middle" fill="#374151" font-size="8.5">64 KiB</text>
-  <line x1="145" y1="504" x2="159" y2="504" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="152" cy="504" r="2.5" fill="#dc2626"/>
-  <text x="165" y="508" fill="#374151" font-size="11" font-weight="500">pyomq</text>
-  <line x1="285" y1="504" x2="299" y2="504" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="292" cy="504" r="2.5" fill="#f97316"/>
-  <text x="305" y="508" fill="#374151" font-size="11" font-weight="500">pyomq async</text>
-  <line x1="425" y1="504" x2="439" y2="504" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="432" cy="504" r="2.5" fill="#2563eb"/>
-  <text x="445" y="508" fill="#374151" font-size="11" font-weight="500">pyzmq</text>
-  <line x1="565" y1="504" x2="579" y2="504" stroke="#8b5cf6" stroke-width="2.5"/>
-  <circle cx="572" cy="504" r="2.5" fill="#8b5cf6"/>
-  <text x="585" y="508" fill="#374151" font-size="11" font-weight="500">pyzmq async</text>
+  <text x="82" y="448.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
+  <line x1="90" y1="430.0" x2="760" y2="430.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="430.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
+  <line x1="90" y1="412.0" x2="760" y2="412.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="412.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
+  <line x1="90" y1="394.0" x2="760" y2="394.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="394.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 µs</text>
+  <line x1="90" y1="376.0" x2="760" y2="376.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="376.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 µs</text>
+  <line x1="90" y1="358.0" x2="760" y2="358.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="358.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 µs</text>
+  <line x1="90" y1="340.0" x2="760" y2="340.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="340.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 µs</text>
+  <line x1="90.0" y1="340" x2="90.0" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="141.5" y1="340" x2="141.5" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="193.1" y1="340" x2="193.1" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="244.6" y1="340" x2="244.6" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="296.2" y1="340" x2="296.2" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="347.7" y1="340" x2="347.7" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="399.2" y1="340" x2="399.2" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="450.8" y1="340" x2="450.8" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="502.3" y1="340" x2="502.3" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="553.8" y1="340" x2="553.8" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="605.4" y1="340" x2="605.4" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="656.9" y1="340" x2="656.9" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="708.5" y1="340" x2="708.5" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="340" x2="760.0" y2="520" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="340" x2="90" y2="520" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="520" x2="760" y2="520" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="430" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,430)">p50 latency (µs)</text>
+  <polyline points="90.0,463.7 141.5,464.4 193.1,465.8 244.6,464.1 296.2,463.7 347.7,465.1 399.2,467.3 450.8,461.2 502.3,462.4 553.8,462.3 605.4,457.0 656.9,453.3 708.5,446.2 760.0,419.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="463.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="464.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="465.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="464.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="463.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="465.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="467.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="461.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="462.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="462.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="457.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="453.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="446.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="419.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,445.1 141.5,442.3 193.1,441.8 244.6,444.4 296.2,442.9 347.7,443.3 399.2,442.8 450.8,438.8 502.3,440.3 553.8,440.6 605.4,438.0 656.9,434.6 708.5,430.3 760.0,403.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="445.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="442.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="441.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="444.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="442.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="443.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="442.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="438.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="440.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="440.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="438.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="434.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="430.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="403.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,458.8 141.5,456.7 193.1,457.2 244.6,456.3 296.2,456.4 347.7,456.9 399.2,456.1 450.8,455.6 502.3,454.4 553.8,454.0 605.4,438.9 656.9,434.1 708.5,427.2 760.0,415.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="458.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="456.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="457.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="456.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="456.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="456.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="456.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="455.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="454.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="454.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="438.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="434.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="427.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="415.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,413.8 141.5,412.2 193.1,414.5 244.6,414.3 296.2,417.6 347.7,415.7 399.2,413.6 450.8,410.5 502.3,409.9 553.8,410.1 605.4,379.8 656.9,377.0 708.5,372.4 760.0,350.1" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="413.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="141.5" cy="412.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="193.1" cy="414.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="244.6" cy="414.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="296.2" cy="417.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="347.7" cy="415.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="399.2" cy="413.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="450.8" cy="410.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="502.3" cy="409.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="553.8" cy="410.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="605.4" cy="379.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="656.9" cy="377.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="708.5" cy="372.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="350.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="534" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
+  <text x="141.5" y="534" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="193.1" y="534" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="244.6" y="534" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="296.2" y="534" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="347.7" y="534" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="399.2" y="534" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="450.8" y="534" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="502.3" y="534" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="553.8" y="534" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="605.4" y="534" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="656.9" y="534" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="708.5" y="534" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <text x="760.0" y="534" text-anchor="middle" fill="#374151" font-size="8.5">64 KiB</text>
+  <line x1="145" y1="560" x2="159" y2="560" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="152" cy="560" r="2.5" fill="#dc2626"/>
+  <text x="165" y="564" fill="#374151" font-size="11" font-weight="500">pyomq</text>
+  <line x1="285" y1="560" x2="299" y2="560" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="292" cy="560" r="2.5" fill="#f97316"/>
+  <text x="305" y="564" fill="#374151" font-size="11" font-weight="500">pyomq async</text>
+  <line x1="425" y1="560" x2="439" y2="560" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="432" cy="560" r="2.5" fill="#2563eb"/>
+  <text x="445" y="564" fill="#374151" font-size="11" font-weight="500">pyzmq</text>
+  <line x1="565" y1="560" x2="579" y2="560" stroke="#8b5cf6" stroke-width="2.5"/>
+  <circle cx="572" cy="560" r="2.5" fill="#8b5cf6"/>
+  <text x="585" y="564" fill="#374151" font-size="11" font-weight="500">pyzmq async</text>
 </svg>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -750,13 +750,13 @@ def _fmt_mbps(val):
 
 def gen_combined_chart(sync_tp, async_tp, sync_lat, async_lat, path):
     n = len(SIZES)
-    svg_w, svg_h = 850, 520
+    svg_w, svg_h = 850, 600
     x_left, x_right = 90, 760
     plot_w = x_right - x_left
 
-    t1_top, t1_bot = 35, 248
+    t1_top, t1_bot = 35, 280
     t1_h = t1_bot - t1_top
-    t2_top, t2_bot = 304, 464
+    t2_top, t2_bot = 340, 520
     t2_h = t2_bot - t2_top
 
     xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
@@ -805,7 +805,7 @@ def gen_combined_chart(sync_tp, async_tp, sync_lat, async_lat, path):
         f'PUSH/PULL throughput — 2-process, TCP loopback (higher is better)</text>'
     )
 
-    n_l_ticks = 5
+    n_l_ticks = 4
     for i in range(n_l_ticks + 1):
         val = i * msg_max / n_l_ticks
         yy = y_msg(val)
@@ -901,7 +901,7 @@ def gen_combined_chart(sync_tp, async_tp, sync_lat, async_lat, path):
     # ── BOTTOM PANEL: LATENCY ─────────────────────────────────────
 
     L.append(
-        f'  <text x="{mid_x}" y="288" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 20}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
         f'REQ/REP latency — 2-process, TCP loopback, p50 µs (lower is better)</text>'
     )
@@ -1135,8 +1135,6 @@ def main():
     with open(README) as f:
         content = f.read()
 
-    content = update_marker(content, "PERF", tp_table)
-    content = update_marker(content, "LATENCY_PERF", lat_table)
     content = update_marker(content, "PROXY_PERF", proxy_table)
 
     with open(README, "w") as f:


### PR DESCRIPTION
- Add "2-process" to both chart titles (throughput + latency)
- Fix msg/s y-axis ticks to 500k, 1M, 1.5M, 2M (was 400k-based steps)
- Increase chart height from 520px to 600px for better readability
- Remove throughput and latency tables from README — chart covers them
- Stop writing PERF/LATENCY_PERF markers in `update_perf.py`
- Regenerate chart with fresh benchmark data