### PR TITLE
fuzz: bump default parser iterations to 10M, document long-run usage

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,12 +40,20 @@ OMQ_SKIP_FUZZ=1 ./scripts/test-all.sh    # skip fuzz for a faster run
 
 ## Fuzz tests
 
-~1M random iterations per suite. Off by default; enable with the
+~10M random iterations per suite. Off by default; enable with the
 `fuzz` feature. Takes a few minutes per backend.
 
 ```sh
 cargo test -p omq-compio --features fuzz
 cargo test -p omq-tokio  --features fuzz
+```
+
+For long runs (e.g. 500M iterations), build with `--release` and set
+`OMQ_FUZZ_ITERS`. Set `OMQ_FUZZ_SEED=<u64>` to reproduce a failure.
+
+```sh
+OMQ_FUZZ_ITERS=500000000 cargo test -p omq-compio --features fuzz --release -- --nocapture
+OMQ_FUZZ_ITERS=500000000 cargo test -p omq-tokio  --features fuzz --release -- --nocapture
 ```
 
 ## Soak tests
@@ -249,6 +257,12 @@ yring ──────────────┤                      │
 `omq-libzmq`, `omq-zeromq`, `pyomq`. Don't skip the small ones.
 
 ## Constraints
+
+**Backend API parity:** `omq-compio` and `omq-tokio` must expose an
+identical public `Socket` API. Adding or changing a method on one
+backend requires the same change on the other. Parity is enforced by
+`tests/coverage_matrix.rs` (both backends) and
+`omq-tokio/tests/interop_compio.rs`.
 
 **interop_compio dep constraint:** `omq-tokio/Cargo.toml`'s compio
 dev-dep must use the same git rev as `omq-compio`'s dep. Different

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ covered by integration tests on both backends. The full suite:
 
 - **600+ integration tests** across omq-compio and omq-tokio (every
   socket-type x transport x mechanism cell).
-- **Protocol fuzzing** (~1M iterations per suite): hand-rolled fuzz of
+- **Protocol fuzzing** (~10M iterations per suite): hand-rolled fuzz of
   the wire parser and the socket-action state machine.
 - **12 soak test scenarios** per backend: peer churn, reconnect storms,
   PUB/SUB churn, compression, PLAIN / CURVE / BLAKE3ZMQ auth, priority

--- a/omq-compio/tests/fuzz_parsers.rs
+++ b/omq-compio/tests/fuzz_parsers.rs
@@ -36,7 +36,7 @@ fn iters() -> usize {
     std::env::var("OMQ_FUZZ_ITERS")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(2_000_000)
+        .unwrap_or(10_000_000)
 }
 
 fn rng() -> StdRng {

--- a/omq-tokio/tests/fuzz_parsers.rs
+++ b/omq-tokio/tests/fuzz_parsers.rs
@@ -36,7 +36,7 @@ fn iters() -> usize {
     std::env::var("OMQ_FUZZ_ITERS")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(2_000_000)
+        .unwrap_or(10_000_000)
 }
 
 fn rng() -> StdRng {


### PR DESCRIPTION
- Bump default `fuzz_parsers` iterations from 2M to 10M in both omq-compio and omq-tokio
- Add `OMQ_FUZZ_ITERS` / `OMQ_FUZZ_SEED` long-run instructions to DEVELOPMENT.md
- Document backend API parity constraint in DEVELOPMENT.md
- Update README.md fuzz iteration count to match