### PR TITLE
omq: make tokio-backend the default; rename bench_peer to bench_peer_compio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+### omq 0.12.2
+
+- Breaking: `tokio-backend` is now the default Cargo feature (was `compio-backend`). Users who relied on the default must either add `--no-default-features --features compio-backend` or leave their `Cargo.toml` as-is (no change needed for tokio users).
+
 ## [0.2.14] - 2026-05-25
 
 ### pyomq 0.10.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,12 @@ out-of-tree (maturin etc.).
   handshakes (NULL / PLAIN / CURVE / BLAKE3ZMQ), compression transforms
   (lz4 / zstd), endpoint parsing, options, subscription matcher.
   No async, no I/O. Mirrors `rustls::ConnectionCommon` / `quinn-proto`.
+- **`omq-tokio`** -- multi-thread tokio backend. **Default backend.**
+  Works on Linux and macOS (and likely other mio targets).
 - **`omq-compio`** -- single-threaded compio backend (io_uring on
-  Linux). **Primary backend.**
-- **`omq-tokio`** -- multi-thread tokio backend. Alternative backend.
+  Linux, IOCP on Windows). Not available on macOS.
 - **`omq`** -- facade crate. Re-exports one backend via Cargo features:
-  `compio-backend` (default) or `tokio-backend`. Mutually exclusive.
+  `tokio-backend` (default) or `compio-backend`. Mutually exclusive.
 - **`blume`** -- batching MPSC channel for `omq-compio` inbound delivery.
 - **`yring`** -- bounded SPSC ring buffer for inproc transport.
 - **`omq-libzmq`** -- libzmq-compatible C interface (`libomq_zmq.so` /

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Lints: `missing_debug_implementations` = **deny**,
 ## Unit and integration tests
 
 ```sh
-cargo test  -p omq-compio               # default features
-cargo test  -p omq-tokio
+cargo test  -p omq-tokio                # default features
+cargo test  -p omq-compio
 cargo test  -p omq-proto
 cargo test  -p blume
 cargo test  -p omq-tokio --test req_rep -- some_test_name

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distributed and concurrent applications. Wire-compatible with libzmq, faster across all message sizes.
 
-- Two async backends: **compio** (io_uring, default) and **tokio**
+- Two async backends: **tokio** (default, Linux/macOS) and **compio** (io_uring, Linux)
 - 20 socket types (11 standard + 9 draft), 8 transports (TCP, IPC, inproc, UDP, WS, WSS, `lz4+tcp://`, `zstd+tcp://`)
 - 4 security mechanisms: NULL, PLAIN, CURVE, BLAKE3ZMQ
 - No C compiler, no vendored C, no libzmq, no libsodium
@@ -33,8 +33,8 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 > **Experimental.** The API is unstable and may change without notice. Not yet battle-tested in production. Bug reports and testing in real workloads are very welcome.
 
 ```sh
-cargo add omq                     # compio backend (default)
-cargo add omq --no-default-features --features tokio-backend
+cargo add omq                     # tokio backend (default)
+cargo add omq --no-default-features --features compio-backend
 ```
 
 If you know ZeroMQ, you know OMQ. Same socket types, same connect/bind/send/recv — just async Rust:
@@ -54,8 +54,8 @@ assert_eq!(&msg[0], b"hello");
 
 `omq` is a thin facade; pick one backend at build time:
 
-- `compio-backend` (default): single-thread io_uring/IOCP ([`omq-compio`](omq-compio/))
-- `tokio-backend`: multi-thread tokio + mio ([`omq-tokio`](omq-tokio/))
+- `tokio-backend` (default): multi-thread tokio + mio ([`omq-tokio`](omq-tokio/))
+- `compio-backend`: single-thread io_uring/IOCP ([`omq-compio`](omq-compio/))
 
 Identical public `Socket` API on both, verified by `coverage_matrix` + `interop_compio` test suites.
 
@@ -66,8 +66,8 @@ TCP / IPC / inproc / UDP, no C compiler required. Enable any of:
 
 | feature           | what it adds                                      | extra deps                       |
 |-------------------|---------------------------------------------------|----------------------------------|
-| `compio-backend`  | (default) compio io_uring/IOCP backend            | -                                |
-| `tokio-backend`   | tokio multi-thread backend                        | -                                |
+| `tokio-backend`   | (default) tokio multi-thread backend              | -                                |
+| `compio-backend`  | compio io_uring/IOCP backend                      | -                                |
 | `plain`           | PLAIN username/password auth (RFC 24)             | -                                |
 | `curve`           | CURVE encrypted-handshake mechanism (RFC 26)      | `crypto_box`, `crypto_secretbox` |
 | `blake3zmq`       | OMQ-native BLAKE3 + ChaCha20 mechanism ([RFC](https://github.com/paddor/omq-blake3zmq/blob/main/RFC.md)) | `blake3`, `chacha20-blake3`, `x25519-dalek` |
@@ -106,8 +106,8 @@ independent, versioned, and published separately.
 |-------|-------------|
 | [`omq`](omq/) | Facade: re-exports `omq-compio` or `omq-tokio` at build time |
 | [`omq-proto`](omq-proto/) | Sans-I/O ZMTP 3.x core: codec, messages, mechanisms, subscriptions |
-| [`omq-compio`](omq-compio/) | Primary backend: single-thread io_uring / IOCP |
-| [`omq-tokio`](omq-tokio/) | Alternative backend: multi-thread tokio |
+| [`omq-tokio`](omq-tokio/) | Default backend: multi-thread tokio |
+| [`omq-compio`](omq-compio/) | io_uring backend: single-thread io_uring / IOCP |
 | [`omq-libzmq`](omq-libzmq/) | libzmq-compatible C interface (`libomq_zmq.so` drop-in) |
 | [`omq-zeromq`](omq-zeromq/) | Drop-in replacement for the [`zeromq`](https://crates.io/crates/zeromq) Rust crate |
 | [`blume`](blume/) | Batching MPSC channel with swap-drain consumer |
@@ -154,8 +154,9 @@ OMQ_FUZZ=1 ./scripts/test-all.sh   # include fuzz suites
 
 ## Platform and requirements
 
-Linux first. `omq-compio` uses io_uring on Linux, kqueue on macOS.
-`omq-tokio` uses mio / epoll / kqueue.
+Linux and macOS (and likely other mio targets). `omq-tokio` uses mio /
+epoll / kqueue. `omq-compio` uses io_uring (Linux 6.0+) and is not
+available on macOS.
 
 - Rust 1.93 or newer (edition 2024).
 - `omq-compio`: Linux 6.0 or newer (io_uring multi-shot recv with

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -11,8 +11,8 @@ runtime backends differ. Detail lives in [`compio.md`](compio.md),
 +------------------------------------------------------------------+
 |  user code                                                       |
 |  +-> omq (facade, picks one backend at build time):              |
-|         omq-compio  (default, single-thread io_uring/IOCP)       |
-|         omq-tokio   (multi-thread, mio/epoll/kqueue)             |
+|         omq-tokio   (default, multi-thread, mio/epoll/kqueue)    |
+|         omq-compio  (single-thread io_uring/IOCP)                |
 +------------------------------------------------------------------+
         |  Socket::send / Socket::recv / connect / bind / monitor
         v

--- a/omq-compio/README.md
+++ b/omq-compio/README.md
@@ -1,7 +1,6 @@
 # omq-compio
 
-compio backend for [omq](https://crates.io/crates/omq). Single-threaded, io_uring-based.
-Primary backend, used by default when you `cargo add omq`.
+compio backend for [omq](https://crates.io/crates/omq). Single-threaded, io_uring-based (Linux / IOCP on Windows).
 
 Built on [omq-proto](https://crates.io/crates/omq-proto) and
 [compio](https://crates.io/crates/compio) (io_uring on Linux, IOCP on Windows).

--- a/omq-compio/src/bin/bench_peer_compio.rs
+++ b/omq-compio/src/bin/bench_peer_compio.rs
@@ -1,10 +1,10 @@
 //! Two-process throughput and latency peer for omq-compio.
 //!
 //! Usage:
-//!   `bench_peer` push \<endpoint\> \<`msg_size_bytes`\>
-//!   `bench_peer` pull \<endpoint\> \<`msg_size_bytes`\> \<`duration_secs`\>
-//!   `bench_peer` rep  \<endpoint\> \<`msg_size_bytes`\>
-//!   `bench_peer` req  \<endpoint\> \<`msg_size_bytes`\> \<iterations\> \<warmup\>
+//!   `bench_peer_compio` push \<endpoint\> \<`msg_size_bytes`\>
+//!   `bench_peer_compio` pull \<endpoint\> \<`msg_size_bytes`\> \<`duration_secs`\>
+//!   `bench_peer_compio` rep  \<endpoint\> \<`msg_size_bytes`\>
+//!   `bench_peer_compio` req  \<endpoint\> \<`msg_size_bytes`\> \<iterations\> \<warmup\>
 //!
 //! Endpoint: a port number (`4000`), an `ip:port` pair (`0.0.0.0:4000`),
 //! a full URI (`tcp://0.0.0.0:4000`), or an IPC path (`ipc:///tmp/foo.sock`).
@@ -108,12 +108,12 @@ fn main() {
                 run_req(ep, size, iterations, warmup).await;
             }
             _ => {
-                eprintln!("usage: bench_peer push <endpoint> <size>");
-                eprintln!("       bench_peer pull <endpoint> <size> <duration_secs>");
-                eprintln!("       bench_peer inproc <name> <size> <duration_secs>");
-                eprintln!("       bench_peer inproc-st <name> <size> <duration_secs>");
-                eprintln!("       bench_peer rep <endpoint> <size>");
-                eprintln!("       bench_peer req <endpoint> <size> <iterations> <warmup>");
+                eprintln!("usage: bench_peer_compio push <endpoint> <size>");
+                eprintln!("       bench_peer_compio pull <endpoint> <size> <duration_secs>");
+                eprintln!("       bench_peer_compio inproc <name> <size> <duration_secs>");
+                eprintln!("       bench_peer_compio inproc-st <name> <size> <duration_secs>");
+                eprintln!("       bench_peer_compio rep <endpoint> <size>");
+                eprintln!("       bench_peer_compio req <endpoint> <size> <iterations> <warmup>");
                 std::process::exit(1);
             }
         }

--- a/omq-tokio/README.md
+++ b/omq-tokio/README.md
@@ -1,7 +1,7 @@
 # omq-tokio
 
 Tokio backend for [omq](https://crates.io/crates/omq). Multi-threaded, actor-based.
-Alternative backend for callers already on a tokio runtime.
+Default backend when you `cargo add omq`. Works on Linux and macOS.
 
 Built on [omq-proto](https://crates.io/crates/omq-proto) and
 [tokio](https://crates.io/crates/tokio).
@@ -31,7 +31,7 @@ let msg = pull.recv().await?;
 ```
 
 Most users should depend on the `omq` facade crate instead of `omq-tokio` directly.
-Use `cargo add omq --no-default-features --features tokio-backend`.
+`cargo add omq` picks this backend by default.
 
 ## Internals
 

--- a/omq/Cargo.toml
+++ b/omq/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Pure Rust ØMQ/ZeroMQ. Facade over omq-compio (default) or omq-tokio. Wire-compatible with libzmq."
+description = "Pure Rust ØMQ/ZeroMQ. Facade over omq-tokio (default) or omq-compio. Wire-compatible with libzmq."
 readme = "README.md"
 keywords = ["zeromq", "zmq", "messaging", "networking", "async"]
 categories = ["network-programming", "asynchronous"]
@@ -15,10 +15,10 @@ categories = ["network-programming", "asynchronous"]
 workspace = true
 
 [features]
-# Pick exactly one backend. compio is the default; tokio-backend is
-# for callers already invested in a tokio runtime. Enabling both is a
+# Pick exactly one backend. tokio is the default; compio-backend is
+# for single-threaded io_uring environments. Enabling both is a
 # compile-time error.
-default = ["compio-backend"]
+default = ["tokio-backend"]
 compio-backend = ["dep:omq-compio"]
 tokio-backend = ["dep:omq-tokio"]
 
@@ -58,5 +58,5 @@ omq-compio = { path = "../omq-compio", version = "0.11.0", default-features = fa
 omq-tokio  = { path = "../omq-tokio",  version = "0.12.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
-features = ["compio-backend", "curve", "blake3zmq", "plain", "lz4", "zstd", "ws", "priority"]
+features = ["tokio-backend", "curve", "blake3zmq", "plain", "lz4", "zstd", "ws", "priority"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/omq/README.md
+++ b/omq/README.md
@@ -4,16 +4,16 @@ Facade crate for [omq](https://github.com/paddor/omq.rs). Re-exports one backend
 
 | Feature | Backend | Crate |
 |---------|---------|-------|
-| `compio-backend` (default) | Single-threaded, io_uring | [omq-compio](https://crates.io/crates/omq-compio) |
-| `tokio-backend` | Multi-threaded, tokio | [omq-tokio](https://crates.io/crates/omq-tokio) |
+| `tokio-backend` (default) | Multi-threaded, tokio | [omq-tokio](https://crates.io/crates/omq-tokio) |
+| `compio-backend` | Single-threaded, io_uring | [omq-compio](https://crates.io/crates/omq-compio) |
 
 Mutually exclusive.
 
 ## Install
 
 ```sh
-cargo add omq                     # compio backend (default)
-cargo add omq --no-default-features --features tokio-backend
+cargo add omq                     # tokio backend (default)
+cargo add omq --no-default-features --features compio-backend
 ```
 
 ## Usage

--- a/scripts/compare_libzmq.sh
+++ b/scripts/compare_libzmq.sh
@@ -9,7 +9,7 @@
 # are created.
 #
 # Inproc requires both sockets in the same process, so each peer binary
-# runs its own push+pull internally (bench_peer inproc / libzmq_bench_peer
+# runs its own push+pull internally (bench_peer_compio inproc / libzmq_bench_peer
 # inproc).
 #
 # Usage:
@@ -65,9 +65,9 @@ fi
 
 # ---------- build ----------
 
-echo "==> building omq-compio bench_peer..."
-cargo build --release -p omq-compio --bin bench_peer -q
-OMQ_PEER="$REPO/target/release/bench_peer"
+echo "==> building omq-compio bench_peer_compio..."
+cargo build --release -p omq-compio --bin bench_peer_compio -q
+OMQ_PEER="$REPO/target/release/bench_peer_compio"
 
 echo "==> building omq-tokio bench_peer..."
 cargo build --release -p omq-tokio --bin bench_peer_tokio -q

--- a/scripts/compare_zmqrs.sh
+++ b/scripts/compare_zmqrs.sh
@@ -71,9 +71,9 @@ echo "==> building omq-tokio bench_peer..."
 cargo build --release -p omq-tokio --bin bench_peer_tokio -q
 TOKIO_PEER="$REPO/target/release/bench_peer_tokio"
 
-echo "==> building omq-compio bench_peer..."
-cargo build --release -p omq-compio --bin bench_peer -q
-COMPIO_PEER="$REPO/target/release/bench_peer"
+echo "==> building omq-compio bench_peer_compio..."
+cargo build --release -p omq-compio --bin bench_peer_compio -q
+COMPIO_PEER="$REPO/target/release/bench_peer_compio"
 
 echo "==> building omq-zeromq bench_peer..."
 cargo build --release -p omq-zeromq --bin bench_peer_zeromq -q


### PR DESCRIPTION
- `omq-compio` uses io_uring (Linux-only), so it cannot be the default on a project that also targets macOS; `omq-tokio` (mio / epoll / kqueue) works on Linux and macOS
- `omq/Cargo.toml`: `default = ["tokio-backend"]`; docs.rs features updated to match
- README, omq/README, omq-tokio/README, omq-compio/README, CLAUDE.md, DEVELOPMENT.md, `doc/architecture.md`: tokio listed first / marked default throughout
- Platform section: clarify Linux+macOS for tokio, Linux-only for compio
- Rename `omq-compio/src/bin/bench_peer.rs` → `bench_peer_compio.rs` and update `--bin` flags and path references in `compare_libzmq.sh` and `compare_zmqrs.sh` to match the existing `bench_peer_tokio` naming pattern