### PR TITLE
trim default-members to cross-platform crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "omq-libzmq",
     "yring",
 ]
-default-members = ["blume", "omq", "omq-compio", "omq-proto", "omq-tokio", "omq-zeromq", "omq-libzmq", "yring"]
+default-members = ["omq", "omq-proto", "omq-tokio"]
 # Bindings live in their own subtree. Each is its own build root - Python's
 # maturin / Ruby's rake-compiler / etc. drive them - and they would otherwise
 # pull foreign-language toolchains into `cargo build --workspace`.


### PR DESCRIPTION
- Remove omq-compio, omq-libzmq, omq-zeromq, blume, and yring from default-members
- Bare `cargo build` / `cargo clippy` now works on macOS (no io_uring / libzmq dep)
- Full workspace still reachable via `--workspace`