### PR TITLE
tokio: fix DirectIo misrouting when multiple peers connect

### DIFF
--- a/doc/performance.md
+++ b/doc/performance.md
@@ -786,6 +786,11 @@ It keeps the reader and codec, handles recv (via `recv_direct` or
 for messages routed through `send_submitter`. The writer is shared
 between `DirectIo` and the driver via `Arc<Mutex<Writer>>`.
 
+When a second peer connects, the actor drops the pending oneshot
+receiver (canceling any in-flight install) and clears the slot.
+Routing socket types (REP, ROUTER, SERVER) would misroute replies
+to the first peer's stream otherwise.
+
 Disabled when a frame transform is active (CURVE, BLAKE3ZMQ).
 The codec's encrypt-in-place flow cannot use the flat-encode path.
 

--- a/doc/tokio.md
+++ b/doc/tokio.md
@@ -223,8 +223,13 @@ It keeps the read half, the codec, and a clone of the shared writer
 - EOF detection: sets `DirectIo`'s dead flag and exits normally;
   `run()` sends `PeerOut::Closed` so the actor can reconnect.
 
-Disabled when a frame transform is active (CURVE, BLAKE3ZMQ) —
-the codec's encrypt-in-place state cannot be split from the writer.
+When a second peer connects, the actor drops the pending oneshot
+receiver (canceling any in-flight install) and clears the slot.
+Without this, routing types (REP/ROUTER/SERVER) would send all
+replies to the first peer's stream.
+
+Disabled when a frame transform is active (CURVE, BLAKE3ZMQ).
+The codec's encrypt-in-place state cannot be split from the writer.
 
 ## Reconnect and monitor
 

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -222,6 +222,8 @@ pub(crate) struct SocketDriver {
     spsc_activated: super::handle::SpscActivated,
     direct_io: super::handle::DirectIoSlot,
     direct_io_pending: super::handle::DirectIoPending,
+    pending_direct_io_rx:
+        Option<futures::channel::oneshot::Receiver<crate::engine::direct_io::DirectIo>>,
 }
 
 impl SocketDriver {
@@ -280,6 +282,7 @@ impl SocketDriver {
             spsc_activated,
             direct_io,
             direct_io_pending,
+            pending_direct_io_rx: None,
         }
     }
 
@@ -324,6 +327,16 @@ impl SocketDriver {
                         },
                     };
                     self.handle_internal_event(evt).await;
+                }
+                Ok(dio) = async {
+                    self.pending_direct_io_rx.as_mut().unwrap().await
+                }, if self.pending_direct_io_rx.is_some() => {
+                    self.pending_direct_io_rx = None;
+                    if self.peers.len() == 1 {
+                        *self.direct_io.lock().await = Some(dio);
+                    }
+                    self.direct_io_pending
+                        .store(false, std::sync::atomic::Ordering::Release);
                 }
             }
         }

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -356,6 +356,10 @@ impl SocketDriver {
         // Disable send fast path when a second peer of any type connects.
         if self.peers.len() > 1 {
             *self.send_ring.write().unwrap() = None;
+            self.pending_direct_io_rx = None;
+            if let Ok(mut guard) = self.direct_io.try_lock() {
+                *guard = None;
+            }
         }
 
         tokio::spawn(async move {
@@ -627,19 +631,10 @@ impl SocketDriver {
         self.recv_strategy.connection_added(peer_id, identity);
         self.replay_state_to_peer(&handle, subs_replay).await;
 
-        // Direct I/O: await the oneshot in a background task so the
-        // actor stays responsive to commands (e.g. QueryConnections).
         if let Some(p) = self.peers.get_mut(&peer_id)
             && let Some(rx) = p.direct_io_rx.take()
         {
-            let dio_slot = self.direct_io.clone();
-            let pending = self.direct_io_pending.clone();
-            tokio::spawn(async move {
-                if let Ok(dio) = rx.await {
-                    *dio_slot.lock().await = Some(dio);
-                }
-                pending.store(false, std::sync::atomic::Ordering::Release);
-            });
+            self.pending_direct_io_rx = Some(rx);
         }
     }
 

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -212,3 +212,45 @@ async fn req_rep_1000_cycles_tcp() {
 
     rep_task.await.unwrap();
 }
+
+/// Three REQ sockets connect to one REP. Each sends a request and
+/// expects its own reply back. Verifies that `DirectIo` (installed for
+/// the first peer) does not misroute replies once more peers arrive.
+#[tokio::test]
+async fn three_req_to_one_rep_direct_io_routing() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let mut reqs: Vec<Socket> = Vec::new();
+    for _ in 0..3 {
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(ep.clone()).await.unwrap();
+        reqs.push(req);
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    for (i, req) in reqs.iter().enumerate() {
+        req.send(Message::single(format!("from-{i}")))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), rep.recv())
+            .await
+            .unwrap_or_else(|_| panic!("rep.recv timed out on req {i}"))
+            .unwrap();
+        assert_eq!(msg.part_bytes(0).unwrap(), format!("from-{i}").as_bytes());
+
+        rep.send(Message::single(format!("reply-{i}")))
+            .await
+            .unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(5), req.recv())
+            .await
+            .unwrap_or_else(|_| panic!("req[{i}].recv timed out"))
+            .unwrap();
+        assert_eq!(
+            reply.part_bytes(0).unwrap(),
+            format!("reply-{i}").as_bytes()
+        );
+    }
+}


### PR DESCRIPTION
- When a second peer connected to a REP/ROUTER/SERVER socket, the DirectIo slot (installed for the first peer) was not invalidated. All replies went to the first peer's TCP stream regardless of routing.
- Fix: move the DirectIo oneshot receiver from a detached `tokio::spawn` into `SocketDriver`'s own select loop. The actor checks `peers.len() == 1` before installing. When a second peer connects, the pending receiver is dropped (canceling any in-flight install) and `try_lock` clears any already-installed DirectIo.
- Adds regression test `three_req_to_one_rep_direct_io_routing`.
- Updates doc/tokio.md and doc/performance.md with the multi-peer invalidation behavior.