### PR TITLE
fix: allow dead_code on send_hwm when priority feature enabled

### DIFF
--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -37,6 +37,7 @@ pub(crate) struct DirectIoState {
     pub(crate) encoded_queue: Mutex<EncodedQueue>,
     pub(crate) driver_in_select: AtomicBool,
     pub(crate) direct_msg_count: AtomicUsize,
+    #[cfg_attr(feature = "priority", allow(dead_code))]
     pub(crate) send_hwm: usize,
     pub(crate) large_recv_pending: AtomicUsize,
     pub(crate) pending_acc: Mutex<Option<BytesMut>>,


### PR DESCRIPTION
- `send_hwm` is only read in `try_direct_encode`, which is `#[cfg(not(feature = "priority"))]`
- Add the same `#[cfg_attr(feature = "priority", allow(dead_code))]` guard already used by `has_transform`, `uses_crypto`, and `transform_passthrough`