### PR TITLE
Add rzmq to comparison benchmarks and charts

### DIFF
--- a/doc/charts/comparison_inproc.svg
+++ b/doc/charts/comparison_inproc.svg
@@ -26,25 +26,29 @@
   <line x1="90.0" y1="44.4" x2="760.0" y2="44.4" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="44.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">24M</text>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="270.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
-  <line x1="90.0" y1="255.9" x2="760.0" y2="255.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="237.1" x2="760.0" y2="237.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="223.0" x2="760.0" y2="223.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="223.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.1 GB/s</text>
-  <line x1="90.0" y1="208.9" x2="760.0" y2="208.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="190.1" x2="760.0" y2="190.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="176.0" x2="760.0" y2="176.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="176.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90.0" y1="161.9" x2="760.0" y2="161.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="143.1" x2="760.0" y2="143.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="129.0" x2="760.0" y2="129.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="129.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
-  <line x1="90.0" y1="114.9" x2="760.0" y2="114.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="96.1" x2="760.0" y2="96.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="82.0" x2="760.0" y2="82.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="82.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100 GB/s</text>
-  <line x1="90.0" y1="67.9" x2="760.0" y2="67.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <line x1="90.0" y1="49.1" x2="760.0" y2="49.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768.0" y="270.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.001 GB/s</text>
+  <line x1="90.0" y1="258.2" x2="760.0" y2="258.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="242.6" x2="760.0" y2="242.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="230.8" x2="760.0" y2="230.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768.0" y="230.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
+  <line x1="90.0" y1="219.0" x2="760.0" y2="219.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="203.5" x2="760.0" y2="203.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="191.7" x2="760.0" y2="191.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768.0" y="191.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.1 GB/s</text>
+  <line x1="90.0" y1="179.9" x2="760.0" y2="179.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="164.3" x2="760.0" y2="164.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="152.5" x2="760.0" y2="152.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768.0" y="152.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90.0" y1="140.7" x2="760.0" y2="140.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="125.1" x2="760.0" y2="125.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="113.3" x2="760.0" y2="113.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768.0" y="113.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
+  <line x1="90.0" y1="101.5" x2="760.0" y2="101.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="86.0" x2="760.0" y2="86.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="74.2" x2="760.0" y2="74.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768.0" y="74.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100 GB/s</text>
+  <line x1="90.0" y1="62.4" x2="760.0" y2="62.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <line x1="90.0" y1="46.8" x2="760.0" y2="46.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
   <line x1="90.0" y1="35.0" x2="760.0" y2="35.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768.0" y="35.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1000 GB/s</text>
   <line x1="90.0" y1="35.0" x2="90.0" y2="270.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -64,66 +68,81 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,166.8 145.8,162.8 201.7,173.5 257.5,205.8 313.3,243.4 369.2,243.2 425.0,243.9 480.8,248.0 536.7,250.3 592.5,252.1 648.3,253.8 704.2,258.4 760.0,262.4" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,237.5 145.8,233.8 201.7,238.7 257.5,237.7 313.3,232.0 369.2,239.1 425.0,238.0 480.8,233.3 536.7,237.3 592.5,235.6 648.3,239.5 704.2,240.3 760.0,233.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,229.3 145.8,229.9 201.7,227.7 257.5,230.5 313.3,229.5 369.2,231.1 425.0,230.7 480.8,229.3 536.7,228.6 592.5,231.1 648.3,230.1 704.2,228.2 760.0,230.4" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,135.8 145.8,126.7 201.7,142.3 257.5,156.3 313.3,160.1 369.2,158.9 425.0,165.9 480.8,161.0 536.7,162.8 592.5,161.2 648.3,160.2 704.2,165.7 760.0,152.6" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,225.7 145.8,210.7 201.7,198.7 257.5,192.9 313.3,196.7 369.2,182.4 425.0,168.8 480.8,158.1 536.7,146.2 592.5,134.1 648.3,122.0 704.2,114.6 760.0,109.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="225.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="210.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="198.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="192.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="196.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="182.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="168.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="158.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="146.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="134.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="122.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="114.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="109.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,249.2 145.8,232.9 201.7,221.7 257.5,206.9 313.3,189.4 369.2,179.6 425.0,164.7 480.8,147.7 536.7,135.9 592.5,120.7 648.3,109.1 704.2,95.5 760.0,77.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="249.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="232.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="221.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="206.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="189.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="179.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="164.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="135.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="120.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="109.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="95.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="77.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,244.7 145.8,230.8 201.7,215.5 257.5,202.8 313.3,188.1 369.2,174.8 425.0,160.5 480.8,145.6 536.7,131.1 592.5,118.2 648.3,103.6 704.2,88.5 760.0,75.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="244.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="230.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="215.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="202.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="188.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="174.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="160.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="145.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="131.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="118.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="103.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="88.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="75.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,220.3 145.8,204.8 201.7,193.0 257.5,181.2 313.3,167.8 369.2,153.4 425.0,140.6 480.8,125.5 536.7,111.7 592.5,97.2 648.3,82.9 704.2,69.8 760.0,53.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="220.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="204.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="193.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="181.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="167.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="153.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="140.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="125.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="111.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="97.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="82.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="69.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="53.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,258.0 145.8,258.3 201.7,258.1 257.5,258.1 313.3,258.6 369.2,258.1 425.0,258.0 480.8,258.0 536.7,258.1 592.5,257.9 648.3,258.3 704.2,257.9 760.0,257.9" fill="none" stroke="#10b981" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,166.1 145.8,162.9 201.7,167.2 257.5,208.2 313.3,245.2 369.2,244.3 425.0,242.9 480.8,248.2 536.7,250.7 592.5,252.9 648.3,252.8 704.2,257.0 760.0,262.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,239.5 145.8,237.7 201.7,238.8 257.5,234.7 313.3,236.1 369.2,232.1 425.0,235.0 480.8,234.8 536.7,237.0 592.5,232.6 648.3,236.5 704.2,235.4 760.0,236.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,227.0 145.8,229.1 201.7,225.8 257.5,228.3 313.3,229.8 369.2,227.8 425.0,229.1 480.8,229.3 536.7,226.2 592.5,228.5 648.3,228.6 704.2,228.2 760.0,226.8" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,127.3 145.8,120.7 201.7,134.9 257.5,103.5 313.3,101.8 369.2,97.1 425.0,107.9 480.8,110.5 536.7,94.9 592.5,101.2 648.3,100.8 704.2,104.2 760.0,105.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,230.5 145.8,219.1 201.7,207.0 257.5,195.3 313.3,184.2 369.2,171.7 425.0,159.7 480.8,148.0 536.7,136.2 592.5,124.2 648.3,113.0 704.2,100.6 760.0,88.9" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="230.5" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="219.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="207.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="195.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="184.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="171.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="159.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="148.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="136.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="124.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="113.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="100.6" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="88.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,193.8 145.8,181.5 201.7,170.4 257.5,167.2 313.3,171.0 369.2,158.6 425.0,145.9 480.8,137.8 536.7,128.1 592.5,118.3 648.3,106.4 704.2,99.5 760.0,97.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="193.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="181.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="170.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="167.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="171.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="158.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="145.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="137.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="128.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="118.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="106.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="99.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="97.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,214.6 145.8,201.8 201.7,190.7 257.5,176.8 313.3,165.7 369.2,152.0 425.0,141.5 480.8,129.7 536.7,118.9 592.5,105.0 648.3,95.1 704.2,82.8 760.0,71.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="214.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="201.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="190.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="176.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="165.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="152.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="141.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="129.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="118.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="105.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="95.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="82.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="71.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,208.8 145.8,197.8 201.7,184.7 257.5,173.9 313.3,162.7 369.2,150.2 425.0,138.9 480.8,127.2 536.7,114.1 592.5,103.3 648.3,91.5 704.2,79.6 760.0,67.2" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="208.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="197.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="184.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="173.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="162.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="150.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="138.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="127.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="114.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="103.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="91.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="79.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="67.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,188.4 145.8,175.8 201.7,165.7 257.5,150.4 313.3,138.4 369.2,126.1 425.0,115.5 480.8,103.9 536.7,90.6 592.5,79.4 648.3,67.6 704.2,56.1 760.0,44.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="188.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="175.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="165.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="150.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="138.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="126.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="115.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="103.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="90.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="79.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="67.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="56.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="44.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -164,62 +183,76 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,387.4 145.8,385.7 201.7,395.0 257.5,398.1 313.3,390.7 369.2,385.7 425.0,397.3 480.8,381.9 536.7,381.6 592.5,381.9 648.3,377.6 704.2,370.2 760.0,363.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="387.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="385.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="395.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="398.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="390.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="385.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="397.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="381.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="381.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="381.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="377.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="370.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,423.7 145.8,429.9 201.7,426.5 257.5,417.8 313.3,390.1 369.2,426.1 425.0,431.4 480.8,418.4 536.7,424.8 592.5,430.4 648.3,424.5 704.2,409.5 760.0,387.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="423.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="429.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="426.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="417.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="390.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="426.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="431.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="418.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="424.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="430.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,397.4 145.8,387.0 201.7,391.4 257.5,392.2 313.3,386.0 369.2,383.1 425.0,383.0 480.8,381.6 536.7,387.5 592.5,386.6 648.3,377.5 704.2,379.3 760.0,359.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="397.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="387.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="391.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="392.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="386.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="383.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="383.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="381.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="387.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="386.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="377.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="379.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="359.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,417.5 145.8,422.4 201.7,389.9 257.5,406.1 313.3,413.8 369.2,421.1 425.0,425.7 480.8,421.4 536.7,423.8 592.5,391.5 648.3,424.5 704.2,418.3 760.0,424.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="417.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="422.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="389.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="406.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="413.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="421.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="425.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="421.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="423.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="391.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="648.3" cy="424.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="409.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="387.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,522.3 145.8,522.3 201.7,522.3 257.5,522.5 313.3,522.5 369.2,522.4 425.0,522.3 480.8,522.5 536.7,522.1 592.5,522.5 648.3,522.4 704.2,522.1 760.0,522.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="418.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="424.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,381.8 145.8,392.4 201.7,393.0 257.5,393.4 313.3,404.9 369.2,398.7 425.0,400.4 480.8,399.9 536.7,388.9 592.5,395.3 648.3,395.2 704.2,396.9 760.0,400.4" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.8" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="392.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="393.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="393.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="404.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="398.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="400.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="399.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="388.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="395.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="395.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="396.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="400.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,522.9 145.8,523.1 201.7,522.3 257.5,523.1 313.3,522.9 369.2,523.2 425.0,522.9 480.8,523.1 536.7,522.7 592.5,522.7 648.3,522.8 704.2,522.6 760.0,522.7" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="522.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="523.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="522.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="522.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="522.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="522.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,408.2 145.8,406.6 201.7,403.0 257.5,406.4 313.3,416.6 369.2,405.0 425.0,405.0 480.8,405.3 536.7,416.0 592.5,405.3 648.3,405.8 704.2,403.8 760.0,423.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="408.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="406.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="403.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="406.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="416.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="405.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="405.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="405.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="416.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="405.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="405.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="403.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="423.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="523.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="522.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="523.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="522.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="523.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="522.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="522.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="522.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="522.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="522.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,406.7 145.8,415.8 201.7,408.8 257.5,408.5 313.3,412.4 369.2,421.4 425.0,410.1 480.8,407.4 536.7,408.7 592.5,415.7 648.3,410.7 704.2,418.7 760.0,404.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="406.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="415.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="408.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="408.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="412.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="421.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="410.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="407.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="408.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="415.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="410.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="418.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="404.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -233,18 +266,21 @@
   <text x="648.3" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
   <text x="704.2" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="760.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="145" y1="600" x2="159" y2="600" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="152" cy="600" r="2.5" fill="#eab308"/>
-  <text x="165" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="285" y1="600" x2="299" y2="600" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="292" cy="600" r="2.5" fill="#dc2626"/>
-  <text x="305" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
-  <line x1="425" y1="600" x2="439" y2="600" stroke="#8b5cf6" stroke-width="2.5"/>
-  <circle cx="432" cy="600" r="2.5" fill="#8b5cf6"/>
-  <text x="445" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (ST)</text>
-  <line x1="565" y1="600" x2="579" y2="600" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="572" cy="600" r="2.5" fill="#f97316"/>
-  <text x="585" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
+  <line x1="75" y1="600" x2="89" y2="600" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="82" cy="600" r="2.5" fill="#eab308"/>
+  <text x="95" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <line x1="215" y1="600" x2="229" y2="600" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="222" cy="600" r="2.5" fill="#dc2626"/>
+  <text x="235" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
+  <line x1="355" y1="600" x2="369" y2="600" stroke="#8b5cf6" stroke-width="2.5"/>
+  <circle cx="362" cy="600" r="2.5" fill="#8b5cf6"/>
+  <text x="375" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (ST)</text>
+  <line x1="495" y1="600" x2="509" y2="600" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="502" cy="600" r="2.5" fill="#f97316"/>
+  <text x="515" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
+  <line x1="635" y1="600" x2="649" y2="600" stroke="#10b981" stroke-width="2.5"/>
+  <circle cx="642" cy="600" r="2.5" fill="#10b981"/>
+  <text x="655" y="604" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.15</text>
   <line x1="265" y1="622" x2="285" y2="622" stroke="#6b7280" stroke-width="2" stroke-dasharray="6,4"/>
   <text x="291" y="626" fill="#6b7280" font-size="10">msg/s (left axis)</text>
   <line x1="435" y1="622" x2="455" y2="622" stroke="#6b7280" stroke-width="2"/>

--- a/doc/charts/comparison_ipc.svg
+++ b/doc/charts/comparison_ipc.svg
@@ -54,66 +54,81 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,263.2 145.8,263.2 201.7,263.3 257.5,263.2 313.3,263.2 369.2,263.6 425.0,263.6 480.8,263.9 536.7,264.3 592.5,265.7 648.3,266.6 704.2,267.9 760.0,268.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,186.2 145.8,186.0 201.7,190.8 257.5,216.5 313.3,241.9 369.2,243.4 425.0,248.0 480.8,257.1 536.7,262.8 592.5,265.9 648.3,267.7 704.2,268.7 760.0,269.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,204.5 145.8,204.3 201.7,205.0 257.5,221.7 313.3,214.4 369.2,216.4 425.0,224.2 480.8,237.9 536.7,252.2 592.5,259.6 648.3,263.9 704.2,266.8 760.0,268.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,58.8 145.8,82.8 201.7,103.1 257.5,151.6 313.3,187.6 369.2,207.8 425.0,225.4 480.8,240.3 536.7,248.8 592.5,257.6 648.3,263.3 704.2,266.7 760.0,268.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,269.8 145.8,269.5 201.7,269.1 257.5,268.2 313.3,266.4 369.2,263.2 425.0,256.4 480.8,243.8 536.7,221.2 592.5,197.1 648.3,152.7 704.2,124.5 760.0,102.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,265.9 145.8,266.1 201.7,266.0 257.5,266.3 313.3,266.1 369.2,266.2 425.0,266.2 480.8,266.6 536.7,266.8 592.5,267.5 648.3,267.9 704.2,268.4 760.0,269.0" fill="none" stroke="#10b981" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,263.2 145.8,263.4 201.7,263.5 257.5,263.3 313.3,263.3 369.2,263.5 425.0,263.4 480.8,263.8 536.7,264.4 592.5,265.6 648.3,266.6 704.2,267.9 760.0,268.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,185.2 145.8,186.5 201.7,190.5 257.5,216.4 313.3,243.5 369.2,242.3 425.0,248.7 480.8,257.2 536.7,262.6 592.5,265.9 648.3,267.6 704.2,268.7 760.0,269.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,199.6 145.8,199.5 201.7,199.5 257.5,207.7 313.3,207.8 369.2,215.0 425.0,223.6 480.8,237.6 536.7,251.9 592.5,259.5 648.3,263.8 704.2,266.9 760.0,268.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,62.4 145.8,76.2 201.7,108.0 257.5,152.0 313.3,189.5 369.2,207.4 425.0,224.4 480.8,239.1 536.7,248.0 592.5,257.2 648.3,263.1 704.2,266.7 760.0,268.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.0 313.3,267.9 369.2,265.9 425.0,261.9 480.8,255.7 536.7,243.1 592.5,226.8 648.3,199.4 704.2,159.4 760.0,138.0" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="269.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="269.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="269.5" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="269.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="267.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="265.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="261.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="255.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="243.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="226.8" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="199.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="159.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="138.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,269.8 145.8,269.6 201.7,269.1 257.5,268.2 313.3,266.5 369.2,263.1 425.0,256.0 480.8,243.6 536.7,222.2 592.5,195.3 648.3,155.2 704.2,127.8 760.0,109.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="269.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="269.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="269.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="268.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="266.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="263.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="256.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="243.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="221.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="197.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="152.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="124.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="102.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.2 145.8,264.4 201.7,259.4 257.5,255.7 313.3,255.0 369.2,241.6 425.0,223.1 480.8,214.9 536.7,208.6 592.5,200.7 648.3,190.6 704.2,183.0 760.0,137.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="313.3" cy="266.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="263.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="256.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="243.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="222.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="195.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="155.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="127.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="109.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.2 145.8,264.4 201.7,259.4 257.5,255.7 313.3,255.9 369.2,240.4 425.0,224.6 480.8,215.5 536.7,206.7 592.5,199.6 648.3,189.8 704.2,183.4 760.0,140.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="267.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="264.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="259.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="255.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="255.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="241.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="223.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="214.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="208.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="200.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="190.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="183.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="137.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.8 145.8,265.6 201.7,261.3 257.5,257.1 313.3,240.4 369.2,212.8 425.0,172.4 480.8,133.1 536.7,117.8 592.5,93.1 648.3,61.3 704.2,52.8 760.0,58.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="265.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="261.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="257.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="240.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="212.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="172.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="133.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="117.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="93.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="61.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="52.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="58.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,263.0 145.8,257.5 201.7,247.7 257.5,238.4 313.3,226.1 369.2,203.7 425.0,174.8 480.8,143.1 536.7,89.3 592.5,57.6 648.3,42.9 704.2,44.0 760.0,44.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="263.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="257.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="247.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="238.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="226.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="203.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="174.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="143.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="89.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="57.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="42.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="44.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="44.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="255.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="240.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="224.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="215.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="206.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="199.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="189.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="183.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="140.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.6 145.8,265.3 201.7,260.6 257.5,253.4 313.3,236.8 369.2,211.3 425.0,171.1 480.8,131.8 536.7,115.8 592.5,90.2 648.3,59.5 704.2,58.1 760.0,66.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="265.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="260.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="253.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="236.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="211.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="171.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="131.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="115.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="90.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="59.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="58.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="66.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,263.1 145.8,257.1 201.7,248.4 257.5,238.5 313.3,227.1 369.2,203.3 425.0,172.7 480.8,138.3 536.7,82.5 592.5,51.4 648.3,32.8 704.2,43.9 760.0,47.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="263.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="257.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="248.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="238.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="227.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="203.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="172.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="138.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="82.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="51.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="32.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="43.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="47.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -154,62 +169,76 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,417.1 145.8,411.8 201.7,419.2 257.5,414.6 313.3,418.9 369.2,411.9 425.0,414.0 480.8,403.2 536.7,409.6 592.5,408.6 648.3,396.8 704.2,392.2 760.0,379.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="417.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="411.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="419.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="414.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="418.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="411.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="414.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="403.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="409.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="408.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="396.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="392.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="379.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,465.3 145.8,462.7 201.7,466.2 257.5,463.2 313.3,465.7 369.2,459.8 425.0,458.9 480.8,466.6 536.7,454.3 592.5,456.3 648.3,452.4 704.2,442.5 760.0,425.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="465.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="462.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="466.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="463.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="465.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="459.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="458.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="466.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="454.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="456.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="452.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="442.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="425.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,480.2 145.8,480.6 201.7,476.2 257.5,484.1 313.3,479.2 369.2,481.7 425.0,483.9 480.8,482.2 536.7,481.1 592.5,480.2 648.3,474.3 704.2,465.1 760.0,433.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="480.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="480.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="476.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="484.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="479.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="481.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="483.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="482.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="481.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="480.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="474.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="465.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="433.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,487.0 145.8,482.6 201.7,486.2 257.5,484.5 313.3,484.5 369.2,488.0 425.0,486.5 480.8,484.5 536.7,480.1 592.5,473.3 648.3,474.5 704.2,467.4 760.0,463.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="487.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="482.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="486.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="488.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="486.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="484.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="480.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="473.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="474.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="467.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="463.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,427.0 145.8,427.7 201.7,421.0 257.5,424.1 313.3,425.5 369.2,427.6 425.0,426.3 480.8,424.3 536.7,424.9 592.5,411.0 648.3,397.8 704.2,393.7 760.0,389.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="427.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="427.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="421.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="424.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="425.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="427.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="426.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="424.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="424.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="411.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="397.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="393.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="389.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,463.6 145.8,454.3 201.7,466.1 257.5,454.3 313.3,463.1 369.2,464.4 425.0,456.6 480.8,465.1 536.7,454.8 592.5,450.6 648.3,453.4 704.2,445.4 760.0,423.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="463.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="454.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="466.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="454.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="463.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="464.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="456.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="465.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="454.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="450.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="453.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="445.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="423.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,407.3 145.8,408.5 201.7,405.1 257.5,395.1 313.3,403.7 369.2,409.6 425.0,391.4 480.8,415.4 536.7,408.3 592.5,408.1 648.3,393.1 704.2,386.4 760.0,353.4" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="407.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="408.5" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="405.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="395.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="403.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="409.6" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="391.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="415.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="408.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="408.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="393.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="386.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="353.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,482.6 145.8,487.5 201.7,492.9 257.5,484.0 313.3,483.7 369.2,490.3 425.0,484.3 480.8,484.0 536.7,481.4 592.5,478.9 648.3,462.6 704.2,452.9 760.0,440.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="482.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="487.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="492.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="484.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="483.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="490.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="484.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="484.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="481.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="478.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="462.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="452.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="440.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,486.6 145.8,483.8 201.7,486.8 257.5,487.1 313.3,486.3 369.2,485.7 425.0,486.0 480.8,480.2 536.7,481.6 592.5,477.0 648.3,475.2 704.2,469.2 760.0,455.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="486.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="483.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="486.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="487.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="486.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="485.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="486.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="480.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="481.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="477.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="475.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="469.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="455.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -223,18 +252,21 @@
   <text x="648.3" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
   <text x="704.2" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="760.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="145" y1="600" x2="159" y2="600" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="152" cy="600" r="2.5" fill="#eab308"/>
-  <text x="165" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="285" y1="600" x2="299" y2="600" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="292" cy="600" r="2.5" fill="#dc2626"/>
-  <text x="305" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
-  <line x1="425" y1="600" x2="439" y2="600" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="432" cy="600" r="2.5" fill="#f97316"/>
-  <text x="445" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
-  <line x1="565" y1="600" x2="579" y2="600" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="572" cy="600" r="2.5" fill="#2563eb"/>
-  <text x="585" y="604" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0</text>
+  <line x1="75" y1="600" x2="89" y2="600" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="82" cy="600" r="2.5" fill="#eab308"/>
+  <text x="95" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <line x1="215" y1="600" x2="229" y2="600" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="222" cy="600" r="2.5" fill="#dc2626"/>
+  <text x="235" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
+  <line x1="355" y1="600" x2="369" y2="600" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="362" cy="600" r="2.5" fill="#f97316"/>
+  <text x="375" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
+  <line x1="495" y1="600" x2="509" y2="600" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="502" cy="600" r="2.5" fill="#2563eb"/>
+  <text x="515" y="604" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0</text>
+  <line x1="635" y1="600" x2="649" y2="600" stroke="#10b981" stroke-width="2.5"/>
+  <circle cx="642" cy="600" r="2.5" fill="#10b981"/>
+  <text x="655" y="604" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.15</text>
   <line x1="265" y1="622" x2="285" y2="622" stroke="#6b7280" stroke-width="2" stroke-dasharray="6,4"/>
   <text x="291" y="626" fill="#6b7280" font-size="10">msg/s (left axis)</text>
   <line x1="435" y1="622" x2="455" y2="622" stroke="#6b7280" stroke-width="2"/>

--- a/doc/charts/comparison_tcp.svg
+++ b/doc/charts/comparison_tcp.svg
@@ -54,66 +54,81 @@
   <line x1="760.0" y1="35.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="270.0" x2="760.0" y2="270.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="152.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,152.5)">msg/s</text>
-  <polyline points="90.0,266.4 145.8,266.2 201.7,266.5 257.5,266.8 313.3,267.0 369.2,267.0 425.0,267.4 480.8,267.2 536.7,267.4 592.5,267.6 648.3,267.9 704.2,268.3 760.0,268.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,192.7 145.8,189.1 201.7,191.1 257.5,215.3 313.3,243.5 369.2,245.9 425.0,252.3 480.8,259.4 536.7,263.9 592.5,266.7 648.3,268.3 704.2,269.2 760.0,269.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,195.6 145.8,199.5 201.7,201.5 257.5,214.4 313.3,214.0 369.2,218.6 425.0,224.3 480.8,232.5 536.7,249.9 592.5,258.6 648.3,263.9 704.2,267.0 760.0,268.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,49.7 145.8,82.7 201.7,113.5 257.5,152.5 313.3,191.1 369.2,215.8 425.0,229.6 480.8,243.8 536.7,251.4 592.5,258.9 648.3,264.0 704.2,266.9 760.0,268.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.1 313.3,268.4 369.2,266.8 425.0,264.5 480.8,257.9 536.7,248.0 592.5,228.7 648.3,196.8 704.2,151.1 760.0,109.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,267.3 145.8,267.2 201.7,267.6 257.5,267.9 313.3,268.1 369.2,268.3 425.0,268.2 480.8,268.1 536.7,268.4 592.5,268.5 648.3,268.5 704.2,268.9 760.0,269.6" fill="none" stroke="#10b981" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,265.9 145.8,266.0 201.7,266.6 257.5,266.7 313.3,266.9 369.2,267.0 425.0,267.1 480.8,267.2 536.7,267.4 592.5,267.7 648.3,268.0 704.2,268.1 760.0,268.9" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,188.2 145.8,187.6 201.7,191.3 257.5,218.0 313.3,243.0 369.2,245.2 425.0,251.5 480.8,260.0 536.7,263.9 592.5,266.5 648.3,268.3 704.2,269.1 760.0,269.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,202.9 145.8,197.3 201.7,195.8 257.5,209.5 313.3,205.6 369.2,216.3 425.0,225.8 480.8,239.0 536.7,249.2 592.5,258.8 648.3,264.0 704.2,266.9 760.0,268.4" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,46.1 145.8,72.9 201.7,119.4 257.5,156.9 313.3,183.4 369.2,215.0 425.0,228.9 480.8,243.3 536.7,252.4 592.5,259.5 648.3,264.2 704.2,267.3 760.0,268.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,269.9 145.8,269.8 201.7,269.7 257.5,269.4 313.3,269.0 369.2,268.2 425.0,266.2 480.8,262.1 536.7,256.6 592.5,244.0 648.3,219.0 704.2,195.8 760.0,208.7" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="269.9" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="269.8" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="269.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="269.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="269.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="268.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="266.2" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="262.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="256.6" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="244.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="219.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="195.8" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="208.7" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,269.9 145.8,269.7 201.7,269.5 257.5,269.1 313.3,268.4 369.2,266.8 425.0,263.8 480.8,258.2 536.7,247.9 592.5,230.6 648.3,200.6 704.2,139.3 760.0,115.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="269.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="269.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="269.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="269.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="268.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="266.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="264.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="257.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="248.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="228.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="196.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="151.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="109.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.4 145.8,264.6 201.7,259.5 257.5,255.4 313.3,255.9 369.2,244.3 425.0,232.3 480.8,224.9 536.7,217.6 592.5,214.0 648.3,211.0 704.2,213.5 760.0,173.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="264.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="263.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="258.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="247.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="230.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="200.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="139.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="115.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.3 145.8,264.5 201.7,259.5 257.5,256.1 313.3,255.6 369.2,243.5 425.0,230.6 480.8,227.5 536.7,217.9 592.5,211.0 648.3,213.7 704.2,211.2 760.0,179.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="264.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="259.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="255.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="255.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="244.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="232.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="224.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="217.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="214.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="211.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="213.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="173.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,267.5 145.8,265.3 201.7,260.9 257.5,255.2 313.3,240.2 369.2,215.1 425.0,172.5 480.8,110.0 536.7,98.3 592.5,75.4 648.3,62.0 704.2,64.0 760.0,60.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="267.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="265.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="260.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="255.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="240.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="215.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="172.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="110.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="98.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="75.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="62.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="64.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="60.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,262.7 145.8,257.5 201.7,249.1 257.5,238.7 313.3,227.9 369.2,212.2 425.0,183.8 480.8,158.3 536.7,111.7 592.5,80.2 648.3,66.4 704.2,55.2 760.0,26.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="262.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="257.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="249.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="238.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="227.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="212.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="183.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="158.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="111.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="80.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="66.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="55.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="26.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="256.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="255.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="243.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="230.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="227.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="217.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="211.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="213.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="211.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="179.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,267.8 145.8,265.2 201.7,260.1 257.5,253.9 313.3,235.7 369.2,212.7 425.0,175.6 480.8,137.7 536.7,92.3 592.5,78.3 648.3,64.5 704.2,61.0 760.0,56.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="267.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="265.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="260.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="253.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="235.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="212.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="175.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="137.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="92.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="78.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="64.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="61.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="56.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,262.5 145.8,256.9 201.7,249.9 257.5,239.8 313.3,223.8 369.2,211.4 425.0,182.3 480.8,155.9 536.7,119.9 592.5,90.0 648.3,73.6 704.2,83.5 760.0,48.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="262.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="256.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="249.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="239.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="223.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="211.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="182.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="155.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="119.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="90.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="73.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="83.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="48.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="284.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -154,62 +169,76 @@
   <line x1="90.0" y1="350.0" x2="90.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="540.0" x2="760.0" y2="540.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="445.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,445.0)">p50 latency (µs)</text>
-  <polyline points="90.0,402.5 145.8,397.9 201.7,403.8 257.5,400.7 313.3,395.7 369.2,403.9 425.0,401.7 480.8,403.6 536.7,398.4 592.5,401.3 648.3,383.1 704.2,377.2 760.0,363.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="402.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="397.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="403.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="400.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="395.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="403.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="401.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="403.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="398.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="401.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="383.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="377.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="363.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,456.5 145.8,441.5 201.7,444.2 257.5,452.0 313.3,457.5 369.2,453.2 425.0,452.9 480.8,453.8 536.7,440.9 592.5,437.2 648.3,436.3 704.2,443.8 760.0,426.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="456.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="441.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="444.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="452.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="457.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="453.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="452.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="453.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="440.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="437.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="436.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="443.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="426.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,460.6 145.8,460.9 201.7,464.8 257.5,448.5 313.3,460.4 369.2,458.7 425.0,460.8 480.8,455.3 536.7,457.0 592.5,457.1 648.3,447.8 704.2,437.7 760.0,416.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="460.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="460.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="464.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="448.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="460.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="458.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="460.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="455.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="457.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="457.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="447.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="437.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="416.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,471.7 145.8,470.7 201.7,471.3 257.5,471.2 313.3,468.4 369.2,470.5 425.0,469.6 480.8,471.9 536.7,468.7 592.5,468.6 648.3,462.1 704.2,457.6 760.0,447.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="471.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="470.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="471.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="471.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="468.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="470.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="469.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="471.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="468.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="468.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="462.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="457.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="447.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,402.0 145.8,398.1 201.7,402.4 257.5,406.5 313.3,405.4 369.2,396.7 425.0,417.0 480.8,405.9 536.7,397.3 592.5,403.5 648.3,380.8 704.2,374.1 760.0,355.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="402.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="398.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="402.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="406.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="405.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="396.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="417.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="405.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="397.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="403.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="380.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="374.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="355.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,453.2 145.8,449.5 201.7,445.9 257.5,444.3 313.3,446.0 369.2,454.3 425.0,447.1 480.8,432.7 536.7,450.7 592.5,442.0 648.3,447.2 704.2,440.5 760.0,422.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="453.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="449.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="445.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="444.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="446.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="454.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="447.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="432.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="450.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="442.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="447.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="440.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="422.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,397.1 145.8,393.0 201.7,392.6 257.5,379.4 313.3,388.1 369.2,388.4 425.0,399.5 480.8,395.4 536.7,377.3 592.5,382.5 648.3,379.8 704.2,374.3 760.0,357.6" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="397.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="393.0" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="392.6" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="379.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="388.1" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="388.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="399.5" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="395.4" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="377.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="382.5" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="379.8" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="374.3" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="357.6" r="3" fill="#10b981" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,462.6 145.8,458.1 201.7,458.7 257.5,463.3 313.3,461.8 369.2,459.7 425.0,465.6 480.8,459.0 536.7,458.4 592.5,460.0 648.3,450.1 704.2,440.7 760.0,426.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="462.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="458.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="458.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="463.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="461.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="459.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="465.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="459.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="458.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="460.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="450.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="440.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="426.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,473.5 145.8,474.4 201.7,472.0 257.5,474.3 313.3,473.2 369.2,469.7 425.0,470.9 480.8,474.3 536.7,472.2 592.5,465.8 648.3,465.8 704.2,461.7 760.0,443.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="473.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="474.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="472.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="474.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="473.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="469.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="470.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="474.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="472.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="465.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="465.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="461.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="443.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <text x="90.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -223,18 +252,21 @@
   <text x="648.3" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
   <text x="704.2" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="760.0" y="554.0" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="145" y1="600" x2="159" y2="600" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="152" cy="600" r="2.5" fill="#eab308"/>
-  <text x="165" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="285" y1="600" x2="299" y2="600" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="292" cy="600" r="2.5" fill="#dc2626"/>
-  <text x="305" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
-  <line x1="425" y1="600" x2="439" y2="600" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="432" cy="600" r="2.5" fill="#f97316"/>
-  <text x="445" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
-  <line x1="565" y1="600" x2="579" y2="600" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="572" cy="600" r="2.5" fill="#2563eb"/>
-  <text x="585" y="604" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0</text>
+  <line x1="75" y1="600" x2="89" y2="600" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="82" cy="600" r="2.5" fill="#eab308"/>
+  <text x="95" y="604" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <line x1="215" y1="600" x2="229" y2="600" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="222" cy="600" r="2.5" fill="#dc2626"/>
+  <text x="235" y="604" fill="#374151" font-size="11" font-weight="500">omq-compio (MT)</text>
+  <line x1="355" y1="600" x2="369" y2="600" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="362" cy="600" r="2.5" fill="#f97316"/>
+  <text x="375" y="604" fill="#374151" font-size="11" font-weight="500">omq-tokio</text>
+  <line x1="495" y1="600" x2="509" y2="600" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="502" cy="600" r="2.5" fill="#2563eb"/>
+  <text x="515" y="604" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0</text>
+  <line x1="635" y1="600" x2="649" y2="600" stroke="#10b981" stroke-width="2.5"/>
+  <circle cx="642" cy="600" r="2.5" fill="#10b981"/>
+  <text x="655" y="604" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.15</text>
   <line x1="265" y1="622" x2="285" y2="622" stroke="#6b7280" stroke-width="2" stroke-dasharray="6,4"/>
   <text x="291" y="626" fill="#6b7280" font-size="10">msg/s (left axis)</text>
   <line x1="435" y1="622" x2="455" y2="622" stroke="#6b7280" stroke-width="2"/>

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -20,6 +20,7 @@ COLORS = {
     "omq-compio-st": "#8b5cf6",
     "omq-tokio": "#f97316",
     "zmq.rs": "#2563eb",
+    "rzmq": "#10b981",
 }
 
 LABELS = {
@@ -28,6 +29,7 @@ LABELS = {
     "omq-compio-st": "omq-compio (ST)",
     "omq-tokio": "omq-tokio",
     "zmq.rs": "zmq.rs v0.6.0",
+    "rzmq": "rzmq v0.5.15",
 }
 
 
@@ -240,7 +242,7 @@ def draw_throughput_panel(
     L.append(svg_text(40, mid_y, "msg/s", weight="600", rotate=-90))
 
     # dashed msg/s lines
-    draw_order = [name for name in ["zmq.rs", "libzmq", "omq-tokio", "omq-compio-st", "omq-compio"]
+    draw_order = [name for name in ["rzmq", "zmq.rs", "libzmq", "omq-tokio", "omq-compio-st", "omq-compio"]
                   if name in impls]
     for name in draw_order:
         pts = [
@@ -305,7 +307,7 @@ def draw_latency_panel(
     mid_y = (y_top + y_bot) / 2
     L.append(svg_text(40, mid_y, "p50 latency (µs)", weight="600", rotate=-90))
 
-    draw_order = [name for name in ["libzmq", "omq-tokio", "zmq.rs", "omq-compio-st", "omq-compio"]
+    draw_order = [name for name in ["libzmq", "omq-tokio", "rzmq", "zmq.rs", "omq-compio-st", "omq-compio"]
                   if name in impls]
     for name in draw_order:
         pts = [
@@ -441,7 +443,7 @@ def main():
     FIXED_INPROC_LAT_MAX = 25.0
 
     # TCP chart (4 impls)
-    tcp_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs"]
+    tcp_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
     tcp_data = load_data("tcp", tcp_impls)
 
     if tcp_data["sizes"]:
@@ -456,7 +458,7 @@ def main():
         print("No TCP data found", file=sys.stderr)
 
     # IPC chart (4 impls, same as TCP)
-    ipc_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs"]
+    ipc_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
     ipc_data = load_data("ipc", ipc_impls)
 
     if ipc_data["sizes"]:
@@ -471,7 +473,7 @@ def main():
         print("No IPC data found", file=sys.stderr)
 
     # Inproc chart (4 impls: libzmq, compio mt+st, tokio; no zmq.rs)
-    inproc_impls = ["libzmq", "omq-compio", "omq-compio-st", "omq-tokio"]
+    inproc_impls = ["libzmq", "omq-compio", "omq-compio-st", "omq-tokio", "rzmq"]
     inproc_data = load_data("inproc", inproc_impls)
 
     if inproc_data["sizes"]:

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -8,7 +8,8 @@ results to benchmarks/comparisons.jsonl.
 Usage:
   scripts/run_comparisons.py                        # all impls, tcp+inproc+ipc, latency on
   scripts/run_comparisons.py --quick-run            # 3 sizes only
-  scripts/run_comparisons.py --scope omq            # omq-compio + omq-tokio only
+  scripts/run_comparisons.py --impl rzmq            # single impl
+  scripts/run_comparisons.py --impl omq-compio --impl libzmq  # subset
   scripts/run_comparisons.py --transport tcp         # TCP only
   scripts/run_comparisons.py --no-latency           # skip REQ/REP latency
   scripts/run_comparisons.py --update-markdown      # update COMPARISONS.md tables
@@ -35,6 +36,7 @@ TABLE_SIZES = [32, 1024, 4096]
 DURATION = 3
 LATENCY_ITERATIONS = 10_000
 LATENCY_WARMUP = 1_000
+LATENCY_TIMEOUT = 30
 
 
 # ── formatting ────────────────────────────────────────────────────
@@ -154,16 +156,20 @@ def spawn_process(binary: str, *args: str) -> subprocess.Popen:
     )
 
 
-def capture_process(binary: str, *args: str) -> str:
+def capture_process(binary: str, *args: str, timeout: int = 30) -> str:
+    proc = subprocess.Popen(
+        [binary, *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
     try:
-        result = subprocess.run(
-            [binary, *args],
-            capture_output=True, text=True,
-            timeout=30,
-        )
-        return result.stdout
+        stdout, _ = proc.communicate(timeout=timeout)
+        return stdout
     except subprocess.TimeoutExpired:
         print(f"WARNING: timeout: {binary} {' '.join(args)}", file=sys.stderr)
+        proc.kill()
+        proc.wait()
         return ""
 
 
@@ -232,11 +238,15 @@ def run_throughput_cell(
 def run_latency_cell(
     binary: str, transport: str, addr: str, size: int,
     inproc_subcmd: str = "inproc-latency",
+    iterations: int = LATENCY_ITERATIONS,
+    warmup: int = LATENCY_WARMUP,
+    timeout: int = LATENCY_TIMEOUT,
 ) -> dict | None:
     if transport == "inproc":
         output = capture_process(
             binary, inproc_subcmd, addr, str(size),
-            str(LATENCY_ITERATIONS), str(LATENCY_WARMUP),
+            str(iterations), str(warmup),
+            timeout=timeout,
         )
         return parse_latency(output)
 
@@ -248,7 +258,8 @@ def run_latency_cell(
     try:
         output = capture_process(
             binary, "req", addr, str(size),
-            str(LATENCY_ITERATIONS), str(LATENCY_WARMUP),
+            str(iterations), str(warmup),
+            timeout=timeout,
         )
     finally:
         kill_process(rep)
@@ -259,10 +270,10 @@ def run_latency_cell(
 
 def addr_for(transport: str, prefix: str, idx: int, base_port: int) -> str:
     if transport == "tcp":
-        offsets = {"c": 0, "t": 100, "z": 200, "q": 300, "s": 400}
+        offsets = {"c": 0, "t": 100, "z": 200, "q": 300, "s": 400, "r": 1000}
         return str(base_port + offsets.get(prefix, 0) + idx)
     if transport == "ws":
-        offsets = {"c": 500, "t": 600, "z": 700, "q": 800, "s": 900}
+        offsets = {"c": 500, "t": 600, "z": 700, "q": 800, "s": 900, "r": 1100}
         return f"ws://127.0.0.1:{base_port + offsets.get(prefix, 500) + idx}/"
     if transport == "ipc":
         return f"ipc://@omq-bench-cmp-{prefix}-{idx}"
@@ -498,30 +509,41 @@ IMPLS = {
         "inproc_tput_subcmd": "inproc",
         "inproc_lat_subcmd": "inproc-latency",
     },
+    "rzmq": {
+        "prefix": "r",
+        "transports": ["tcp", "inproc", "ipc"],
+        "inproc_tput_subcmd": "inproc",
+        "inproc_lat_subcmd": "inproc-latency",
+    },
 }
 
 
-def build_peers(scope: str, ws_needed: bool):
+def build_peers(impl_names: set[str], ws_needed: bool):
     binaries = {}
     features = ["ws"] if ws_needed else []
 
-    print("==> building omq-compio bench_peer...", file=sys.stderr)
-    cargo_build("omq-compio", "bench_peer_compio", features=features or None)
-    compio_bin = str(ROOT / "target" / "release" / "bench_peer_compio")
-    binaries["omq-compio"] = compio_bin
-    binaries["omq-compio-st"] = compio_bin
+    if "omq-compio" in impl_names or "omq-compio-st" in impl_names:
+        print("==> building omq-compio bench_peer...", file=sys.stderr)
+        cargo_build("omq-compio", "bench_peer_compio", features=features or None)
+        compio_bin = str(ROOT / "target" / "release" / "bench_peer_compio")
+        if "omq-compio" in impl_names:
+            binaries["omq-compio"] = compio_bin
+        if "omq-compio-st" in impl_names:
+            binaries["omq-compio-st"] = compio_bin
 
-    print("==> building omq-tokio bench_peer...", file=sys.stderr)
-    cargo_build("omq-tokio", "bench_peer_tokio", features=features or None)
-    binaries["omq-tokio"] = str(ROOT / "target" / "release" / "bench_peer_tokio")
+    if "omq-tokio" in impl_names:
+        print("==> building omq-tokio bench_peer...", file=sys.stderr)
+        cargo_build("omq-tokio", "bench_peer_tokio", features=features or None)
+        binaries["omq-tokio"] = str(ROOT / "target" / "release" / "bench_peer_tokio")
 
-    if scope == "all":
+    if "libzmq" in impl_names:
         print("==> building libzmq bench_peer...", file=sys.stderr)
         src = ROOT / "scripts" / "libzmq_bench_peer.c"
         out = ROOT / "scripts" / "libzmq_bench_peer"
         gcc_build(src, out)
         binaries["libzmq"] = str(out)
 
+    if "zmq.rs" in impl_names:
         print("==> building zmq.rs bench_peer...", file=sys.stderr)
         zmqrs_dir = ROOT / "scripts" / "zmqrs_bench_peer"
         subprocess.run(
@@ -529,6 +551,15 @@ def build_peers(scope: str, ws_needed: bool):
             cwd=zmqrs_dir, check=True,
         )
         binaries["zmq.rs"] = str(zmqrs_dir / "target" / "release" / "zmqrs_bench_peer")
+
+    if "rzmq" in impl_names:
+        print("==> building rzmq bench_peer...", file=sys.stderr)
+        rzmq_dir = ROOT / "scripts" / "rzmq_bench_peer"
+        subprocess.run(
+            ["cargo", "build", "--release", "-q"],
+            cwd=rzmq_dir, check=True,
+        )
+        binaries["rzmq"] = str(rzmq_dir / "target" / "release" / "rzmq_bench_peer")
 
     return binaries
 
@@ -540,6 +571,9 @@ def run_benchmarks(
     run_latency: bool,
     base_port: int,
     run_id: str,
+    latency_iterations: int = LATENCY_ITERATIONS,
+    latency_warmup: int = LATENCY_WARMUP,
+    latency_timeout: int = LATENCY_TIMEOUT,
 ):
     for transport in transports:
         active = {
@@ -598,7 +632,10 @@ def run_benchmarks(
                     addr = addr_for(transport, prefix, idx + len(sizes), base_port)
                     subcmd = impl_def.get("inproc_lat_subcmd", "inproc-latency")
                     result = run_latency_cell(binary, transport, addr, size,
-                                             inproc_subcmd=subcmd)
+                                             inproc_subcmd=subcmd,
+                                             iterations=latency_iterations,
+                                             warmup=latency_warmup,
+                                             timeout=latency_timeout)
                     cells[name] = result
                     if result:
                         append_jsonl({
@@ -629,8 +666,9 @@ def run_benchmarks(
 def main():
     parser = argparse.ArgumentParser(description="Run comparison benchmarks")
     parser.add_argument(
-        "--scope", choices=["omq", "all"], default="all",
-        help="omq = omq-compio + omq-tokio only; all = include libzmq + zmq.rs",
+        "--impl", action="append", dest="impls",
+        choices=list(IMPLS.keys()),
+        help="implementation(s) to benchmark (default: all)",
     )
     parser.add_argument(
         "--transport", action="append",
@@ -644,6 +682,18 @@ def main():
     parser.add_argument(
         "--no-latency", action="store_true",
         help="skip REQ/REP latency benchmarks (on by default)",
+    )
+    parser.add_argument(
+        "--latency-iterations", type=int, default=LATENCY_ITERATIONS,
+        help=f"measured round-trips per latency cell (default: {LATENCY_ITERATIONS})",
+    )
+    parser.add_argument(
+        "--latency-warmup", type=int, default=LATENCY_WARMUP,
+        help=f"warmup round-trips before measuring (default: {LATENCY_WARMUP})",
+    )
+    parser.add_argument(
+        "--latency-timeout", type=int, default=LATENCY_TIMEOUT,
+        help=f"timeout in seconds for latency subprocess (default: {LATENCY_TIMEOUT})",
     )
     parser.add_argument(
         "--update-markdown", action="store_true",
@@ -665,23 +715,25 @@ def main():
     run_latency = not args.no_latency
     ws_needed = "ws" in transports
 
-    binaries = build_peers(args.scope, ws_needed)
+    impl_names = set(args.impls) if args.impls else set(IMPLS.keys())
 
-    omq_ver = cargo_version("omq-compio")
-    if args.scope == "all":
-        zmq_ver = libzmq_version()
-        zmqrs_ver = cargo_version(
-            "zeromq",
-            manifest=ROOT / "scripts" / "zmqrs_bench_peer" / "Cargo.toml",
-        )
-        print(
-            f"omq {omq_ver} vs libzmq {zmq_ver} vs zmq.rs {zmqrs_ver}",
-            file=sys.stderr,
-        )
-    else:
-        print(f"omq {omq_ver} (omq-only refresh)", file=sys.stderr)
+    binaries = build_peers(impl_names, ws_needed)
 
-    run_benchmarks(binaries, transports, sizes, run_latency, args.base_port, run_id)
+    versions = []
+    if impl_names & {"omq-compio", "omq-compio-st", "omq-tokio"}:
+        versions.append(f"omq {cargo_version('omq-compio')}")
+    if "libzmq" in impl_names:
+        versions.append(f"libzmq {libzmq_version()}")
+    if "zmq.rs" in impl_names:
+        versions.append(f"zmq.rs {cargo_version('zeromq', manifest=ROOT / 'scripts' / 'zmqrs_bench_peer' / 'Cargo.toml')}")
+    if "rzmq" in impl_names:
+        versions.append(f"rzmq {cargo_version('rzmq', manifest=ROOT / 'scripts' / 'rzmq_bench_peer' / 'Cargo.toml')}")
+    print(" vs ".join(versions), file=sys.stderr)
+
+    run_benchmarks(binaries, transports, sizes, run_latency, args.base_port, run_id,
+                   latency_iterations=args.latency_iterations,
+                   latency_warmup=args.latency_warmup,
+                   latency_timeout=args.latency_timeout)
 
     if args.update_markdown:
         update_comparisons_md(transports)

--- a/scripts/rzmq_bench_peer/Cargo.toml
+++ b/scripts/rzmq_bench_peer/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+
+[package]
+name = "rzmq_bench_peer"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rzmq_bench_peer"
+path = "src/main.rs"
+
+[dependencies]
+rzmq = { git = "https://github.com/excsn/rzmq.git", rev = "e3e5745", features = ["io-uring", "curve"] }
+tokio = { version = "1", features = ["full"] }

--- a/scripts/rzmq_bench_peer/src/main.rs
+++ b/scripts/rzmq_bench_peer/src/main.rs
@@ -1,0 +1,279 @@
+//! Two-process throughput peer for rzmq.
+//!
+//! Usage:
+//!   rzmq_bench_peer push <addr> <msg_size_bytes>
+//!   rzmq_bench_peer pull <addr> <msg_size_bytes> <duration_secs>
+//!   rzmq_bench_peer rep  <addr> <msg_size_bytes>
+//!   rzmq_bench_peer req  <addr> <msg_size_bytes> <iterations> <warmup>
+//!   rzmq_bench_peer inproc <addr> <msg_size_bytes> <duration_secs>
+//!   rzmq_bench_peer inproc-latency <addr> <msg_size_bytes> <iterations> <warmup>
+//!
+//! <addr>: a port number (-> tcp://127.0.0.1:<port>) or a full ZMQ address
+//!         (e.g. ipc:///tmp/bench.sock or tcp://127.0.0.1:15655).
+//!
+//! Push: binds, sends <msg_size> byte messages forever.
+//! Pull: connects, warms up for 500 ms, then counts messages for <duration>
+//!       seconds and prints one line to stdout:
+//!         <count> <elapsed_secs> <msg_size>
+//! Rep:  binds, echoes received messages back forever.
+//! Req:  connects, runs warmup + measured round-trips, prints latency
+//!       percentiles (p50 p99 p999 max iterations) in microseconds.
+//! Inproc: single-process PUSH/PULL throughput.
+//! Inproc-latency: single-process REQ/REP latency.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use rzmq::{Context, Msg, Socket, SocketType};
+
+
+fn print_latency(rtts: &[u64], iterations: usize) {
+    let percentile = |sorted: &[u64], p: f64| -> f64 {
+        let n = sorted.len();
+        let mut idx = (n as f64 * p / 100.0) as usize;
+        if idx >= n {
+            idx = n - 1;
+        }
+        sorted[idx] as f64 / 1000.0
+    };
+
+    let p50 = percentile(rtts, 50.0);
+    let p99 = percentile(rtts, 99.0);
+    let p999 = percentile(rtts, 99.9);
+    let max = rtts[iterations - 1] as f64 / 1000.0;
+    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations}");
+}
+
+fn resolve_addr(s: &str) -> String {
+    if s.chars().all(|c| c.is_ascii_digit()) {
+        format!("tcp://127.0.0.1:{s}")
+    } else {
+        s.to_owned()
+    }
+}
+
+fn leaked_payload(size: usize) -> &'static [u8] {
+    Box::leak(vec![b'x'; size].into_boxed_slice())
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("push") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            run_push(&addr, size).await;
+        }
+        Some("pull") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            run_pull(&addr, size, Duration::from_secs_f64(duration)).await;
+        }
+        Some("rep") => {
+            let addr = resolve_addr(&args[2]);
+            run_rep(&addr).await;
+        }
+        Some("req") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let iterations: usize = args[4].parse().expect("iterations");
+            let warmup: usize = args[5].parse().expect("warmup");
+            run_req(&addr, size, iterations, warmup).await;
+        }
+        Some("inproc") => {
+            let addr = format!("inproc://{}", &args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            run_inproc_throughput(&addr, size, Duration::from_secs_f64(duration)).await;
+        }
+        Some("inproc-latency") => {
+            let addr = format!("inproc://{}", &args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let iterations: usize = args[4].parse().expect("iterations");
+            let warmup: usize = args[5].parse().expect("warmup");
+            run_inproc_latency(&addr, size, iterations, warmup).await;
+        }
+        _ => {
+            eprintln!("usage: rzmq_bench_peer push <addr> <size>");
+            eprintln!("       rzmq_bench_peer pull <addr> <size> <duration_secs>");
+            eprintln!("       rzmq_bench_peer rep <addr> <size>");
+            eprintln!("       rzmq_bench_peer req <addr> <size> <iterations> <warmup>");
+            eprintln!("       rzmq_bench_peer inproc <addr> <size> <duration_secs>");
+            eprintln!("       rzmq_bench_peer inproc-latency <addr> <size> <iters> <warmup>");
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn run_push(addr: &str, size: usize) {
+    let ctx = Context::new().expect("context");
+    let push = ctx.socket(SocketType::Push).expect("push socket");
+    push.bind(addr).await.expect("push bind");
+    let payload = leaked_payload(size);
+    loop {
+        if push.send(Msg::from_static(payload)).await.is_err() {
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
+async fn run_rep(addr: &str) {
+    let ctx = Context::new().expect("context");
+    let rep = ctx.socket(SocketType::Rep).expect("rep socket");
+    rep.bind(addr).await.expect("rep bind");
+    loop {
+        match rep.recv().await {
+            Ok(msg) => {
+                if rep.send(msg).await.is_err() {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+async fn run_req(addr: &str, size: usize, iterations: usize, warmup: usize) {
+    let ctx = Context::new().expect("context");
+    let req = ctx.socket(SocketType::Req).expect("req socket");
+    req.connect(addr).await.expect("req connect");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let payload = leaked_payload(size);
+
+    for _ in 0..warmup {
+        req.send(Msg::from_static(payload)).await.unwrap();
+        req.recv().await.unwrap();
+    }
+
+    let mut rtts: Vec<u64> = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let t = Instant::now();
+        req.send(Msg::from_static(payload)).await.unwrap();
+        req.recv().await.unwrap();
+        rtts.push(t.elapsed().as_nanos() as u64);
+    }
+    rtts.sort_unstable();
+
+    print_latency(&rtts, iterations);
+    std::process::exit(0);
+}
+
+async fn run_pull(addr: &str, size: usize, duration: Duration) {
+    let ctx = Context::new().expect("context");
+    let pull = ctx.socket(SocketType::Pull).expect("pull socket");
+    pull.connect(addr).await.expect("pull connect");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let count = Arc::new(AtomicU64::new(0));
+    let count_recv = count.clone();
+    let recv_handle = tokio::spawn(async move {
+        loop {
+            if pull.recv().await.is_err() {
+                break;
+            }
+            count_recv.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+
+    let t0 = Instant::now();
+    tokio::time::sleep(duration).await;
+    let elapsed = t0.elapsed().as_secs_f64();
+    let final_count = count.load(Ordering::Relaxed);
+    recv_handle.abort();
+
+    println!("{final_count} {elapsed:.6} {size}");
+    std::process::exit(0);
+}
+
+async fn run_inproc_throughput(addr: &str, size: usize, duration: Duration) {
+    let ctx = Context::new().expect("context");
+
+    let push = ctx.socket(SocketType::Push).expect("push socket");
+    let pull = ctx.socket(SocketType::Pull).expect("pull socket");
+
+    push.bind(addr).await.expect("push bind");
+    pull.connect(addr).await.expect("pull connect");
+
+    let count = Arc::new(AtomicU64::new(0));
+
+    let push_handle = tokio::spawn(async move {
+        let payload = leaked_payload(size);
+        loop {
+            if push.send(Msg::from_static(payload)).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let count_recv = count.clone();
+    let recv_handle = tokio::spawn(async move {
+        loop {
+            if pull.recv().await.is_err() {
+                break;
+            }
+            count_recv.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    count.store(0, Ordering::Relaxed);
+
+    let t0 = Instant::now();
+    tokio::time::sleep(duration).await;
+    let elapsed = t0.elapsed().as_secs_f64();
+    let final_count = count.load(Ordering::Relaxed);
+
+    push_handle.abort();
+    recv_handle.abort();
+
+    println!("{final_count} {elapsed:.6} {size}");
+    std::process::exit(0);
+}
+
+async fn run_inproc_latency(addr: &str, size: usize, iterations: usize, warmup: usize) {
+    let ctx = Context::new().expect("context");
+
+    let req = ctx.socket(SocketType::Req).expect("req socket");
+    let rep = ctx.socket(SocketType::Rep).expect("rep socket");
+
+    rep.bind(addr).await.expect("rep bind");
+    req.connect(addr).await.expect("req connect");
+
+    let rep_handle = tokio::spawn(async move {
+        loop {
+            match rep.recv().await {
+                Ok(msg) => {
+                    if rep.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let payload = leaked_payload(size);
+
+    for _ in 0..warmup {
+        req.send(Msg::from_static(payload)).await.unwrap();
+        req.recv().await.unwrap();
+    }
+
+    let mut rtts: Vec<u64> = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let t = Instant::now();
+        req.send(Msg::from_static(payload)).await.unwrap();
+        req.recv().await.unwrap();
+        rtts.push(t.elapsed().as_nanos() as u64);
+    }
+    rtts.sort_unstable();
+
+    rep_handle.abort();
+    print_latency(&rtts, iterations);
+    std::process::exit(0);
+}


### PR DESCRIPTION
- Add rzmq bench peer (REQ/REP latency + PUSH/PULL throughput, TCP/IPC/inproc)
- Add rzmq to comparison charts (all three transports)
- Add rzmq to `run_comparisons.py` impl registry
- Fix `capture_process` to kill child on timeout (was leaking processes)
- Was blocked on excsn/rzmq#11 (REQ socket state machine bug causing stochastic recv failures)