### PR TITLE
fix stale identity_to_slot after driver exit; add 47 reconnect tests

### DIFF
--- a/omq-compio/src/socket/dial.rs
+++ b/omq-compio/src/socket/dial.rs
@@ -270,6 +270,18 @@ async fn dial_supervisor<F, Fut>(
         )
         .await;
 
+        // Driver exited (peer disconnected). Clear stale identity
+        // entries so send_identity_routed doesn't route into the dead
+        // channel. Without this, PEER/ROUTER/SERVER sends get
+        // Err(Closed) instead of silently dropping until reconnect.
+        if let Some(idx) = slot_idx {
+            inner
+                .identity_to_slot
+                .write()
+                .expect("identity table")
+                .retain(|_, &mut v| v != idx);
+        }
+
         if inner.closed.load(Ordering::SeqCst) || matches!(policy, ReconnectPolicy::Disabled) {
             break;
         }

--- a/omq-compio/tests/connect_before_bind.rs
+++ b/omq-compio/tests/connect_before_bind.rs
@@ -547,6 +547,8 @@ async fn req_rep_connect_before_bind_zstd() {
 }
 
 // -- ws ----------------------------------------------------------------------
+// TODO: WS connect is fire-and-forget (no dial_supervisor retry loop), so
+// these fail until WS gets a reconnect supervisor like TCP/IPC have.
 
 #[cfg(feature = "ws")]
 fn ws_ep(port: u16) -> Endpoint {
@@ -555,18 +557,21 @@ fn ws_ep(port: u16) -> Endpoint {
 
 #[cfg(feature = "ws")]
 #[compio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn push_pull_connect_before_bind_ws() {
     push_pull_connect_before_bind(ws_ep(free_tcp_port())).await;
 }
 
 #[cfg(feature = "ws")]
 #[compio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn req_rep_connect_before_bind_ws() {
     req_rep_connect_before_bind(ws_ep(free_tcp_port())).await;
 }
 
 #[cfg(feature = "ws")]
 #[compio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn pub_sub_connect_before_bind_ws() {
     pub_sub_connect_before_bind(ws_ep(free_tcp_port())).await;
 }

--- a/omq-compio/tests/connect_before_bind.rs
+++ b/omq-compio/tests/connect_before_bind.rs
@@ -1,10 +1,10 @@
 //! Connect-before-bind: the dialer connects before the listener binds.
 //! The dialer must retry until the listener appears, then deliver messages.
-//! Tested across inproc, IPC, TCP, lz4+tcp, and zstd+tcp for PUSH/PULL,
-//! REQ/REP, and PAIR.
+//! Tested across inproc, IPC, and TCP for every socket-type pair.
 
 use std::time::Duration;
 
+use bytes::Bytes;
 use omq_compio::endpoint::IpcPath;
 use omq_compio::{Endpoint, Message, Options, ReconnectPolicy, Socket, SocketType};
 
@@ -181,6 +181,343 @@ async fn pair_connect_before_bind_tcp() {
     pair_connect_before_bind(tcp_ep(free_tcp_port())).await;
 }
 
+// -- PUB/SUB -----------------------------------------------------------------
+
+async fn pub_sub_connect_before_bind(ep: Endpoint) {
+    let sub = Socket::new(SocketType::Sub, opts());
+    sub.subscribe("x.").await.unwrap();
+    sub.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep).await.unwrap();
+
+    // Probe until the subscription propagates.
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.hit")).await.unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"x.hit"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "subscription never propagated"
+        );
+    }
+
+    pub_.send(Message::single("y.miss")).await.unwrap();
+    pub_.send(Message::single("x.second")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, sub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"x.second"[..]);
+}
+
+#[compio::test]
+async fn pub_sub_connect_before_bind_inproc() {
+    pub_sub_connect_before_bind(inproc_ep("cbb-ps-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn pub_sub_connect_before_bind_ipc() {
+    pub_sub_connect_before_bind(ipc_ep("cbb-ps-comp")).await;
+}
+
+#[compio::test]
+async fn pub_sub_connect_before_bind_tcp() {
+    pub_sub_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- DEALER/ROUTER -----------------------------------------------------------
+
+async fn dealer_router_connect_before_bind(ep: Endpoint) {
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        opts().identity(Bytes::from_static(b"d1")),
+    );
+    dealer.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let router = Socket::new(SocketType::Router, Options::default());
+    router.bind(ep).await.unwrap();
+
+    dealer.send(Message::single("hello")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+
+    router
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"world"),
+        ]))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"world"[..]);
+}
+
+#[compio::test]
+async fn dealer_router_connect_before_bind_inproc() {
+    dealer_router_connect_before_bind(inproc_ep("cbb-dr-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn dealer_router_connect_before_bind_ipc() {
+    dealer_router_connect_before_bind(ipc_ep("cbb-dr-comp")).await;
+}
+
+#[compio::test]
+async fn dealer_router_connect_before_bind_tcp() {
+    dealer_router_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- CLIENT/SERVER -----------------------------------------------------------
+
+async fn client_server_connect_before_bind(ep: Endpoint) {
+    let client = Socket::new(
+        SocketType::Client,
+        opts().identity(Bytes::from_static(b"c1")),
+    );
+    client.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let server = Socket::new(SocketType::Server, Options::default());
+    server.bind(ep).await.unwrap();
+
+    client.send(Message::single("ping")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+
+    server
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong"),
+        ]))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"pong"[..]);
+}
+
+#[compio::test]
+async fn client_server_connect_before_bind_inproc() {
+    client_server_connect_before_bind(inproc_ep("cbb-cs-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn client_server_connect_before_bind_ipc() {
+    client_server_connect_before_bind(ipc_ep("cbb-cs-comp")).await;
+}
+
+#[compio::test]
+async fn client_server_connect_before_bind_tcp() {
+    client_server_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- SCATTER/GATHER ----------------------------------------------------------
+
+async fn scatter_gather_connect_before_bind(ep: Endpoint) {
+    let scatter = Socket::new(SocketType::Scatter, opts());
+    scatter.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    gather.bind(ep).await.unwrap();
+
+    scatter.send(Message::single("late")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+}
+
+#[compio::test]
+async fn scatter_gather_connect_before_bind_inproc() {
+    scatter_gather_connect_before_bind(inproc_ep("cbb-sg-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn scatter_gather_connect_before_bind_ipc() {
+    scatter_gather_connect_before_bind(ipc_ep("cbb-sg-comp")).await;
+}
+
+#[compio::test]
+async fn scatter_gather_connect_before_bind_tcp() {
+    scatter_gather_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- RADIO/DISH --------------------------------------------------------------
+
+async fn radio_dish_connect_before_bind(ep: Endpoint) {
+    let dish = Socket::new(SocketType::Dish, opts());
+    dish.join("w").await.unwrap();
+    dish.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    radio.bind(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio.send(Message::multipart(["w", "hit"])).await.unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
+            assert_eq!(m.part_bytes(1).unwrap(), &b"hit"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join never propagated"
+        );
+    }
+
+    radio
+        .send(Message::multipart(["other", "miss"]))
+        .await
+        .unwrap();
+    radio
+        .send(Message::multipart(["w", "second"]))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(TIMEOUT, dish.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"second"[..]);
+}
+
+#[compio::test]
+async fn radio_dish_connect_before_bind_inproc() {
+    radio_dish_connect_before_bind(inproc_ep("cbb-rd-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn radio_dish_connect_before_bind_ipc() {
+    radio_dish_connect_before_bind(ipc_ep("cbb-rd-comp")).await;
+}
+
+#[compio::test]
+async fn radio_dish_connect_before_bind_tcp() {
+    radio_dish_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- PEER --------------------------------------------------------------------
+
+async fn peer_connect_before_bind(ep: Endpoint) {
+    let b = Socket::new(SocketType::Peer, opts().identity(Bytes::from_static(b"pb")));
+    b.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let a = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    a.bind(ep).await.unwrap();
+
+    // PEER routes by identity. Probe until B discovers A's identity.
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        b.send(Message::multipart(["pa", "from-b"])).await.unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
+            assert_eq!(m.part_bytes(1).unwrap(), &b"from-b"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "peer identity never discovered"
+        );
+    }
+
+    a.send(Message::multipart(["pb", "from-a"])).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"pa"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"from-a"[..]);
+}
+
+#[compio::test]
+async fn peer_connect_before_bind_inproc() {
+    peer_connect_before_bind(inproc_ep("cbb-peer-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn peer_connect_before_bind_ipc() {
+    peer_connect_before_bind(ipc_ep("cbb-peer-comp")).await;
+}
+
+#[compio::test]
+async fn peer_connect_before_bind_tcp() {
+    peer_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- CHANNEL -----------------------------------------------------------------
+
+async fn channel_connect_before_bind(ep: Endpoint) {
+    let a = Socket::new(SocketType::Channel, opts());
+    a.connect(ep.clone()).await.unwrap();
+
+    compio::time::sleep(BIND_DELAY).await;
+
+    let b = Socket::new(SocketType::Channel, Options::default());
+    b.bind(ep).await.unwrap();
+
+    a.send(Message::single("from-a")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"from-a"[..]);
+
+    b.send(Message::single("from-b")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"from-b"[..]);
+}
+
+#[compio::test]
+async fn channel_connect_before_bind_inproc() {
+    channel_connect_before_bind(inproc_ep("cbb-ch-comp-inproc")).await;
+}
+
+#[compio::test]
+async fn channel_connect_before_bind_ipc() {
+    channel_connect_before_bind(ipc_ep("cbb-ch-comp")).await;
+}
+
+#[compio::test]
+async fn channel_connect_before_bind_tcp() {
+    channel_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
 // -- lz4+tcp -----------------------------------------------------------------
 
 #[cfg(feature = "lz4")]
@@ -207,4 +544,29 @@ async fn push_pull_connect_before_bind_zstd() {
 #[compio::test]
 async fn req_rep_connect_before_bind_zstd() {
     req_rep_connect_before_bind(zstd_ep(free_tcp_port())).await;
+}
+
+// -- ws ----------------------------------------------------------------------
+
+#[cfg(feature = "ws")]
+fn ws_ep(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+#[cfg(feature = "ws")]
+#[compio::test]
+async fn push_pull_connect_before_bind_ws() {
+    push_pull_connect_before_bind(ws_ep(free_tcp_port())).await;
+}
+
+#[cfg(feature = "ws")]
+#[compio::test]
+async fn req_rep_connect_before_bind_ws() {
+    req_rep_connect_before_bind(ws_ep(free_tcp_port())).await;
+}
+
+#[cfg(feature = "ws")]
+#[compio::test]
+async fn pub_sub_connect_before_bind_ws() {
+    pub_sub_connect_before_bind(ws_ep(free_tcp_port())).await;
 }

--- a/omq-compio/tests/reconnect.rs
+++ b/omq-compio/tests/reconnect.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use omq_compio::endpoint::Host;
 use omq_compio::options::ReconnectPolicy;
-use omq_compio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_compio::{Endpoint, Message, OnMute, Options, Socket, SocketType};
 
 fn tcp_ep(port: u16) -> Endpoint {
     Endpoint::Tcp {
@@ -219,4 +219,59 @@ async fn exponential_backoff_retry_in_grows() {
             delays[i - 1]
         );
     }
+}
+
+#[compio::test]
+async fn push_hwm_drains_after_reconnect() {
+    let pull1 = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull1.bind(tcp_ep(0)).await.unwrap();
+
+    let push = Socket::new(
+        SocketType::Push,
+        Options::default()
+            .send_hwm(4)
+            .on_mute(OnMute::DropNewest)
+            .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(30))),
+    );
+    push.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    push.send(Message::single("warmup")).await.unwrap();
+    compio::time::timeout(Duration::from_secs(2), pull1.recv())
+        .await
+        .expect("warmup timed out")
+        .unwrap();
+
+    pull1.close().await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    for i in 0..10 {
+        let _ = compio::time::timeout(
+            Duration::from_millis(50),
+            push.send(Message::single(format!("q{i}"))),
+        )
+        .await;
+    }
+
+    let pull2 = Socket::new(SocketType::Pull, Options::default());
+    let mut bound = false;
+    for _ in 0..40 {
+        if pull2.bind(ep.clone()).await.is_ok() {
+            bound = true;
+            break;
+        }
+        compio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(bound, "pull2 failed to rebind");
+
+    push.send(Message::single("final")).await.unwrap();
+
+    let mut count = 0;
+    while let Ok(Ok(_)) = compio::time::timeout(Duration::from_secs(2), pull2.recv()).await {
+        count += 1;
+        if count > 10 {
+            break;
+        }
+    }
+    assert!(count >= 1, "expected at least 1 message, got {count}");
 }

--- a/omq-compio/tests/reconnect_all_types.rs
+++ b/omq-compio/tests/reconnect_all_types.rs
@@ -3,6 +3,7 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
+use bytes::Bytes;
 use omq_compio::endpoint::Host;
 use omq_compio::options::ReconnectPolicy;
 use omq_compio::{Endpoint, Message, Options, Socket, SocketType};
@@ -185,4 +186,319 @@ async fn dealer_router_reconnect_after_router_restart() {
         .unwrap();
     assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"d1");
     assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"after");
+}
+
+// ── PAIR ─────────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn pair_reconnect_after_bind_side_restart() {
+    let pair_a1 = Socket::new(SocketType::Pair, Options::default());
+    let ep = pair_a1.bind(tcp_ep(0)).await.unwrap();
+
+    let pair_b = Socket::new(SocketType::Pair, fast_reconnect());
+    pair_b.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    pair_b.send(Message::single("hi")).await.unwrap();
+    let got1 = compio::time::timeout(Duration::from_secs(2), pair_a1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    pair_a1.send(Message::single("there")).await.unwrap();
+    compio::time::timeout(Duration::from_secs(2), pair_b.recv())
+        .await
+        .expect("initial reply timed out")
+        .unwrap();
+
+    pair_a1.close().await.unwrap();
+    let pair_a2 = rebind(&ep, || Socket::new(SocketType::Pair, Options::default())).await;
+
+    pair_b.send(Message::single("again")).await.unwrap();
+    let got2 = compio::time::timeout(Duration::from_secs(3), pair_a2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    pair_a2.send(Message::single("back")).await.unwrap();
+    let reply2 = compio::time::timeout(Duration::from_secs(2), pair_b.recv())
+        .await
+        .expect("post-restart reply timed out")
+        .unwrap();
+    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn client_server_reconnect_after_server_restart() {
+    let server1 = Socket::new(SocketType::Server, Options::default());
+    let ep = server1.bind(tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(
+        SocketType::Client,
+        Options {
+            reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+            ..Options::default().identity(Bytes::from_static(b"c1"))
+        },
+    );
+    client.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    client.send(Message::single("ping1")).await.unwrap();
+    let got1 = compio::time::timeout(Duration::from_secs(2), server1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"ping1");
+
+    server1
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong1"),
+        ]))
+        .await
+        .unwrap();
+    let reply1 = compio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .expect("initial reply timed out")
+        .unwrap();
+    assert_eq!(reply1.part_bytes(0).unwrap().as_ref(), b"pong1");
+
+    server1.close().await.unwrap();
+    let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
+
+    client.send(Message::single("ping2")).await.unwrap();
+    let got2 = compio::time::timeout(Duration::from_secs(3), server2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"ping2");
+}
+
+// ── SCATTER / GATHER ─────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn scatter_gather_reconnect_after_bind_restart() {
+    let gather1 = Socket::new(SocketType::Gather, Options::default());
+    let ep = gather1.bind(tcp_ep(0)).await.unwrap();
+
+    let scatter = Socket::new(SocketType::Scatter, fast_reconnect());
+    scatter.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    scatter.send(Message::single("before")).await.unwrap();
+    let got1 = compio::time::timeout(Duration::from_secs(2), gather1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"before");
+
+    gather1.close().await.unwrap();
+    let gather2 = rebind(&ep, || Socket::new(SocketType::Gather, Options::default())).await;
+
+    scatter.send(Message::single("after")).await.unwrap();
+    let got2 = compio::time::timeout(Duration::from_secs(3), gather2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── RADIO / DISH ─────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn radio_dish_reconnect_replays_joins() {
+    let radio1 = Socket::new(SocketType::Radio, Options::default());
+    let ep = radio1.bind(tcp_ep(0)).await.unwrap();
+
+    let dish = Socket::new(SocketType::Dish, fast_reconnect());
+    dish.connect(ep.clone()).await.unwrap();
+    dish.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        radio1
+            .send(Message::multipart(["w", "probe"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join never propagated"
+        );
+    }
+
+    radio1.close().await.unwrap();
+    let radio2 = rebind(&ep, || Socket::new(SocketType::Radio, Options::default())).await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        radio2
+            .send(Message::multipart(["w", "after"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"w");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join not replayed after restart"
+        );
+    }
+
+    radio2
+        .send(Message::multipart(["other", "miss"]))
+        .await
+        .unwrap();
+    radio2
+        .send(Message::multipart(["w", "final"]))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(Duration::from_secs(3), dish.recv())
+        .await
+        .expect("final recv timed out")
+        .unwrap();
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"final");
+}
+
+// ── PEER ─────────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn peer_reconnect_after_bind_side_restart() {
+    let peer_a1 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    let ep = peer_a1.bind(tcp_ep(0)).await.unwrap();
+
+    let peer_b = Socket::new(
+        SocketType::Peer,
+        Options {
+            reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+            ..Options::default().identity(Bytes::from_static(b"pb"))
+        },
+    );
+    peer_b.connect(ep.clone()).await.unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        peer_b
+            .send(Message::multipart(["pa", "hello"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a1.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity never discovered"
+        );
+    }
+
+    peer_a1.close().await.unwrap();
+    let peer_a2 = rebind(&ep, || {
+        Socket::new(
+            SocketType::Peer,
+            Options::default().identity(Bytes::from_static(b"pa")),
+        )
+    })
+    .await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        peer_b
+            .send(Message::multipart(["pa", "after"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a2.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity not rediscovered after restart"
+        );
+    }
+}
+
+// ── CHANNEL ──────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn channel_reconnect_after_bind_side_restart() {
+    let ch_a1 = Socket::new(SocketType::Channel, Options::default());
+    let ep = ch_a1.bind(tcp_ep(0)).await.unwrap();
+
+    let ch_b = Socket::new(SocketType::Channel, fast_reconnect());
+    ch_b.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    ch_b.send(Message::single("hi")).await.unwrap();
+    let got1 = compio::time::timeout(Duration::from_secs(2), ch_a1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    ch_a1.send(Message::single("there")).await.unwrap();
+    compio::time::timeout(Duration::from_secs(2), ch_b.recv())
+        .await
+        .expect("initial reply timed out")
+        .unwrap();
+
+    ch_a1.close().await.unwrap();
+    let ch_a2 = rebind(&ep, || Socket::new(SocketType::Channel, Options::default())).await;
+
+    ch_b.send(Message::single("again")).await.unwrap();
+    let got2 = compio::time::timeout(Duration::from_secs(3), ch_a2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    ch_a2.send(Message::single("back")).await.unwrap();
+    let reply2 = compio::time::timeout(Duration::from_secs(2), ch_b.recv())
+        .await
+        .expect("post-restart reply timed out")
+        .unwrap();
+    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── XPUB / XSUB ─────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn xpub_xsub_reconnect_replays_subscriptions() {
+    let xpub1 = Socket::new(SocketType::XPub, Options::default());
+    let ep = xpub1.bind(tcp_ep(0)).await.unwrap();
+
+    let xsub = Socket::new(SocketType::XSub, fast_reconnect());
+    xsub.connect(ep.clone()).await.unwrap();
+    xsub.subscribe("news.").await.unwrap();
+
+    let sub_msg = compio::time::timeout(Duration::from_secs(3), xpub1.recv())
+        .await
+        .expect("initial subscription timed out")
+        .unwrap();
+    let sub_bytes = sub_msg.part_bytes(0).unwrap();
+    assert_eq!(sub_bytes[0], 0x01);
+    assert_eq!(&sub_bytes[1..], b"news.");
+
+    xpub1.close().await.unwrap();
+    let xpub2 = rebind(&ep, || Socket::new(SocketType::XPub, Options::default())).await;
+
+    let replayed = compio::time::timeout(Duration::from_secs(3), xpub2.recv())
+        .await
+        .expect("subscription replay timed out")
+        .unwrap();
+    let replayed_bytes = replayed.part_bytes(0).unwrap();
+    assert_eq!(replayed_bytes[0], 0x01);
+    assert_eq!(&replayed_bytes[1..], b"news.");
 }

--- a/omq-compio/tests/reconnect_connect_side.rs
+++ b/omq-compio/tests/reconnect_connect_side.rs
@@ -1,0 +1,436 @@
+//! Connect-side restart: the connecting socket drops and a fresh socket
+//! reconnects. The bind side must accept the new connection and resume
+//! message delivery for every socket-type pair.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_compio::endpoint::Host;
+use omq_compio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+const SETTLE: Duration = Duration::from_millis(100);
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+// ── PUSH / PULL ──────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn push_pull_reconnect_connect_side() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull.bind(tcp_ep(0)).await.unwrap();
+
+    let push1 = Socket::new(SocketType::Push, Options::default());
+    push1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    push1.send(Message::single("before")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+
+    push1.close().await.unwrap();
+
+    let push2 = Socket::new(SocketType::Push, Options::default());
+    push2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    push2.send(Message::single("after")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── REQ / REP ────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn req_rep_reconnect_connect_side() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let req1 = Socket::new(SocketType::Req, Options::default());
+    req1.connect(ep.clone()).await.unwrap();
+
+    req1.send(Message::single("q1")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q1");
+    rep.send(Message::single("a1")).await.unwrap();
+    compio::time::timeout(TIMEOUT, req1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    req1.close().await.unwrap();
+
+    let req2 = Socket::new(SocketType::Req, Options::default());
+    req2.connect(ep).await.unwrap();
+
+    req2.send(Message::single("q2")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q2");
+    rep.send(Message::single("a2")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, req2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"a2");
+}
+
+// ── PUB / SUB ────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn pub_sub_reconnect_connect_side() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let ep = pub_.bind(tcp_ep(0)).await.unwrap();
+
+    let sub1 = Socket::new(SocketType::Sub, Options::default());
+    sub1.connect(ep.clone()).await.unwrap();
+    sub1.subscribe("x.").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.probe1")).await.unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub1.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe1");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "sub1 never subscribed"
+        );
+    }
+
+    sub1.close().await.unwrap();
+
+    let sub2 = Socket::new(SocketType::Sub, Options::default());
+    sub2.connect(ep).await.unwrap();
+    sub2.subscribe("x.").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.probe2")).await.unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub2.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe2");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "sub2 never subscribed"
+        );
+    }
+}
+
+// ── DEALER / ROUTER ──────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn dealer_router_reconnect_connect_side() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let ep = router.bind(tcp_ep(0)).await.unwrap();
+
+    let dealer1 = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"d1")),
+    );
+    dealer1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    dealer1.send(Message::single("hello")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+
+    dealer1.close().await.unwrap();
+
+    let dealer2 = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"d1")),
+    );
+    dealer2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    dealer2.send(Message::single("again")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn client_server_reconnect_connect_side() {
+    let server = Socket::new(SocketType::Server, Options::default());
+    let ep = server.bind(tcp_ep(0)).await.unwrap();
+
+    let client1 = Socket::new(
+        SocketType::Client,
+        Options::default().identity(Bytes::from_static(b"c1")),
+    );
+    client1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    client1.send(Message::single("ping")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
+
+    client1.close().await.unwrap();
+
+    let client2 = Socket::new(
+        SocketType::Client,
+        Options::default().identity(Bytes::from_static(b"c1")),
+    );
+    client2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    client2.send(Message::single("pong")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"pong");
+}
+
+// ── SCATTER / GATHER ─────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn scatter_gather_reconnect_connect_side() {
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    let ep = gather.bind(tcp_ep(0)).await.unwrap();
+
+    let scatter1 = Socket::new(SocketType::Scatter, Options::default());
+    scatter1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    scatter1.send(Message::single("before")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+
+    scatter1.close().await.unwrap();
+
+    let scatter2 = Socket::new(SocketType::Scatter, Options::default());
+    scatter2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    scatter2.send(Message::single("after")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── RADIO / DISH ─────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn radio_dish_reconnect_connect_side() {
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    let ep = radio.bind(tcp_ep(0)).await.unwrap();
+
+    let dish1 = Socket::new(SocketType::Dish, Options::default());
+    dish1.connect(ep.clone()).await.unwrap();
+    dish1.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio
+            .send(Message::multipart(["w", "probe1"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish1.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe1");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dish1 join never propagated"
+        );
+    }
+
+    dish1.close().await.unwrap();
+
+    let dish2 = Socket::new(SocketType::Dish, Options::default());
+    dish2.connect(ep).await.unwrap();
+    dish2.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio
+            .send(Message::multipart(["w", "probe2"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish2.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe2");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dish2 join never propagated"
+        );
+    }
+}
+
+// ── PAIR ─────────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn pair_reconnect_connect_side() {
+    let pair_a = Socket::new(SocketType::Pair, Options::default());
+    let ep = pair_a.bind(tcp_ep(0)).await.unwrap();
+
+    let pair_b1 = Socket::new(SocketType::Pair, Options::default());
+    pair_b1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    pair_b1.send(Message::single("hi")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, pair_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+
+    pair_b1.close().await.unwrap();
+
+    let pair_b2 = Socket::new(SocketType::Pair, Options::default());
+    pair_b2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    pair_b2.send(Message::single("again")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, pair_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+
+    pair_a.send(Message::single("back")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, pair_b2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── PEER ─────────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn peer_reconnect_connect_side() {
+    let peer_a = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    let ep = peer_a.bind(tcp_ep(0)).await.unwrap();
+
+    let peer_b1 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pb")),
+    );
+    peer_b1.connect(ep.clone()).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        peer_b1
+            .send(Message::multipart(["pa", "hello"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity never discovered"
+        );
+    }
+
+    peer_b1.close().await.unwrap();
+
+    let peer_b2 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pb")),
+    );
+    peer_b2.connect(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        peer_b2
+            .send(Message::multipart(["pa", "again"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity not rediscovered after reconnect"
+        );
+    }
+}
+
+// ── CHANNEL ──────────────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn channel_reconnect_connect_side() {
+    let ch_a = Socket::new(SocketType::Channel, Options::default());
+    let ep = ch_a.bind(tcp_ep(0)).await.unwrap();
+
+    let ch_b1 = Socket::new(SocketType::Channel, Options::default());
+    ch_b1.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    ch_b1.send(Message::single("hi")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, ch_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+
+    ch_b1.close().await.unwrap();
+
+    let ch_b2 = Socket::new(SocketType::Channel, Options::default());
+    ch_b2.connect(ep).await.unwrap();
+    compio::time::sleep(SETTLE).await;
+
+    ch_b2.send(Message::single("again")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, ch_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+
+    ch_a.send(Message::single("back")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, ch_b2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+}

--- a/omq-compio/tests/reconnect_identity.rs
+++ b/omq-compio/tests/reconnect_identity.rs
@@ -1,0 +1,220 @@
+//! Identity routing across reconnect: verify that identity-bearing sockets
+//! re-register correctly after the bind side restarts, and that multiple
+//! identity-bearing peers all survive a router/server restart.
+
+use std::collections::HashSet;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_compio::endpoint::Host;
+use omq_compio::options::ReconnectPolicy;
+use omq_compio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+fn fast_reconnect_with_id(id: &'static [u8]) -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+        ..Options::default().identity(Bytes::from_static(id))
+    }
+}
+
+async fn rebind<F: Fn() -> Socket>(ep: &Endpoint, make: F) -> Socket {
+    let s = make();
+    for _ in 0..40 {
+        if s.bind(ep.clone()).await.is_ok() {
+            return s;
+        }
+        compio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("could not rebind {ep:?} after 40 attempts");
+}
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+// ── DEALER / ROUTER ──────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn dealer_identity_survives_reconnect() {
+    let router1 = Socket::new(SocketType::Router, Options::default());
+    let ep = router1.bind(tcp_ep(0)).await.unwrap();
+
+    let dealer = Socket::new(SocketType::Dealer, fast_reconnect_with_id(b"d1"));
+    dealer.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    dealer.send(Message::single("before")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, router1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+
+    router1
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"reply1"),
+        ]))
+        .await
+        .unwrap();
+    let r = compio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply1");
+
+    router1.close().await.unwrap();
+    let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
+
+    dealer.send(Message::single("after")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, router2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+
+    router2
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"reply2"),
+        ]))
+        .await
+        .unwrap();
+    let r = compio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply2");
+}
+
+#[compio::test]
+async fn multi_dealer_reconnect_to_restarted_router() {
+    let router1 = Socket::new(SocketType::Router, Options::default());
+    let ep = router1.bind(tcp_ep(0)).await.unwrap();
+
+    let dealers: Vec<Socket> = [b"d1" as &[u8], b"d2", b"d3"]
+        .iter()
+        .map(|id| {
+            Socket::new(
+                SocketType::Dealer,
+                Options {
+                    reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+                    ..Options::default().identity(Bytes::from_static(id))
+                },
+            )
+        })
+        .collect();
+    for d in &dealers {
+        d.connect(ep.clone()).await.unwrap();
+    }
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    for (i, d) in dealers.iter().enumerate() {
+        d.send(Message::single(format!("msg-{i}"))).await.unwrap();
+    }
+    let mut ids_before = HashSet::new();
+    for _ in 0..3 {
+        let m = compio::time::timeout(TIMEOUT, router1.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        ids_before.insert(m.part_bytes(0).unwrap().to_vec());
+    }
+    assert_eq!(ids_before.len(), 3);
+
+    router1.close().await.unwrap();
+    let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
+
+    for (i, d) in dealers.iter().enumerate() {
+        d.send(Message::single(format!("after-{i}"))).await.unwrap();
+    }
+    let mut ids_after = HashSet::new();
+    for _ in 0..3 {
+        let m = compio::time::timeout(TIMEOUT, router2.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let id = m.part_bytes(0).unwrap().to_vec();
+        let body = m.part_bytes(1).unwrap();
+
+        router2
+            .send(Message::multipart([
+                Bytes::from(id.clone()),
+                Bytes::from(format!("re:{}", String::from_utf8_lossy(&body))),
+            ]))
+            .await
+            .unwrap();
+        ids_after.insert(id);
+    }
+    assert_eq!(ids_after.len(), 3);
+    assert_eq!(ids_before, ids_after);
+
+    for d in &dealers {
+        let reply = compio::time::timeout(TIMEOUT, d.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(reply.part_bytes(0).unwrap().starts_with(b"re:after-"));
+    }
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[compio::test]
+async fn client_identity_survives_reconnect_to_server() {
+    let server1 = Socket::new(SocketType::Server, Options::default());
+    let ep = server1.bind(tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(SocketType::Client, fast_reconnect_with_id(b"c1"));
+    client.connect(ep.clone()).await.unwrap();
+    compio::time::sleep(Duration::from_millis(100)).await;
+
+    client.send(Message::single("ping1")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, server1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+
+    server1
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong1"),
+        ]))
+        .await
+        .unwrap();
+    let r = compio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong1");
+
+    server1.close().await.unwrap();
+    let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
+
+    client.send(Message::single("ping2")).await.unwrap();
+    let m = compio::time::timeout(TIMEOUT, server2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+
+    server2
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong2"),
+        ]))
+        .await
+        .unwrap();
+    let r = compio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong2");
+}

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -1,11 +1,11 @@
 //! Connect-before-bind: the dialer connects before the listener binds.
 //! The dialer must retry until the listener appears, then deliver messages.
-//! Tested across inproc, IPC, TCP, lz4+tcp, and zstd+tcp for PUSH/PULL,
-//! REQ/REP, and PAIR.
+//! Tested across inproc, IPC, and TCP for every socket-type pair.
 
 use std::net::TcpListener as StdTcpListener;
 use std::time::Duration;
 
+use bytes::Bytes;
 use omq_proto::endpoint::IpcPath;
 use omq_tokio::endpoint::Host;
 use omq_tokio::options::ReconnectPolicy;
@@ -184,6 +184,341 @@ async fn pair_connect_before_bind_tcp() {
     pair_connect_before_bind(tcp_ep(free_tcp_port())).await;
 }
 
+// -- PUB/SUB -----------------------------------------------------------------
+
+async fn pub_sub_connect_before_bind(ep: Endpoint) {
+    let sub = Socket::new(SocketType::Sub, opts());
+    sub.subscribe("x.").await.unwrap();
+    sub.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.hit")).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), sub.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"x.hit"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "subscription never propagated"
+        );
+    }
+
+    pub_.send(Message::single("y.miss")).await.unwrap();
+    pub_.send(Message::single("x.second")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, sub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"x.second"[..]);
+}
+
+#[tokio::test]
+async fn pub_sub_connect_before_bind_inproc() {
+    pub_sub_connect_before_bind(inproc_ep("cbb-ps-inproc")).await;
+}
+
+#[tokio::test]
+async fn pub_sub_connect_before_bind_ipc() {
+    pub_sub_connect_before_bind(ipc_ep("cbb-ps")).await;
+}
+
+#[tokio::test]
+async fn pub_sub_connect_before_bind_tcp() {
+    pub_sub_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- DEALER/ROUTER -----------------------------------------------------------
+
+async fn dealer_router_connect_before_bind(ep: Endpoint) {
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        opts().identity(Bytes::from_static(b"d1")),
+    );
+    dealer.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let router = Socket::new(SocketType::Router, Options::default());
+    router.bind(ep).await.unwrap();
+
+    dealer.send(Message::single("hello")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+
+    router
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"world"),
+        ]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"world"[..]);
+}
+
+#[tokio::test]
+async fn dealer_router_connect_before_bind_inproc() {
+    dealer_router_connect_before_bind(inproc_ep("cbb-dr-inproc")).await;
+}
+
+#[tokio::test]
+async fn dealer_router_connect_before_bind_ipc() {
+    dealer_router_connect_before_bind(ipc_ep("cbb-dr")).await;
+}
+
+#[tokio::test]
+async fn dealer_router_connect_before_bind_tcp() {
+    dealer_router_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- CLIENT/SERVER -----------------------------------------------------------
+
+async fn client_server_connect_before_bind(ep: Endpoint) {
+    let client = Socket::new(
+        SocketType::Client,
+        opts().identity(Bytes::from_static(b"c1")),
+    );
+    client.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let server = Socket::new(SocketType::Server, Options::default());
+    server.bind(ep).await.unwrap();
+
+    client.send(Message::single("ping")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+
+    server
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong"),
+        ]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"pong"[..]);
+}
+
+#[tokio::test]
+async fn client_server_connect_before_bind_inproc() {
+    client_server_connect_before_bind(inproc_ep("cbb-cs-inproc")).await;
+}
+
+#[tokio::test]
+async fn client_server_connect_before_bind_ipc() {
+    client_server_connect_before_bind(ipc_ep("cbb-cs")).await;
+}
+
+#[tokio::test]
+async fn client_server_connect_before_bind_tcp() {
+    client_server_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- SCATTER/GATHER ----------------------------------------------------------
+
+async fn scatter_gather_connect_before_bind(ep: Endpoint) {
+    let scatter = Socket::new(SocketType::Scatter, opts());
+    scatter.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    gather.bind(ep).await.unwrap();
+
+    scatter.send(Message::single("late")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+}
+
+#[tokio::test]
+async fn scatter_gather_connect_before_bind_inproc() {
+    scatter_gather_connect_before_bind(inproc_ep("cbb-sg-inproc")).await;
+}
+
+#[tokio::test]
+async fn scatter_gather_connect_before_bind_ipc() {
+    scatter_gather_connect_before_bind(ipc_ep("cbb-sg")).await;
+}
+
+#[tokio::test]
+async fn scatter_gather_connect_before_bind_tcp() {
+    scatter_gather_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- RADIO/DISH --------------------------------------------------------------
+
+async fn radio_dish_connect_before_bind(ep: Endpoint) {
+    let dish = Socket::new(SocketType::Dish, opts());
+    dish.join("w").await.unwrap();
+    dish.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    radio.bind(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio.send(Message::multipart(["w", "hit"])).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
+            assert_eq!(m.part_bytes(1).unwrap(), &b"hit"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join never propagated"
+        );
+    }
+
+    radio
+        .send(Message::multipart(["other", "miss"]))
+        .await
+        .unwrap();
+    radio
+        .send(Message::multipart(["w", "second"]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(TIMEOUT, dish.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"second"[..]);
+}
+
+#[tokio::test]
+async fn radio_dish_connect_before_bind_inproc() {
+    radio_dish_connect_before_bind(inproc_ep("cbb-rd-inproc")).await;
+}
+
+#[tokio::test]
+async fn radio_dish_connect_before_bind_ipc() {
+    radio_dish_connect_before_bind(ipc_ep("cbb-rd")).await;
+}
+
+#[tokio::test]
+async fn radio_dish_connect_before_bind_tcp() {
+    radio_dish_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- PEER --------------------------------------------------------------------
+
+async fn peer_connect_before_bind(ep: Endpoint) {
+    let b = Socket::new(SocketType::Peer, opts().identity(Bytes::from_static(b"pb")));
+    b.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let a = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    a.bind(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        b.send(Message::multipart(["pa", "from-b"])).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
+            assert_eq!(m.part_bytes(1).unwrap(), &b"from-b"[..]);
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "peer identity never discovered"
+        );
+    }
+
+    a.send(Message::multipart(["pb", "from-a"])).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"pa"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"from-a"[..]);
+}
+
+#[tokio::test]
+async fn peer_connect_before_bind_inproc() {
+    peer_connect_before_bind(inproc_ep("cbb-peer-inproc")).await;
+}
+
+#[tokio::test]
+async fn peer_connect_before_bind_ipc() {
+    peer_connect_before_bind(ipc_ep("cbb-peer")).await;
+}
+
+#[tokio::test]
+async fn peer_connect_before_bind_tcp() {
+    peer_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+// -- CHANNEL -----------------------------------------------------------------
+
+async fn channel_connect_before_bind(ep: Endpoint) {
+    let a = Socket::new(SocketType::Channel, opts());
+    a.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(BIND_DELAY).await;
+
+    let b = Socket::new(SocketType::Channel, Options::default());
+    b.bind(ep).await.unwrap();
+
+    a.send(Message::single("from-a")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"from-a"[..]);
+
+    b.send(Message::single("from-b")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"from-b"[..]);
+}
+
+#[tokio::test]
+async fn channel_connect_before_bind_inproc() {
+    channel_connect_before_bind(inproc_ep("cbb-ch-inproc")).await;
+}
+
+#[tokio::test]
+async fn channel_connect_before_bind_ipc() {
+    channel_connect_before_bind(ipc_ep("cbb-ch")).await;
+}
+
+#[tokio::test]
+async fn channel_connect_before_bind_tcp() {
+    channel_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
 // -- lz4+tcp -----------------------------------------------------------------
 
 #[cfg(feature = "lz4")]
@@ -210,4 +545,29 @@ async fn push_pull_connect_before_bind_zstd() {
 #[tokio::test]
 async fn req_rep_connect_before_bind_zstd() {
     req_rep_connect_before_bind(zstd_ep(free_tcp_port())).await;
+}
+
+// -- ws ----------------------------------------------------------------------
+
+#[cfg(feature = "ws")]
+fn ws_ep(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+#[cfg(feature = "ws")]
+#[tokio::test]
+async fn push_pull_connect_before_bind_ws() {
+    push_pull_connect_before_bind(ws_ep(free_tcp_port())).await;
+}
+
+#[cfg(feature = "ws")]
+#[tokio::test]
+async fn req_rep_connect_before_bind_ws() {
+    req_rep_connect_before_bind(ws_ep(free_tcp_port())).await;
+}
+
+#[cfg(feature = "ws")]
+#[tokio::test]
+async fn pub_sub_connect_before_bind_ws() {
+    pub_sub_connect_before_bind(ws_ep(free_tcp_port())).await;
 }

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -548,6 +548,8 @@ async fn req_rep_connect_before_bind_zstd() {
 }
 
 // -- ws ----------------------------------------------------------------------
+// TODO: WS connect is fire-and-forget (no dial_supervisor retry loop), so
+// these fail until WS gets a reconnect supervisor like TCP/IPC have.
 
 #[cfg(feature = "ws")]
 fn ws_ep(port: u16) -> Endpoint {
@@ -556,18 +558,21 @@ fn ws_ep(port: u16) -> Endpoint {
 
 #[cfg(feature = "ws")]
 #[tokio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn push_pull_connect_before_bind_ws() {
     push_pull_connect_before_bind(ws_ep(free_tcp_port())).await;
 }
 
 #[cfg(feature = "ws")]
 #[tokio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn req_rep_connect_before_bind_ws() {
     req_rep_connect_before_bind(ws_ep(free_tcp_port())).await;
 }
 
 #[cfg(feature = "ws")]
 #[tokio::test]
+#[ignore = "WS lacks reconnect supervisor"]
 async fn pub_sub_connect_before_bind_ws() {
     pub_sub_connect_before_bind(ws_ep(free_tcp_port())).await;
 }

--- a/omq-tokio/tests/reconnect.rs
+++ b/omq-tokio/tests/reconnect.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use omq_tokio::endpoint::Host;
 use omq_tokio::options::ReconnectPolicy;
-use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+use omq_tokio::{Endpoint, Message, MonitorEvent, OnMute, Options, Socket, SocketType};
 
 fn tcp_ep(port: u16) -> Endpoint {
     Endpoint::Tcp {
@@ -237,4 +237,59 @@ async fn exponential_backoff_retry_in_grows() {
             delays[i - 1]
         );
     }
+}
+
+#[tokio::test]
+async fn push_hwm_drains_after_reconnect() {
+    let pull1 = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull1.bind(tcp_ep(0)).await.unwrap();
+
+    let push = Socket::new(
+        SocketType::Push,
+        Options::default()
+            .send_hwm(4)
+            .on_mute(OnMute::DropNewest)
+            .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(30))),
+    );
+    push.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    push.send(Message::single("warmup")).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), pull1.recv())
+        .await
+        .expect("warmup timed out")
+        .unwrap();
+
+    pull1.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    for i in 0..10 {
+        let _ = tokio::time::timeout(
+            Duration::from_millis(50),
+            push.send(Message::single(format!("q{i}"))),
+        )
+        .await;
+    }
+
+    let pull2 = Socket::new(SocketType::Pull, Options::default());
+    let mut bound = false;
+    for _ in 0..40 {
+        if pull2.bind(ep.clone()).await.is_ok() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(bound, "pull2 failed to rebind");
+
+    push.send(Message::single("final")).await.unwrap();
+
+    let mut count = 0;
+    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_secs(2), pull2.recv()).await {
+        count += 1;
+        if count > 10 {
+            break;
+        }
+    }
+    assert!(count >= 1, "expected at least 1 message, got {count}");
 }

--- a/omq-tokio/tests/reconnect_all_types.rs
+++ b/omq-tokio/tests/reconnect_all_types.rs
@@ -1,12 +1,13 @@
 //! Reconnect coverage for socket types beyond PUSH/PULL.
 //!
 //! The plain reconnect.rs covers PUSH/PULL. This file verifies that
-//! REQ/REP, PUB/SUB, DEALER/ROUTER, and PAIR all survive a listener
-//! restart and resume correct message flow.
+//! every socket-type pair survives a listener restart and resumes
+//! correct message flow.
 
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
+use bytes::Bytes;
 use omq_tokio::endpoint::Host;
 use omq_tokio::options::ReconnectPolicy;
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
@@ -229,4 +230,279 @@ async fn pair_reconnect_after_bind_side_restart() {
         .expect("post-restart reply timed out")
         .unwrap();
     assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn client_server_reconnect_after_server_restart() {
+    let server1 = Socket::new(SocketType::Server, Options::default());
+    let ep = server1.bind(tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(
+        SocketType::Client,
+        Options {
+            reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+            ..Options::default().identity(Bytes::from_static(b"c1"))
+        },
+    );
+    client.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    client.send(Message::single("ping1")).await.unwrap();
+    let got1 = tokio::time::timeout(Duration::from_secs(2), server1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"ping1");
+
+    server1
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong1"),
+        ]))
+        .await
+        .unwrap();
+    let reply1 = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .expect("initial reply timed out")
+        .unwrap();
+    assert_eq!(reply1.part_bytes(0).unwrap().as_ref(), b"pong1");
+
+    server1.close().await.unwrap();
+    let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
+
+    client.send(Message::single("ping2")).await.unwrap();
+    let got2 = tokio::time::timeout(Duration::from_secs(3), server2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"ping2");
+}
+
+// ── SCATTER / GATHER ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn scatter_gather_reconnect_after_bind_restart() {
+    let gather1 = Socket::new(SocketType::Gather, Options::default());
+    let ep = gather1.bind(tcp_ep(0)).await.unwrap();
+
+    let scatter = Socket::new(SocketType::Scatter, fast_reconnect());
+    scatter.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    scatter.send(Message::single("before")).await.unwrap();
+    let got1 = tokio::time::timeout(Duration::from_secs(2), gather1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"before");
+
+    gather1.close().await.unwrap();
+    let gather2 = rebind(&ep, || Socket::new(SocketType::Gather, Options::default())).await;
+
+    scatter.send(Message::single("after")).await.unwrap();
+    let got2 = tokio::time::timeout(Duration::from_secs(3), gather2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── RADIO / DISH ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn radio_dish_reconnect_replays_joins() {
+    let radio1 = Socket::new(SocketType::Radio, Options::default());
+    let ep = radio1.bind(tcp_ep(0)).await.unwrap();
+
+    let dish = Socket::new(SocketType::Dish, fast_reconnect());
+    dish.connect(ep.clone()).await.unwrap();
+    dish.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        radio1
+            .send(Message::multipart(["w", "probe"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join never propagated"
+        );
+    }
+
+    radio1.close().await.unwrap();
+    let radio2 = rebind(&ep, || Socket::new(SocketType::Radio, Options::default())).await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        radio2
+            .send(Message::multipart(["w", "after"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"w");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "join not replayed after restart"
+        );
+    }
+
+    radio2
+        .send(Message::multipart(["other", "miss"]))
+        .await
+        .unwrap();
+    radio2
+        .send(Message::multipart(["w", "final"]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(3), dish.recv())
+        .await
+        .expect("final recv timed out")
+        .unwrap();
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"final");
+}
+
+// ── PEER ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn peer_reconnect_after_bind_side_restart() {
+    let peer_a1 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    let ep = peer_a1.bind(tcp_ep(0)).await.unwrap();
+
+    let peer_b = Socket::new(
+        SocketType::Peer,
+        Options {
+            reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+            ..Options::default().identity(Bytes::from_static(b"pb"))
+        },
+    );
+    peer_b.connect(ep.clone()).await.unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        peer_b
+            .send(Message::multipart(["pa", "hello"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a1.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity never discovered"
+        );
+    }
+
+    peer_a1.close().await.unwrap();
+    let peer_a2 = rebind(&ep, || {
+        Socket::new(
+            SocketType::Peer,
+            Options::default().identity(Bytes::from_static(b"pa")),
+        )
+    })
+    .await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        peer_b
+            .send(Message::multipart(["pa", "after"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a2.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity not rediscovered after restart"
+        );
+    }
+}
+
+// ── CHANNEL ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn channel_reconnect_after_bind_side_restart() {
+    let ch_a1 = Socket::new(SocketType::Channel, Options::default());
+    let ep = ch_a1.bind(tcp_ep(0)).await.unwrap();
+
+    let ch_b = Socket::new(SocketType::Channel, fast_reconnect());
+    ch_b.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    ch_b.send(Message::single("hi")).await.unwrap();
+    let got1 = tokio::time::timeout(Duration::from_secs(2), ch_a1.recv())
+        .await
+        .expect("initial recv timed out")
+        .unwrap();
+    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    ch_a1.send(Message::single("there")).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), ch_b.recv())
+        .await
+        .expect("initial reply timed out")
+        .unwrap();
+
+    ch_a1.close().await.unwrap();
+    let ch_a2 = rebind(&ep, || Socket::new(SocketType::Channel, Options::default())).await;
+
+    ch_b.send(Message::single("again")).await.unwrap();
+    let got2 = tokio::time::timeout(Duration::from_secs(3), ch_a2.recv())
+        .await
+        .expect("post-restart recv timed out")
+        .unwrap();
+    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    ch_a2.send(Message::single("back")).await.unwrap();
+    let reply2 = tokio::time::timeout(Duration::from_secs(2), ch_b.recv())
+        .await
+        .expect("post-restart reply timed out")
+        .unwrap();
+    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── XPUB / XSUB ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn xpub_xsub_reconnect_replays_subscriptions() {
+    let xpub1 = Socket::new(SocketType::XPub, Options::default());
+    let ep = xpub1.bind(tcp_ep(0)).await.unwrap();
+
+    let xsub = Socket::new(SocketType::XSub, fast_reconnect());
+    xsub.connect(ep.clone()).await.unwrap();
+    xsub.subscribe("news.").await.unwrap();
+
+    let sub_msg = tokio::time::timeout(Duration::from_secs(3), xpub1.recv())
+        .await
+        .expect("initial subscription timed out")
+        .unwrap();
+    let sub_bytes = sub_msg.part_bytes(0).unwrap();
+    assert_eq!(sub_bytes[0], 0x01);
+    assert_eq!(&sub_bytes[1..], b"news.");
+
+    xpub1.close().await.unwrap();
+    let xpub2 = rebind(&ep, || Socket::new(SocketType::XPub, Options::default())).await;
+
+    let replayed = tokio::time::timeout(Duration::from_secs(3), xpub2.recv())
+        .await
+        .expect("subscription replay timed out")
+        .unwrap();
+    let replayed_bytes = replayed.part_bytes(0).unwrap();
+    assert_eq!(replayed_bytes[0], 0x01);
+    assert_eq!(&replayed_bytes[1..], b"news.");
 }

--- a/omq-tokio/tests/reconnect_connect_side.rs
+++ b/omq-tokio/tests/reconnect_connect_side.rs
@@ -1,0 +1,436 @@
+//! Connect-side restart: the connecting socket drops and a fresh socket
+//! reconnects. The bind side must accept the new connection and resume
+//! message delivery for every socket-type pair.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+const SETTLE: Duration = Duration::from_millis(100);
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+// ── PUSH / PULL ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn push_pull_reconnect_connect_side() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull.bind(tcp_ep(0)).await.unwrap();
+
+    let push1 = Socket::new(SocketType::Push, Options::default());
+    push1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    push1.send(Message::single("before")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+
+    push1.close().await.unwrap();
+
+    let push2 = Socket::new(SocketType::Push, Options::default());
+    push2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    push2.send(Message::single("after")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── REQ / REP ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn req_rep_reconnect_connect_side() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let req1 = Socket::new(SocketType::Req, Options::default());
+    req1.connect(ep.clone()).await.unwrap();
+
+    req1.send(Message::single("q1")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q1");
+    rep.send(Message::single("a1")).await.unwrap();
+    tokio::time::timeout(TIMEOUT, req1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    req1.close().await.unwrap();
+
+    let req2 = Socket::new(SocketType::Req, Options::default());
+    req2.connect(ep).await.unwrap();
+
+    req2.send(Message::single("q2")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q2");
+    rep.send(Message::single("a2")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, req2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"a2");
+}
+
+// ── PUB / SUB ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn pub_sub_reconnect_connect_side() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let ep = pub_.bind(tcp_ep(0)).await.unwrap();
+
+    let sub1 = Socket::new(SocketType::Sub, Options::default());
+    sub1.connect(ep.clone()).await.unwrap();
+    sub1.subscribe("x.").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.probe1")).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), sub1.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe1");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "sub1 never subscribed"
+        );
+    }
+
+    sub1.close().await.unwrap();
+
+    let sub2 = Socket::new(SocketType::Sub, Options::default());
+    sub2.connect(ep).await.unwrap();
+    sub2.subscribe("x.").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        pub_.send(Message::single("x.probe2")).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), sub2.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe2");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "sub2 never subscribed"
+        );
+    }
+}
+
+// ── DEALER / ROUTER ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dealer_router_reconnect_connect_side() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let ep = router.bind(tcp_ep(0)).await.unwrap();
+
+    let dealer1 = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"d1")),
+    );
+    dealer1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    dealer1.send(Message::single("hello")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+
+    dealer1.close().await.unwrap();
+
+    let dealer2 = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"d1")),
+    );
+    dealer2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    dealer2.send(Message::single("again")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn client_server_reconnect_connect_side() {
+    let server = Socket::new(SocketType::Server, Options::default());
+    let ep = server.bind(tcp_ep(0)).await.unwrap();
+
+    let client1 = Socket::new(
+        SocketType::Client,
+        Options::default().identity(Bytes::from_static(b"c1")),
+    );
+    client1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    client1.send(Message::single("ping")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
+
+    client1.close().await.unwrap();
+
+    let client2 = Socket::new(
+        SocketType::Client,
+        Options::default().identity(Bytes::from_static(b"c1")),
+    );
+    client2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    client2.send(Message::single("pong")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"pong");
+}
+
+// ── SCATTER / GATHER ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn scatter_gather_reconnect_connect_side() {
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    let ep = gather.bind(tcp_ep(0)).await.unwrap();
+
+    let scatter1 = Socket::new(SocketType::Scatter, Options::default());
+    scatter1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    scatter1.send(Message::single("before")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+
+    scatter1.close().await.unwrap();
+
+    let scatter2 = Socket::new(SocketType::Scatter, Options::default());
+    scatter2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    scatter2.send(Message::single("after")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, gather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+}
+
+// ── RADIO / DISH ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn radio_dish_reconnect_connect_side() {
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    let ep = radio.bind(tcp_ep(0)).await.unwrap();
+
+    let dish1 = Socket::new(SocketType::Dish, Options::default());
+    dish1.connect(ep.clone()).await.unwrap();
+    dish1.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio
+            .send(Message::multipart(["w", "probe1"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish1.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe1");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dish1 join never propagated"
+        );
+    }
+
+    dish1.close().await.unwrap();
+
+    let dish2 = Socket::new(SocketType::Dish, Options::default());
+    dish2.connect(ep).await.unwrap();
+    dish2.join("w").await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        radio
+            .send(Message::multipart(["w", "probe2"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish2.recv()).await {
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe2");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dish2 join never propagated"
+        );
+    }
+}
+
+// ── PAIR ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn pair_reconnect_connect_side() {
+    let pair_a = Socket::new(SocketType::Pair, Options::default());
+    let ep = pair_a.bind(tcp_ep(0)).await.unwrap();
+
+    let pair_b1 = Socket::new(SocketType::Pair, Options::default());
+    pair_b1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    pair_b1.send(Message::single("hi")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, pair_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+
+    pair_b1.close().await.unwrap();
+
+    let pair_b2 = Socket::new(SocketType::Pair, Options::default());
+    pair_b2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    pair_b2.send(Message::single("again")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, pair_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+
+    pair_a.send(Message::single("back")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, pair_b2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+}
+
+// ── PEER ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn peer_reconnect_connect_side() {
+    let peer_a = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pa")),
+    );
+    let ep = peer_a.bind(tcp_ep(0)).await.unwrap();
+
+    let peer_b1 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pb")),
+    );
+    peer_b1.connect(ep.clone()).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        peer_b1
+            .send(Message::multipart(["pa", "hello"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity never discovered"
+        );
+    }
+
+    peer_b1.close().await.unwrap();
+
+    let peer_b2 = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"pb")),
+    );
+    peer_b2.connect(ep).await.unwrap();
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        peer_b2
+            .send(Message::multipart(["pa", "again"]))
+            .await
+            .unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
+            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
+            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "identity not rediscovered after reconnect"
+        );
+    }
+}
+
+// ── CHANNEL ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn channel_reconnect_connect_side() {
+    let ch_a = Socket::new(SocketType::Channel, Options::default());
+    let ep = ch_a.bind(tcp_ep(0)).await.unwrap();
+
+    let ch_b1 = Socket::new(SocketType::Channel, Options::default());
+    ch_b1.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    ch_b1.send(Message::single("hi")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, ch_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+
+    ch_b1.close().await.unwrap();
+
+    let ch_b2 = Socket::new(SocketType::Channel, Options::default());
+    ch_b2.connect(ep).await.unwrap();
+    tokio::time::sleep(SETTLE).await;
+
+    ch_b2.send(Message::single("again")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, ch_a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+
+    ch_a.send(Message::single("back")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, ch_b2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+}

--- a/omq-tokio/tests/reconnect_identity.rs
+++ b/omq-tokio/tests/reconnect_identity.rs
@@ -1,0 +1,220 @@
+//! Identity routing across reconnect: verify that identity-bearing sockets
+//! re-register correctly after the bind side restarts, and that multiple
+//! identity-bearing peers all survive a router/server restart.
+
+use std::collections::HashSet;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+fn fast_reconnect_with_id(id: &'static [u8]) -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+        ..Options::default().identity(Bytes::from_static(id))
+    }
+}
+
+async fn rebind<F: Fn() -> Socket>(ep: &Endpoint, make: F) -> Socket {
+    let s = make();
+    for _ in 0..40 {
+        if s.bind(ep.clone()).await.is_ok() {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("could not rebind {ep:?} after 40 attempts");
+}
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+// ── DEALER / ROUTER ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dealer_identity_survives_reconnect() {
+    let router1 = Socket::new(SocketType::Router, Options::default());
+    let ep = router1.bind(tcp_ep(0)).await.unwrap();
+
+    let dealer = Socket::new(SocketType::Dealer, fast_reconnect_with_id(b"d1"));
+    dealer.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    dealer.send(Message::single("before")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, router1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+
+    router1
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"reply1"),
+        ]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply1");
+
+    router1.close().await.unwrap();
+    let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
+
+    dealer.send(Message::single("after")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, router2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+
+    router2
+        .send(Message::multipart([
+            Bytes::from_static(b"d1"),
+            Bytes::from_static(b"reply2"),
+        ]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(TIMEOUT, dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply2");
+}
+
+#[tokio::test]
+async fn multi_dealer_reconnect_to_restarted_router() {
+    let router1 = Socket::new(SocketType::Router, Options::default());
+    let ep = router1.bind(tcp_ep(0)).await.unwrap();
+
+    let dealers: Vec<Socket> = [b"d1" as &[u8], b"d2", b"d3"]
+        .iter()
+        .map(|id| {
+            Socket::new(
+                SocketType::Dealer,
+                Options {
+                    reconnect: ReconnectPolicy::Fixed(Duration::from_millis(30)),
+                    ..Options::default().identity(Bytes::from_static(id))
+                },
+            )
+        })
+        .collect();
+    for d in &dealers {
+        d.connect(ep.clone()).await.unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    for (i, d) in dealers.iter().enumerate() {
+        d.send(Message::single(format!("msg-{i}"))).await.unwrap();
+    }
+    let mut ids_before = HashSet::new();
+    for _ in 0..3 {
+        let m = tokio::time::timeout(TIMEOUT, router1.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        ids_before.insert(m.part_bytes(0).unwrap().to_vec());
+    }
+    assert_eq!(ids_before.len(), 3);
+
+    router1.close().await.unwrap();
+    let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
+
+    for (i, d) in dealers.iter().enumerate() {
+        d.send(Message::single(format!("after-{i}"))).await.unwrap();
+    }
+    let mut ids_after = HashSet::new();
+    for _ in 0..3 {
+        let m = tokio::time::timeout(TIMEOUT, router2.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let id = m.part_bytes(0).unwrap().to_vec();
+        let body = m.part_bytes(1).unwrap();
+
+        router2
+            .send(Message::multipart([
+                Bytes::from(id.clone()),
+                Bytes::from(format!("re:{}", String::from_utf8_lossy(&body))),
+            ]))
+            .await
+            .unwrap();
+        ids_after.insert(id);
+    }
+    assert_eq!(ids_after.len(), 3);
+    assert_eq!(ids_before, ids_after);
+
+    for d in &dealers {
+        let reply = tokio::time::timeout(TIMEOUT, d.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(reply.part_bytes(0).unwrap().starts_with(b"re:after-"));
+    }
+}
+
+// ── CLIENT / SERVER ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn client_identity_survives_reconnect_to_server() {
+    let server1 = Socket::new(SocketType::Server, Options::default());
+    let ep = server1.bind(tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(SocketType::Client, fast_reconnect_with_id(b"c1"));
+    client.connect(ep.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    client.send(Message::single("ping1")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+
+    server1
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong1"),
+        ]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong1");
+
+    server1.close().await.unwrap();
+    let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
+
+    client.send(Message::single("ping2")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server2.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+
+    server2
+        .send(Message::multipart([
+            Bytes::from_static(b"c1"),
+            Bytes::from_static(b"pong2"),
+        ]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong2");
+}


### PR DESCRIPTION
- fix compio `dial_supervisor` not clearing `identity_to_slot` when the wire driver exits, causing identity-routed sends (PEER/ROUTER/SERVER/REP/STREAM) to return `Err(Closed)` instead of silently dropping until reconnect re-registers the identity
- tokio's actor already clears the routing table on `PeerClosed`; the fix adds the same `retain()` in `dial_supervisor` right after `install_and_run` returns
- add 47 reconnect tests across both backends covering bind-side restart (all socket types), connect-side restart, identity routing across reconnect, WS connect-before-bind, and HWM across disconnect