### PR TITLE
rewrite compression offload pool, fix encode_msg errors, bump bench defaults

### DIFF
--- a/omq-compio/benches/common/mod.rs
+++ b/omq-compio/benches/common/mod.rs
@@ -29,16 +29,30 @@ pub(crate) const DEFAULT_TRANSPORTS: &[&str] = &["inproc", "ipc", "tcp"];
 pub(crate) const PRIME_ITERS: usize = 2_000;
 pub(crate) const PRIME_BUDGET: Duration = Duration::from_millis(500);
 pub(crate) const WARMUP_DURATION: Duration = Duration::from_millis(100);
-pub(crate) const DEFAULT_ROUND_DURATION: Duration = Duration::from_millis(500);
+pub(crate) const DEFAULT_ROUND_DURATION: Duration = Duration::from_secs(2);
 pub(crate) const DEFAULT_ROUNDS: usize = 3;
+pub(crate) const QUICK_ROUND_DURATION: Duration = Duration::from_millis(1500);
+pub(crate) const QUICK_ROUNDS: usize = 1;
+
+fn is_quick() -> bool {
+    std::env::var("OMQ_BENCH_QUICK").is_ok_and(|v| v == "1")
+}
 
 /// Per-round timed budget. Override with `OMQ_BENCH_ROUND_MS` for
-/// longer rounds (overnight, less-noisy runs).
+/// longer rounds (overnight, less-noisy runs). `OMQ_BENCH_QUICK=1`
+/// reduces to 1.5 s rounds, 1 round.
 pub(crate) fn round_duration() -> Duration {
     std::env::var("OMQ_BENCH_ROUND_MS")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
-        .map_or(DEFAULT_ROUND_DURATION, Duration::from_millis)
+        .map_or(
+            if is_quick() {
+                QUICK_ROUND_DURATION
+            } else {
+                DEFAULT_ROUND_DURATION
+            },
+            Duration::from_millis,
+        )
 }
 
 /// Number of timed rounds per cell. Override with `OMQ_BENCH_ROUNDS`.
@@ -47,7 +61,11 @@ pub(crate) fn rounds() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|&n: &usize| n > 0)
-        .unwrap_or(DEFAULT_ROUNDS)
+        .unwrap_or(if is_quick() {
+            QUICK_ROUNDS
+        } else {
+            DEFAULT_ROUNDS
+        })
 }
 
 /// Hard ceiling per cell — a hang guard, not a tight bound. The 30s

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -291,14 +291,19 @@ impl Connection {
             our_props = our_props.with_identity(self.config.identity.clone());
         }
         let mut cmds = Vec::new();
-        self.mechanism
+        if self
+            .mechanism
             .start(
                 &mut cmds,
                 our_props,
                 &self.our_greeting,
                 &self.peer_greeting,
             )
-            .expect("mechanism start failed");
+            .is_err()
+        {
+            self.state = State::Closed;
+            return;
+        }
         self.write_outbound_commands(&cmds);
     }
 

--- a/omq-proto/src/proto/frame.rs
+++ b/omq-proto/src/proto/frame.rs
@@ -301,7 +301,9 @@ pub(crate) fn peek_frame_header(buf: &ChunkedInputBuf) -> Result<Option<PeekedFr
             return Ok(None);
         };
         let size = u64::from_be_bytes(hdr[1..].try_into().expect("8 bytes"));
-        (MAX_FRAME_HEADER_LEN, size as usize)
+        let payload_len = usize::try_from(size)
+            .map_err(|_| Error::Protocol(format!("frame size {size} exceeds platform usize")))?;
+        (MAX_FRAME_HEADER_LEN, payload_len)
     } else {
         let Some(hdr) = buf.peek_array::<2>() else {
             return Ok(None);

--- a/omq-proto/src/proto/transform/lz4.rs
+++ b/omq-proto/src/proto/transform/lz4.rs
@@ -80,46 +80,6 @@ unsafe extern "C" {
     fn LZ4_resetStream(stream: *mut lz4_sys::LZ4StreamEncode);
 }
 
-/// Owning wrapper around an LZ4 compression stream. The raw stream is
-/// mutable working state (hash tables, history); the dict and level
-/// are applied per-encode, so a bare stream is codec-agnostic and
-/// reusable across connections.
-pub struct Lz4Stream(*mut lz4_sys::LZ4StreamEncode);
-
-impl std::fmt::Debug for Lz4Stream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Lz4Stream").finish_non_exhaustive()
-    }
-}
-
-unsafe impl Send for Lz4Stream {}
-
-impl Default for Lz4Stream {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Lz4Stream {
-    pub fn new() -> Self {
-        Self(unsafe { lz4_sys::LZ4_createStream() })
-    }
-
-    fn into_raw(self) -> *mut lz4_sys::LZ4StreamEncode {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
-impl Drop for Lz4Stream {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe { lz4_sys::LZ4_freeStream(self.0) };
-        }
-    }
-}
-
 /// Send-side per-connection LZ4 state.
 pub struct Lz4Encoder {
     /// Outbound dict, validated at construction. Shipped on the first
@@ -248,37 +208,30 @@ impl Lz4Encoder {
         }
     }
 
-    /// True when this encoder has completed any one-time setup (dict
-    /// shipping) and offloading encode work to a background thread is safe.
+    /// True when no dict shipment is pending and offloading is safe.
     pub fn can_offload(&self) -> bool {
         self.send_dict.is_none() || self.send_dict_shipped
     }
 
-    /// Build an offload encoder from a borrowed [`Lz4Stream`]. The
-    /// returned encoder shares this encoder's config (dict, thresholds)
-    /// but has `send_dict_shipped = true` so it never re-ships the dict.
-    /// Call [`take_stream`] on the result to reclaim the stream for the
-    /// pool after encoding.
+    /// Create a pool encoder with the same config but its own stream.
+    /// The returned encoder has `send_dict_shipped = true` (never
+    /// re-ships the dict) and a lazy-initialized stream.
     #[must_use]
-    pub fn with_borrowed_stream(&self, stream: Lz4Stream) -> Self {
+    pub fn new_offload(&self) -> Self {
         Self {
             send_dict: self.send_dict.clone(),
             send_dict_shipped: true,
             max_message_size: self.max_message_size,
             block_size: self.block_size,
             out_buf: Vec::new(),
-            stream: stream.into_raw(),
+            stream: std::ptr::null_mut(),
             threshold_override: self.threshold_override,
         }
     }
 
-    /// Consume this encoder and return the raw stream for pool return.
-    #[must_use]
-    pub fn take_stream(mut self) -> Lz4Stream {
-        let ptr = self.stream;
-        self.stream = std::ptr::null_mut();
-        Lz4Stream(ptr)
-    }
+    /// Update dict from the primary encoder. No-op for LZ4 (dict is
+    /// static, configured at construction).
+    pub fn sync_dict(&mut self, _primary: &Self) {}
 
     pub fn encode(&mut self, msg: &Message) -> Result<TransformedOut> {
         let mut out: TransformedOut = SmallVec::new();
@@ -1001,5 +954,55 @@ mod tests {
         let mut dec = test_dec().with_max_message_size(Some(TEST_BLOCK));
         let err = dec.decode(wire.into_iter().next().unwrap()).unwrap_err();
         assert!(matches!(err, Error::MessageTooLarge { .. }));
+    }
+
+    #[test]
+    fn new_offload_copies_config() {
+        let dict = Bytes::from_static(b"some-dict-bytes-here");
+        let primary = Lz4Encoder::with_send_dict(dict.clone())
+            .unwrap()
+            .with_block_size(TEST_BLOCK)
+            .with_threshold(256);
+        let offload = primary.new_offload();
+        assert_eq!(offload.send_dict.as_ref().unwrap(), &dict);
+        assert!(offload.send_dict_shipped);
+        assert_eq!(offload.block_size, TEST_BLOCK);
+        assert_eq!(offload.threshold_override, Some(256));
+        assert!(offload.stream.is_null());
+    }
+
+    #[test]
+    fn new_offload_roundtrip_with_dict() {
+        let dict = Bytes::from(vec![b'q'; 256]);
+        let plain = vec![b'q'; 4096];
+        let msg = Message::single(plain.clone());
+
+        let mut primary = Lz4Encoder::with_send_dict(dict).unwrap();
+        let first_wire = primary.encode(&Message::single("warmup")).unwrap();
+        assert_eq!(first_wire.len(), 2, "first send ships dict + payload");
+
+        let mut dec = Lz4Decoder::new();
+        let consumed = dec.decode(first_wire[0].clone()).unwrap();
+        assert!(consumed.is_none(), "dict shipment consumed silently");
+
+        let mut offload = primary.new_offload();
+        let wire = offload.encode(&msg).unwrap();
+        assert_eq!(wire.len(), 1, "offload encoder must not re-ship dict");
+
+        let out = dec
+            .decode(wire.into_iter().next().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(out.part_bytes(0).unwrap().to_vec(), plain);
+    }
+
+    #[test]
+    fn sync_dict_is_noop() {
+        let dict = Bytes::from_static(b"some-dict-bytes-here");
+        let primary = Lz4Encoder::with_send_dict(dict.clone()).unwrap();
+        let mut offload = primary.new_offload();
+        let ptr_before = offload.send_dict.as_ref().unwrap().as_ptr();
+        offload.sync_dict(&primary);
+        assert_eq!(offload.send_dict.as_ref().unwrap().as_ptr(), ptr_before);
     }
 }

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -26,11 +26,9 @@ pub mod lz4;
 pub mod zstd;
 
 #[cfg(feature = "lz4")]
-pub use lz4::{Lz4Decoder, Lz4Encoder, Lz4Stream};
+pub use lz4::{Lz4Decoder, Lz4Encoder};
 #[cfg(feature = "zstd")]
 pub use zstd::{ZstdDecoder, ZstdEncoder, train_zdict};
-#[cfg(feature = "zstd")]
-pub use zstd_safe::CCtx as ZstdCCtx;
 
 use smallvec::SmallVec;
 
@@ -158,8 +156,7 @@ impl MessageEncoder {
         }
     }
 
-    /// True when dict shipping and auto-train are complete and
-    /// compression can be offloaded to a background thread.
+    /// True when no dict shipment is pending and offloading is safe.
     pub fn can_offload(&self) -> bool {
         match self {
             #[cfg(feature = "lz4")]
@@ -168,6 +165,42 @@ impl MessageEncoder {
             Self::Zstd(t) => t.can_offload(),
             #[cfg(not(any(feature = "lz4", feature = "zstd")))]
             _ => unreachable!(),
+        }
+    }
+
+    /// Create a pool encoder with the same config but its own context.
+    #[must_use]
+    pub fn new_offload(&self) -> Self {
+        match self {
+            #[cfg(feature = "lz4")]
+            Self::Lz4(t) => Self::Lz4(t.new_offload()),
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => Self::Zstd(t.new_offload()),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
+            _ => unreachable!(),
+        }
+    }
+
+    /// Update dict from the primary encoder if it changed.
+    pub fn sync_dict(&mut self, primary: &Self) {
+        match (self, primary) {
+            #[cfg(feature = "lz4")]
+            (Self::Lz4(me), Self::Lz4(p)) => me.sync_dict(p),
+            #[cfg(feature = "zstd")]
+            (Self::Zstd(me), Self::Zstd(p)) => me.sync_dict(p),
+            _ => {}
+        }
+    }
+
+    /// True if both encoders are the same compression variant.
+    pub fn variant_matches(&self, other: &Self) -> bool {
+        #[allow(unreachable_patterns)]
+        match (self, other) {
+            #[cfg(feature = "lz4")]
+            (Self::Lz4(_), Self::Lz4(_)) => true,
+            #[cfg(feature = "zstd")]
+            (Self::Zstd(_), Self::Zstd(_)) => true,
+            _ => false,
         }
     }
 }

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -183,6 +183,7 @@ impl MessageEncoder {
 
     /// Update dict from the primary encoder if it changed.
     pub fn sync_dict(&mut self, primary: &Self) {
+        #[allow(unreachable_patterns)]
         match (self, primary) {
             #[cfg(feature = "lz4")]
             (Self::Lz4(me), Self::Lz4(p)) => me.sync_dict(p),

--- a/omq-proto/src/proto/transform/zstd.rs
+++ b/omq-proto/src/proto/transform/zstd.rs
@@ -243,26 +243,23 @@ impl ZstdEncoder {
         self
     }
 
-    /// True when this encoder has completed any one-time setup (dict
-    /// shipping, auto-train) and offloading encode work is safe.
+    /// True when no dict shipment is pending and offloading is safe.
     pub fn can_offload(&self) -> bool {
-        let dict_ready = self.send_dict.is_none() || self.send_dict_shipped;
-        let train_done = self.train.is_none();
-        dict_ready && train_done
+        self.send_dict.is_none() || self.send_dict_shipped
     }
 
-    /// Build an offload encoder from a borrowed [`CCtx`]. The returned
-    /// encoder shares this encoder's config (dict, level, thresholds)
-    /// but has `send_dict_shipped = true` and no auto-train state.
-    /// Call [`take_cctx`] on the result to reclaim the `CCtx` for the pool.
+    /// Create a pool encoder with the same config but its own `CCtx`.
+    /// The returned encoder has `send_dict_shipped = true` (never
+    /// re-ships the dict), no auto-train state, and a fresh `CCtx`
+    /// that will be configured lazily on first `encode_part`.
     #[must_use]
-    pub fn with_borrowed_cctx(&self, cctx: CCtx<'static>) -> Self {
+    pub fn new_offload(&self) -> Self {
         Self {
             send_dict: self.send_dict.clone(),
             send_dict_shipped: true,
             max_message_size: self.max_message_size,
             level: self.level,
-            cctx,
+            cctx: CCtx::create(),
             cctx_configured: false,
             train: None,
             out_buf: Vec::new(),
@@ -271,10 +268,19 @@ impl ZstdEncoder {
         }
     }
 
-    /// Consume this encoder and return the raw `CCtx` for pool return.
-    #[must_use]
-    pub fn take_cctx(self) -> CCtx<'static> {
-        self.cctx
+    /// Update dict from the primary encoder. If the primary's dict
+    /// changed (e.g. after auto-train), update ours and force
+    /// `CCtx` reconfiguration on the next encode.
+    pub fn sync_dict(&mut self, primary: &Self) {
+        let same = match (&self.send_dict, &primary.send_dict) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.as_ptr() == b.as_ptr(),
+            _ => false,
+        };
+        if !same {
+            self.send_dict.clone_from(&primary.send_dict);
+            self.cctx_configured = false;
+        }
     }
 
     pub fn encode(&mut self, msg: &Message) -> Result<TransformedOut> {
@@ -755,5 +761,54 @@ mod tests {
         let dict = trained_dict();
         let enc = ZstdEncoder::with_send_dict(dict).unwrap().with_auto_train();
         assert!(enc.train.is_none(), "static dict should disable auto-train");
+    }
+
+    #[test]
+    fn can_offload_true_during_auto_train() {
+        let enc = ZstdEncoder::new().with_auto_train();
+        assert!(enc.train.is_some());
+        assert!(enc.can_offload(), "send_dict is None so offloading is safe");
+    }
+
+    #[test]
+    fn new_offload_copies_config() {
+        let enc = ZstdEncoder::new().with_auto_train().with_level(-1);
+        let offload = enc.new_offload();
+        assert!(offload.send_dict_shipped);
+        assert!(offload.train.is_none());
+        assert!(!offload.cctx_configured);
+        assert_eq!(offload.level, -1);
+    }
+
+    #[test]
+    fn sync_dict_detects_change() {
+        let mut primary = ZstdEncoder::new().with_auto_train();
+        let sample = br#"{"event":"login","user":"alice","ip":"10.0.0.1","ok":true}"#;
+        for _ in 0..2000 {
+            let _ = primary.encode(&Message::single(sample.as_slice())).unwrap();
+            if primary.send_dict.is_some() {
+                break;
+            }
+        }
+        assert!(
+            primary.send_dict.is_some(),
+            "auto-train must produce a dict"
+        );
+
+        let mut offload = ZstdEncoder::new().new_offload();
+        assert!(offload.send_dict.is_none());
+        offload.sync_dict(&primary);
+        assert!(offload.send_dict.is_some());
+        assert!(!offload.cctx_configured);
+    }
+
+    #[test]
+    fn sync_dict_noop_when_same() {
+        let dict = trained_dict();
+        let primary = ZstdEncoder::with_send_dict(dict).unwrap();
+        let mut offload = primary.new_offload();
+        offload.cctx_configured = true;
+        offload.sync_dict(&primary);
+        assert!(offload.cctx_configured, "same dict must not reset cctx");
     }
 }

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -48,14 +48,27 @@ pub(crate) const WARMUP_DURATION: Duration = Duration::from_millis(100);
 /// across rounds (= peak throughput, closest to the hardware ceiling).
 /// Override via env for longer overnight runs (`OMQ_BENCH_ROUND_MS`,
 /// `OMQ_BENCH_ROUNDS`).
-pub(crate) const DEFAULT_ROUND_DURATION: Duration = Duration::from_millis(500);
+pub(crate) const DEFAULT_ROUND_DURATION: Duration = Duration::from_secs(2);
 pub(crate) const DEFAULT_ROUNDS: usize = 3;
+pub(crate) const QUICK_ROUND_DURATION: Duration = Duration::from_millis(1500);
+pub(crate) const QUICK_ROUNDS: usize = 1;
+
+fn is_quick() -> bool {
+    std::env::var("OMQ_BENCH_QUICK").is_ok_and(|v| v == "1")
+}
 
 pub(crate) fn round_duration() -> Duration {
     std::env::var("OMQ_BENCH_ROUND_MS")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
-        .map_or(DEFAULT_ROUND_DURATION, Duration::from_millis)
+        .map_or(
+            if is_quick() {
+                QUICK_ROUND_DURATION
+            } else {
+                DEFAULT_ROUND_DURATION
+            },
+            Duration::from_millis,
+        )
 }
 
 pub(crate) fn rounds() -> usize {
@@ -63,7 +76,11 @@ pub(crate) fn rounds() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|&n: &usize| n > 0)
-        .unwrap_or(DEFAULT_ROUNDS)
+        .unwrap_or(if is_quick() {
+            QUICK_ROUNDS
+        } else {
+            DEFAULT_ROUNDS
+        })
 }
 
 /// Hard ceiling per cell — a hang guard, not a tight bound. The 30s

--- a/omq-tokio/src/engine/compression_pool.rs
+++ b/omq-tokio/src/engine/compression_pool.rs
@@ -1,33 +1,16 @@
-#[cfg(any(feature = "lz4", feature = "zstd"))]
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use omq_proto::proto::transform::MessageEncoder;
 
-#[cfg(feature = "lz4")]
-use omq_proto::proto::transform::Lz4Stream;
-#[cfg(feature = "zstd")]
-use omq_proto::proto::transform::ZstdCCtx;
-
-/// Variant tag so the pool knows which sub-pool to return a context to.
-/// `Inline` is used for small messages that were encoded on the submitting
-/// thread without borrowing a pool context.
-pub(crate) enum RawCtx {
-    Inline,
-    #[cfg(feature = "lz4")]
-    Lz4(Lz4Stream),
-    #[cfg(feature = "zstd")]
-    Zstd(ZstdCCtx<'static>),
-}
-
-/// Runtime-global pool of reusable compression contexts, shared across
+/// Runtime-global pool of reusable compression encoders, shared across
 /// all connections on a socket. Sized to `available_parallelism()`.
+///
+/// Encoders keep their warm `out_buf` and configured compression
+/// context across borrows, avoiding per-message allocation.
 pub(crate) struct CompressionPool {
-    #[cfg(feature = "lz4")]
-    lz4: Mutex<Vec<Lz4Stream>>,
-    #[cfg(feature = "zstd")]
-    zstd: Mutex<Vec<ZstdCCtx<'static>>>,
-    outstanding: AtomicUsize,
+    encoders: Mutex<Vec<MessageEncoder>>,
+    in_flight: AtomicUsize,
     cap: usize,
 }
 
@@ -35,7 +18,7 @@ impl std::fmt::Debug for CompressionPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CompressionPool")
             .field("cap", &self.cap)
-            .field("outstanding", &self.outstanding.load(Ordering::Relaxed))
+            .field("in_flight", &self.in_flight.load(Ordering::Relaxed))
             .finish_non_exhaustive()
     }
 }
@@ -44,64 +27,37 @@ impl CompressionPool {
     pub(crate) fn new() -> Self {
         let cap = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
         Self {
-            #[cfg(feature = "lz4")]
-            lz4: Mutex::new(Vec::new()),
-            #[cfg(feature = "zstd")]
-            zstd: Mutex::new(Vec::new()),
-            outstanding: AtomicUsize::new(0),
+            encoders: Mutex::new(Vec::new()),
+            in_flight: AtomicUsize::new(0),
             cap,
         }
     }
 
-    /// Try to acquire a raw compression context matching the encoder's
-    /// variant. Returns `None` if the pool is at capacity (all contexts
-    /// are in flight). New contexts are created on demand up to `cap`.
-    #[allow(unused_variables, clippy::unused_self, dead_code)]
-    pub(crate) fn try_take(&self, encoder: &MessageEncoder) -> Option<RawCtx> {
-        match encoder {
-            #[cfg(feature = "lz4")]
-            MessageEncoder::Lz4(_) => {
-                if let Some(s) = self.lz4.lock().unwrap().pop() {
-                    self.outstanding.fetch_add(1, Ordering::Relaxed);
-                    return Some(RawCtx::Lz4(s));
-                }
-                if self.outstanding.load(Ordering::Relaxed) < self.cap {
-                    self.outstanding.fetch_add(1, Ordering::Relaxed);
-                    return Some(RawCtx::Lz4(Lz4Stream::new()));
-                }
-                None
+    /// Borrow a pool encoder matching the primary's variant, syncing
+    /// its dict state. Returns `None` when all `cap` encoders are
+    /// in flight. New encoders are created on demand up to `cap`.
+    #[allow(dead_code)]
+    pub(crate) fn try_take(&self, primary: &MessageEncoder) -> Option<MessageEncoder> {
+        {
+            let mut pool = self.encoders.lock().unwrap();
+            if let Some(pos) = pool.iter().position(|e| e.variant_matches(primary)) {
+                let mut enc = pool.swap_remove(pos);
+                drop(pool);
+                self.in_flight.fetch_add(1, Ordering::Relaxed);
+                enc.sync_dict(primary);
+                return Some(enc);
             }
-            #[cfg(feature = "zstd")]
-            MessageEncoder::Zstd(_) => {
-                if let Some(c) = self.zstd.lock().unwrap().pop() {
-                    self.outstanding.fetch_add(1, Ordering::Relaxed);
-                    return Some(RawCtx::Zstd(c));
-                }
-                if self.outstanding.load(Ordering::Relaxed) < self.cap {
-                    self.outstanding.fetch_add(1, Ordering::Relaxed);
-                    return Some(RawCtx::Zstd(ZstdCCtx::create()));
-                }
-                None
-            }
-            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
-            _ => None,
         }
+        let prev = self.in_flight.fetch_add(1, Ordering::Relaxed);
+        if prev >= self.cap {
+            self.in_flight.fetch_sub(1, Ordering::Relaxed);
+            return None;
+        }
+        Some(MessageEncoder::new_offload(primary))
     }
 
-    #[allow(clippy::needless_pass_by_value, clippy::unused_self)]
-    pub(crate) fn put(&self, ctx: RawCtx) {
-        match ctx {
-            RawCtx::Inline => {}
-            #[cfg(feature = "lz4")]
-            RawCtx::Lz4(s) => {
-                self.lz4.lock().unwrap().push(s);
-                self.outstanding.fetch_sub(1, Ordering::Relaxed);
-            }
-            #[cfg(feature = "zstd")]
-            RawCtx::Zstd(c) => {
-                self.zstd.lock().unwrap().push(c);
-                self.outstanding.fetch_sub(1, Ordering::Relaxed);
-            }
-        }
+    pub(crate) fn put(&self, enc: MessageEncoder) {
+        self.encoders.lock().unwrap().push(enc);
+        self.in_flight.fetch_sub(1, Ordering::Relaxed);
     }
 }

--- a/omq-tokio/src/engine/compression_pool.rs
+++ b/omq-tokio/src/engine/compression_pool.rs
@@ -36,7 +36,7 @@ impl CompressionPool {
     /// Borrow a pool encoder matching the primary's variant, syncing
     /// its dict state. Returns `None` when all `cap` encoders are
     /// in flight. New encoders are created on demand up to `cap`.
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code, unused_mut, unused_variables)]
     pub(crate) fn try_take(&self, primary: &MessageEncoder) -> Option<MessageEncoder> {
         {
             let mut pool = self.encoders.lock().unwrap();
@@ -56,6 +56,7 @@ impl CompressionPool {
         Some(MessageEncoder::new_offload(primary))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn put(&self, enc: MessageEncoder) {
         self.encoders.lock().unwrap().push(enc);
         self.in_flight.fetch_sub(1, Ordering::Relaxed);

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -48,7 +48,7 @@ macro_rules! batch_encode_flush {
                 $pipeline,
             );
         } else {
-            encode_msg(&$first, $encoder, $codec, $eq, $passthrough);
+            encode_msg(&$first, $encoder, $codec, $eq, $passthrough)?;
         }
         let mut count = 1usize;
         let mut bytes = $first.byte_len();
@@ -65,7 +65,7 @@ macro_rules! batch_encode_flush {
                             $pipeline,
                         );
                     } else {
-                        encode_msg(&next, $encoder, $codec, $eq, $passthrough);
+                        encode_msg(&next, $encoder, $codec, $eq, $passthrough)?;
                     }
                     count += 1;
                 }
@@ -439,7 +439,7 @@ where
                             &mut codec,
                             &mut eq,
                             passthrough.as_ref(),
-                        );
+                        )?;
                         n += 1;
                     }
                     if n > 0 {
@@ -690,7 +690,7 @@ async fn drain_on_cancel<W: AsyncWrite + Unpin>(
     while let Ok(cmd) = inbox.try_recv() {
         match cmd {
             DriverCommand::SendMessage(msg) => {
-                encode_msg(&msg, encoder, codec, eq, passthrough);
+                encode_msg(&msg, encoder, codec, eq, passthrough).ok();
             }
             DriverCommand::SendCommand(c) => {
                 let _ = codec.send_command(&c);
@@ -701,7 +701,7 @@ async fn drain_on_cancel<W: AsyncWrite + Unpin>(
     if let Some(rx) = shared_msg_rx {
         let mut drained = 0usize;
         while let Some(msg) = rx.try_pop() {
-            encode_msg(&msg, encoder, codec, eq, passthrough);
+            encode_msg(&msg, encoder, codec, eq, passthrough).ok();
             drained += 1;
         }
         rx.release_permits(drained);
@@ -832,7 +832,7 @@ fn encode_msg(
     codec: &mut Connection,
     eq: &mut EncodedQueue,
     passthrough: Option<&(Bytes, usize)>,
-) {
+) -> Result<()> {
     #[cfg(feature = "ws")]
     if codec.is_ws() && !codec.has_frame_transform() {
         let masked = matches!(
@@ -840,29 +840,30 @@ fn encode_msg(
             Some(omq_proto::proto::connection::WsRole::Client)
         );
         eq.encode_ws(msg, masked);
-        return;
+        return Ok(());
     }
     if codec.has_frame_transform() {
         if let Some(enc) = encoder.as_mut() {
-            for wire in enc.encode(msg).unwrap_or_default() {
-                let _ = codec.send_message(&wire);
+            for wire in enc.encode(msg)? {
+                codec.send_message(&wire)?;
             }
         } else {
-            let _ = codec.send_message(msg);
+            codec.send_message(msg)?;
         }
-        return;
+        return Ok(());
     }
     if let Some((sentinel, threshold)) = passthrough
         && msg.iter().all(|b| b.len() < *threshold)
     {
         eq.encode_prefixed_auto(sentinel, msg);
     } else if let Some(enc) = encoder.as_mut() {
-        for wire in enc.encode(msg).unwrap_or_default() {
+        for wire in enc.encode(msg)? {
             eq.encode_auto(&wire);
         }
     } else {
         eq.encode_auto(msg);
     }
+    Ok(())
 }
 
 /// Flush the `EncodedQueue` to the writer. Drains chunks into a
@@ -1058,14 +1059,14 @@ async fn run_direct_io_continuation<R: AsyncRead + Unpin>(
                         return Ok(());
                     }
                     Some(first) => {
-                        encode_msg(&first, encoder, codec, eq, passthrough);
+                        encode_msg(&first, encoder, codec, eq, passthrough)?;
                         let mut count = 1usize;
                         let mut bytes = first.byte_len();
                         while count < SHARED_MAX_BATCH_MSGS && bytes < max_batch_bytes() {
                             match shared_msg_rx.and_then(QueueReceiver::try_pop) {
                                 Some(next) => {
                                     bytes += next.byte_len();
-                                    encode_msg(&next, encoder, codec, eq, passthrough);
+                                    encode_msg(&next, encoder, codec, eq, passthrough)?;
                                     count += 1;
                                 }
                                 None => break,
@@ -1104,14 +1105,14 @@ async fn run_direct_io_continuation<R: AsyncRead + Unpin>(
 
             cmd = inbox.recv() => match cmd {
                 Some(DriverCommand::SendMessage(first)) => {
-                    encode_msg(&first, encoder, codec, eq, passthrough);
+                    encode_msg(&first, encoder, codec, eq, passthrough)?;
                     let mut count = 1usize;
                     let mut bytes = first.byte_len();
                     while count < SHARED_MAX_BATCH_MSGS && bytes < max_batch_bytes() {
                         match inbox.try_recv() {
                             Ok(DriverCommand::SendMessage(m)) => {
                                 bytes += m.byte_len();
-                                encode_msg(&m, encoder, codec, eq, passthrough);
+                                encode_msg(&m, encoder, codec, eq, passthrough)?;
                                 count += 1;
                             }
                             Ok(DriverCommand::SendCommand(c)) => {

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -18,7 +18,7 @@ use omq_proto::message::Message;
 use omq_proto::proto::transform::{MessageDecoder, MessageEncoder, TransformedOut};
 use omq_proto::proto::{Command, Connection, Event};
 
-use super::compression_pool::{CompressionPool, RawCtx};
+use super::compression_pool::CompressionPool;
 use super::direct_io::{DirectIo, SharedWriter};
 use crate::routing::drop_queue::QueueReceiver;
 use omq_proto::encoded_queue::EncodedQueue;
@@ -554,11 +554,11 @@ where
                 }
 
                 // Drain completed offloaded compressions and flush.
-                Some((raw, frames)) = async {
+                Some((pool_enc, frames)) = async {
                     use futures::StreamExt;
                     offload_pipeline.next().await
                 }, if !offload_pipeline.is_empty() => {
-                    drain_offload_result(raw, frames, compression_pool.as_ref(), &mut eq)?;
+                    drain_offload_result(pool_enc, frames, compression_pool.as_ref(), &mut eq)?;
                     flush_encoded_queue(&mut writer, &mut eq, &mut drain_buf).await?;
                     while codec.has_pending_transmit() {
                         flush_once(&mut writer, &mut codec).await?;
@@ -745,12 +745,17 @@ async fn handle_large_messages<R: AsyncRead + Unpin>(
 }
 
 type OffloadPipeline = FuturesOrdered<
-    std::pin::Pin<Box<dyn std::future::Future<Output = (RawCtx, Result<TransformedOut>)> + Send>>,
+    std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = (Option<MessageEncoder>, Result<TransformedOut>)>
+                + Send,
+        >,
+    >,
 >;
 
 /// Submit one message to the offload pipeline. Large messages (above
-/// `threshold`) get `spawn_blocking`; small messages are encoded inline
-/// on the driver thread and wrapped in `ready()`.
+/// `threshold`) get `spawn_blocking` via a pool encoder; small messages
+/// and pool-exhausted fallbacks are encoded inline on the driver thread.
 #[allow(unused_variables)]
 fn submit_to_pipeline(
     msg: &Message,
@@ -761,25 +766,26 @@ fn submit_to_pipeline(
 ) {
     #[cfg(any(feature = "lz4", feature = "zstd"))]
     if msg.byte_len() >= threshold
-        && let Some(raw) = pool.try_take(encoder)
+        && let Some(mut pool_enc) = pool.try_take(encoder)
     {
         let msg = msg.clone();
-        let mut offload_enc = build_offload_encoder(encoder, raw);
         let handle = tokio::task::spawn_blocking(move || {
-            let result = offload_enc.encode(&msg);
-            let raw = reclaim_raw_ctx(offload_enc);
-            (raw, result)
+            let result = pool_enc.encode(&msg);
+            (Some(pool_enc), result)
         });
         pipeline.push_back(Box::pin(async move {
-            handle.await.expect("offload task panicked")
+            match handle.await {
+                Ok(pair) => pair,
+                Err(_) => (
+                    None,
+                    Err(Error::Protocol("compression offload task panicked".into())),
+                ),
+            }
         }));
         return;
     }
-    let frames = encoder.encode(msg).unwrap_or_default();
-    pipeline.push_back(Box::pin(futures::future::ready((
-        RawCtx::Inline,
-        Ok(frames),
-    ))));
+    let result = encoder.encode(msg);
+    pipeline.push_back(Box::pin(futures::future::ready((None, result))));
 }
 
 /// Drain all completed futures from the pipeline into `EncodedQueue`.
@@ -789,46 +795,20 @@ async fn drain_pipeline(
     eq: &mut EncodedQueue,
 ) -> Result<()> {
     use futures::StreamExt;
-    while let Some((raw, frames)) = pipeline.next().await {
-        drain_offload_result(raw, frames, pool, eq)?;
+    while let Some((pool_enc, frames)) = pipeline.next().await {
+        drain_offload_result(pool_enc, frames, pool, eq)?;
     }
     Ok(())
 }
 
-#[cfg(any(feature = "lz4", feature = "zstd"))]
-fn build_offload_encoder(primary: &MessageEncoder, raw: RawCtx) -> MessageEncoder {
-    match (primary, raw) {
-        #[cfg(feature = "lz4")]
-        (MessageEncoder::Lz4(enc), RawCtx::Lz4(stream)) => {
-            MessageEncoder::Lz4(enc.with_borrowed_stream(stream))
-        }
-        #[cfg(feature = "zstd")]
-        (MessageEncoder::Zstd(enc), RawCtx::Zstd(cctx)) => {
-            MessageEncoder::Zstd(enc.with_borrowed_cctx(cctx))
-        }
-        _ => unreachable!("encoder/ctx variant mismatch"),
-    }
-}
-
-#[cfg(any(feature = "lz4", feature = "zstd"))]
-fn reclaim_raw_ctx(enc: MessageEncoder) -> RawCtx {
-    match enc {
-        #[cfg(feature = "lz4")]
-        MessageEncoder::Lz4(e) => RawCtx::Lz4(e.take_stream()),
-        #[cfg(feature = "zstd")]
-        MessageEncoder::Zstd(e) => RawCtx::Zstd(e.take_cctx()),
-    }
-}
-
-/// Write completed offloaded frames into the `EncodedQueue`.
 fn drain_offload_result(
-    raw: RawCtx,
+    pool_enc: Option<MessageEncoder>,
     frames: Result<TransformedOut>,
     pool: Option<&Arc<CompressionPool>>,
     eq: &mut EncodedQueue,
 ) -> Result<()> {
-    if let Some(pool) = pool {
-        pool.put(raw);
+    if let (Some(enc), Some(pool)) = (pool_enc, pool) {
+        pool.put(enc);
     }
     for wire in frames? {
         eq.encode_auto(&wire);

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -17,6 +17,7 @@ Usage:
 
 import argparse
 import json
+import os
 import re
 import signal
 import subprocess
@@ -33,7 +34,10 @@ FULL_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
 QUICK_SIZES = [32, 1024, 4096]
 TABLE_SIZES = [32, 1024, 4096]
 
-DURATION = 2
+DEFAULT_DURATION = float(os.environ.get("OMQ_BENCH_DURATION", "2.0"))
+QUICK_DURATION = 1.5
+DEFAULT_ROUNDS = int(os.environ.get("OMQ_BENCH_ROUNDS", "3"))
+QUICK_ROUNDS = 1
 LATENCY_ITERATIONS = 5_000
 LATENCY_WARMUP = 500
 LATENCY_TIMEOUT = 15
@@ -218,9 +222,25 @@ def parse_latency(output: str) -> dict | None:
 def run_throughput_cell(
     binary: str, transport: str, addr: str, size: int,
     inproc_subcmd: str = "inproc",
+    duration: float = DEFAULT_DURATION,
+    rounds: int = DEFAULT_ROUNDS,
 ) -> dict | None:
+    best = None
+    for _ in range(rounds):
+        result = _run_throughput_once(binary, transport, addr, size,
+                                      inproc_subcmd, duration)
+        if result and (best is None or result["msgs_s"] > best["msgs_s"]):
+            best = result
+    return best
+
+
+def _run_throughput_once(
+    binary: str, transport: str, addr: str, size: int,
+    inproc_subcmd: str, duration: float,
+) -> dict | None:
+    dur = str(duration)
     if transport == "inproc":
-        output = capture_process(binary, inproc_subcmd, addr, str(size), str(DURATION))
+        output = capture_process(binary, inproc_subcmd, addr, str(size), dur)
         return parse_throughput(output, size)
 
     push = spawn_process(binary, "push", addr, str(size))
@@ -229,7 +249,7 @@ def run_throughput_cell(
         print(f"WARNING: push died (rc={push.returncode}) for {binary} {addr}", file=sys.stderr)
         return None
     try:
-        output = capture_process(binary, "pull", addr, str(size), str(DURATION))
+        output = capture_process(binary, "pull", addr, str(size), dur)
     finally:
         kill_process(push)
     return parse_throughput(output, size)
@@ -571,6 +591,8 @@ def run_benchmarks(
     run_latency: bool,
     base_port: int,
     run_id: str,
+    duration: float = DEFAULT_DURATION,
+    rounds: int = DEFAULT_ROUNDS,
     latency_iterations: int = LATENCY_ITERATIONS,
     latency_warmup: int = LATENCY_WARMUP,
     latency_timeout: int = LATENCY_TIMEOUT,
@@ -596,7 +618,8 @@ def run_benchmarks(
                 addr = addr_for(transport, prefix, idx, base_port)
                 subcmd = impl_def.get("inproc_tput_subcmd", "inproc")
                 result = run_throughput_cell(binary, transport, addr, size,
-                                            inproc_subcmd=subcmd)
+                                            inproc_subcmd=subcmd,
+                                            duration=duration, rounds=rounds)
                 cells[name] = result
                 if result:
                     append_jsonl({
@@ -677,7 +700,15 @@ def main():
     )
     parser.add_argument(
         "--quick-run", action="store_true",
-        help="3 sizes (32B, 1KiB, 4KiB) instead of full 13-size sweep",
+        help=f"3 sizes, {QUICK_ROUNDS} round of {QUICK_DURATION}s (unless overridden)",
+    )
+    parser.add_argument(
+        "--duration", type=float, default=None,
+        help=f"seconds per throughput round (default: {DEFAULT_DURATION}, quick: {QUICK_DURATION})",
+    )
+    parser.add_argument(
+        "--rounds", type=int, default=None,
+        help=f"throughput rounds per cell, best-of-N (default: {DEFAULT_ROUNDS}, quick: {QUICK_ROUNDS})",
     )
     parser.add_argument(
         "--no-latency", action="store_true",
@@ -711,6 +742,12 @@ def main():
 
     transports = args.transport or ["tcp", "inproc", "ipc"]
     sizes = QUICK_SIZES if args.quick_run else FULL_SIZES
+    if args.quick_run:
+        duration = args.duration if args.duration is not None else QUICK_DURATION
+        rounds = args.rounds if args.rounds is not None else QUICK_ROUNDS
+    else:
+        duration = args.duration if args.duration is not None else DEFAULT_DURATION
+        rounds = args.rounds if args.rounds is not None else DEFAULT_ROUNDS
     run_id = args.id or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
     run_latency = not args.no_latency
     ws_needed = "ws" in transports
@@ -731,6 +768,7 @@ def main():
     print(" vs ".join(versions), file=sys.stderr)
 
     run_benchmarks(binaries, transports, sizes, run_latency, args.base_port, run_id,
+                   duration=duration, rounds=rounds,
                    latency_iterations=args.latency_iterations,
                    latency_warmup=args.latency_warmup,
                    latency_timeout=args.latency_timeout)


### PR DESCRIPTION
- `CompressionPool` stores `MessageEncoder` directly instead of raw `CCtx`/`Lz4Stream`. Pool encoders keep warm `out_buf` and configured compression context across borrows, eliminating per-message allocation, dict cloning, and `CCtx` reconfiguration.
- `Lz4Encoder`/`ZstdEncoder`: add `new_offload`/`sync_dict`, remove `with_borrowed_stream`/`take_stream`/`with_borrowed_cctx`/`take_cctx` and `Lz4Stream`/`ZstdCCtx` re-exports.
- Fix `ZstdEncoder::can_offload` to not block on auto-train: offloading works from message #1 when `send_dict` is `None`.
- Fix TOCTOU race in pool cap enforcement via `fetch_add` + check + undo.
- Fix silent message loss: `encode_msg` returns `Result<()>` instead of swallowing errors via `unwrap_or_default()` and `let _ = codec.send_message()`.
- Fix panic in `Connection::init_ws_mode`: set `State::Closed` on mechanism start failure instead of `.expect()`.
- Fix `spawn_blocking` panic crashing the driver: handle `JoinError` gracefully.
- Fix `u64 as usize` truncation in `frame.rs` on 32-bit platforms.
- Bump bench defaults from 500 ms/3 rounds to 2 s/3 rounds. Add `--quick-run` to `run_comparisons.py` (1 round, 1.5 s) and `OMQ_BENCH_QUICK=1` to cargo bench harnesses.