### PR TITLE
Pre-peer message staging and test race fixes

### DIFF
--- a/omq-compio/tests/interop_ruby.rs
+++ b/omq-compio/tests/interop_ruby.rs
@@ -7,7 +7,6 @@
 //! compio runtime can keep driving the Rust socket while Ruby runs.
 
 use std::io::Write;
-use std::net::TcpListener as StdTcpListener;
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::time::Duration;
 
@@ -89,25 +88,6 @@ async fn wait_status(mut child: Child) -> ExitStatus {
     await_blocking(move || child.wait().expect("wait")).await
 }
 
-#[derive(Clone, Debug)]
-struct Transport {
-    rust: Endpoint,
-    cli: String,
-}
-
-fn tcp_transport() -> Transport {
-    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
-    let port = listener.local_addr().unwrap().port();
-    drop(listener);
-    Transport {
-        rust: Endpoint::Tcp {
-            host: Host::Ip("127.0.0.1".parse().unwrap()),
-            port,
-        },
-        cli: format!("tcp://127.0.0.1:{port}"),
-    }
-}
-
 fn tcp_endpoint_port_zero() -> Endpoint {
     Endpoint::Tcp {
         host: Host::Ip("127.0.0.1".parse().unwrap()),
@@ -123,7 +103,7 @@ fn cli_addr(sock: &Socket) -> String {
     }
 }
 
-fn ipc_transport(name: &str) -> Transport {
+fn ipc_endpoint(name: &str) -> Endpoint {
     let path = std::env::temp_dir().join(format!(
         "omq-compio-interop-{name}-{}-{}.sock",
         std::process::id(),
@@ -133,11 +113,7 @@ fn ipc_transport(name: &str) -> Transport {
             .as_nanos()
     ));
     let _ = std::fs::remove_file(&path);
-    let cli = format!("ipc://{}", path.display());
-    Transport {
-        rust: Endpoint::Ipc(IpcPath::Filesystem(path)),
-        cli,
-    }
+    Endpoint::Ipc(IpcPath::Filesystem(path))
 }
 
 async fn wait_for_handshake(sock: &Socket) {
@@ -204,7 +180,7 @@ async fn rust_push_to_ruby_pull_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    rust_push_to_ruby_pull(ipc_transport("push-pull").rust).await;
+    rust_push_to_ruby_pull(ipc_endpoint("push-pull")).await;
 }
 
 async fn ruby_push_to_rust_pull(ep: Endpoint) {
@@ -256,25 +232,27 @@ async fn ruby_push_to_rust_pull_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    ruby_push_to_rust_pull(ipc_transport("push-pull-rev").rust).await;
+    ruby_push_to_rust_pull(ipc_endpoint("push-pull-rev")).await;
 }
 
 // =====================================================================
 // REQ / REP
 // =====================================================================
 
-async fn rust_req_to_ruby_rep(t: Transport) {
+async fn rust_req_to_ruby_rep(ep: Endpoint) {
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.bind(ep).await.unwrap();
+    let cli = cli_addr(&req);
+
     let mut guard = ChildGuard::new(
         Command::new("omq")
-            .args(["rep", "-b", &t.cli, "--echo", "-n", "3"])
+            .args(["rep", "-c", &cli, "--echo", "-n", "3"])
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
             .expect("spawn omq rep"),
     );
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(t.rust).await.unwrap();
     wait_for_handshake(&req).await;
 
     for i in 0..3 {
@@ -296,7 +274,7 @@ async fn rust_req_to_ruby_rep_tcp() {
     if skip_if_no_omq() {
         return;
     }
-    rust_req_to_ruby_rep(tcp_transport()).await;
+    rust_req_to_ruby_rep(tcp_endpoint_port_zero()).await;
 }
 
 #[compio::test]
@@ -304,7 +282,7 @@ async fn rust_req_to_ruby_rep_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    rust_req_to_ruby_rep(ipc_transport("req-rep")).await;
+    rust_req_to_ruby_rep(ipc_endpoint("req-rep")).await;
 }
 
 // =====================================================================
@@ -361,7 +339,7 @@ async fn rust_pub_to_ruby_sub_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    rust_pub_to_ruby_sub(ipc_transport("pub-sub").rust).await;
+    rust_pub_to_ruby_sub(ipc_endpoint("pub-sub")).await;
 }
 
 // =====================================================================
@@ -417,7 +395,7 @@ async fn rust_router_sees_ruby_dealer_identity_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    rust_router_sees_ruby_dealer_identity(ipc_transport("router-dealer").rust).await;
+    rust_router_sees_ruby_dealer_identity(ipc_endpoint("router-dealer")).await;
 }
 
 // =====================================================================
@@ -477,5 +455,5 @@ async fn rust_radio_to_ruby_dish_ipc() {
     if skip_if_no_omq() {
         return;
     }
-    rust_radio_to_ruby_dish(ipc_transport("radio-dish").rust).await;
+    rust_radio_to_ruby_dish(ipc_endpoint("radio-dish")).await;
 }

--- a/omq-compio/tests/push_pull.rs
+++ b/omq-compio/tests/push_pull.rs
@@ -216,7 +216,6 @@ async fn push_pull_under_backpressure_delivers_everything() {
 }
 
 #[compio::test]
-#[ignore = "pre-peer queueing not implemented: PUSH uses per-peer queues, so send blocks until a peer arrives. libzmq buffers up to HWM in a socket-wide queue."]
 async fn push_send_before_peer_connects_queues() {
     let ep = inproc_ep("pp-before-peer");
 

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -33,8 +33,10 @@
 //! how the test suite synchronises on this.
 
 #[cfg(feature = "priority")]
+use std::collections::VecDeque;
+#[cfg(feature = "priority")]
 use std::sync::{
-    Arc, RwLock,
+    Arc, Mutex, RwLock,
     atomic::{AtomicUsize, Ordering},
 };
 
@@ -47,6 +49,8 @@ use crate::engine::DriverHandle;
 use omq_proto::error::Error;
 use omq_proto::error::Result;
 use omq_proto::message::Message;
+#[cfg(feature = "priority")]
+use omq_proto::options::OnMute;
 use omq_proto::options::Options;
 
 #[cfg(not(feature = "priority"))]
@@ -152,11 +156,21 @@ struct PriorityPeer {
 }
 
 #[cfg(feature = "priority")]
+enum PriorityOutcome {
+    Sent,
+    AwaitOn(DriverHandle),
+    NoLivePeers,
+}
+
+#[cfg(feature = "priority")]
 #[derive(Clone)]
 pub(crate) struct Submitter {
     peers: Arc<RwLock<Arc<Vec<PriorityPeer>>>>,
     rr_index: Arc<AtomicUsize>,
     on_change: Arc<tokio::sync::Notify>,
+    staging: Arc<Mutex<VecDeque<Message>>>,
+    hwm: usize,
+    on_mute: OnMute,
 }
 
 #[cfg(feature = "priority")]
@@ -168,80 +182,114 @@ impl std::fmt::Debug for Submitter {
 
 #[cfg(feature = "priority")]
 impl Submitter {
-    /// Walk peers in priority order; `try_send` on each peer's driver
-    /// inbox. Returns Ok on first success.
-    ///
-    /// **Strict precedence:** within each tier, attempt every peer
-    /// (round-robin start). On any `Ok`, return `Sent`. If every peer
-    /// in this tier is `Full` (queues saturated, peers alive), back-
-    /// pressure on the first `Full` peer in this tier — never fall
-    /// through to a lower-priority tier when the higher tier is alive
-    /// but back-pressured. Only when every peer in a tier is `Closed`
-    /// do we advance to the next tier. If every peer at every tier is
-    /// `Closed` (or no peers at all), wait for a peer-set change
-    /// notification and retry.
     pub(crate) async fn send(&self, msg: Message) -> Result<()> {
+        self.drain_staging().await;
+
         loop {
-            let snapshot = self.peers.read().expect("peers lock").clone();
-            if snapshot.is_empty() {
-                let waiter = self.on_change.notified();
-                if !self.peers.read().expect("peers lock").is_empty() {
+            match self.try_send_priority_walk(&msg) {
+                PriorityOutcome::Sent => return Ok(()),
+                PriorityOutcome::AwaitOn(h) => {
+                    return h
+                        .inbox
+                        .send(DriverCommand::SendMessage(msg))
+                        .await
+                        .map_err(|_| Error::Closed);
+                }
+                PriorityOutcome::NoLivePeers => {
+                    let staged = {
+                        let mut buf = self.staging.lock().expect("staging lock");
+                        if buf.len() < self.hwm {
+                            buf.push_back(msg);
+                            return Ok(());
+                        }
+                        match self.on_mute {
+                            OnMute::DropNewest => return Ok(()),
+                            OnMute::DropOldest => {
+                                let _ = buf.pop_front();
+                                buf.push_back(msg);
+                                return Ok(());
+                            }
+                            OnMute::Block => false,
+                            _ => unreachable!(),
+                        }
+                    };
+                    if !staged {
+                        let waiter = self.on_change.notified();
+                        if self.has_live_peer() {
+                            continue;
+                        }
+                        waiter.await;
+                        self.drain_staging().await;
+                    }
+                }
+            }
+        }
+    }
+
+    fn try_send_priority_walk(&self, msg: &Message) -> PriorityOutcome {
+        let snapshot = self.peers.read().expect("peers lock").clone();
+        if snapshot.is_empty() {
+            return PriorityOutcome::NoLivePeers;
+        }
+        let rr = self.rr_index.fetch_add(1, Ordering::Relaxed);
+        let mut tier_back_pressure: Option<DriverHandle> = None;
+        let mut i = 0;
+        while i < snapshot.len() {
+            let prio = snapshot[i].priority;
+            let mut j = i;
+            while j < snapshot.len() && snapshot[j].priority == prio {
+                j += 1;
+            }
+            let tier_size = j - i;
+            let offset = rr % tier_size;
+            let mut tier_full: Option<DriverHandle> = None;
+            let mut tier_has_alive = false;
+            for k in 0..tier_size {
+                let peer = &snapshot[i + (offset + k) % tier_size];
+                if peer.handle.cancel.is_cancelled() {
                     continue;
                 }
-                waiter.await;
-                continue;
-            }
-            let rr = self.rr_index.fetch_add(1, Ordering::Relaxed);
-            let mut tier_back_pressure: Option<DriverHandle> = None;
-            let mut i = 0;
-            while i < snapshot.len() {
-                let prio = snapshot[i].priority;
-                let mut j = i;
-                while j < snapshot.len() && snapshot[j].priority == prio {
-                    j += 1;
-                }
-                let tier_size = j - i;
-                let offset = rr % tier_size;
-                let mut tier_full: Option<DriverHandle> = None;
-                let mut tier_has_alive = false;
-                for k in 0..tier_size {
-                    let peer = &snapshot[i + (offset + k) % tier_size];
-                    if peer.handle.cancel.is_cancelled() {
-                        continue;
-                    }
-                    match peer
-                        .handle
-                        .inbox
-                        .try_send(DriverCommand::SendMessage(msg.clone()))
-                    {
-                        Ok(()) => return Ok(()),
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                            tier_has_alive = true;
-                            if tier_full.is_none() {
-                                tier_full = Some(peer.handle.clone());
-                            }
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
-                    }
-                }
-                if tier_has_alive {
-                    tier_back_pressure = tier_full;
-                    break;
-                }
-                i = j;
-            }
-            if let Some(h) = tier_back_pressure {
-                return h
+                match peer
+                    .handle
                     .inbox
-                    .send(DriverCommand::SendMessage(msg))
-                    .await
-                    .map_err(|_| Error::Closed);
+                    .try_send(DriverCommand::SendMessage(msg.clone()))
+                {
+                    Ok(()) => return PriorityOutcome::Sent,
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        tier_has_alive = true;
+                        if tier_full.is_none() {
+                            tier_full = Some(peer.handle.clone());
+                        }
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+                }
             }
-            let waiter = self.on_change.notified();
-            if self.has_live_peer() {
-                continue;
+            if tier_has_alive {
+                tier_back_pressure = tier_full;
+                break;
             }
-            waiter.await;
+            i = j;
+        }
+        match tier_back_pressure {
+            Some(h) => PriorityOutcome::AwaitOn(h),
+            None => PriorityOutcome::NoLivePeers,
+        }
+    }
+
+    async fn drain_staging(&self) {
+        loop {
+            let queued = self.staging.lock().expect("staging lock").pop_front();
+            let Some(msg) = queued else { return };
+            match self.try_send_priority_walk(&msg) {
+                PriorityOutcome::Sent => {}
+                PriorityOutcome::AwaitOn(h) => {
+                    let _ = h.inbox.send(DriverCommand::SendMessage(msg)).await;
+                }
+                PriorityOutcome::NoLivePeers => {
+                    self.staging.lock().expect("staging lock").push_front(msg);
+                    return;
+                }
+            }
         }
     }
 
@@ -260,16 +308,23 @@ pub(crate) struct RoundRobinSend {
     peers: Arc<RwLock<Arc<Vec<PriorityPeer>>>>,
     rr_index: Arc<AtomicUsize>,
     on_change: Arc<tokio::sync::Notify>,
+    staging: Arc<Mutex<VecDeque<Message>>>,
+    hwm: usize,
+    on_mute: OnMute,
     root_cancel: CancellationToken,
 }
 
 #[cfg(feature = "priority")]
 impl RoundRobinSend {
-    pub(crate) fn new(_options: &Options) -> Self {
+    pub(crate) fn new(options: &Options) -> Self {
+        let (hwm, on_mute) = super::effective_queue_params(options);
         Self {
             peers: Arc::new(RwLock::new(Arc::new(Vec::new()))),
             rr_index: Arc::new(AtomicUsize::new(0)),
             on_change: Arc::new(tokio::sync::Notify::new()),
+            staging: Arc::new(Mutex::new(VecDeque::new())),
+            hwm,
+            on_mute,
             root_cancel: CancellationToken::new(),
         }
     }
@@ -279,6 +334,7 @@ impl RoundRobinSend {
         self.connection_added_with_priority(peer_id, handle, omq_proto::DEFAULT_PRIORITY);
     }
 
+    #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn connection_added_with_priority(
         &mut self,
         peer_id: u64,
@@ -290,11 +346,30 @@ impl RoundRobinSend {
         new_peers.push(PriorityPeer {
             peer_id,
             priority,
-            handle,
+            handle: handle.clone(),
         });
         new_peers.sort_by_key(|p| p.priority);
         *guard = Arc::new(new_peers);
         drop(guard);
+
+        let mut buf = self.staging.lock().expect("staging lock");
+        while let Some(msg) = buf.pop_front() {
+            match handle.inbox.try_send(DriverCommand::SendMessage(msg)) {
+                Ok(()) => {}
+                Err(
+                    tokio::sync::mpsc::error::TrySendError::Full(cmd)
+                    | tokio::sync::mpsc::error::TrySendError::Closed(cmd),
+                ) => {
+                    let DriverCommand::SendMessage(msg) = cmd else {
+                        unreachable!()
+                    };
+                    buf.push_front(msg);
+                    break;
+                }
+            }
+        }
+        drop(buf);
+
         self.on_change.notify_waiters();
     }
 
@@ -315,6 +390,9 @@ impl RoundRobinSend {
             peers: self.peers.clone(),
             rr_index: self.rr_index.clone(),
             on_change: self.on_change.clone(),
+            staging: self.staging.clone(),
+            hwm: self.hwm,
+            on_mute: self.on_mute,
         }
     }
 
@@ -322,13 +400,7 @@ impl RoundRobinSend {
         self.root_cancel.cancel();
     }
 
-    /// In priority mode the "queue" lives in the per-peer driver
-    /// inboxes - `is_drained` tells the socket driver "all sends have
-    /// been dispatched"; once we've handed each `SendMessage` off to
-    /// an inbox via `try_send/send`, it's the connection driver's job
-    /// to flush, not ours.
-    #[expect(clippy::unused_self)]
     pub(crate) fn is_drained(&self) -> bool {
-        true
+        self.staging.lock().expect("staging lock").is_empty()
     }
 }

--- a/omq-tokio/tests/interop_ruby.rs
+++ b/omq-tokio/tests/interop_ruby.rs
@@ -10,7 +10,6 @@
 //! Avoids fixed Ruby-boot sleeps so the suite stays fast.
 
 use std::io::Write;
-use std::net::TcpListener as StdTcpListener;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
@@ -94,26 +93,19 @@ struct Transport {
     cli: String,
 }
 
-/// Ephemeral TCP transport with a pre-reserved port. Used only when
-/// Ruby binds (REQ/REP test). Rust-bind tests use `bind_tcp` instead
-/// to avoid the bind-drop-rebind TOCTOU race.
 fn tcp_transport() -> Transport {
-    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
-    let port = listener.local_addr().unwrap().port();
-    drop(listener);
     Transport {
         rust: Endpoint::Tcp {
             host: Host::Ip("127.0.0.1".parse().unwrap()),
-            port,
+            port: 0,
         },
-        cli: format!("tcp://127.0.0.1:{port}"),
+        cli: String::new(),
     }
 }
 
 /// Bind the Rust socket and return the CLI endpoint string. For TCP,
-/// binds port 0 and reads the kernel-assigned port from the monitor
-/// to avoid the TOCTOU race in `tcp_transport()`. For IPC, binds
-/// directly and returns `t.cli`.
+/// binds port 0 and reads the kernel-assigned port from the monitor.
+/// For IPC, binds directly and returns `t.cli`.
 async fn bind_tcp_or_ipc(sock: &Socket, t: &Transport) -> String {
     if matches!(&t.rust, Endpoint::Tcp { .. }) {
         let mut mon = sock.monitor();
@@ -288,17 +280,18 @@ async fn ruby_push_to_rust_pull_ipc() {
 // ---------------------------------------------------------------------
 
 async fn rust_req_to_ruby_rep(t: Transport) {
+    let req = Socket::new(SocketType::Req, Options::default());
+    let cli = bind_tcp_or_ipc(&req, &t).await;
+
     let mut guard = ChildGuard::new(
         Command::new("omq")
-            .args(["rep", "-b", &t.cli, "--echo", "-n", "3"])
+            .args(["rep", "-c", &cli, "--echo", "-n", "3"])
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
             .expect("spawn omq rep"),
     );
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(t.rust.clone()).await.unwrap();
     wait_for_handshake(&req).await;
 
     for i in 0..3 {

--- a/omq-tokio/tests/lz4_tcp.rs
+++ b/omq-tokio/tests/lz4_tcp.rs
@@ -15,6 +15,21 @@ use rand::Rng;
 
 /// Bind an `lz4+tcp://` Pull socket to an ephemeral port and return both
 /// the socket and the discovered loopback endpoint.
+async fn wait_for_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("handshake did not arrive within 5s");
+}
+
 async fn pull_on_loopback() -> (Socket, Endpoint) {
     let pull = Socket::new(SocketType::Pull, Options::default());
     let mut mon = pull.monitor();
@@ -241,6 +256,7 @@ async fn many_messages_in_a_row() {
     let (pull, ep) = pull_on_loopback().await;
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(ep).await.unwrap();
+    wait_for_handshake(&pull).await;
 
     for i in 0..N {
         push.send(Message::single(format!("m-{i}"))).await.unwrap();

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -221,7 +221,6 @@ async fn push_pull_under_backpressure_delivers_everything() {
 }
 
 #[tokio::test]
-#[ignore = "pre-peer queueing not implemented: PUSH uses per-peer queues, so send blocks until a peer arrives. libzmq buffers up to HWM in a socket-wide queue."]
 async fn push_send_before_peer_connects_queues() {
     // Publish messages before any PULL exists; they should accumulate in the
     // socket's shared queue and flush once a peer comes online.

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -19,6 +19,21 @@ fn make_test_dict(seed: &[u8]) -> Bytes {
     train_zdict(&samples, 8 * 1024).expect("train_zdict")
 }
 
+async fn wait_for_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("handshake did not arrive within 5s");
+}
+
 async fn pull_on_loopback() -> (Socket, Endpoint) {
     let pull = Socket::new(SocketType::Pull, Options::default());
     let mut mon = pull.monitor();
@@ -238,6 +253,7 @@ async fn many_messages_in_a_row() {
     let (pull, ep) = pull_on_loopback().await;
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(ep).await.unwrap();
+    wait_for_handshake(&pull).await;
 
     for i in 0..N {
         push.send(Message::single(format!("m-{i}"))).await.unwrap();
@@ -315,6 +331,7 @@ async fn auto_train_survives_reconnect() {
             Options::default().linger(Duration::from_secs(4)),
         );
         push.connect(ep.clone()).await.unwrap();
+        wait_for_handshake(&pull).await;
         for i in 0..FIRST {
             push.send(Message::single(make_payload(i))).await.unwrap();
         }
@@ -330,6 +347,7 @@ async fn auto_train_survives_reconnect() {
             Options::default().linger(Duration::from_secs(2)),
         );
         push.connect(ep.clone()).await.unwrap();
+        wait_for_handshake(&pull).await;
         for i in 0..SECOND {
             push.send(Message::single(make_payload(i))).await.unwrap();
         }


### PR DESCRIPTION
- Priority-mode PUSH now buffers messages in a staging VecDeque when no peers are connected, matching default mode and omq-compio behavior. Drains on peer arrival and at the top of every send().
- Un-ignore `push_send_before_peer_connects_queues` in both backends.
- Fix interop_ruby REQ/REP race: flip to Rust-binds/Ruby-connects so tests don't race Ruby startup.
- Fix lz4_tcp and zstd_tcp flaky tests: add handshake synchronization before send bursts (`many_messages_in_a_row`, `auto_train_survives_reconnect`).
- Clean up dead `Transport`/`tcp_transport` code in compio interop tests.