### PR TITLE
bench infra: CPU time, Message::clone(), chart layout, XDG cache

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,8 +125,8 @@ cargo bench -p omq-compio --bench push_pull
 Env knobs: `OMQ_BENCH_TRANSPORTS`, `OMQ_BENCH_SIZES`,
 `OMQ_BENCH_PEERS`, `OMQ_BENCH_ROUND_MS`, `OMQ_BENCH_ROUNDS`.
 Full size sweep: `-- --all-sizes`.
-Results append to `<crate>/benches/results.jsonl` unless
-`OMQ_BENCH_NO_WRITE=1`.
+Results append to `$XDG_CACHE_HOME/omq/` (default `~/.cache/omq/`)
+unless `OMQ_BENCH_NO_WRITE=1`.
 
 Compression benchmarks run separately with bandwidth limiting.
 See [BENCHMARKS_COMPRESSION.md](BENCHMARKS_COMPRESSION.md) for commands and results.
@@ -153,8 +153,8 @@ libzmq or zmq.rs baselines are stale.
 Produces `doc/charts/compression/compio_2048.svg` and `doc/charts/compression/tokio_2048.svg`:
 
 ```sh
-cargo bench -p omq-compio --bench compression --features lz4,zstd  # → omq-compio/benches/results_compression.jsonl
-cargo bench -p omq-tokio  --bench compression --features lz4,zstd  # → omq-tokio/benches/results_compression.jsonl
+cargo bench -p omq-compio --bench compression --features lz4,zstd  # → ~/.cache/omq/results_compression_compio.jsonl
+cargo bench -p omq-tokio  --bench compression --features lz4,zstd  # → ~/.cache/omq/results_compression_tokio.jsonl
 python3 scripts/gen_compression_chart.py --backend compio           # JSONL → doc/charts/compression/compio_*.svg
 python3 scripts/gen_compression_chart.py --backend tokio            # JSONL → doc/charts/compression/tokio_*.svg
 ```

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -749,15 +749,36 @@ def _fmt_mbps(val):
     return f"{val:.1f} MB/s"
 
 
+def _detect_hardware():
+    try:
+        cpu = None
+        for line in open("/proc/cpuinfo"):
+            if line.startswith("model name"):
+                cpu = line.split(":", 1)[1].strip()
+                cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
+                break
+        cores = os.cpu_count()
+        if cpu and cores:
+            return f"{cpu}, {cores} cores"
+    except OSError:
+        pass
+    return None
+
+
 def gen_combined_chart(data, path):
     n = len(SIZES)
-    svg_w, svg_h = 850, 600
+    hw_label = _detect_hardware()
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 670 + hw_offset
     x_left, x_right = 90, 760
     plot_w = x_right - x_left
 
-    t1_top, t1_bot = 35, 280
+    t1_top = 35 + hw_offset
+    t1_bot = 370 + hw_offset
     t1_h = t1_bot - t1_top
-    t2_top, t2_bot = 340, 520
+    t2_top = t1_bot + 80
+    t2_bot = t2_top + 120
     t2_h = t2_bot - t2_top
 
     xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
@@ -795,10 +816,15 @@ def gen_combined_chart(data, path):
     # ── TOP PANEL: THROUGHPUT ──────────────────────────────────────
 
     L.append(
-        f'  <text x="{mid_x}" y="18" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
         f'PUSH/PULL throughput — 2-process, TCP loopback (higher is better)</text>'
     )
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="{t1_top - 3}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
 
     n_l_ticks = 4
     for i in range(n_l_ticks + 1):
@@ -891,7 +917,7 @@ def gen_combined_chart(data, path):
     # ── BOTTOM PANEL: LATENCY ─────────────────────────────────────
 
     L.append(
-        f'  <text x="{mid_x}" y="{t2_top - 20}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
         f'REQ/REP latency — 2-process, TCP loopback, p50 µs (lower is better)</text>'
     )

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -24,7 +24,8 @@ LATENCY_WARMUP = 1000
 LATENCY_ITERS = 10000
 README = os.path.join(os.path.dirname(__file__), "..", "README.md")
 CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
-JSONL_FILE = os.path.join(os.path.dirname(__file__), "..", "doc", "charts", "bindings.jsonl")
+_CACHE_DIR = os.path.join(os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")), "omq")
+JSONL_FILE = os.path.join(_CACHE_DIR, "bindings.jsonl")
 
 
 def load_jsonl():

--- a/omq-compio/benches/common/mod.rs
+++ b/omq-compio/benches/common/mod.rs
@@ -322,11 +322,11 @@ where
 
     let mut rounds_data = Vec::with_capacity(n_rounds);
     for _ in 0..n_rounds {
-        let cpu0 = thread_cpu_time();
+        let cpu0 = process_cpu_time();
         let t = Instant::now();
         burst(final_n).await;
         let wall = t.elapsed();
-        let cpu = thread_cpu_time().saturating_sub(cpu0);
+        let cpu = process_cpu_time().saturating_sub(cpu0);
         rounds_data.push((wall, cpu));
     }
     let &(elapsed, cpu_time) = rounds_data
@@ -353,12 +353,12 @@ pub(crate) struct Cell {
     pub cpu_time: Duration,
 }
 
-pub(crate) fn thread_cpu_time() -> Duration {
+pub(crate) fn process_cpu_time() -> Duration {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, std::ptr::from_mut(&mut ts)) };
+    unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, std::ptr::from_mut(&mut ts)) };
     Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }
 

--- a/omq-compio/benches/common/mod.rs
+++ b/omq-compio/benches/common/mod.rs
@@ -93,22 +93,31 @@ pub(crate) fn build_bench_runtime() -> std::io::Result<compio::runtime::Runtime>
         .build()
 }
 
+fn cache_dir() -> PathBuf {
+    let base = std::env::var("XDG_CACHE_HOME").map_or_else(
+        |_| {
+            let home = std::env::var("HOME").expect("HOME not set");
+            PathBuf::from(home).join(".cache")
+        },
+        PathBuf::from,
+    );
+    base.join("omq")
+}
+
 pub(crate) fn results_path() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.push("benches");
+    let mut p = cache_dir();
     let suffix = std::env::var("OMQ_BENCH_RESULTS_SUFFIX").unwrap_or_default();
     if suffix.is_empty() {
-        p.push("results.jsonl");
+        p.push("results_compio.jsonl");
     } else {
-        p.push(format!("results_{suffix}.jsonl"));
+        p.push(format!("results_compio_{suffix}.jsonl"));
     }
     p
 }
 
 pub(crate) fn compression_results_path() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.push("benches");
-    p.push("results_compression.jsonl");
+    let mut p = cache_dir();
+    p.push("results_compression_compio.jsonl");
     p
 }
 

--- a/omq-compio/benches/push_pull.rs
+++ b/omq-compio/benches/push_pull.rs
@@ -114,8 +114,9 @@ fn run_cell_single(transport: &str, peers: usize, size: usize, seq: usize) -> co
                     let p = pushes.clone();
                     let payload = payload.clone();
                     handles.push(compio::runtime::spawn(async move {
+                        let msg = Message::from_slice(&payload);
                         for _ in 0..per {
-                            p[i].send(Message::single(payload.clone())).await.unwrap();
+                            p[i].send(msg.clone()).await.unwrap();
                         }
                     }));
                 }
@@ -226,8 +227,9 @@ fn run_cell_threaded(
                             let p = pushes.clone();
                             let payload = payload.clone();
                             handles.push(compio::runtime::spawn(async move {
+                                let msg = Message::from_slice(&payload);
                                 for _ in 0..per {
-                                    p[i].send(Message::single(payload.clone())).await.unwrap();
+                                    p[i].send(msg.clone()).await.unwrap();
                                 }
                             }));
                         }

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -301,11 +301,11 @@ where
 
     let mut rounds_data = Vec::with_capacity(n_rounds);
     for _ in 0..n_rounds {
-        let cpu0 = thread_cpu_time();
+        let cpu0 = process_cpu_time();
         let t = Instant::now();
         burst(final_n).await;
         let wall = t.elapsed();
-        let cpu = thread_cpu_time().saturating_sub(cpu0);
+        let cpu = process_cpu_time().saturating_sub(cpu0);
         rounds_data.push((wall, cpu));
     }
     let &(elapsed, cpu_time) = rounds_data
@@ -332,12 +332,12 @@ pub(crate) struct Cell {
     pub cpu_time: Duration,
 }
 
-pub(crate) fn thread_cpu_time() -> Duration {
+pub(crate) fn process_cpu_time() -> Duration {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, std::ptr::from_mut(&mut ts)) };
+    unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, std::ptr::from_mut(&mut ts)) };
     Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }
 

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -93,15 +93,24 @@ pub(crate) fn run_timeout() -> Duration {
     per.saturating_mul(r * 2) + Duration::from_secs(30)
 }
 
-/// `omq/benches/results.jsonl`. One row per cell.
+fn cache_dir() -> PathBuf {
+    let base = std::env::var("XDG_CACHE_HOME").map_or_else(
+        |_| {
+            let home = std::env::var("HOME").expect("HOME not set");
+            PathBuf::from(home).join(".cache")
+        },
+        PathBuf::from,
+    );
+    base.join("omq")
+}
+
 pub(crate) fn results_path() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.push("benches");
+    let mut p = cache_dir();
     let suffix = std::env::var("OMQ_BENCH_RESULTS_SUFFIX").unwrap_or_default();
     if suffix.is_empty() {
-        p.push("results.jsonl");
+        p.push("results_tokio.jsonl");
     } else {
-        p.push(format!("results_{suffix}.jsonl"));
+        p.push(format!("results_tokio_{suffix}.jsonl"));
     }
     p
 }
@@ -122,9 +131,8 @@ pub(crate) fn run_id() -> String {
 }
 
 pub(crate) fn compression_results_path() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.push("benches");
-    p.push("results_compression.jsonl");
+    let mut p = cache_dir();
+    p.push("results_compression_tokio.jsonl");
     p
 }
 

--- a/omq-tokio/benches/push_pull.rs
+++ b/omq-tokio/benches/push_pull.rs
@@ -68,8 +68,9 @@ async fn run_cell(transport: &str, peers: usize, size: usize, seq: usize) -> com
                 let p = pushes.clone();
                 let payload = payload.clone();
                 handles.push(tokio::spawn(async move {
+                    let msg = Message::from_slice(&payload);
                     for _ in 0..per {
-                        p[i].send(Message::single(payload.clone())).await.unwrap();
+                        p[i].send(msg.clone()).await.unwrap();
                     }
                 }));
             }

--- a/scripts/bench_compression_tokio.py
+++ b/scripts/bench_compression_tokio.py
@@ -22,7 +22,8 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 PEER = REPO / "target" / "release" / "bench_peer_tokio"
-JSONL = REPO / "omq-tokio" / "benches" / "results_compression.jsonl"
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+JSONL = CACHE_DIR / "results_compression_tokio.jsonl"
 CHART_SCRIPT = REPO / "scripts" / "gen_compression_chart.py"
 
 CHART_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -13,7 +13,8 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-JSONL_PATH = REPO / "benchmarks" / "comparisons.jsonl"
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
 
 COLORS = {
     "libzmq": "#eab308",

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -371,13 +371,13 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
 
     hw_offset = 14 if hw_label else 0
     svg_w = 850
-    svg_h = (665 if has_latency else 400) + hw_offset
+    svg_h = (670 if has_latency else 400) + hw_offset
     x_left, x_right = 90, 760
     plot_w = x_right - x_left
     mid_x = (x_left + x_right) / 2
 
     t1_y_top = 35 + hw_offset
-    t1_y_bot = (330 if has_latency else 305) + hw_offset
+    t1_y_bot = (370 if has_latency else 305) + hw_offset
 
     xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
 
@@ -403,7 +403,7 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
 
     if has_latency:
         t2_y_top = t1_y_bot + 80
-        t2_y_bot = t2_y_top + 160
+        t2_y_bot = t2_y_top + 120
         draw_latency_panel(
             L, sizes, xs, lat, impls, x_left, x_right, t2_y_top, t2_y_bot,
             f"REQ/REP latency — {transport_label} (p50 µs, lower is better)",

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Generate doc/charts/compression.svg -- three-panel combined chart.
+"""Generate doc/charts/compression.svg -- four-panel combined chart.
 
-Panels (top to bottom): 1 Gbps, 100 Mbps, 10 Mbps.
-Each panel: dashed = msg/s log scale (left axis), solid = virtual throughput (right axis).
+Panels (top to bottom): 10 Gbps, 1 Gbps, 100 Mbps, 10 Mbps.
+Each panel: dashed = CPU % (left axis), solid = virtual throughput (right axis).
 
 The bench runs at full loopback speed.  Each panel projects what throughput
 would be at its link speed: effective_msgs_s = min(cpu_msgs_s, link_bytes_s / wire_bytes).
+CPU % is projected proportionally when wire-limited.
 """
 
 import json
@@ -46,12 +47,8 @@ def fmt_size(b: int) -> str:
     return f"{b} B"
 
 
-def _fmt_y_rate(val):
-    if val >= 1_000_000:
-        return f"{val / 1_000_000:g}M"
-    if val >= 1_000:
-        return f"{val / 1_000:g}k"
-    return f"{val:g}"
+def _fmt_cpu(val):
+    return f"{val:g}%"
 
 
 def _fmt_tput(mb):
@@ -118,6 +115,23 @@ def _log_ticks(data_min, data_max):
     return axis_min, axis_max, ticks
 
 
+def _cpu_ticks(data_max):
+    """Return (axis_max, tick_values) for a linear 0-based CPU% axis."""
+    if data_max <= 0:
+        data_max = 100
+    candidates = [50, 100, 200, 400, 500, 800, 1000]
+    ceil = data_max
+    for c in candidates:
+        if c >= data_max:
+            ceil = c
+            break
+    else:
+        ceil = math.ceil(data_max / 100) * 100
+    step = 50 if ceil <= 400 else 100
+    ticks = list(range(step, int(ceil) + 1, step))
+    return ceil, ticks
+
+
 def load_raw_data(jsonl_path: Path, dict_size: int | None = None) -> dict:
     """Load the latest run and return per-series raw data (cpu_msgs_s, wire_bytes, msg_size).
 
@@ -162,8 +176,12 @@ def load_raw_data(jsonl_path: Path, dict_size: int | None = None) -> dict:
         else:
             key = transport
         sizes_set.add(r["msg_size"])
+        elapsed = r.get("elapsed", 0)
+        cpu_time = r.get("cpu_time", 0)
+        cpu_pct = (cpu_time / elapsed * 100.0) if elapsed > 0 else 0.0
         series.setdefault(key, {})[r["msg_size"]] = {
             "cpu_msgs_s": r["msgs_s"],
+            "cpu_pct": cpu_pct,
             "msg_size": r["msg_size"],
             "wire_bytes": r.get("wire_bytes", r["msg_size"]),
         }
@@ -172,7 +190,7 @@ def load_raw_data(jsonl_path: Path, dict_size: int | None = None) -> dict:
 
 
 def project(raw: dict, link_bytes_s: float) -> dict:
-    """Project throughput at a given link speed."""
+    """Project throughput and CPU% at a given link speed."""
     series = {}
     for key, size_data in raw["series"].items():
         series[key] = {}
@@ -182,9 +200,11 @@ def project(raw: dict, link_bytes_s: float) -> dict:
             wire_limited = link_bytes_s / max(wire, 1)
             eff_msgs_s = min(cpu, wire_limited)
             virt_mbps = eff_msgs_s * d["msg_size"] / 1_000_000
+            ratio = eff_msgs_s / cpu if cpu > 0 else 0
             series[key][sz] = {
                 "msgs_s": eff_msgs_s,
                 "virt_mbps": virt_mbps,
+                "cpu_pct": d["cpu_pct"] * ratio,
             }
     return {"sizes": raw["sizes"], "series": series}
 
@@ -192,7 +212,6 @@ def project(raw: dict, link_bytes_s: float) -> dict:
 def generate_svg(
     panels: dict[str, dict],
     tput_ranges: dict[str, tuple[float, float]] | None = None,
-    msgs_ranges: dict[str, tuple[float, float]] | None = None,
     dict_size_label: str | None = None,
     backend: str = "compio",
     hw_label: str | None = None,
@@ -252,15 +271,8 @@ def generate_svg(
         y_bot = y_top + panel_h
         plot_h = y_bot - y_top
 
-        if msgs_ranges and link in msgs_ranges:
-            axis_min, axis_max, msg_ticks = _log_ticks(
-                msgs_ranges[link][0], msgs_ranges[link][1])
-        else:
-            all_msgs = [d["msgs_s"] for s in series.values()
-                        for d in s.values() if d["msgs_s"] > 0]
-            msg_min = min(all_msgs) if all_msgs else 1
-            msg_max = max(all_msgs) if all_msgs else 1e6
-            axis_min, axis_max, msg_ticks = _log_ticks(msg_min, msg_max)
+        cpu_ceil = 400
+        cpu_ticks = [100, 200, 300, 400]
 
         if tput_ranges and link in tput_ranges:
             virt_min, virt_max = tput_ranges[link]
@@ -274,11 +286,8 @@ def generate_svg(
             tp_max = math.log10(tput_ranges[link][1])
             tp_ticks = [t for t in tp_ticks if t <= tput_ranges[link][1]]
 
-        def y_msg(v, _bot=y_bot, _h=plot_h, _lmin=axis_min, _lmax=axis_max):
-            if v <= 0:
-                return _bot
-            lv = math.log10(v)
-            frac = max(0, min(1, (lv - _lmin) / (_lmax - _lmin)))
+        def y_cpu(v, _bot=y_bot, _h=plot_h, _ceil=cpu_ceil):
+            frac = max(0, min(1, v / _ceil))
             return _bot - frac * _h
 
         def y_tput(v, _bot=y_bot, _h=plot_h, _lmin=tp_min, _lmax=tp_max):
@@ -295,9 +304,9 @@ def generate_svg(
             f'{link_label}</text>'
         )
 
-        # Left-axis gridlines (msg/s, log scale)
-        for val in msg_ticks:
-            yy = y_msg(val)
+        # Left-axis gridlines (CPU %, linear)
+        for val in cpu_ticks:
+            yy = y_cpu(val)
             L.append(
                 f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
                 f' stroke="#e5e7eb" stroke-width="1"/>'
@@ -305,7 +314,7 @@ def generate_svg(
             L.append(
                 f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
                 f' dominant-baseline="middle" fill="#374151" font-size="9">'
-                f'{_fmt_y_rate(val)}</text>'
+                f'{_fmt_cpu(val)}</text>'
             )
 
         # Right-axis gridlines (virtual throughput, log scale)
@@ -351,20 +360,20 @@ def generate_svg(
         L.append(
             f'  <text x="40" y="{mid_y:.1f}" text-anchor="middle"'
             f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
-            f' transform="rotate(-90,40,{mid_y:.1f})">msg/s (log)</text>'
+            f' transform="rotate(-90,40,{mid_y:.1f})">CPU %</text>'
         )
 
         # Plot lines
         present = [k for k in SERIES_ORDER if k in series]
 
-        # Dashed: msg/s (log)
+        # Dashed: CPU %
         for name in present:
             d = series[name]
             active = [(i, sizes[i]) for i in range(n) if sizes[i] in d]
             if not active:
                 continue
             pts = " ".join(
-                f"{xs[i]:.1f},{y_msg(d[s]['msgs_s']):.1f}" for i, s in active
+                f"{xs[i]:.1f},{y_cpu(d[s]['cpu_pct']):.1f}" for i, s in active
             )
             L.append(
                 f'  <polyline points="{pts}" fill="none" stroke="{COLORS[name]}"'
@@ -422,7 +431,7 @@ def generate_svg(
     L.append(
         f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
         f' fill="#9ca3af" font-size="9">'
-        f'dashed = msg/s log (left) · solid = virtual throughput log (right)</text>'
+        f'dashed = CPU % (left) · solid = virtual throughput log (right)</text>'
     )
     L.append("</svg>")
 
@@ -467,14 +476,6 @@ def main():
                         help="throughput range for 100 Mbps panel (min,max MB/s)")
     parser.add_argument("--tput-10m", type=str, default=None,
                         help="throughput range for 10 Mbps panel (min,max MB/s)")
-    parser.add_argument("--msgs-10g", type=str, default=None,
-                        help="msg/s range for 10 Gbps panel (min,max)")
-    parser.add_argument("--msgs-1g", type=str, default=None,
-                        help="msg/s range for 1 Gbps panel (min,max)")
-    parser.add_argument("--msgs-100m", type=str, default=None,
-                        help="msg/s range for 100 Mbps panel (min,max)")
-    parser.add_argument("--msgs-10m", type=str, default=None,
-                        help="msg/s range for 10 Mbps panel (min,max)")
     args = parser.parse_args()
 
     repo = Path(__file__).resolve().parent.parent
@@ -498,20 +499,12 @@ def main():
         return default
 
     default_tput = {"10g": (10, 4000), "1g": (5, 2000), "100m": (1, 400), "10m": (1, 40)}
-    default_msgs = {"10g": (1000, 20_000_000), "1g": (100, 20_000_000),
-                    "100m": (10, 2_000_000), "10m": (1, 200_000)}
 
     tput_ranges = {
         "10g": parse_range(args.tput_10g, default_tput["10g"]),
         "1g": parse_range(args.tput_1g, default_tput["1g"]),
         "100m": parse_range(args.tput_100m, default_tput["100m"]),
         "10m": parse_range(args.tput_10m, default_tput["10m"]),
-    }
-    msgs_ranges = {
-        "10g": parse_range(args.msgs_10g, default_msgs["10g"]),
-        "1g": parse_range(args.msgs_1g, default_msgs["1g"]),
-        "100m": parse_range(args.msgs_100m, default_msgs["100m"]),
-        "10m": parse_range(args.msgs_10m, default_msgs["10m"]),
     }
 
     ds = args.dict_size or 2048
@@ -520,7 +513,7 @@ def main():
     else:
         dict_size_label = f"{ds} B"
 
-    svg = generate_svg(panels, tput_ranges, msgs_ranges, dict_size_label,
+    svg = generate_svg(panels, tput_ranges, dict_size_label,
                        backend=args.backend, hw_label=detect_hardware())
     output = repo / "doc" / "charts" / "compression" / f"{args.backend}_{ds}.svg"
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -479,7 +479,8 @@ def main():
     args = parser.parse_args()
 
     repo = Path(__file__).resolve().parent.parent
-    jsonl = repo / f"omq-{args.backend}" / "benches" / "results_compression.jsonl"
+    cache_dir = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+    jsonl = cache_dir / f"results_compression_{args.backend}.jsonl"
 
     if not jsonl.exists():
         print(f"ERROR: {jsonl} not found. Run the compression bench first.",

--- a/scripts/gen_mechanism_chart.py
+++ b/scripts/gen_mechanism_chart.py
@@ -3,6 +3,7 @@
 
 import json
 import math
+import os
 import sys
 from pathlib import Path
 
@@ -237,8 +238,8 @@ def generate_svg(data: dict) -> str:
 
 
 def main():
-    repo = Path(__file__).resolve().parent.parent
-    jsonl = repo / "omq-compio" / "benches" / "results.jsonl"
+    cache_dir = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+    jsonl = cache_dir / "results_compio.jsonl"
 
     if not jsonl.exists():
         print(f"ERROR: {jsonl} not found", file=sys.stderr)

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -27,7 +27,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-JSONL_PATH = ROOT / "benchmarks" / "comparisons.jsonl"
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
 COMPARISONS_MD = ROOT / "COMPARISONS.md"
 
 FULL_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]


### PR DESCRIPTION
- Switch benchmarks from `CLOCK_THREAD_CPUTIME_ID` to `CLOCK_PROCESS_CPUTIME_ID` for accurate multi-thread CPU cost; plot CPU% (0-400% scale) in compression charts
- Pre-construct `Message` outside the bench loop and use `Message::clone()` per iteration to avoid per-send `Bytes` allocation for inline payloads
- Adjust chart panel heights (taller throughput, shorter latency); add hardware subtitle to pyomq bindings chart
- Store benchmark JSONL in `$XDG_CACHE_HOME/omq/` (`~/.cache/omq/`) so multiple checkout dirs share one result set