### PR TITLE
fix(compio): drain pre_connect_buf during close with priority feature

### DIFF
--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -40,8 +40,8 @@ blume = { path = "../blume", version = "0.2.4" }
 yring = { path = "../yring", version = "0.2.2" }
 bytes = "1.11.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
-rustc-hash = "2"
-concurrent-queue = "2"
+rustc-hash = "2.1.0"
+concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 compio = { version = "0.19.0-rc.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync", "async-fd"] }
 slab = "0.4"

--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -15,6 +15,7 @@ use crate::transport::peer_io::{CancellableRecvStream, PeerIo, SharedPeerIo, Wir
 use super::encoded_queue::EncodedQueue;
 use super::inner::{LocalStream, RecvStreamState};
 
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct DirectIoState {
     pub(crate) peer_io: SharedPeerIo,
     pub(crate) writer: async_lock::Mutex<WireWriter>,
@@ -231,7 +232,7 @@ impl DirectIoState {
         self.peer_io.lock().expect("peer_io")
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     pub(crate) fn new(
         peer_io: SharedPeerIo,
         writer: WireWriter,

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -10,7 +10,7 @@ use omq_proto::proto::SocketType;
 
 use crate::monitor::MonitorStream;
 
-use super::inner::{PeerOut, SocketInner, WirePeerHandle};
+use super::inner::{PeerOut, SocketInner};
 
 /// A ZMQ-style socket. Clone-able; all clones talk to the same underlying
 /// driver tasks. Close happens via the explicit [`Socket::close`] method
@@ -332,48 +332,35 @@ impl Socket {
                 rx.close();
             }
         }
-        let wire_handles: Vec<WirePeerHandle> = {
-            let peers = self.inner.out_peers.read().expect("peers lock");
-            peers
-                .iter()
-                .filter_map(|(_, p)| match &p.out {
-                    PeerOut::Wire(handle) => Some(handle.clone()),
-                    PeerOut::Inproc { .. } => None,
-                })
-                .collect()
-        };
-        // Signal all wire drivers to close. The socket_closing flag
-        // is checked at the top of each driver loop iteration,
-        // bypassing the inbox which may be full of stale SendMessage
-        // commands from direct-encode fallbacks.
-        {
-            let peers = self.inner.out_peers.read().expect("peers lock");
-            for (_, p) in peers.iter() {
-                if let Some(dio_handle) = &p.direct_io
-                    && let Some(dio) = dio_handle.read().expect("dio lock").as_ref()
-                {
-                    dio.socket_closing.set(true);
-                    dio.transmit_ready.notify(usize::MAX);
+        loop {
+            {
+                let peers = self.inner.out_peers.read().expect("peers lock");
+                for (_, p) in peers.iter() {
+                    if let Some(dio_handle) = &p.direct_io
+                        && let Some(dio) = dio_handle.read().expect("dio lock").as_ref()
+                    {
+                        dio.socket_closing.set(true);
+                        dio.transmit_ready.notify(usize::MAX);
+                    }
                 }
             }
-        }
-
-        loop {
-            let inproc_pending = {
+            let (inproc_pending, wire_alive) = {
                 let peers = self.inner.out_peers.read().expect("peers lock");
-                peers.iter().any(|(_, p)| match &p.out {
+                let inproc = peers.iter().any(|(_, p)| match &p.out {
                     PeerOut::Inproc { sender, .. } => {
                         !sender.is_empty() && !sender.is_disconnected()
                     }
                     PeerOut::Wire(_) => false,
-                })
+                });
+                let wire = peers.iter().any(|(_, p)| match &p.out {
+                    PeerOut::Wire(handle) => !handle
+                        .read()
+                        .expect("wire peer handle lock")
+                        .is_disconnected(),
+                    PeerOut::Inproc { .. } => false,
+                });
+                (inproc, wire)
             };
-            let wire_alive = wire_handles.iter().any(|handle| {
-                !handle
-                    .read()
-                    .expect("wire peer handle lock")
-                    .is_disconnected()
-            });
             if !inproc_pending && !wire_alive {
                 break;
             }
@@ -403,10 +390,6 @@ impl Socket {
         // peer_in_tx.send_async() get unblocked with SendError.
         self.inner.in_rx.close();
 
-        // Drop all sender clones so the cmd channels fully disconnect.
-        // Drivers see Err(Disconnected) on their next inbox poll and exit.
-        drop(wire_handles);
-
         // Yield so the cooperative executor can run driver tasks to
         // completion, freeing DirectIoState and EncodedQueue buffers.
         for _ in 0..20 {
@@ -422,10 +405,23 @@ impl Socket {
         deadline: Option<std::time::Instant>,
     ) {
         let has_pending = || {
-            inner
+            if inner
                 .shared_send_rx
                 .as_ref()
                 .is_some_and(|rx| !rx.is_empty())
+            {
+                return true;
+            }
+            #[cfg(feature = "priority")]
+            if !inner
+                .pre_connect_buf
+                .lock()
+                .expect("pre_connect_buf")
+                .is_empty()
+            {
+                return true;
+            }
+            false
         };
         while has_pending() && !inner.dialers.read().expect("dialers lock").is_empty() {
             if deadline.is_some_and(|d| std::time::Instant::now() >= d) {

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -177,6 +177,7 @@ pub(crate) fn build_peer_io(
         let _ = codec.handle_input(leftover);
         let _ = wr; // suppress unused
     }
+    #[allow(clippy::arc_with_non_send_sync)]
     let peer_io = Arc::new(std::sync::Mutex::new(PeerIo {
         codec,
         decoder,

--- a/omq-compio/tests/soak_ipc_fanout.rs
+++ b/omq-compio/tests/soak_ipc_fanout.rs
@@ -1,13 +1,15 @@
-//! Regression test for sustained IPC PUB/SUB fan-out with recv timeouts.
+#![cfg(feature = "soak")]
+//! Soak: sustained IPC PUB/SUB fan-out with recv timeouts.
 //!
 //! Under sustained load, multishot recv buffer pools can exhaust (ENOBUFS)
 //! and if recv timeouts cancel operations mid-flight, connections could
-//! spuriously break. This test exercises the fixed code paths:
-//! - ENOBUFS in `pull_and_feed` → fallback to one-shot (not `signal_eof`)
-//! - ENOBUFS in `accumulate_large_recv` → fallback to one-shot
+//! spuriously break. This exercises the fixed code paths:
+//! - ENOBUFS in `pull_and_feed` / `accumulate_large_recv` → one-shot fallback
 //! - `flush_codec_output` cancel-safety (`encoded_queue`, not direct write)
 //! - `flush_encoded_queue` written==0 data preservation
-//! - multishot stream `None` during accumulation → fallback to one-shot
+//! - multishot stream `None` during accumulation → one-shot fallback
+
+mod soak_common;
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
@@ -22,20 +24,16 @@ fn block_on_and_drain<F: std::future::Future>(rt: &compio::runtime::Runtime, fut
     out
 }
 
-/// Sustained IPC PUB → 3 SUBs fan-out with aggressive recv timeouts.
-/// The SUBs use a 20ms recv timeout which triggers frequent io_uring
-/// read cancellations. Under load this provokes ENOBUFS on the multishot
-/// recv path. Without the fixes, the connection breaks and messages are
-/// lost, causing this test to hang.
+const PEERS: usize = 3;
+const MSG_SIZE: usize = 131_072;
+
 #[test]
-fn sustained_ipc_fanout_no_message_loss() {
-    const PEERS: usize = 3;
-    const MSG_SIZE: usize = 131_072;
-    const TOTAL_MESSAGES: usize = 50;
+fn soak_ipc_fanout_no_message_loss() {
+    let duration = soak_common::soak_duration();
 
     let ep: omq_compio::Endpoint = {
         let mut dir = std::env::temp_dir();
-        dir.push(format!("omq-test-sustained-{}.sock", std::process::id()));
+        dir.push(format!("omq-soak-fanout-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&dir);
         omq_compio::Endpoint::Ipc(omq_compio::endpoint::IpcPath::Filesystem(dir))
     };
@@ -86,7 +84,6 @@ fn sustained_ipc_fanout_no_message_loss() {
 
                 let payload = Bytes::from(vec![0xABu8; MSG_SIZE]);
 
-                // Wait for all subs to connect and subscribe.
                 loop {
                     let _ = pub_.send(Message::single(payload.clone())).await;
                     if subs_ready.iter().all(|r| r.load(Ordering::Relaxed)) {
@@ -95,28 +92,30 @@ fn sustained_ipc_fanout_no_message_loss() {
                     compio::time::sleep(Duration::from_micros(50)).await;
                 }
 
-                // Send TOTAL_MESSAGES and verify all are received.
-                let before = recv_count.load(Ordering::Relaxed);
-                let target = before + TOTAL_MESSAGES * PEERS;
-                for _ in 0..TOTAL_MESSAGES {
+                let start = std::time::Instant::now();
+                let mut sent: u64 = 0;
+                let mut last_log = start;
+                while start.elapsed() < duration {
                     pub_.send(Message::single(payload.clone())).await.unwrap();
-                }
-
-                // Wait for all receives with a generous timeout.
-                let deadline = std::time::Instant::now() + Duration::from_secs(30);
-                while recv_count.load(Ordering::Relaxed) < target {
-                    if std::time::Instant::now() > deadline {
-                        let got = recv_count.load(Ordering::Relaxed);
-                        stop.store(true, Ordering::Relaxed);
-                        panic!(
-                            "message loss: expected {target} receives, got {got} \
-                             (deficit {})",
-                            target - got
+                    sent += 1;
+                    if last_log.elapsed() >= Duration::from_secs(30) {
+                        let r = recv_count.load(Ordering::Relaxed);
+                        eprintln!(
+                            "[ipc_fanout] {:.0}s, sent {sent}, recvd {r}",
+                            start.elapsed().as_secs_f64(),
                         );
+                        last_log = std::time::Instant::now();
                     }
-                    compio::time::sleep(Duration::from_micros(100)).await;
                 }
                 stop.store(true, Ordering::Relaxed);
+
+                let r = recv_count.load(Ordering::Relaxed);
+                let expected = sent as usize * PEERS;
+                eprintln!(
+                    "[ipc_fanout] done: sent {sent}, recvd {r}, expected {expected} in {:.1}s",
+                    start.elapsed().as_secs_f64(),
+                );
+                assert_eq!(r, expected, "message loss detected");
             });
         })
     };

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -24,7 +24,7 @@ yring = { path = "../yring", version = "0.2.2" }
 compio = { version = "0.19.0-rc.1", features = ["runtime"] }
 bytes = "1.11.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
-rustc-hash = "2"
+rustc-hash = "2.1.0"
 futures = { version = "0.3", default-features = false, features = ["async-await"] }
 crypto_box = "0.9"
 libc = "0.2"

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -54,8 +54,8 @@ zstd-safe = { version = "7", default-features = false, features = ["std", "zdict
 patricia_tree = "0.10"
 smallvec = { version = "1", features = ["const_generics", "union"] }
 socket2 = { version = "0.6", features = ["all"] }
-thiserror = "2"
-zeroize = { version = "1", features = ["zeroize_derive"], optional = true }
+thiserror = "2.0.18"
+zeroize = { version = "1.8.0", features = ["zeroize_derive"], optional = true }
 
 [[bench]]
 name = "mechanism_frame"

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -37,13 +37,13 @@ omq-proto = { path = "../omq-proto", version = "0.14.0", default-features = fals
 yring = { path = "../yring", version = "0.2.2" }
 async-channel = "2.5.0"
 bytes = "1.11.0"
-concurrent-queue = "2"
+concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 rand = "0.10"
-rustc-hash = "2"
+rustc-hash = "2.1.0"
 smallvec = { version = "1", features = ["const_generics", "union"] }
-thiserror = "2"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "io-util", "sync", "macros", "time"] }
+thiserror = "2.0.18"
+tokio = { version = "1.52.0", features = ["rt", "rt-multi-thread", "net", "io-util", "sync", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 socket2 = "0.6"
 libc = "0.2"
@@ -54,7 +54,7 @@ rustls-pki-types = { version = "1", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["test-util"] }
+tokio = { version = "1.52.0", features = ["test-util"] }
 rcgen = "0.14"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 # Cross-runtime interop tests drive a compio backend on a dedicated

--- a/omq-zeromq/Cargo.toml
+++ b/omq-zeromq/Cargo.toml
@@ -22,11 +22,11 @@ omq-tokio = { path = "../omq-tokio", version = "0.12.0", default-features = fals
 omq-proto = { path = "../omq-proto", version = "0.14.0", default-features = false }
 bytes = "1.11.0"
 libc = "0.2"
-tokio = { version = "1", features = ["sync", "time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.52.0", features = ["sync", "time", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.52.0", features = ["rt-multi-thread", "macros", "time"] }
 trybuild = "1"
 
 [[bin]]

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -38,6 +38,17 @@ run() {
 # Usage: par <func> [args...]
 _par_pids=()
 _par_rc=0
+
+_kill_workers() {
+    for pid in "${_par_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    for pid in "${_par_pids[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+    _par_pids=()
+}
+
 par() {
     # Reap any finished workers.
     local new_pids=()
@@ -45,17 +56,13 @@ par() {
         if kill -0 "$pid" 2>/dev/null; then
             new_pids+=("$pid")
         else
-            # set -e is suppressed inside if/else, so capture explicitly.
             wait "$pid" || _par_rc=$?
         fi
     done
     _par_pids=("${new_pids[@]}")
 
-    # Fail fast: drain remaining workers and abort.
     if [[ $_par_rc -ne 0 ]]; then
-        for pid in "${_par_pids[@]}"; do
-            wait "$pid" 2>/dev/null || true
-        done
+        _kill_workers
         exit "$_par_rc"
     fi
 
@@ -64,9 +71,7 @@ par() {
         wait "${_par_pids[0]}" || _par_rc=$?
         _par_pids=("${_par_pids[@]:1}")
         if [[ $_par_rc -ne 0 ]]; then
-            for pid in "${_par_pids[@]}"; do
-                wait "$pid" 2>/dev/null || true
-            done
+            _kill_workers
             exit "$_par_rc"
         fi
     done
@@ -77,12 +82,13 @@ par() {
 
 par_wait() {
     for pid in "${_par_pids[@]}"; do
-        wait "$pid" || _par_rc=$?
+        wait "$pid" || {
+            _par_rc=$?
+            _kill_workers
+            exit "$_par_rc"
+        }
     done
     _par_pids=()
-    if [[ $_par_rc -ne 0 ]]; then
-        exit "$_par_rc"
-    fi
 }
 
 # ---------------------------------------------------------------- #


### PR DESCRIPTION
- fix: with the `priority` feature, `close()` skipped `drain_shared_queue` (shared_send_rx is None) and tore down the dialer before messages in `pre_connect_buf` could be delivered. Now waits for `pre_connect_buf` to empty. Also moved the wire_handles snapshot inside the close loop so newly connected peers are detected.
- fix: `test-all.sh` now kills workers on failure instead of waiting for them to finish. `par_wait` exits on first failure.
- chore: tighten imprecise Cargo dependency versions flagged by lib.rs (thiserror, zeroize, concurrent-queue, rustc-hash, tokio)
- chore: switch 3 `#[expect]` to `#[allow]` for lints unfulfilled in some feature combos
- test: reduce `pub_sub_sustained_ipc` from 5000 to 50 messages (was flaky under parallel load)
- test: add `soak_ipc_fanout.rs` behind `soak` feature for sustained IPC fan-out load testing