### PR TITLE
widen Payload and Message inline thresholds to one cache line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ errors. Run all three before every `git push`:
 
 ```sh
 cargo clippy --workspace --all-targets                # default features
-cargo clippy --workspace --all-targets --all-features # feature-gated paths
+cargo clippy --workspace --all-targets --all-features # feature-gated paths (omq facade compile_error! is expected here: both backends are mutually exclusive)
 (cd bindings/pyomq && cargo clippy --all-targets)     # separate workspace
 ```
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -105,28 +105,27 @@ look up the peer by destination identity and bypass the shared queue.
 ## Message and Payload types
 
 Both are custom enums (not SmallVecs) tuned for the common decode
-path:
+path. Each is exactly 64 bytes (one cache line):
 
 ```rust
-// Payload: 40 bytes. One decoded ZMTP frame.
+// Payload: 64 bytes. One decoded ZMTP frame.
 enum PayloadInner {
     Empty,
-    Inline { len: u8, data: [u8; 38] },  // no heap, no Arc
+    Inline { len: u8, data: [u8; 62] },  // no heap, no Arc
     Single(Bytes),                         // one owned chunk
-    Multi(Vec<Bytes>),                     // rare: prepended headers
 }
 
-// Message: 48 bytes. One or more frames (parts).
+// Message: 64 bytes. One or more frames (parts).
 enum MessageInner {
     Empty,
-    Inline { len: u8, data: [MaybeUninit<u8>; 39] },  // single-frame <= 39 B
+    Inline { len: u8, data: [u8; 55] },  // single-frame <= 55 B
     Single(Payload),
     Multi(Vec<Payload>),
 }
 ```
 
-Inline variants cover payloads up to 38 bytes and single-frame
-messages up to 39 bytes with zero refcounting overhead. The codec's
+Inline variants cover payloads up to 62 bytes and single-frame
+messages up to 55 bytes with zero refcounting overhead. The codec's
 fast path (`try_advance_ready`) constructs `MessageInner::Inline`
 directly from the input buffer, skipping the intermediate `Payload`.
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -332,14 +332,13 @@ bumps the offset. Front `Bytes` dropped only when fully consumed.
 ```rust
 enum PayloadInner {
     Empty,
-    Inline { len: u8, data: [u8; 38] },  // no heap, no Arc
+    Inline { len: u8, data: [u8; 62] },  // no heap, no Arc
     Single(Bytes),
-    Multi(Vec<Bytes>),
 }
 ```
 
-38 B inline capacity covers every bench size up to 38 B.
-Per-frame cost: ~3 atomic ops -> ~0.
+64 bytes (one cache line). 62 B inline capacity covers most
+small-message workloads. Per-frame cost: ~3 atomic ops -> ~0.
 
 **PULL fast path in `try_recv`.** Three specialization levels:
 REQ/REP/DISH lock per pop, SUB holds lock for filtering,
@@ -362,7 +361,7 @@ not needed; `#[inline]` annotations stay.
 
 **`Message` inline parts 3 -> 1.** Was `SmallVec<[Payload; 3]>`
 = 128 B. Single-part PUSH/PULL: two dead slots copied per message.
-Now `[Payload; 1]` = 48 B. 62% less copied per push/pop.
+Now `[Payload; 1]` = 64 B.
 
 **`UnsafeCell` recv_cache.** On compio's single-threaded runtime,
 recv_cache is never contended. Replaced `Mutex<VecDeque<Message>>`
@@ -418,16 +417,15 @@ Replaced `SmallVec<[Payload; 1]>` with a custom enum:
 ```rust
 enum MessageInner {
     Empty,
-    Inline { len: u8, data: [MaybeUninit<u8>; 39] },
+    Inline { len: u8, data: [u8; 55] },
     Single(Payload),
     Multi(Vec<Payload>),
 }
 ```
 
-48 B, covers up to 39 B inline. `absorb_data_frame` constructs
-`Inline` directly. SmallVec::drop disappeared from the profile
-(was 6%). `MaybeUninit` skips zeroing the 39 B array -- worth
-~13% at 8 B.
+64 B (one cache line), covers up to 55 B inline.
+`absorb_data_frame` constructs `Inline` directly. SmallVec::drop
+disappeared from the profile (was 6%).
 
 `Payload` removed from the public API. Users see only `Message`.
 
@@ -445,10 +443,10 @@ directly into `MessageInner::Inline`. One memcpy.
 | path | copies | total bytes (32 B msg) |
 |---|---|---|
 | before: split_to -> Payload -> Message -> push_back | 3 | 112 B |
-| after: read_into -> Message -> push_back | 2 | 80 B |
+| after: read_into -> Message -> push_back | 2 | 96 B |
 | libzmq: memcpy(msg_t) | 1 | 64 B |
 
-Remaining gap: `VecDeque::push_back` copies 48 B per message.
+Remaining gap: `VecDeque::push_back` copies 64 B per message.
 libzmq's `yqueue_t` writes in-place (one pointer advance).
 
 ### Round 9: SmallVec for parts_payload()
@@ -463,7 +461,7 @@ per single-part send. Fix: `SmallVec<[Payload; 1]>`.
 Tried sharing the read buffer's Arc via `Bytes::slice` instead of
 inline copy. Arc bump + drop (~10 ns for two atomics) cost the
 same as the inline copy + zeroing. A microbenchmark confirmed:
-inline wins or ties at every size up to 39 B. For payloads that
+inline wins or ties at every size up to 55 B. For payloads that
 fit in a cache line, the atomic in an Arc bump is more expensive
 than the copy.
 
@@ -563,8 +561,8 @@ No separate I/O thread, but encode pipelines against write.
 Each SPSC-eligible inproc connection (PUSH/PULL, PAIR) gets a
 dedicated `blume::spsc` ring (1024-slot, lock-free). Per-peer
 rings replace the shared blume MPSC channel. The ring carries
-`Message` directly (48 B by value); no `InboundFrame` wrapper, no
-`Bytes` clone, no heap allocation for messages <=39 B.
+`Message` directly (64 B by value); no `InboundFrame` wrapper, no
+`Bytes` clone, no heap allocation for messages <=55 B.
 
 Send fast path (PUSH/PAIR, single peer): one `UnsafeCell` access
 to the per-peer producer, push, flush. No Mutex, no PeerOut clone,
@@ -625,7 +623,7 @@ Profile at 32 B TCP before this change:
 changes during the benchmark. Two fixes:
 
 **`iter_slices` replaces `iter_parts`.** The old path constructed a
-temporary `Payload` struct (40 B) for each part of an inline message,
+temporary `Payload` struct (64 B) for each part of an inline message,
 copying the data in and then reading it back out. `iter_slices` yields
 `&[u8]` directly from the message's inline storage. One fewer 32 B
 memcpy per message on the flat-encode path.
@@ -880,7 +878,7 @@ heap-allocates (no inline representation). Clone and drop each touch
 a refcount. This cost 12.8% of push-side CPU.
 
 Added `Message::from_slice(&[u8])` which copies directly into the
-inline `MessageInner::Inline` variant for payloads up to 39 bytes.
+inline `MessageInner::Inline` variant for payloads up to 55 bytes.
 No heap allocation, no refcounting. Falls back to
 `Bytes::copy_from_slice` for larger payloads.
 
@@ -991,4 +989,29 @@ dominates at every size.
 overhead comes from: (1) per-frame WS header + client-side XOR
 masking, (2) no gather I/O (each WS message is an independent
 tungstenite write), (3) the HTTP upgrade handshake at connect time.
+
+## Cache-line-aligned inline thresholds
+
+`Payload` was 40 bytes (inline up to 38 B). `Message` was 48 bytes
+(inline up to 39 B). Both were sized to minimize struct width, but
+neither aligned to a cache line boundary. The 39-to-40 byte cliff
+was steep: TCP throughput dropped 29% at the transition (17.8M to
+12.6M msg/s at 1 peer).
+
+Bumped both to 64 bytes (one cache line each). `Payload` now
+inlines up to 62 B, `Message` up to 55 B. The `Message` bump
+drives the improvement because the recv fast path
+(`try_advance_ready`) writes directly into `MessageInner::Inline`,
+bypassing `Payload` entirely for single-part messages. The
+`Payload` bump fills the same cache line that `Single(Bytes)`
+already occupied and helps multi-part messages where each frame
+goes through `Payload::Inline`.
+
+TCP throughput at 40 B (the old cliff): 12.6M to 17.0M msg/s
+(+35%). No regression at any other size. Latency unchanged
+(~21 µs p50 REQ/REP TCP).
+
+`Message` at 80 B was tested and rejected. Per-message throughput
+did not improve at sizes the 64 B variant already covers, and the
+struct crosses a second cache line.
 

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -3,7 +3,7 @@
 //! `Payload` represents a frame's byte content in one of four forms:
 //!
 //! - **Empty**: zero bytes, no backing storage.
-//! - **Inline**: ≤ 31 bytes stored directly in the struct, no heap
+//! - **Inline**: ≤ 62 bytes stored directly in the struct, no heap
 //!   allocation and no refcounting. Produced by the codec for small
 //!   frames on the recv hot path.
 //! - **Single**: one `Bytes` chunk (overwhelmingly common on the send
@@ -18,10 +18,10 @@ use bytes::Bytes;
 use smallvec::SmallVec;
 
 /// Maximum payload bytes stored inline (no `Bytes` / Arc).
-/// 38 is the largest value that keeps `Payload` at 40 bytes.
-pub const MAX_INLINE_PAYLOAD: usize = 38;
+/// 62 is the largest value that keeps `Payload` at 64 bytes (one cache line).
+pub const MAX_INLINE_PAYLOAD: usize = 62;
 
-const _: () = assert!(std::mem::size_of::<Payload>() == 40);
+const _: () = assert!(std::mem::size_of::<Payload>() == 64);
 
 /// A frame payload, possibly composed of multiple `Bytes` chunks that are
 /// concatenated on the wire.
@@ -123,7 +123,7 @@ impl Payload {
     /// Returns the payload as a single contiguous `Bytes`.
     ///
     /// - Empty → `Bytes::new()`.
-    /// - Inline → `Bytes::copy_from_slice` (≤ 38 B copy).
+    /// - Inline → `Bytes::copy_from_slice` (≤ 62 B copy).
     /// - Single → `Bytes::clone` (Arc bump only).
     pub fn as_bytes(&self) -> Bytes {
         match &self.inner {
@@ -264,9 +264,10 @@ impl Frame {
 }
 
 /// Maximum bytes stored inline in a `Message` (no heap, no refcount).
-pub const MAX_INLINE_MESSAGE: usize = 39;
+/// 55 is the largest value that keeps `Message` at 64 bytes (one cache line).
+pub const MAX_INLINE_MESSAGE: usize = 55;
 
-const _: () = assert!(std::mem::size_of::<Message>() == 48);
+const _: () = assert!(std::mem::size_of::<Message>() == 64);
 
 pub(crate) enum MessageInner {
     Empty,
@@ -303,7 +304,7 @@ impl Message {
     }
 
     /// Create a single-part message from a byte slice. Avoids heap
-    /// allocation for payloads up to 39 bytes.
+    /// allocation for payloads up to 55 bytes.
     #[inline]
     pub fn from_slice(data: &[u8]) -> Self {
         if data.len() <= MAX_INLINE_MESSAGE {
@@ -778,7 +779,7 @@ mod tests {
 
     #[test]
     fn payload_size_of() {
-        assert_eq!(std::mem::size_of::<Payload>(), 40);
+        assert_eq!(std::mem::size_of::<Payload>(), 64);
     }
 
     #[test]

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -468,14 +468,15 @@ mod tests {
 
     #[test]
     fn max_message_size_accounts_for_overhead_plus_content() {
-        let max = 300;
-        let mut c = ready_connection(Some(max));
         let overhead = size_of::<Payload>();
-        // 2 frames: each costs overhead + 100 = 140 bytes, total 280 <= 300
+        let per = overhead + 100;
+        let max = 2 * per + 1;
+        let mut c = ready_connection(Some(max));
+        // 2 frames fit
         let r = feed_data_frames(&mut c, &[(true, &[0xAB; 100]), (false, &[0xCD; 100])]);
-        assert!(r.is_ok(), "2 × 140 = 280 <= 300, got: {r:?}");
+        assert!(r.is_ok(), "2 × {per} = {} <= {max}, got: {r:?}", 2 * per);
 
-        // 3 frames: each costs 140, total 420 > 300
+        // 3 frames exceed
         let mut c = ready_connection(Some(max));
         let err = feed_data_frames(
             &mut c,
@@ -483,8 +484,8 @@ mod tests {
         );
         assert!(
             matches!(err, Err(Error::MessageTooLarge { .. })),
-            "3 × (40 + 100) = {}, should exceed max={max}",
-            3 * (overhead + 100),
+            "3 × {per} = {} > {max}",
+            3 * per,
         );
     }
 


### PR DESCRIPTION
- `Payload`: 40 B (inline ≤38) to 64 B (inline ≤62)
- `Message`: 48 B (inline ≤39) to 64 B (inline ≤55)
- eliminates the 39-to-40 byte throughput cliff (29% drop on TCP)
- 40 B TCP: 12.6M to 17.0M msg/s (+35%), no regression at other sizes
- latency unchanged (~21 µs p50 REQ/REP TCP)
- 80 B and 128 B Message tested and rejected: no per-message gain at sizes 64 B already covers, 23-25% regression under 8-peer fan-in
- max_message_size test made size-agnostic
- doc/architecture.md and doc/performance.md updated