### PR TITLE
yring perf + inproc recv fixes

### DIFF
--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -165,7 +165,7 @@ pub(super) struct InprocSendPipe {
 
 impl Drop for InprocSendPipe {
     fn drop(&mut self) {
-        let _ = self.producer.flush();
+        self.producer.flush();
         self.notify.notify(usize::MAX);
     }
 }

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -358,14 +358,16 @@ impl Socket {
                 for i in 0..n {
                     let idx = (start + i) % n;
                     let c = &mut recv_state.consumers[idx];
-                    c.prefetch();
-                    while let Some(msg) = c.pop() {
-                        if max.is_some_and(|m| msg.byte_len() > m) {
-                            continue;
+                    let got = c.prefetch();
+                    if got > 0 {
+                        while let Some(msg) = c.pop() {
+                            if max.is_some_and(|m| msg.byte_len() > m) {
+                                continue;
+                            }
+                            cache.push_back(msg);
                         }
-                        cache.push_back(msg);
+                        c.release();
                     }
-                    c.release();
                     if !cache.is_empty() {
                         recv_state.fq_index = idx + 1;
                     }
@@ -524,14 +526,16 @@ impl Socket {
             let cache = inner.recv_cache.get();
             let max = inner.options.max_message_size;
             for c in &mut recv_state.consumers {
-                c.prefetch();
-                while let Some(msg) = c.pop() {
-                    if max.is_some_and(|m| msg.byte_len() > m) {
-                        continue;
+                let got = c.prefetch();
+                if got > 0 {
+                    while let Some(msg) = c.pop() {
+                        if max.is_some_and(|m| msg.byte_len() > m) {
+                            continue;
+                        }
+                        cache.push_back(msg);
                     }
-                    cache.push_back(msg);
+                    c.release();
                 }
-                c.release();
             }
             if let Some(msg) = cache.pop_front() {
                 return Ok(msg);

--- a/omq-libzmq/src/inproc_bypass.rs
+++ b/omq-libzmq/src/inproc_bypass.rs
@@ -69,7 +69,7 @@ impl BypassSend {
         self.producer.push(msg)?;
         if let yring::FlushResult::Flushed {
             was_empty: true, ..
-        } = self.producer.flush()
+        } = self.producer.flush_and_check()
         {
             NotifyFd::signal_recv(self.pipe.recv_signal_fd);
         }

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -917,6 +917,9 @@ async fn inproc_peer_driver(
     }
     .await;
     let () = result;
+    if let Some(ref ring) = spsc {
+        ring.recv_notify.notify_one();
+    }
     let _ = peer_out.send((peer_id, PeerOut::Closed)).await;
 }
 

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -94,9 +94,15 @@ impl SpscAwareRecv {
                     () = self.activated.notified() => continue,
                 }
             } else {
+                let notified = self.recv_notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if let Some(msg) = self.try_drain_consumers() {
+                    return Ok(msg);
+                }
                 tokio::select! {
                     biased;
-                    () = self.recv_notify.notified() => continue,
+                    () = notified => continue,
                     res = self.rx.recv() => {
                         return res.map_err(|_| Error::Closed);
                     }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -66,11 +66,13 @@ impl SpscAwareRecv {
         let mut cache = self.inproc_cache.lock().unwrap();
         for p in &consumers {
             if let Ok(mut consumer) = p.consumer.try_lock() {
-                consumer.prefetch();
-                while let Some(msg) = consumer.pop() {
-                    cache.push_back(msg);
+                let got = consumer.prefetch();
+                if got > 0 {
+                    while let Some(msg) = consumer.pop() {
+                        cache.push_back(msg);
+                    }
+                    consumer.release();
                 }
-                consumer.release();
             }
         }
         cache.pop_front()

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -88,7 +88,7 @@ impl<T> AsyncProducer<T> {
 
     /// Make all pushed items visible and wake the consumer if the ring was empty.
     #[inline]
-    pub fn flush(&mut self) -> FlushResult {
+    pub fn flush(&mut self) {
         let r = self.ring.ring.flush_to(self.tail, &mut self.cached_head);
         if matches!(
             r,
@@ -99,14 +99,14 @@ impl<T> AsyncProducer<T> {
         ) {
             self.ring.waker.0.wake();
         }
-        r
     }
 
     /// Push + flush in one call.
     #[inline]
-    pub fn push_and_flush(&mut self, val: T) -> Result<FlushResult, T> {
+    pub fn push_and_flush(&mut self, val: T) -> Result<(), T> {
         self.push(val)?;
-        Ok(self.flush())
+        self.flush();
+        Ok(())
     }
 
     #[inline]

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -234,16 +234,27 @@ impl<T> Producer<T> {
     }
 
     /// Make all pushed items visible to the consumer. One Release store.
+    /// Does NOT load `head`; `push()` refreshes `cached_head` on demand
+    /// when the ring appears full.
     #[inline]
-    pub fn flush(&mut self) -> FlushResult {
+    pub fn flush(&mut self) {
+        self.ring.flush.0.store(self.tail, Ordering::Release);
+    }
+
+    /// Flush and report whether the ring was empty (consumer fully caught
+    /// up). Loads `head` (one Acquire) in addition to the Release store.
+    /// Only needed when the caller uses `was_empty` for wakeup decisions.
+    #[inline]
+    pub fn flush_and_check(&mut self) -> FlushResult {
         self.ring.flush_to(self.tail, &mut self.cached_head)
     }
 
     /// Push + flush in one call (convenience for single-item sends).
     #[inline]
-    pub fn push_and_flush(&mut self, val: T) -> Result<FlushResult, T> {
+    pub fn push_and_flush(&mut self, val: T) -> Result<(), T> {
         self.push(val)?;
-        Ok(self.flush())
+        self.flush();
+        Ok(())
     }
 
     #[inline]
@@ -385,10 +396,10 @@ mod tests {
     }
 
     #[test]
-    fn flush_reports_was_empty() {
+    fn flush_and_check_reports_was_empty() {
         let (mut p, mut c) = spsc::<u32>(4);
         p.push(1).unwrap();
-        let r = p.flush();
+        let r = p.flush_and_check();
         assert_eq!(
             r,
             FlushResult::Flushed {
@@ -398,7 +409,7 @@ mod tests {
         );
 
         p.push(2).unwrap();
-        let r = p.flush();
+        let r = p.flush_and_check();
         // Consumer hasn't read yet, so was_empty depends on cached_head
         assert!(matches!(r, FlushResult::Flushed { count: 1, .. }));
 
@@ -410,7 +421,7 @@ mod tests {
         let _ = p.push(5);
         let _ = p.push(6);
         // After consumer consumed, the producer might see stale cached_head
-        let r = p.flush();
+        let r = p.flush_and_check();
         assert!(matches!(r, FlushResult::Flushed { .. }));
     }
 
@@ -504,17 +515,15 @@ mod tests {
     }
 
     #[test]
-    fn flush_was_empty_after_consumer_drains() {
+    fn flush_and_check_was_empty_after_consumer_drains() {
         let (mut p, mut c) = spsc::<u32>(4);
         for i in 0..5 {
             p.push_and_flush(i).unwrap();
             let val = c.prefetch_and_pop().unwrap();
             assert_eq!(val, i);
-            // Next flush must see was_empty == true because the
-            // consumer drained the ring.
         }
         p.push(99).unwrap();
-        let r = p.flush();
+        let r = p.flush_and_check();
         assert_eq!(
             r,
             FlushResult::Flushed {


### PR DESCRIPTION
- `yring::flush()`: eliminate Acquire load of head on every call, reduce to a single Release store of `flush`. The old `flush_and_check()` is preserved for callers that need `was_empty` (AsyncProducer waker, omq-libzmq eventfd signaling)
- Skip spurious `Consumer::release()` in `omq-compio` and `omq-tokio` inproc recv when `prefetch()` returned 0 (avoids dirtying the head cache line for no benefit)
- Fix lost-wakeup race in `omq-tokio` `SpscAwareRecv::recv()`: register `recv_notify.notified()` before the recheck drain, and wake `recv_notify` before sending `PeerOut::Closed` so the receiver doesn't hang on inproc peer exit