### PR TITLE
fix: inproc name leak on signal_close + perf test hang

### DIFF
--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -28,7 +28,7 @@ omq-proto = { path = "../../omq-proto", default-features = false }
 omq-compio = { path = "../../omq-compio", default-features = false }
 # We need direct access to compio's runtime spawn / Runtime to host the
 # Socket registry on the compio thread.
-compio = { version = "0.19.0-rc.1", features = ["macros", "runtime", "io-uring", "time", "io", "async-fd"] }
+compio = { git = "https://github.com/compio-rs/compio.git", tag = "v0.19.0-rc.2", features = ["macros", "runtime", "io-uring", "time", "io", "async-fd"] }
 
 bytes = "1"
 libc = "0.2"

--- a/bindings/pyomq/tests/test_perf.py
+++ b/bindings/pyomq/tests/test_perf.py
@@ -22,6 +22,7 @@ def _measure_pyomq(endpoint: str, size: int, n_target_per_s: int = 200_000) -> f
     ctx = pyomq.Context()
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
+    pull.setsockopt(pyomq.RCVTIMEO, 10_000)
     pull.bind(endpoint)
     push.connect(endpoint)
 
@@ -51,6 +52,7 @@ def _measure_pyzmq(endpoint: str, size: int, n_target_per_s: int = 200_000) -> f
     ctx = zmq_pyzmq.Context.instance()
     pull = ctx.socket(zmq_pyzmq.PULL)
     push = ctx.socket(zmq_pyzmq.PUSH)
+    pull.setsockopt(zmq_pyzmq.RCVTIMEO, 10_000)
     pull.bind(endpoint)
     push.connect(endpoint)
 

--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -43,7 +43,7 @@ flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"
 concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-compio = { version = "0.19.0-rc.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync", "async-fd"] }
+compio = { git = "https://github.com/compio-rs/compio.git", tag = "v0.19.0-rc.2", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync", "async-fd"] }
 slab = "0.4"
 event-listener = "5.4.0"
 async-lock = "3.4.0"
@@ -54,7 +54,7 @@ rustls = { version = "0.23", optional = true, default-features = false, features
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-pki-types = { version = "1", optional = true }
-compio-tls = { version = "0.10.0-rc.2", optional = true, default-features = false, features = ["rustls"] }
+compio-tls = { git = "https://github.com/compio-rs/compio.git", tag = "v0.19.0-rc.2", optional = true, default-features = false, features = ["rustls"] }
 
 
 [dev-dependencies]

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -294,8 +294,17 @@ impl Socket {
     }
 
     /// Set the closed flag without draining or awaiting linger.
+    /// Also releases inproc names from the global registry so
+    /// rebinding succeeds even when the socket outlives this call.
     pub fn signal_close(&self) {
         self.inner.closed.store(true, Ordering::SeqCst);
+        let listeners = self.inner.listeners.write().expect("listeners lock");
+        for entry in listeners.iter() {
+            if let Endpoint::Inproc { name } = &entry.endpoint {
+                crate::transport::inproc::force_unbind(name);
+            }
+        }
+        drop(listeners);
     }
 
     /// Graceful close: stop accepting, drain pending sends up to linger, then shut down.

--- a/omq-compio/src/transport/inproc.rs
+++ b/omq-compio/src/transport/inproc.rs
@@ -136,6 +136,15 @@ pub fn is_bound(name: &str) -> bool {
         .contains_key(name)
 }
 
+/// Explicitly remove `name` from the registry. Used by `signal_close()`
+/// to free inproc names without waiting for the accept task to be
+/// cancelled and its `InprocListener` to be dropped.
+pub fn force_unbind(name: &str) {
+    if let Ok(mut reg) = REGISTRY.lock() {
+        reg.bound.remove(name);
+    }
+}
+
 /// Default per-socket inbound capacity (whole messages).
 pub const DEFAULT_INPROC_HWM: usize = 1024;
 

--- a/omq-compio/tests/inproc_rebind.rs
+++ b/omq-compio/tests/inproc_rebind.rs
@@ -1,0 +1,46 @@
+//! Regression: binding an inproc name, closing via `signal_close()` (the
+//! fallback path when the socket Rc has surviving refs), then rebinding
+//! the same name on a new socket must succeed.
+
+use std::time::Duration;
+
+use omq_compio::{Endpoint, Options, Socket, SocketType};
+
+fn inproc(name: &str) -> Endpoint {
+    Endpoint::Inproc { name: name.into() }
+}
+
+#[compio::test]
+async fn rebind_after_signal_close() {
+    let ep = inproc("rebind-signal-close");
+
+    let s1 = Socket::new(SocketType::Pull, Options::default());
+    s1.bind(ep.clone()).await.unwrap();
+
+    // Simulate the pyomq destroy_socket fallback: Rc::try_unwrap fails,
+    // so we call signal_close() and drop the handle without awaiting close.
+    let s1_clone = s1.clone();
+    s1.signal_close();
+    drop(s1);
+    drop(s1_clone);
+
+    // Must not fail with "inproc name already bound".
+    let s2 = Socket::new(SocketType::Pull, Options::default());
+    let bound = compio::time::timeout(Duration::from_secs(2), s2.bind(ep)).await;
+    bound.expect("bind timed out").expect("rebind failed");
+    s2.close().await.unwrap();
+}
+
+#[compio::test]
+async fn rebind_after_graceful_close() {
+    let ep = inproc("rebind-graceful-close");
+
+    let s1 = Socket::new(SocketType::Pull, Options::default());
+    s1.bind(ep.clone()).await.unwrap();
+    s1.close().await.unwrap();
+
+    let s2 = Socket::new(SocketType::Pull, Options::default());
+    let bound = compio::time::timeout(Duration::from_secs(2), s2.bind(ep)).await;
+    bound.expect("bind timed out").expect("rebind failed");
+    s2.close().await.unwrap();
+}

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 omq-compio = { path = "../omq-compio", version = "0.12.0", features = ["plain", "curve", "lz4", "zstd"] }
 yring = { path = "../yring", version = "0.2.2" }
-compio = { version = "0.19.0-rc.1", features = ["runtime"] }
+compio = { git = "https://github.com/compio-rs/compio.git", tag = "v0.19.0-rc.2", features = ["runtime"] }
 bytes = "1.11.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -60,7 +60,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 # Cross-runtime interop tests drive a compio backend on a dedicated
 # thread while the tokio backend runs in the test's own runtime.
 omq-compio = { path = "../omq-compio", default-features = false, features = ["ws"] }
-compio = { version = "0.19.0-rc.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
+compio = { git = "https://github.com/compio-rs/compio.git", tag = "v0.19.0-rc.2", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 
 [[bin]]
 name = "bench_peer_tokio"

--- a/omq-tokio/tests/inproc_rebind.rs
+++ b/omq-tokio/tests/inproc_rebind.rs
@@ -1,0 +1,41 @@
+//! Verify that dropping a socket releases its inproc name so a new
+//! socket can rebind the same name.
+
+use std::time::Duration;
+
+use omq_tokio::{Endpoint, Options, Socket, SocketType};
+
+fn inproc(name: &str) -> Endpoint {
+    Endpoint::Inproc { name: name.into() }
+}
+
+#[tokio::test]
+async fn rebind_after_close() {
+    let ep = inproc("tokio-rebind-close");
+
+    let s1 = Socket::new(SocketType::Pull, Options::default());
+    s1.bind(ep.clone()).await.unwrap();
+    s1.close().await.unwrap();
+
+    let s2 = Socket::new(SocketType::Pull, Options::default());
+    let bound = tokio::time::timeout(Duration::from_secs(2), s2.bind(ep)).await;
+    bound.expect("bind timed out").expect("rebind failed");
+    s2.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn rebind_after_drop() {
+    let ep = inproc("tokio-rebind-drop");
+
+    let s1 = Socket::new(SocketType::Pull, Options::default());
+    s1.bind(ep.clone()).await.unwrap();
+    drop(s1);
+
+    // Give the actor a moment to run teardown.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let s2 = Socket::new(SocketType::Pull, Options::default());
+    let bound = tokio::time::timeout(Duration::from_secs(2), s2.bind(ep)).await;
+    bound.expect("bind timed out").expect("rebind failed");
+    s2.close().await.unwrap();
+}


### PR DESCRIPTION
- Add RCVTIMEO (10s) to pyomq throughput test PULL sockets so tests fail with an error instead of blocking forever when message flow stalls (native recv holds the GIL, blocking Ctrl-C)
- Fix inproc name leak: `signal_close()` now calls `force_unbind()` for each inproc listener, freeing names from the global registry immediately rather than relying on async task cancellation cascading to `InprocListener::drop`
- Add regression tests for inproc rebind in both omq-compio and omq-tokio