### PR TITLE
ci: reduce job count to cut costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         toolchain: [stable, "1.93"]
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        exclude:
+          - toolchain: "1.93"
+            os: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -40,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         feature: [curve, blake3zmq, lz4, zstd, priority]
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -49,12 +52,8 @@ jobs:
       - run: cargo test -p omq-compio --features ${{ matrix.feature }}
 
   facade:
-    name: omq facade (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+    name: omq facade
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -81,28 +80,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets
 
-  clippy-examples:
-    name: clippy (zguide examples)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with: { components: clippy }
-      - uses: Swatinem/rust-cache@v2
-      - name: clippy (zguide-compio)
-        working-directory: examples/zguide-compio
-        run: cargo clippy --workspace --all-targets
-      - name: clippy (zguide-tokio)
-        working-directory: examples/zguide-tokio
-        run: cargo clippy --workspace --all-targets
-
   pyomq:
-    name: pyomq + pyzmq interop (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+    name: pyomq + pyzmq interop
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -140,7 +120,7 @@ jobs:
 
   ci-success:
     name: CI success
-    needs: [test, feature-matrix, facade, fmt, clippy, clippy-examples, pyomq, ruby-interop]
+    needs: [test, feature-matrix, facade, fmt, clippy, pyomq, ruby-interop]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,8 +1,6 @@
 name: soak
 
 on:
-  schedule:
-    - cron: '0 3 * * *'  # 3 AM UTC daily
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
- Drop soak scheduled trigger; keep \`workflow_dispatch\` for manual runs
- Remove ARM from \`feature-matrix\`, \`facade\`, and \`pyomq\` (ARM costs 2×)
- Exclude MSRV (1.93) from ARM in the \`test\` matrix
- Remove \`clippy-examples\` job

23 → 14 jobs per run; ARM jobs down from 9 to 1.