### PR TITLE
fix: RFC 23 compliance violations in ZMTP greeting and property parsing

### DIFF
--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -495,6 +495,9 @@ impl Socket {
         while let Some(ev) = io.codec.poll_event() {
             match ev {
                 Event::Message(_) => unreachable!("messages use poll_message"),
+                // Direct-recv sockets (PULL/SUB/PAIR/…) don't process
+                // post-handshake commands here; PING/PONG are already
+                // handled inside the codec.
                 Event::Command(_) => {}
                 Event::HandshakeSucceeded { .. } => {
                     io.handshake_done = true;

--- a/omq-compio/tests/fuzz_parsers.rs
+++ b/omq-compio/tests/fuzz_parsers.rs
@@ -1,21 +1,33 @@
 #![cfg(feature = "fuzz")]
-//! Hand-rolled fuzz tests for the wire parsers and the codec
-//! state machine. Uses `rand` (already a dep) to generate
-//! random byte sequences and asserts that decoders never panic
-//! on hostile input - they must return `Result::Err`.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_lossless,
+    clippy::too_many_lines,
+    clippy::collapsible_if,
+    clippy::missing_panics_doc,
+    clippy::items_after_statements,
+    clippy::doc_markdown
+)]
+//! Fuzz tests for the wire parsers and the codec state machine.
 //!
-//! This is coverage-blind (no libfuzzer / no cargo-fuzz on stable),
-//! but at ~1 M iterations per target it still surfaces panics on
-//! the cheap. Set `OMQ_FUZZ_SEED=<u64>` to reproduce a given run;
-//! set `OMQ_FUZZ_ITERS=<N>` to tune the per-target budget.
+//! Two tiers:
+//!   1. Crash resistance — hostile bytes must never panic (Err is fine).
+//!   2. RFC compliance — valid inputs must be accepted, invalid must be
+//!      rejected, with specific assertions on which.
+//!
+//! Set `OMQ_FUZZ_SEED=<u64>` to reproduce; `OMQ_FUZZ_ITERS=<N>` to tune.
 
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 
+use omq_compio::error::Error;
+use omq_compio::message::Message;
 use omq_compio::proto::{
     SocketType, command,
     connection::{Connection, ConnectionConfig, Role},
+    greeting::{GREETING_LEN, Greeting, MechanismName},
     mechanism::MechanismSetup,
     z85,
 };
@@ -47,6 +59,163 @@ fn random_bytes(rng: &mut StdRng, max_len: usize) -> Vec<u8> {
     v
 }
 
+const VALID_PROP_CHARS: &[u8] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.+";
+
+const ALL_SOCKET_TYPES: [SocketType; 11] = [
+    SocketType::Pair,
+    SocketType::Pub,
+    SocketType::Sub,
+    SocketType::Req,
+    SocketType::Rep,
+    SocketType::Dealer,
+    SocketType::Router,
+    SocketType::Pull,
+    SocketType::Push,
+    SocketType::XPub,
+    SocketType::XSub,
+];
+
+/// Build a valid NULL client greeting as raw bytes.
+fn null_client_greeting() -> Vec<u8> {
+    let g = Greeting::current(MechanismName::NULL, false);
+    let mut buf = BytesMut::new();
+    g.encode(&mut buf);
+    buf.to_vec()
+}
+
+/// Build a COMMAND frame (short form if <=255, long form otherwise).
+fn command_frame(body: &[u8]) -> Vec<u8> {
+    if body.len() <= 255 {
+        let mut out = Vec::with_capacity(2 + body.len());
+        out.push(0x04); // COMMAND flag, short form
+        out.push(body.len() as u8);
+        out.extend_from_slice(body);
+        out
+    } else {
+        long_command_frame(body)
+    }
+}
+
+/// Build a long-form COMMAND frame.
+fn long_command_frame(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(9 + body.len());
+    out.push(0x06); // COMMAND | LONG
+    out.extend_from_slice(&(body.len() as u64).to_be_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
+/// Encode a READY command body with the given properties.
+fn ready_body(socket_type: &str, identity: Option<&[u8]>, extra: &[(&[u8], &[u8])]) -> Vec<u8> {
+    let mut buf = BytesMut::new();
+    buf.put_u8(5);
+    buf.put_slice(b"READY");
+    // Socket-Type
+    buf.put_u8(11);
+    buf.put_slice(b"Socket-Type");
+    buf.put_u32(socket_type.len() as u32);
+    buf.put_slice(socket_type.as_bytes());
+    // Identity
+    if let Some(id) = identity {
+        buf.put_u8(8);
+        buf.put_slice(b"Identity");
+        buf.put_u32(id.len() as u32);
+        buf.put_slice(id);
+    }
+    for &(name, value) in extra {
+        buf.put_u8(name.len() as u8);
+        buf.put_slice(name);
+        buf.put_u32(value.len() as u32);
+        buf.put_slice(value);
+    }
+    buf.to_vec()
+}
+
+/// Build a complete valid handshake byte stream (greeting + READY frame).
+fn valid_handshake(socket_type: &str) -> Vec<u8> {
+    let mut wire = null_client_greeting();
+    let body = ready_body(socket_type, None, &[]);
+    wire.extend_from_slice(&command_frame(&body));
+    wire
+}
+
+/// Create a fresh server-side NULL Connection.
+fn server_conn(st: SocketType) -> Connection {
+    Connection::new(ConnectionConfig::new(Role::Server, st).mechanism(MechanismSetup::Null))
+}
+
+/// Create a fresh client-side NULL Connection.
+fn client_conn(st: SocketType) -> Connection {
+    Connection::new(ConnectionConfig::new(Role::Client, st).mechanism(MechanismSetup::Null))
+}
+
+/// Pump a Connection: drain all events and messages, return counts.
+fn drain(conn: &mut Connection) -> (usize, usize) {
+    let mut events = 0;
+    let mut msgs = 0;
+    while conn.poll_event().is_some() {
+        events += 1;
+    }
+    while conn.poll_message().is_some() {
+        msgs += 1;
+    }
+    (events, msgs)
+}
+
+/// Feed bytes to a connection in random-sized chunks (1..max_chunk).
+fn feed_chunked(
+    conn: &mut Connection,
+    data: &[u8],
+    rng: &mut StdRng,
+    max_chunk: usize,
+) -> Result<(), Error> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let chunk = rng.random_range(1..=max_chunk).min(data.len() - pos);
+        conn.handle_input(Bytes::copy_from_slice(&data[pos..pos + chunk]))?;
+        drain(conn);
+        pos += chunk;
+    }
+    Ok(())
+}
+
+/// Do a real handshake between two Connections. Returns the bytes each
+/// side transmitted (a_to_b, b_to_a).
+fn capture_handshake(a: &mut Connection, b: &mut Connection) -> (Vec<u8>, Vec<u8>) {
+    let mut a_to_b = Vec::new();
+    let mut b_to_a = Vec::new();
+    for _ in 0..20 {
+        let a_out = a.poll_transmit();
+        let b_out = b.poll_transmit();
+        if a_out.is_empty() && b_out.is_empty() {
+            break;
+        }
+        a_to_b.extend_from_slice(&a_out);
+        b_to_a.extend_from_slice(&b_out);
+        a.advance_transmit(a_out.len());
+        b.advance_transmit(b_out.len());
+        if !a_to_b.is_empty() {
+            let _ = b.handle_input(Bytes::copy_from_slice(&a_to_b));
+            a_to_b.clear();
+        }
+        if !b_to_a.is_empty() {
+            let _ = a.handle_input(Bytes::copy_from_slice(&b_to_a));
+            b_to_a.clear();
+        }
+        drain(a);
+        drain(b);
+    }
+    // Capture any final bytes
+    let a_final = a.poll_transmit().to_vec();
+    let b_final = b.poll_transmit().to_vec();
+    (a_final, b_final)
+}
+
+// ================================================================
+// Tier 1: crash resistance
+// ================================================================
+
 #[test]
 fn fuzz_command_decode() {
     let mut rng = rng();
@@ -59,9 +228,6 @@ fn fuzz_command_decode() {
     }
 }
 
-/// Feed a server-side codec a random byte stream as one big chunk and
-/// drain events. Catches panics in the full state machine
-/// (greeting → mechanism → ready) under hostile input.
 #[test]
 fn fuzz_handle_input_full_stream() {
     let mut rng = rng();
@@ -71,46 +237,26 @@ fn fuzz_handle_input_full_stream() {
         let mut conn = Connection::new(cfg);
         let raw = random_bytes(&mut rng, 4096);
         let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-        // Drain whatever events the codec emitted.
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("full_stream iter {i}");
         }
     }
 }
 
-/// Same as above but feeds the bytes in random-sized chunks. Exercises
-/// partial-read paths in the state machine where the buffer holds an
-/// incomplete header / frame between drives.
 #[test]
 fn fuzz_handle_input_chunked() {
     let mut rng = rng();
     for i in 0..iters() / 4 {
-        let cfg =
-            ConnectionConfig::new(Role::Server, SocketType::Pull).mechanism(MechanismSetup::Null);
-        let mut conn = Connection::new(cfg);
+        let mut conn = server_conn(SocketType::Pull);
         let raw = random_bytes(&mut rng, 4096);
-        let mut pos = 0;
-        while pos < raw.len() {
-            let chunk_len = rng.random_range(1..=raw.len() - pos).min(64);
-            if conn
-                .handle_input(Bytes::copy_from_slice(&raw[pos..pos + chunk_len]))
-                .is_err()
-            {
-                break; // codec rejected; further input would panic? no, but stop anyway
-            }
-            while conn.poll_event().is_some() {}
-            pos += chunk_len;
-        }
+        let _ = feed_chunked(&mut conn, &raw, &mut rng, 64);
         if i % 10_000 == 0 {
             eprintln!("chunked iter {i}");
         }
     }
 }
 
-/// Exercise both client and server roles end-to-end: feed each side a
-/// random stream and ensure neither panics. Doesn't require a valid
-/// handshake - any rejected input must surface as Err.
 #[test]
 fn fuzz_handle_input_both_roles() {
     let mut rng = rng();
@@ -120,34 +266,24 @@ fn fuzz_handle_input_both_roles() {
         } else {
             Role::Client
         };
-        let st = match rng.random_range(0..4) {
-            0 => SocketType::Push,
-            1 => SocketType::Pull,
-            2 => SocketType::Pair,
-            _ => SocketType::Dealer,
-        };
+        let st = ALL_SOCKET_TYPES[rng.random_range(0..ALL_SOCKET_TYPES.len())];
         let cfg = ConnectionConfig::new(role, st).mechanism(MechanismSetup::Null);
         let mut conn = Connection::new(cfg);
         let raw = random_bytes(&mut rng, 2048);
         let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("both_roles iter {i}");
         }
     }
 }
 
-/// Roundtrip property: encode an arbitrary frame, decode it, must
-/// match. Catches asymmetries in the LONG / SHORT length encoding,
-/// flag bit handling, or buffer-management bugs in either side.
 #[test]
 fn fuzz_frame_roundtrip() {
     use omq_compio::message::{Frame, FrameFlags, Payload};
     use omq_compio::proto::frame::{decode_frame_from_bytes, encode_frame};
     let mut rng = rng();
     for i in 0..iters() / 2 {
-        // Random size sweep covering both short (<=255) and long (>255)
-        // header forms, plus boundary +/- 1.
         let size = match rng.random_range(0..6) {
             0 => 0,
             1 => rng.random_range(1..=255),
@@ -159,7 +295,6 @@ fn fuzz_frame_roundtrip() {
         let mut payload = vec![0u8; size];
         rng.fill_bytes(&mut payload);
         let bytes = Bytes::from(payload);
-        // command + more is illegal; flip them independently but never both on.
         let (more, command) = match rng.random_range(0..3) {
             0 => (false, false),
             1 => (true, false),
@@ -184,57 +319,36 @@ fn fuzz_frame_roundtrip() {
     }
 }
 
-/// Structured-mutation fuzz: start with a valid client greeting prefix
-/// and randomly perturb a small number of bytes. This drives the
-/// state machine PAST the greeting check so the mechanism / frame
-/// parsers see exercise (purely random bytes almost always fail at
-/// the magic-byte check, leaving deeper paths unexplored).
 #[test]
 fn fuzz_handle_input_perturbed_greeting() {
     let mut rng = rng();
-    // A valid 64-byte ZMTP 3.1 client greeting with NULL mechanism.
-    // sig(10) + version(2) + mechanism(20) + as-server(1) + filler(31)
-    let mut base: [u8; 64] = [0; 64];
-    base[0] = 0xff;
-    base[9] = 0x7f;
-    base[10] = 0x03; // major
-    base[11] = 0x01; // minor
-    base[12..16].copy_from_slice(b"NULL");
-    base[31] = 0; // as-server = false (client)
+    let base = null_client_greeting();
     for i in 0..iters() / 4 {
-        let mut buf = base.to_vec();
-        // Append a random tail of frame-or-junk bytes.
+        let mut buf = base.clone();
         let tail_len = rng.random_range(0..=512);
         let mut tail = vec![0u8; tail_len];
         rng.fill_bytes(&mut tail);
         buf.extend_from_slice(&tail);
-        // Flip 0..3 random bytes in the greeting prefix.
         let flips = rng.random_range(0..=3);
         for _ in 0..flips {
             let pos = rng.random_range(0..64);
             buf[pos] = rng.random();
         }
-        let cfg =
-            ConnectionConfig::new(Role::Server, SocketType::Pull).mechanism(MechanismSetup::Null);
-        let mut conn = Connection::new(cfg);
+        let mut conn = server_conn(SocketType::Pull);
         let _ = conn.handle_input(Bytes::copy_from_slice(&buf));
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("perturbed iter {i}");
         }
     }
 }
 
-/// z85 is the ASCII armor used for CURVE keys - fed user-supplied
-/// strings, must never panic on hostile input (incl. invalid chars,
-/// lengths not divisible by 5, leading/trailing whitespace, etc.).
 #[test]
 fn fuzz_z85_decode() {
     let mut rng = rng();
     let alphabet: &[u8] =
         b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
     for i in 0..iters() / 4 {
-        // Mix 90% z85-alphabet bytes with 10% arbitrary, length 0..256.
         let len = rng.random_range(0..=256);
         let mut s = String::with_capacity(len);
         for _ in 0..len {
@@ -254,18 +368,13 @@ fn fuzz_z85_decode() {
     }
 }
 
-/// LZ4 transform decoder fuzz: random byte parts fed to the decoder,
-/// must never panic (must reject as Err). Catches panics in the
-/// SENTINEL parsing, declared-size handling, and decompress paths.
 #[cfg(feature = "lz4")]
 #[test]
 fn fuzz_lz4_decode() {
-    use omq_compio::message::Message;
     use omq_compio::proto::transform::lz4::Lz4Decoder;
     let mut rng = rng();
     for i in 0..iters() / 4 {
         let mut tx = Lz4Decoder::new();
-        // Build a random message with 1..=4 random parts.
         let n_parts = rng.random_range(1..=4);
         let mut parts_vec: Vec<Bytes> = Vec::new();
         for _ in 0..n_parts {
@@ -283,7 +392,6 @@ fn fuzz_lz4_decode() {
 #[cfg(feature = "zstd")]
 #[test]
 fn fuzz_zstd_decode() {
-    use omq_compio::message::Message;
     use omq_compio::proto::transform::zstd::ZstdDecoder;
     let mut rng = rng();
     for i in 0..iters() / 4 {
@@ -302,16 +410,845 @@ fn fuzz_zstd_decode() {
     }
 }
 
+// ================================================================
+// Tier 2: RFC compliance + adversarial structured inputs
+// ================================================================
+
+/// Greeting version + as_server compliance across all 256 major values,
+/// random minors, every mechanism name variant.
+#[test]
+fn fuzz_greeting_compliance() {
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let major: u8 = rng.random();
+        let minor: u8 = rng.random();
+        let as_server = rng.random_bool(0.5);
+        let g = Greeting {
+            major,
+            minor,
+            mechanism: MechanismName::NULL,
+            as_server,
+        };
+        let mut wire = BytesMut::new();
+        g.encode(&mut wire);
+
+        let mut conn = server_conn(SocketType::Pull);
+        let result = conn.handle_input(wire.freeze());
+
+        if major < 3 {
+            assert!(result.is_err(), "major {major} must be rejected");
+        } else if as_server {
+            assert!(result.is_err(), "NULL + as_server=1 must be rejected");
+        } else {
+            assert!(
+                result.is_ok(),
+                "major {major} + as_server=0 must be accepted"
+            );
+        }
+        if i % 10_000 == 0 {
+            eprintln!("greeting_compliance iter {i}");
+        }
+    }
+}
+
+/// Our own NULL greeting must always have as_server=0.
+#[test]
+fn fuzz_null_greeting_output() {
+    for role in [Role::Client, Role::Server] {
+        for &st in &ALL_SOCKET_TYPES {
+            let cfg = ConnectionConfig::new(role, st).mechanism(MechanismSetup::Null);
+            let conn = Connection::new(cfg);
+            let wire = conn.poll_transmit();
+            assert!(wire.len() >= 33, "greeting too short");
+            assert_eq!(
+                wire[32], 0,
+                "NULL greeting must have as_server=0 ({role:?}/{st:?})"
+            );
+        }
+    }
+}
+
+/// Byte surgery on a captured real handshake: corrupt 1-8 random bytes,
+/// then deliver in 1-byte chunks. Exercises every partial-parse path
+/// under corruption.
+#[test]
+fn fuzz_handshake_byte_surgery() {
+    let mut rng = rng();
+    let base = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let mut wire = base.clone();
+        let n_flips = rng.random_range(1..=8);
+        for _ in 0..n_flips {
+            let pos = rng.random_range(0..wire.len());
+            wire[pos] = rng.random();
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        // Deliver one byte at a time — maximizes partial-parse coverage.
+        let _ = feed_chunked(&mut conn, &wire, &mut rng, 1);
+        if i % 10_000 == 0 {
+            eprintln!("byte_surgery iter {i}");
+        }
+    }
+}
+
+/// Truncate a valid handshake at every possible offset. The codec must
+/// never panic, regardless of where the cut lands (mid-signature,
+/// mid-mechanism-name, mid-frame-header, mid-property, etc.).
+#[test]
+fn fuzz_handshake_truncation() {
+    let mut rng = rng();
+    let base = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let cut = rng.random_range(0..=base.len());
+        let mut conn = server_conn(SocketType::Pull);
+        // Sometimes deliver as one chunk, sometimes byte-by-byte.
+        if rng.random_bool(0.5) {
+            let _ = conn.handle_input(Bytes::copy_from_slice(&base[..cut]));
+        } else {
+            let _ = feed_chunked(&mut conn, &base[..cut], &mut rng, 3);
+        }
+        drain(&mut conn);
+        if i % 10_000 == 0 {
+            eprintln!("truncation iter {i}");
+        }
+    }
+}
+
+/// Valid handshake followed by adversarial post-handshake data:
+/// random frames, illegal flag combos (COMMAND|MORE), huge declared
+/// sizes with tiny payloads, zero-length frames, rapid-fire multi-frame
+/// messages, commands after ready.
+#[test]
+fn fuzz_post_handshake_chaos() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        assert!(pull.is_ready(), "handshake must succeed");
+
+        // Now feed hostile frames directly into pull.
+        let n_frames = rng.random_range(1..=20);
+        for _ in 0..n_frames {
+            let frame = match rng.random_range(0..8) {
+                // Random garbage
+                0 => random_bytes(&mut rng, 512),
+                // Short data frame, random payload
+                1 => {
+                    let payload = random_bytes(&mut rng, 255);
+                    let mut f = vec![0x00u8]; // data, short
+                    f.push(payload.len() as u8);
+                    f.extend_from_slice(&payload);
+                    f
+                }
+                // Long data frame with huge declared size, tiny actual
+                2 => {
+                    let mut f = vec![0x02u8]; // data, long
+                    let declared: u64 = rng.random_range(0..=u32::MAX as u64);
+                    f.extend_from_slice(&declared.to_be_bytes());
+                    let actual = random_bytes(&mut rng, 64);
+                    f.extend_from_slice(&actual);
+                    f
+                }
+                // Illegal flag combo: COMMAND | MORE (0x05)
+                3 => {
+                    let payload = random_bytes(&mut rng, 128);
+                    let mut f = vec![0x05u8]; // COMMAND|MORE — illegal
+                    f.push(payload.len() as u8);
+                    f.extend_from_slice(&payload);
+                    f
+                }
+                // Command frame with random body
+                4 => {
+                    let body = random_bytes(&mut rng, 512);
+                    long_command_frame(&body)
+                }
+                // Zero-length frame
+                5 => vec![0x00, 0x00],
+                // Frame with all flag bits set (0x07 = MORE|LONG|COMMAND)
+                6 => {
+                    let mut f = vec![0x07u8];
+                    f.extend_from_slice(&0u64.to_be_bytes());
+                    f
+                }
+                // READY/ERROR command after handshake (should be rejected)
+                _ => {
+                    let body = ready_body("PUSH", None, &[]);
+                    command_frame(&body)
+                }
+            };
+            if pull.handle_input(Bytes::from(frame)).is_err() {
+                break;
+            }
+            drain(&mut pull);
+        }
+        if i % 5_000 == 0 {
+            eprintln!("post_handshake iter {i}");
+        }
+    }
+}
+
+/// Bidirectional corruption: two real connections, but we randomly
+/// corrupt, duplicate, drop, or truncate bytes flowing between them.
+#[test]
+fn fuzz_bidirectional_corruption() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut a = client_conn(SocketType::Pair);
+        let mut b = server_conn(SocketType::Pair);
+        let mut a_err = false;
+        let mut b_err = false;
+
+        for _ in 0..30 {
+            let a_out = a.poll_transmit().to_vec();
+            let b_out = b.poll_transmit().to_vec();
+            a.advance_transmit(a_out.len());
+            b.advance_transmit(b_out.len());
+
+            if a_out.is_empty() && b_out.is_empty() {
+                break;
+            }
+
+            // Corrupt a→b
+            if !a_out.is_empty() && !b_err {
+                let wire = corrupt_wire(&a_out, &mut rng);
+                if b.handle_input(Bytes::from(wire)).is_err() {
+                    b_err = true;
+                }
+                drain(&mut b);
+            }
+            // Corrupt b→a
+            if !b_out.is_empty() && !a_err {
+                let wire = corrupt_wire(&b_out, &mut rng);
+                if a.handle_input(Bytes::from(wire)).is_err() {
+                    a_err = true;
+                }
+                drain(&mut a);
+            }
+            if a_err && b_err {
+                break;
+            }
+        }
+
+        // If handshake survived, send some messages through
+        if a.is_ready() && b.is_ready() {
+            for _ in 0..5 {
+                let msg = Message::single(random_bytes(&mut rng, 128));
+                if a.send_message(&msg).is_err() {
+                    break;
+                }
+                let wire = a.poll_transmit().to_vec();
+                a.advance_transmit(wire.len());
+                let wire = corrupt_wire(&wire, &mut rng);
+                let _ = b.handle_input(Bytes::from(wire));
+                drain(&mut b);
+            }
+        }
+        if i % 5_000 == 0 {
+            eprintln!("bidirectional iter {i}");
+        }
+    }
+}
+
+fn corrupt_wire(data: &[u8], rng: &mut StdRng) -> Vec<u8> {
+    let mut wire = data.to_vec();
+    match rng.random_range(0..6) {
+        // Pass through clean (10% of the time)
+        0 => {}
+        // Flip 1-3 random bytes
+        1 => {
+            let n = rng.random_range(1..=3).min(wire.len().max(1));
+            for _ in 0..n {
+                if !wire.is_empty() {
+                    let pos = rng.random_range(0..wire.len());
+                    wire[pos] = rng.random();
+                }
+            }
+        }
+        // Truncate
+        2 => {
+            if !wire.is_empty() {
+                let cut = rng.random_range(0..wire.len());
+                wire.truncate(cut);
+            }
+        }
+        // Duplicate a random slice
+        3 => {
+            if wire.len() > 1 {
+                let start = rng.random_range(0..wire.len());
+                let len = rng.random_range(1..=(wire.len() - start).min(64));
+                let dup = wire[start..start + len].to_vec();
+                let insert_at = rng.random_range(0..=wire.len());
+                wire.splice(insert_at..insert_at, dup);
+            }
+        }
+        // Insert random garbage
+        4 => {
+            let garbage_len = rng.random_range(1..=32);
+            let mut garbage = vec![0u8; garbage_len];
+            rng.fill_bytes(&mut garbage);
+            let insert_at = rng.random_range(0..=wire.len());
+            wire.splice(insert_at..insert_at, garbage);
+        }
+        // Drop a random range of bytes
+        _ => {
+            if wire.len() > 1 {
+                let start = rng.random_range(0..wire.len());
+                let len = rng.random_range(1..=(wire.len() - start).min(16));
+                wire.drain(start..start + len);
+            }
+        }
+    }
+    wire
+}
+
+/// Property parsing stress: boundary-length names (1, 127, 254, 255),
+/// every byte value in names, many properties, truncation at every
+/// offset within the property list, duplicate well-known properties,
+/// declared-vs-actual value length mismatches.
+#[test]
+fn fuzz_property_adversarial() {
+    let mut rng = rng();
+    for i in 0..iters() / 2 {
+        let scenario = rng.random_range(0..8);
+        let result = match scenario {
+            // Random name length, random chars (mix valid/invalid)
+            0 => {
+                let name_len: u8 = rng.random_range(0..=20);
+                let mut name = Vec::with_capacity(name_len as usize);
+                for _ in 0..name_len {
+                    if rng.random_bool(0.5) {
+                        name.push(VALID_PROP_CHARS[rng.random_range(0..VALID_PROP_CHARS.len())]);
+                    } else {
+                        name.push(rng.random());
+                    }
+                }
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(name_len);
+                body.put_slice(&name);
+                body.put_u32(1);
+                body.put_u8(b'v');
+                command::decode(body.freeze())
+            }
+            // Boundary-length property name (254, 255 bytes)
+            1 => {
+                let name_len = if rng.random_bool(0.5) { 254 } else { 255 };
+                let name: Vec<u8> = (0..name_len)
+                    .map(|_| VALID_PROP_CHARS[rng.random_range(0..VALID_PROP_CHARS.len())])
+                    .collect();
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(name_len as u8);
+                body.put_slice(&name);
+                body.put_u32(3);
+                body.put_slice(b"yes");
+                command::decode(body.freeze())
+            }
+            // Duplicate Socket-Type
+            2 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PULL");
+                command::decode(body.freeze())
+            }
+            // Duplicate Identity
+            3 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(8);
+                body.put_slice(b"Identity");
+                body.put_u32(3);
+                body.put_slice(b"aaa");
+                body.put_u8(8);
+                body.put_slice(b"Identity");
+                body.put_u32(3);
+                body.put_slice(b"bbb");
+                command::decode(body.freeze())
+            }
+            // Many properties (50-200), all valid
+            4 => {
+                let n_props = rng.random_range(50..=200);
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                for j in 0..n_props {
+                    let name = format!("X-Prop-{j}");
+                    body.put_u8(name.len() as u8);
+                    body.put_slice(name.as_bytes());
+                    body.put_u32(1);
+                    body.put_u8(b'v');
+                }
+                command::decode(body.freeze())
+            }
+            // Truncation: build valid properties, cut at random offset
+            5 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(5);
+                body.put_slice(b"X-Foo");
+                body.put_u32(10);
+                body.put_slice(b"0123456789");
+                let full = body.freeze();
+                let cut = rng.random_range(0..=full.len());
+                command::decode(full.slice(..cut))
+            }
+            // Declared value length >> actual remaining bytes
+            6 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(5);
+                body.put_slice(b"X-Big");
+                // Declare huge value length but provide tiny payload
+                body.put_u32(rng.random_range(1000..=u16::MAX as u32));
+                let actual = random_bytes(&mut rng, 10);
+                body.put_slice(&actual);
+                command::decode(body.freeze())
+            }
+            // Every possible byte value in a 1-char property name
+            _ => {
+                let byte: u8 = rng.random();
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(1);
+                body.put_u8(byte);
+                body.put_u32(1);
+                body.put_u8(b'v');
+                let r = command::decode(body.freeze());
+                let valid = byte.is_ascii_alphanumeric()
+                    || byte == b'-'
+                    || byte == b'_'
+                    || byte == b'.'
+                    || byte == b'+';
+                match &r {
+                    Ok(_) => assert!(valid, "accepted invalid prop name byte 0x{byte:02x}"),
+                    Err(e) => assert!(!valid, "rejected valid prop name byte 0x{byte:02x}: {e}"),
+                }
+                r
+            }
+        };
+        // scenarios 2-3 (duplicate props) must always be rejected
+        if scenario == 2 {
+            assert!(result.is_err(), "duplicate Socket-Type must be rejected");
+        }
+        if scenario == 3 {
+            assert!(result.is_err(), "duplicate Identity must be rejected");
+        }
+        // scenario 6 (huge declared value) must be rejected (truncated)
+        if scenario == 6 {
+            assert!(result.is_err(), "declared len >> actual must be rejected");
+        }
+        let _ = result;
+        if i % 50_000 == 0 {
+            eprintln!("property_adversarial iter {i}");
+        }
+    }
+}
+
+/// Greeting with mechanism name mismatches, non-NULL mechanisms against
+/// NULL server, and every possible mechanism name byte pattern.
+#[test]
+fn fuzz_greeting_mechanism_mismatch() {
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let mut raw = null_client_greeting();
+        // Corrupt the mechanism name region (bytes 12..32)
+        match rng.random_range(0..5) {
+            // Random mechanism name
+            0 => {
+                for b in &mut raw[12..32] {
+                    *b = rng.random();
+                }
+            }
+            // "CURVE" against NULL server
+            1 => {
+                raw[12..32].fill(0);
+                raw[12..17].copy_from_slice(b"CURVE");
+            }
+            // "PLAIN" against NULL server
+            2 => {
+                raw[12..32].fill(0);
+                raw[12..17].copy_from_slice(b"PLAIN");
+            }
+            // Valid NULL but with garbage in padding after NUL
+            3 => {
+                raw[16] = rng.random_range(1..=255); // non-zero after "NULL"
+            }
+            // Empty mechanism name (all zeros)
+            _ => {
+                raw[12..32].fill(0);
+            }
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        let _ = conn.handle_input(Bytes::from(raw));
+        drain(&mut conn);
+        if i % 10_000 == 0 {
+            eprintln!("mech_mismatch iter {i}");
+        }
+    }
+}
+
+/// Full-sequence structured fuzz: valid greeting → adversarial command
+/// frame → random tail. The command frame exercises the mechanism
+/// handshake path (NULL READY parsing) with hostile content.
+#[test]
+fn fuzz_greeting_then_hostile_ready() {
+    let mut rng = rng();
+    let greeting = null_client_greeting();
+    for i in 0..iters() / 4 {
+        let mut wire = greeting.clone();
+        // Build a command frame with random body that might or might not
+        // look like READY.
+        let body_len = rng.random_range(0..=512);
+        let mut body = vec![0u8; body_len];
+        rng.fill_bytes(&mut body);
+        // 50%: make it look READY-shaped (name_len=5, "READY", then garbage)
+        if rng.random_bool(0.5) && body_len >= 6 {
+            body[0] = 5;
+            body[1..6].copy_from_slice(b"READY");
+        }
+        // 20%: make it ERROR-shaped
+        if rng.random_bool(0.2) && body_len >= 6 {
+            body[0] = 5;
+            body[1..6].copy_from_slice(b"ERROR");
+        }
+        if body_len <= 255 {
+            wire.extend_from_slice(&command_frame(&body));
+        } else {
+            wire.extend_from_slice(&long_command_frame(&body));
+        }
+        // Sometimes append more garbage after the command frame.
+        if rng.random_bool(0.3) {
+            let tail = random_bytes(&mut rng, 256);
+            wire.extend_from_slice(&tail);
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        // Sometimes deliver chunked, sometimes all at once.
+        if rng.random_bool(0.5) {
+            let _ = feed_chunked(&mut conn, &wire, &mut rng, 16);
+        } else {
+            let _ = conn.handle_input(Bytes::from(wire));
+            drain(&mut conn);
+        }
+        if i % 10_000 == 0 {
+            eprintln!("hostile_ready iter {i}");
+        }
+    }
+}
+
+/// Deliver a valid greeting one byte at a time with random delays
+/// (interleaved with zero-length inputs), then follow with a READY
+/// that has random corruption at each byte position.
+#[test]
+fn fuzz_greeting_byte_drip() {
+    let mut rng = rng();
+    let full = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let mut conn = server_conn(SocketType::Pull);
+        let mut ok = true;
+        for (j, &byte) in full.iter().enumerate() {
+            // Occasionally corrupt this byte
+            let b = if rng.random_bool(0.05) {
+                rng.random()
+            } else {
+                byte
+            };
+            // Occasionally send a zero-length input (must be a no-op)
+            if rng.random_bool(0.1) {
+                if conn.handle_input(Bytes::new()).is_err() {
+                    ok = false;
+                    break;
+                }
+            }
+            if conn.handle_input(Bytes::copy_from_slice(&[b])).is_err() {
+                ok = false;
+                break;
+            }
+            drain(&mut conn);
+            // If we're past greeting (byte 63) and handshake completed, stop
+            if j >= GREETING_LEN && conn.is_ready() {
+                break;
+            }
+        }
+        let _ = ok;
+        if i % 10_000 == 0 {
+            eprintln!("byte_drip iter {i}");
+        }
+    }
+}
+
+/// Frame decoder stress: adversarial flag bytes, size fields, and
+/// payloads fed directly through the Connection state machine after a
+/// valid handshake. Tests frame parsing in the post-handshake data path.
+#[test]
+fn fuzz_frame_adversarial() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        if !pull.is_ready() {
+            continue;
+        }
+
+        // Build adversarial frames and feed them
+        let n_frames = rng.random_range(1..=10);
+        let mut wire = Vec::new();
+        for _ in 0..n_frames {
+            let flags: u8 = rng.random();
+            let is_long = flags & 0x02 != 0;
+            if is_long {
+                wire.push(flags);
+                let size: u64 = match rng.random_range(0..4) {
+                    0 => 0,
+                    1 => rng.random_range(0..=255),
+                    2 => rng.random_range(256..=65536),
+                    _ => rng.random_range(0..=u32::MAX as u64),
+                };
+                wire.extend_from_slice(&size.to_be_bytes());
+                // Only provide a small amount of actual payload
+                let actual = rng.random_range(0..=64).min(size as usize);
+                let mut payload = vec![0u8; actual];
+                rng.fill_bytes(&mut payload);
+                wire.extend_from_slice(&payload);
+            } else {
+                wire.push(flags);
+                let size: u8 = rng.random();
+                wire.push(size);
+                let actual = rng.random_range(0..=size as usize);
+                let mut payload = vec![0u8; actual];
+                rng.fill_bytes(&mut payload);
+                wire.extend_from_slice(&payload);
+            }
+        }
+
+        if rng.random_bool(0.5) {
+            let _ = pull.handle_input(Bytes::from(wire));
+        } else {
+            let _ = feed_chunked(&mut pull, &wire, &mut rng, 8);
+        }
+        drain(&mut pull);
+        if i % 5_000 == 0 {
+            eprintln!("frame_adversarial iter {i}");
+        }
+    }
+}
+
+/// Message roundtrip under corruption: encode real messages through
+/// push's Connection, corrupt the wire bytes, feed to pull. Must never
+/// panic; corrupted messages must surface as Err or silently dropped,
+/// never as garbage data presented as a valid message.
+#[test]
+fn fuzz_message_roundtrip_corrupt() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        if !push.is_ready() {
+            continue;
+        }
+
+        // Send 1-5 messages, collect all wire bytes
+        let n_msgs = rng.random_range(1..=5);
+        let mut original_payloads: Vec<Vec<u8>> = Vec::new();
+        for _ in 0..n_msgs {
+            let n_parts = rng.random_range(1..=4);
+            let parts: Vec<Vec<u8>> = (0..n_parts).map(|_| random_bytes(&mut rng, 256)).collect();
+            let msg = Message::multipart(parts.iter().map(|p| Bytes::from(p.clone())));
+            original_payloads.push(parts.into_iter().flatten().collect());
+            if push.send_message(&msg).is_err() {
+                break;
+            }
+        }
+        let wire = push.poll_transmit().to_vec();
+        push.advance_transmit(wire.len());
+
+        // Corrupt the wire
+        let corrupted = corrupt_wire(&wire, &mut rng);
+
+        // Feed to pull
+        if rng.random_bool(0.5) {
+            let _ = pull.handle_input(Bytes::from(corrupted));
+        } else {
+            let _ = feed_chunked(&mut pull, &corrupted, &mut rng, 32);
+        }
+        drain(&mut pull);
+        if i % 5_000 == 0 {
+            eprintln!("msg_corrupt iter {i}");
+        }
+    }
+}
+
+/// State machine confusion: interleave greeting bytes from multiple
+/// different connections, simulating stream mixup or injection.
+#[test]
+fn fuzz_interleaved_streams() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        // Build 2-4 different valid handshake streams
+        let n_streams = rng.random_range(2..=4);
+        let socket_types = ["PUSH", "PULL", "PAIR", "DEALER", "ROUTER"];
+        let streams: Vec<Vec<u8>> = (0..n_streams)
+            .map(|_| valid_handshake(socket_types[rng.random_range(0..socket_types.len())]))
+            .collect();
+
+        // Interleave bytes from all streams into one Franken-stream
+        let mut franken = Vec::new();
+        let mut positions: Vec<usize> = vec![0; n_streams];
+        while positions.iter().zip(&streams).any(|(p, s)| *p < s.len()) {
+            let stream_idx = rng.random_range(0..n_streams);
+            if positions[stream_idx] < streams[stream_idx].len() {
+                let chunk_len = rng
+                    .random_range(1..=16)
+                    .min(streams[stream_idx].len() - positions[stream_idx]);
+                franken.extend_from_slice(
+                    &streams[stream_idx][positions[stream_idx]..positions[stream_idx] + chunk_len],
+                );
+                positions[stream_idx] += chunk_len;
+            }
+        }
+
+        let mut conn = server_conn(SocketType::Pull);
+        let _ = feed_chunked(&mut conn, &franken, &mut rng, 32);
+        if i % 5_000 == 0 {
+            eprintln!("interleaved iter {i}");
+        }
+    }
+}
+
+/// Replay attack: complete a valid handshake, then replay the greeting
+/// and READY again. The state machine must reject the second greeting.
+#[test]
+fn fuzz_replay_attack() {
+    let mut rng = rng();
+    let handshake = valid_handshake("PULL");
+    for i in 0..iters() / 8 {
+        let mut conn = server_conn(SocketType::Pull);
+        if conn.handle_input(Bytes::from(handshake.clone())).is_err() {
+            continue;
+        }
+        drain(&mut conn);
+
+        // Replay: send the handshake bytes again
+        let _ = conn.handle_input(Bytes::from(handshake.clone()));
+        drain(&mut conn);
+
+        // Also try replaying just the READY
+        let ready_bytes = &handshake[GREETING_LEN..];
+        let _ = conn.handle_input(Bytes::copy_from_slice(ready_bytes));
+        drain(&mut conn);
+
+        // Random data after replay
+        let garbage = random_bytes(&mut rng, 512);
+        let _ = conn.handle_input(Bytes::from(garbage));
+        drain(&mut conn);
+        if i % 5_000 == 0 {
+            eprintln!("replay iter {i}");
+        }
+    }
+}
+
+/// Massive message: send a message close to max_message_size, then
+/// slightly over, through corrupt and clean paths.
+#[test]
+fn fuzz_message_size_boundary() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let max_size = rng.random_range(64..=8192);
+        let cfg = ConnectionConfig::new(Role::Server, SocketType::Pull)
+            .mechanism(MechanismSetup::Null)
+            .max_message_size(max_size);
+        let mut pull = Connection::new(cfg);
+        let mut push = client_conn(SocketType::Push);
+        capture_handshake(&mut push, &mut pull);
+        if !push.is_ready() {
+            continue;
+        }
+
+        // Send a message right at the boundary
+        for delta in [-2i64, -1, 0, 1, 2, 64] {
+            let size = (max_size as i64 + delta).max(0) as usize;
+            let payload = vec![0xAA; size];
+            let msg = Message::single(Bytes::from(payload));
+            if push.send_message(&msg).is_err() {
+                continue;
+            }
+            let wire = push.poll_transmit().to_vec();
+            push.advance_transmit(wire.len());
+
+            let result = pull.handle_input(Bytes::from(wire));
+            if result.is_err() {
+                // Re-create pull for next iteration since it's in error state
+                pull = Connection::new(
+                    ConnectionConfig::new(Role::Server, SocketType::Pull)
+                        .mechanism(MechanismSetup::Null)
+                        .max_message_size(max_size),
+                );
+                push = client_conn(SocketType::Push);
+                capture_handshake(&mut push, &mut pull);
+                if !push.is_ready() {
+                    break;
+                }
+            }
+            drain(&mut pull);
+        }
+        if i % 5_000 == 0 {
+            eprintln!("size_boundary iter {i}");
+        }
+    }
+}
+
+// ================================================================
+// Mechanism-specific fuzz (feature-gated)
+// ================================================================
+
 #[cfg(any(feature = "curve", feature = "blake3zmq"))]
 mod mech_fuzz {
     use super::*;
-    use omq_compio::proto::mechanism::MechanismSetup;
 
-    /// Build a valid 64-byte client-side greeting for the given
-    /// mechanism name (≤ 20 ASCII bytes, NUL-padded to 20). Fed into
-    /// the mechanism-specific server fuzzers below so the random
-    /// post-greeting bytes actually reach the mechanism handshake
-    /// parsers.
     fn greeting_bytes(mech_name: &[u8]) -> Vec<u8> {
         let mut g = vec![0u8; 64];
         g[0] = 0xff;
@@ -319,24 +1256,10 @@ mod mech_fuzz {
         g[10] = 0x03;
         g[11] = 0x01;
         g[12..12 + mech_name.len()].copy_from_slice(mech_name);
-        g[31] = 0; // as-server = false (we're the client side of greeting)
+        // as-server at offset 32 is implicitly 0 from zero-init.
         g
     }
 
-    /// Wrap a body as a long-form COMMAND frame: flags=0x06 (CMD|LONG)
-    /// + 8-byte size + body. Long form covers all command sizes
-    ///   without us guessing whether short form fits.
-    fn long_command_frame(body: &[u8]) -> Vec<u8> {
-        let mut out = Vec::with_capacity(9 + body.len());
-        out.push(0b0000_0110); // COMMAND | LONG
-        out.extend_from_slice(&(body.len() as u64).to_be_bytes());
-        out.extend_from_slice(body);
-        out
-    }
-
-    /// CURVE server-side fuzz, raw bytes only - most attempts fail at
-    /// greeting; deeper paths exercised by the structured variant
-    /// below.
     #[cfg(feature = "curve")]
     #[test]
     fn fuzz_curve_server_input() {
@@ -355,16 +1278,13 @@ mod mech_fuzz {
             let mut conn = Connection::new(cfg);
             let raw = random_bytes(&mut rng, 1024);
             let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("curve iter {i}");
             }
         }
     }
 
-    /// CURVE server-side, structured: feed a valid greeting + a
-    /// random HELLO-shaped command, so the random bytes actually
-    /// land in `parse_hello`.
     #[cfg(feature = "curve")]
     #[test]
     fn fuzz_curve_hello_body() {
@@ -383,11 +1303,7 @@ mod mech_fuzz {
             );
             let mut conn = Connection::new(cfg);
             let _ = conn.handle_input(Bytes::copy_from_slice(&greeting));
-            // HELLO is 194-byte body for the well-formed case;
-            // mutate length 0..256 to also hit the early-reject paths.
             let body_len = rng.random_range(0..=256);
-            // First byte of body is the command-name length; spelling
-            // "HELLO" is what makes the dispatcher route here.
             let mut body = Vec::with_capacity(1 + 5 + body_len);
             body.push(5);
             body.extend_from_slice(b"HELLO");
@@ -396,7 +1312,7 @@ mod mech_fuzz {
             body.extend_from_slice(&tail);
             let frame = long_command_frame(&body);
             let _ = conn.handle_input(Bytes::copy_from_slice(&frame));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("curve hello iter {i}");
             }
@@ -423,17 +1339,13 @@ mod mech_fuzz {
             let mut conn = Connection::new(cfg);
             let raw = random_bytes(&mut rng, 1024);
             let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("blake3zmq iter {i}");
             }
         }
     }
 
-    /// BLAKE3ZMQ server-side, structured HELLO. Greeting carries the
-    /// mechanism name "BLAKE3" (7 bytes), then a random HELLO body of
-    /// the expected ~232-byte shape (or shorter, to exercise reject
-    /// paths).
     #[cfg(feature = "blake3zmq")]
     #[test]
     fn fuzz_blake3zmq_hello_body() {
@@ -463,7 +1375,7 @@ mod mech_fuzz {
             body.extend_from_slice(&tail);
             let frame = long_command_frame(&body);
             let _ = conn.handle_input(Bytes::copy_from_slice(&frame));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("blake3zmq hello iter {i}");
             }

--- a/omq-proto/src/proto/command.rs
+++ b/omq-proto/src/proto/command.rs
@@ -264,10 +264,21 @@ pub(crate) fn decode_properties_inner(mut body: Bytes) -> Result<PeerProperties>
     let mut props = PeerProperties::default();
     while !body.is_empty() {
         let name_len = body[0] as usize;
+        if name_len == 0 {
+            return Err(Error::Protocol("READY property name is empty".into()));
+        }
         if body.len() < 1 + name_len + 4 {
             return Err(Error::Protocol("READY property truncated".into()));
         }
         let name = body.slice(1..=name_len);
+        if !name
+            .iter()
+            .all(|&b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'+')
+        {
+            return Err(Error::Protocol(
+                "READY property name contains invalid characters".into(),
+            ));
+        }
         let value_len =
             u32::from_be_bytes(body[1 + name_len..1 + name_len + 4].try_into().unwrap()) as usize;
         let val_start = 1 + name_len + 4;
@@ -277,9 +288,12 @@ pub(crate) fn decode_properties_inner(mut body: Bytes) -> Result<PeerProperties>
         let value = body.slice(val_start..val_start + value_len);
         body = body.slice(val_start + value_len..);
 
-        let name_str = std::str::from_utf8(&name)
-            .map_err(|_| Error::Protocol("READY property name not ASCII".into()))?;
+        // Safe: we validated ASCII alphanumeric + [-_.+] above.
+        let name_str = std::str::from_utf8(&name).expect("validated ASCII");
         if name_str.eq_ignore_ascii_case("Socket-Type") {
+            if props.socket_type.is_some() {
+                return Err(Error::Protocol("duplicate Socket-Type property".into()));
+            }
             let t = SocketType::from_wire(&value).ok_or_else(|| {
                 Error::Protocol(format!(
                     "unknown peer socket type: {:?}",
@@ -288,6 +302,9 @@ pub(crate) fn decode_properties_inner(mut body: Bytes) -> Result<PeerProperties>
             })?;
             props.socket_type = Some(t);
         } else if name_str.eq_ignore_ascii_case("Identity") {
+            if props.identity.is_some() {
+                return Err(Error::Protocol("duplicate Identity property".into()));
+            }
             if !value.is_empty() {
                 props.identity = Some(value);
             }
@@ -458,6 +475,54 @@ mod tests {
     fn decode_truncated_name() {
         let b = Bytes::from_static(&[5, b'x']);
         assert!(matches!(decode(b), Err(Error::Protocol(_))));
+    }
+
+    #[test]
+    fn rejects_empty_property_name() {
+        let mut body = BytesMut::new();
+        body.put_u8(0); // name_len = 0
+        body.put_u32(1);
+        body.put_u8(b'x');
+        assert!(matches!(
+            decode_properties_inner(body.freeze()),
+            Err(Error::Protocol(msg)) if msg.contains("empty")
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_property_name_chars() {
+        let mut body = BytesMut::new();
+        body.put_u8(3);
+        body.put_slice(b"a b"); // space is invalid
+        body.put_u32(1);
+        body.put_u8(b'v');
+        assert!(matches!(
+            decode_properties_inner(body.freeze()),
+            Err(Error::Protocol(msg)) if msg.contains("invalid characters")
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_socket_type() {
+        let mut body = BytesMut::new();
+        write_property(&mut body, b"Socket-Type", b"PUSH");
+        write_property(&mut body, b"Socket-Type", b"PULL");
+        assert!(matches!(
+            decode_properties_inner(body.freeze()),
+            Err(Error::Protocol(msg)) if msg.contains("duplicate Socket-Type")
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_identity() {
+        let mut body = BytesMut::new();
+        write_property(&mut body, b"Socket-Type", b"PUSH");
+        write_property(&mut body, b"Identity", b"alice");
+        write_property(&mut body, b"Identity", b"bob");
+        assert!(matches!(
+            decode_properties_inner(body.freeze()),
+            Err(Error::Protocol(msg)) if msg.contains("duplicate Identity")
+        ));
     }
 
     #[test]

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::message::{FrameFlags, Message, Payload};
 
 use super::super::command::{self, Command, PeerProperties};
-use super::super::greeting::{self, effective_minor};
+use super::super::greeting::{self, MechanismName, effective_minor};
 use super::super::mechanism::MechanismStep;
 use super::super::{frame, is_compatible};
 #[cfg(any(feature = "curve", feature = "blake3zmq"))]
@@ -68,6 +68,13 @@ impl Connection {
                 our_mech.as_str().unwrap_or("<invalid>"),
                 g.mechanism.as_str().unwrap_or("<invalid>"),
             )));
+        }
+        // RFC 23: "When a peer uses the NULL security mechanism, the as-server
+        // field MUST be zero."
+        if our_mech == MechanismName::NULL && g.as_server {
+            return Err(Error::HandshakeFailed(
+                "peer sent as-server=1 with NULL mechanism".into(),
+            ));
         }
         self.peer_minor = effective_minor(g.minor);
         self.peer_greeting = raw;

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -303,10 +303,10 @@ impl Connection {
     }
 
     fn queue_greeting(&mut self) {
-        let g = Greeting::current(
-            self.config.mechanism_name(),
-            self.config.role == Role::Server,
-        );
+        let mech = self.config.mechanism_name();
+        // RFC 23: "When a peer uses the NULL security mechanism, the as-server field MUST be zero."
+        let as_server = mech != MechanismName::NULL && self.config.role == Role::Server;
+        let g = Greeting::current(mech, as_server);
         let mut buf = BytesMut::new();
         g.encode(&mut buf);
         let bytes = buf.freeze();

--- a/omq-proto/src/proto/greeting.rs
+++ b/omq-proto/src/proto/greeting.rs
@@ -187,7 +187,7 @@ pub(crate) fn try_decode(buf: &mut ChunkedInputBuf) -> Result<Option<(Greeting, 
     let raw_bytes = raw_payload.as_bytes();
     let major = raw[10];
     let minor = raw[11];
-    if major != ZMTP_MAJOR {
+    if major < ZMTP_MAJOR {
         return Err(Error::UnsupportedZmtpVersion { major, minor });
     }
     let mut mech_raw = [0u8; MECHANISM_BYTES];
@@ -329,5 +329,25 @@ mod tests {
         let mut buf = encode_to_buf(&s);
         let (d, _) = try_decode(&mut buf).unwrap().unwrap();
         assert!(d.as_server);
+    }
+
+    #[test]
+    fn accepts_higher_major_version() {
+        let mut g = Greeting::current(MechanismName::NULL, false);
+        g.major = 4;
+        let mut buf = encode_to_buf(&g);
+        let (decoded, _) = try_decode(&mut buf).unwrap().unwrap();
+        assert_eq!(decoded.major, 4);
+    }
+
+    #[test]
+    fn rejects_lower_major_version() {
+        let mut g = Greeting::current(MechanismName::NULL, false);
+        g.major = 2;
+        let mut buf = encode_to_buf(&g);
+        assert!(matches!(
+            try_decode(&mut buf),
+            Err(Error::UnsupportedZmtpVersion { major: 2, .. })
+        ));
     }
 }

--- a/omq-proto/src/proto/mechanism/mod.rs
+++ b/omq-proto/src/proto/mechanism/mod.rs
@@ -368,6 +368,20 @@ impl NullMechanism {
     }
 
     fn on_command(&mut self, cmd: Command, _out: &mut Vec<Command>) -> Result<MechanismStep> {
+        if let Command::Unknown { ref name, ref body } = cmd
+            && name.as_ref() == b"ERROR"
+        {
+            let reason = if body.is_empty() {
+                String::new()
+            } else {
+                let reason_len = body[0] as usize;
+                let end = (1 + reason_len).min(body.len());
+                String::from_utf8_lossy(&body[1..end]).into_owned()
+            };
+            return Err(Error::HandshakeFailed(format!(
+                "NULL peer sent ERROR: {reason}"
+            )));
+        }
         match (self.state, cmd) {
             (NullState::AwaitingReady, Command::Ready(props)) => {
                 self.state = NullState::Done;
@@ -452,6 +466,27 @@ mod tests {
             .on_command(Command::Subscribe(bytes::Bytes::default()), &mut out)
             .unwrap_err();
         assert!(matches!(err, Error::HandshakeFailed(_)));
+    }
+
+    #[test]
+    fn null_surfaces_error_reason() {
+        let mut m = NullMechanism::new();
+        let mut out = Vec::new();
+        m.start(&mut out, PeerProperties::default());
+        out.clear();
+        let err = m
+            .on_command(
+                Command::Unknown {
+                    name: bytes::Bytes::from_static(b"ERROR"),
+                    body: bytes::Bytes::from_static(b"\x04auth"),
+                },
+                &mut out,
+            )
+            .unwrap_err();
+        match err {
+            Error::HandshakeFailed(msg) => assert!(msg.contains("auth"), "{msg}"),
+            other => panic!("expected HandshakeFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/omq-proto/tests/connection.rs
+++ b/omq-proto/tests/connection.rs
@@ -675,3 +675,24 @@ mod ws {
         panic!("expected incompatible socket type rejection");
     }
 }
+
+#[test]
+fn null_rejects_peer_as_server() {
+    use bytes::BytesMut;
+    use omq_proto::proto::greeting::{Greeting, MechanismName};
+
+    let mut pull = Connection::new(ConnectionConfig::new(Role::Server, SocketType::Pull));
+    // Drain the greeting pull wants to send
+    let _ = pull.poll_transmit();
+
+    // Craft a greeting with as_server=1 and NULL mechanism
+    let bad_greeting = Greeting::current(MechanismName::NULL, true);
+    let mut buf = BytesMut::new();
+    bad_greeting.encode(&mut buf);
+
+    let err = pull.handle_input(buf.freeze()).unwrap_err();
+    assert!(
+        matches!(err, Error::HandshakeFailed(ref msg) if msg.contains("as-server")),
+        "expected as-server rejection, got: {err:?}"
+    );
+}

--- a/omq-tokio/tests/fuzz_parsers.rs
+++ b/omq-tokio/tests/fuzz_parsers.rs
@@ -1,21 +1,33 @@
 #![cfg(feature = "fuzz")]
-//! Hand-rolled fuzz tests for the wire parsers and the codec
-//! state machine. Uses `rand` (already a dep) to generate
-//! random byte sequences and asserts that decoders never panic
-//! on hostile input - they must return `Result::Err`.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_lossless,
+    clippy::too_many_lines,
+    clippy::collapsible_if,
+    clippy::missing_panics_doc,
+    clippy::items_after_statements,
+    clippy::doc_markdown
+)]
+//! Fuzz tests for the wire parsers and the codec state machine.
 //!
-//! This is coverage-blind (no libfuzzer / no cargo-fuzz on stable),
-//! but at ~1 M iterations per target it still surfaces panics on
-//! the cheap. Set `OMQ_FUZZ_SEED=<u64>` to reproduce a given run;
-//! set `OMQ_FUZZ_ITERS=<N>` to tune the per-target budget.
+//! Two tiers:
+//!   1. Crash resistance — hostile bytes must never panic (Err is fine).
+//!   2. RFC compliance — valid inputs must be accepted, invalid must be
+//!      rejected, with specific assertions on which.
+//!
+//! Set `OMQ_FUZZ_SEED=<u64>` to reproduce; `OMQ_FUZZ_ITERS=<N>` to tune.
 
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 
+use omq_tokio::error::Error;
+use omq_tokio::message::Message;
 use omq_tokio::proto::{
     SocketType, command,
     connection::{Connection, ConnectionConfig, Role},
+    greeting::{GREETING_LEN, Greeting, MechanismName},
     mechanism::MechanismSetup,
     z85,
 };
@@ -47,6 +59,163 @@ fn random_bytes(rng: &mut StdRng, max_len: usize) -> Vec<u8> {
     v
 }
 
+const VALID_PROP_CHARS: &[u8] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.+";
+
+const ALL_SOCKET_TYPES: [SocketType; 11] = [
+    SocketType::Pair,
+    SocketType::Pub,
+    SocketType::Sub,
+    SocketType::Req,
+    SocketType::Rep,
+    SocketType::Dealer,
+    SocketType::Router,
+    SocketType::Pull,
+    SocketType::Push,
+    SocketType::XPub,
+    SocketType::XSub,
+];
+
+/// Build a valid NULL client greeting as raw bytes.
+fn null_client_greeting() -> Vec<u8> {
+    let g = Greeting::current(MechanismName::NULL, false);
+    let mut buf = BytesMut::new();
+    g.encode(&mut buf);
+    buf.to_vec()
+}
+
+/// Build a COMMAND frame (short form if <=255, long form otherwise).
+fn command_frame(body: &[u8]) -> Vec<u8> {
+    if body.len() <= 255 {
+        let mut out = Vec::with_capacity(2 + body.len());
+        out.push(0x04); // COMMAND flag, short form
+        out.push(body.len() as u8);
+        out.extend_from_slice(body);
+        out
+    } else {
+        long_command_frame(body)
+    }
+}
+
+/// Build a long-form COMMAND frame.
+fn long_command_frame(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(9 + body.len());
+    out.push(0x06); // COMMAND | LONG
+    out.extend_from_slice(&(body.len() as u64).to_be_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
+/// Encode a READY command body with the given properties.
+fn ready_body(socket_type: &str, identity: Option<&[u8]>, extra: &[(&[u8], &[u8])]) -> Vec<u8> {
+    let mut buf = BytesMut::new();
+    buf.put_u8(5);
+    buf.put_slice(b"READY");
+    // Socket-Type
+    buf.put_u8(11);
+    buf.put_slice(b"Socket-Type");
+    buf.put_u32(socket_type.len() as u32);
+    buf.put_slice(socket_type.as_bytes());
+    // Identity
+    if let Some(id) = identity {
+        buf.put_u8(8);
+        buf.put_slice(b"Identity");
+        buf.put_u32(id.len() as u32);
+        buf.put_slice(id);
+    }
+    for &(name, value) in extra {
+        buf.put_u8(name.len() as u8);
+        buf.put_slice(name);
+        buf.put_u32(value.len() as u32);
+        buf.put_slice(value);
+    }
+    buf.to_vec()
+}
+
+/// Build a complete valid handshake byte stream (greeting + READY frame).
+fn valid_handshake(socket_type: &str) -> Vec<u8> {
+    let mut wire = null_client_greeting();
+    let body = ready_body(socket_type, None, &[]);
+    wire.extend_from_slice(&command_frame(&body));
+    wire
+}
+
+/// Create a fresh server-side NULL Connection.
+fn server_conn(st: SocketType) -> Connection {
+    Connection::new(ConnectionConfig::new(Role::Server, st).mechanism(MechanismSetup::Null))
+}
+
+/// Create a fresh client-side NULL Connection.
+fn client_conn(st: SocketType) -> Connection {
+    Connection::new(ConnectionConfig::new(Role::Client, st).mechanism(MechanismSetup::Null))
+}
+
+/// Pump a Connection: drain all events and messages, return counts.
+fn drain(conn: &mut Connection) -> (usize, usize) {
+    let mut events = 0;
+    let mut msgs = 0;
+    while conn.poll_event().is_some() {
+        events += 1;
+    }
+    while conn.poll_message().is_some() {
+        msgs += 1;
+    }
+    (events, msgs)
+}
+
+/// Feed bytes to a connection in random-sized chunks (1..max_chunk).
+fn feed_chunked(
+    conn: &mut Connection,
+    data: &[u8],
+    rng: &mut StdRng,
+    max_chunk: usize,
+) -> Result<(), Error> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let chunk = rng.random_range(1..=max_chunk).min(data.len() - pos);
+        conn.handle_input(Bytes::copy_from_slice(&data[pos..pos + chunk]))?;
+        drain(conn);
+        pos += chunk;
+    }
+    Ok(())
+}
+
+/// Do a real handshake between two Connections. Returns the bytes each
+/// side transmitted (a_to_b, b_to_a).
+fn capture_handshake(a: &mut Connection, b: &mut Connection) -> (Vec<u8>, Vec<u8>) {
+    let mut a_to_b = Vec::new();
+    let mut b_to_a = Vec::new();
+    for _ in 0..20 {
+        let a_out = a.poll_transmit();
+        let b_out = b.poll_transmit();
+        if a_out.is_empty() && b_out.is_empty() {
+            break;
+        }
+        a_to_b.extend_from_slice(&a_out);
+        b_to_a.extend_from_slice(&b_out);
+        a.advance_transmit(a_out.len());
+        b.advance_transmit(b_out.len());
+        if !a_to_b.is_empty() {
+            let _ = b.handle_input(Bytes::copy_from_slice(&a_to_b));
+            a_to_b.clear();
+        }
+        if !b_to_a.is_empty() {
+            let _ = a.handle_input(Bytes::copy_from_slice(&b_to_a));
+            b_to_a.clear();
+        }
+        drain(a);
+        drain(b);
+    }
+    // Capture any final bytes
+    let a_final = a.poll_transmit().to_vec();
+    let b_final = b.poll_transmit().to_vec();
+    (a_final, b_final)
+}
+
+// ================================================================
+// Tier 1: crash resistance
+// ================================================================
+
 #[test]
 fn fuzz_command_decode() {
     let mut rng = rng();
@@ -59,9 +228,6 @@ fn fuzz_command_decode() {
     }
 }
 
-/// Feed a server-side codec a random byte stream as one big chunk and
-/// drain events. Catches panics in the full state machine
-/// (greeting → mechanism → ready) under hostile input.
 #[test]
 fn fuzz_handle_input_full_stream() {
     let mut rng = rng();
@@ -71,46 +237,26 @@ fn fuzz_handle_input_full_stream() {
         let mut conn = Connection::new(cfg);
         let raw = random_bytes(&mut rng, 4096);
         let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-        // Drain whatever events the codec emitted.
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("full_stream iter {i}");
         }
     }
 }
 
-/// Same as above but feeds the bytes in random-sized chunks. Exercises
-/// partial-read paths in the state machine where the buffer holds an
-/// incomplete header / frame between drives.
 #[test]
 fn fuzz_handle_input_chunked() {
     let mut rng = rng();
     for i in 0..iters() / 4 {
-        let cfg =
-            ConnectionConfig::new(Role::Server, SocketType::Pull).mechanism(MechanismSetup::Null);
-        let mut conn = Connection::new(cfg);
+        let mut conn = server_conn(SocketType::Pull);
         let raw = random_bytes(&mut rng, 4096);
-        let mut pos = 0;
-        while pos < raw.len() {
-            let chunk_len = rng.random_range(1..=raw.len() - pos).min(64);
-            if conn
-                .handle_input(Bytes::copy_from_slice(&raw[pos..pos + chunk_len]))
-                .is_err()
-            {
-                break; // codec rejected; further input would panic? no, but stop anyway
-            }
-            while conn.poll_event().is_some() {}
-            pos += chunk_len;
-        }
+        let _ = feed_chunked(&mut conn, &raw, &mut rng, 64);
         if i % 10_000 == 0 {
             eprintln!("chunked iter {i}");
         }
     }
 }
 
-/// Exercise both client and server roles end-to-end: feed each side a
-/// random stream and ensure neither panics. Doesn't require a valid
-/// handshake - any rejected input must surface as Err.
 #[test]
 fn fuzz_handle_input_both_roles() {
     let mut rng = rng();
@@ -120,34 +266,24 @@ fn fuzz_handle_input_both_roles() {
         } else {
             Role::Client
         };
-        let st = match rng.random_range(0..4) {
-            0 => SocketType::Push,
-            1 => SocketType::Pull,
-            2 => SocketType::Pair,
-            _ => SocketType::Dealer,
-        };
+        let st = ALL_SOCKET_TYPES[rng.random_range(0..ALL_SOCKET_TYPES.len())];
         let cfg = ConnectionConfig::new(role, st).mechanism(MechanismSetup::Null);
         let mut conn = Connection::new(cfg);
         let raw = random_bytes(&mut rng, 2048);
         let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("both_roles iter {i}");
         }
     }
 }
 
-/// Roundtrip property: encode an arbitrary frame, decode it, must
-/// match. Catches asymmetries in the LONG / SHORT length encoding,
-/// flag bit handling, or buffer-management bugs in either side.
 #[test]
 fn fuzz_frame_roundtrip() {
     use omq_tokio::message::{Frame, FrameFlags, Payload};
     use omq_tokio::proto::frame::{decode_frame_from_bytes, encode_frame};
     let mut rng = rng();
     for i in 0..iters() / 2 {
-        // Random size sweep covering both short (<=255) and long (>255)
-        // header forms, plus boundary +/- 1.
         let size = match rng.random_range(0..6) {
             0 => 0,
             1 => rng.random_range(1..=255),
@@ -159,7 +295,6 @@ fn fuzz_frame_roundtrip() {
         let mut payload = vec![0u8; size];
         rng.fill_bytes(&mut payload);
         let bytes = Bytes::from(payload);
-        // command + more is illegal; flip them independently but never both on.
         let (more, command) = match rng.random_range(0..3) {
             0 => (false, false),
             1 => (true, false),
@@ -184,57 +319,36 @@ fn fuzz_frame_roundtrip() {
     }
 }
 
-/// Structured-mutation fuzz: start with a valid client greeting prefix
-/// and randomly perturb a small number of bytes. This drives the
-/// state machine PAST the greeting check so the mechanism / frame
-/// parsers see exercise (purely random bytes almost always fail at
-/// the magic-byte check, leaving deeper paths unexplored).
 #[test]
 fn fuzz_handle_input_perturbed_greeting() {
     let mut rng = rng();
-    // A valid 64-byte ZMTP 3.1 client greeting with NULL mechanism.
-    // sig(10) + version(2) + mechanism(20) + as-server(1) + filler(31)
-    let mut base: [u8; 64] = [0; 64];
-    base[0] = 0xff;
-    base[9] = 0x7f;
-    base[10] = 0x03; // major
-    base[11] = 0x01; // minor
-    base[12..16].copy_from_slice(b"NULL");
-    base[31] = 0; // as-server = false (client)
+    let base = null_client_greeting();
     for i in 0..iters() / 4 {
-        let mut buf = base.to_vec();
-        // Append a random tail of frame-or-junk bytes.
+        let mut buf = base.clone();
         let tail_len = rng.random_range(0..=512);
         let mut tail = vec![0u8; tail_len];
         rng.fill_bytes(&mut tail);
         buf.extend_from_slice(&tail);
-        // Flip 0..3 random bytes in the greeting prefix.
         let flips = rng.random_range(0..=3);
         for _ in 0..flips {
             let pos = rng.random_range(0..64);
             buf[pos] = rng.random();
         }
-        let cfg =
-            ConnectionConfig::new(Role::Server, SocketType::Pull).mechanism(MechanismSetup::Null);
-        let mut conn = Connection::new(cfg);
+        let mut conn = server_conn(SocketType::Pull);
         let _ = conn.handle_input(Bytes::copy_from_slice(&buf));
-        while conn.poll_event().is_some() {}
+        drain(&mut conn);
         if i % 10_000 == 0 {
             eprintln!("perturbed iter {i}");
         }
     }
 }
 
-/// z85 is the ASCII armor used for CURVE keys - fed user-supplied
-/// strings, must never panic on hostile input (incl. invalid chars,
-/// lengths not divisible by 5, leading/trailing whitespace, etc.).
 #[test]
 fn fuzz_z85_decode() {
     let mut rng = rng();
     let alphabet: &[u8] =
         b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
     for i in 0..iters() / 4 {
-        // Mix 90% z85-alphabet bytes with 10% arbitrary, length 0..256.
         let len = rng.random_range(0..=256);
         let mut s = String::with_capacity(len);
         for _ in 0..len {
@@ -254,18 +368,13 @@ fn fuzz_z85_decode() {
     }
 }
 
-/// LZ4 transform decoder fuzz: random byte parts fed to the decoder,
-/// must never panic (must reject as Err). Catches panics in the
-/// SENTINEL parsing, declared-size handling, and decompress paths.
 #[cfg(feature = "lz4")]
 #[test]
 fn fuzz_lz4_decode() {
-    use omq_tokio::message::Message;
     use omq_tokio::proto::transform::lz4::Lz4Decoder;
     let mut rng = rng();
     for i in 0..iters() / 4 {
         let mut tx = Lz4Decoder::new();
-        // Build a random message with 1..=4 random parts.
         let n_parts = rng.random_range(1..=4);
         let mut parts_vec: Vec<Bytes> = Vec::new();
         for _ in 0..n_parts {
@@ -283,7 +392,6 @@ fn fuzz_lz4_decode() {
 #[cfg(feature = "zstd")]
 #[test]
 fn fuzz_zstd_decode() {
-    use omq_tokio::message::Message;
     use omq_tokio::proto::transform::zstd::ZstdDecoder;
     let mut rng = rng();
     for i in 0..iters() / 4 {
@@ -302,16 +410,845 @@ fn fuzz_zstd_decode() {
     }
 }
 
+// ================================================================
+// Tier 2: RFC compliance + adversarial structured inputs
+// ================================================================
+
+/// Greeting version + as_server compliance across all 256 major values,
+/// random minors, every mechanism name variant.
+#[test]
+fn fuzz_greeting_compliance() {
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let major: u8 = rng.random();
+        let minor: u8 = rng.random();
+        let as_server = rng.random_bool(0.5);
+        let g = Greeting {
+            major,
+            minor,
+            mechanism: MechanismName::NULL,
+            as_server,
+        };
+        let mut wire = BytesMut::new();
+        g.encode(&mut wire);
+
+        let mut conn = server_conn(SocketType::Pull);
+        let result = conn.handle_input(wire.freeze());
+
+        if major < 3 {
+            assert!(result.is_err(), "major {major} must be rejected");
+        } else if as_server {
+            assert!(result.is_err(), "NULL + as_server=1 must be rejected");
+        } else {
+            assert!(
+                result.is_ok(),
+                "major {major} + as_server=0 must be accepted"
+            );
+        }
+        if i % 10_000 == 0 {
+            eprintln!("greeting_compliance iter {i}");
+        }
+    }
+}
+
+/// Our own NULL greeting must always have as_server=0.
+#[test]
+fn fuzz_null_greeting_output() {
+    for role in [Role::Client, Role::Server] {
+        for &st in &ALL_SOCKET_TYPES {
+            let cfg = ConnectionConfig::new(role, st).mechanism(MechanismSetup::Null);
+            let conn = Connection::new(cfg);
+            let wire = conn.poll_transmit();
+            assert!(wire.len() >= 33, "greeting too short");
+            assert_eq!(
+                wire[32], 0,
+                "NULL greeting must have as_server=0 ({role:?}/{st:?})"
+            );
+        }
+    }
+}
+
+/// Byte surgery on a captured real handshake: corrupt 1-8 random bytes,
+/// then deliver in 1-byte chunks. Exercises every partial-parse path
+/// under corruption.
+#[test]
+fn fuzz_handshake_byte_surgery() {
+    let mut rng = rng();
+    let base = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let mut wire = base.clone();
+        let n_flips = rng.random_range(1..=8);
+        for _ in 0..n_flips {
+            let pos = rng.random_range(0..wire.len());
+            wire[pos] = rng.random();
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        // Deliver one byte at a time — maximizes partial-parse coverage.
+        let _ = feed_chunked(&mut conn, &wire, &mut rng, 1);
+        if i % 10_000 == 0 {
+            eprintln!("byte_surgery iter {i}");
+        }
+    }
+}
+
+/// Truncate a valid handshake at every possible offset. The codec must
+/// never panic, regardless of where the cut lands (mid-signature,
+/// mid-mechanism-name, mid-frame-header, mid-property, etc.).
+#[test]
+fn fuzz_handshake_truncation() {
+    let mut rng = rng();
+    let base = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let cut = rng.random_range(0..=base.len());
+        let mut conn = server_conn(SocketType::Pull);
+        // Sometimes deliver as one chunk, sometimes byte-by-byte.
+        if rng.random_bool(0.5) {
+            let _ = conn.handle_input(Bytes::copy_from_slice(&base[..cut]));
+        } else {
+            let _ = feed_chunked(&mut conn, &base[..cut], &mut rng, 3);
+        }
+        drain(&mut conn);
+        if i % 10_000 == 0 {
+            eprintln!("truncation iter {i}");
+        }
+    }
+}
+
+/// Valid handshake followed by adversarial post-handshake data:
+/// random frames, illegal flag combos (COMMAND|MORE), huge declared
+/// sizes with tiny payloads, zero-length frames, rapid-fire multi-frame
+/// messages, commands after ready.
+#[test]
+fn fuzz_post_handshake_chaos() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        assert!(pull.is_ready(), "handshake must succeed");
+
+        // Now feed hostile frames directly into pull.
+        let n_frames = rng.random_range(1..=20);
+        for _ in 0..n_frames {
+            let frame = match rng.random_range(0..8) {
+                // Random garbage
+                0 => random_bytes(&mut rng, 512),
+                // Short data frame, random payload
+                1 => {
+                    let payload = random_bytes(&mut rng, 255);
+                    let mut f = vec![0x00u8]; // data, short
+                    f.push(payload.len() as u8);
+                    f.extend_from_slice(&payload);
+                    f
+                }
+                // Long data frame with huge declared size, tiny actual
+                2 => {
+                    let mut f = vec![0x02u8]; // data, long
+                    let declared: u64 = rng.random_range(0..=u32::MAX as u64);
+                    f.extend_from_slice(&declared.to_be_bytes());
+                    let actual = random_bytes(&mut rng, 64);
+                    f.extend_from_slice(&actual);
+                    f
+                }
+                // Illegal flag combo: COMMAND | MORE (0x05)
+                3 => {
+                    let payload = random_bytes(&mut rng, 128);
+                    let mut f = vec![0x05u8]; // COMMAND|MORE — illegal
+                    f.push(payload.len() as u8);
+                    f.extend_from_slice(&payload);
+                    f
+                }
+                // Command frame with random body
+                4 => {
+                    let body = random_bytes(&mut rng, 512);
+                    long_command_frame(&body)
+                }
+                // Zero-length frame
+                5 => vec![0x00, 0x00],
+                // Frame with all flag bits set (0x07 = MORE|LONG|COMMAND)
+                6 => {
+                    let mut f = vec![0x07u8];
+                    f.extend_from_slice(&0u64.to_be_bytes());
+                    f
+                }
+                // READY/ERROR command after handshake (should be rejected)
+                _ => {
+                    let body = ready_body("PUSH", None, &[]);
+                    command_frame(&body)
+                }
+            };
+            if pull.handle_input(Bytes::from(frame)).is_err() {
+                break;
+            }
+            drain(&mut pull);
+        }
+        if i % 5_000 == 0 {
+            eprintln!("post_handshake iter {i}");
+        }
+    }
+}
+
+/// Bidirectional corruption: two real connections, but we randomly
+/// corrupt, duplicate, drop, or truncate bytes flowing between them.
+#[test]
+fn fuzz_bidirectional_corruption() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut a = client_conn(SocketType::Pair);
+        let mut b = server_conn(SocketType::Pair);
+        let mut a_err = false;
+        let mut b_err = false;
+
+        for _ in 0..30 {
+            let a_out = a.poll_transmit().to_vec();
+            let b_out = b.poll_transmit().to_vec();
+            a.advance_transmit(a_out.len());
+            b.advance_transmit(b_out.len());
+
+            if a_out.is_empty() && b_out.is_empty() {
+                break;
+            }
+
+            // Corrupt a→b
+            if !a_out.is_empty() && !b_err {
+                let wire = corrupt_wire(&a_out, &mut rng);
+                if b.handle_input(Bytes::from(wire)).is_err() {
+                    b_err = true;
+                }
+                drain(&mut b);
+            }
+            // Corrupt b→a
+            if !b_out.is_empty() && !a_err {
+                let wire = corrupt_wire(&b_out, &mut rng);
+                if a.handle_input(Bytes::from(wire)).is_err() {
+                    a_err = true;
+                }
+                drain(&mut a);
+            }
+            if a_err && b_err {
+                break;
+            }
+        }
+
+        // If handshake survived, send some messages through
+        if a.is_ready() && b.is_ready() {
+            for _ in 0..5 {
+                let msg = Message::single(random_bytes(&mut rng, 128));
+                if a.send_message(&msg).is_err() {
+                    break;
+                }
+                let wire = a.poll_transmit().to_vec();
+                a.advance_transmit(wire.len());
+                let wire = corrupt_wire(&wire, &mut rng);
+                let _ = b.handle_input(Bytes::from(wire));
+                drain(&mut b);
+            }
+        }
+        if i % 5_000 == 0 {
+            eprintln!("bidirectional iter {i}");
+        }
+    }
+}
+
+fn corrupt_wire(data: &[u8], rng: &mut StdRng) -> Vec<u8> {
+    let mut wire = data.to_vec();
+    match rng.random_range(0..6) {
+        // Pass through clean (10% of the time)
+        0 => {}
+        // Flip 1-3 random bytes
+        1 => {
+            let n = rng.random_range(1..=3).min(wire.len().max(1));
+            for _ in 0..n {
+                if !wire.is_empty() {
+                    let pos = rng.random_range(0..wire.len());
+                    wire[pos] = rng.random();
+                }
+            }
+        }
+        // Truncate
+        2 => {
+            if !wire.is_empty() {
+                let cut = rng.random_range(0..wire.len());
+                wire.truncate(cut);
+            }
+        }
+        // Duplicate a random slice
+        3 => {
+            if wire.len() > 1 {
+                let start = rng.random_range(0..wire.len());
+                let len = rng.random_range(1..=(wire.len() - start).min(64));
+                let dup = wire[start..start + len].to_vec();
+                let insert_at = rng.random_range(0..=wire.len());
+                wire.splice(insert_at..insert_at, dup);
+            }
+        }
+        // Insert random garbage
+        4 => {
+            let garbage_len = rng.random_range(1..=32);
+            let mut garbage = vec![0u8; garbage_len];
+            rng.fill_bytes(&mut garbage);
+            let insert_at = rng.random_range(0..=wire.len());
+            wire.splice(insert_at..insert_at, garbage);
+        }
+        // Drop a random range of bytes
+        _ => {
+            if wire.len() > 1 {
+                let start = rng.random_range(0..wire.len());
+                let len = rng.random_range(1..=(wire.len() - start).min(16));
+                wire.drain(start..start + len);
+            }
+        }
+    }
+    wire
+}
+
+/// Property parsing stress: boundary-length names (1, 127, 254, 255),
+/// every byte value in names, many properties, truncation at every
+/// offset within the property list, duplicate well-known properties,
+/// declared-vs-actual value length mismatches.
+#[test]
+fn fuzz_property_adversarial() {
+    let mut rng = rng();
+    for i in 0..iters() / 2 {
+        let scenario = rng.random_range(0..8);
+        let result = match scenario {
+            // Random name length, random chars (mix valid/invalid)
+            0 => {
+                let name_len: u8 = rng.random_range(0..=20);
+                let mut name = Vec::with_capacity(name_len as usize);
+                for _ in 0..name_len {
+                    if rng.random_bool(0.5) {
+                        name.push(VALID_PROP_CHARS[rng.random_range(0..VALID_PROP_CHARS.len())]);
+                    } else {
+                        name.push(rng.random());
+                    }
+                }
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(name_len);
+                body.put_slice(&name);
+                body.put_u32(1);
+                body.put_u8(b'v');
+                command::decode(body.freeze())
+            }
+            // Boundary-length property name (254, 255 bytes)
+            1 => {
+                let name_len = if rng.random_bool(0.5) { 254 } else { 255 };
+                let name: Vec<u8> = (0..name_len)
+                    .map(|_| VALID_PROP_CHARS[rng.random_range(0..VALID_PROP_CHARS.len())])
+                    .collect();
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(name_len as u8);
+                body.put_slice(&name);
+                body.put_u32(3);
+                body.put_slice(b"yes");
+                command::decode(body.freeze())
+            }
+            // Duplicate Socket-Type
+            2 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PULL");
+                command::decode(body.freeze())
+            }
+            // Duplicate Identity
+            3 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(8);
+                body.put_slice(b"Identity");
+                body.put_u32(3);
+                body.put_slice(b"aaa");
+                body.put_u8(8);
+                body.put_slice(b"Identity");
+                body.put_u32(3);
+                body.put_slice(b"bbb");
+                command::decode(body.freeze())
+            }
+            // Many properties (50-200), all valid
+            4 => {
+                let n_props = rng.random_range(50..=200);
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                for j in 0..n_props {
+                    let name = format!("X-Prop-{j}");
+                    body.put_u8(name.len() as u8);
+                    body.put_slice(name.as_bytes());
+                    body.put_u32(1);
+                    body.put_u8(b'v');
+                }
+                command::decode(body.freeze())
+            }
+            // Truncation: build valid properties, cut at random offset
+            5 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(5);
+                body.put_slice(b"X-Foo");
+                body.put_u32(10);
+                body.put_slice(b"0123456789");
+                let full = body.freeze();
+                let cut = rng.random_range(0..=full.len());
+                command::decode(full.slice(..cut))
+            }
+            // Declared value length >> actual remaining bytes
+            6 => {
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(5);
+                body.put_slice(b"X-Big");
+                // Declare huge value length but provide tiny payload
+                body.put_u32(rng.random_range(1000..=u16::MAX as u32));
+                let actual = random_bytes(&mut rng, 10);
+                body.put_slice(&actual);
+                command::decode(body.freeze())
+            }
+            // Every possible byte value in a 1-char property name
+            _ => {
+                let byte: u8 = rng.random();
+                let mut body = BytesMut::new();
+                body.put_u8(5);
+                body.put_slice(b"READY");
+                body.put_u8(11);
+                body.put_slice(b"Socket-Type");
+                body.put_u32(4);
+                body.put_slice(b"PUSH");
+                body.put_u8(1);
+                body.put_u8(byte);
+                body.put_u32(1);
+                body.put_u8(b'v');
+                let r = command::decode(body.freeze());
+                let valid = byte.is_ascii_alphanumeric()
+                    || byte == b'-'
+                    || byte == b'_'
+                    || byte == b'.'
+                    || byte == b'+';
+                match &r {
+                    Ok(_) => assert!(valid, "accepted invalid prop name byte 0x{byte:02x}"),
+                    Err(e) => assert!(!valid, "rejected valid prop name byte 0x{byte:02x}: {e}"),
+                }
+                r
+            }
+        };
+        // scenarios 2-3 (duplicate props) must always be rejected
+        if scenario == 2 {
+            assert!(result.is_err(), "duplicate Socket-Type must be rejected");
+        }
+        if scenario == 3 {
+            assert!(result.is_err(), "duplicate Identity must be rejected");
+        }
+        // scenario 6 (huge declared value) must be rejected (truncated)
+        if scenario == 6 {
+            assert!(result.is_err(), "declared len >> actual must be rejected");
+        }
+        let _ = result;
+        if i % 50_000 == 0 {
+            eprintln!("property_adversarial iter {i}");
+        }
+    }
+}
+
+/// Greeting with mechanism name mismatches, non-NULL mechanisms against
+/// NULL server, and every possible mechanism name byte pattern.
+#[test]
+fn fuzz_greeting_mechanism_mismatch() {
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let mut raw = null_client_greeting();
+        // Corrupt the mechanism name region (bytes 12..32)
+        match rng.random_range(0..5) {
+            // Random mechanism name
+            0 => {
+                for b in &mut raw[12..32] {
+                    *b = rng.random();
+                }
+            }
+            // "CURVE" against NULL server
+            1 => {
+                raw[12..32].fill(0);
+                raw[12..17].copy_from_slice(b"CURVE");
+            }
+            // "PLAIN" against NULL server
+            2 => {
+                raw[12..32].fill(0);
+                raw[12..17].copy_from_slice(b"PLAIN");
+            }
+            // Valid NULL but with garbage in padding after NUL
+            3 => {
+                raw[16] = rng.random_range(1..=255); // non-zero after "NULL"
+            }
+            // Empty mechanism name (all zeros)
+            _ => {
+                raw[12..32].fill(0);
+            }
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        let _ = conn.handle_input(Bytes::from(raw));
+        drain(&mut conn);
+        if i % 10_000 == 0 {
+            eprintln!("mech_mismatch iter {i}");
+        }
+    }
+}
+
+/// Full-sequence structured fuzz: valid greeting → adversarial command
+/// frame → random tail. The command frame exercises the mechanism
+/// handshake path (NULL READY parsing) with hostile content.
+#[test]
+fn fuzz_greeting_then_hostile_ready() {
+    let mut rng = rng();
+    let greeting = null_client_greeting();
+    for i in 0..iters() / 4 {
+        let mut wire = greeting.clone();
+        // Build a command frame with random body that might or might not
+        // look like READY.
+        let body_len = rng.random_range(0..=512);
+        let mut body = vec![0u8; body_len];
+        rng.fill_bytes(&mut body);
+        // 50%: make it look READY-shaped (name_len=5, "READY", then garbage)
+        if rng.random_bool(0.5) && body_len >= 6 {
+            body[0] = 5;
+            body[1..6].copy_from_slice(b"READY");
+        }
+        // 20%: make it ERROR-shaped
+        if rng.random_bool(0.2) && body_len >= 6 {
+            body[0] = 5;
+            body[1..6].copy_from_slice(b"ERROR");
+        }
+        if body_len <= 255 {
+            wire.extend_from_slice(&command_frame(&body));
+        } else {
+            wire.extend_from_slice(&long_command_frame(&body));
+        }
+        // Sometimes append more garbage after the command frame.
+        if rng.random_bool(0.3) {
+            let tail = random_bytes(&mut rng, 256);
+            wire.extend_from_slice(&tail);
+        }
+        let mut conn = server_conn(SocketType::Pull);
+        // Sometimes deliver chunked, sometimes all at once.
+        if rng.random_bool(0.5) {
+            let _ = feed_chunked(&mut conn, &wire, &mut rng, 16);
+        } else {
+            let _ = conn.handle_input(Bytes::from(wire));
+            drain(&mut conn);
+        }
+        if i % 10_000 == 0 {
+            eprintln!("hostile_ready iter {i}");
+        }
+    }
+}
+
+/// Deliver a valid greeting one byte at a time with random delays
+/// (interleaved with zero-length inputs), then follow with a READY
+/// that has random corruption at each byte position.
+#[test]
+fn fuzz_greeting_byte_drip() {
+    let mut rng = rng();
+    let full = valid_handshake("PULL");
+    for i in 0..iters() / 4 {
+        let mut conn = server_conn(SocketType::Pull);
+        let mut ok = true;
+        for (j, &byte) in full.iter().enumerate() {
+            // Occasionally corrupt this byte
+            let b = if rng.random_bool(0.05) {
+                rng.random()
+            } else {
+                byte
+            };
+            // Occasionally send a zero-length input (must be a no-op)
+            if rng.random_bool(0.1) {
+                if conn.handle_input(Bytes::new()).is_err() {
+                    ok = false;
+                    break;
+                }
+            }
+            if conn.handle_input(Bytes::copy_from_slice(&[b])).is_err() {
+                ok = false;
+                break;
+            }
+            drain(&mut conn);
+            // If we're past greeting (byte 63) and handshake completed, stop
+            if j >= GREETING_LEN && conn.is_ready() {
+                break;
+            }
+        }
+        let _ = ok;
+        if i % 10_000 == 0 {
+            eprintln!("byte_drip iter {i}");
+        }
+    }
+}
+
+/// Frame decoder stress: adversarial flag bytes, size fields, and
+/// payloads fed directly through the Connection state machine after a
+/// valid handshake. Tests frame parsing in the post-handshake data path.
+#[test]
+fn fuzz_frame_adversarial() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        if !pull.is_ready() {
+            continue;
+        }
+
+        // Build adversarial frames and feed them
+        let n_frames = rng.random_range(1..=10);
+        let mut wire = Vec::new();
+        for _ in 0..n_frames {
+            let flags: u8 = rng.random();
+            let is_long = flags & 0x02 != 0;
+            if is_long {
+                wire.push(flags);
+                let size: u64 = match rng.random_range(0..4) {
+                    0 => 0,
+                    1 => rng.random_range(0..=255),
+                    2 => rng.random_range(256..=65536),
+                    _ => rng.random_range(0..=u32::MAX as u64),
+                };
+                wire.extend_from_slice(&size.to_be_bytes());
+                // Only provide a small amount of actual payload
+                let actual = rng.random_range(0..=64).min(size as usize);
+                let mut payload = vec![0u8; actual];
+                rng.fill_bytes(&mut payload);
+                wire.extend_from_slice(&payload);
+            } else {
+                wire.push(flags);
+                let size: u8 = rng.random();
+                wire.push(size);
+                let actual = rng.random_range(0..=size as usize);
+                let mut payload = vec![0u8; actual];
+                rng.fill_bytes(&mut payload);
+                wire.extend_from_slice(&payload);
+            }
+        }
+
+        if rng.random_bool(0.5) {
+            let _ = pull.handle_input(Bytes::from(wire));
+        } else {
+            let _ = feed_chunked(&mut pull, &wire, &mut rng, 8);
+        }
+        drain(&mut pull);
+        if i % 5_000 == 0 {
+            eprintln!("frame_adversarial iter {i}");
+        }
+    }
+}
+
+/// Message roundtrip under corruption: encode real messages through
+/// push's Connection, corrupt the wire bytes, feed to pull. Must never
+/// panic; corrupted messages must surface as Err or silently dropped,
+/// never as garbage data presented as a valid message.
+#[test]
+fn fuzz_message_roundtrip_corrupt() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let mut push = client_conn(SocketType::Push);
+        let mut pull = server_conn(SocketType::Pull);
+        capture_handshake(&mut push, &mut pull);
+        if !push.is_ready() {
+            continue;
+        }
+
+        // Send 1-5 messages, collect all wire bytes
+        let n_msgs = rng.random_range(1..=5);
+        let mut original_payloads: Vec<Vec<u8>> = Vec::new();
+        for _ in 0..n_msgs {
+            let n_parts = rng.random_range(1..=4);
+            let parts: Vec<Vec<u8>> = (0..n_parts).map(|_| random_bytes(&mut rng, 256)).collect();
+            let msg = Message::multipart(parts.iter().map(|p| Bytes::from(p.clone())));
+            original_payloads.push(parts.into_iter().flatten().collect());
+            if push.send_message(&msg).is_err() {
+                break;
+            }
+        }
+        let wire = push.poll_transmit().to_vec();
+        push.advance_transmit(wire.len());
+
+        // Corrupt the wire
+        let corrupted = corrupt_wire(&wire, &mut rng);
+
+        // Feed to pull
+        if rng.random_bool(0.5) {
+            let _ = pull.handle_input(Bytes::from(corrupted));
+        } else {
+            let _ = feed_chunked(&mut pull, &corrupted, &mut rng, 32);
+        }
+        drain(&mut pull);
+        if i % 5_000 == 0 {
+            eprintln!("msg_corrupt iter {i}");
+        }
+    }
+}
+
+/// State machine confusion: interleave greeting bytes from multiple
+/// different connections, simulating stream mixup or injection.
+#[test]
+fn fuzz_interleaved_streams() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        // Build 2-4 different valid handshake streams
+        let n_streams = rng.random_range(2..=4);
+        let socket_types = ["PUSH", "PULL", "PAIR", "DEALER", "ROUTER"];
+        let streams: Vec<Vec<u8>> = (0..n_streams)
+            .map(|_| valid_handshake(socket_types[rng.random_range(0..socket_types.len())]))
+            .collect();
+
+        // Interleave bytes from all streams into one Franken-stream
+        let mut franken = Vec::new();
+        let mut positions: Vec<usize> = vec![0; n_streams];
+        while positions.iter().zip(&streams).any(|(p, s)| *p < s.len()) {
+            let stream_idx = rng.random_range(0..n_streams);
+            if positions[stream_idx] < streams[stream_idx].len() {
+                let chunk_len = rng
+                    .random_range(1..=16)
+                    .min(streams[stream_idx].len() - positions[stream_idx]);
+                franken.extend_from_slice(
+                    &streams[stream_idx][positions[stream_idx]..positions[stream_idx] + chunk_len],
+                );
+                positions[stream_idx] += chunk_len;
+            }
+        }
+
+        let mut conn = server_conn(SocketType::Pull);
+        let _ = feed_chunked(&mut conn, &franken, &mut rng, 32);
+        if i % 5_000 == 0 {
+            eprintln!("interleaved iter {i}");
+        }
+    }
+}
+
+/// Replay attack: complete a valid handshake, then replay the greeting
+/// and READY again. The state machine must reject the second greeting.
+#[test]
+fn fuzz_replay_attack() {
+    let mut rng = rng();
+    let handshake = valid_handshake("PULL");
+    for i in 0..iters() / 8 {
+        let mut conn = server_conn(SocketType::Pull);
+        if conn.handle_input(Bytes::from(handshake.clone())).is_err() {
+            continue;
+        }
+        drain(&mut conn);
+
+        // Replay: send the handshake bytes again
+        let _ = conn.handle_input(Bytes::from(handshake.clone()));
+        drain(&mut conn);
+
+        // Also try replaying just the READY
+        let ready_bytes = &handshake[GREETING_LEN..];
+        let _ = conn.handle_input(Bytes::copy_from_slice(ready_bytes));
+        drain(&mut conn);
+
+        // Random data after replay
+        let garbage = random_bytes(&mut rng, 512);
+        let _ = conn.handle_input(Bytes::from(garbage));
+        drain(&mut conn);
+        if i % 5_000 == 0 {
+            eprintln!("replay iter {i}");
+        }
+    }
+}
+
+/// Massive message: send a message close to max_message_size, then
+/// slightly over, through corrupt and clean paths.
+#[test]
+fn fuzz_message_size_boundary() {
+    let mut rng = rng();
+    for i in 0..iters() / 8 {
+        let max_size = rng.random_range(64..=8192);
+        let cfg = ConnectionConfig::new(Role::Server, SocketType::Pull)
+            .mechanism(MechanismSetup::Null)
+            .max_message_size(max_size);
+        let mut pull = Connection::new(cfg);
+        let mut push = client_conn(SocketType::Push);
+        capture_handshake(&mut push, &mut pull);
+        if !push.is_ready() {
+            continue;
+        }
+
+        // Send a message right at the boundary
+        for delta in [-2i64, -1, 0, 1, 2, 64] {
+            let size = (max_size as i64 + delta).max(0) as usize;
+            let payload = vec![0xAA; size];
+            let msg = Message::single(Bytes::from(payload));
+            if push.send_message(&msg).is_err() {
+                continue;
+            }
+            let wire = push.poll_transmit().to_vec();
+            push.advance_transmit(wire.len());
+
+            let result = pull.handle_input(Bytes::from(wire));
+            if result.is_err() {
+                // Re-create pull for next iteration since it's in error state
+                pull = Connection::new(
+                    ConnectionConfig::new(Role::Server, SocketType::Pull)
+                        .mechanism(MechanismSetup::Null)
+                        .max_message_size(max_size),
+                );
+                push = client_conn(SocketType::Push);
+                capture_handshake(&mut push, &mut pull);
+                if !push.is_ready() {
+                    break;
+                }
+            }
+            drain(&mut pull);
+        }
+        if i % 5_000 == 0 {
+            eprintln!("size_boundary iter {i}");
+        }
+    }
+}
+
+// ================================================================
+// Mechanism-specific fuzz (feature-gated)
+// ================================================================
+
 #[cfg(any(feature = "curve", feature = "blake3zmq"))]
 mod mech_fuzz {
     use super::*;
-    use omq_tokio::proto::mechanism::MechanismSetup;
 
-    /// Build a valid 64-byte client-side greeting for the given
-    /// mechanism name (≤ 20 ASCII bytes, NUL-padded to 20). Fed into
-    /// the mechanism-specific server fuzzers below so the random
-    /// post-greeting bytes actually reach the mechanism handshake
-    /// parsers.
     fn greeting_bytes(mech_name: &[u8]) -> Vec<u8> {
         let mut g = vec![0u8; 64];
         g[0] = 0xff;
@@ -319,24 +1256,10 @@ mod mech_fuzz {
         g[10] = 0x03;
         g[11] = 0x01;
         g[12..12 + mech_name.len()].copy_from_slice(mech_name);
-        g[31] = 0; // as-server = false (we're the client side of greeting)
+        // as-server at offset 32 is implicitly 0 from zero-init.
         g
     }
 
-    /// Wrap a body as a long-form COMMAND frame: flags=0x06 (CMD|LONG)
-    /// + 8-byte size + body. Long form covers all command sizes
-    ///   without us guessing whether short form fits.
-    fn long_command_frame(body: &[u8]) -> Vec<u8> {
-        let mut out = Vec::with_capacity(9 + body.len());
-        out.push(0b0000_0110); // COMMAND | LONG
-        out.extend_from_slice(&(body.len() as u64).to_be_bytes());
-        out.extend_from_slice(body);
-        out
-    }
-
-    /// CURVE server-side fuzz, raw bytes only - most attempts fail at
-    /// greeting; deeper paths exercised by the structured variant
-    /// below.
     #[cfg(feature = "curve")]
     #[test]
     fn fuzz_curve_server_input() {
@@ -355,16 +1278,13 @@ mod mech_fuzz {
             let mut conn = Connection::new(cfg);
             let raw = random_bytes(&mut rng, 1024);
             let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("curve iter {i}");
             }
         }
     }
 
-    /// CURVE server-side, structured: feed a valid greeting + a
-    /// random HELLO-shaped command, so the random bytes actually
-    /// land in `parse_hello`.
     #[cfg(feature = "curve")]
     #[test]
     fn fuzz_curve_hello_body() {
@@ -383,11 +1303,7 @@ mod mech_fuzz {
             );
             let mut conn = Connection::new(cfg);
             let _ = conn.handle_input(Bytes::copy_from_slice(&greeting));
-            // HELLO is 194-byte body for the well-formed case;
-            // mutate length 0..256 to also hit the early-reject paths.
             let body_len = rng.random_range(0..=256);
-            // First byte of body is the command-name length; spelling
-            // "HELLO" is what makes the dispatcher route here.
             let mut body = Vec::with_capacity(1 + 5 + body_len);
             body.push(5);
             body.extend_from_slice(b"HELLO");
@@ -396,7 +1312,7 @@ mod mech_fuzz {
             body.extend_from_slice(&tail);
             let frame = long_command_frame(&body);
             let _ = conn.handle_input(Bytes::copy_from_slice(&frame));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("curve hello iter {i}");
             }
@@ -423,17 +1339,13 @@ mod mech_fuzz {
             let mut conn = Connection::new(cfg);
             let raw = random_bytes(&mut rng, 1024);
             let _ = conn.handle_input(Bytes::copy_from_slice(&raw));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("blake3zmq iter {i}");
             }
         }
     }
 
-    /// BLAKE3ZMQ server-side, structured HELLO. Greeting carries the
-    /// mechanism name "BLAKE3" (7 bytes), then a random HELLO body of
-    /// the expected ~232-byte shape (or shorter, to exercise reject
-    /// paths).
     #[cfg(feature = "blake3zmq")]
     #[test]
     fn fuzz_blake3zmq_hello_body() {
@@ -463,7 +1375,7 @@ mod mech_fuzz {
             body.extend_from_slice(&tail);
             let frame = long_command_frame(&body);
             let _ = conn.handle_input(Bytes::copy_from_slice(&frame));
-            while conn.poll_event().is_some() {}
+            drain(&mut conn);
             if i % 5_000 == 0 {
                 eprintln!("blake3zmq hello iter {i}");
             }


### PR DESCRIPTION
- Accept major version >= 3 instead of == 3 (RFC 23 requires accepting higher protocol versions)
- Send `as_server=0` in greeting when using NULL mechanism (RFC 23: "the as-server field MUST be zero" for NULL)
- Reject peer greeting with `as_server=1` when mechanism is NULL
- Validate READY property name charset `[A-Za-z0-9\-_.+]` per RFC 23
- Reject zero-length property names (RFC 23 requires 1-255 characters)
- Reject duplicate `Socket-Type` and `Identity` properties
- Surface ERROR reason in NULL mechanism (matching PLAIN's behavior)
- Document intentional command drop in compio direct-recv drain path
- 12 new adversarial fuzz targets with RFC compliance assertions (greeting version/as_server, property validation, handshake byte surgery, truncation, post-handshake chaos, bidirectional corruption, mechanism mismatches, hostile READY/ERROR, byte-drip, frame adversarial, message corruption, interleaved streams, replay attacks, size boundaries)
- Fix misleading as_server offset comments in fuzz greeting base (byte 32, not 31)