### PR TITLE
use random 1 B–8 KiB payloads in peer_churn soak test

### DIFF
--- a/omq-compio/tests/soak_peer_churn.rs
+++ b/omq-compio/tests/soak_peer_churn.rs
@@ -53,9 +53,11 @@ fn soak_peer_churn() {
 
                 // Send a burst. Short timeout: if HWM is full, move on to drain.
                 for _ in 0..100 {
+                    let len = rng.random_range(1..=8192);
+                    let payload = vec![0xABu8; len];
                     if let Ok(Ok(())) = compio::time::timeout(
                         Duration::from_millis(1),
-                        push.send(Message::single("soak")),
+                        push.send(Message::single(payload)),
                     )
                     .await
                     {

--- a/omq-tokio/tests/soak_peer_churn.rs
+++ b/omq-tokio/tests/soak_peer_churn.rs
@@ -44,9 +44,11 @@ fn soak_peer_churn() {
             }
 
             for _ in 0..100 {
+                let len = rng.random_range(1..=8192);
+                let payload = vec![0xABu8; len];
                 if let Ok(Ok(())) = tokio::time::timeout(
                     Duration::from_millis(1),
-                    push.send(Message::single("soak")),
+                    push.send(Message::single(payload)),
                 )
                 .await
                 {


### PR DESCRIPTION
- Replace fixed 4-byte `"soak"` message with random 1 B–8 KiB payloads
- Exercises allocator and codec paths under peer churn more realistically
- Both backends pass 5-minute soak with no leaks