### PR TITLE
chore: code smell cleanup from Rust patterns audit

### DIFF
--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -267,6 +267,7 @@ impl Overlay {
                 ReconnectPolicy::Fixed(d) => Some(d),
                 ReconnectPolicy::Exponential { min, .. } => Some(min),
                 ReconnectPolicy::Disabled => None,
+                _ => unreachable!(),
             },
             reconnect_ivl_max: match o.reconnect {
                 ReconnectPolicy::Exponential { max, .. } => Some(max),
@@ -631,6 +632,7 @@ pub fn getsockopt<'py>(
                 KeepAlive::Default => -1,
                 KeepAlive::Disabled => 0,
                 KeepAlive::Enabled { .. } => 1,
+                _ => unreachable!(),
             };
             Ok(int_to_bound(py, v))
         }
@@ -798,6 +800,7 @@ pub fn getsockopt<'py>(
                 OnMute::Block => 0,
                 OnMute::DropNewest => 1,
                 OnMute::DropOldest => 2,
+                _ => unreachable!(),
             };
             Ok(int_to_bound(py, v))
         }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -309,6 +309,9 @@ fn monitor_event_to_dict(py: Python<'_>, ev: &MonitorEvent) -> PyResult<PyObject
         MonitorEvent::Closed => {
             d.set_item("event", "closed")?;
         }
+        _ => {
+            d.set_item("event", "unknown")?;
+        }
     }
     Ok(d.into())
 }

--- a/omq-compio/benches/push_pull.rs
+++ b/omq-compio/benches/push_pull.rs
@@ -284,6 +284,7 @@ async fn wait_connected_with_monitors(socks: &[&Socket], monitors: &mut [Monitor
                         MonitorEvent::Disconnected { .. } => "disconnected",
                         MonitorEvent::Closed => "closed",
                         MonitorEvent::PeerCommand { .. } => "peer_command",
+                        _ => "unknown",
                     };
                     *counts.entry(k).or_default() += 1;
                 }

--- a/omq-compio/src/monitor.rs
+++ b/omq-compio/src/monitor.rs
@@ -47,7 +47,7 @@ impl MonitorPublisher {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn publish(&self, event: MonitorEvent) {
         let mut sinks = self.sinks.lock().expect("monitor sinks");
         sinks.retain(|sink| !sink.tx.is_disconnected());

--- a/omq-compio/src/socket/bind.rs
+++ b/omq-compio/src/socket/bind.rs
@@ -39,7 +39,6 @@ impl Socket {
         if endpoint.is_ws_family() {
             return self.bind_ws(endpoint).await;
         }
-        #[allow(unreachable_patterns, clippy::match_wildcard_for_single_variants)]
         match endpoint {
             Endpoint::Inproc { name } => self.bind_inproc(name).await,
             Endpoint::Ipc(_) => self.bind_ipc(endpoint).await,
@@ -50,7 +49,7 @@ impl Socket {
         }
     }
 
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     async fn bind_inproc(&self, name: String) -> Result<Endpoint> {
         let snapshot = self.inner().snapshot();
         let listener = inproc::bind(

--- a/omq-compio/src/socket/connect.rs
+++ b/omq-compio/src/socket/connect.rs
@@ -43,7 +43,7 @@ impl Socket {
         self.connect_inner(endpoint, opts.priority.get()).await
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     async fn connect_inner(
         &self,
         endpoint: Endpoint,
@@ -124,7 +124,6 @@ impl Socket {
             .detach();
             return Ok(());
         }
-        #[allow(unreachable_patterns, clippy::match_wildcard_for_single_variants)]
         match endpoint {
             Endpoint::Inproc { name } => {
                 let snapshot = self.inner().snapshot();
@@ -144,7 +143,7 @@ impl Socket {
                 } else {
                     let inner = self.inner().clone();
                     #[cfg(feature = "priority")]
-                    #[allow(clippy::redundant_locals)]
+                    #[expect(clippy::redundant_locals)]
                     let priority = priority;
                     compio::runtime::spawn(async move {
                         let Ok(conn) =

--- a/omq-compio/src/socket/dial.rs
+++ b/omq-compio/src/socket/dial.rs
@@ -85,7 +85,7 @@ fn reset_peer_channel(
     (cmd_tx, cmd_rx)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn install_and_run(
     inner: &Arc<SocketInner>,
     state: std::sync::Arc<DirectIoState>,
@@ -167,7 +167,7 @@ async fn install_and_run(
 /// Spawn the TCP dial supervisor and register the dialer entry.
 /// Returns immediately. See [`super::Socket::connect`] for the
 /// public-facing semantics.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub(super) fn connect_tcp_with_reconnect(
     inner: &Arc<SocketInner>,
     endpoint: Endpoint,
@@ -185,9 +185,8 @@ pub(super) fn connect_tcp_with_reconnect(
     // that races a send before the dialer installs a real sender
     // hits the buffered slot then errors. In practice send()
     // blocks on on_peer_ready until the peer slot lands.
-    #[allow(clippy::arc_with_non_send_sync)]
     let handle: WirePeerHandle = Arc::new(RwLock::new(flume::bounded::<DriverCommand>(1).0));
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[expect(clippy::arc_with_non_send_sync)]
     let direct_io_handle: DirectIoHandle = Arc::new(RwLock::new(None));
     let dialer_endpoint = wrapper.clone();
 
@@ -216,7 +215,7 @@ pub(super) fn connect_tcp_with_reconnect(
         });
 }
 
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[expect(clippy::too_many_arguments)]
 async fn dial_supervisor_tcp(
     inner: Arc<SocketInner>,
     wrapper: Endpoint,
@@ -346,9 +345,8 @@ pub(super) fn connect_ipc_with_reconnect(
     let info_holder: Arc<RwLock<Option<PeerInfo>>> = Arc::new(RwLock::new(None));
     let peer_sub = pub_side_peer_sub(inner.socket_type);
     let peer_groups = radio_side_peer_groups(inner.socket_type);
-    #[allow(clippy::arc_with_non_send_sync)]
     let handle: WirePeerHandle = Arc::new(RwLock::new(flume::bounded::<DriverCommand>(1).0));
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[expect(clippy::arc_with_non_send_sync)]
     let direct_io_handle: DirectIoHandle = Arc::new(RwLock::new(None));
     let dialer_endpoint = endpoint.clone();
 
@@ -376,7 +374,7 @@ pub(super) fn connect_ipc_with_reconnect(
         });
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn dial_supervisor_ipc(
     inner: Arc<SocketInner>,
     endpoint: Endpoint,

--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -14,7 +14,7 @@ use crate::transport::peer_io::{CancellableRecvStream, PeerIo, SharedPeerIo, Wir
 use super::encoded_queue::EncodedQueue;
 use super::inner::{LocalStream, RecvStreamState};
 
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct DirectIoState {
     pub(crate) peer_io: SharedPeerIo,
     pub(crate) writer: async_lock::Mutex<WireWriter>,
@@ -229,7 +229,7 @@ impl DirectIoState {
         self.peer_io.lock().expect("peer_io")
     }
 
-    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+    #[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     pub(crate) fn new(
         peer_io: SharedPeerIo,
         writer: WireWriter,
@@ -246,7 +246,7 @@ impl DirectIoState {
             Some(s) => Some(RecvStreamState::MultiShot(s)),
             None => Some(RecvStreamState::OneShot),
         };
-        #[allow(clippy::arc_with_non_send_sync)]
+        #[expect(clippy::arc_with_non_send_sync)]
         Arc::new(Self {
             peer_io,
             writer: async_lock::Mutex::new(writer),

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -111,7 +111,7 @@ impl Socket {
     }
 
     /// Remove a previously-established bind.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn unbind(&self, endpoint: Endpoint) -> Result<()> {
         let mut listeners = self.inner.listeners.write().expect("listeners lock");
         let before = listeners.len();
@@ -124,7 +124,7 @@ impl Socket {
     }
 
     /// Remove a previously-started connect.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn disconnect(&self, endpoint: Endpoint) -> Result<()> {
         let mut dialers = self.inner.dialers.write().expect("dialers lock");
         let mut udp = self.inner.udp_dialers.write().expect("udp_dialers lock");
@@ -139,7 +139,7 @@ impl Socket {
     }
 
     /// Snapshot the live status of one connected peer by `connection_id`.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn connection_info(
         &self,
         connection_id: u64,
@@ -163,7 +163,7 @@ impl Socket {
     }
 
     /// Snapshot every currently-connected peer.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn connections(&self) -> Result<Vec<crate::monitor::ConnectionStatus>> {
         let peers = self.inner.out_peers.read().expect("peers lock");
         Ok(peers
@@ -212,7 +212,7 @@ impl Socket {
             .subscriptions
             .write()
             .expect("subscriptions lock")
-            .add(prefix.clone());
+            .add(&prefix);
         {
             let mut subs = self.inner.our_subs.write().expect("our_subs lock");
             if !subs.iter().any(|p| p == &prefix) {

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -38,7 +38,7 @@ impl RecvCache {
     /// Borrow the inner deque mutably. Caller must be on the owning
     /// runtime thread (always true in compio's cooperative model).
     #[inline]
-    #[allow(clippy::mut_from_ref)]
+    #[expect(clippy::mut_from_ref)]
     pub(super) fn get(&self) -> &mut VecDeque<Message> {
         unsafe { &mut *self.0.get() }
     }
@@ -122,7 +122,7 @@ impl LocalStream {
     /// `ENOBUFS` under sustained delivery on a small `BUF_RING` pool.
     /// The previous stream's lingering op is cancelled when its slot
     /// drops.
-    #[allow(clippy::await_holding_lock)]
+    #[expect(clippy::await_holding_lock)]
     pub(crate) async fn rearm(&self, peer_io: &SharedPeerIo) -> std::io::Result<()> {
         let io = peer_io.lock().expect("peer_io");
         if !io.reader.supports_multishot() {
@@ -384,7 +384,7 @@ impl SocketInner {
         } else {
             options.identity.clone()
         };
-        #[allow(clippy::arc_with_non_send_sync)] // compio is single-threaded by design
+        #[expect(clippy::arc_with_non_send_sync)] // compio is single-threaded by design
         Arc::new(Self {
             socket_type,
             inproc_identity,

--- a/omq-compio/src/socket/install.rs
+++ b/omq-compio/src/socket/install.rs
@@ -59,7 +59,7 @@ pub(super) fn install_inproc_peer(
     // SubscriptionSet, so nothing is over-delivered.
     let peer_sub = if matches!(inner.socket_type, SocketType::Pub | SocketType::XPub) {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::new());
+        s.add(b"");
         Some(Arc::new(RwLock::new(s)))
     } else {
         None
@@ -135,7 +135,6 @@ pub(super) fn install_inproc_peer(
     inner.monitor.handshake_succeeded(endpoint, info);
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) fn install_accepted_wire_peer(
     inner: &Arc<SocketInner>,
     reader: WireReader,
@@ -328,7 +327,7 @@ pub(super) fn install_ws_peer(
             );
         }
         WsTransport::Tls(tls) => {
-            #[allow(clippy::arc_with_non_send_sync)]
+            #[expect(clippy::arc_with_non_send_sync)]
             let shared: crate::transport::ws::SharedTls =
                 std::sync::Arc::new(async_lock::Mutex::new(*tls));
             install_accepted_wire_peer_with_leftover(
@@ -380,9 +379,8 @@ fn transport_crypto_config(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_lines)]
-#[cfg_attr(not(feature = "ws"), allow(clippy::needless_pass_by_value))]
+#[expect(clippy::too_many_arguments)]
+#[cfg_attr(not(feature = "ws"), expect(clippy::needless_pass_by_value))]
 fn install_accepted_wire_peer_with_leftover(
     inner: &Arc<SocketInner>,
     reader: WireReader,
@@ -391,7 +389,7 @@ fn install_accepted_wire_peer_with_leftover(
     endpoint: Endpoint,
     connection_id: u64,
     peer_addr: Option<std::net::SocketAddr>,
-    #[cfg_attr(not(feature = "ws"), allow(unused_variables))] leftover: Option<bytes::Bytes>,
+    #[cfg_attr(not(feature = "ws"), expect(unused_variables))] leftover: Option<bytes::Bytes>,
 ) {
     let cap = cmd_channel_capacity(&inner.options);
     let (cmd_tx, cmd_rx) = flume::bounded::<DriverCommand>(cap);
@@ -451,7 +449,7 @@ fn install_accepted_wire_peer_with_leftover(
         #[cfg(feature = "ws")]
         ws_masked,
     );
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[expect(clippy::arc_with_non_send_sync)]
     let direct_io_handle: DirectIoHandle = Arc::new(RwLock::new(Some(state.clone())));
     let slot_idx = inner.insert_peer_slot(
         PeerSlot {

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -486,7 +486,7 @@ impl Socket {
         handle.read().expect("direct_io handle lock").clone()
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn drain_and_swap(
         &self,
         io: &mut PeerIo,

--- a/omq-compio/src/transport/dispatch.rs
+++ b/omq-compio/src/transport/dispatch.rs
@@ -48,7 +48,7 @@ async fn handle_sub_cmd(
     {
         let mut s = set.write().expect("peer_sub lock");
         match cmd {
-            Command::Subscribe(_) => s.add(prefix.clone()),
+            Command::Subscribe(_) => s.add(&prefix),
             Command::Cancel(_) => s.remove(&prefix),
             _ => {}
         }

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -70,7 +70,7 @@ async fn maybe_sleep_until(deadline: Option<Instant>) {
     }
 }
 
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct DriverLoopState {
     closing: bool,
     deadline: Option<Instant>,
@@ -159,7 +159,7 @@ pub(crate) fn build_peer_io(
     } else {
         None
     };
-    #[cfg_attr(not(feature = "ws"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "ws"), expect(unused_mut))]
     let mut codec = make_codec(
         role,
         socket_type,
@@ -175,7 +175,7 @@ pub(crate) fn build_peer_io(
         let _ = codec.handle_input(leftover);
         let _ = wr; // suppress unused
     }
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[expect(clippy::arc_with_non_send_sync)]
     let peer_io = Arc::new(std::sync::Mutex::new(PeerIo {
         codec,
         decoder,
@@ -404,7 +404,7 @@ impl DriverLoopState {
 /// fastest absorbs more work (work-stealing). `None` for
 /// per-peer-routing socket types (PUB / XPUB / RADIO / ROUTER /
 /// XSUB).
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[expect(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) async fn run_connection(
     state: Arc<DirectIoState>,
     socket_type: SocketType,

--- a/omq-compio/src/transport/recv_stream.rs
+++ b/omq-compio/src/transport/recv_stream.rs
@@ -30,7 +30,7 @@ impl From<crate::socket::OneShotLargeRecvOutcome> for StreamArmOutcome {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(super) async fn pull_stream(
     state: &Arc<DirectIoState>,
     peer_io: &SharedPeerIo,

--- a/omq-compio/src/transport/tcp.rs
+++ b/omq-compio/src/transport/tcp.rs
@@ -25,6 +25,7 @@ fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
         Host::Wildcard => Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => resolve_name(name, port),
+        _ => unreachable!(),
     }
 }
 
@@ -35,6 +36,7 @@ fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
         )),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => resolve_name(name, port),
+        _ => unreachable!(),
     }
 }
 

--- a/omq-compio/src/transport/udp.rs
+++ b/omq-compio/src/transport/udp.rs
@@ -67,6 +67,7 @@ pub async fn bind(endpoint: &Endpoint) -> Result<UdpSocket> {
                 "udp bind requires an IP literal or *, not a hostname".into(),
             ));
         }
+        _ => unreachable!(),
     };
     let sock = UdpSocket::bind(SocketAddr::new(ip, port))
         .await
@@ -111,5 +112,6 @@ fn host_to_lookup(host: &Host, port: u16) -> Result<SocketAddr> {
                 .next()
                 .ok_or_else(|| Error::InvalidEndpoint(format!("udp: no address for {name}")))
         }
+        _ => unreachable!(),
     }
 }

--- a/omq-compio/src/transport/ws.rs
+++ b/omq-compio/src/transport/ws.rs
@@ -15,7 +15,7 @@ use omq_proto::options::MechanismConfig;
 use omq_proto::proto::ws_handshake;
 
 fn mechanism_subprotocol(
-    #[cfg_attr(not(feature = "plain"), allow(unused_variables))] mechanism: &MechanismConfig,
+    #[cfg_attr(not(feature = "plain"), expect(unused_variables))] mechanism: &MechanismConfig,
 ) -> &'static str {
     #[cfg(feature = "plain")]
     match mechanism {
@@ -37,6 +37,7 @@ fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
         Host::Wildcard => Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => super::tcp::resolve_name(name, port),
+        _ => unreachable!(),
     }
 }
 
@@ -47,6 +48,7 @@ fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
         )),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => super::tcp::resolve_name(name, port),
+        _ => unreachable!(),
     }
 }
 
@@ -55,7 +57,7 @@ fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
 pub(crate) type TlsStream = compio_tls::TlsStream<TcpStream>;
 pub(crate) type SharedTls = std::sync::Arc<async_lock::Mutex<TlsStream>>;
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn build_tls_connector(accept_invalid_certs: bool) -> Result<compio_tls::TlsConnector> {
     use std::sync::Arc;
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -244,7 +246,6 @@ fn extract_leftover(http: &HttpRead) -> bytes::Bytes {
     }
 }
 
-#[allow(clippy::result_large_err)]
 pub(crate) async fn accept(
     stream: TcpStream,
     tls_acceptor: Option<&compio_tls::TlsAcceptor>,
@@ -325,6 +326,7 @@ pub(crate) async fn connect(
                 return connect_tls_ip(&connector, stream, ip, port, path, subprotocol).await;
             }
             Host::Wildcard => "localhost",
+            _ => unreachable!(),
         };
         let mut tls = connector.connect(domain, stream).await.map_err(Error::Io)?;
         let host_header = format!("{host}:{port}");

--- a/omq-compio/src/transport/ws_driver.rs
+++ b/omq-compio/src/transport/ws_driver.rs
@@ -120,7 +120,7 @@ impl WsLoopState {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) async fn run_ws_connection(
     mut ws: WsStream,
     role: Role,

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -16,7 +16,7 @@ type Job = Box<dyn FnOnce() + Send + 'static>;
 pub(crate) struct IoThread {
     submit: flume::Sender<Job>,
     // Keep the JoinHandle so the thread is joined when the context drops.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     handle: Option<thread::JoinHandle<()>>,
 }
 
@@ -65,7 +65,7 @@ fn build_compio_runtime() -> std::io::Result<compio::runtime::Runtime> {
 }
 
 impl OmqContext {
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[expect(clippy::arc_with_non_send_sync)]
     fn new(n_io_threads: usize) -> Arc<Self> {
         let n = n_io_threads.max(1);
         let terminated = Arc::new(AtomicBool::new(false));
@@ -222,7 +222,7 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
         ZMQ_MAX_MSGSZ => {
             ctx.max_msg_size.store(i64::from(value), Ordering::Relaxed);
         }
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         ZMQ_SOCKET_LIMIT | ZMQ_IPV6_CTX => {}
         _ => return crate::error::fail(libc::EINVAL),
     }

--- a/omq-libzmq/src/lib.rs
+++ b/omq-libzmq/src/lib.rs
@@ -1,5 +1,5 @@
 //! omq-libzmq -- libzmq-compatible C interface backed by omq-compio.
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![expect(clippy::not_unsafe_ptr_arg_deref)]
 
 mod context;
 pub mod curve;

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, c_int};
 use bytes::Bytes;
 
 // kind discriminants
-#[allow(dead_code)]
+#[expect(dead_code)]
 const KIND_EMPTY: u8 = 0;
 const KIND_HEAP: u8 = 1;
 const KIND_EXTERNAL: u8 = 2;
@@ -165,7 +165,7 @@ pub extern "C" fn zmq_msg_close(msg: *mut OmqMsgRepr) -> c_int {
         return crate::error::fail(libc::EFAULT);
     }
     let r = unsafe { repr(msg) };
-    #[allow(clippy::collapsible_match)]
+    #[expect(clippy::collapsible_match)]
     match r.kind {
         KIND_HEAP => {
             if !r.ptr.is_null() {
@@ -458,7 +458,7 @@ pub extern "C" fn zmq_msg_recv(
             r.hint = std::ptr::null_mut();
             r.boxed = Box::into_raw(boxed).cast::<libc::c_void>();
             r.reserved = [0; 16];
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             {
                 sz as c_int
             }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -1,5 +1,5 @@
 //! Socket options overlay and `zmq_setsockopt` / `zmq_getsockopt`.
-#![allow(clippy::cast_possible_wrap)]
+#![expect(clippy::cast_possible_wrap)]
 
 use std::ffi::c_int;
 use std::time::Duration;
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use omq_compio::options::{KeepAlive, MechanismConfig, ReconnectPolicy};
 
 #[derive(Clone, Debug, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct SocketOverlay {
     pub send_hwm: Option<u32>,
     pub recv_hwm: Option<u32>,
@@ -207,7 +207,7 @@ const ZMQ_NULL: c_int = 0;
 const ZMQ_PLAIN: c_int = 1;
 const ZMQ_CURVE: c_int = 2;
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_setsockopt(
     sock: *mut libc::c_void,
@@ -455,7 +455,7 @@ pub extern "C" fn zmq_setsockopt(
             sock_arc.overlay.lock().unwrap().ipv6 = read_i32(optval, optvallen) != 0;
         }
         // Always-on in omq; accept silently.
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         ZMQ_ROUTER_HANDOVER => {}
         ZMQ_BACKLOG => {
             sock_arc.overlay.lock().unwrap().backlog = read_i32(optval, optvallen);
@@ -478,7 +478,7 @@ pub extern "C" fn zmq_setsockopt(
         ZMQ_XPUB_NODROP => {
             sock_arc.overlay.lock().unwrap().xpub_nodrop = read_i32(optval, optvallen) != 0;
         }
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         ZMQ_AFFINITY
         | ZMQ_RATE
         | ZMQ_RECOVERY_IVL
@@ -536,7 +536,7 @@ fn do_subscribe(
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_getsockopt(
     sock: *mut libc::c_void,
@@ -605,7 +605,6 @@ pub extern "C" fn zmq_getsockopt(
         }
         ZMQ_TYPE => {
             use omq_compio::SocketType;
-            #[allow(clippy::wildcard_in_or_patterns)]
             let v: i32 = match sock_arc.socket_type {
                 SocketType::Pair => 0,
                 SocketType::Pub => 1,
@@ -627,6 +626,7 @@ pub extern "C" fn zmq_getsockopt(
                 SocketType::Peer => 19,
                 SocketType::Channel => 20,
                 SocketType::Stream => 11,
+                _ => unreachable!(),
             };
             write_i32(optval, optvallen, v)
         }

--- a/omq-libzmq/src/proxy.rs
+++ b/omq-libzmq/src/proxy.rs
@@ -12,8 +12,7 @@ const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_RCVMORE: i32 = 13;
 const ZMQ_DONTWAIT: i32 = 1;
 
-#[allow(clippy::large_stack_arrays)]
-#[allow(clippy::borrow_as_ptr, clippy::ref_as_ptr)]
+#[expect(clippy::large_stack_arrays)]
 fn forward(from: *mut c_void, to: *mut c_void, capture: *mut c_void) -> libc::c_int {
     let mut buf = [0u8; 65536];
     loop {
@@ -40,7 +39,7 @@ fn forward(from: *mut c_void, to: *mut c_void, capture: *mut c_void) -> libc::c_
     0
 }
 
-#[allow(clippy::borrow_as_ptr, clippy::ref_as_ptr)]
+#[expect(clippy::borrow_as_ptr)]
 fn getsockopt_rcvmore(sock: *mut c_void) -> bool {
     let mut v: i32 = 0;
     let mut sz = std::mem::size_of::<i32>();

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -1,5 +1,5 @@
 //! `zmq_send` / `zmq_recv` entry points.
-#![allow(clippy::cast_possible_wrap)]
+#![expect(clippy::cast_possible_wrap)]
 
 use std::ffi::c_int;
 use std::sync::Arc;

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -124,7 +124,7 @@ impl NotifyFd {
 }
 
 // socket_type read in Phase 3 (ZMQ_TYPE getsockopt).
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug)]
 pub(crate) struct OmqSocket {
     pub id: u64,
@@ -294,7 +294,6 @@ fn register_inproc_bind(sock: &Arc<OmqSocket>, name: &str) {
 }
 
 /// Register an inproc connect. If the binder exists, install bypass.
-#[allow(clippy::collapsible_if)]
 fn register_inproc_connect(sock: &Arc<OmqSocket>, name: &str) {
     let ctx = &sock.ctx;
     let binder = ctx
@@ -324,7 +323,7 @@ fn register_inproc_connect(sock: &Arc<OmqSocket>, name: &str) {
 }
 
 #[unsafe(no_mangle)]
-#[allow(clippy::arc_with_non_send_sync)]
+#[expect(clippy::arc_with_non_send_sync)]
 pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_void {
     if ctx_ptr.is_null() {
         set_errno(libc::EFAULT);
@@ -713,7 +712,6 @@ pub extern "C" fn zmq_socket_monitor(
             use omq_compio::monitor::MonitorEvent;
 
             while let Ok(ev) = stream.recv().await {
-                #[allow(clippy::match_wildcard_for_single_variants)]
                 let (event_id, value, endpoint): (u16, i32, String) = match &ev {
                     MonitorEvent::Listening { endpoint } => (0x0008, 0, endpoint.to_string()),
                     MonitorEvent::Accepted { endpoint, .. } => (0x0020, 0, endpoint.to_string()),

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -17,6 +17,7 @@ use crate::error::{Error, Result};
 /// The scheme picks the transport; the rest of the string carries transport-
 /// specific addressing.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Endpoint {
     /// `tcp://host:port` (IPv4, IPv6, or DNS name).
     Tcp { host: Host, port: u16 },
@@ -52,6 +53,7 @@ pub enum Endpoint {
 /// Kept as a distinct variant so resolution can be deferred until bind/connect
 /// time without forcing callers to reparse.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Host {
     Ip(IpAddr),
     Name(String),
@@ -61,6 +63,7 @@ pub enum Host {
 
 /// IPC path, possibly in the Linux abstract namespace (leading `@`).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IpcPath {
     Filesystem(PathBuf),
     /// Linux abstract namespace (no filesystem entry).
@@ -69,6 +72,7 @@ pub enum IpcPath {
 
 /// Role for an endpoint in a single-string spec: bind, connect, or default.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EndpointRole {
     /// `@endpoint` -- explicit bind.
     Bind,

--- a/omq-proto/src/monitor.rs
+++ b/omq-proto/src/monitor.rs
@@ -20,6 +20,7 @@ use crate::proto::PeerProperties;
 /// monitor events and by identity-routed strategies that want to
 /// distinguish peers before the ZMTP handshake completes.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PeerIdent {
     Socket(SocketAddr),
     Path(String),
@@ -38,6 +39,7 @@ impl fmt::Display for PeerIdent {
 
 /// A connection-lifecycle event emitted by a socket.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum MonitorEvent {
     /// Bind succeeded and the listener is active.
     Listening { endpoint: Endpoint },
@@ -88,6 +90,7 @@ pub enum MonitorEvent {
 
 /// The peer-sent commands surfaced via [`MonitorEvent::PeerCommand`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum PeerCommandKind {
     /// The peer sent ZMTP `ERROR { reason }`.
     Error { reason: String },
@@ -112,6 +115,7 @@ pub struct ConnectionStatus {
 
 /// Why a connection was closed.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DisconnectReason {
     /// Peer closed the TCP/IPC/inproc stream.
     PeerClosed,
@@ -141,6 +145,7 @@ pub struct PeerInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum MonitorRecvError {
     #[error("socket closed")]
     Closed,
@@ -149,6 +154,7 @@ pub enum MonitorRecvError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum MonitorTryRecvError {
     #[error("no events ready")]
     Empty,

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -154,6 +154,7 @@ pub struct WssTls {
 /// available behind the opt-in `curve` feature; BLAKE3ZMQ behind
 /// the opt-in `blake3zmq` feature.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub enum MechanismConfig {
     /// NULL: no encryption, no peer authentication.
     #[default]
@@ -706,6 +707,7 @@ impl From<Bytes> for Options {
 
 /// Reconnection policy applied after a lost connection on `connect()` sockets.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ReconnectPolicy {
     /// No reconnect; the connection is dropped permanently on failure.
     Disabled,
@@ -726,6 +728,7 @@ impl Default for ReconnectPolicy {
 
 /// What to do when the send HWM is reached and a new message arrives.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OnMute {
     /// Block the sender until room is available.
     #[default]
@@ -740,6 +743,7 @@ pub enum OnMute {
 /// libzmq's `ZMQ_TCP_KEEPALIVE = -1`); `Disabled` clears `SO_KEEPALIVE`;
 /// `Enabled` sets `SO_KEEPALIVE` and pins the three timing knobs.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum KeepAlive {
     /// OS defaults; nothing applied to the socket.
     #[default]

--- a/omq-proto/src/proto/command.rs
+++ b/omq-proto/src/proto/command.rs
@@ -31,6 +31,7 @@ pub const PING_CONTEXT_MAX: usize = 16;
 
 /// A parsed ZMTP command.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Command {
     /// Handshake completion, carries peer properties.
     Ready(PeerProperties),
@@ -57,6 +58,7 @@ pub enum Command {
 
 /// One kind per [`Command`] variant, useful for telemetry and dispatch logic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CommandKind {
     Ready,
     Subscribe,
@@ -179,7 +181,7 @@ pub fn encode(cmd: &Command, out: &mut BytesMut) {
 }
 
 /// Parse a command from the payload bytes of a COMMAND-flagged frame.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn decode(body: Bytes) -> Result<Command> {
     if body.is_empty() {
         return Err(Error::Protocol("empty command frame".into()));
@@ -296,7 +298,7 @@ pub(crate) fn decode_properties_inner(mut body: Bytes) -> Result<PeerProperties>
     Ok(props)
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn decode_ping(body: Bytes) -> Result<Command> {
     if body.len() < 2 {
         return Err(Error::Protocol("PING body missing TTL".into()));
@@ -312,7 +314,7 @@ fn decode_ping(body: Bytes) -> Result<Command> {
     })
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn decode_error(body: Bytes) -> Result<Command> {
     if body.is_empty() {
         return Err(Error::Protocol("ERROR body missing reason length".into()));
@@ -331,7 +333,7 @@ fn decode_error(body: Bytes) -> Result<Command> {
 mod tests {
     use super::*;
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn roundtrip(cmd: Command) -> Command {
         let mut buf = BytesMut::new();
         encode(&cmd, &mut buf);

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -40,7 +40,7 @@ use super::frame;
 /// without applying name-dispatched body parsing. Used during the mechanism
 /// handshake where opaque CURVE READY / INITIATE bodies must reach the
 /// mechanism untouched.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn decode_command_raw(body: bytes::Bytes) -> Result<Command> {
     if body.is_empty() {
         return Err(Error::Protocol("empty command frame".into()));

--- a/omq-proto/src/proto/mechanism/blake3zmq/handshake.rs
+++ b/omq-proto/src/proto/mechanism/blake3zmq/handshake.rs
@@ -86,7 +86,7 @@ impl std::fmt::Debug for SessionKeys {
 }
 
 /// Server-side handshake state machine.
-#[allow(missing_debug_implementations, reason = "fields hold secret material")]
+#[expect(missing_debug_implementations, reason = "fields hold secret material")]
 pub struct Server {
     permanent: Keypair,
     /// Shared cookie keyring with periodic rotation per RFC §9.2.
@@ -398,7 +398,7 @@ impl Server {
 }
 
 /// Client-side handshake state machine.
-#[allow(missing_debug_implementations, reason = "fields hold secret material")]
+#[expect(missing_debug_implementations, reason = "fields hold secret material")]
 pub struct Client {
     permanent: Keypair,
     server_public: X25519Public,

--- a/omq-proto/src/proto/mechanism/blake3zmq/mod.rs
+++ b/omq-proto/src/proto/mechanism/blake3zmq/mod.rs
@@ -117,7 +117,7 @@ enum HandshakeState {
 }
 
 impl Blake3ZmqMechanism {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn new_server(
         keypair: Blake3ZmqKeypair,
         cookie_keyring: Arc<CookieKeyring>,
@@ -136,7 +136,7 @@ impl Blake3ZmqMechanism {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn new_client(keypair: Blake3ZmqKeypair, server_public: Blake3ZmqPublicKey) -> Self {
         Self {
             is_client: true,
@@ -151,7 +151,7 @@ impl Blake3ZmqMechanism {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn start(
         &mut self,
         out: &mut Vec<Command>,
@@ -186,7 +186,7 @@ impl Blake3ZmqMechanism {
         Ok(())
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn on_command(
         &mut self,
         cmd: Command,

--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -44,7 +44,7 @@ fn nonce_short(prefix: &[u8; 16], counter: u64) -> [u8; 24] {
 }
 
 /// Construct a 24-byte nonce as `prefix(8) || suffix(16)`.
-#[allow(clippy::trivially_copy_pass_by_ref)]
+#[expect(clippy::trivially_copy_pass_by_ref)]
 fn nonce_long(prefix: &[u8; 8], suffix: &[u8; 16]) -> [u8; 24] {
     let mut n = [0u8; 24];
     n[..8].copy_from_slice(prefix);
@@ -174,12 +174,10 @@ pub(crate) enum CurveMechanism {
 }
 
 impl CurveMechanism {
-    #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn new_client(our_keypair: CurveKeypair, server_public: CurvePublicKey) -> Self {
         Self::Client(CurveClient::new(our_keypair, server_public))
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn new_server(
         our_keypair: CurveKeypair,
         cookie_keyring: Arc<CurveCookieKeyring>,
@@ -267,7 +265,7 @@ impl std::fmt::Debug for CurveClientState {
 }
 
 impl CurveClient {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn new(our_keypair: CurveKeypair, server_public: CurvePublicKey) -> Self {
         let our_lt_secret = SecretKey::from_bytes(*our_keypair.secret.as_bytes());
         let our_lt_public = PublicKey::from_bytes(*our_keypair.public.as_bytes());
@@ -564,8 +562,6 @@ enum CurveServerState {
     Done {
         our_eph_secret: SecretKey,
         peer_eph_public: PublicKey,
-        #[allow(dead_code)]
-        peer_lt_public: PublicKey,
     },
 }
 
@@ -580,7 +576,7 @@ impl std::fmt::Debug for CurveServerState {
 }
 
 impl CurveServer {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn new(
         our_keypair: CurveKeypair,
         cookie_keyring: Arc<CurveCookieKeyring>,
@@ -776,7 +772,6 @@ impl CurveServer {
         self.state = CurveServerState::Done {
             our_eph_secret: sn_secret,
             peer_eph_public: cp,
-            peer_lt_public: cl,
         };
         Ok(props)
     }

--- a/omq-proto/src/proto/mechanism/curve_cookie.rs
+++ b/omq-proto/src/proto/mechanism/curve_cookie.rs
@@ -18,7 +18,7 @@ use crate::error::{Error, Result};
 const NONCE_COOKIE_PREFIX: &[u8; 8] = b"COOKIE--";
 const DEFAULT_ROTATION_INTERVAL: Duration = Duration::from_secs(30);
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
+#[expect(clippy::trivially_copy_pass_by_ref)]
 fn nonce_long(prefix: &[u8; 8], suffix: &[u8; 16]) -> [u8; 24] {
     let mut n = [0u8; 24];
     n[..8].copy_from_slice(prefix);

--- a/omq-proto/src/proto/mechanism/mod.rs
+++ b/omq-proto/src/proto/mechanism/mod.rs
@@ -311,7 +311,7 @@ impl SecurityMechanism {
     /// data-phase AEAD that operates on raw frame payloads;
     /// CURVE produces a per-part MESSAGE-command transform.
     #[cfg(any(feature = "curve", feature = "blake3zmq"))]
-    #[cfg_attr(not(feature = "curve"), allow(clippy::unnecessary_wraps))]
+    #[cfg_attr(not(feature = "curve"), expect(clippy::unnecessary_wraps))]
     pub(crate) fn build_transform(&self) -> Result<Option<FrameTransform>> {
         match self {
             Self::Null(_) => Ok(None),

--- a/omq-proto/src/proto/mod.rs
+++ b/omq-proto/src/proto/mod.rs
@@ -38,6 +38,7 @@ pub use greeting::{Greeting, MechanismName, VERSION_SNIFF_LEN, ZMTP_MAJOR, ZMTP_
 ///
 /// The value carries the wire-level ASCII name returned by [`Self::as_str`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum SocketType {
     // Standard
     Req,

--- a/omq-proto/src/proto/transform/lz4.rs
+++ b/omq-proto/src/proto/transform/lz4.rs
@@ -54,7 +54,6 @@ pub const MAX_DICT_BYTES: usize = 8192;
 
 // Dict-aware bindings missing from `lz4-sys` 1.11. The symbols live in
 // the `liblz4` static lib that `lz4-sys` already links (`links = "lz4"`).
-#[allow(non_snake_case)]
 unsafe extern "C" {
     fn LZ4_loadDict(
         stream: *mut lz4_sys::LZ4StreamEncode,
@@ -163,8 +162,16 @@ impl Lz4Encoder {
 
     /// Override the multi-block threshold. Parts larger than this use
     /// LZ4M encoding. Both peers must agree on this value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` exceeds `i32::MAX` (lz4 API limit).
     #[must_use]
     pub fn with_block_size(mut self, size: usize) -> Self {
+        assert!(
+            i32::try_from(size).is_ok(),
+            "LZ4 block size {size} exceeds i32::MAX"
+        );
         self.block_size = size;
         self
     }
@@ -196,7 +203,7 @@ impl Lz4Encoder {
         Ok(out)
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     fn encode_part(&mut self, part: &Payload) -> Result<Payload> {
         let plain = part.as_bytes();
         let threshold = if self.send_dict.is_some() {
@@ -241,7 +248,7 @@ impl Lz4Encoder {
         )))
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     fn encode_part_multiblock(&mut self, plain: &[u8]) -> Result<Payload> {
         let total = plain.len();
         let block_size = self.block_size;
@@ -308,8 +315,16 @@ impl Lz4Decoder {
     }
 
     /// Override the multi-block threshold. Must match the encoder's value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` exceeds `i32::MAX` (lz4 API limit).
     #[must_use]
     pub fn with_block_size(mut self, size: usize) -> Self {
+        assert!(
+            i32::try_from(size).is_ok(),
+            "LZ4 block size {size} exceeds i32::MAX"
+        );
         self.block_size = size;
         self
     }
@@ -384,7 +399,7 @@ fn ensure_stream(stream: &mut *mut lz4_sys::LZ4StreamEncode) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_wrap)]
 fn compress_block(
     stream: *mut lz4_sys::LZ4StreamEncode,
     dict: Option<&Bytes>,
@@ -416,7 +431,7 @@ fn compress_block(
     Ok(n as usize)
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_wrap)]
 fn decode_lz4b(
     body: &[u8],
     dict: Option<&Bytes>,
@@ -473,7 +488,7 @@ fn decode_lz4b(
     Ok(Payload::from_bytes(Bytes::from(out)))
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_wrap)]
 fn decode_lz4m(
     body: &[u8],
     dict: Option<&Bytes>,
@@ -558,7 +573,7 @@ fn decode_lz4m(
 mod tests {
     use super::*;
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn rt(msg: Message) -> Message {
         let mut enc = Lz4Encoder::new();
         let mut dec = Lz4Decoder::new();

--- a/omq-proto/src/proto/ws_codec.rs
+++ b/omq-proto/src/proto/ws_codec.rs
@@ -21,6 +21,7 @@ const LEN_MASK: u8 = 0x7F;
 
 /// Which side of the WebSocket connection this codec represents.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum WsRole {
     Client,
     Server,

--- a/omq-proto/src/proto/ws_handshake.rs
+++ b/omq-proto/src/proto/ws_handshake.rs
@@ -195,7 +195,7 @@ pub fn parse_server_upgrade(response: &[u8], expected_key: &str) -> Result<Strin
 
 // --- Inline SHA-1 (RFC 3174) ---
 
-#[allow(clippy::many_single_char_names, clippy::unreadable_literal)]
+#[expect(clippy::many_single_char_names, clippy::unreadable_literal)]
 fn sha1(data: &[u8]) -> [u8; 20] {
     let mut h: [u32; 5] = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
 

--- a/omq-proto/src/socket_api.rs
+++ b/omq-proto/src/socket_api.rs
@@ -4,7 +4,7 @@ use crate::message::Message;
 use crate::options::Options;
 use crate::proto::SocketType;
 
-#[allow(async_fn_in_trait)]
+#[expect(async_fn_in_trait)]
 pub trait SocketApi: Clone {
     fn new(socket_type: SocketType, options: Options) -> Self;
     fn socket_type(&self) -> SocketType;

--- a/omq-proto/src/subscription.rs
+++ b/omq-proto/src/subscription.rs
@@ -6,7 +6,6 @@
 //! as an explicit flag - it would otherwise be an awkward special
 //! case for `get_longest_common_prefix` against an empty stored key.
 
-use bytes::Bytes;
 use patricia_tree::PatriciaSet;
 
 #[derive(Debug, Default, Clone)]
@@ -22,12 +21,11 @@ impl SubscriptionSet {
     }
 
     /// Add a subscription. Empty prefix is recorded as `subscribe_all`.
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn add(&mut self, prefix: Bytes) {
+    pub fn add(&mut self, prefix: &[u8]) {
         if prefix.is_empty() {
             self.subscribe_all = true;
         } else {
-            self.set.insert(&prefix[..]);
+            self.set.insert(prefix);
         }
     }
 
@@ -63,7 +61,7 @@ mod tests {
     #[test]
     fn subscribe_all_matches_everything() {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::new());
+        s.add(b"");
         assert!(s.matches(b""));
         assert!(s.matches(b"anything"));
         assert!(s.matches(b"\xff\xff"));
@@ -72,7 +70,7 @@ mod tests {
     #[test]
     fn prefix_match() {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::from_static(b"news."));
+        s.add(b"news.");
         assert!(s.matches(b"news.sports"));
         assert!(s.matches(b"news."));
         assert!(!s.matches(b"weather"));
@@ -82,8 +80,8 @@ mod tests {
     #[test]
     fn multiple_prefixes() {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::from_static(b"a"));
-        s.add(Bytes::from_static(b"b"));
+        s.add(b"a");
+        s.add(b"b");
         assert!(s.matches(b"apple"));
         assert!(s.matches(b"banana"));
         assert!(!s.matches(b"cherry"));
@@ -92,7 +90,7 @@ mod tests {
     #[test]
     fn remove_clears_prefix() {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::from_static(b"x"));
+        s.add(b"x");
         assert!(s.matches(b"x"));
         s.remove(b"x");
         assert!(!s.matches(b"x"));
@@ -101,8 +99,8 @@ mod tests {
     #[test]
     fn remove_empty_clears_subscribe_all() {
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::new());
-        s.add(Bytes::from_static(b"x"));
+        s.add(b"");
+        s.add(b"x");
         s.remove(b"");
         assert!(!s.matches(b"y"));
         assert!(s.matches(b"x"));
@@ -114,8 +112,8 @@ mod tests {
         // "foo*" topics match. Add the longer one first to make sure
         // the trie shape doesn't trip the match.
         let mut s = SubscriptionSet::new();
-        s.add(Bytes::from_static(b"foobar"));
-        s.add(Bytes::from_static(b"foo"));
+        s.add(b"foobar");
+        s.add(b"foo");
         assert!(s.matches(b"foo"));
         assert!(s.matches(b"foobar"));
         assert!(s.matches(b"foobaz"));
@@ -132,7 +130,8 @@ mod tests {
         // do anything pathological.
         let mut s = SubscriptionSet::new();
         for i in 0..1000u32 {
-            s.add(Bytes::from(format!("topic-{i:04}-")));
+            let topic = format!("topic-{i:04}-");
+            s.add(topic.as_bytes());
         }
         assert!(s.matches(b"topic-0042-payload"));
         assert!(s.matches(b"topic-0999-x"));

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -107,7 +107,6 @@ pub struct DriverHandle {
 /// per-connection shim task that wrapped Events into the
 /// `SocketDriver`'s `InternalEvent::PeerEvent` / `PeerClosed`.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum PeerOut {
     Event(Event),
     Closed,
@@ -246,7 +245,7 @@ where
         result
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     async fn run_inner(self) -> Result<()> {
         let Self {
             stream,
@@ -477,7 +476,7 @@ async fn sleep_until_opt(deadline: Option<Instant>) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn drain_on_cancel<W: AsyncWrite + Unpin>(
     inbox: &mut mpsc::Receiver<DriverCommand>,
     shared_msg_rx: Option<&QueueReceiver>,
@@ -567,6 +566,7 @@ fn encode_msg(
         match codec.ws_role() {
             Some(omq_proto::proto::connection::WsRole::Server) => eq.encode_ws(msg),
             Some(omq_proto::proto::connection::WsRole::Client) => eq.encode_ws_masked(msg),
+            Some(_) => unreachable!(),
             None => unreachable!(),
         }
         return;
@@ -697,7 +697,7 @@ mod tests {
     /// is the simplest way to test it without involving the inproc
     /// transport (which since the inproc fast-path landed bypasses
     /// the codec entirely).
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     async fn inproc_pair(_name: &str) -> (DriverHandle, EventAdapter, DriverHandle, EventAdapter) {
         let (server_stream, client_stream) = tokio::io::duplex(64 * 1024);
 

--- a/omq-tokio/src/routing/drop_queue.rs
+++ b/omq-tokio/src/routing/drop_queue.rs
@@ -117,6 +117,7 @@ impl DropQueue {
                     }
                 }
             }
+            _ => unreachable!(),
         }
     }
 

--- a/omq-tokio/src/routing/fair_queue.rs
+++ b/omq-tokio/src/routing/fair_queue.rs
@@ -21,10 +21,10 @@ impl FairQueueRecv {
         Self { recv_tx }
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn connection_added(&mut self, _peer_id: u64) {}
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn connection_removed(&mut self, _peer_id: u64) {}
 
     pub(crate) async fn deliver(&self, _peer_id: u64, msg: Message) -> Result<()> {

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -192,10 +192,11 @@ impl FanOutSend {
     }
 
     /// Record a SUBSCRIBE command from the given peer.
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn peer_subscribe(&self, peer_id: u64, prefix: Bytes) {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if let Some(p) = g.peers.get_mut(&peer_id) {
-            p.subscriptions.add(prefix);
+            p.subscriptions.add(&prefix);
         }
     }
 

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -199,7 +199,6 @@ impl IdentityRecv {
     /// Produce the identity-prefixed message without sending it. Used when
     /// the socket type applies a post-recv transform (REP) before
     /// delivery.
-    #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn wrap(&self, peer_id: u64, msg: Message) -> Message {
         let identity = {
             let g = self.peers.lock().expect("identity recv poisoned");

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -258,7 +258,7 @@ impl RecvStrategy {
     /// sees the full envelope; for `FairQueue`, returns the message
     /// unchanged. Used when the `type_state` needs to post-process (REQ,
     /// REP) rather than hitting the recv channel directly.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub(crate) async fn wrap_for_transform(&self, peer_id: u64, msg: Message) -> Option<Message> {
         match self {
             Self::None => None,

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -115,7 +115,7 @@ impl RoundRobinSend {
         // Byte-stream: driver reads from shared_rx directly; no pump needed.
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn connection_removed(&mut self, _peer_id: u64) {
         // Byte-stream drivers self-cancel via their CancellationToken.
         // Inproc pumps self-cancel when peer inbox closes (driver exits).
@@ -274,7 +274,7 @@ impl RoundRobinSend {
         }
     }
 
-    #[allow(dead_code)] // kept for parity with the non-priority impl's API
+    #[expect(dead_code)] // kept for parity with the non-priority impl's API
     pub(crate) fn connection_added(&mut self, peer_id: u64, handle: DriverHandle) {
         self.connection_added_with_priority(peer_id, handle, omq_proto::DEFAULT_PRIORITY);
     }
@@ -327,7 +327,7 @@ impl RoundRobinSend {
     /// been dispatched"; once we've handed each `SendMessage` off to
     /// an inbox via `try_send/send`, it's the connection driver's job
     /// to flush, not ours.
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn is_drained(&self) -> bool {
         true
     }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -219,7 +219,7 @@ pub(crate) struct SocketDriver {
 }
 
 impl SocketDriver {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         socket_type: SocketType,
         options: Options,
@@ -442,7 +442,7 @@ impl SocketDriver {
         }
     }
 
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     async fn teardown(&mut self) {
         self.send_strategy.shutdown();
         for p in self.peers.values() {

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -734,7 +734,7 @@ struct InprocDriverCtx {
 /// exchange), then forwards Messages and Commands between the
 /// `SocketDriver`'s inbox and the partner's channels until either
 /// side drops.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn inproc_peer_driver(
     mut inbox: mpsc::Receiver<crate::engine::DriverCommand>,
     mut in_rx: mpsc::Receiver<InprocFrame>,
@@ -754,7 +754,7 @@ async fn inproc_peer_driver(
         spsc,
     } = ctx;
 
-    #[allow(clippy::items_after_statements)]
+    #[expect(clippy::items_after_statements)]
     async fn emit_event(
         peer_out: &mpsc::Sender<(u64, crate::engine::PeerOut)>,
         peer_id: u64,

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -24,7 +24,6 @@ use crate::transport::{
 /// Byte-stream dispatch across TCP-shaped transports (TCP, IPC, WS).
 /// Inproc does NOT go through this - it skips the ZMTP codec entirely
 /// and uses its own Message-typed channel pair (see `AnyConn`).
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum AnyStream {
     Tcp(TcpStream),
@@ -104,7 +103,6 @@ impl AsyncWrite for AnyStream {
 /// (TCP / IPC - runs the ZMTP codec via `ConnectionDriver`) or a
 /// pre-paired Message channel (inproc - runs the codec-less
 /// `InprocPeerDriver`).
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum AnyConn {
     ByteStream {
         stream: AnyStream,
@@ -136,14 +134,6 @@ impl AnyConn {
     pub(crate) fn peer_ident(&self) -> &PeerIdent {
         match self {
             Self::ByteStream { peer_ident, .. } | Self::Inproc { peer_ident, .. } => peer_ident,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn leftover(&self) -> bytes::Bytes {
-        match self {
-            Self::ByteStream { leftover, .. } => leftover.clone(),
-            Self::Inproc { .. } => bytes::Bytes::new(),
         }
     }
 }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -62,7 +62,7 @@ impl SpscAwareRecv {
         None
     }
 
-    #[allow(clippy::needless_continue)]
+    #[expect(clippy::needless_continue)]
     async fn recv(&self) -> Result<Message> {
         loop {
             if let Some(msg) = self.try_drain_consumers() {

--- a/omq-tokio/src/transport/ipc.rs
+++ b/omq-tokio/src/transport/ipc.rs
@@ -52,7 +52,7 @@ impl Transport for IpcTransport {
     }
 }
 
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async)]
 async fn bind_filesystem(endpoint: &Endpoint, path: &Path) -> Result<IpcListener> {
     // Best-effort cleanup of any stale socket at this path. Ignore
     // failure: the real bind below surfaces a precise error if the

--- a/omq-tokio/src/transport/tcp.rs
+++ b/omq-tokio/src/transport/tcp.rs
@@ -84,6 +84,7 @@ async fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
         Host::Wildcard => Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => resolve_first(&format!("{name}:{port}")).await,
+        _ => unreachable!(),
     }
 }
 
@@ -94,6 +95,7 @@ async fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
         )),
         Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
         Host::Name(name) => resolve_first(&format!("{name}:{port}")).await,
+        _ => unreachable!(),
     }
 }
 

--- a/omq-tokio/src/transport/udp.rs
+++ b/omq-tokio/src/transport/udp.rs
@@ -74,6 +74,7 @@ pub async fn bind(endpoint: &Endpoint) -> Result<UdpSocket> {
                 "udp bind requires an IP literal or *, not a hostname".into(),
             ));
         }
+        _ => unreachable!(),
     };
     let sock = UdpSocket::bind(SocketAddr::new(ip, port)).await?;
     Ok(sock)
@@ -119,6 +120,7 @@ fn host_to_lookup(host: &Host, port: u16) -> Result<SocketAddr> {
                 .next()
                 .ok_or_else(|| Error::InvalidEndpoint(format!("udp: no address for {name}")))
         }
+        _ => unreachable!(),
     }
 }
 

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -78,9 +78,8 @@ impl tokio::io::AsyncWrite for WsTransport {
     }
 }
 
-#[allow(clippy::match_wildcard_for_single_variants)]
 fn mechanism_subprotocol(
-    #[cfg_attr(not(feature = "plain"), allow(unused_variables))]
+    #[cfg_attr(not(feature = "plain"), expect(unused_variables))]
     mechanism: &omq_proto::options::MechanismConfig,
 ) -> &'static str {
     #[cfg(feature = "plain")]
@@ -128,6 +127,7 @@ pub(crate) async fn bind(
             .map_err(Error::Io)?
             .next()
             .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
+        _ => unreachable!(),
     };
     let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
     let local = listener.local_addr().map_err(Error::Io)?;
@@ -145,7 +145,6 @@ pub(crate) struct WsAccepted {
     pub leftover: bytes::Bytes,
 }
 
-#[allow(clippy::result_large_err)]
 pub(crate) async fn accept(
     stream: TcpStream,
     tls_acceptor: Option<&tokio_rustls::TlsAcceptor>,
@@ -233,6 +232,7 @@ pub(crate) async fn connect(
             .map_err(Error::Io)?
             .next()
             .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
+        _ => unreachable!(),
     };
     let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
     let _ = stream.set_nodelay(true);
@@ -243,6 +243,7 @@ pub(crate) async fn connect(
             omq_proto::endpoint::Host::Name(n) => n.clone(),
             omq_proto::endpoint::Host::Ip(ip) => ip.to_string(),
             omq_proto::endpoint::Host::Wildcard => "localhost".into(),
+            _ => unreachable!(),
         };
         let domain = rustls_pki_types::ServerName::try_from(host_str).map_err(ws_err)?;
         let tls_stream = connector.connect(domain, stream).await.map_err(Error::Io)?;
@@ -295,7 +296,7 @@ pub(crate) async fn connect(
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn build_tls_connector(accept_invalid_certs: bool) -> Result<tokio_rustls::TlsConnector> {
     use std::sync::Arc;
     let _ = rustls::crypto::ring::default_provider().install_default();

--- a/omq-zeromq/src/endpoint.rs
+++ b/omq-zeromq/src/endpoint.rs
@@ -74,6 +74,7 @@ pub(crate) fn from_omq_endpoint(ep: &omq_proto::Endpoint) -> ZmqResult<Endpoint>
                         "unresolved hostname in endpoint: {name}"
                     )));
                 }
+                _ => unreachable!(),
             };
             Ok(Endpoint::Tcp(SocketAddr::new(ip, *port)))
         }
@@ -88,6 +89,7 @@ pub(crate) fn from_omq_endpoint(ep: &omq_proto::Endpoint) -> ZmqResult<Endpoint>
                         "unresolved hostname in endpoint: {name}"
                     )));
                 }
+                _ => unreachable!(),
             };
             Ok(Endpoint::Udp(SocketAddr::new(ip, *port)))
         }

--- a/omq-zeromq/src/monitor.rs
+++ b/omq-zeromq/src/monitor.rs
@@ -40,7 +40,7 @@ impl MonitorStream {
                     }
                 }
                 Err(omq_proto::MonitorRecvError::Lagged(_)) => {}
-                Err(omq_proto::MonitorRecvError::Closed) => return None,
+                Err(_) => return None,
             }
         }
     }
@@ -69,7 +69,7 @@ pub(crate) fn map_event(event: &omq_proto::monitor::MonitorEvent) -> Option<Sock
         }
         ME::Disconnected { .. } => Some(SocketEvent::Disconnected),
         ME::Closed => Some(SocketEvent::Closed),
-        ME::PeerCommand { .. } => None,
+        _ => None,
     }
 }
 


### PR DESCRIPTION
- Remove dead `CurveServerState::Done::peer_lt_public` field and `AnyConn::leftover()` method
- Validate LZ4 `block_size <= i32::MAX` at encoder/decoder construction; convert `cast_possible_wrap` allows to `#[expect]`
- Migrate ~120 `#[allow]` to `#[expect]` across the workspace; remove 19 where the lint no longer fires
- Add `#[non_exhaustive]` to 18 public enums in omq-proto; add wildcard arms in downstream crates
- Change `SubscriptionSet::add` to accept `&[u8]` instead of `Bytes` (only borrows, never owns)