### PR TITLE
fix(curve): carry the COMMAND flag in the encrypted inner byte

### DIFF
--- a/omq-compio/tests/interop_pyzmq_curve.rs
+++ b/omq-compio/tests/interop_pyzmq_curve.rs
@@ -334,3 +334,176 @@ ctx.term()
         let _ = child.wait_with_output();
     });
 }
+
+// ---------------------------------------------------------------------
+// compio CURVE PUB -> pyzmq CURVE SUB
+// Exercises the inbound SUBSCRIBE-over-CURVE path: libzmq's SUB sends
+// SUBSCRIBE as a CURVE MESSAGE with the COMMAND bit (0x02) in the
+// encrypted inner flags byte. omq must read that bit to demux the
+// subscription; without it the PUB never registers the filter and the
+// SUB receives nothing.
+// ---------------------------------------------------------------------
+
+#[compio::test]
+async fn rust_curve_pub_to_pyzmq_sub() {
+    if skip_if_no_pyzmq_curve() {
+        return;
+    }
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub_z85 = server_kp.public.to_z85();
+    let client_pub_z85 = client_kp.public.to_z85();
+    let client_sec_z85 = client_kp.secret.to_z85();
+
+    let port = free_tcp_port();
+    let pub_sock = Socket::new(SocketType::Pub, Options::default().curve_server(server_kp));
+    pub_sock.bind(loopback(port)).await.unwrap();
+
+    let script = r#"
+import os, sys, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.SUB)
+s.curve_secretkey = os.environ['CLI_SEC'].encode()
+s.curve_publickey = os.environ['CLI_PUB'].encode()
+s.curve_serverkey = os.environ['SRV_PUB'].encode()
+s.subscribe(b"")
+s.connect(f"tcp://127.0.0.1:{os.environ['PORT']}")
+for _ in range(3):
+    sys.stdout.write(s.recv().decode() + "\n"); sys.stdout.flush()
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let child = Command::new("python3")
+        .args(["-c", script])
+        .env("PORT", port.to_string())
+        .env("SRV_PUB", &server_pub_z85)
+        .env("CLI_PUB", &client_pub_z85)
+        .env("CLI_SEC", &client_sec_z85)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 sub");
+
+    wait_for_curve_handshake(&pub_sock).await;
+
+    for _ in 0..60 {
+        let _ = pub_sock.send(Message::single("curve-pubsub")).await;
+        compio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+    let out = rx
+        .recv()
+        .expect("python child join failed")
+        .expect("python wait failed");
+    assert!(
+        out.status.success(),
+        "pyzmq sub exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let lines: Vec<&str> = std::str::from_utf8(&out.stdout).unwrap().lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines.iter().all(|l| *l == "curve-pubsub"));
+}
+
+// ---------------------------------------------------------------------
+// pyzmq CURVE PUB -> compio CURVE SUB
+// Exercises the outbound SUBSCRIBE-over-CURVE path: omq's SUB must
+// set the COMMAND bit (0x02) in the encrypted inner flags byte when
+// sending SUBSCRIBE, so that libzmq's PUB recognizes it as a command
+// and registers the subscription filter.
+// ---------------------------------------------------------------------
+
+#[compio::test]
+async fn pyzmq_curve_pub_to_rust_sub() {
+    if skip_if_no_pyzmq_curve() {
+        return;
+    }
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub_z85 = server_kp.public.to_z85();
+    let server_sec_z85 = server_kp.secret.to_z85();
+    let server_pub_for_client = server_kp.public;
+
+    let port = free_tcp_port();
+
+    let script = r#"
+import os, sys, zmq, time
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.PUB)
+s.curve_server = True
+s.curve_secretkey = os.environ['SRV_SEC'].encode()
+s.curve_publickey = os.environ['SRV_PUB'].encode()
+s.bind(f"tcp://127.0.0.1:{os.environ['PORT']}")
+sys.stdout.write("READY\n"); sys.stdout.flush()
+for i in range(60):
+    s.send(f"msg-{i}".encode())
+    time.sleep(0.05)
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let mut child = Command::new("python3")
+        .args(["-c", script])
+        .env("PORT", port.to_string())
+        .env("SRV_PUB", &server_pub_z85)
+        .env("SRV_SEC", &server_sec_z85)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 pub");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut r = BufReader::new(stdout);
+        let mut first = String::new();
+        let _ = r.read_line(&mut first);
+        let _ = ready_tx.send(first.trim() == "READY");
+    });
+    let ready = compio::time::timeout(Duration::from_secs(5), async move {
+        loop {
+            match ready_rx.try_recv() {
+                Ok(v) => return v,
+                Err(mpsc::TryRecvError::Empty) => {
+                    compio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(_) => return false,
+            }
+        }
+    })
+    .await
+    .expect("python bind timed out");
+    assert!(ready, "python pub did not signal READY");
+
+    let sub = Socket::new(
+        SocketType::Sub,
+        Options::default().curve_client(client_kp, server_pub_for_client),
+    );
+    sub.subscribe("").await.unwrap();
+    sub.connect(loopback(port)).await.unwrap();
+
+    let Ok(Ok(m)) = compio::time::timeout(Duration::from_secs(10), sub.recv()).await else {
+        let _ = child.kill();
+        let mut err = String::new();
+        let _ = stderr.read_to_string(&mut err);
+        panic!("SUB never received from pyzmq PUB over CURVE\nstderr={err}");
+    };
+    assert!(
+        std::str::from_utf8(&m.part_bytes(0).unwrap())
+            .unwrap()
+            .starts_with("msg-")
+    );
+
+    let _ = thread::spawn(move || {
+        let _ = child.wait();
+        let _ = stderr;
+    });
+}

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -238,17 +238,20 @@ impl Connection {
             return self.dispatch_decrypted(flags.command, flags.more, plaintext);
         }
 
-        // CURVE: wire body is `\x07 "MESSAGE" flags(1) nonce(8) box(...)`.
-        // libzmq does NOT set the COMMAND bit; the wire flag is forwarded
-        // after decrypt so the receiver demuxes command-vs-data.
+        // CURVE: wire body is `\x07 "MESSAGE" nonce(8) box(flags(1) || data)`.
+        // The MORE and COMMAND bits live in the *encrypted* inner flags byte
+        // (libzmq msg flags: MORE 0x01, COMMAND 0x02), so the command-vs-data
+        // demux must use the decrypted flag — the outer wire frame is never
+        // COMMAND-flagged for CURVE traffic.
         #[cfg(feature = "curve")]
         if let Some(FrameTransform::Curve(tx)) = self.transform.as_mut() {
             let body = payload.as_bytes();
             if body.len() >= CURVE_MESSAGE_PREFIX.len()
                 && &body[..CURVE_MESSAGE_PREFIX.len()] == CURVE_MESSAGE_PREFIX
             {
-                let (more, plaintext) = tx.decrypt_message(&body[CURVE_MESSAGE_PREFIX.len()..])?;
-                return self.dispatch_decrypted(flags.command, more, plaintext);
+                let (more, command, plaintext) =
+                    tx.decrypt_message(&body[CURVE_MESSAGE_PREFIX.len()..])?;
+                return self.dispatch_decrypted(command, more, plaintext);
             }
             return Err(Error::Protocol(
                 "expected CURVE-wrapped MESSAGE on data-phase connection".into(),

--- a/omq-proto/src/proto/connection/outbound.rs
+++ b/omq-proto/src/proto/connection/outbound.rs
@@ -52,7 +52,7 @@ impl Connection {
                 && let Some(FrameTransform::Curve(tx)) = self.transform.as_mut()
             {
                 let plaintext = body.freeze();
-                let Ok(enc) = tx.encrypt_message(false, &plaintext) else {
+                let Ok(enc) = tx.encrypt_message(false, true, &plaintext) else {
                     continue;
                 };
                 let mut wire = BytesMut::with_capacity(8 + enc.len());
@@ -240,7 +240,7 @@ impl Connection {
             unreachable!("send_part_curve called without curve transform");
         };
         let plaintext = part.as_bytes();
-        let body = tx.encrypt_message(more, &plaintext)?;
+        let body = tx.encrypt_message(more, false, &plaintext)?;
         let mut wire = BytesMut::with_capacity(8 + body.len());
         wire.put_u8(b"MESSAGE".len() as u8);
         wire.put_slice(b"MESSAGE");

--- a/omq-proto/src/proto/connection/outbound.rs
+++ b/omq-proto/src/proto/connection/outbound.rs
@@ -45,8 +45,8 @@ impl Connection {
                 continue;
             }
 
-            // CURVE post-handshake: commands traverse MESSAGE encryption;
-            // the wire COMMAND bit stays set so the receiver demuxes.
+            // CURVE post-handshake: commands traverse MESSAGE encryption.
+            // The inner flags byte carries COMMAND (0x02) for the peer.
             #[cfg(feature = "curve")]
             if matches!(self.state, State::Ready)
                 && let Some(FrameTransform::Curve(tx)) = self.transform.as_mut()
@@ -228,12 +228,9 @@ impl Connection {
         );
     }
 
-    /// CURVE-encrypted part: wrap the plaintext per RFC 26 (`"\x07"
-    /// "MESSAGE" flags(1) nonce(8) box`) and queue it as one ZMTP DATA
-    /// frame. libzmq sends these as data frames (not COMMAND frames);
-    /// the inner plaintext flag byte carries the application-level MORE.
-    /// Caller has already verified `self.transform` is
-    /// `Some(FrameTransform::Curve(_))`.
+    /// CURVE-encrypted data part: wrap the plaintext per RFC 26 and queue
+    /// it as one ZMTP DATA frame. The inner flags byte carries MORE (0x01);
+    /// COMMAND (0x02) is clear since this is application data.
     #[cfg(feature = "curve")]
     fn send_part_curve(&mut self, more: bool, part: &Payload) -> Result<()> {
         let Some(FrameTransform::Curve(tx)) = self.transform.as_mut() else {

--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -90,18 +90,25 @@ impl std::fmt::Debug for CurveTransform {
 }
 
 impl CurveTransform {
-    /// Encrypt a single application frame's payload, returning the body of
-    /// the MESSAGE command after the `\x07MESSAGE` name prefix:
-    /// `nonce(8) || box(flags(1) || plaintext)`. The MORE bit lives
-    /// *inside* the encrypted plaintext per RFC 26 / libzmq.
-    pub(crate) fn encrypt_message(&mut self, more: bool, plaintext: &[u8]) -> Result<Bytes> {
+    /// Encrypt a single frame's payload, returning the body of the MESSAGE
+    /// command after the `\x07MESSAGE` name prefix:
+    /// `nonce(8) || box(flags(1) || plaintext)`. The flags byte lives *inside*
+    /// the encrypted plaintext per RFC 26 / libzmq and carries MORE (0x01) and
+    /// COMMAND (0x02), so a wrapped ZMTP command (e.g. SUBSCRIBE) is told apart
+    /// from application data by the peer.
+    pub(crate) fn encrypt_message(
+        &mut self,
+        more: bool,
+        command: bool,
+        plaintext: &[u8],
+    ) -> Result<Bytes> {
         self.out_counter = self
             .out_counter
             .checked_add(1)
             .ok_or_else(|| Error::Protocol("CURVE outbound nonce counter exhausted".into()))?;
         let nonce = nonce_short(&self.out_prefix, self.out_counter);
         let mut pt = Vec::with_capacity(1 + plaintext.len());
-        pt.push(u8::from(more));
+        pt.push(u8::from(more) | (u8::from(command) << 1));
         pt.extend_from_slice(plaintext);
         let ct = self
             .salsa
@@ -114,8 +121,11 @@ impl CurveTransform {
     }
 
     /// Decrypt a MESSAGE command body (post-`\x07MESSAGE` prefix). Returns
-    /// `(more, plaintext)`. Body layout: `nonce(8) || box(flags(1) || data)`.
-    pub(crate) fn decrypt_message(&mut self, body: &[u8]) -> Result<(bool, Bytes)> {
+    /// `(more, command, plaintext)`. Body layout: `nonce(8) || box(flags(1) || data)`.
+    /// The inner flags byte carries libzmq's msg flags — MORE (0x01) and COMMAND
+    /// (0x02) — so a CURVE-wrapped ZMTP command (e.g. SUBSCRIBE) can be told apart
+    /// from application data.
+    pub(crate) fn decrypt_message(&mut self, body: &[u8]) -> Result<(bool, bool, Bytes)> {
         if body.len() < 8 + 16 + 1 {
             return Err(Error::Protocol("MESSAGE command too short".into()));
         }
@@ -137,8 +147,9 @@ impl CurveTransform {
             ));
         }
         let more = pt[0] & 0x01 != 0;
+        let command = pt[0] & 0x02 != 0;
         self.in_counter = counter;
-        Ok((more, Bytes::copy_from_slice(&pt[1..])))
+        Ok((more, command, Bytes::copy_from_slice(&pt[1..])))
     }
 }
 
@@ -940,15 +951,27 @@ mod tests {
         let mut s_tx = server.build_transform().unwrap();
         let mut c_tx = client.build_transform().unwrap();
 
-        let body = c_tx.encrypt_message(false, b"hello server").unwrap();
-        let (more, pt) = s_tx.decrypt_message(&body).unwrap();
+        let body = c_tx.encrypt_message(false, false, b"hello server").unwrap();
+        let (more, _command, pt) = s_tx.decrypt_message(&body).unwrap();
         assert!(!more);
         assert_eq!(&pt[..], b"hello server");
 
-        let body = s_tx.encrypt_message(true, b"hi client").unwrap();
-        let (more, pt) = c_tx.decrypt_message(&body).unwrap();
+        let body = s_tx.encrypt_message(true, false, b"hi client").unwrap();
+        let (more, _command, pt) = c_tx.decrypt_message(&body).unwrap();
         assert!(more);
         assert_eq!(&pt[..], b"hi client");
+
+        // The COMMAND bit must round-trip independently of MORE: it's what lets a
+        // CURVE-wrapped ZMTP command (e.g. SUBSCRIBE) be told apart from application data
+        // on the far side. Dropping it silently turned every SUBSCRIBE into data, so a PUB
+        // never registered a (libzmq) SUB's subscription and the SUB received nothing.
+        for (more, command) in [(false, false), (true, false), (false, true), (true, true)] {
+            let body = c_tx.encrypt_message(more, command, b"payload").unwrap();
+            let (got_more, got_command, pt) = s_tx.decrypt_message(&body).unwrap();
+            assert_eq!(got_more, more, "MORE bit changed over CURVE");
+            assert_eq!(got_command, command, "COMMAND bit lost over CURVE (more={more})");
+            assert_eq!(&pt[..], b"payload");
+        }
     }
 
     #[test]

--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -969,7 +969,10 @@ mod tests {
             let body = c_tx.encrypt_message(more, command, b"payload").unwrap();
             let (got_more, got_command, pt) = s_tx.decrypt_message(&body).unwrap();
             assert_eq!(got_more, more, "MORE bit changed over CURVE");
-            assert_eq!(got_command, command, "COMMAND bit lost over CURVE (more={more})");
+            assert_eq!(
+                got_command, command,
+                "COMMAND bit lost over CURVE (more={more})"
+            );
             assert_eq!(&pt[..], b"payload");
         }
     }

--- a/omq-proto/tests/connection.rs
+++ b/omq-proto/tests/connection.rs
@@ -271,6 +271,95 @@ fn curve_handshake_and_message_roundtrip() {
     assert_eq!(m.part_bytes(0).unwrap(), &b"encrypted hello"[..]);
 }
 
+/// SUBSCRIBE sent through CURVE must arrive as `Event::Command` even when
+/// the outer wire frame is DATA (not COMMAND). This simulates libzmq's
+/// behavior: it wraps all post-handshake traffic in DATA frames and relies
+/// on the encrypted inner flags byte (bit 0x02 = COMMAND) for demux.
+///
+/// Without the fix, the receiver trusted the outer frame's COMMAND bit,
+/// which is never set by libzmq for CURVE traffic. SUBSCRIBE was then
+/// misclassified as application data and silently dropped.
+#[cfg(feature = "curve")]
+#[test]
+fn curve_command_demux() {
+    use omq_proto::proto::command::Command;
+    use omq_proto::proto::mechanism::{CurveKeypair, MechanismSetup};
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub = server_kp.public;
+
+    let mut pub_conn = Connection::new(
+        ConnectionConfig::new(Role::Server, SocketType::Pub).mechanism(
+            MechanismSetup::CurveServer {
+                keypair: server_kp,
+                cookie_keyring: std::sync::Arc::new(omq_proto::CurveCookieKeyring::new()),
+                authenticator: None,
+            },
+        ),
+    );
+    let mut sub_conn = Connection::new(
+        ConnectionConfig::new(Role::Client, SocketType::Sub).mechanism(
+            MechanismSetup::CurveClient {
+                keypair: client_kp,
+                server_public: server_pub,
+            },
+        ),
+    );
+
+    pump(&mut pub_conn, &mut sub_conn);
+    while pub_conn.poll_event().is_some() {}
+    while sub_conn.poll_event().is_some() {}
+
+    // SUB sends SUBSCRIBE "news." through CURVE. omq emits this as a wire
+    // COMMAND frame (outer bit 0x04 set). Clear that bit to simulate what
+    // libzmq sends: a DATA frame whose encrypted inner byte carries COMMAND.
+    sub_conn
+        .send_command(&Command::Subscribe(Bytes::from_static(b"news.")))
+        .unwrap();
+    let wire = sub_conn.poll_transmit();
+    sub_conn.advance_transmit(wire.len());
+
+    let mut libzmq_wire = wire.to_vec();
+    assert_ne!(libzmq_wire[0] & 0x04, 0, "sanity: starts as COMMAND frame");
+    libzmq_wire[0] &= !0x04; // clear COMMAND bit -> DATA frame
+
+    pub_conn
+        .handle_input(Bytes::from(libzmq_wire))
+        .expect("pub accepts subscribe in DATA frame");
+
+    let ev = pub_conn.poll_event().expect("expected command event");
+    match ev {
+        Event::Command(Command::Subscribe(prefix)) => {
+            assert_eq!(&prefix[..], b"news.");
+        }
+        Event::Message(_) => panic!("SUBSCRIBE misclassified as data (COMMAND flag lost in CURVE)"),
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    // Same for CANCEL.
+    sub_conn
+        .send_command(&Command::Cancel(Bytes::from_static(b"news.")))
+        .unwrap();
+    let wire = sub_conn.poll_transmit();
+    sub_conn.advance_transmit(wire.len());
+
+    let mut libzmq_wire = wire.to_vec();
+    libzmq_wire[0] &= !0x04;
+
+    pub_conn
+        .handle_input(Bytes::from(libzmq_wire))
+        .expect("pub accepts cancel in DATA frame");
+
+    let ev = pub_conn.poll_event().expect("expected cancel event");
+    match ev {
+        Event::Command(Command::Cancel(prefix)) => {
+            assert_eq!(&prefix[..], b"news.");
+        }
+        other => panic!("expected Cancel, got: {other:?}"),
+    }
+}
+
 // --- Direct-recv codec API: peek / begin / supply -----------------
 
 fn ready_pair() -> (Connection, Connection) {

--- a/omq-tokio/tests/interop_pyzmq_curve.rs
+++ b/omq-tokio/tests/interop_pyzmq_curve.rs
@@ -299,3 +299,173 @@ ctx.term()
 
     let _ = tokio::task::spawn_blocking(move || child.wait_with_output()).await;
 }
+
+// ---------------------------------------------------------------------
+// Rust CURVE PUB -> pyzmq CURVE SUB
+// Exercises the inbound SUBSCRIBE-over-CURVE path: libzmq's SUB sends
+// SUBSCRIBE as a CURVE MESSAGE with the COMMAND bit (0x02) in the
+// encrypted inner flags byte. omq must read that bit to demux the
+// subscription; without it the PUB never registers the filter and the
+// SUB receives nothing.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn rust_curve_pub_to_pyzmq_sub() {
+    if skip_if_no_pyzmq_curve() {
+        return;
+    }
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub_z85 = server_kp.public.to_z85();
+    let client_pub_z85 = client_kp.public.to_z85();
+    let client_sec_z85 = client_kp.secret.to_z85();
+
+    let port = free_tcp_port();
+    let pub_sock = Socket::new(SocketType::Pub, Options::default().curve_server(server_kp));
+    pub_sock.bind(loopback(port)).await.unwrap();
+
+    // pyzmq SUB client: subscribe(""), receive 3 messages, print each.
+    let script = r#"
+import os, sys, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.SUB)
+s.curve_secretkey = os.environ['CLI_SEC'].encode()
+s.curve_publickey = os.environ['CLI_PUB'].encode()
+s.curve_serverkey = os.environ['SRV_PUB'].encode()
+s.subscribe(b"")
+s.connect(f"tcp://127.0.0.1:{os.environ['PORT']}")
+for _ in range(3):
+    sys.stdout.write(s.recv().decode() + "\n"); sys.stdout.flush()
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let child = Command::new("python3")
+        .args(["-c", script])
+        .env("PORT", port.to_string())
+        .env("SRV_PUB", &server_pub_z85)
+        .env("CLI_PUB", &client_pub_z85)
+        .env("CLI_SEC", &client_sec_z85)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 sub");
+
+    wait_for_curve_handshake(&pub_sock).await;
+
+    // Retry loop: the SUB's subscription may take a moment to propagate.
+    for _ in 0..60 {
+        let _ = pub_sock.send(Message::single("curve-pubsub")).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let out = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pyzmq sub exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let lines: Vec<&str> = std::str::from_utf8(&out.stdout).unwrap().lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines.iter().all(|l| *l == "curve-pubsub"));
+}
+
+// ---------------------------------------------------------------------
+// pyzmq CURVE PUB -> Rust CURVE SUB
+// Exercises the outbound SUBSCRIBE-over-CURVE path: omq's SUB must
+// set the COMMAND bit (0x02) in the encrypted inner flags byte when
+// sending SUBSCRIBE, so that libzmq's PUB recognizes it as a command
+// and registers the subscription filter.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn pyzmq_curve_pub_to_rust_sub() {
+    if skip_if_no_pyzmq_curve() {
+        return;
+    }
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub_z85 = server_kp.public.to_z85();
+    let server_sec_z85 = server_kp.secret.to_z85();
+    let server_pub_for_client = server_kp.public;
+
+    let port = free_tcp_port();
+
+    // pyzmq PUB server: bind, wait for READY signal on stdin, then
+    // publish 60 messages with 50ms spacing (enough for the SUB's
+    // subscription to propagate).
+    let script = r#"
+import os, sys, zmq, time
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.PUB)
+s.curve_server = True
+s.curve_secretkey = os.environ['SRV_SEC'].encode()
+s.curve_publickey = os.environ['SRV_PUB'].encode()
+s.bind(f"tcp://127.0.0.1:{os.environ['PORT']}")
+sys.stdout.write("READY\n"); sys.stdout.flush()
+for i in range(60):
+    s.send(f"msg-{i}".encode())
+    time.sleep(0.05)
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let mut child = Command::new("python3")
+        .args(["-c", script])
+        .env("PORT", port.to_string())
+        .env("SRV_PUB", &server_pub_z85)
+        .env("SRV_SEC", &server_sec_z85)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 pub");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    tokio::task::spawn_blocking(move || {
+        use std::io::{BufRead, BufReader};
+        let mut r = BufReader::new(stdout);
+        let mut first = String::new();
+        r.read_line(&mut first).ok();
+        let _ = ready_tx.send(first.trim() == "READY");
+    });
+    let ready = tokio::time::timeout(Duration::from_secs(5), ready_rx)
+        .await
+        .expect("python bind timed out")
+        .unwrap();
+    assert!(ready, "python pub did not signal READY");
+
+    let sub = Socket::new(
+        SocketType::Sub,
+        Options::default().curve_client(client_kp, server_pub_for_client),
+    );
+    sub.subscribe("").await.unwrap();
+    sub.connect(loopback(port)).await.unwrap();
+
+    let m = match tokio::time::timeout(Duration::from_secs(10), sub.recv()).await {
+        Ok(Ok(m)) => m,
+        Ok(Err(e)) => panic!("recv error: {e}"),
+        Err(_) => {
+            let _ = child.kill();
+            let mut err = String::new();
+            let _ = stderr.read_to_string(&mut err);
+            panic!("SUB never received from pyzmq PUB over CURVE\nstderr={err}");
+        }
+    };
+    assert!(
+        std::str::from_utf8(&m.part_bytes(0).unwrap())
+            .unwrap()
+            .starts_with("msg-")
+    );
+
+    let _ = tokio::task::spawn_blocking(move || {
+        let _ = child.wait();
+        let _ = stderr;
+    })
+    .await;
+}


### PR DESCRIPTION
Under CURVE, libzmq keeps the MORE/COMMAND bits in the encrypted inner flags byte, not the outer frame. omq read and wrote only MORE, so a CURVE-wrapped SUBSCRIBE from a libzmq SUB was treated as data and dropped — the PUB never registered the subscription. Set and read bit 0x02 (COMMAND) on both sides.