### PR TITLE
Fix stale flat-buf references and arena threshold in docs

### DIFF
--- a/doc/compio.md
+++ b/doc/compio.md
@@ -182,7 +182,7 @@ EncodedQueue {
   scratch: BytesMut,         // reused header buffer -- zero alloc post-warmup
 }
 
-const ARENA_THRESHOLD: usize = 32 * 1024;
+const ARENA_THRESHOLD: usize = 96 * 1024;
 ```
 
 Two encoding paths, chosen per message:

--- a/omq-compio/README.md
+++ b/omq-compio/README.md
@@ -11,7 +11,7 @@ Built on [omq-proto](https://crates.io/crates/omq-proto) and
 |-|-|
 | Thread-per-core | One compio runtime per thread, no cross-thread sync on the hot path |
 | io_uring multi-shot recv | One persistent SQE per connection, no re-arming |
-| Direct-encode send | Encodes ZMTP frames into `EncodedQueue` under a sync mutex, bypassing the driver. Small messages (< 32 KiB) packed into one flat buffer, one `writev` call. |
+| Direct-encode send | Encodes ZMTP frames into `EncodedQueue` under a sync mutex, bypassing the driver. Small messages (< 96 KiB) packed into one arena buffer, one `writev` call. |
 | Direct-recv | `Socket::recv` claims the read side from the driver and feeds the codec inline. Saves ~12 µs per round-trip. |
 | Large-message recv | Payloads above 128 KiB accumulated into a pre-allocated `BytesMut`. Frames above pool capacity fall back to one-shot read. |
 

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -161,7 +161,7 @@ pub struct Options {
     /// larger messages produce per-frame iovecs referencing the original
     /// `Bytes` payload.
     ///
-    /// `None` uses the default (`ARENA_THRESHOLD`, 32 KiB). Raise this
+    /// `None` uses the default (`ARENA_THRESHOLD`, 96 KiB). Raise this
     /// when payloads are owned by an external runtime (e.g. Python
     /// refcounted objects) where the gather path's per-chunk refcount
     /// traffic is more expensive than a flat memcpy.
@@ -419,7 +419,7 @@ impl Options {
 
     /// Set the per-`EncodedQueue` arena threshold. Messages smaller than
     /// this are copied into a contiguous arena buffer; larger ones use
-    /// zero-copy gather-write. Default: 32 KiB.
+    /// zero-copy gather-write. Default: 96 KiB.
     #[must_use]
     pub fn arena_threshold(mut self, bytes: usize) -> Self {
         self.arena_threshold = Some(bytes);

--- a/omq-tokio/README.md
+++ b/omq-tokio/README.md
@@ -12,7 +12,7 @@ Built on [omq-proto](https://crates.io/crates/omq-proto) and
 |-|-|
 | Multi-threaded | Concurrent `send`/`recv` from multiple tasks is safe |
 | Actor with bypass | `SocketDriver` actor owns mutable state. Common message path bypasses it: `send` pushes into the routing strategy directly, `recv` pulls from the user channel directly. |
-| Flat-buf encoding | Small messages (< 48 KiB) packed into one `BytesMut`, one `write_all` per batch |
+| Arena encoding | Small messages (< 96 KiB) packed into one `BytesMut`, one `write_all` per batch |
 | Shared-queue work stealing | Round-robin types (PUSH/DEALER) share one `flume` queue. Each connection driver polls it in a `select!` arm, draining up to 256 messages per wakeup. |
 
 <p align="center">
@@ -39,7 +39,7 @@ let msg = pull.recv().await?;
 ## Internals
 
 [`doc/tokio.md`](../doc/tokio.md) covers the actor shape, send/recv bypass, routing
-strategies, and flat-buf encoding threshold.
+strategies, and arena encoding threshold.
 
 ## License
 


### PR DESCRIPTION
- Rename flat-buf → arena in `omq-compio/README.md`, `omq-tokio/README.md`, `doc/compio.md`
- Update `ARENA_THRESHOLD` from 32 KiB to 96 KiB in `doc/compio.md` code snippet and `omq-proto/src/options.rs` doc comments