### PR TITLE
fix: set SO_REUSEADDR on TCP listener sockets

### DIFF
--- a/omq-compio/src/transport/tcp.rs
+++ b/omq-compio/src/transport/tcp.rs
@@ -40,6 +40,7 @@ fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
     }
 }
 
+#[expect(clippy::unused_async)]
 pub async fn bind(endpoint: &Endpoint) -> Result<(TcpListener, SocketAddr)> {
     let Endpoint::Tcp { host, port } = endpoint else {
         return Err(Error::InvalidEndpoint(format!(
@@ -47,9 +48,24 @@ pub async fn bind(endpoint: &Endpoint) -> Result<(TcpListener, SocketAddr)> {
         )));
     };
     let addr = resolve_bind(host, *port)?;
-    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let listener = reuse_addr_bind(addr)?;
     let local = listener.local_addr().map_err(Error::Io)?;
     Ok((listener, local))
+}
+
+pub(crate) fn reuse_addr_bind(addr: SocketAddr) -> Result<TcpListener> {
+    let domain = if addr.is_ipv4() {
+        socket2::Domain::IPV4
+    } else {
+        socket2::Domain::IPV6
+    };
+    let sock = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))
+        .map_err(Error::Io)?;
+    sock.set_reuse_address(true).map_err(Error::Io)?;
+    sock.set_nonblocking(true).map_err(Error::Io)?;
+    sock.bind(&addr.into()).map_err(Error::Io)?;
+    sock.listen(1024).map_err(Error::Io)?;
+    TcpListener::from_std(std::net::TcpListener::from(sock)).map_err(Error::Io)
 }
 
 pub async fn connect(endpoint: &Endpoint) -> Result<TcpStream> {

--- a/omq-compio/src/transport/ws.rs
+++ b/omq-compio/src/transport/ws.rs
@@ -156,6 +156,7 @@ pub(crate) struct WsUpgraded {
     pub leftover: bytes::Bytes,
 }
 
+#[expect(clippy::unused_async)]
 pub(crate) async fn bind(
     endpoint: &Endpoint,
     tls_acceptor: Option<compio_tls::TlsAcceptor>,
@@ -169,7 +170,7 @@ pub(crate) async fn bind(
         }
     };
     let addr = resolve_bind(host, port)?;
-    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let listener = super::tcp::reuse_addr_bind(addr)?;
     let local = listener.local_addr().map_err(Error::Io)?;
     Ok(WsListener {
         inner: listener,

--- a/omq-tokio/src/transport/tcp.rs
+++ b/omq-tokio/src/transport/tcp.rs
@@ -33,7 +33,7 @@ impl Transport for TcpTransport {
             )));
         };
         let addr = resolve_bind(host, *port).await?;
-        let listener = TokioTcpListener::bind(addr).await?;
+        let listener = reuse_addr_bind(addr)?;
         let local = listener.local_addr()?;
         let bound = Endpoint::Tcp {
             host: Host::Ip(local.ip()),
@@ -77,6 +77,22 @@ impl Listener for TcpListener {
         stream.set_nodelay(true)?;
         Ok((stream, PeerIdent::Socket(peer)))
     }
+}
+
+pub(crate) fn reuse_addr_bind(addr: SocketAddr) -> Result<TokioTcpListener> {
+    let domain = if addr.is_ipv4() {
+        socket2::Domain::IPV4
+    } else {
+        socket2::Domain::IPV6
+    };
+    let sock = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+    sock.set_reuse_address(true)?;
+    sock.set_nonblocking(true)?;
+    sock.bind(&addr.into())?;
+    sock.listen(1024)?;
+    Ok(TokioTcpListener::from_std(std::net::TcpListener::from(
+        sock,
+    ))?)
 }
 
 async fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -129,7 +129,7 @@ pub(crate) async fn bind(
             .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
         _ => unreachable!(),
     };
-    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let listener = super::tcp::reuse_addr_bind(addr)?;
     let local = listener.local_addr().map_err(Error::Io)?;
     Ok(WsListener {
         inner: listener,


### PR DESCRIPTION
- Build TCP listeners via socket2 with SO_REUSEADDR before bind, matching libzmq's default
- Fixes EADDRINUSE on rapid re-binds (back-to-back benchmark runs, tests)
- Both backends (compio + tokio), TCP and WS transports
- Shared `reuse_addr_bind` helper in each backend's `transport::tcp`