### PR TITLE
Add release-plz for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,26 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -12,7 +12,7 @@ Compared against libzmq v4.3.5 and zmq.rs (zeromq crate v0.6.0).
   <img src="doc/charts/comparison_inproc.svg" alt="PUSH/PULL throughput and REQ/REP latency: inproc" width="850">
 </p>
 
-## libzmq vs omq — inproc
+## libzmq vs omq: inproc
 
 Same process, no kernel socket overhead. libzmq v4.3.5 (C binary) vs omq-compio (io_uring, single thread) and omq-tokio (multi-thread).
 
@@ -42,7 +42,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport inproc --latency --upda
 
 <!-- END libzmq_comparison_inproc_tokio -->
 
-## libzmq vs omq — IPC
+## libzmq vs omq: IPC
 
 Abstract-namespace Unix socket. Push binds, pull connects. libzmq v4.3.5 (C binary) vs omq-compio (io_uring, single thread) and omq-tokio (multi-thread).
 
@@ -70,7 +70,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport ipc --update-markdown`
 
 <!-- END libzmq_comparison_ipc_tokio -->
 
-## libzmq vs omq — TCP
+## libzmq vs omq: TCP
 
 TCP loopback, each process pinned to one core. Push binds, pull connects. libzmq v4.3.5 (C binary) vs omq-compio (io_uring, single thread) and omq-tokio (multi-thread).
 
@@ -98,7 +98,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport tcp --update-markdown`
 
 <!-- END libzmq_comparison_tcp_tokio -->
 
-## libzmq vs omq — WebSocket
+## libzmq vs omq: WebSocket
 
 ZWS/2.0 (RFC 45) over TCP loopback. Push binds, pull connects. Requires libzmq built with WebSocket support (4.3.5+) and omq built with the `ws` feature.
 
@@ -126,9 +126,9 @@ Refresh: `python3 scripts/run_comparisons.py --transport ws --update-markdown`
 
 <!-- END libzmq_comparison_ws_tokio -->
 
-> **zmq.rs inproc:** zeromq 0.6 does not implement the inproc transport, so no zmq.rs vs omq inproc comparison is available. See the libzmq vs omq — inproc table above for omq's inproc numbers against a reference implementation.
+> **zmq.rs inproc:** zeromq 0.6 does not implement the inproc transport, so no zmq.rs vs omq inproc comparison is available. See the libzmq vs omq: inproc table above for omq's inproc numbers against a reference implementation.
 
-## zmq.rs vs omq — IPC
+## zmq.rs vs omq: IPC
 
 Push binds, pull connects. zmq.rs uses a socket file; omq uses abstract-namespace sockets. zmq.rs peer: `scripts/zmqrs_bench_peer/` (zeromq crate, tokio multi-thread). omq-compio: single io_uring thread. omq-tokio: multi-thread.
 
@@ -156,7 +156,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport ipc --update-markdown`
 
 <!-- END zmqrs_comparison_ipc_tokio -->
 
-## zmq.rs vs omq — TCP
+## zmq.rs vs omq: TCP
 
 TCP loopback, push binds, pull connects. zmq.rs <-> omq-tokio is apples-to-apples (both tokio multi-thread). omq-compio is intentionally CPU-constrained (single io_uring thread).
 
@@ -184,7 +184,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport tcp --update-markdown`
 
 <!-- END zmqrs_comparison_tcp_tokio -->
 
-## REQ/REP latency — libzmq vs omq
+## REQ/REP latency: libzmq vs omq
 
 Serial ping-pong: one REQ/REP round-trip at a time, p50 and p99 in microseconds.
 Lower is better; speedup = libzmq / omq.
@@ -236,7 +236,7 @@ Refresh: `python3 scripts/run_comparisons.py --transport ws --update-markdown`
 (run `python3 scripts/run_comparisons.py --transport ws --update-markdown` to populate)
 <!-- END libzmq_latency_ws -->
 
-## REQ/REP latency — zmq.rs vs omq
+## REQ/REP latency: zmq.rs vs omq
 
 ### IPC
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -187,71 +187,40 @@ yring ──────────────┤                      │
                                    └─ omq-zeromq
 ```
 
+### Automation (release-plz)
+
+`release-plz` runs on every push to `main`
+(`.github/workflows/release-plz.yml`). It:
+
+- Opens/updates a release PR with version bumps for changed crates,
+  including cascading dep updates across the workspace.
+- After the PR merges: creates annotated tags, publishes to crates.io
+  in dependency order, creates GitHub releases.
+
+Configuration: `release-plz.toml`. Changelogs are hand-curated, not
+generated.
+
+Uses trusted publishing (OIDC) for crates.io authentication. Each
+crate must be configured as a trusted publisher on crates.io.
+
 ### Steps
 
-1. **Identify changed crates.** For each crate, compare against its
-   last release tag:
+1. **Review the release-plz PR.** Verify the semver bumps are correct
+   (patch for bug fixes, minor for features/perf/refactors).
 
-   ```sh
-   git log <crate>-v<last>..HEAD --no-merges -- <crate>/src/ <crate>/Cargo.toml
-   ```
+2. **Curate changelogs.** For each bumped crate, insert a new
+   `## [x.y.z]` section below `## [Unreleased]` in `CHANGELOG.md`.
+   Never modify existing versioned sections.
 
-2. **Determine semver bump.** Bug fixes only: patch. Anything else
-   (features, perf, refactors): minor. Apply the cascade rule: if
-   any dependency is bumped, bump every dependent too (even if only
-   the dep version changed).
+3. **Update zguide examples.** Bump `omq` version in
+   `examples/zguide-*/*/Cargo.toml`.
 
-3. **Update each crate:**
-   - Bump `version` in `Cargo.toml`.
-   - Update dep versions in all dependents' `Cargo.toml` files.
-   - Insert a new `## [x.y.z]` section below `## [Unreleased]` in
-     `CHANGELOG.md`. Never modify existing versioned sections.
-   - Update `omq` version in `examples/zguide-*/*/Cargo.toml`.
-   - For pyomq: bump version in both `Cargo.toml` and
-     `pyproject.toml`.
+4. **Merge the release PR.** release-plz tags and publishes to
+   crates.io automatically.
 
-4. **Verify.** `cargo check --workspace` and
-   `cargo clippy --workspace --all-targets`.
-
-5. **Commit and PR.** One commit for the entire release wave. Push
-   to a branch, create a PR, wait for CI, merge.
-
-6. **Tag.** After merge, create annotated tags on the merge commit:
-
-   ```sh
-   for t in omq-proto-v0.X.0 blume-v0.X.0 ...; do
-     git tag -a "$t" -m "$t"
-   done
-   ```
-
-7. **Push tags.** Push workspace tags (everything except pyomq):
-
-   ```sh
-   git push origin omq-proto-v0.X.0 blume-v0.X.0 ...
-   ```
-
-   Push the pyomq tag **separately** so its release workflow
-   triggers independently:
-
-   ```sh
-   git push origin pyomq-v0.X.0
-   ```
-
-8. **Publish to crates.io** in dependency order:
-
-   ```sh
-   cargo publish -p omq-proto
-   cargo publish -p blume
-   cargo publish -p omq-compio
-   cargo publish -p omq-tokio
-   cargo publish -p omq
-   cargo publish -p omq-libzmq
-   cargo publish -p omq-zeromq
-   ```
-
-   Each `cargo publish` waits for the previous crate to propagate
-   before proceeding. pyomq is published by the `release-pyomq.yml`
-   GitHub Actions workflow triggered by the `pyomq-v*` tag.
+5. **pyomq** (if changed): bump version in
+   `bindings/pyomq/Cargo.toml` and `bindings/pyomq/pyproject.toml`,
+   push a `pyomq-v*` tag to trigger the wheel build/publish workflow.
 
 ### Crates to check
 

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -819,7 +819,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
-        f'PUSH/PULL throughput — 2-process, TCP loopback (higher is better)</text>'
+        f'PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>'
     )
     if hw_label:
         L.append(
@@ -920,7 +920,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
-        f'REQ/REP latency — 2-process, TCP loopback, p50 µs (lower is better)</text>'
+        f'REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>'
     )
 
     sync_omq_lat = data["sync_omq_lat"]

--- a/omq-tokio/tests/inproc_recv_race.rs
+++ b/omq-tokio/tests/inproc_recv_race.rs
@@ -1,0 +1,155 @@
+//! Regression tests for c331369: lost-wakeup race and hang on inproc
+//! peer exit in tokio recv (`SpscAwareRecv`).
+//!
+//! Bug 1: `recv_notify.notified()` created after `try_drain_consumers()`
+//! returned empty. A `notify_one()` firing in that gap was lost.
+//!
+//! Bug 2: inproc peer driver exit sent `PeerOut::Closed` to the actor,
+//! but the receiver was stuck on `recv_notify.notified()` (biased first
+//! in select) and never polled `self.rx`. Messages arriving via the
+//! actor path (from other peers) were invisible until a new inproc
+//! message happened to wake `recv_notify`.
+
+use std::time::Duration;
+
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn inproc(name: &str) -> Endpoint {
+    Endpoint::Inproc { name: name.into() }
+}
+
+fn tcp_ep() -> Endpoint {
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+    let l = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+    let port = l.local_addr().unwrap().port();
+    drop(l);
+    Endpoint::Tcp {
+        host: omq_tokio::endpoint::Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+/// Bug 2: after an inproc peer exits, `recv()` must still be able to
+/// pick up messages arriving via the actor path (`self.rx`).
+///
+/// Before the fix, `recv()` was stuck on `recv_notify.notified()` and
+/// never polled `self.rx`, so the TCP peer's message was invisible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recv_after_inproc_peer_close_sees_tcp_messages() {
+    let tcp = tcp_ep();
+
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    pull.bind(inproc("race-close-tcp")).await.unwrap();
+    pull.bind(tcp.clone()).await.unwrap();
+
+    // Inproc peer: connect, send, close.
+    let push_inproc = Socket::new(SocketType::Push, Options::default());
+    push_inproc.connect(inproc("race-close-tcp")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push_inproc
+        .send(Message::single("from-inproc"))
+        .await
+        .unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("recv inproc msg timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"from-inproc");
+
+    push_inproc.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // TCP peer: connect and send. The pull must see this message
+    // despite the inproc peer's exit.
+    let push_tcp = Socket::new(SocketType::Push, Options::default());
+    push_tcp.connect(tcp).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    push_tcp.send(Message::single("from-tcp")).await.unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("pull.recv() hung after inproc peer closed (bug #2: recv stuck on recv_notify)")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"from-tcp");
+}
+
+/// Bug 2 variant: after an inproc peer exits, messages from a second
+/// inproc peer (arriving via SPSC + `recv_notify`) must still be received.
+/// The recv loop must unblock from the stale `recv_notify` wait and
+/// re-drain consumers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recv_after_inproc_peer_close_sees_new_inproc_messages() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    pull.bind(inproc("race-close-new")).await.unwrap();
+
+    // First inproc peer: connect, send, close.
+    let push_a = Socket::new(SocketType::Push, Options::default());
+    push_a.connect(inproc("race-close-new")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push_a.send(Message::single("a")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("recv a timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"a");
+
+    push_a.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Second inproc peer.
+    let push_b = Socket::new(SocketType::Push, Options::default());
+    push_b.connect(inproc("race-close-new")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push_b.send(Message::single("b")).await.unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("pull.recv() hung after first inproc peer closed (bug #2)")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"b");
+}
+
+/// Bug 1: lost wakeup when `notify_one()` fires between
+/// `try_drain_consumers()` returning empty and `notified()` future creation.
+/// Stress by sending many messages with interleaved yields.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn recv_no_lost_wakeup_under_rapid_sends() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    pull.bind(inproc("recv-race-wakeup")).await.unwrap();
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(inproc("recv-race-wakeup")).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let n = 200;
+    let sender = {
+        let push = push.clone();
+        tokio::spawn(async move {
+            for i in 0..n {
+                push.send(Message::single(format!("{i}"))).await.unwrap();
+                if i % 7 == 0 {
+                    tokio::task::yield_now().await;
+                }
+            }
+        })
+    };
+
+    let mut received = 0u64;
+    while received < n {
+        let res = tokio::time::timeout(Duration::from_secs(5), pull.recv()).await;
+        match res {
+            Ok(Ok(_)) => received += 1,
+            Ok(Err(e)) => panic!("unexpected recv error: {e:?}"),
+            Err(elapsed) => panic!(
+                "recv timed out after {received}/{n} messages \
+                 (bug #1: lost wakeup under rapid sends): {elapsed}"
+            ),
+        }
+    }
+
+    sender.await.unwrap();
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = false
+git_tag_name = "{{ package }}-v{{ version }}"

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -391,7 +391,7 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
 
     draw_throughput_panel(
         L, sizes, xs, tput, impls, x_left, x_right, t1_y_top, t1_y_bot,
-        f"PUSH/PULL throughput — {transport_label} (higher is better)",
+        f"PUSH/PULL throughput: {transport_label} (higher is better)",
         log_gbs=log_gbs,
         fixed_msg_max=fixed_msg_max,
         fixed_gbs_max=fixed_gbs_max,
@@ -407,7 +407,7 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
         t2_y_bot = t2_y_top + 120
         draw_latency_panel(
             L, sizes, xs, lat, impls, x_left, x_right, t2_y_top, t2_y_bot,
-            f"REQ/REP latency — {transport_label} (p50 µs, lower is better)",
+            f"REQ/REP latency: {transport_label} (p50 µs, lower is better)",
             fixed_lat_max=fixed_lat_max,
         )
         leg_y = t2_y_bot + 60

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -254,7 +254,7 @@ def generate_svg(
         f'  <text x="{mid_x}" y="16" text-anchor="middle" fill="#111827"'
         f' font-size="12" font-weight="700">'
         f'Compression transports: structured JSON, PUSH/PULL, {THREAD_MODELS[backend]} (omq-{backend})'
-        f'{f" — dict {dict_size_label}" if dict_size_label else ""}</text>'
+        f'{f", dict {dict_size_label}" if dict_size_label else ""}</text>'
     )
     if hw_label:
         L.append(


### PR DESCRIPTION
- Add `release-plz.toml` with `changelog_update = false` and `<crate>-v<version>` tag format
- Add `.github/workflows/release-plz.yml` with trusted publishing (OIDC, no `CARGO_REGISTRY_TOKEN`)
- Rewrite DEVELOPMENT.md releasing section: 8 manual steps down to 5, with version bumps/tagging/publishing automated
- Replace em-dashes with colons in chart titles and comparison headings
- Add regression tests for inproc recv race and lost-wakeup bugs