### PR TITLE
Rename InprocFrame to InboundFrame everywhere

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -64,7 +64,7 @@ connected:
               +----------+-----------+
               |   socket-wide        |   <- single queue per socket
               |   inbound queue      |      (no per-peer recv queues)
-              |   (InprocFrame)      |
+              |   (InboundFrame)     |
               +----------------------+
                   ^       ^       ^
                   |       |       |     drivers push decoded

--- a/doc/compio.md
+++ b/doc/compio.md
@@ -45,7 +45,7 @@ SocketInner {
   identity_to_slot: RwLock<HashMap<Bytes,usize>>, // ROUTER lookup
 
   // Inbound
-  in_tx/in_rx: blume::channel<InprocFrame>,   // socket-wide receive queue (batching MPSC)
+  in_tx/in_rx: blume::channel<InboundFrame>,   // socket-wide receive queue (batching MPSC)
   on_peer_ready: Event,                      // notified on peer add/handshake
 
   // Subscription / group state (SUB / XSUB / DISH)
@@ -86,7 +86,7 @@ fast path reads the inner `Option`; `None` means reconnect is in flight
 
 ```rust
 enum PeerOut {
-  Inproc { sender: blume::Sender<InprocFrame>, our_identity: Bytes },
+  Inproc { sender: blume::Sender<InboundFrame>, our_identity: Bytes },
   Wire(WirePeerHandle),  // Arc<RwLock<flume::Sender<DriverCommand>>>
 }
 ```
@@ -514,7 +514,7 @@ Cancel-safety: dropping the recv future at any `.await` is safe.
 
 ### `in_rx` fallback loop
 
-Processes `InprocFrame` variants from the socket-wide bounded channel:
+Processes `InboundFrame` variants from the socket-wide bounded channel:
 - `SinglePart { peer_identity, body }` -- hot path, ~72 B slot
 - `Message(Box<InprocFullMessage>)` -- multipart, boxed to keep slot small
 - `Command(Command)` -- XPUB-only: wrap as `\x01<topic>` or `\x00<topic>`
@@ -538,7 +538,7 @@ No driver, no codec, no handshake. A global `REGISTRY`
 sends a request.
 
 Peers exchange an `InprocPeerSnapshot` (socket type + identity)
-synchronously. Messages flow as `InprocFrame` through blume channels
+synchronously. Messages flow as `InboundFrame` through blume channels
 (batching MPSC -- swap-drain consumer amortizes cross-core cache
 coherency cost). The `InprocListener` drops from the registry on
 `Drop`.
@@ -607,7 +607,7 @@ after each handshake via `our_subs` and `joined_groups`.
 
 ## Memory and allocation model
 
-### `InprocFrame::SinglePart`
+### `InboundFrame::SinglePart`
 
 The single-part variant carries `Option<Bytes>` (identity) and `Bytes`
 (body) inline (~72 B). The `Message` struct is 48 B (custom enum with

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -223,7 +223,7 @@ blocked by the driver's read path.
 ## Inproc bypasses ZMTP
 
 Same-process `inproc://` connections skip wire framing entirely.
-Global name registry, direct `InprocFrame` exchange via channels.
+Global name registry, direct `InboundFrame` exchange via channels.
 Hot-path `SinglePart` variant is ~72 B. Throughput: ~3M msg/s
 for any size below 32 KiB, >100 GB/s nominal at 32 KiB+ (no
 kernel crossing).
@@ -567,7 +567,7 @@ separate I/O thread, but it pipelines encode against write.
 Each SPSC-eligible inproc connection (PUSH/PULL, PAIR) gets a
 dedicated `blume::spsc` ring (1024-slot, lock-free). Per-peer
 rings replace the shared blume MPSC channel. The ring carries
-`Message` directly (48 B by value); no `InprocFrame` wrapper, no
+`Message` directly (48 B by value); no `InboundFrame` wrapper, no
 `Bytes` clone, no heap allocation for messages <=39 B.
 
 Send fast path (PUSH/PAIR, single peer): one `UnsafeCell` access

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -33,7 +33,7 @@ use crate::routing::{
     RecvStrategy, SendStrategy, SendSubmitter, max_peer_count, supports_groups, supports_subscribe,
 };
 use crate::transport::{
-    Canceled, InprocConn, InprocFrame, InprocPeerSnapshot, PeerIdent, dial_with_backoff,
+    Canceled, InboundFrame, InprocConn, InprocPeerSnapshot, PeerIdent, dial_with_backoff,
 };
 use omq_proto::endpoint::Endpoint;
 use omq_proto::endpoint::reject_encrypted_inproc;

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -1,6 +1,6 @@
 use super::{
     AnyConn, AnyStream, ConnectionConfig, ConnectionDriver, DisconnectReason, DriverConfig,
-    DriverHandle, Duration, Endpoint, InprocConn, InprocFrame, InprocPeerSnapshot, InternalEvent,
+    DriverHandle, Duration, Endpoint, InboundFrame, InprocConn, InprocPeerSnapshot, InternalEvent,
     Message, MessageEncoder, MonitorEvent, PeerCommandKind, PeerEntry, PeerIdent, PeerInfo,
     ReconnectPolicy, Result, Role, SocketDriver, SocketType, ZmtpConnection, ZmtpEvent,
     generated_identity, max_peer_count, mpsc, peer_ident_socket_addr, supports_groups,
@@ -737,8 +737,8 @@ struct InprocDriverCtx {
 #[expect(clippy::too_many_lines)]
 async fn inproc_peer_driver(
     mut inbox: mpsc::Receiver<crate::engine::DriverCommand>,
-    mut in_rx: mpsc::Receiver<InprocFrame>,
-    out: mpsc::Sender<InprocFrame>,
+    mut in_rx: mpsc::Receiver<InboundFrame>,
+    out: mpsc::Sender<InboundFrame>,
     ctx: InprocDriverCtx,
 ) {
     use crate::engine::{DriverCommand, PeerOut};
@@ -789,19 +789,19 @@ async fn inproc_peer_driver(
                 () = cancel.cancelled() => return,
                 cmd = inbox.recv() => match cmd {
                     Some(DriverCommand::SendMessage(m)) => {
-                        if out.send(InprocFrame::Message(m)).await.is_err() {
+                        if out.send(InboundFrame::Message(m)).await.is_err() {
                             return;
                         }
                     }
                     Some(DriverCommand::SendCommand(c)) => {
-                        if out.send(InprocFrame::Command(c)).await.is_err() {
+                        if out.send(InboundFrame::Command(c)).await.is_err() {
                             return;
                         }
                     }
                     Some(DriverCommand::Close) | None => return,
                 },
                 frame = in_rx.recv() => match frame {
-                    Some(InprocFrame::Message(m)) => {
+                    Some(InboundFrame::Message(m)) => {
                         if let Some(max) = max_message_size
                             && m.byte_len() > max
                         {
@@ -841,7 +841,7 @@ async fn inproc_peer_driver(
                             }
                         }
                     }
-                    Some(InprocFrame::Command(c)) => {
+                    Some(InboundFrame::Command(c)) => {
                         if emit_event(&peer_out, peer_id, ZmtpEvent::Command(c))
                             .await
                             .is_err()

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -73,7 +73,7 @@ fn is_recv_side(t: SocketType) -> bool {
 /// CANCEL, JOIN, LEAVE, ERROR). No frame headers, no greeting,
 /// no codec.
 #[derive(Debug)]
-pub enum InprocFrame {
+pub enum InboundFrame {
     Message(Message),
     Command(Command),
 }
@@ -92,8 +92,8 @@ pub struct InprocPeerSnapshot {
 /// `in_rx` is what WE receive from.
 #[derive(Debug)]
 pub struct InprocConn {
-    pub out: mpsc::Sender<InprocFrame>,
-    pub in_rx: mpsc::Receiver<InprocFrame>,
+    pub out: mpsc::Sender<InboundFrame>,
+    pub in_rx: mpsc::Receiver<InboundFrame>,
     pub peer: InprocPeerSnapshot,
     pub spsc: Option<Arc<InprocSpsc>>,
 }
@@ -109,8 +109,8 @@ pub const DEFAULT_INPROC_HWM: usize = 1024;
 /// returns its own snapshot to the connector.
 struct InprocConnectRequest {
     connector: InprocPeerSnapshot,
-    connector_to_listener_rx: mpsc::Receiver<InprocFrame>,
-    listener_to_connector_tx: mpsc::Sender<InprocFrame>,
+    connector_to_listener_rx: mpsc::Receiver<InboundFrame>,
+    listener_to_connector_tx: mpsc::Sender<InboundFrame>,
     connector_recv_notify: Arc<tokio::sync::Notify>,
     accept_ack: oneshot::Sender<(InprocPeerSnapshot, Option<Arc<InprocSpsc>>)>,
 }
@@ -166,8 +166,8 @@ pub async fn connect(
     .ok_or_else(|| Error::InvalidEndpoint(format!("no inproc binding: {name}")))?;
 
     // (connector→listener) and (listener→connector) directions.
-    let (c2l_tx, c2l_rx) = mpsc::channel::<InprocFrame>(DEFAULT_INPROC_HWM);
-    let (l2c_tx, l2c_rx) = mpsc::channel::<InprocFrame>(DEFAULT_INPROC_HWM);
+    let (c2l_tx, c2l_rx) = mpsc::channel::<InboundFrame>(DEFAULT_INPROC_HWM);
+    let (l2c_tx, l2c_rx) = mpsc::channel::<InboundFrame>(DEFAULT_INPROC_HWM);
     let (ack_tx, ack_rx) = oneshot::channel();
 
     let request = InprocConnectRequest {
@@ -298,7 +298,7 @@ mod tests {
 
         client_side
             .out
-            .send(InprocFrame::Message(Message::single("hi")))
+            .send(InboundFrame::Message(Message::single("hi")))
             .await
             .unwrap();
         let f = tokio::time::timeout(std::time::Duration::from_millis(100), {
@@ -309,10 +309,10 @@ mod tests {
         .unwrap()
         .unwrap();
         match f {
-            InprocFrame::Message(m) => {
+            InboundFrame::Message(m) => {
                 assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
             }
-            InprocFrame::Command(_) => panic!("expected Message"),
+            InboundFrame::Command(_) => panic!("expected Message"),
         }
     }
 

--- a/omq-tokio/src/transport/mod.rs
+++ b/omq-tokio/src/transport/mod.rs
@@ -25,7 +25,7 @@ pub mod tcp;
 pub mod udp;
 
 pub use backoff::{Canceled, dial_with_backoff};
-pub use inproc::{InprocConn, InprocFrame, InprocListener, InprocPeerSnapshot};
+pub use inproc::{InboundFrame, InprocConn, InprocListener, InprocPeerSnapshot};
 pub use ipc::IpcTransport;
 pub use tcp::TcpTransport;
 #[cfg(feature = "ws")]


### PR DESCRIPTION
- omq-compio already used `InboundFrame` but omq-tokio and docs still referenced the old `InprocFrame` name
- Renamed in 4 Rust files (`omq-tokio`) and 3 doc files (`doc/architecture.md`, `doc/compio.md`, `doc/performance.md`)