### PR TITLE
fix: replace slope-based heap leak detection with post-close residual check

### DIFF
--- a/omq-compio/tests/soak_blake3zmq.rs
+++ b/omq-compio/tests/soak_blake3zmq.rs
@@ -31,93 +31,98 @@ fn soak_blake3zmq() {
     let client_kp = Blake3ZmqKeypair::generate();
     let server_pub = server_kp.public;
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let pull = Socket::new(
-            SocketType::Pull,
-            Options::default().blake3zmq_server(server_kp),
-        );
-        let mut mon = pull.monitor();
-        pull.bind(soak_common::tcp_ep(0)).await.unwrap();
-        let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        let port = match ev {
-            MonitorEvent::Listening {
-                endpoint: Endpoint::Tcp { port, .. },
-            } => port,
-            other => panic!("expected Tcp Listening, got {other:?}"),
-        };
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let pull = Socket::new(
+                SocketType::Pull,
+                Options::default().blake3zmq_server(server_kp),
+            );
+            let mut mon = pull.monitor();
+            pull.bind(soak_common::tcp_ep(0)).await.unwrap();
+            let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            let port = match ev {
+                MonitorEvent::Listening {
+                    endpoint: Endpoint::Tcp { port, .. },
+                } => port,
+                other => panic!("expected Tcp Listening, got {other:?}"),
+            };
 
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default()
-                .blake3zmq_client(client_kp, server_pub)
-                .linger(Duration::from_secs(5)),
-        );
-        push.connect(soak_common::tcp_ep(port)).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default()
+                    .blake3zmq_client(client_kp, server_pub)
+                    .linger(Duration::from_secs(5)),
+            );
+            push.connect(soak_common::tcp_ep(port)).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            while !send_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(())) =
-                    compio::time::timeout(Duration::from_secs(2), push.send(Message::single("b")))
-                        .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                while !send_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single("b")),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(_)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(_)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    let s = timer_sent.load(Ordering::Relaxed);
-                    let r = timer_recvd.load(Ordering::Relaxed);
-                    eprintln!(
-                        "[blake3zmq] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let s = timer_sent.load(Ordering::Relaxed);
+                        let r = timer_recvd.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[blake3zmq] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[blake3zmq] done: sent {s}, recvd {r} in {:.1}s",
-            duration.as_secs_f64(),
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[blake3zmq] done: sent {s}, recvd {r} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("blake3zmq");

--- a/omq-compio/tests/soak_common/mod.rs
+++ b/omq-compio/tests/soak_common/mod.rs
@@ -89,10 +89,12 @@ type Samples = (
 pub struct ResourceMonitor {
     stop: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<Samples>>,
+    heap_baseline: usize,
 }
 
 impl ResourceMonitor {
     pub fn start() -> Self {
+        let heap_baseline = alloc::LIVE_BYTES.load(std::sync::atomic::Ordering::Relaxed);
         let stop = Arc::new(AtomicBool::new(false));
         let stop2 = stop.clone();
         let handle = std::thread::spawn(move || {
@@ -115,6 +117,7 @@ impl ResourceMonitor {
         Self {
             stop,
             handle: Some(handle),
+            heap_baseline,
         }
     }
 
@@ -125,6 +128,7 @@ impl ResourceMonitor {
             rss_samples,
             fd_samples,
             heap_samples,
+            heap_baseline: self.heap_baseline,
         }
     }
 }
@@ -156,12 +160,14 @@ pub struct ResourceReport {
     pub rss_samples: Vec<(Instant, usize)>,
     pub fd_samples: Vec<(Instant, usize)>,
     pub heap_samples: Vec<(Instant, usize)>,
+    heap_baseline: usize,
 }
 
 impl ResourceReport {
     pub fn assert_no_leak(&self, label: &str) {
         self.report_rss(label);
-        self.assert_heap_stable(label);
+        self.report_heap_slope(label);
+        self.assert_heap_residual(label);
         self.assert_fd_stable(label);
     }
 
@@ -177,10 +183,9 @@ impl ResourceReport {
         );
     }
 
-    fn assert_heap_stable(&self, label: &str) {
+    fn report_heap_slope(&self, label: &str) {
         let n = self.heap_samples.len();
         if n < 10 {
-            eprintln!("[{label}] too few heap samples ({n}) to check for leaks");
             return;
         }
 
@@ -221,28 +226,43 @@ impl ResourceReport {
 
         let slope_bytes_per_sec = (n_f * dot_xy - sum_x * sum_y) / (n_f * sum_xx - sum_x * sum_x);
         let slope_kib_s = slope_bytes_per_sec / 1024.0;
-
         let avg: f64 = sum_y / n_f;
 
         eprintln!(
-            "[{label}] heap: avg {:.1} MiB, slope {slope_kib_s:.1} KiB/s",
+            "[{label}] heap: avg {:.1} MiB, slope {slope_kib_s:.1} KiB/s (informational)",
             avg / 1_048_576.0,
         );
+    }
 
-        // 50 KiB/s sustained = 30 MiB over 10 min; anything below is
-        // noise from in-flight message buffers and allocator jitter.
-        // Short runs are noisier; only enforce tight bounds with enough
-        // samples for the regression to be meaningful.
-        let threshold_kib_s = if post_warmup.len() >= 120 {
-            50.0
-        } else {
-            500.0
-        };
+    fn assert_heap_residual(&self, label: &str) {
+        std::thread::sleep(Duration::from_millis(200));
+        let current = alloc::LIVE_BYTES.load(std::sync::atomic::Ordering::Relaxed);
+        let baseline = self.heap_baseline;
+
+        let peak = self
+            .heap_samples
+            .iter()
+            .map(|(_, v)| *v)
+            .max()
+            .unwrap_or(baseline);
+        let threshold = (peak / 20).max(8 * 1024 * 1024);
+
+        let growth = current.saturating_sub(baseline);
+
+        eprintln!(
+            "[{label}] heap residual: {:.1} KiB (baseline {:.1} MiB, current {:.1} MiB)",
+            growth as f64 / 1024.0,
+            baseline as f64 / 1_048_576.0,
+            current as f64 / 1_048_576.0,
+        );
         assert!(
-            slope_kib_s < threshold_kib_s,
-            "[{label}] heap leak detected: slope {slope_kib_s:.1} KiB/s \
-             (avg {:.1} MiB over {elapsed_secs:.0}s)",
-            avg / 1_048_576.0,
+            growth < threshold,
+            "[{label}] heap leak: {:.1} KiB residual after close \
+             (baseline {:.1} MiB, current {:.1} MiB, threshold {:.1} MiB)",
+            growth as f64 / 1024.0,
+            baseline as f64 / 1_048_576.0,
+            current as f64 / 1_048_576.0,
+            threshold as f64 / 1_048_576.0,
         );
     }
 

--- a/omq-compio/tests/soak_compression.rs
+++ b/omq-compio/tests/soak_compression.rs
@@ -69,87 +69,90 @@ fn soak_compression_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = omq_compio::build_default_runtime().expect("runtime");
-    rt.block_on(async {
-        let (pull, ep) = pull_on_loopback().await;
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default().linger(Duration::from_secs(5)),
-        );
-        push.connect(ep).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+    {
+        let rt = omq_compio::build_default_runtime().expect("runtime");
+        rt.block_on(async {
+            let (pull, ep) = pull_on_loopback().await;
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default().linger(Duration::from_secs(5)),
+            );
+            push.connect(ep).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            let mut idx: u64 = 0;
-            while !send_stop.load(Ordering::Relaxed) {
-                let size = SIZES[idx as usize % SIZES.len()];
-                let payload = make_payload(idx, size);
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_secs(2),
-                    push.send(Message::single(payload)),
-                )
-                .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                let mut idx: u64 = 0;
+                while !send_stop.load(Ordering::Relaxed) {
+                    let size = SIZES[idx as usize % SIZES.len()];
+                    let payload = make_payload(idx, size);
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single(payload)),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
+                    idx += 1;
                 }
-                idx += 1;
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(m)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    let part = m.part_bytes(0).unwrap();
-                    assert!(
-                        SIZES.contains(&part.len()),
-                        "unexpected message size: {}",
-                        part.len()
-                    );
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(m)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        let part = m.part_bytes(0).unwrap();
+                        assert!(
+                            SIZES.contains(&part.len()),
+                            "unexpected message size: {}",
+                            part.len()
+                        );
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    let s = timer_sent.load(Ordering::Relaxed);
-                    let r = timer_recvd.load(Ordering::Relaxed);
-                    eprintln!(
-                        "[compression] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let s = timer_sent.load(Ordering::Relaxed);
+                        let r = timer_recvd.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[compression] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[compression] done: sent {s}, recvd {r} in {:.1}s",
-            duration.as_secs_f64(),
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[compression] done: sent {s}, recvd {r} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("compression");

--- a/omq-compio/tests/soak_compression_lz4.rs
+++ b/omq-compio/tests/soak_compression_lz4.rs
@@ -66,87 +66,90 @@ fn soak_compression_lz4_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = omq_compio::build_default_runtime().expect("runtime");
-    rt.block_on(async {
-        let (pull, ep) = pull_on_loopback().await;
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default().linger(Duration::from_secs(5)),
-        );
-        push.connect(ep).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+    {
+        let rt = omq_compio::build_default_runtime().expect("runtime");
+        rt.block_on(async {
+            let (pull, ep) = pull_on_loopback().await;
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default().linger(Duration::from_secs(5)),
+            );
+            push.connect(ep).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            let mut idx: u64 = 0;
-            while !send_stop.load(Ordering::Relaxed) {
-                let size = SIZES[idx as usize % SIZES.len()];
-                let payload = make_payload(idx, size);
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_secs(2),
-                    push.send(Message::single(payload)),
-                )
-                .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                let mut idx: u64 = 0;
+                while !send_stop.load(Ordering::Relaxed) {
+                    let size = SIZES[idx as usize % SIZES.len()];
+                    let payload = make_payload(idx, size);
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single(payload)),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
+                    idx += 1;
                 }
-                idx += 1;
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(m)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    let part = m.part_bytes(0).unwrap();
-                    assert!(
-                        SIZES.contains(&part.len()),
-                        "unexpected message size: {}",
-                        part.len()
-                    );
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(m)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        let part = m.part_bytes(0).unwrap();
+                        assert!(
+                            SIZES.contains(&part.len()),
+                            "unexpected message size: {}",
+                            part.len()
+                        );
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    let s = timer_sent.load(Ordering::Relaxed);
-                    let r = timer_recvd.load(Ordering::Relaxed);
-                    eprintln!(
-                        "[compression_lz4] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let s = timer_sent.load(Ordering::Relaxed);
+                        let r = timer_recvd.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[compression_lz4] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[compression_lz4] done: sent {s}, recvd {r} in {:.1}s",
-            duration.as_secs_f64(),
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[compression_lz4] done: sent {s}, recvd {r} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("compression_lz4");

--- a/omq-compio/tests/soak_curve.rs
+++ b/omq-compio/tests/soak_curve.rs
@@ -31,90 +31,95 @@ fn soak_curve() {
     let client_kp = CurveKeypair::generate();
     let server_pub = server_kp.public;
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let pull = Socket::new(SocketType::Pull, Options::default().curve_server(server_kp));
-        let mut mon = pull.monitor();
-        pull.bind(soak_common::tcp_ep(0)).await.unwrap();
-        let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        let port = match ev {
-            MonitorEvent::Listening {
-                endpoint: Endpoint::Tcp { port, .. },
-            } => port,
-            other => panic!("expected Tcp Listening, got {other:?}"),
-        };
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let pull = Socket::new(SocketType::Pull, Options::default().curve_server(server_kp));
+            let mut mon = pull.monitor();
+            pull.bind(soak_common::tcp_ep(0)).await.unwrap();
+            let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            let port = match ev {
+                MonitorEvent::Listening {
+                    endpoint: Endpoint::Tcp { port, .. },
+                } => port,
+                other => panic!("expected Tcp Listening, got {other:?}"),
+            };
 
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default()
-                .curve_client(client_kp, server_pub)
-                .linger(Duration::from_secs(5)),
-        );
-        push.connect(soak_common::tcp_ep(port)).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default()
+                    .curve_client(client_kp, server_pub)
+                    .linger(Duration::from_secs(5)),
+            );
+            push.connect(soak_common::tcp_ep(port)).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            while !send_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(())) =
-                    compio::time::timeout(Duration::from_secs(2), push.send(Message::single("c")))
-                        .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                while !send_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single("c")),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(_)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(_)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    let s = timer_sent.load(Ordering::Relaxed);
-                    let r = timer_recvd.load(Ordering::Relaxed);
-                    eprintln!(
-                        "[curve] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let s = timer_sent.load(Ordering::Relaxed);
+                        let r = timer_recvd.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[curve] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[curve] done: sent {s}, recvd {r} in {:.1}s",
-            duration.as_secs_f64(),
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[curve] done: sent {s}, recvd {r} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("curve");

--- a/omq-compio/tests/soak_large_throughput.rs
+++ b/omq-compio/tests/soak_large_throughput.rs
@@ -30,87 +30,90 @@ fn soak_large_message_throughput() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = build_default_runtime().expect("runtime");
-    rt.block_on(async {
-        let pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(4));
-        let ep = pull.bind(soak_common::tcp_ep(0)).await.unwrap();
+    {
+        let rt = build_default_runtime().expect("runtime");
+        rt.block_on(async {
+            let pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(4));
+            let ep = pull.bind(soak_common::tcp_ep(0)).await.unwrap();
 
-        let push = Socket::new(SocketType::Push, Options::default().send_hwm(4));
-        push.connect(ep).await.unwrap();
-        compio::time::sleep(Duration::from_millis(50)).await;
+            let push = Socket::new(SocketType::Push, Options::default().send_hwm(4));
+            push.connect(ep).await.unwrap();
+            compio::time::sleep(Duration::from_millis(50)).await;
 
-        let payload: Vec<u8> = (0..MSG_SIZE).map(|i| (i & 0xFF) as u8).collect();
+            let payload: Vec<u8> = (0..MSG_SIZE).map(|i| (i & 0xFF) as u8).collect();
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            while !send_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_secs(2),
-                    push.send(Message::single(payload.clone())),
-                )
-                .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                while !send_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single(payload.clone())),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(m)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    assert_eq!(
-                        m.part_bytes(0).unwrap().len(),
-                        MSG_SIZE,
-                        "payload size mismatch"
-                    );
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(m)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        assert_eq!(
+                            m.part_bytes(0).unwrap().len(),
+                            MSG_SIZE,
+                            "payload size mismatch"
+                        );
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
-            let mut tracker = soak_common::ThroughputTracker::new(Duration::from_secs(10));
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
+                let mut tracker = soak_common::ThroughputTracker::new(Duration::from_secs(10));
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
-                let s = timer_sent.load(Ordering::Relaxed);
-                let r = timer_recvd.load(Ordering::Relaxed);
-                tracker.record(r);
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
+                    let s = timer_sent.load(Ordering::Relaxed);
+                    let r = timer_recvd.load(Ordering::Relaxed);
+                    tracker.record(r);
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    eprintln!(
-                        "[large_throughput] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        eprintln!(
+                            "[large_throughput] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-            tracker.assert_stable("large_throughput");
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+                tracker.assert_stable("large_throughput");
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[large_throughput] done: sent {s}, recvd {r} in {:.1}s ({:.1} MiB/s)",
-            duration.as_secs_f64(),
-            r as f64 * MSG_SIZE as f64 / duration.as_secs_f64() / 1_048_576.0,
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[large_throughput] done: sent {s}, recvd {r} in {:.1}s ({:.1} MiB/s)",
+                duration.as_secs_f64(),
+                r as f64 * MSG_SIZE as f64 / duration.as_secs_f64() / 1_048_576.0,
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("large_throughput");

--- a/omq-compio/tests/soak_multi_socket.rs
+++ b/omq-compio/tests/soak_multi_socket.rs
@@ -74,79 +74,83 @@ fn soak_multi_socket() {
     let monitor = soak_common::ResourceMonitor::start();
     let mut tracker = soak_common::ThroughputTracker::new(Duration::from_secs(10));
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let pairs = create_pairs().await;
-        eprintln!("[multi_socket] created {} socket pairs", pairs.len());
-        compio::time::sleep(Duration::from_millis(100)).await;
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let pairs = create_pairs().await;
+            eprintln!("[multi_socket] created {} socket pairs", pairs.len());
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let start = Instant::now();
-        let mut total_exchanged: u64 = 0;
-        let mut last_log = start;
+            let start = Instant::now();
+            let mut total_exchanged: u64 = 0;
+            let mut last_log = start;
 
-        while start.elapsed() < duration {
-            // Multiple messages per pair per iteration to increase throughput.
-            for _ in 0..10 {
-                for pair in &pairs {
-                    let sent = compio::time::timeout(
-                        Duration::from_millis(1),
-                        pair.sender.send(Message::single("multi")),
-                    )
-                    .await;
-
-                    if sent.is_err() || sent.unwrap().is_err() {
-                        continue;
-                    }
-
-                    if pair.kind != "req/rep-tcp" {
-                        continue;
-                    }
-
-                    if let Ok(Ok(_)) =
-                        compio::time::timeout(Duration::from_millis(5), pair.receiver.recv()).await
-                    {
-                        total_exchanged += 1;
-                        let _ = compio::time::timeout(
-                            Duration::from_millis(5),
-                            pair.receiver.send(Message::single("reply")),
+            while start.elapsed() < duration {
+                // Multiple messages per pair per iteration to increase throughput.
+                for _ in 0..10 {
+                    for pair in &pairs {
+                        let sent = compio::time::timeout(
+                            Duration::from_millis(1),
+                            pair.sender.send(Message::single("multi")),
                         )
                         .await;
-                        let _ = compio::time::timeout(Duration::from_millis(5), pair.sender.recv())
+
+                        if sent.is_err() || sent.unwrap().is_err() {
+                            continue;
+                        }
+
+                        if pair.kind != "req/rep-tcp" {
+                            continue;
+                        }
+
+                        if let Ok(Ok(_)) =
+                            compio::time::timeout(Duration::from_millis(5), pair.receiver.recv())
+                                .await
+                        {
+                            total_exchanged += 1;
+                            let _ = compio::time::timeout(
+                                Duration::from_millis(5),
+                                pair.receiver.send(Message::single("reply")),
+                            )
                             .await;
+                            let _ =
+                                compio::time::timeout(Duration::from_millis(5), pair.sender.recv())
+                                    .await;
+                        }
                     }
+                }
+
+                // Drain non-REQ/REP receivers without blocking.
+                for pair in &pairs {
+                    if pair.kind != "req/rep-tcp" {
+                        while pair.receiver.try_recv().is_ok() {
+                            total_exchanged += 1;
+                        }
+                    }
+                }
+
+                tracker.record(total_exchanged);
+
+                if last_log.elapsed() >= Duration::from_secs(30) {
+                    eprintln!(
+                        "[multi_socket] {:.0}s, exchanged {total_exchanged}",
+                        start.elapsed().as_secs_f64(),
+                    );
+                    last_log = Instant::now();
                 }
             }
 
-            // Drain non-REQ/REP receivers without blocking.
-            for pair in &pairs {
-                if pair.kind != "req/rep-tcp" {
-                    while pair.receiver.try_recv().is_ok() {
-                        total_exchanged += 1;
-                    }
-                }
+            for pair in pairs {
+                pair.sender.close().await.unwrap();
+                pair.receiver.close().await.unwrap();
             }
 
-            tracker.record(total_exchanged);
-
-            if last_log.elapsed() >= Duration::from_secs(30) {
-                eprintln!(
-                    "[multi_socket] {:.0}s, exchanged {total_exchanged}",
-                    start.elapsed().as_secs_f64(),
-                );
-                last_log = Instant::now();
-            }
-        }
-
-        for pair in pairs {
-            pair.sender.close().await.unwrap();
-            pair.receiver.close().await.unwrap();
-        }
-
-        eprintln!(
-            "[multi_socket] done: {total_exchanged} messages across 50 pairs in {:.1}s",
-            start.elapsed().as_secs_f64(),
-        );
-    });
+            eprintln!(
+                "[multi_socket] done: {total_exchanged} messages across 50 pairs in {:.1}s",
+                start.elapsed().as_secs_f64(),
+            );
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("multi_socket");

--- a/omq-compio/tests/soak_peer_churn.rs
+++ b/omq-compio/tests/soak_peer_churn.rs
@@ -21,72 +21,74 @@ use omq_compio::{Message, Options, Socket, SocketType};
 fn soak_peer_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let push = Socket::new(SocketType::Push, Options::default().send_hwm(1024));
-        let ep = push.bind(soak_common::tcp_ep(0)).await.unwrap();
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let push = Socket::new(SocketType::Push, Options::default().send_hwm(1024));
+            let ep = push.bind(soak_common::tcp_ep(0)).await.unwrap();
 
-        // Ensure at least one peer is connected before entering the main loop.
-        let initial_pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(64));
-        initial_pull.connect(ep.clone()).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+            // Ensure at least one peer is connected before entering the main loop.
+            let initial_pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(64));
+            initial_pull.connect(ep.clone()).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let mut rng = rand::make_rng::<StdRng>();
-        let mut peers: Vec<Socket> = vec![initial_pull];
-        let mut sent: u64 = 0;
-        let start = Instant::now();
-        let mut last_log = start;
+            let mut rng = rand::make_rng::<StdRng>();
+            let mut peers: Vec<Socket> = vec![initial_pull];
+            let mut sent: u64 = 0;
+            let start = Instant::now();
+            let mut last_log = start;
 
-        while start.elapsed() < duration {
-            // Peer management: add or remove with some probability.
-            let action = rng.random_range(0u8..10);
-            if action < 3 && peers.len() < 20 {
-                let pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(64));
-                pull.connect(ep.clone()).await.unwrap();
-                peers.push(pull);
-            } else if action < 5 && peers.len() > 1 {
-                let idx = rng.random_range(0..peers.len());
-                let peer = peers.swap_remove(idx);
-                peer.close().await.unwrap();
-            }
+            while start.elapsed() < duration {
+                // Peer management: add or remove with some probability.
+                let action = rng.random_range(0u8..10);
+                if action < 3 && peers.len() < 20 {
+                    let pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(64));
+                    pull.connect(ep.clone()).await.unwrap();
+                    peers.push(pull);
+                } else if action < 5 && peers.len() > 1 {
+                    let idx = rng.random_range(0..peers.len());
+                    let peer = peers.swap_remove(idx);
+                    peer.close().await.unwrap();
+                }
 
-            // Send a burst. Short timeout: if HWM is full, move on to drain.
-            for _ in 0..100 {
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_millis(1),
-                    push.send(Message::single("soak")),
-                )
-                .await
-                {
-                    sent += 1;
+                // Send a burst. Short timeout: if HWM is full, move on to drain.
+                for _ in 0..100 {
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_millis(1),
+                        push.send(Message::single("soak")),
+                    )
+                    .await
+                    {
+                        sent += 1;
+                    }
+                }
+
+                // Drain all live peers without blocking.
+                for peer in &peers {
+                    while peer.try_recv().is_ok() {}
+                }
+
+                if last_log.elapsed() >= Duration::from_secs(30) {
+                    eprintln!(
+                        "[peer_churn] {:.0}s, sent {sent}, peers {}",
+                        start.elapsed().as_secs_f64(),
+                        peers.len(),
+                    );
+                    last_log = Instant::now();
                 }
             }
 
-            // Drain all live peers without blocking.
-            for peer in &peers {
-                while peer.try_recv().is_ok() {}
+            for peer in peers {
+                peer.close().await.unwrap();
             }
+            push.close().await.unwrap();
 
-            if last_log.elapsed() >= Duration::from_secs(30) {
-                eprintln!(
-                    "[peer_churn] {:.0}s, sent {sent}, peers {}",
-                    start.elapsed().as_secs_f64(),
-                    peers.len(),
-                );
-                last_log = Instant::now();
-            }
-        }
-
-        for peer in peers {
-            peer.close().await.unwrap();
-        }
-        push.close().await.unwrap();
-
-        eprintln!(
-            "[peer_churn] done: {sent} messages in {:.1}s",
-            start.elapsed().as_secs_f64()
-        );
-    });
+            eprintln!(
+                "[peer_churn] done: {sent} messages in {:.1}s",
+                start.elapsed().as_secs_f64()
+            );
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("peer_churn");

--- a/omq-compio/tests/soak_plain.rs
+++ b/omq-compio/tests/soak_plain.rs
@@ -31,93 +31,98 @@ fn soak_plain() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let pull = Socket::new(
-            SocketType::Pull,
-            Options::default().plain_server(accept_alice),
-        );
-        let mut mon = pull.monitor();
-        pull.bind(soak_common::tcp_ep(0)).await.unwrap();
-        let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        let port = match ev {
-            MonitorEvent::Listening {
-                endpoint: Endpoint::Tcp { port, .. },
-            } => port,
-            other => panic!("expected Tcp Listening, got {other:?}"),
-        };
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let pull = Socket::new(
+                SocketType::Pull,
+                Options::default().plain_server(accept_alice),
+            );
+            let mut mon = pull.monitor();
+            pull.bind(soak_common::tcp_ep(0)).await.unwrap();
+            let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            let port = match ev {
+                MonitorEvent::Listening {
+                    endpoint: Endpoint::Tcp { port, .. },
+                } => port,
+                other => panic!("expected Tcp Listening, got {other:?}"),
+            };
 
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default()
-                .plain_client("alice", "secret")
-                .linger(Duration::from_secs(5)),
-        );
-        push.connect(soak_common::tcp_ep(port)).await.unwrap();
-        compio::time::sleep(Duration::from_millis(100)).await;
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default()
+                    .plain_client("alice", "secret")
+                    .linger(Duration::from_secs(5)),
+            );
+            push.connect(soak_common::tcp_ep(port)).await.unwrap();
+            compio::time::sleep(Duration::from_millis(100)).await;
 
-        let send_sent = sent.clone();
-        let send_stop = stop.clone();
-        let send_fut = async {
-            while !send_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(())) =
-                    compio::time::timeout(Duration::from_secs(2), push.send(Message::single("p")))
-                        .await
-                {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+            let send_sent = sent.clone();
+            let send_stop = stop.clone();
+            let send_fut = async {
+                while !send_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_secs(2),
+                        push.send(Message::single("p")),
+                    )
+                    .await
+                    {
+                        send_sent.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let recv_recvd = recvd.clone();
-        let recv_stop = stop.clone();
-        let recv_fut = async {
-            while !recv_stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(_)) = compio::time::timeout(Duration::from_secs(2), pull.recv()).await
-                {
-                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+            let recv_recvd = recvd.clone();
+            let recv_stop = stop.clone();
+            let recv_fut = async {
+                while !recv_stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(_)) =
+                        compio::time::timeout(Duration::from_secs(2), pull.recv()).await
+                    {
+                        recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-            }
-        };
+            };
 
-        let timer_stop = stop.clone();
-        let timer_sent = sent.clone();
-        let timer_recvd = recvd.clone();
-        let timer_fut = async {
-            let start = Instant::now();
-            let mut last_log = start;
+            let timer_stop = stop.clone();
+            let timer_sent = sent.clone();
+            let timer_recvd = recvd.clone();
+            let timer_fut = async {
+                let start = Instant::now();
+                let mut last_log = start;
 
-            while start.elapsed() < duration {
-                compio::time::sleep(Duration::from_secs(1)).await;
+                while start.elapsed() < duration {
+                    compio::time::sleep(Duration::from_secs(1)).await;
 
-                if last_log.elapsed() >= Duration::from_secs(30) {
-                    let s = timer_sent.load(Ordering::Relaxed);
-                    let r = timer_recvd.load(Ordering::Relaxed);
-                    eprintln!(
-                        "[plain] {:.0}s, sent {s}, recvd {r}",
-                        start.elapsed().as_secs_f64(),
-                    );
-                    last_log = Instant::now();
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let s = timer_sent.load(Ordering::Relaxed);
+                        let r = timer_recvd.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[plain] {:.0}s, sent {s}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
+                        );
+                        last_log = Instant::now();
+                    }
                 }
-            }
-            timer_stop.store(true, Ordering::Relaxed);
-        };
+                timer_stop.store(true, Ordering::Relaxed);
+            };
 
-        join!(send_fut, recv_fut, timer_fut);
+            join!(send_fut, recv_fut, timer_fut);
 
-        let s = sent.load(Ordering::Relaxed);
-        let r = recvd.load(Ordering::Relaxed);
-        eprintln!(
-            "[plain] done: sent {s}, recvd {r} in {:.1}s",
-            duration.as_secs_f64(),
-        );
+            let s = sent.load(Ordering::Relaxed);
+            let r = recvd.load(Ordering::Relaxed);
+            eprintln!(
+                "[plain] done: sent {s}, recvd {r} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        push.close().await.unwrap();
-        pull.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("plain");

--- a/omq-compio/tests/soak_priority.rs
+++ b/omq-compio/tests/soak_priority.rs
@@ -26,107 +26,109 @@ fn soak_priority() {
     let sent = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let ep1 = Endpoint::Inproc {
-            name: "soak-prio-1".into(),
-        };
-        let ep3 = Endpoint::Inproc {
-            name: "soak-prio-3".into(),
-        };
-        let ep5 = Endpoint::Inproc {
-            name: "soak-prio-5".into(),
-        };
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let ep1 = Endpoint::Inproc {
+                name: "soak-prio-1".into(),
+            };
+            let ep3 = Endpoint::Inproc {
+                name: "soak-prio-3".into(),
+            };
+            let ep5 = Endpoint::Inproc {
+                name: "soak-prio-5".into(),
+            };
 
-        let pull1 = Socket::new(SocketType::Pull, Options::default());
-        let pull3 = Socket::new(SocketType::Pull, Options::default());
-        let pull5 = Socket::new(SocketType::Pull, Options::default());
-        pull1.bind(ep1.clone()).await.unwrap();
-        pull3.bind(ep3.clone()).await.unwrap();
-        pull5.bind(ep5.clone()).await.unwrap();
+            let pull1 = Socket::new(SocketType::Pull, Options::default());
+            let pull3 = Socket::new(SocketType::Pull, Options::default());
+            let pull5 = Socket::new(SocketType::Pull, Options::default());
+            pull1.bind(ep1.clone()).await.unwrap();
+            pull3.bind(ep3.clone()).await.unwrap();
+            pull5.bind(ep5.clone()).await.unwrap();
 
-        let push = Socket::new(SocketType::Push, Options::default());
-        push.connect_with(
-            ep1,
-            ConnectOpts {
-                priority: NonZeroU8::new(1).unwrap(),
-            },
-        )
-        .await
-        .unwrap();
-        push.connect_with(
-            ep3,
-            ConnectOpts {
-                priority: NonZeroU8::new(3).unwrap(),
-            },
-        )
-        .await
-        .unwrap();
-        push.connect_with(
-            ep5,
-            ConnectOpts {
-                priority: NonZeroU8::new(5).unwrap(),
-            },
-        )
-        .await
-        .unwrap();
+            let push = Socket::new(SocketType::Push, Options::default());
+            push.connect_with(
+                ep1,
+                ConnectOpts {
+                    priority: NonZeroU8::new(1).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+            push.connect_with(
+                ep3,
+                ConnectOpts {
+                    priority: NonZeroU8::new(3).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+            push.connect_with(
+                ep5,
+                ConnectOpts {
+                    priority: NonZeroU8::new(5).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
 
-        let start = Instant::now();
-        let mut last_log = start;
+            let start = Instant::now();
+            let mut last_log = start;
 
-        while start.elapsed() < duration {
-            // Send a batch.
-            for _ in 0..100 {
-                if stop.load(Ordering::Relaxed) {
-                    break;
+            while start.elapsed() < duration {
+                // Send a batch.
+                for _ in 0..100 {
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_millis(50),
+                        push.send(Message::single("x")),
+                    )
+                    .await
+                    {
+                        sent.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_millis(50),
-                    push.send(Message::single("x")),
-                )
-                .await
-                {
-                    sent.fetch_add(1, Ordering::Relaxed);
+
+                // Drain all PULLs.
+                for pull in [&pull1, &pull3, &pull5] {
+                    while pull.try_recv().is_ok() {
+                        delivered.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+
+                if last_log.elapsed() >= Duration::from_secs(30) {
+                    let s = sent.load(Ordering::Relaxed);
+                    let d = delivered.load(Ordering::Relaxed);
+                    eprintln!(
+                        "[priority] {:.0}s, sent {s}, delivered {d}",
+                        start.elapsed().as_secs_f64(),
+                    );
+                    last_log = Instant::now();
                 }
             }
 
-            // Drain all PULLs.
+            // Final drain.
             for pull in [&pull1, &pull3, &pull5] {
                 while pull.try_recv().is_ok() {
                     delivered.fetch_add(1, Ordering::Relaxed);
                 }
             }
 
-            if last_log.elapsed() >= Duration::from_secs(30) {
-                let s = sent.load(Ordering::Relaxed);
-                let d = delivered.load(Ordering::Relaxed);
-                eprintln!(
-                    "[priority] {:.0}s, sent {s}, delivered {d}",
-                    start.elapsed().as_secs_f64(),
-                );
-                last_log = Instant::now();
-            }
-        }
+            let s = sent.load(Ordering::Relaxed);
+            let d = delivered.load(Ordering::Relaxed);
+            eprintln!(
+                "[priority] done: sent {s}, delivered {d} in {:.1}s",
+                duration.as_secs_f64(),
+            );
 
-        // Final drain.
-        for pull in [&pull1, &pull3, &pull5] {
-            while pull.try_recv().is_ok() {
-                delivered.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-
-        let s = sent.load(Ordering::Relaxed);
-        let d = delivered.load(Ordering::Relaxed);
-        eprintln!(
-            "[priority] done: sent {s}, delivered {d} in {:.1}s",
-            duration.as_secs_f64(),
-        );
-
-        push.close().await.unwrap();
-        pull1.close().await.unwrap();
-        pull3.close().await.unwrap();
-        pull5.close().await.unwrap();
-    });
+            push.close().await.unwrap();
+            pull1.close().await.unwrap();
+            pull3.close().await.unwrap();
+            pull5.close().await.unwrap();
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("priority");

--- a/omq-compio/tests/soak_pub_sub_churn.rs
+++ b/omq-compio/tests/soak_pub_sub_churn.rs
@@ -26,83 +26,85 @@ fn soak_pub_sub_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        let ep = soak_common::inproc_ep("soak-pub-sub-churn");
-        let publisher = Socket::new(SocketType::Pub, Options::default());
-        publisher.bind(ep.clone()).await.unwrap();
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let ep = soak_common::inproc_ep("soak-pub-sub-churn");
+            let publisher = Socket::new(SocketType::Pub, Options::default());
+            publisher.bind(ep.clone()).await.unwrap();
 
-        let mut rng = rand::make_rng::<StdRng>();
-        let mut subs: Vec<Socket> = Vec::new();
-        let mut pub_count: u64 = 0;
-        let start = Instant::now();
-        let mut last_churn = start;
-        let mut last_log = start;
+            let mut rng = rand::make_rng::<StdRng>();
+            let mut subs: Vec<Socket> = Vec::new();
+            let mut pub_count: u64 = 0;
+            let start = Instant::now();
+            let mut last_churn = start;
+            let mut last_log = start;
 
-        while start.elapsed() < duration {
-            // Publish a large burst. PUB drops to absent/slow subscribers,
-            // so sends never block.
-            for _ in 0..10_000 {
-                let topic = TOPICS[pub_count as usize % TOPICS.len()];
-                let msg = format!("{topic}{pub_count}");
-                if let Ok(Ok(())) = compio::time::timeout(
-                    Duration::from_millis(1),
-                    publisher.send(Message::single(msg)),
-                )
-                .await
-                {
-                    pub_count += 1;
+            while start.elapsed() < duration {
+                // Publish a large burst. PUB drops to absent/slow subscribers,
+                // so sends never block.
+                for _ in 0..10_000 {
+                    let topic = TOPICS[pub_count as usize % TOPICS.len()];
+                    let msg = format!("{topic}{pub_count}");
+                    if let Ok(Ok(())) = compio::time::timeout(
+                        Duration::from_millis(1),
+                        publisher.send(Message::single(msg)),
+                    )
+                    .await
+                    {
+                        pub_count += 1;
+                    }
+                }
+
+                // Drain all subscribers without blocking.
+                for sub in &subs {
+                    while sub.try_recv().is_ok() {}
+                }
+
+                // Churn subscribers every ~500ms.
+                if last_churn.elapsed() >= Duration::from_millis(500) {
+                    last_churn = Instant::now();
+
+                    // Remove a random subscriber.
+                    if !subs.is_empty() && rng.random_bool(0.5) {
+                        let idx = rng.random_range(0..subs.len());
+                        let sub = subs.swap_remove(idx);
+                        sub.close().await.unwrap();
+                    }
+
+                    // Add a new subscriber (up to 10).
+                    if subs.len() < 10 {
+                        let sub = Socket::new(SocketType::Sub, Options::default().recv_hwm(32));
+                        sub.connect(ep.clone()).await.unwrap();
+                        let prefix = TOPICS[rng.random_range(0..TOPICS.len())];
+                        sub.subscribe(Bytes::from(prefix.to_string()))
+                            .await
+                            .unwrap();
+                        subs.push(sub);
+                    }
+                }
+
+                if last_log.elapsed() >= Duration::from_secs(30) {
+                    eprintln!(
+                        "[pub_sub_churn] {:.0}s, pub_count {pub_count}, subs {}",
+                        start.elapsed().as_secs_f64(),
+                        subs.len(),
+                    );
+                    last_log = Instant::now();
                 }
             }
 
-            // Drain all subscribers without blocking.
-            for sub in &subs {
-                while sub.try_recv().is_ok() {}
+            for sub in subs {
+                sub.close().await.unwrap();
             }
+            publisher.close().await.unwrap();
 
-            // Churn subscribers every ~500ms.
-            if last_churn.elapsed() >= Duration::from_millis(500) {
-                last_churn = Instant::now();
-
-                // Remove a random subscriber.
-                if !subs.is_empty() && rng.random_bool(0.5) {
-                    let idx = rng.random_range(0..subs.len());
-                    let sub = subs.swap_remove(idx);
-                    sub.close().await.unwrap();
-                }
-
-                // Add a new subscriber (up to 10).
-                if subs.len() < 10 {
-                    let sub = Socket::new(SocketType::Sub, Options::default().recv_hwm(32));
-                    sub.connect(ep.clone()).await.unwrap();
-                    let prefix = TOPICS[rng.random_range(0..TOPICS.len())];
-                    sub.subscribe(Bytes::from(prefix.to_string()))
-                        .await
-                        .unwrap();
-                    subs.push(sub);
-                }
-            }
-
-            if last_log.elapsed() >= Duration::from_secs(30) {
-                eprintln!(
-                    "[pub_sub_churn] {:.0}s, pub_count {pub_count}, subs {}",
-                    start.elapsed().as_secs_f64(),
-                    subs.len(),
-                );
-                last_log = Instant::now();
-            }
-        }
-
-        for sub in subs {
-            sub.close().await.unwrap();
-        }
-        publisher.close().await.unwrap();
-
-        eprintln!(
-            "[pub_sub_churn] done: {pub_count} pub_count in {:.1}s",
-            start.elapsed().as_secs_f64(),
-        );
-    });
+            eprintln!(
+                "[pub_sub_churn] done: {pub_count} pub_count in {:.1}s",
+                start.elapsed().as_secs_f64(),
+            );
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("pub_sub_churn");

--- a/omq-compio/tests/soak_reconnect_storm.rs
+++ b/omq-compio/tests/soak_reconnect_storm.rs
@@ -21,84 +21,86 @@ fn soak_reconnect_storm() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = compio::runtime::Runtime::new().expect("runtime");
-    rt.block_on(async {
-        // Grab a free port by binding a temporary socket, then close it.
-        // The PUSH dialer reconnects to this fixed endpoint across PULL restarts.
-        let tmp = Socket::new(SocketType::Pull, Options::default());
-        let ep = tmp.bind(soak_common::tcp_ep(0)).await.unwrap();
-        tmp.close().await.unwrap();
+    {
+        let rt = compio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            // Grab a free port by binding a temporary socket, then close it.
+            // The PUSH dialer reconnects to this fixed endpoint across PULL restarts.
+            let tmp = Socket::new(SocketType::Pull, Options::default());
+            let ep = tmp.bind(soak_common::tcp_ep(0)).await.unwrap();
+            tmp.close().await.unwrap();
 
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default()
-                .send_hwm(16)
-                .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(10))),
-        );
-        push.connect(ep.clone()).await.unwrap();
+            let push = Socket::new(
+                SocketType::Push,
+                Options::default()
+                    .send_hwm(16)
+                    .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(10))),
+            );
+            push.connect(ep.clone()).await.unwrap();
 
-        let start = Instant::now();
-        let mut cycles: u64 = 0;
-        let mut delivered: u64 = 0;
-        let mut last_log = start;
+            let start = Instant::now();
+            let mut cycles: u64 = 0;
+            let mut delivered: u64 = 0;
+            let mut last_log = start;
 
-        while start.elapsed() < duration {
-            let pull = Socket::new(SocketType::Pull, Options::default());
+            while start.elapsed() < duration {
+                let pull = Socket::new(SocketType::Pull, Options::default());
 
-            let mut bound = false;
-            for _ in 0..40 {
-                if pull.bind(ep.clone()).await.is_ok() {
-                    bound = true;
-                    break;
+                let mut bound = false;
+                for _ in 0..40 {
+                    if pull.bind(ep.clone()).await.is_ok() {
+                        bound = true;
+                        break;
+                    }
+                    compio::time::sleep(Duration::from_millis(25)).await;
                 }
-                compio::time::sleep(Duration::from_millis(25)).await;
-            }
-            if !bound {
-                eprintln!("[reconnect_storm] bind failed at cycle {cycles}, retrying");
-                continue;
-            }
-
-            let tag = format!("c-{cycles}");
-            push.send(Message::single(tag.clone())).await.unwrap();
-
-            match compio::time::timeout(Duration::from_secs(5), pull.recv()).await {
-                Ok(Ok(m)) => {
-                    assert_eq!(m.part_bytes(0).unwrap(), tag.as_bytes());
-                    delivered += 1;
+                if !bound {
+                    eprintln!("[reconnect_storm] bind failed at cycle {cycles}, retrying");
+                    continue;
                 }
-                _ => {
-                    eprintln!("[reconnect_storm] missed delivery at cycle {cycles}");
+
+                let tag = format!("c-{cycles}");
+                push.send(Message::single(tag.clone())).await.unwrap();
+
+                match compio::time::timeout(Duration::from_secs(5), pull.recv()).await {
+                    Ok(Ok(m)) => {
+                        assert_eq!(m.part_bytes(0).unwrap(), tag.as_bytes());
+                        delivered += 1;
+                    }
+                    _ => {
+                        eprintln!("[reconnect_storm] missed delivery at cycle {cycles}");
+                    }
+                }
+
+                pull.close().await.unwrap();
+                cycles += 1;
+
+                if last_log.elapsed() >= Duration::from_secs(30) {
+                    eprintln!(
+                        "[reconnect_storm] {:.0}s, cycles {cycles}, delivered {delivered}",
+                        start.elapsed().as_secs_f64(),
+                    );
+                    last_log = Instant::now();
                 }
             }
 
-            pull.close().await.unwrap();
-            cycles += 1;
+            push.close().await.unwrap();
 
-            if last_log.elapsed() >= Duration::from_secs(30) {
-                eprintln!(
-                    "[reconnect_storm] {:.0}s, cycles {cycles}, delivered {delivered}",
-                    start.elapsed().as_secs_f64(),
-                );
-                last_log = Instant::now();
-            }
-        }
-
-        push.close().await.unwrap();
-
-        let pct = if cycles > 0 {
-            delivered as f64 / cycles as f64 * 100.0
-        } else {
-            100.0
-        };
-        eprintln!(
-            "[reconnect_storm] done: {delivered}/{cycles} delivered ({pct:.1}%) in {:.1}s",
-            start.elapsed().as_secs_f64(),
-        );
-        assert!(
-            pct >= 90.0,
-            "reconnect storm delivery rate too low: {pct:.1}%"
-        );
-    });
+            let pct = if cycles > 0 {
+                delivered as f64 / cycles as f64 * 100.0
+            } else {
+                100.0
+            };
+            eprintln!(
+                "[reconnect_storm] done: {delivered}/{cycles} delivered ({pct:.1}%) in {:.1}s",
+                start.elapsed().as_secs_f64(),
+            );
+            assert!(
+                pct >= 90.0,
+                "reconnect storm delivery rate too low: {pct:.1}%"
+            );
+        });
+    }
 
     let report = monitor.stop();
     report.assert_no_leak("reconnect_storm");

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -89,10 +89,12 @@ type Samples = (
 pub struct ResourceMonitor {
     stop: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<Samples>>,
+    heap_baseline: usize,
 }
 
 impl ResourceMonitor {
     pub fn start() -> Self {
+        let heap_baseline = alloc::LIVE_BYTES.load(std::sync::atomic::Ordering::Relaxed);
         let stop = Arc::new(AtomicBool::new(false));
         let stop2 = stop.clone();
         let handle = std::thread::spawn(move || {
@@ -115,6 +117,7 @@ impl ResourceMonitor {
         Self {
             stop,
             handle: Some(handle),
+            heap_baseline,
         }
     }
 
@@ -125,6 +128,7 @@ impl ResourceMonitor {
             rss_samples,
             fd_samples,
             heap_samples,
+            heap_baseline: self.heap_baseline,
         }
     }
 }
@@ -156,12 +160,14 @@ pub struct ResourceReport {
     pub rss_samples: Vec<(Instant, usize)>,
     pub fd_samples: Vec<(Instant, usize)>,
     pub heap_samples: Vec<(Instant, usize)>,
+    heap_baseline: usize,
 }
 
 impl ResourceReport {
     pub fn assert_no_leak(&self, label: &str) {
         self.report_rss(label);
-        self.assert_heap_stable(label);
+        self.report_heap_slope(label);
+        self.assert_heap_residual(label);
         self.assert_fd_stable(label);
     }
 
@@ -177,10 +183,9 @@ impl ResourceReport {
         );
     }
 
-    fn assert_heap_stable(&self, label: &str) {
+    fn report_heap_slope(&self, label: &str) {
         let n = self.heap_samples.len();
         if n < 10 {
-            eprintln!("[{label}] too few heap samples ({n}) to check for leaks");
             return;
         }
 
@@ -221,28 +226,49 @@ impl ResourceReport {
 
         let slope_bytes_per_sec = (n_f * dot_xy - sum_x * sum_y) / (n_f * sum_xx - sum_x * sum_x);
         let slope_kib_s = slope_bytes_per_sec / 1024.0;
-
         let avg: f64 = sum_y / n_f;
 
         eprintln!(
-            "[{label}] heap: avg {:.1} MiB, slope {slope_kib_s:.1} KiB/s",
+            "[{label}] heap: avg {:.1} MiB, slope {slope_kib_s:.1} KiB/s (informational)",
             avg / 1_048_576.0,
         );
+    }
 
-        // 50 KiB/s sustained = 30 MiB over 10 min; anything below is
-        // noise from in-flight message buffers and allocator jitter.
-        // Short runs are noisier; only enforce tight bounds with enough
-        // samples for the regression to be meaningful.
-        let threshold_kib_s = if post_warmup.len() >= 120 {
-            50.0
-        } else {
-            500.0
-        };
+    fn assert_heap_residual(&self, label: &str) {
+        std::thread::sleep(Duration::from_millis(200));
+        let current = alloc::LIVE_BYTES.load(std::sync::atomic::Ordering::Relaxed);
+        let baseline = self.heap_baseline;
+
+        // Use the peak seen during the run to scale the threshold:
+        // a true leak accumulates relative to throughput, so residual
+        // after close should be a tiny fraction of the peak.
+        let peak = self
+            .heap_samples
+            .iter()
+            .map(|(_, v)| *v)
+            .max()
+            .unwrap_or(baseline);
+        // 5% of peak or 4 MiB, whichever is larger. Covers runtime
+        // overhead (compio io_uring buffers, tokio internals) that
+        // persists until the runtime itself is dropped.
+        let threshold = (peak / 20).max(8 * 1024 * 1024);
+
+        let growth = current.saturating_sub(baseline);
+
+        eprintln!(
+            "[{label}] heap residual: {:.1} KiB (baseline {:.1} MiB, current {:.1} MiB)",
+            growth as f64 / 1024.0,
+            baseline as f64 / 1_048_576.0,
+            current as f64 / 1_048_576.0,
+        );
         assert!(
-            slope_kib_s < threshold_kib_s,
-            "[{label}] heap leak detected: slope {slope_kib_s:.1} KiB/s \
-             (avg {:.1} MiB over {elapsed_secs:.0}s)",
-            avg / 1_048_576.0,
+            growth < threshold,
+            "[{label}] heap leak: {:.1} KiB residual after close \
+             (baseline {:.1} MiB, current {:.1} MiB, threshold {:.1} MiB)",
+            growth as f64 / 1024.0,
+            baseline as f64 / 1_048_576.0,
+            current as f64 / 1_048_576.0,
+            threshold as f64 / 1_048_576.0,
         );
     }
 


### PR DESCRIPTION
- Replace `assert_heap_stable` (slope regression) with `assert_heap_residual` (baseline vs post-close live bytes); slope is now informational-only via `report_heap_slope`
- Threshold: 5% of peak heap or 8 MiB floor — covers runtime overhead that persists until the runtime drops
- Wrap all compio soak test runtimes in `{ }` blocks so io_uring buffers and runtime internals are freed before the residual check
- Mirror the same `soak_common` changes in both `omq-compio` and `omq-tokio`