### PR TITLE
fix omq-tokio publish: add version to compio git dep

### DIFF
--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -53,7 +53,7 @@ rustls-pemfile = { version = "2.2", optional = true }
 rustls-pki-types = { version = "1", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 omq-compio = { path = "../omq-compio", optional = true, default-features = false, features = ["ws"] }
-compio = { git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
+compio = { version = "0.19.0", git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.52.0", features = ["test-util"] }


### PR DESCRIPTION
- crates.io requires all deps to specify a version, even optional git deps
- adds `version = "0.19.0"` to the compio git dep (the git rev still pins the actual source)
- unblocks `cargo publish -p omq-tokio` which failed in the release-plz run