### PR TITLE
compio: optimize 8 B recv and send-path atomics, 14M -> 22M msg/s

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -77,8 +77,8 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |   877 k/s |   522 k/s | **1.68×** |
-| REQ/REP rt/s       |  11,510/s |   6,363/s | **1.81×** |
+| PUSH/PULL msg/s    |   986 k/s |   522 k/s | **1.89×** |
+| REQ/REP rt/s       |  11,406/s |   6,221/s | **1.83×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the compio thread —

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -40,67 +40,66 @@
   <line x1="760" y1="35" x2="760" y2="280" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="280" x2="760" y2="280" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="158" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,158)">msg/s</text>
-  <text x="835" y="158" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,835,158)">throughput</text>
-  <polyline points="90.0,98.8 145.8,99.6 201.7,101.4 257.5,104.1 313.3,103.5 369.2,107.6 425.0,114.9 480.8,130.0 536.7,170.2 592.5,208.7 648.3,238.8 704.2,258.6 760.0,266.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,158.0 145.8,159.2 201.7,160.5 257.5,165.6 313.3,166.3 369.2,170.0 425.0,176.1 480.8,191.4 536.7,206.9 592.5,225.1 648.3,243.8 704.2,259.6 760.0,266.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,211.5 145.8,212.0 201.7,213.2 257.5,217.7 313.3,221.7 369.2,223.6 425.0,224.0 480.8,225.7 536.7,237.0 592.5,255.2 648.3,266.7 704.2,273.3 760.0,274.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,273.5 145.8,273.4 201.7,273.3 257.5,273.5 313.3,273.7 369.2,273.6 425.0,273.8 480.8,274.1 536.7,273.7 592.5,274.1 648.3,273.9 704.2,275.1 760.0,275.9" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,279.4 145.8,278.8 201.7,277.7 257.5,275.5 313.3,271.0 369.2,262.3 425.0,246.2 480.8,218.6 536.7,190.0 592.5,163.3 648.3,145.1 704.2,139.5 760.0,102.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,86.9 145.8,92.4 201.7,91.0 257.5,96.7 313.3,97.3 369.2,99.0 425.0,107.6 480.8,129.5 536.7,168.1 592.5,206.8 648.3,237.2 704.2,258.1 760.0,266.7" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,150.5 145.8,152.7 201.7,154.3 257.5,161.4 313.3,164.0 369.2,166.5 425.0,175.3 480.8,188.7 536.7,205.4 592.5,224.9 648.3,244.2 704.2,259.5 760.0,266.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,211.2 145.8,214.3 201.7,211.4 257.5,216.0 313.3,222.1 369.2,222.1 425.0,222.4 480.8,224.9 536.7,236.9 592.5,255.2 648.3,266.5 704.2,273.0 760.0,274.3" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,273.5 145.8,273.5 201.7,273.7 257.5,273.6 313.3,273.8 369.2,273.8 425.0,273.8 480.8,274.0 536.7,274.0 592.5,274.2 648.3,274.4 704.2,275.0 760.0,275.9" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,279.4 145.8,278.8 201.7,277.6 257.5,275.3 313.3,270.6 369.2,261.5 425.0,244.7 480.8,218.4 536.7,188.3 592.5,160.0 648.3,139.7 704.2,136.3 760.0,105.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="279.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="278.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="277.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="275.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="271.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="262.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="246.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="218.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="190.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="163.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="145.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="139.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="102.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,279.6 145.8,279.2 201.7,278.5 257.5,277.1 313.3,274.2 369.2,268.7 425.0,258.7 480.8,243.7 536.7,220.1 592.5,190.1 648.3,161.5 704.2,146.5 760.0,104.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="201.7" cy="277.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="275.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="270.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="261.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="244.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="218.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="188.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="160.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="139.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="136.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="105.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,279.6 145.8,279.2 201.7,278.4 257.5,277.0 313.3,274.1 369.2,268.4 425.0,258.6 480.8,242.6 536.7,218.9 592.5,189.7 648.3,162.6 704.2,145.4 760.0,104.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="279.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="279.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="278.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="277.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="274.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="268.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="258.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="243.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="220.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="190.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="161.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="146.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="104.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,279.8 145.8,279.6 201.7,279.1 257.5,278.4 313.3,277.0 369.2,274.2 425.0,268.5 480.8,257.8 536.7,244.8 592.5,239.4 648.3,236.4 704.2,236.2 760.0,207.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="201.7" cy="278.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="277.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="274.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="268.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="258.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="242.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="218.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="189.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="162.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="145.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="104.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,279.8 145.8,279.6 201.7,279.1 257.5,278.4 313.3,277.0 369.2,274.1 425.0,268.2 480.8,257.4 536.7,244.7 592.5,239.3 648.3,235.7 704.2,234.4 760.0,205.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="279.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="279.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="279.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="278.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="277.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="274.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="268.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="257.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="244.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="239.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="236.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="236.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="207.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,280.0 145.8,280.0 201.7,279.9 257.5,279.8 313.3,279.7 369.2,279.3 425.0,278.7 480.8,277.6 536.7,274.9 592.5,270.3 648.3,260.2 704.2,247.7 760.0,225.8" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="369.2" cy="274.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="268.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="257.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="244.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="239.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="235.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="234.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="205.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,280.0 145.8,280.0 201.7,279.9 257.5,279.8 313.3,279.7 369.2,279.4 425.0,278.7 480.8,277.5 536.7,275.1 592.5,270.5 648.3,261.8 704.2,247.4 760.0,226.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="280.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="280.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="279.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="279.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="279.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="279.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="279.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="425.0" cy="278.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="277.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="274.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="270.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="260.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="247.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="225.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="277.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="275.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="270.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="261.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="247.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="226.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="294" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="294" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="294" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -151,62 +150,62 @@
   <line x1="90" y1="340" x2="90" y2="520" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="520" x2="760" y2="520" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="430" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,430)">p50 latency (µs)</text>
-  <polyline points="90.0,463.4 145.8,463.8 201.7,460.0 257.5,464.1 313.3,462.0 369.2,462.6 425.0,459.5 480.8,456.7 536.7,459.6 592.5,456.6 648.3,454.6 704.2,452.1 760.0,441.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="463.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="463.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="460.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="464.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="462.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="462.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="459.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="456.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="459.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="456.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="454.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="452.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="441.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,439.1 145.8,443.1 201.7,443.7 257.5,440.2 313.3,441.8 369.2,441.2 425.0,440.2 480.8,441.1 536.7,443.3 592.5,438.2 648.3,438.5 704.2,432.2 760.0,424.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="439.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="443.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="443.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="440.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="441.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="441.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="440.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="441.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="443.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="438.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="438.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="432.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="424.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,457.4 145.8,456.9 201.7,457.8 257.5,456.0 313.3,454.7 369.2,455.8 425.0,454.6 480.8,454.4 536.7,451.4 592.5,453.0 648.3,438.1 704.2,434.7 760.0,425.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="457.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="456.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="457.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="456.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="454.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="455.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="454.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="454.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="451.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="453.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="438.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="434.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="425.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,412.3 145.8,414.0 201.7,417.2 257.5,416.1 313.3,416.6 369.2,412.9 425.0,415.7 480.8,410.5 536.7,409.2 592.5,407.1 648.3,381.0 704.2,379.2 760.0,368.5" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="412.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="414.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="417.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="416.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,462.2 145.8,461.5 201.7,464.1 257.5,462.4 313.3,465.3 369.2,464.4 425.0,462.6 480.8,461.4 536.7,461.7 592.5,455.0 648.3,453.2 704.2,456.0 760.0,443.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="462.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="461.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="464.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="462.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="465.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="464.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="462.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="461.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="461.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="455.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="453.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="456.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="443.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,446.1 145.8,441.2 201.7,442.1 257.5,441.3 313.3,441.3 369.2,443.1 425.0,440.6 480.8,439.5 536.7,439.0 592.5,440.4 648.3,439.4 704.2,434.3 760.0,426.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="446.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="441.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="442.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="441.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="441.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="443.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="440.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="439.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="439.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="440.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="439.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="434.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="426.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,456.1 145.8,455.7 201.7,454.8 257.5,456.7 313.3,456.5 369.2,452.7 425.0,452.9 480.8,454.0 536.7,453.0 592.5,453.4 648.3,436.7 704.2,436.7 760.0,426.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="456.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="455.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="454.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="456.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="456.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="452.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="452.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="454.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="453.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="453.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="436.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="436.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="426.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,414.2 145.8,412.5 201.7,411.2 257.5,415.0 313.3,416.6 369.2,408.4 425.0,414.8 480.8,409.7 536.7,407.8 592.5,407.0 648.3,382.6 704.2,378.3 760.0,370.6" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="414.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="412.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="411.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="415.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="416.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="412.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="415.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="410.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="409.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="407.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="381.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="379.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="368.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="408.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="414.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="409.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="407.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="407.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="382.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="378.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="370.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="534" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="534" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="534" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -232,4 +231,5 @@
   <line x1="565" y1="560" x2="579" y2="560" stroke="#8b5cf6" stroke-width="2.5"/>
   <circle cx="572" cy="560" r="2.5" fill="#8b5cf6"/>
   <text x="585" y="564" fill="#374151" font-size="11" font-weight="500">pyzmq async</text>
+  <text x="425.0" y="578" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = throughput (right)</text>
 </svg>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -853,11 +853,6 @@ def gen_combined_chart(data, path):
         f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
     )
-    L.append(
-        f'  <text x="835" y="{t1_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600"'
-        f' transform="rotate(90,835,{t1_mid:.0f})">throughput</text>'
-    )
 
     tp_series = [
         ("pyomq", C_PYOMQ, sync_omq_tp),
@@ -990,6 +985,13 @@ def gen_combined_chart(data, path):
             f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
             f' font-size="11" font-weight="500">{label}</text>'
         )
+
+    footer_y = leg_y + 18
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f'dashed = msg/s (left) · solid = throughput (right)</text>'
+    )
 
     L.append("</svg>")
 

--- a/doc/charts/comparison_inproc.svg
+++ b/doc/charts/comparison_inproc.svg
@@ -1,22 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — inproc (higher is better)</text>
-  <line x1="90.0" y1="240.6" x2="760.0" y2="240.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="240.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="211.2" x2="760.0" y2="211.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="211.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="181.9" x2="760.0" y2="181.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="181.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="123.1" x2="760.0" y2="123.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="123.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="93.8" x2="760.0" y2="93.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="93.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="64.4" x2="760.0" y2="64.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="64.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="270.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
   <line x1="90.0" y1="255.9" x2="760.0" y2="255.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
@@ -56,66 +60,66 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,107.7 145.8,102.7 201.7,109.4 257.5,173.4 313.3,231.2 369.2,229.8 425.0,227.6 480.8,235.9 536.7,239.9 592.5,243.3 648.3,243.1 704.2,249.8 760.0,258.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,222.5 145.8,223.4 201.7,219.5 257.5,211.2 313.3,214.3 369.2,211.6 425.0,214.1 480.8,224.4 536.7,207.5 592.5,222.0 648.3,220.4 704.2,219.5 760.0,224.4" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,207.2 145.8,206.8 201.7,205.2 257.5,208.1 313.3,208.5 369.2,209.9 425.0,210.3 480.8,205.9 536.7,205.7 592.5,210.1 648.3,208.4 704.2,212.7 760.0,209.0" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,51.0 145.8,55.9 201.7,62.6 257.5,98.8 313.3,106.0 369.2,83.4 425.0,91.8 480.8,106.4 536.7,104.2 592.5,106.3 648.3,98.6 704.2,100.5 760.0,98.1" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,225.5 145.8,210.8 201.7,197.4 257.5,193.7 313.3,198.2 369.2,183.3 425.0,168.0 480.8,158.3 536.7,146.7 592.5,135.0 648.3,120.7 704.2,112.4 760.0,109.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="225.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="210.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="197.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="193.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="198.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="183.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="168.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="158.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="146.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="135.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="120.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="112.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="109.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,250.6 145.8,236.8 201.7,221.1 257.5,203.8 313.3,190.7 369.2,175.6 425.0,162.4 480.8,152.4 536.7,131.8 592.5,123.0 648.3,108.2 704.2,93.7 760.0,81.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="250.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="236.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="221.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="203.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="190.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="175.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="162.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="152.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="131.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,141.0 145.8,136.0 201.7,149.4 257.5,189.8 313.3,236.8 369.2,236.4 425.0,237.4 480.8,242.5 536.7,245.3 592.5,247.6 648.3,249.8 704.2,255.5 760.0,260.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,232.6 145.8,233.3 201.7,232.4 257.5,230.2 313.3,229.4 369.2,230.5 425.0,221.9 480.8,233.3 536.7,228.4 592.5,231.5 648.3,232.8 704.2,226.3 760.0,231.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,219.6 145.8,219.6 201.7,218.8 257.5,218.8 313.3,222.5 369.2,223.4 425.0,220.3 480.8,216.9 536.7,217.8 592.5,218.6 648.3,218.1 704.2,220.1 760.0,220.1" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,92.3 145.8,102.4 201.7,95.3 257.5,129.9 313.3,139.1 369.2,129.3 425.0,138.1 480.8,140.8 536.7,132.2 592.5,132.3 648.3,132.1 704.2,127.9 760.0,139.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,225.7 145.8,210.7 201.7,198.7 257.5,192.9 313.3,196.7 369.2,182.4 425.0,168.8 480.8,158.1 536.7,146.2 592.5,134.1 648.3,122.0 704.2,114.6 760.0,109.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="225.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="210.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="198.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="192.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="196.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="182.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="168.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="158.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="146.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="134.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="122.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="114.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="109.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,250.9 145.8,237.2 201.7,222.5 257.5,207.2 313.3,192.6 369.2,179.1 425.0,160.9 480.8,152.2 536.7,135.5 592.5,123.0 648.3,109.6 704.2,92.1 760.0,80.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="250.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="237.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="222.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="207.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="192.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="179.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="160.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="152.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="135.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="592.5" cy="123.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="108.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="93.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="81.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,244.9 145.8,230.6 201.7,216.0 257.5,202.7 313.3,188.7 369.2,175.1 425.0,161.0 480.8,145.4 536.7,131.2 592.5,118.5 648.3,103.8 704.2,91.1 760.0,75.7" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="244.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="230.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="216.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="202.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="188.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="175.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="161.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="145.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="131.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="118.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="103.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="91.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="75.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,219.4 145.8,205.7 201.7,192.2 257.5,182.0 313.3,168.7 369.2,151.9 425.0,138.7 480.8,126.3 536.7,111.9 592.5,98.0 648.3,82.9 704.2,69.0 760.0,54.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="219.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="205.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="192.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="182.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="168.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="151.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="138.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="126.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="111.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="98.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="82.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="69.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="54.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="109.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="92.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="80.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,244.8 145.8,230.7 201.7,216.2 257.5,202.1 313.3,189.4 369.2,175.7 425.0,160.2 480.8,144.7 536.7,130.9 592.5,117.1 648.3,102.7 704.2,89.4 760.0,75.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="244.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="230.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="216.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="202.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="189.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="175.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="160.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="144.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="130.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="117.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="102.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="89.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="75.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,219.1 145.8,206.2 201.7,191.2 257.5,181.5 313.3,168.8 369.2,153.1 425.0,140.3 480.8,126.6 536.7,111.1 592.5,97.0 648.3,82.8 704.2,68.0 760.0,55.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="219.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="206.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="191.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="181.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="168.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="153.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="140.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="126.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="111.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="97.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="82.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="68.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="55.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -156,62 +160,62 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,397.4 145.8,387.0 201.7,391.4 257.5,392.2 313.3,386.0 369.2,383.1 425.0,383.0 480.8,381.6 536.7,387.5 592.5,386.6 648.3,377.5 704.2,379.3 760.0,359.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="397.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="387.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="391.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="392.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="386.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="383.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="383.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="381.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="387.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="386.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="377.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="379.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="359.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,419.3 145.8,427.4 201.7,423.1 257.5,406.5 313.3,417.1 369.2,419.8 425.0,424.1 480.8,427.0 536.7,421.9 592.5,419.4 648.3,423.6 704.2,394.4 760.0,421.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="419.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="427.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="423.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="406.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="417.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="419.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="424.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="427.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="421.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="419.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="423.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="394.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="421.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,521.9 145.8,522.5 201.7,522.4 257.5,522.5 313.3,522.5 369.2,522.5 425.0,522.5 480.8,522.4 536.7,522.5 592.5,522.5 648.3,522.4 704.2,521.7 760.0,522.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="521.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,387.4 145.8,385.7 201.7,395.0 257.5,398.1 313.3,390.7 369.2,385.7 425.0,397.3 480.8,381.9 536.7,381.6 592.5,381.9 648.3,377.6 704.2,370.2 760.0,363.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="387.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="385.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="395.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="398.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="390.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="385.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="397.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="381.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="381.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="381.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="377.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="370.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,388.1 145.8,423.5 201.7,406.0 257.5,417.4 313.3,385.3 369.2,424.6 425.0,425.2 480.8,389.7 536.7,387.9 592.5,423.2 648.3,401.3 704.2,406.5 760.0,423.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="388.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="423.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="406.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="417.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="385.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="424.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="425.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="389.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="387.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="423.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="401.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="406.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="423.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,522.4 145.8,522.4 201.7,522.3 257.5,522.3 313.3,522.4 369.2,522.4 425.0,522.3 480.8,522.5 536.7,522.5 592.5,522.6 648.3,522.4 704.2,522.6 760.0,522.5" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="536.7" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="522.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="648.3" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="521.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,403.8 145.8,405.3 201.7,415.0 257.5,405.1 313.3,408.3 369.2,408.5 425.0,415.6 480.8,413.7 536.7,416.6 592.5,408.8 648.3,420.1 704.2,413.7 760.0,413.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="403.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="405.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="415.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="405.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="408.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="408.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="415.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="413.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="416.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="408.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="420.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="413.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="413.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="522.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,404.4 145.8,416.8 201.7,406.1 257.5,405.9 313.3,424.4 369.2,404.7 425.0,423.3 480.8,415.6 536.7,416.9 592.5,404.4 648.3,404.2 704.2,404.6 760.0,417.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="404.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="416.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="406.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="405.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="424.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="404.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="423.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="415.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="416.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="404.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="404.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="404.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="417.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/comparison_inproc.svg
+++ b/doc/charts/comparison_inproc.svg
@@ -1,26 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — inproc (higher is better)</text>
-  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="251.2" x2="760.0" y2="251.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="251.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="232.4" x2="760.0" y2="232.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="232.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="213.6" x2="760.0" y2="213.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="213.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="194.8" x2="760.0" y2="194.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="194.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="157.2" x2="760.0" y2="157.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="157.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="138.4" x2="760.0" y2="138.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="138.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="119.6" x2="760.0" y2="119.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="119.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="100.8" x2="760.0" y2="100.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="100.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
-  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
-  <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <line x1="90.0" y1="63.2" x2="760.0" y2="63.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="63.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">22M</text>
+  <line x1="90.0" y1="44.4" x2="760.0" y2="44.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="44.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">24M</text>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="270.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
   <line x1="90.0" y1="255.9" x2="760.0" y2="255.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
@@ -60,10 +64,10 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,141.0 145.8,136.0 201.7,149.4 257.5,189.8 313.3,236.8 369.2,236.4 425.0,237.4 480.8,242.5 536.7,245.3 592.5,247.6 648.3,249.8 704.2,255.5 760.0,260.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,232.6 145.8,233.3 201.7,232.4 257.5,230.2 313.3,229.4 369.2,230.5 425.0,221.9 480.8,233.3 536.7,228.4 592.5,231.5 648.3,232.8 704.2,226.3 760.0,231.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,219.6 145.8,219.6 201.7,218.8 257.5,218.8 313.3,222.5 369.2,223.4 425.0,220.3 480.8,216.9 536.7,217.8 592.5,218.6 648.3,218.1 704.2,220.1 760.0,220.1" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,92.3 145.8,102.4 201.7,95.3 257.5,129.9 313.3,139.1 369.2,129.3 425.0,138.1 480.8,140.8 536.7,132.2 592.5,132.3 648.3,132.1 704.2,127.9 760.0,139.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,166.8 145.8,162.8 201.7,173.5 257.5,205.8 313.3,243.4 369.2,243.2 425.0,243.9 480.8,248.0 536.7,250.3 592.5,252.1 648.3,253.8 704.2,258.4 760.0,262.4" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,237.5 145.8,233.8 201.7,238.7 257.5,237.7 313.3,232.0 369.2,239.1 425.0,238.0 480.8,233.3 536.7,237.3 592.5,235.6 648.3,239.5 704.2,240.3 760.0,233.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,229.3 145.8,229.9 201.7,227.7 257.5,230.5 313.3,229.5 369.2,231.1 425.0,230.7 480.8,229.3 536.7,228.6 592.5,231.1 648.3,230.1 704.2,228.2 760.0,230.4" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,135.8 145.8,126.7 201.7,142.3 257.5,156.3 313.3,160.1 369.2,158.9 425.0,165.9 480.8,161.0 536.7,162.8 592.5,161.2 648.3,160.2 704.2,165.7 760.0,152.6" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,225.7 145.8,210.7 201.7,198.7 257.5,192.9 313.3,196.7 369.2,182.4 425.0,168.8 480.8,158.1 536.7,146.2 592.5,134.1 648.3,122.0 704.2,114.6 760.0,109.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="225.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="210.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -78,48 +82,48 @@
   <circle cx="648.3" cy="122.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="114.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="109.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,250.9 145.8,237.2 201.7,222.5 257.5,207.2 313.3,192.6 369.2,179.1 425.0,160.9 480.8,152.2 536.7,135.5 592.5,123.0 648.3,109.6 704.2,92.1 760.0,80.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="250.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="237.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="222.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="207.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="192.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="179.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="160.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="152.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="135.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="123.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="109.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="92.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="80.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,244.8 145.8,230.7 201.7,216.2 257.5,202.1 313.3,189.4 369.2,175.7 425.0,160.2 480.8,144.7 536.7,130.9 592.5,117.1 648.3,102.7 704.2,89.4 760.0,75.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="244.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="230.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="216.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="202.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="189.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="175.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="160.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="144.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="130.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="117.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="102.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="89.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="75.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,219.1 145.8,206.2 201.7,191.2 257.5,181.5 313.3,168.8 369.2,153.1 425.0,140.3 480.8,126.6 536.7,111.1 592.5,97.0 648.3,82.8 704.2,68.0 760.0,55.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="219.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="206.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="191.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="181.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="168.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="153.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="140.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="126.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="111.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="97.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="82.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="68.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="55.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,249.2 145.8,232.9 201.7,221.7 257.5,206.9 313.3,189.4 369.2,179.6 425.0,164.7 480.8,147.7 536.7,135.9 592.5,120.7 648.3,109.1 704.2,95.5 760.0,77.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="249.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="232.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="221.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="206.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="189.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="179.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="164.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="135.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="120.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="109.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="95.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="77.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,244.7 145.8,230.8 201.7,215.5 257.5,202.8 313.3,188.1 369.2,174.8 425.0,160.5 480.8,145.6 536.7,131.1 592.5,118.2 648.3,103.6 704.2,88.5 760.0,75.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="244.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="230.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="215.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="202.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="188.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="174.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="160.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="145.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="131.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="118.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="103.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="88.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="75.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,220.3 145.8,204.8 201.7,193.0 257.5,181.2 313.3,167.8 369.2,153.4 425.0,140.6 480.8,125.5 536.7,111.7 592.5,97.2 648.3,82.9 704.2,69.8 760.0,53.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="220.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="204.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="193.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="181.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="167.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="153.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="140.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="125.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="111.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="97.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="82.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="69.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="53.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -174,48 +178,48 @@
   <circle cx="648.3" cy="377.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="370.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,388.1 145.8,423.5 201.7,406.0 257.5,417.4 313.3,385.3 369.2,424.6 425.0,425.2 480.8,389.7 536.7,387.9 592.5,423.2 648.3,401.3 704.2,406.5 760.0,423.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="388.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="423.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="406.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="417.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="385.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="424.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="425.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="389.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="387.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="423.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="401.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="406.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="423.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,522.4 145.8,522.4 201.7,522.3 257.5,522.3 313.3,522.4 369.2,522.4 425.0,522.3 480.8,522.5 536.7,522.5 592.5,522.6 648.3,522.4 704.2,522.6 760.0,522.5" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,423.7 145.8,429.9 201.7,426.5 257.5,417.8 313.3,390.1 369.2,426.1 425.0,431.4 480.8,418.4 536.7,424.8 592.5,430.4 648.3,424.5 704.2,409.5 760.0,387.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="423.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="429.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="426.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="417.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="390.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="426.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="431.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="418.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="424.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="430.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="424.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="409.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="387.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,522.3 145.8,522.3 201.7,522.3 257.5,522.5 313.3,522.5 369.2,522.4 425.0,522.3 480.8,522.5 536.7,522.1 592.5,522.5 648.3,522.4 704.2,522.1 760.0,522.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="425.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="480.8" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="522.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="522.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="648.3" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="522.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,404.4 145.8,416.8 201.7,406.1 257.5,405.9 313.3,424.4 369.2,404.7 425.0,423.3 480.8,415.6 536.7,416.9 592.5,404.4 648.3,404.2 704.2,404.6 760.0,417.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="404.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="416.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="406.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="405.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="424.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="404.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="423.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="415.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="416.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="404.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="404.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="404.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="417.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="522.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,408.2 145.8,406.6 201.7,403.0 257.5,406.4 313.3,416.6 369.2,405.0 425.0,405.0 480.8,405.3 536.7,416.0 592.5,405.3 648.3,405.8 704.2,403.8 760.0,423.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="408.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="406.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="403.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="406.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="416.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="405.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="405.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="405.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="416.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="405.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="405.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="403.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="423.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/comparison_ipc.svg
+++ b/doc/charts/comparison_ipc.svg
@@ -1,26 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — IPC, 2-process (higher is better)</text>
-  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="251.2" x2="760.0" y2="251.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="251.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="232.4" x2="760.0" y2="232.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="232.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="213.6" x2="760.0" y2="213.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="213.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="194.8" x2="760.0" y2="194.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="194.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="157.2" x2="760.0" y2="157.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="157.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="138.4" x2="760.0" y2="138.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="138.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="119.6" x2="760.0" y2="119.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="119.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="100.8" x2="760.0" y2="100.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="100.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
-  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
-  <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <line x1="90.0" y1="63.2" x2="760.0" y2="63.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="63.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">22M</text>
+  <line x1="90.0" y1="44.4" x2="760.0" y2="44.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="44.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">24M</text>
   <line x1="90.0" y1="230.8" x2="760.0" y2="230.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="230.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
   <line x1="90.0" y1="191.7" x2="760.0" y2="191.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -50,10 +54,10 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,261.5 145.8,261.5 201.7,261.7 257.5,261.5 313.3,261.5 369.2,262.0 425.0,262.1 480.8,262.3 536.7,262.8 592.5,264.7 648.3,265.7 704.2,267.3 760.0,268.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,165.2 145.8,165.0 201.7,171.0 257.5,203.1 313.3,234.9 369.2,236.8 425.0,242.5 480.8,253.9 536.7,261.0 592.5,264.9 648.3,267.1 704.2,268.4 760.0,268.8" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,184.6 145.8,189.0 201.7,184.6 257.5,205.2 313.3,206.6 369.2,208.2 425.0,213.4 480.8,228.2 536.7,247.7 592.5,257.3 648.3,262.7 704.2,266.1 760.0,268.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,70.0 145.8,79.3 201.7,115.3 257.5,163.4 313.3,194.7 369.2,208.4 425.0,229.7 480.8,239.6 536.7,250.9 592.5,259.0 648.3,264.2 704.2,267.0 760.0,268.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,263.2 145.8,263.2 201.7,263.3 257.5,263.2 313.3,263.2 369.2,263.6 425.0,263.6 480.8,263.9 536.7,264.3 592.5,265.7 648.3,266.6 704.2,267.9 760.0,268.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,186.2 145.8,186.0 201.7,190.8 257.5,216.5 313.3,241.9 369.2,243.4 425.0,248.0 480.8,257.1 536.7,262.8 592.5,265.9 648.3,267.7 704.2,268.7 760.0,269.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,204.5 145.8,204.3 201.7,205.0 257.5,221.7 313.3,214.4 369.2,216.4 425.0,224.2 480.8,237.9 536.7,252.2 592.5,259.6 648.3,263.9 704.2,266.8 760.0,268.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,58.8 145.8,82.8 201.7,103.1 257.5,151.6 313.3,187.6 369.2,207.8 425.0,225.4 480.8,240.3 536.7,248.8 592.5,257.6 648.3,263.3 704.2,266.7 760.0,268.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,269.8 145.8,269.5 201.7,269.1 257.5,268.2 313.3,266.4 369.2,263.2 425.0,256.4 480.8,243.8 536.7,221.2 592.5,197.1 648.3,152.7 704.2,124.5 760.0,102.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="269.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -82,34 +86,34 @@
   <circle cx="648.3" cy="190.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="183.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="137.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.7 145.8,265.7 201.7,260.9 257.5,256.2 313.3,243.0 369.2,217.2 425.0,173.4 480.8,127.4 536.7,117.8 592.5,97.0 648.3,71.2 704.2,57.3 760.0,64.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="265.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="260.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="256.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="243.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="217.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="173.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="127.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.8 145.8,265.6 201.7,261.3 257.5,257.1 313.3,240.4 369.2,212.8 425.0,172.4 480.8,133.1 536.7,117.8 592.5,93.1 648.3,61.3 704.2,52.8 760.0,58.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="265.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="261.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="257.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="240.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="212.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="172.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="133.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="536.7" cy="117.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="97.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="71.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="57.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="64.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,264.7 145.8,259.8 201.7,253.5 257.5,247.3 313.3,237.9 369.2,217.4 425.0,201.1 480.8,166.1 536.7,139.7 592.5,120.4 648.3,112.3 704.2,104.0 760.0,78.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="264.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="259.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="253.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="247.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="237.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="217.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="201.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="166.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="139.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="120.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="112.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="104.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="78.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="93.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="61.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="52.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="58.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,263.0 145.8,257.5 201.7,247.7 257.5,238.4 313.3,226.1 369.2,203.7 425.0,174.8 480.8,143.1 536.7,89.3 592.5,57.6 648.3,42.9 704.2,44.0 760.0,44.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="263.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="257.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="247.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="238.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="226.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="203.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="174.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="143.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="89.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="57.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="42.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="44.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="44.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -164,20 +168,20 @@
   <circle cx="648.3" cy="396.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="392.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="379.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,465.6 145.8,464.4 201.7,459.7 257.5,460.1 313.3,453.4 369.2,458.6 425.0,461.8 480.8,459.2 536.7,463.0 592.5,461.3 648.3,455.3 704.2,449.6 760.0,436.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="465.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="464.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="459.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="460.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="453.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="458.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="461.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="459.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="463.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="461.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="455.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="449.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="436.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,465.3 145.8,462.7 201.7,466.2 257.5,463.2 313.3,465.7 369.2,459.8 425.0,458.9 480.8,466.6 536.7,454.3 592.5,456.3 648.3,452.4 704.2,442.5 760.0,425.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="465.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="462.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="466.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="463.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="465.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="459.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="458.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="466.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="454.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="456.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="452.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="442.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="425.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,480.2 145.8,480.6 201.7,476.2 257.5,484.1 313.3,479.2 369.2,481.7 425.0,483.9 480.8,482.2 536.7,481.1 592.5,480.2 648.3,474.3 704.2,465.1 760.0,433.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="480.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="480.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -192,20 +196,20 @@
   <circle cx="648.3" cy="474.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="465.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="433.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,483.9 145.8,483.6 201.7,484.3 257.5,480.6 313.3,483.7 369.2,483.6 425.0,483.2 480.8,485.3 536.7,480.7 592.5,475.8 648.3,471.8 704.2,467.7 760.0,455.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="483.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="483.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="484.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="480.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="483.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="483.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="483.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="485.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="480.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="475.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="471.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="467.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="455.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,487.0 145.8,482.6 201.7,486.2 257.5,484.5 313.3,484.5 369.2,488.0 425.0,486.5 480.8,484.5 536.7,480.1 592.5,473.3 648.3,474.5 704.2,467.4 760.0,463.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="487.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="482.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="486.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="488.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="486.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="480.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="473.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="474.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="467.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="463.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/comparison_ipc.svg
+++ b/doc/charts/comparison_ipc.svg
@@ -1,22 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — IPC, 2-process (higher is better)</text>
-  <line x1="90.0" y1="240.6" x2="760.0" y2="240.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="240.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="211.2" x2="760.0" y2="211.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="211.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="181.9" x2="760.0" y2="181.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="181.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="123.1" x2="760.0" y2="123.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="123.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="93.8" x2="760.0" y2="93.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="93.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="64.4" x2="760.0" y2="64.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="64.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
   <line x1="90.0" y1="230.8" x2="760.0" y2="230.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="230.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
   <line x1="90.0" y1="191.7" x2="760.0" y2="191.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -46,66 +50,66 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,259.4 145.8,259.7 201.7,259.8 257.5,259.5 313.3,259.6 369.2,259.9 425.0,259.8 480.8,260.3 536.7,261.3 592.5,263.2 648.3,264.7 704.2,266.7 760.0,268.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,137.5 145.8,139.5 201.7,145.8 257.5,186.2 313.3,228.5 369.2,226.7 425.0,236.7 480.8,250.0 536.7,258.4 592.5,263.6 648.3,266.3 704.2,268.0 760.0,268.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,164.8 145.8,169.1 201.7,174.2 257.5,189.9 313.3,190.0 369.2,193.7 425.0,199.1 480.8,218.5 536.7,242.0 592.5,253.9 648.3,260.5 704.2,265.1 760.0,267.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,71.0 145.8,78.4 201.7,98.1 257.5,123.1 313.3,164.7 369.2,181.7 425.0,206.7 480.8,227.1 536.7,239.5 592.5,250.4 648.3,259.4 704.2,264.7 760.0,267.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,269.8 145.8,269.6 201.7,269.1 257.5,268.2 313.3,266.5 369.2,263.1 425.0,256.0 480.8,243.6 536.7,222.2 592.5,195.3 648.3,155.2 704.2,127.8 760.0,109.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,261.5 145.8,261.5 201.7,261.7 257.5,261.5 313.3,261.5 369.2,262.0 425.0,262.1 480.8,262.3 536.7,262.8 592.5,264.7 648.3,265.7 704.2,267.3 760.0,268.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,165.2 145.8,165.0 201.7,171.0 257.5,203.1 313.3,234.9 369.2,236.8 425.0,242.5 480.8,253.9 536.7,261.0 592.5,264.9 648.3,267.1 704.2,268.4 760.0,268.8" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,184.6 145.8,189.0 201.7,184.6 257.5,205.2 313.3,206.6 369.2,208.2 425.0,213.4 480.8,228.2 536.7,247.7 592.5,257.3 648.3,262.7 704.2,266.1 760.0,268.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,70.0 145.8,79.3 201.7,115.3 257.5,163.4 313.3,194.7 369.2,208.4 425.0,229.7 480.8,239.6 536.7,250.9 592.5,259.0 648.3,264.2 704.2,267.0 760.0,268.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,269.8 145.8,269.5 201.7,269.1 257.5,268.2 313.3,266.4 369.2,263.2 425.0,256.4 480.8,243.8 536.7,221.2 592.5,197.1 648.3,152.7 704.2,124.5 760.0,102.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="269.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="269.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="269.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="268.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="266.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="263.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="256.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="243.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="222.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="195.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="155.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="127.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="109.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.2 145.8,264.4 201.7,259.4 257.5,255.7 313.3,255.9 369.2,240.4 425.0,224.6 480.8,215.5 536.7,206.7 592.5,199.6 648.3,189.8 704.2,183.4 760.0,140.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="313.3" cy="266.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="263.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="256.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="243.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="221.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="197.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="152.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="124.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="102.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.2 145.8,264.4 201.7,259.4 257.5,255.7 313.3,255.0 369.2,241.6 425.0,223.1 480.8,214.9 536.7,208.6 592.5,200.7 648.3,190.6 704.2,183.0 760.0,137.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="267.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="264.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="259.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="255.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="255.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="240.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="224.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="215.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="206.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="199.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="189.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="183.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="140.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.8 145.8,265.7 201.7,261.8 257.5,256.3 313.3,242.7 369.2,217.9 425.0,173.2 480.8,129.4 536.7,116.8 592.5,94.3 648.3,61.9 704.2,53.8 760.0,50.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="255.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="241.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="223.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="214.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="208.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="200.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="190.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="183.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="137.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.7 145.8,265.7 201.7,260.9 257.5,256.2 313.3,243.0 369.2,217.2 425.0,173.4 480.8,127.4 536.7,117.8 592.5,97.0 648.3,71.2 704.2,57.3 760.0,64.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="265.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="261.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="256.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="242.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="217.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="173.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="129.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="116.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="94.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="61.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="53.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="50.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,265.8 145.8,261.8 201.7,255.3 257.5,244.9 313.3,234.0 369.2,209.8 425.0,183.6 480.8,152.9 536.7,103.6 592.5,55.7 648.3,38.4 704.2,40.3 760.0,50.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="265.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="261.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="255.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="244.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="234.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="209.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="183.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="152.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="103.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="55.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="38.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="40.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="50.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="260.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="256.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="243.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="217.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="173.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="127.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="117.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="97.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="71.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="57.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="64.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,264.7 145.8,259.8 201.7,253.5 257.5,247.3 313.3,237.9 369.2,217.4 425.0,201.1 480.8,166.1 536.7,139.7 592.5,120.4 648.3,112.3 704.2,104.0 760.0,78.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="264.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="259.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="253.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="247.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="237.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="217.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="201.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="166.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="139.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="120.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="112.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="104.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="78.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -146,62 +150,62 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,427.0 145.8,427.7 201.7,421.0 257.5,424.1 313.3,425.5 369.2,427.6 425.0,426.3 480.8,424.3 536.7,424.9 592.5,411.0 648.3,397.8 704.2,393.7 760.0,389.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="427.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="427.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="421.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="424.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="425.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="427.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="426.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="424.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="424.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="411.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="397.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="393.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="389.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,464.1 145.8,461.0 201.7,467.7 257.5,468.0 313.3,463.9 369.2,466.5 425.0,464.7 480.8,461.7 536.7,462.2 592.5,456.5 648.3,455.7 704.2,450.5 760.0,431.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="464.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="461.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="467.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="468.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="463.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="466.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="464.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="461.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="462.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="456.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="455.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="450.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="431.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,482.6 145.8,487.5 201.7,492.9 257.5,484.0 313.3,483.7 369.2,490.3 425.0,484.3 480.8,484.0 536.7,481.4 592.5,478.9 648.3,462.6 704.2,452.9 760.0,440.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="482.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="487.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="492.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="484.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="483.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="490.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="484.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="484.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="481.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="478.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="462.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="452.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="440.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,484.5 145.8,487.1 201.7,485.4 257.5,484.2 313.3,484.2 369.2,483.5 425.0,483.4 480.8,480.9 536.7,479.2 592.5,473.2 648.3,472.0 704.2,467.8 760.0,457.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="487.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="485.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="484.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="484.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="483.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="483.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="480.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="479.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="473.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="472.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="467.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="457.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,417.1 145.8,411.8 201.7,419.2 257.5,414.6 313.3,418.9 369.2,411.9 425.0,414.0 480.8,403.2 536.7,409.6 592.5,408.6 648.3,396.8 704.2,392.2 760.0,379.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="417.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="411.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="419.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="414.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="418.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="411.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="414.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="403.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="409.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="408.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="396.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="392.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="379.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,465.6 145.8,464.4 201.7,459.7 257.5,460.1 313.3,453.4 369.2,458.6 425.0,461.8 480.8,459.2 536.7,463.0 592.5,461.3 648.3,455.3 704.2,449.6 760.0,436.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="465.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="464.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="459.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="460.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="453.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="458.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="461.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="459.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="463.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="461.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="455.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="449.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="436.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,480.2 145.8,480.6 201.7,476.2 257.5,484.1 313.3,479.2 369.2,481.7 425.0,483.9 480.8,482.2 536.7,481.1 592.5,480.2 648.3,474.3 704.2,465.1 760.0,433.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="480.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="480.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="476.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="484.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="479.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="481.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="483.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="482.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="481.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="480.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="474.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="465.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="433.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,483.9 145.8,483.6 201.7,484.3 257.5,480.6 313.3,483.7 369.2,483.6 425.0,483.2 480.8,485.3 536.7,480.7 592.5,475.8 648.3,471.8 704.2,467.7 760.0,455.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="483.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="483.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="484.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="480.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="483.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="483.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="483.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="485.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="480.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="475.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="471.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="467.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="455.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/comparison_tcp.svg
+++ b/doc/charts/comparison_tcp.svg
@@ -1,26 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — TCP loopback, 2-process (higher is better)</text>
-  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="251.2" x2="760.0" y2="251.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="251.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="232.4" x2="760.0" y2="232.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="232.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="213.6" x2="760.0" y2="213.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="213.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="194.8" x2="760.0" y2="194.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="194.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="157.2" x2="760.0" y2="157.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="157.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="138.4" x2="760.0" y2="138.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="138.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="119.6" x2="760.0" y2="119.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="119.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="100.8" x2="760.0" y2="100.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="100.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
-  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
-  <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <line x1="90.0" y1="63.2" x2="760.0" y2="63.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="63.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">22M</text>
+  <line x1="90.0" y1="44.4" x2="760.0" y2="44.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="44.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">24M</text>
   <line x1="90.0" y1="230.8" x2="760.0" y2="230.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="230.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
   <line x1="90.0" y1="191.7" x2="760.0" y2="191.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -50,10 +54,10 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,265.5 145.8,265.3 201.7,265.7 257.5,266.0 313.3,266.2 369.2,266.2 425.0,266.8 480.8,266.4 536.7,266.8 592.5,267.0 648.3,267.3 704.2,267.8 760.0,268.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,173.4 145.8,168.9 201.7,171.4 257.5,201.6 313.3,236.9 369.2,239.8 425.0,247.9 480.8,256.8 536.7,262.3 592.5,265.9 648.3,267.8 704.2,269.0 760.0,269.1" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,181.1 145.8,183.9 201.7,185.3 257.5,198.9 313.3,197.0 369.2,204.7 425.0,213.5 480.8,226.9 536.7,245.1 592.5,255.6 648.3,262.2 704.2,266.1 760.0,268.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,66.1 145.8,90.7 201.7,99.3 257.5,165.6 313.3,190.0 369.2,214.5 425.0,227.3 480.8,242.2 536.7,252.5 592.5,260.8 648.3,265.0 704.2,267.4 760.0,268.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,266.4 145.8,266.2 201.7,266.5 257.5,266.8 313.3,267.0 369.2,267.0 425.0,267.4 480.8,267.2 536.7,267.4 592.5,267.6 648.3,267.9 704.2,268.3 760.0,268.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,192.7 145.8,189.1 201.7,191.1 257.5,215.3 313.3,243.5 369.2,245.9 425.0,252.3 480.8,259.4 536.7,263.9 592.5,266.7 648.3,268.3 704.2,269.2 760.0,269.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,195.6 145.8,199.5 201.7,201.5 257.5,214.4 313.3,214.0 369.2,218.6 425.0,224.3 480.8,232.5 536.7,249.9 592.5,258.6 648.3,263.9 704.2,267.0 760.0,268.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,49.7 145.8,82.7 201.7,113.5 257.5,152.5 313.3,191.1 369.2,215.8 425.0,229.6 480.8,243.8 536.7,251.4 592.5,258.9 648.3,264.0 704.2,266.9 760.0,268.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.1 313.3,268.4 369.2,266.8 425.0,264.5 480.8,257.9 536.7,248.0 592.5,228.7 648.3,196.8 704.2,151.1 760.0,109.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="269.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -82,34 +86,34 @@
   <circle cx="648.3" cy="211.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="213.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="173.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.6 145.8,265.4 201.7,261.0 257.5,254.8 313.3,238.9 369.2,214.2 425.0,173.5 480.8,122.8 536.7,99.8 592.5,73.7 648.3,57.3 704.2,57.4 760.0,66.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="265.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="261.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="254.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="238.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="214.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="173.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="122.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="99.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="73.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="57.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="57.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="66.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,264.6 145.8,260.4 201.7,251.8 257.5,247.7 313.3,235.9 369.2,222.6 425.0,197.2 480.8,175.0 536.7,150.8 592.5,143.9 648.3,133.4 704.2,130.6 760.0,99.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="264.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="260.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="251.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="247.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="235.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="222.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="197.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="175.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="150.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="143.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="133.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="130.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="99.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.5 145.8,265.3 201.7,260.9 257.5,255.2 313.3,240.2 369.2,215.1 425.0,172.5 480.8,110.0 536.7,98.3 592.5,75.4 648.3,62.0 704.2,64.0 760.0,60.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="265.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="260.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="255.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="240.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="215.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="172.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="110.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="98.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="75.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="62.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="64.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="60.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,262.7 145.8,257.5 201.7,249.1 257.5,238.7 313.3,227.9 369.2,212.2 425.0,183.8 480.8,158.3 536.7,111.7 592.5,80.2 648.3,66.4 704.2,55.2 760.0,26.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="262.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="257.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="249.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="238.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="227.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="212.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="183.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="158.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="111.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="80.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="66.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="55.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="26.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -164,20 +168,20 @@
   <circle cx="648.3" cy="383.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="377.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,452.9 145.8,444.0 201.7,447.8 257.5,443.4 313.3,452.8 369.2,440.0 425.0,442.3 480.8,456.0 536.7,445.5 592.5,444.9 648.3,451.3 704.2,444.4 760.0,413.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="452.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="444.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="447.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="443.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="452.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="440.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="442.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="456.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="445.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="444.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="451.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="444.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="413.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,456.5 145.8,441.5 201.7,444.2 257.5,452.0 313.3,457.5 369.2,453.2 425.0,452.9 480.8,453.8 536.7,440.9 592.5,437.2 648.3,436.3 704.2,443.8 760.0,426.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="456.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="441.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="444.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="452.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="457.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="453.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="452.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="453.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="440.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="437.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="436.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="443.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="426.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,460.6 145.8,460.9 201.7,464.8 257.5,448.5 313.3,460.4 369.2,458.7 425.0,460.8 480.8,455.3 536.7,457.0 592.5,457.1 648.3,447.8 704.2,437.7 760.0,416.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="460.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="460.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -192,20 +196,20 @@
   <circle cx="648.3" cy="447.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="437.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="416.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,466.9 145.8,469.9 201.7,471.8 257.5,471.5 313.3,470.7 369.2,472.0 425.0,469.7 480.8,468.1 536.7,469.5 592.5,464.0 648.3,459.0 704.2,453.0 760.0,446.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="466.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="469.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="471.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="471.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="470.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="472.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="469.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="468.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="469.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="464.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="459.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="453.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="446.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,471.7 145.8,470.7 201.7,471.3 257.5,471.2 313.3,468.4 369.2,470.5 425.0,469.6 480.8,471.9 536.7,468.7 592.5,468.6 648.3,462.1 704.2,457.6 760.0,447.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="471.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="470.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="471.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="471.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="468.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="470.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="469.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="471.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="468.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="468.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="462.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="457.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="447.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/comparison_tcp.svg
+++ b/doc/charts/comparison_tcp.svg
@@ -1,22 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 665" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="665" fill="white"/>
   <text x="425.0" y="18.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput — TCP loopback, 2-process (higher is better)</text>
-  <line x1="90.0" y1="240.6" x2="760.0" y2="240.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="240.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <line x1="90.0" y1="211.2" x2="760.0" y2="211.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="211.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <line x1="90.0" y1="181.9" x2="760.0" y2="181.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="181.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="246.5" x2="760.0" y2="246.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="246.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="223.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <line x1="90.0" y1="199.5" x2="760.0" y2="199.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="199.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <line x1="90.0" y1="123.1" x2="760.0" y2="123.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="123.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <line x1="90.0" y1="93.8" x2="760.0" y2="93.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="93.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
-  <line x1="90.0" y1="64.4" x2="760.0" y2="64.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="64.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82.0" y="152.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <line x1="90.0" y1="105.5" x2="760.0" y2="105.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="105.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="82.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <line x1="90.0" y1="58.5" x2="760.0" y2="58.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82.0" y="58.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
   <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <text x="82.0" y="35.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
   <line x1="90.0" y1="230.8" x2="760.0" y2="230.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="230.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
   <line x1="90.0" y1="191.7" x2="760.0" y2="191.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -46,66 +50,66 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,264.2 145.8,264.0 201.7,264.7 257.5,264.9 313.3,265.2 369.2,265.3 425.0,265.5 480.8,265.6 536.7,265.9 592.5,266.3 648.3,266.8 704.2,267.0 760.0,268.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,152.8 145.8,142.5 201.7,152.4 257.5,185.6 313.3,229.1 369.2,232.5 425.0,242.0 480.8,253.2 536.7,260.5 592.5,265.2 648.3,267.4 704.2,268.7 760.0,269.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,157.6 145.8,164.3 201.7,168.7 257.5,184.8 313.3,187.7 369.2,195.3 425.0,203.1 480.8,214.0 536.7,237.8 592.5,252.0 648.3,260.6 704.2,265.3 760.0,267.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,70.5 145.8,78.7 201.7,111.1 257.5,131.2 313.3,166.7 369.2,198.6 425.0,214.9 480.8,230.0 536.7,244.2 592.5,254.0 648.3,261.2 704.2,265.4 760.0,267.6" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.1 313.3,268.3 369.2,266.8 425.0,263.9 480.8,257.9 536.7,247.9 592.5,230.1 648.3,200.6 704.2,139.3 760.0,115.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,265.5 145.8,265.3 201.7,265.7 257.5,266.0 313.3,266.2 369.2,266.2 425.0,266.8 480.8,266.4 536.7,266.8 592.5,267.0 648.3,267.3 704.2,267.8 760.0,268.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,173.4 145.8,168.9 201.7,171.4 257.5,201.6 313.3,236.9 369.2,239.8 425.0,247.9 480.8,256.8 536.7,262.3 592.5,265.9 648.3,267.8 704.2,269.0 760.0,269.1" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,181.1 145.8,183.9 201.7,185.3 257.5,198.9 313.3,197.0 369.2,204.7 425.0,213.5 480.8,226.9 536.7,245.1 592.5,255.6 648.3,262.2 704.2,266.1 760.0,268.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,66.1 145.8,90.7 201.7,99.3 257.5,165.6 313.3,190.0 369.2,214.5 425.0,227.3 480.8,242.2 536.7,252.5 592.5,260.8 648.3,265.0 704.2,267.4 760.0,268.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.1 313.3,268.4 369.2,266.8 425.0,264.5 480.8,257.9 536.7,248.0 592.5,228.7 648.3,196.8 704.2,151.1 760.0,109.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="269.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="269.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="269.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="268.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="268.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="266.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="263.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="264.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="480.8" cy="257.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="247.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="230.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="200.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="139.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="115.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.5 145.8,264.6 201.7,260.0 257.5,255.6 313.3,256.0 369.2,244.4 425.0,231.8 480.8,224.2 536.7,217.9 592.5,217.5 648.3,213.7 704.2,211.2 760.0,179.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="248.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="228.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="196.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="151.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="109.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.4 145.8,264.6 201.7,259.5 257.5,255.4 313.3,255.9 369.2,244.3 425.0,232.3 480.8,224.9 536.7,217.6 592.5,214.0 648.3,211.0 704.2,213.5 760.0,173.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="264.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="260.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="255.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="256.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="244.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="231.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="224.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="217.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="217.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="213.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="211.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="179.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.6 145.8,265.5 201.7,261.4 257.5,255.5 313.3,241.9 369.2,219.0 425.0,178.7 480.8,117.1 536.7,94.4 592.5,73.6 648.3,65.5 704.2,66.3 760.0,62.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="201.7" cy="259.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="255.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="255.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="244.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="232.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="224.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="217.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="214.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="211.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="213.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="173.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.6 145.8,265.4 201.7,261.0 257.5,254.8 313.3,238.9 369.2,214.2 425.0,173.5 480.8,122.8 536.7,99.8 592.5,73.7 648.3,57.3 704.2,57.4 760.0,66.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="265.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="261.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="255.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="241.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="219.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="178.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="117.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="94.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="73.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="65.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="66.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="62.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,265.7 145.8,261.8 201.7,256.4 257.5,246.3 313.3,234.7 369.2,221.3 425.0,194.8 480.8,160.9 536.7,129.2 592.5,95.2 648.3,78.4 704.2,67.1 760.0,61.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="265.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="261.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="256.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="246.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="234.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="221.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="194.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="160.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="129.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="95.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="78.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="67.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="61.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="265.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="261.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="254.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="238.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="214.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="173.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="122.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="99.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="73.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="57.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="57.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="66.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,264.6 145.8,260.4 201.7,251.8 257.5,247.7 313.3,235.9 369.2,222.6 425.0,197.2 480.8,175.0 536.7,150.8 592.5,143.9 648.3,133.4 704.2,130.6 760.0,99.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="264.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="260.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="251.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="247.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="235.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="222.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="197.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="175.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="150.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="143.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="133.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="130.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="99.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -146,62 +150,62 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,402.0 145.8,398.1 201.7,402.1 257.5,406.5 313.3,405.4 369.2,396.7 425.0,417.0 480.8,405.7 536.7,397.3 592.5,401.8 648.3,380.8 704.2,374.1 760.0,355.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="402.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="398.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="402.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="406.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="405.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="396.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="417.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="405.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="397.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="401.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="380.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="374.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="355.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,445.4 145.8,461.0 201.7,456.5 257.5,449.6 313.3,455.6 369.2,458.2 425.0,455.9 480.8,449.5 536.7,457.3 592.5,444.7 648.3,442.1 704.2,428.7 760.0,433.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="445.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="461.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="456.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="449.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="455.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="458.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="455.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="449.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="457.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="444.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="442.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="428.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="433.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,462.6 145.8,458.1 201.7,460.0 257.5,463.3 313.3,461.8 369.2,459.7 425.0,465.6 480.8,462.0 536.7,458.4 592.5,457.6 648.3,450.1 704.2,440.7 760.0,426.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="462.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="458.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="460.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="463.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="461.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="459.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="465.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="462.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="458.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="457.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="450.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="440.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="426.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,466.2 145.8,466.5 201.7,473.4 257.5,470.7 313.3,468.4 369.2,468.0 425.0,474.0 480.8,469.1 536.7,469.4 592.5,462.1 648.3,466.6 704.2,457.2 760.0,444.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="466.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="466.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="473.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="470.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="468.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="468.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="474.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="469.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="469.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="462.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="466.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="457.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="444.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,402.5 145.8,397.9 201.7,403.8 257.5,400.7 313.3,395.7 369.2,403.9 425.0,401.7 480.8,403.6 536.7,398.4 592.5,401.3 648.3,383.1 704.2,377.2 760.0,363.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="402.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="397.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="403.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="400.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="395.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="403.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="401.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="403.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="398.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="401.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="383.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="377.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,452.9 145.8,444.0 201.7,447.8 257.5,443.4 313.3,452.8 369.2,440.0 425.0,442.3 480.8,456.0 536.7,445.5 592.5,444.9 648.3,451.3 704.2,444.4 760.0,413.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="452.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="444.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="447.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="443.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="452.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="440.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="442.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="456.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="445.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="444.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="451.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="444.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="413.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,460.6 145.8,460.9 201.7,464.8 257.5,448.5 313.3,460.4 369.2,458.7 425.0,460.8 480.8,455.3 536.7,457.0 592.5,457.1 648.3,447.8 704.2,437.7 760.0,416.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="460.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="460.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="464.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="448.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="460.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="458.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="460.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="455.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="457.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="457.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="447.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="437.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="416.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,466.9 145.8,469.9 201.7,471.8 257.5,471.5 313.3,470.7 369.2,472.0 425.0,469.7 480.8,468.1 536.7,469.5 592.5,464.0 648.3,459.0 704.2,453.0 760.0,446.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="466.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="469.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="471.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="471.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="470.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="472.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="469.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="468.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="469.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="464.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="459.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="453.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="446.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/compression_2048.svg
+++ b/doc/charts/compression_2048.svg
@@ -2,36 +2,48 @@
   <rect width="865" height="980" fill="white"/>
   <text x="425.0" y="16" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">Compression transports: structured JSON, PUSH/PULL, 2-thread (omq-compio) — dict 2 KiB</text>
   <text x="425.0" y="45" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">1 Gbps</text>
-  <line x1="90" y1="252.0" x2="760" y2="252.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="252.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10</text>
-  <line x1="90" y1="219.2" x2="760" y2="219.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="219.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100</text>
-  <line x1="90" y1="186.4" x2="760" y2="186.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="186.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
-  <line x1="90" y1="153.5" x2="760" y2="153.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="153.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
-  <line x1="90" y1="120.7" x2="760" y2="120.7" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="120.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
-  <line x1="90" y1="87.8" x2="760" y2="87.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="87.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
+  <line x1="90" y1="275.0" x2="760" y2="275.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="275.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200</text>
+  <line x1="90" y1="257.5" x2="760" y2="257.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="257.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500</text>
+  <line x1="90" y1="244.2" x2="760" y2="244.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="244.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
+  <line x1="90" y1="231.0" x2="760" y2="231.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="231.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2k</text>
+  <line x1="90" y1="213.5" x2="760" y2="213.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="213.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5k</text>
+  <line x1="90" y1="200.2" x2="760" y2="200.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="200.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
+  <line x1="90" y1="187.0" x2="760" y2="187.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="187.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20k</text>
+  <line x1="90" y1="169.5" x2="760" y2="169.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="169.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50k</text>
+  <line x1="90" y1="156.2" x2="760" y2="156.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="156.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
+  <line x1="90" y1="143.0" x2="760" y2="143.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="143.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
+  <line x1="90" y1="125.5" x2="760" y2="125.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="125.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500k</text>
+  <line x1="90" y1="112.2" x2="760" y2="112.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="112.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
+  <line x1="90" y1="99.0" x2="760" y2="99.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="99.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2M</text>
+  <line x1="90" y1="81.5" x2="760" y2="81.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5M</text>
+  <line x1="90" y1="68.2" x2="760" y2="68.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="68.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
   <line x1="90" y1="55.0" x2="760" y2="55.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="55.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
-  <line x1="90" y1="247.5" x2="760" y2="247.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="247.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">100 MB/s</text>
-  <line x1="90" y1="220.0" x2="760" y2="220.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="220.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">200 MB/s</text>
-  <line x1="90" y1="192.5" x2="760" y2="192.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="192.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">300 MB/s</text>
-  <line x1="90" y1="165.0" x2="760" y2="165.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="165.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">400 MB/s</text>
-  <line x1="90" y1="137.5" x2="760" y2="137.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="137.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">500 MB/s</text>
-  <line x1="90" y1="110.0" x2="760" y2="110.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="110.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">600 MB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">700 MB/s</text>
+  <text x="82" y="55.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20M</text>
+  <line x1="90" y1="231.0" x2="760" y2="231.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="231.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">200 MB/s</text>
+  <line x1="90" y1="187.0" x2="760" y2="187.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="187.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">400 MB/s</text>
+  <line x1="90" y1="143.0" x2="760" y2="143.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="143.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">600 MB/s</text>
+  <line x1="90" y1="99.0" x2="760" y2="99.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="99.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">800 MB/s</text>
   <line x1="90" y1="55.0" x2="760" y2="55.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="55.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">800 MB/s</text>
+  <text x="768" y="55.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1000 MB/s</text>
   <line x1="90.0" y1="55" x2="90.0" y2="275" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="134.7" y1="55" x2="134.7" y2="275" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="179.3" y1="55" x2="179.3" y2="275" stroke="#e5e7eb" stroke-width="1"/>
@@ -68,94 +80,111 @@
   <text x="715.3" y="289" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="289" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="165.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,165.0)">msg/s (log)</text>
-  <text x="840" y="165.0" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,840,165.0)">virtual throughput</text>
-  <polyline points="90.0,62.0 134.7,61.9 179.3,68.4 224.0,78.3 268.7,88.2 313.3,98.1 358.0,108.0 402.7,117.8 447.3,127.7 492.0,137.6 536.7,147.5 581.3,157.4 626.0,167.3 670.7,177.2 715.3,187.0 760.0,196.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,69.1 134.7,70.0 179.3,70.2 224.0,79.2 268.7,88.6 313.3,98.3 358.0,102.4 402.7,108.4 447.3,114.2 492.0,121.4 536.7,128.9 581.3,137.2 626.0,146.2 670.7,155.7 715.3,166.4 760.0,177.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,75.0 134.7,75.2 179.3,74.5 224.0,79.2 268.7,95.5 313.3,98.4 358.0,96.1 402.7,97.8 447.3,102.1 492.0,114.2 536.7,124.4 581.3,134.9 626.0,145.0 670.7,156.3 715.3,170.4 760.0,180.7" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,76.9 134.7,77.8 179.3,77.2 224.0,111.4 268.7,112.3 313.3,111.9 358.0,112.1 402.7,112.0 447.3,113.5 492.0,121.4 536.7,134.4 581.3,146.9 626.0,160.0 670.7,170.3 715.3,180.6 760.0,191.3" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,261.5 134.7,247.9 179.3,240.6 224.0,240.6 268.7,240.6 313.3,240.6 358.0,240.6 402.7,240.6 447.3,240.6 492.0,240.6 536.7,240.6 581.3,240.6 626.0,240.6 670.7,240.6 715.3,240.6 760.0,240.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="261.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="247.9" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="240.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,266.8 134.7,259.6 179.3,244.7 224.0,242.6 268.7,241.7 313.3,241.2 358.0,224.1 402.7,208.2 447.3,186.0 492.0,167.8 536.7,148.2 581.3,133.5 626.0,124.7 670.7,120.1 715.3,128.8 760.0,144.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="266.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="259.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="244.7" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="242.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="241.7" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="241.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="224.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="208.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="186.0" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="167.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="148.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="133.5" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="124.7" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="120.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="128.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="144.5" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,269.6 134.7,264.3 179.3,252.5 224.0,242.6 268.7,254.5 313.3,241.5 358.0,196.0 402.7,134.9 447.3,68.1 492.0,97.4 536.7,101.6 581.3,109.0 626.0,111.3 670.7,126.8 715.3,164.9 760.0,167.6" fill="none" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="269.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="264.3" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="252.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="242.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="254.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="241.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="196.0" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="134.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="68.1" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="97.4" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="101.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="109.0" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="111.3" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="126.8" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="164.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="167.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,270.3 134.7,266.1 179.3,256.5 224.0,271.6 268.7,268.7 313.3,262.0 358.0,249.2 402.7,223.4 447.3,182.0 492.0,168.1 536.7,188.9 581.3,203.1 626.0,217.9 670.7,219.4 715.3,220.9 760.0,224.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="270.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="266.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="256.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="271.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="268.7" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="262.0" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="249.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="223.4" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="182.0" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="168.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="188.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="203.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="217.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="219.4" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="220.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="224.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,59.7 134.7,73.0 179.3,86.2 224.0,99.5 268.7,112.7 313.3,125.9 358.0,139.2 402.7,152.4 447.3,165.7 492.0,178.9 536.7,192.2 581.3,205.4 626.0,218.7 670.7,231.9 715.3,245.2 760.0,258.4" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,82.3 134.7,81.6 179.3,88.5 224.0,100.6 268.7,113.3 313.3,126.2 358.0,131.7 402.7,139.7 447.3,147.5 492.0,157.2 536.7,167.2 581.3,178.4 626.0,190.5 670.7,203.1 715.3,216.3 760.0,232.4" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,81.9 134.7,82.0 179.3,88.5 224.0,100.6 268.7,114.5 313.3,111.8 358.0,112.7 402.7,114.3 447.3,126.1 492.0,146.6 536.7,161.2 581.3,175.3 626.0,188.8 670.7,203.2 715.3,221.2 760.0,236.7" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,82.6 134.7,82.9 179.3,88.5 224.0,145.1 268.7,143.8 313.3,144.9 358.0,145.2 402.7,145.0 447.3,146.3 492.0,155.7 536.7,174.0 581.3,192.2 626.0,207.4 670.7,222.6 715.3,237.6 760.0,250.9" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,247.5 134.7,247.5 179.3,247.5 224.0,247.5 268.7,247.5 313.3,247.5 358.0,247.5 402.7,247.5 447.3,247.5 492.0,247.5 536.7,247.5 581.3,247.5 626.0,247.5 670.7,247.5 715.3,247.5 760.0,247.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="247.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,266.6 134.7,257.5 179.3,250.6 224.0,249.1 268.7,248.3 313.3,247.9 358.0,234.3 402.7,221.6 447.3,203.8 492.0,189.3 536.7,173.6 581.3,161.8 626.0,154.8 670.7,151.1 715.3,150.4 760.0,167.7" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="266.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="257.5" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="250.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="249.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="248.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="247.9" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="234.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="221.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="203.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="189.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="173.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="161.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="154.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="151.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="150.4" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="167.7" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,266.4 134.7,257.8 179.3,250.6 224.0,249.1 268.7,249.9 313.3,217.4 358.0,165.2 402.7,72.2 447.3,56.7 492.0,125.7 536.7,136.3 581.3,142.2 626.0,144.1 670.7,151.6 715.3,178.4 760.0,189.6" fill="none" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="266.4" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="257.8" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="250.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="249.1" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="249.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="217.4" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="165.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="72.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="56.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="125.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="136.3" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="142.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="144.1" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="151.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="178.4" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="189.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,266.7 134.7,258.6 179.3,250.6 224.0,272.5 268.7,269.6 313.3,264.8 358.0,254.9 402.7,234.5 447.3,199.3 492.0,182.3 536.7,203.8 581.3,220.2 626.0,225.5 670.7,230.3 715.3,234.2 760.0,234.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="266.7" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="258.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="250.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="272.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="269.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="264.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="254.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="234.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="199.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="182.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="203.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="220.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="225.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="230.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="234.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="234.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="355" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">100 Mbps</text>
-  <line x1="90" y1="562.0" x2="760" y2="562.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="562.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10</text>
-  <line x1="90" y1="529.2" x2="760" y2="529.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="529.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100</text>
-  <line x1="90" y1="496.4" x2="760" y2="496.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="496.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
-  <line x1="90" y1="463.5" x2="760" y2="463.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="463.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
-  <line x1="90" y1="430.7" x2="760" y2="430.7" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="430.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
-  <line x1="90" y1="397.8" x2="760" y2="397.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="397.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
+  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20</text>
+  <line x1="90" y1="567.5" x2="760" y2="567.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="567.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50</text>
+  <line x1="90" y1="554.2" x2="760" y2="554.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="554.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100</text>
+  <line x1="90" y1="541.0" x2="760" y2="541.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="541.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200</text>
+  <line x1="90" y1="523.5" x2="760" y2="523.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="523.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500</text>
+  <line x1="90" y1="510.2" x2="760" y2="510.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="510.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
+  <line x1="90" y1="497.0" x2="760" y2="497.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="497.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2k</text>
+  <line x1="90" y1="479.5" x2="760" y2="479.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="479.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5k</text>
+  <line x1="90" y1="466.2" x2="760" y2="466.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="466.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
+  <line x1="90" y1="453.0" x2="760" y2="453.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="453.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20k</text>
+  <line x1="90" y1="435.5" x2="760" y2="435.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="435.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50k</text>
+  <line x1="90" y1="422.2" x2="760" y2="422.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="422.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
+  <line x1="90" y1="409.0" x2="760" y2="409.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="409.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
+  <line x1="90" y1="391.5" x2="760" y2="391.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="391.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500k</text>
+  <line x1="90" y1="378.2" x2="760" y2="378.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="378.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
   <line x1="90" y1="365.0" x2="760" y2="365.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="365.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
+  <text x="82" y="365.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2M</text>
   <line x1="90" y1="557.5" x2="760" y2="557.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="557.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">50 MB/s</text>
   <line x1="90" y1="530.0" x2="760" y2="530.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -208,11 +237,10 @@
   <text x="715.3" y="599" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="599" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="475.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,475.0)">msg/s (log)</text>
-  <text x="840" y="475.0" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,840,475.0)">virtual throughput</text>
-  <polyline points="90.0,391.5 134.7,401.4 179.3,411.2 224.0,421.1 268.7,431.0 313.3,440.9 358.0,450.8 402.7,460.7 447.3,470.6 492.0,480.5 536.7,490.3 581.3,500.2 626.0,510.1 670.7,520.0 715.3,529.9 760.0,539.8" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,397.3 134.7,404.5 179.3,412.9 224.0,422.0 268.7,431.5 313.3,441.1 358.0,445.2 402.7,451.2 447.3,457.0 492.0,464.2 536.7,471.7 581.3,480.0 626.0,489.1 670.7,498.5 715.3,508.3 760.0,518.2" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,397.3 134.7,404.5 179.3,412.9 224.0,422.0 268.7,412.1 313.3,412.1 358.0,412.5 402.7,413.3 447.3,435.2 492.0,455.3 536.7,467.3 581.3,477.8 626.0,487.9 670.7,497.9 715.3,508.0 760.0,518.0" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,397.3 134.7,404.5 179.3,412.9 224.0,421.4 268.7,422.3 313.3,421.9 358.0,422.1 402.7,422.0 447.3,432.6 492.0,451.5 536.7,464.1 581.3,474.1 626.0,482.3 670.7,492.3 715.3,502.2 760.0,512.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,369.7 134.7,383.0 179.3,396.2 224.0,409.5 268.7,422.7 313.3,435.9 358.0,449.2 402.7,462.4 447.3,475.7 492.0,488.9 536.7,502.2 581.3,515.4 626.0,528.7 670.7,541.9 715.3,555.2 760.0,568.4" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,377.5 134.7,387.2 179.3,398.5 224.0,410.6 268.7,423.3 313.3,436.2 358.0,441.7 402.7,449.7 447.3,457.5 492.0,467.2 536.7,477.2 581.3,488.4 626.0,500.5 670.7,513.1 715.3,526.3 760.0,539.5" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,377.5 134.7,387.2 179.3,398.5 224.0,410.6 268.7,397.4 313.3,397.4 358.0,397.9 402.7,399.0 447.3,428.3 492.0,455.2 536.7,471.2 581.3,485.3 626.0,498.8 670.7,512.3 715.3,525.9 760.0,539.3" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,377.5 134.7,387.2 179.3,398.5 224.0,411.1 268.7,409.8 313.3,410.9 358.0,411.2 402.7,411.0 447.3,424.8 492.0,450.2 536.7,467.0 581.3,480.4 626.0,491.4 670.7,504.8 715.3,518.1 760.0,531.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,578.1 134.7,578.1 179.3,578.1 224.0,578.1 268.7,578.1 313.3,578.1 358.0,578.1 402.7,578.1 447.3,578.1 492.0,578.1 536.7,578.1 581.3,578.1 626.0,578.1 670.7,578.1 715.3,578.1 760.0,578.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="578.1" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="578.1" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -264,15 +292,15 @@
   <circle cx="670.7" cy="552.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="715.3" cy="553.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="553.4" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,580.4 134.7,579.5 179.3,578.9 224.0,578.2 268.7,572.3 313.3,558.9 358.0,533.5 402.7,481.8 447.3,486.5 492.0,532.8 536.7,541.6 581.3,542.0 626.0,536.6 670.7,537.0 715.3,537.2 760.0,537.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,580.4 134.7,579.5 179.3,578.9 224.0,578.7 268.7,571.5 313.3,559.5 358.0,534.8 402.7,483.8 447.3,486.5 492.0,532.8 536.7,541.6 581.3,542.0 626.0,536.6 670.7,537.0 715.3,537.2 760.0,537.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="580.4" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="579.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="179.3" cy="578.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="578.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="572.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="558.9" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="533.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="481.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="578.7" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="571.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="559.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="534.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="483.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="447.3" cy="486.5" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="492.0" cy="532.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="536.7" cy="541.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
@@ -282,20 +310,38 @@
   <circle cx="715.3" cy="537.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="537.4" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="665" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Mbps</text>
-  <line x1="90" y1="872.0" x2="760" y2="872.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="872.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10</text>
-  <line x1="90" y1="839.2" x2="760" y2="839.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="839.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100</text>
-  <line x1="90" y1="806.4" x2="760" y2="806.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="806.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
-  <line x1="90" y1="773.5" x2="760" y2="773.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="773.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
-  <line x1="90" y1="740.7" x2="760" y2="740.7" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="740.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
-  <line x1="90" y1="707.8" x2="760" y2="707.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="707.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
+  <line x1="90" y1="895.0" x2="760" y2="895.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="895.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2</text>
+  <line x1="90" y1="877.5" x2="760" y2="877.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="877.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5</text>
+  <line x1="90" y1="864.2" x2="760" y2="864.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="864.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10</text>
+  <line x1="90" y1="851.0" x2="760" y2="851.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="851.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20</text>
+  <line x1="90" y1="833.5" x2="760" y2="833.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="833.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50</text>
+  <line x1="90" y1="820.2" x2="760" y2="820.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="820.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100</text>
+  <line x1="90" y1="807.0" x2="760" y2="807.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="807.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200</text>
+  <line x1="90" y1="789.5" x2="760" y2="789.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="789.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500</text>
+  <line x1="90" y1="776.2" x2="760" y2="776.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="776.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1k</text>
+  <line x1="90" y1="763.0" x2="760" y2="763.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="763.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2k</text>
+  <line x1="90" y1="745.5" x2="760" y2="745.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="745.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5k</text>
+  <line x1="90" y1="732.2" x2="760" y2="732.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="732.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10k</text>
+  <line x1="90" y1="719.0" x2="760" y2="719.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="719.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">20k</text>
+  <line x1="90" y1="701.5" x2="760" y2="701.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="701.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50k</text>
+  <line x1="90" y1="688.2" x2="760" y2="688.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="688.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
   <line x1="90" y1="675.0" x2="760" y2="675.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="675.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
+  <text x="82" y="675.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
   <line x1="90" y1="858.3" x2="760" y2="858.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="858.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">10 MB/s</text>
   <line x1="90" y1="821.7" x2="760" y2="821.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -344,11 +390,10 @@
   <text x="715.3" y="909" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="909" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="785.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,785.0)">msg/s (log)</text>
-  <text x="840" y="785.0" text-anchor="middle" dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600" transform="rotate(90,840,785.0)">virtual throughput</text>
-  <polyline points="90.0,734.3 134.7,744.2 179.3,754.1 224.0,764.0 268.7,773.9 313.3,783.7 358.0,793.6 402.7,803.5 447.3,813.4 492.0,823.3 536.7,833.2 581.3,843.1 626.0,852.9 670.7,862.8 715.3,872.7 760.0,882.6" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,740.1 134.7,747.4 179.3,755.8 224.0,764.8 268.7,774.3 313.3,784.0 358.0,788.0 402.7,794.0 447.3,799.8 492.0,807.1 536.7,814.6 581.3,822.9 626.0,831.9 670.7,841.4 715.3,851.2 760.0,861.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,740.1 134.7,747.4 179.3,755.8 224.0,764.8 268.7,755.0 313.3,755.0 358.0,755.4 402.7,756.2 447.3,778.1 492.0,798.1 536.7,810.1 581.3,820.6 626.0,830.7 670.7,840.8 715.3,850.9 760.0,860.9" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,740.1 134.7,747.4 179.3,755.8 224.0,750.6 268.7,751.1 313.3,751.7 358.0,751.7 402.7,751.7 447.3,775.4 492.0,794.4 536.7,806.9 581.3,816.9 626.0,825.1 670.7,835.1 715.3,845.1 760.0,855.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,679.7 134.7,693.0 179.3,706.2 224.0,719.5 268.7,732.7 313.3,745.9 358.0,759.2 402.7,772.4 447.3,785.7 492.0,798.9 536.7,812.2 581.3,825.4 626.0,838.7 670.7,851.9 715.3,865.2 760.0,878.4" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,687.5 134.7,697.2 179.3,708.5 224.0,720.6 268.7,733.3 313.3,746.2 358.0,751.7 402.7,759.7 447.3,767.5 492.0,777.2 536.7,787.2 581.3,798.4 626.0,810.5 670.7,823.1 715.3,836.3 760.0,849.5" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,687.5 134.7,697.2 179.3,708.5 224.0,720.6 268.7,707.4 313.3,707.4 358.0,707.9 402.7,709.0 447.3,738.3 492.0,765.2 536.7,781.2 581.3,795.3 626.0,808.8 670.7,822.3 715.3,835.9 760.0,849.3" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,687.5 134.7,697.2 179.3,708.5 224.0,701.5 268.7,702.2 313.3,703.0 358.0,703.0 402.7,703.0 447.3,734.8 492.0,760.2 536.7,777.0 581.3,790.4 626.0,801.4 670.7,814.8 715.3,828.1 760.0,841.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,890.4 134.7,890.4 179.3,890.4 224.0,890.4 268.7,890.4 313.3,890.4 358.0,890.4 402.7,890.4 447.3,890.4 492.0,890.4 536.7,890.4 581.3,890.4 626.0,890.4 670.7,890.4 715.3,890.4 760.0,890.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="890.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="890.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -835,6 +835,82 @@ it detects EOF natively, writes heartbeat PINGs directly, and
 applies backpressure through `write_all`. Cost: recv goes through
 the driver (~3 µs per message on the latency path).
 
+### ChunkedInputBuf front-cache
+
+`ChunkedInputBuf` is the codec's inbound byte buffer. It held received
+data as a `VecDeque<Bytes>`. Every `peek_array` call (two per frame:
+flags byte then header) went through `VecDeque::front()` which does
+ring buffer indexing (`to_physical_idx` + `wrap_add`). At 14M msg/s
+that was 28M ring-index operations per second, showing as 12% self-time
+in `peek_frame_header`.
+
+Pulled the front chunk out of the `VecDeque` into a dedicated `front:
+Bytes` field on `ChunkedInputBuf`. Reads go through `self.front`
+(direct field access) instead of `self.chunks.front()`. When the front
+is consumed, `advance_front()` pops the next chunk from the remaining
+`VecDeque`.
+
+Result: `peek_frame_header` dropped from 12.3% to 10.1%.
+Small but real. The remaining cost is bounds-checked slice indexing
+on `self.front[self.front_offset..]`, which is inherent.
+
+### Specialized try_recv for PULL/PAIR
+
+Profiling showed `try_recv` at 29% self-time and `drain_recv_cache`
+at 7%. For a PULL socket, every call evaluated five `matches!` checks
+(all constant), wrapped/unwrapped two `Result`s that could never be
+`Err`, and called two functions whose PULL branches were trivial.
+The `Result::branch` from the `?` operator alone was 12.6%.
+
+Added a `simple_recv: bool` flag on `SocketInner`, set at construction
+for PULL and PAIR. When true, `try_recv` takes an inline fast path:
+direct `cache.pop_front()`, then lock + `swap_messages` + pop. No
+function calls, no `Result` wrapping, no `matches!` dispatch. The
+generic path for SUB/REQ/REP/etc. is unchanged.
+
+Result: `try_recv` self-time dropped from 29% to 15%.
+`drain_recv_cache` disappeared from the top. Combined with the push-side
+fix below, 8 B TCP throughput went from ~14M to ~17M msg/s.
+
+### Message::from_slice
+
+The bench was constructing messages via `Bytes::from(vec![b'x'; 8])`
+then cloning the `Bytes` each iteration. For 8 bytes, `Bytes` still
+heap-allocates (no inline representation). Clone and drop each touch
+a refcount. This cost 12.8% of push-side CPU.
+
+Added `Message::from_slice(&[u8])` which copies directly into the
+inline `MessageInner::Inline` variant for payloads up to 39 bytes.
+No heap allocation, no refcounting. Falls back to
+`Bytes::copy_from_slice` for larger payloads.
+
+A real user sending small messages from a `&[u8]` buffer gets the
+same benefit. This is the realistic fast path, not a benchmark trick.
+
+### Dead end: Vec for Connection::messages (replacing VecDeque)
+
+Profiling 8 B TCP PULL at ~14M msg/s showed 10% self-time attributed
+to `VecDeque::push_back` / `clear` inside `drive_zmtp`. The theory:
+`VecDeque`'s ring buffer indexing (`wrap_index`: add + branch per
+`push_back` and `pop_front`) is overhead that a flat `Vec` avoids.
+
+Replaced `messages: VecDeque<Message>` with `Vec<Message>` plus a
+`messages_drain: usize` index. `push` is a pointer bump. `poll_message`
+reads via `ptr::read` at the drain index (no replacement write).
+`swap_messages` exchanges the `Vec` with the recv cache and resets the
+drain index. Same O(1) swap semantics.
+
+Also replaced the compio `RecvCache` (`VecDeque<Message>`) with the
+same `Vec` + drain index pattern.
+
+Result: neutral. 13.8-14.5M msg/s, same range as before. The perf
+attribution was misleading: `mod.rs:1917` pointed at `VecDeque::clear`
+(which is never called on the hot path), not `push_back`. The actual
+`push_back` cost is already low because `VecDeque` at steady state
+never reallocates, and `wrap_index` is a single well-predicted branch.
+The `Vec` traded ring buffer indexing for `ptr::read` + `set_len`
+bookkeeping with no net gain. Reverted.
+
 ## What remains
 
 **Single-wire-peer bypass on tokio (send-side encode).** The compio

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -887,6 +887,34 @@ No heap allocation, no refcounting. Falls back to
 A real user sending small messages from a `&[u8]` buffer gets the
 same benefit. This is the realistic fast path, not a benchmark trick.
 
+### Cell-based send path (replacing atomics and Mutex)
+
+After the recv-side optimizations, the push side became the bottleneck.
+Profiling showed 13.8% on `encoded_queue: Mutex<EncodedQueue>` lock
+and unlock (two atomic CAS operations per message), plus 5.9% on
+`direct_msg_count: AtomicUsize` and `driver_in_select: AtomicBool`.
+All accesses are on a single compio runtime thread. The atomics are
+correct but unnecessary: each costs 5-20 ns vs <1 ns for a plain
+memory write.
+
+Replaced five fields on `DirectIoState` with non-atomic equivalents:
+
+- `encoded_queue: Mutex<EncodedQueue>` -> `EncodedQueueCell` (a
+  `Cell<bool>` borrow flag + `UnsafeCell<EncodedQueue>`, with a RAII
+  guard that clears the flag on drop). `try_borrow_mut()` is a plain
+  bool check instead of an atomic CAS.
+- `direct_msg_count: AtomicUsize` -> `Cell<usize>`
+- `driver_in_select: AtomicBool` -> `Cell<bool>`
+- `handshake_done: AtomicBool` -> `Cell<bool>`
+- `socket_closing: AtomicBool` -> `Cell<bool>`
+
+The safety invariant is the same one that already covers `RecvCache`,
+`LocalStream`, and the `UnsafeCell` fields on `SocketInner`: compio
+is single-threaded, `DirectIoState` never crosses thread boundaries,
+and the existing `unsafe impl Sync` on the `Arc` covers `Cell` fields.
+
+Result: 8 B TCP throughput went from 17M to 22M msg/s.
+
 ### Dead end: Vec for Connection::messages (replacing VecDeque)
 
 Profiling 8 B TCP PULL at ~14M msg/s showed 10% self-time attributed

--- a/omq-compio/benches/compression.rs
+++ b/omq-compio/benches/compression.rs
@@ -372,6 +372,7 @@ mod inner {
 
                     let pushes = Rc::new(pushes);
 
+                    let inline = payload.len() <= omq_proto::message::MAX_INLINE_MESSAGE;
                     let burst = |k: usize| {
                         let pushes = pushes.clone();
                         let payload = payload.clone();
@@ -384,8 +385,15 @@ mod inner {
                                 let p = pushes.clone();
                                 let payload = payload.clone();
                                 handles.push(compio::runtime::spawn(async move {
-                                    for _ in 0..per {
-                                        p[i].send(Message::single(payload.clone())).await.unwrap();
+                                    if inline {
+                                        for _ in 0..per {
+                                            p[i].send(Message::from_slice(&payload)).await.unwrap();
+                                        }
+                                    } else {
+                                        let msg = Message::single(payload);
+                                        for _ in 0..per {
+                                            p[i].send(msg.clone()).await.unwrap();
+                                        }
                                     }
                                 }));
                             }

--- a/omq-compio/src/bin/bench_peer_compio.rs
+++ b/omq-compio/src/bin/bench_peer_compio.rs
@@ -144,9 +144,9 @@ fn main() {
 async fn run_push(ep: Endpoint, size: usize) {
     let push = Socket::new(SocketType::Push, bench_options(size));
     push.bind(ep).await.expect("push bind");
-    let payload = Bytes::from(vec![b'x'; size]);
+    let payload = vec![b'x'; size];
     loop {
-        push.send(Message::single(payload.clone())).await.unwrap();
+        push.send(Message::from_slice(&payload)).await.unwrap();
     }
 }
 

--- a/omq-compio/src/bin/bench_peer_compio.rs
+++ b/omq-compio/src/bin/bench_peer_compio.rs
@@ -145,8 +145,15 @@ async fn run_push(ep: Endpoint, size: usize) {
     let push = Socket::new(SocketType::Push, bench_options(size));
     push.bind(ep).await.expect("push bind");
     let payload = vec![b'x'; size];
-    loop {
-        push.send(Message::from_slice(&payload)).await.unwrap();
+    if size <= omq_proto::message::MAX_INLINE_MESSAGE {
+        loop {
+            push.send(Message::from_slice(&payload)).await.unwrap();
+        }
+    } else {
+        let msg = Message::single(payload);
+        loop {
+            push.send(msg.clone()).await.unwrap();
+        }
     }
 }
 

--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -1,6 +1,7 @@
+use std::cell::Cell;
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering},
+    atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering},
 };
 use std::time::Instant;
 
@@ -26,7 +27,7 @@ pub(crate) struct DirectIoState {
     pub(crate) eof_signal: Event,
     pub(crate) last_input_nanos: AtomicU64,
     pub(crate) hb_epoch: Instant,
-    pub(crate) handshake_done: AtomicBool,
+    pub(crate) handshake_done: Cell<bool>,
     #[cfg_attr(feature = "priority", allow(dead_code))]
     pub(crate) has_transform: bool,
     #[cfg_attr(feature = "priority", allow(dead_code))]
@@ -34,10 +35,10 @@ pub(crate) struct DirectIoState {
     #[cfg_attr(feature = "priority", allow(dead_code))]
     pub(crate) transform_passthrough: Option<(Bytes, usize)>,
     pub(crate) encoder: async_lock::Mutex<Option<MessageEncoder>>,
-    pub(crate) encoded_queue: Mutex<EncodedQueue>,
-    pub(crate) driver_in_select: AtomicBool,
-    pub(crate) direct_msg_count: AtomicUsize,
-    pub(crate) socket_closing: AtomicBool,
+    pub(crate) encoded_queue: EncodedQueueCell,
+    pub(crate) driver_in_select: Cell<bool>,
+    pub(crate) direct_msg_count: Cell<usize>,
+    pub(crate) socket_closing: Cell<bool>,
     pub(crate) large_recv_pending: AtomicUsize,
     pub(crate) pending_acc: Mutex<Option<BytesMut>>,
     pub(crate) large_message_threshold: usize,
@@ -260,15 +261,15 @@ impl DirectIoState {
             eof_signal: Event::new(),
             last_input_nanos: AtomicU64::new(0),
             hb_epoch: Instant::now(),
-            handshake_done: AtomicBool::new(false),
+            handshake_done: Cell::new(false),
             has_transform,
             uses_crypto,
             transform_passthrough,
             encoder: async_lock::Mutex::new(encoder),
-            encoded_queue: Mutex::new(EncodedQueue::new()),
-            driver_in_select: AtomicBool::new(false),
-            direct_msg_count: AtomicUsize::new(0),
-            socket_closing: AtomicBool::new(false),
+            encoded_queue: EncodedQueueCell::new(),
+            driver_in_select: Cell::new(false),
+            direct_msg_count: Cell::new(0),
+            socket_closing: Cell::new(false),
             large_recv_pending: AtomicUsize::new(0),
             pending_acc: Mutex::new(None),
             large_message_threshold,
@@ -278,5 +279,76 @@ impl DirectIoState {
             #[cfg(feature = "ws")]
             ws_masked,
         })
+    }
+}
+
+/// Non-atomic interior-mutable wrapper for `EncodedQueue`.
+///
+/// Sound only on a single thread (compio's cooperative runtime).
+/// Replaces `Mutex<EncodedQueue>` to avoid atomic CAS on every
+/// lock/unlock in the send hot path.
+pub(crate) struct EncodedQueueCell {
+    borrowed: Cell<bool>,
+    inner: std::cell::UnsafeCell<EncodedQueue>,
+}
+
+impl EncodedQueueCell {
+    fn new() -> Self {
+        Self {
+            borrowed: Cell::new(false),
+            inner: std::cell::UnsafeCell::new(EncodedQueue::new()),
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn try_borrow_mut(&self) -> Option<EncodedQueueGuard<'_>> {
+        if self.borrowed.get() {
+            return None;
+        }
+        self.borrowed.set(true);
+        Some(EncodedQueueGuard { cell: self })
+    }
+
+    #[inline]
+    pub(crate) fn borrow_mut(&self) -> EncodedQueueGuard<'_> {
+        debug_assert!(!self.borrowed.get(), "EncodedQueueCell: already borrowed");
+        self.borrowed.set(true);
+        EncodedQueueGuard { cell: self }
+    }
+}
+
+pub(crate) struct EncodedQueueGuard<'a> {
+    cell: &'a EncodedQueueCell,
+}
+
+impl std::ops::Deref for EncodedQueueGuard<'_> {
+    type Target = EncodedQueue;
+    #[inline]
+    fn deref(&self) -> &EncodedQueue {
+        unsafe { &*self.cell.inner.get() }
+    }
+}
+
+impl std::ops::DerefMut for EncodedQueueGuard<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut EncodedQueue {
+        unsafe { &mut *self.cell.inner.get() }
+    }
+}
+
+impl Drop for EncodedQueueGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.cell.borrowed.set(false);
+    }
+}
+
+#[expect(clippy::missing_fields_in_debug)]
+impl std::fmt::Debug for EncodedQueueCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncodedQueueCell")
+            .field("borrowed", &self.borrowed.get())
+            .finish()
     }
 }

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -352,7 +352,7 @@ impl Socket {
                 if let Some(dio_handle) = &p.direct_io
                     && let Some(dio) = dio_handle.read().expect("dio lock").as_ref()
                 {
-                    dio.socket_closing.store(true, Ordering::Release);
+                    dio.socket_closing.set(true);
                     dio.transmit_ready.notify(usize::MAX);
                 }
             }

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -178,6 +178,7 @@ pub(super) struct InprocRecvState {
 
 pub(super) struct SocketInner {
     pub(super) socket_type: SocketType,
+    pub(super) simple_recv: bool,
     pub(super) options: Options,
     /// Stable identity for inproc peer tagging. Equal to `options.identity`
     /// when one is set; otherwise a 9-byte auto-generated value (leading 0x00
@@ -387,6 +388,7 @@ impl SocketInner {
         #[expect(clippy::arc_with_non_send_sync)] // compio is single-threaded by design
         Arc::new(Self {
             socket_type,
+            simple_recv: matches!(socket_type, SocketType::Pull | SocketType::Pair),
             inproc_identity,
             options,
             out_peers: RwLock::new(Slab::new()),

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -292,16 +292,47 @@ impl Socket {
     }
 
     /// Receive the next message, blocking until one is available or the socket is closed.
+    #[expect(clippy::too_many_lines)]
     pub async fn recv(&self) -> Result<Message> {
         use futures::FutureExt;
-        let st = self.inner().socket_type;
-        if direct_recv_eligible(st) {
+        let inner = self.inner();
+        let st = inner.socket_type;
+        if inner.simple_recv {
+            let cache = inner.recv_cache.get();
+            if let Some(msg) = cache.pop_front() {
+                return Ok(msg);
+            }
+            let dio = unsafe { &*inner.direct_recv_io.get() };
+            if let Some(ref state) = *dio
+                && let Ok(mut io) = state.peer_io.try_lock()
+            {
+                while let Some(ev) = io.codec.poll_event() {
+                    if let Event::HandshakeSucceeded { .. } = ev {
+                        io.handshake_done = true;
+                    }
+                }
+                if !cache.is_empty() {
+                    return Ok(cache.pop_front().expect("non-empty"));
+                }
+                if io.decoder.is_some() {
+                    self.drain_decoder_into(&mut io, cache)?;
+                } else {
+                    io.codec.swap_messages(cache);
+                }
+                if let Some(msg) = cache.pop_front() {
+                    return Ok(msg);
+                }
+            }
+            if let Some(msg) = self.try_direct_recv().await? {
+                return Ok(msg);
+            }
+        } else if direct_recv_eligible(st) {
             if let Some(msg) = self.drain_recv_cache(st)? {
                 return Ok(msg);
             }
             if !post_recv_needs_type_state(st) && !self.needs_subscription_filter() {
-                let cache = self.inner().recv_cache.get();
-                let dio = unsafe { &*self.inner().direct_recv_io.get() };
+                let cache = inner.recv_cache.get();
+                let dio = unsafe { &*inner.direct_recv_io.get() };
                 if let Some(ref state) = *dio
                     && let Ok(mut io) = state.peer_io.try_lock()
                     && let Ok(Some(msg)) = self.drain_and_swap(&mut io, cache)
@@ -439,24 +470,52 @@ impl Socket {
     /// Non-blocking receive; returns `Err(WouldBlock)` if no message is queued.
     #[inline]
     pub fn try_recv(&self) -> Result<Message> {
-        let st = self.inner().socket_type;
-        if direct_recv_eligible(st) {
-            if let Some(msg) = self.drain_recv_cache(st)? {
+        let inner = self.inner();
+        if inner.simple_recv {
+            let cache = inner.recv_cache.get();
+            if let Some(msg) = cache.pop_front() {
                 return Ok(msg);
             }
-            if !post_recv_needs_type_state(st) && !self.needs_subscription_filter() {
-                let dio = unsafe { &*self.inner().direct_recv_io.get() };
-                if let Some(ref state) = *dio {
-                    let cache = self.inner().recv_cache.get();
-                    let mut io = state.lock_io();
-                    if let Ok(Some(msg)) = self.drain_and_swap(&mut io, cache) {
-                        return Ok(msg);
+            let dio = unsafe { &*inner.direct_recv_io.get() };
+            if let Some(ref state) = *dio {
+                let mut io = state.lock_io();
+                while let Some(ev) = io.codec.poll_event() {
+                    if let Event::HandshakeSucceeded { .. } = ev {
+                        io.handshake_done = true;
+                    }
+                }
+                if !cache.is_empty() {
+                    return Ok(cache.pop_front().expect("non-empty"));
+                }
+                if io.decoder.is_some() {
+                    self.drain_decoder_into(&mut io, cache)?;
+                } else {
+                    io.codec.swap_messages(cache);
+                }
+                if let Some(msg) = cache.pop_front() {
+                    return Ok(msg);
+                }
+            }
+        } else {
+            let st = inner.socket_type;
+            if direct_recv_eligible(st) {
+                if let Some(msg) = self.drain_recv_cache(st)? {
+                    return Ok(msg);
+                }
+                if !post_recv_needs_type_state(st) && !self.needs_subscription_filter() {
+                    let dio = unsafe { &*inner.direct_recv_io.get() };
+                    if let Some(ref state) = *dio {
+                        let cache = inner.recv_cache.get();
+                        let mut io = state.lock_io();
+                        if let Ok(Some(msg)) = self.drain_and_swap(&mut io, cache) {
+                            return Ok(msg);
+                        }
                     }
                 }
             }
         }
-        let recv_state = unsafe { &mut *self.inner().inproc_recv.get() };
-        let max = self.inner().options.max_message_size;
+        let recv_state = unsafe { &mut *inner.inproc_recv.get() };
+        let max = inner.options.max_message_size;
         for c in &mut recv_state.consumers {
             if let Some(msg) = c.prefetch_and_pop() {
                 if max.is_some_and(|m| msg.byte_len() > m) {
@@ -466,7 +525,7 @@ impl Socket {
             }
         }
         loop {
-            let frame = self.inner().in_rx.try_recv().map_err(|e| match e {
+            let frame = inner.in_rx.try_recv().map_err(|e| match e {
                 blume::TryRecvError::Empty => Error::WouldBlock,
                 blume::TryRecvError::Disconnected => Error::Closed,
             })?;
@@ -523,6 +582,27 @@ impl Socket {
             io.codec.swap_messages(cache);
         }
         Ok(cache.pop_front())
+    }
+
+    #[inline(never)]
+    #[expect(clippy::unused_self)]
+    fn drain_decoder_into(
+        &self,
+        io: &mut PeerIo,
+        cache: &mut std::collections::VecDeque<Message>,
+    ) -> Result<()> {
+        while let Some(m) = io.codec.poll_message() {
+            let m = if let Some(dec) = io.decoder.as_mut() {
+                match dec.decode(m)? {
+                    Some(plain) => plain,
+                    None => continue,
+                }
+            } else {
+                m
+            };
+            cache.push_back(m);
+        }
+        Ok(())
     }
 
     fn post_recv_apply(&self, msg: Message) -> Result<Option<Message>> {

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -762,12 +762,8 @@ impl Socket {
         io.codec.advance_transmit(total);
         drop(io);
         if !chunks.is_empty() {
-            state
-                .encoded_queue
-                .lock()
-                .expect("encoded_queue")
-                .push_raw(chunks);
-            if state.driver_in_select.load(Ordering::Relaxed) {
+            state.encoded_queue.borrow_mut().push_raw(chunks);
+            if state.driver_in_select.get() {
                 state.transmit_ready.notify(1);
             }
         }

--- a/omq-compio/src/socket/send.rs
+++ b/omq-compio/src/socket/send.rs
@@ -60,15 +60,13 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
     }
 
     if !state.has_transform {
-        if !state.handshake_done.load(Ordering::Relaxed) {
+        if !state.handshake_done.get() {
             return Ok(false);
         }
-        let Ok(mut eq) = state.encoded_queue.try_lock() else {
+        let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
             return Ok(false);
         };
-        if eq.total_bytes() >= DIRECT_CAP
-            || state.direct_msg_count.load(Ordering::Relaxed) >= DIRECT_MSG_CAP
-        {
+        if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
             return Ok(false);
         }
         let msg_total = msg.byte_len();
@@ -76,8 +74,8 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
         if state.is_ws {
             eq.encode_and_push_flat_ws(msg, state.ws_masked);
             drop(eq);
-            state.direct_msg_count.fetch_add(1, Ordering::Relaxed);
-            if state.driver_in_select.load(Ordering::Relaxed) {
+            state.direct_msg_count.set(state.direct_msg_count.get() + 1);
+            if state.driver_in_select.get() {
                 state.transmit_ready.notify(1);
             }
             return Ok(true);
@@ -88,29 +86,21 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
             eq.encode_and_push(msg);
         }
         drop(eq);
-        state.direct_msg_count.fetch_add(1, Ordering::Relaxed);
-        if state.driver_in_select.load(Ordering::Relaxed) {
+        state.direct_msg_count.set(state.direct_msg_count.get() + 1);
+        if state.driver_in_select.get() {
             state.transmit_ready.notify(1);
         }
         return Ok(true);
     }
 
-    // Passthrough-transform fast path: lz4+tcp / zstd+tcp with message
-    // parts below the compression threshold.  All parts will be encoded
-    // as `SENTINEL_PLAIN | payload` regardless — no actual compression.
-    // We bypass the codec async-mutex and encode directly into
-    // `encoded_queue` just like the no-transform path, but prepend the
-    // 4-byte plaintext sentinel to each part payload.
     if let Some((ref sentinel, threshold)) = state.transform_passthrough
-        && state.handshake_done.load(Ordering::Relaxed)
+        && state.handshake_done.get()
         && msg.iter().all(|b| b.len() < threshold)
     {
-        let Ok(mut eq) = state.encoded_queue.try_lock() else {
+        let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
             return Ok(false);
         };
-        if eq.total_bytes() >= DIRECT_CAP
-            || state.direct_msg_count.load(Ordering::Relaxed) >= DIRECT_MSG_CAP
-        {
+        if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
             return Ok(false);
         }
         let prefix_len = sentinel.len();
@@ -121,20 +111,17 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
             eq.encode_and_push_prefixed(sentinel, msg);
         }
         drop(eq);
-        state.direct_msg_count.fetch_add(1, Ordering::Relaxed);
-        if state.driver_in_select.load(Ordering::Relaxed) {
+        state.direct_msg_count.set(state.direct_msg_count.get() + 1);
+        if state.driver_in_select.get() {
             state.transmit_ready.notify(1);
         }
         return Ok(true);
     }
 
-    // Transform active with large or dict-aware messages: encode via the
-    // encoder mutex (separate from peer_io) then push into encoded_queue.
-    // This avoids contending with the read loop on peer_io.
     let Some(mut enc_guard) = state.encoder.try_lock() else {
         return Ok(false);
     };
-    if !state.handshake_done.load(Ordering::Relaxed) {
+    if !state.handshake_done.get() {
         return Ok(false);
     }
     let enc = enc_guard
@@ -143,12 +130,10 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
     let wires = enc.encode(msg)?;
     drop(enc_guard);
 
-    let Ok(mut eq) = state.encoded_queue.try_lock() else {
+    let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
         return Ok(false);
     };
-    if eq.total_bytes() >= DIRECT_CAP
-        || state.direct_msg_count.load(Ordering::Relaxed) >= DIRECT_MSG_CAP
-    {
+    if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
         return Ok(false);
     }
     for wire in &wires {
@@ -159,8 +144,8 @@ fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> 
         }
     }
     drop(eq);
-    state.direct_msg_count.fetch_add(1, Ordering::Relaxed);
-    if state.driver_in_select.load(Ordering::Relaxed) {
+    state.direct_msg_count.set(state.direct_msg_count.get() + 1);
+    if state.driver_in_select.get() {
         state.transmit_ready.notify(1);
     }
     Ok(true)

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -603,7 +603,7 @@ pub(crate) async fn run_connection(
                     return Ok(());
                 }
                 ls.stream_rounds += 1;
-                if ls.stream_rounds >= 64 {
+                if ls.stream_rounds >= 256 {
                     ls.stream_rounds = 0;
                     if let Ok(cmd) = inbox.try_recv() {
                         ls.drain_inbox(cmd, &inbox, &state, cap)

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -203,7 +203,7 @@ impl DriverLoopState {
                 .expect("has_transform but no encoder")
                 .encode(m)?;
             drop(enc);
-            let mut eq = state.encoded_queue.lock().expect("encoded_queue");
+            let mut eq = state.encoded_queue.borrow_mut();
             let cr = eq.total_bytes() >= cap;
             for wire in &wires {
                 if wire.byte_len() < crate::socket::FLAT_THRESHOLD {
@@ -221,7 +221,7 @@ impl DriverLoopState {
             self.codec_maybe_dirty = true;
             Ok(cr)
         } else {
-            let mut eq = state.encoded_queue.lock().expect("encoded_queue");
+            let mut eq = state.encoded_queue.borrow_mut();
             let cr = eq.total_bytes() >= cap;
             #[cfg(feature = "ws")]
             if state.is_ws {
@@ -251,7 +251,7 @@ impl DriverLoopState {
                             .expect("has_transform but no encoder")
                             .encode(&m)?;
                         drop(enc);
-                        let mut eq = state.encoded_queue.lock().expect("encoded_queue");
+                        let mut eq = state.encoded_queue.borrow_mut();
                         for wire in &wires {
                             if wire.byte_len() < crate::socket::FLAT_THRESHOLD {
                                 eq.encode_and_push_flat(wire);
@@ -262,7 +262,7 @@ impl DriverLoopState {
                     } else if state.uses_crypto {
                         io.codec.send_message(&m)?;
                     } else {
-                        let mut eq = state.encoded_queue.lock().expect("encoded_queue");
+                        let mut eq = state.encoded_queue.borrow_mut();
                         #[cfg(feature = "ws")]
                         if state.is_ws {
                             eq.encode_and_push_flat_ws(&m, state.ws_masked);
@@ -293,7 +293,7 @@ impl DriverLoopState {
         hb_interval: Option<Duration>,
     ) -> Result<()> {
         io.handshake_done = true;
-        state.handshake_done.store(true, Ordering::Relaxed);
+        state.handshake_done.set(true);
         self.deadline = None;
         if let Some(iv) = hb_interval {
             self.hb_next = Some(Instant::now() + iv);
@@ -315,7 +315,7 @@ impl DriverLoopState {
     ) -> Result<()> {
         let mut next = Some(first);
         while let Some(cmd) = next.take() {
-            let cap_reached = if state.handshake_done.load(Ordering::Relaxed) {
+            let cap_reached = if state.handshake_done.get() {
                 match cmd {
                     DriverCommand::SendMessage(m) => {
                         self.encode_outbound_message(state, &m, cap).await?
@@ -355,7 +355,7 @@ impl DriverLoopState {
     ) -> Result<()> {
         let mut next = Some(first);
         while let Some(m) = next.take() {
-            let cap_reached = if state.handshake_done.load(Ordering::Relaxed) {
+            let cap_reached = if state.handshake_done.get() {
                 self.encode_outbound_message(state, &m, cap).await?
             } else {
                 self.pending_cmds.push_back(DriverCommand::SendMessage(m));
@@ -379,7 +379,7 @@ impl DriverLoopState {
     ) -> Result<()> {
         let mut next = Some(first);
         while let Some(m) = next.take() {
-            let cap_reached = if state.handshake_done.load(Ordering::Relaxed) {
+            let cap_reached = if state.handshake_done.get() {
                 self.encode_outbound_message(state, &m, cap).await?
             } else {
                 self.pending_cmds.push_back(DriverCommand::SendMessage(m));
@@ -442,9 +442,9 @@ pub(crate) async fn run_connection(
         // The flag is set again just before we park in select_biased!
         // so the fast-path sender can tell whether a transmit_ready
         // notification is worth issuing.
-        state.driver_in_select.store(false, Ordering::Relaxed);
+        state.driver_in_select.set(false);
 
-        if !ls.closing && state.socket_closing.load(Ordering::Acquire) {
+        if !ls.closing && state.socket_closing.get() {
             ls.closing = true;
             // Drain inbox in one shot so stale SendMessage commands
             // don't block the close condition via one-at-a-time
@@ -458,7 +458,7 @@ pub(crate) async fn run_connection(
 
         if ls.closing {
             let io = state.lock_io();
-            let eq = state.encoded_queue.lock().expect("encoded_queue");
+            let eq = state.encoded_queue.borrow_mut();
             if io.handshake_done
                 && ls.pending_cmds.is_empty()
                 && !io.codec.has_pending_transmit()
@@ -491,7 +491,7 @@ pub(crate) async fn run_connection(
         }
 
         // 3a) Flush codec buffer.
-        if !state.handshake_done.load(Ordering::Relaxed) || ls.codec_maybe_dirty {
+        if !state.handshake_done.get() || ls.codec_maybe_dirty {
             let flushed = ls.flush_codec_to_wire(&state).await?;
             if flushed {
                 continue;
@@ -541,13 +541,8 @@ pub(crate) async fn run_connection(
         // the store and the actual yield inside select_biased!. After setting
         // the flag, check encoded_queue one last time to close the race where
         // the sender encoded but saw driver_in_select=false and skipped notify.
-        state.driver_in_select.store(true, Ordering::Relaxed);
-        if !state
-            .encoded_queue
-            .lock()
-            .expect("encoded_queue")
-            .is_empty()
-        {
+        state.driver_in_select.set(true);
+        if !state.encoded_queue.borrow_mut().is_empty() {
             continue;
         }
 
@@ -642,7 +637,7 @@ impl DriverLoopState {
         monitor_ctx: Option<&MonitorCtx>,
         hb_interval: Option<Duration>,
     ) -> Result<SmallVec<[Drained; 8]>> {
-        let post_handshake = state.handshake_done.load(Ordering::Relaxed);
+        let post_handshake = state.handshake_done.get();
         let recv_claimed = state.recv_claim.load(Ordering::Acquire) == 1;
         if post_handshake && (!self.codec_has_input || recv_claimed) {
             return Ok(SmallVec::new());
@@ -808,16 +803,14 @@ impl DriverLoopState {
         if written == 0 {
             state
                 .encoded_queue
-                .lock()
-                .expect("encoded_queue")
+                .borrow_mut()
                 .put_back_unwritten(returned, 0);
             return Ok(false);
         }
         if written < total {
             state
                 .encoded_queue
-                .lock()
-                .expect("encoded_queue")
+                .borrow_mut()
                 .put_back_unwritten(returned, written);
         }
         Ok(true)
@@ -826,7 +819,7 @@ impl DriverLoopState {
     async fn flush_encoded_queue(&mut self, state: &DirectIoState) -> Result<bool> {
         self.drain_buf.clear();
         {
-            let mut eq = state.encoded_queue.lock().expect("encoded_queue");
+            let mut eq = state.encoded_queue.borrow_mut();
             eq.drain_into_vec(&mut self.drain_buf, 1024);
         }
         if self.drain_buf.is_empty() {
@@ -838,8 +831,7 @@ impl DriverLoopState {
         if written == 0 {
             state
                 .encoded_queue
-                .lock()
-                .expect("encoded_queue")
+                .borrow_mut()
                 .put_back_unwritten(returned, 0);
             return Ok(false);
         }
@@ -847,19 +839,13 @@ impl DriverLoopState {
         if written < total_drained {
             state
                 .encoded_queue
-                .lock()
-                .expect("encoded_queue")
+                .borrow_mut()
                 .put_back_unwritten(returned, written);
         } else {
             self.drain_buf = returned;
         }
-        if state
-            .encoded_queue
-            .lock()
-            .expect("encoded_queue")
-            .is_empty()
-        {
-            state.direct_msg_count.store(0, Ordering::Relaxed);
+        if state.encoded_queue.borrow_mut().is_empty() {
+            state.direct_msg_count.set(0);
         }
         Ok(true)
     }

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -302,6 +302,16 @@ impl Message {
         }
     }
 
+    /// Create a single-part message from a byte slice. Avoids heap
+    /// allocation for payloads up to 39 bytes.
+    #[inline]
+    pub fn from_slice(data: &[u8]) -> Self {
+        if data.len() <= MAX_INLINE_MESSAGE {
+            return Self::from_inline(data);
+        }
+        Self::single(Bytes::copy_from_slice(data))
+    }
+
     /// Create a multi-part message from an iterator of byte-like values.
     pub fn multipart<I, P>(parts: I) -> Self
     where

--- a/omq-proto/src/proto/chunked_buf.rs
+++ b/omq-proto/src/proto/chunked_buf.rs
@@ -12,7 +12,10 @@ use crate::message::{MAX_INLINE_PAYLOAD, Payload};
 /// so no memcpy occurs on read paths either.
 #[derive(Debug, Default)]
 pub(crate) struct ChunkedInputBuf {
-    chunks: VecDeque<Bytes>,
+    /// Current front chunk, accessed directly without `VecDeque` indirection.
+    front: Bytes,
+    /// Remaining chunks after `front`.
+    rest: VecDeque<Bytes>,
     total_len: usize,
     front_offset: usize,
 }
@@ -28,7 +31,12 @@ impl ChunkedInputBuf {
             return;
         }
         self.total_len += chunk.len();
-        self.chunks.push_back(chunk);
+        if self.front_offset >= self.front.len() {
+            self.front = chunk;
+            self.front_offset = 0;
+        } else {
+            self.rest.push_back(chunk);
+        }
     }
 
     #[inline]
@@ -49,17 +57,22 @@ impl ChunkedInputBuf {
             return None;
         }
         let mut out = [0u8; N];
-        let front = self.chunks.front()?;
-        let front_remaining = &front[self.front_offset..];
+        let front_remaining = &self.front[self.front_offset..];
         if front_remaining.len() >= N {
             out.copy_from_slice(&front_remaining[..N]);
             return Some(out);
         }
-        // Slow path: data spans multiple chunks.
+        // Slow path: data spans front + rest chunks.
         let mut pos = 0;
-        for (i, chunk) in self.chunks.iter().enumerate() {
-            let start = if i == 0 { self.front_offset } else { 0 };
-            for &b in &chunk[start..] {
+        for &b in front_remaining {
+            out[pos] = b;
+            pos += 1;
+            if pos == N {
+                return Some(out);
+            }
+        }
+        for chunk in &self.rest {
+            for &b in chunk.as_ref() {
                 out[pos] = b;
                 pos += 1;
                 if pos == N {
@@ -80,9 +93,20 @@ impl ChunkedInputBuf {
         let mut out = [0u8; N];
         let mut pos = 0;
         let mut skipped = 0;
-        for (i, chunk) in self.chunks.iter().enumerate() {
-            let start = if i == 0 { self.front_offset } else { 0 };
-            let slice = &chunk[start..];
+        let front_remaining = &self.front[self.front_offset..];
+        if skipped + front_remaining.len() > offset {
+            let begin = offset - skipped;
+            for &b in &front_remaining[begin..] {
+                out[pos] = b;
+                pos += 1;
+                if pos == N {
+                    return Some(out);
+                }
+            }
+        }
+        skipped += front_remaining.len();
+        for chunk in &self.rest {
+            let slice = chunk.as_ref();
             if skipped + slice.len() <= offset {
                 skipped += slice.len();
                 continue;
@@ -100,6 +124,16 @@ impl ChunkedInputBuf {
         Some(out)
     }
 
+    #[inline]
+    fn advance_front(&mut self) {
+        if let Some(next) = self.rest.pop_front() {
+            self.front = next;
+        } else {
+            self.front = Bytes::new();
+        }
+        self.front_offset = 0;
+    }
+
     /// Consume the first `n` bytes without returning them.
     /// Panics in debug mode if `n > self.len()`.
     #[inline]
@@ -107,12 +141,10 @@ impl ChunkedInputBuf {
         debug_assert!(n <= self.total_len, "advance past end");
         self.total_len -= n;
         while n > 0 {
-            let front = self.chunks.front().expect("total_len accounting");
-            let avail = front.len() - self.front_offset;
+            let avail = self.front.len() - self.front_offset;
             if n >= avail {
                 n -= avail;
-                self.chunks.pop_front();
-                self.front_offset = 0;
+                self.advance_front();
             } else {
                 self.front_offset += n;
                 break;
@@ -131,34 +163,28 @@ impl ChunkedInputBuf {
             return;
         }
         self.total_len -= n;
-        let front = self.chunks.front().expect("total_len accounting");
-        let avail = front.len() - self.front_offset;
+        let avail = self.front.len() - self.front_offset;
         if n <= avail {
-            let src = &front[self.front_offset..self.front_offset + n];
+            let src = &self.front[self.front_offset..self.front_offset + n];
             // SAFETY: `&[u8]` and `&[MaybeUninit<u8>]` have identical
             // layout (guaranteed by MaybeUninit's repr(transparent)).
-            // The cast reinterprets initialized bytes as MaybeUninit so
-            // copy_from_slice can write into the uninit destination.
             let src_mu: &[std::mem::MaybeUninit<u8>] = unsafe {
                 &*(std::ptr::from_ref::<[u8]>(src) as *const [std::mem::MaybeUninit<u8>])
             };
             dest[..n].copy_from_slice(src_mu);
             self.front_offset += n;
-            if self.front_offset >= front.len() {
-                self.chunks.pop_front();
-                self.front_offset = 0;
+            if self.front_offset >= self.front.len() {
+                self.advance_front();
             }
             return;
         }
         let mut remaining = n;
         let mut pos = 0;
         while remaining > 0 {
-            let front = self.chunks.front().expect("total_len accounting");
             let start = self.front_offset;
-            let avail = front.len() - start;
+            let avail = self.front.len() - start;
             let take = remaining.min(avail);
-            let src = &front[start..start + take];
-            // SAFETY: same cast as above — initialized &[u8] to &[MaybeUninit<u8>].
+            let src = &self.front[start..start + take];
             let src_mu: &[std::mem::MaybeUninit<u8>] = unsafe {
                 &*(std::ptr::from_ref::<[u8]>(src) as *const [std::mem::MaybeUninit<u8>])
             };
@@ -166,8 +192,7 @@ impl ChunkedInputBuf {
             pos += take;
             remaining -= take;
             if take >= avail {
-                self.chunks.pop_front();
-                self.front_offset = 0;
+                self.advance_front();
             } else {
                 self.front_offset += take;
             }
@@ -187,41 +212,37 @@ impl ChunkedInputBuf {
         self.total_len -= n;
 
         // Fast path: entirely within the front chunk past front_offset.
-        let front = self.chunks.front().expect("total_len accounting");
-        let avail = front.len() - self.front_offset;
+        let avail = self.front.len() - self.front_offset;
         if n <= avail {
             let start = self.front_offset;
             let payload = if n <= MAX_INLINE_PAYLOAD {
-                Payload::inline(&front[start..start + n])
+                Payload::inline(&self.front[start..start + n])
             } else {
-                Payload::from_bytes(front.slice(start..start + n))
+                Payload::from_bytes(self.front.slice(start..start + n))
             };
             self.front_offset += n;
-            if self.front_offset >= front.len() {
-                self.chunks.pop_front();
-                self.front_offset = 0;
+            if self.front_offset >= self.front.len() {
+                self.advance_front();
             }
             return payload;
         }
 
-        // Slow path: spans multiple chunks — coalesce into one contiguous buffer.
+        // Slow path: spans front + rest chunks. Coalesce into one contiguous buffer.
         let mut remaining = n;
         let mut buf = BytesMut::with_capacity(n);
 
-        let first = self.chunks.pop_front().expect("total_len accounting");
-        let tail = &first[self.front_offset..];
-        remaining -= tail.len();
-        buf.extend_from_slice(tail);
-        self.front_offset = 0;
+        buf.extend_from_slice(&self.front[self.front_offset..]);
+        remaining -= avail;
+        self.advance_front();
 
         while remaining > 0 {
-            let front = self.chunks.front().expect("total_len accounting");
-            if remaining >= front.len() {
-                let chunk = self.chunks.pop_front().expect("total_len accounting");
-                remaining -= chunk.len();
-                buf.extend_from_slice(&chunk);
+            let chunk_len = self.front.len();
+            if remaining >= chunk_len {
+                buf.extend_from_slice(&self.front);
+                remaining -= chunk_len;
+                self.advance_front();
             } else {
-                buf.extend_from_slice(&front[..remaining]);
+                buf.extend_from_slice(&self.front[..remaining]);
                 self.front_offset = remaining;
                 remaining = 0;
             }

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -183,12 +183,18 @@ def draw_throughput_panel(
     L.append(svg_text(mid_x, y_top - 17, title, size=13, weight="700", fill="#111827"))
 
     # msg/s gridlines (left axis)
-    step_msg = nice_step(msg_max, 8)
+    step_msg = nice_step(msg_max, 10)
     v = step_msg
     while v <= msg_max:
         yy = y_msg(v)
         L.append(svg_line(x_left, yy, x_right, yy))
-        label = f"{v / 1e6:.0f}M" if v >= 1e6 else f"{v / 1e3:.0f}k"
+        millions = v / 1e6
+        if millions >= 1 and millions == int(millions):
+            label = f"{int(millions)}M"
+        elif v >= 1e6:
+            label = f"{millions:.1f}M"
+        else:
+            label = f"{v / 1e3:.0f}k"
         L.append(svg_text(x_left - 8, yy, label, anchor="end", baseline="middle"))
         v += step_msg
 
@@ -429,7 +435,7 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
 
 
 def main():
-    FIXED_MSG_MAX = 16e6
+    FIXED_MSG_MAX = 20e6
     FIXED_GBS_MAX = 6.0
     FIXED_LAT_MAX = 100.0
     FIXED_INPROC_LAT_MAX = 25.0

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -183,7 +183,7 @@ def draw_throughput_panel(
     L.append(svg_text(mid_x, y_top - 17, title, size=13, weight="700", fill="#111827"))
 
     # msg/s gridlines (left axis)
-    step_msg = nice_step(msg_max, 10)
+    step_msg = nice_step(msg_max, 12)
     v = step_msg
     while v <= msg_max:
         yy = y_msg(v)
@@ -435,7 +435,7 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
 
 
 def main():
-    FIXED_MSG_MAX = 20e6
+    FIXED_MSG_MAX = 25e6
     FIXED_GBS_MAX = 6.0
     FIXED_LAT_MAX = 100.0
     FIXED_INPROC_LAT_MAX = 25.0

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -106,9 +106,12 @@ def _log_ticks(data_min, data_max):
     axis_min = math.log10(lo)
     axis_max = math.log10(hi)
 
-    first_dec = math.ceil(axis_min)
-    last_dec = math.floor(axis_max)
-    ticks = [10 ** e for e in range(first_dec, last_dec + 1)]
+    ticks = []
+    for e in range(math.floor(axis_min), math.ceil(axis_max) + 1):
+        for s in [1, 2, 5]:
+            v = s * 10 ** e
+            if lo <= v <= hi:
+                ticks.append(v)
 
     return axis_min, axis_max, ticks
 
@@ -340,11 +343,6 @@ def generate_svg(
             f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
             f' transform="rotate(-90,40,{mid_y:.1f})">msg/s (log)</text>'
         )
-        L.append(
-            f'  <text x="840" y="{mid_y:.1f}" text-anchor="middle"'
-            f' dominant-baseline="middle" fill="#6b7280" font-size="10" font-weight="600"'
-            f' transform="rotate(90,840,{mid_y:.1f})">virtual throughput</text>'
-        )
 
         # Plot lines
         present = [k for k in SERIES_ORDER if k in series]
@@ -454,13 +452,12 @@ def main():
     for label, link_bytes_s in LINK_SPEEDS:
         panels[label] = project(raw, link_bytes_s)
 
-    tput_caps = {}
-    if args.tput_1g is not None:
-        tput_caps["1g"] = args.tput_1g
-    if args.tput_100m is not None:
-        tput_caps["100m"] = args.tput_100m
-    if args.tput_10m is not None:
-        tput_caps["10m"] = args.tput_10m
+    default_caps = {"1g": 1000, "100m": 400, "10m": 60}
+    tput_caps = {
+        "1g": args.tput_1g if args.tput_1g is not None else default_caps["1g"],
+        "100m": args.tput_100m if args.tput_100m is not None else default_caps["100m"],
+        "10m": args.tput_10m if args.tput_10m is not None else default_caps["10m"],
+    }
 
     msgs_ranges = {}
     for key, attr in [("1g", "msgs_1g"), ("100m", "msgs_100m"), ("10m", "msgs_10m")]:
@@ -475,7 +472,7 @@ def main():
     else:
         dict_size_label = f"{ds} B"
 
-    svg = generate_svg(panels, tput_caps or None, msgs_ranges or None, dict_size_label)
+    svg = generate_svg(panels, tput_caps, msgs_ranges or None, dict_size_label)
     output = repo / "doc" / "charts" / f"compression_{ds}.svg"
     output.write_text(svg)
     print(f"Written: {output}", file=sys.stderr)


### PR DESCRIPTION
- Optimize 8 B TCP recv from 14M to 17M msg/s: inline read_into_uninit fast path in chunked_buf, direct-recv codec event drain, reduce recv-path branching.
- Replace send-path AtomicUsize/AtomicBool with Cell on DirectIoState (compio is single-threaded), 17M to 22M msg/s.
- Use Message::from_slice for inline sizes (<=39 B) in bench_peer and compression bench to avoid per-message heap allocation.
- Fix compression chart gen: default Y-axis caps (1 GB/s, 400 MB/s, 60 MB/s), 1-2-5 log ticks for msg/s axis, remove redundant right-axis labels.
- Fix bindings chart gen: remove right-axis label, add dashed/solid legend footer.
- Refresh all charts (comparison, compression, bindings).