### PR TITLE
docs: fix compression chart subtitles, ordering, CI filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           filters: |
             code:
               - '!**/*.md'
+              - '!**/*.svg'
+              - '!**/*.py'
               - '!doc/**'
 
   test:

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -66,8 +66,8 @@ without it BLAKE3ZMQ drops to ~50 MiB/s at bulk sizes. CURVE plateaus at
 > production.
 
 <p align="center">
-  <img src="doc/charts/mechanism/compio.svg" alt="Mechanism overhead (compio)" width="850">
   <img src="doc/charts/mechanism/tokio.svg" alt="Mechanism overhead (tokio)" width="850">
+  <img src="doc/charts/mechanism/compio.svg" alt="Mechanism overhead (compio)" width="850">
 </p>
 
 ## Compression transport benchmarks
@@ -79,18 +79,18 @@ and are run separately from the charts above.
 ## Reproducing
 
 ```sh
-cargo bench -p omq-compio --bench push_pull
 cargo bench -p omq-tokio  --bench push_pull
-cargo bench -p omq-compio --bench req_rep
+cargo bench -p omq-compio --bench push_pull
 cargo bench -p omq-tokio  --bench req_rep
+cargo bench -p omq-compio --bench req_rep
 
 # Convenience:
 ./scripts/bench_run.rb [--all-features] [--all-sizes]    # adds results to JSONL
 ./scripts/bench_run.rb --chart-sizes                     # dense ×2 sweep for charts
 
 # WebSocket transport (requires ws feature):
-OMQ_BENCH_TRANSPORTS=ws cargo bench -p omq-compio --features ws --bench push_pull
 OMQ_BENCH_TRANSPORTS=ws cargo bench -p omq-tokio  --features ws --bench push_pull
+OMQ_BENCH_TRANSPORTS=ws cargo bench -p omq-compio --features ws --bench push_pull
 
 # Override transports / sizes / peer counts via env:
 OMQ_BENCH_TRANSPORTS=tcp OMQ_BENCH_PEERS=3 OMQ_BENCH_SIZES=128,2048,32768 cargo bench -p omq-compio --bench push_pull
@@ -106,9 +106,9 @@ python3 scripts/gen_mechanism_chart.py            # doc/charts/mechanism/{compio
 
 # Compression charts require a bench run first (writes JSONL):
 #   1. Run bench:
-#      cargo bench -p omq-compio --features lz4,zstd --bench compression
 #      cargo bench -p omq-tokio  --features lz4,zstd --bench compression
+#      cargo bench -p omq-compio --features lz4,zstd --bench compression
 #   2. Generate chart:
-python3 scripts/gen_compression_chart.py --backend compio    # doc/charts/compression/compio_2048.svg
 python3 scripts/gen_compression_chart.py --backend tokio     # doc/charts/compression/tokio_2048.svg
+python3 scripts/gen_compression_chart.py --backend compio    # doc/charts/compression/compio_2048.svg
 ```

--- a/BENCHMARKS_COMPRESSION.md
+++ b/BENCHMARKS_COMPRESSION.md
@@ -15,10 +15,10 @@ on a constrained link). Charts show projected throughput at 10 Gbps,
   (<= 2 KiB), the receiver is the bottleneck, so neither level matters.
 
 <p align="center">
-  <img src="doc/charts/compression/compio_2048.svg" alt="Compression throughput: omq-compio" width="850">
+  <img src="doc/charts/compression/tokio_2048.svg" alt="Compression throughput: omq-tokio" width="850">
 </p>
 <p align="center">
-  <img src="doc/charts/compression/tokio_2048.svg" alt="Compression throughput: omq-tokio" width="850">
+  <img src="doc/charts/compression/compio_2048.svg" alt="Compression throughput: omq-compio" width="850">
 </p>
 
 ### Compression thresholds
@@ -71,12 +71,12 @@ No kernel-level rate limiting is used; slow-link simulation via `tc`/`netem`
 is unreliable on loopback due to kernel buffering.
 
 ```sh
-cargo bench -p omq-compio --features lz4,zstd --bench compression
 cargo bench -p omq-tokio  --features lz4,zstd --bench compression
+cargo bench -p omq-compio --features lz4,zstd --bench compression
 
 # Generate charts
-python3 scripts/gen_compression_chart.py --backend compio
 python3 scripts/gen_compression_chart.py --backend tokio
+python3 scripts/gen_compression_chart.py --backend compio
 ```
 
 Environment variables:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -10,7 +10,7 @@ runtime backends differ. Detail lives in [`compio.md`](compio.md),
 ```
 +------------------------------------------------------------------+
 |  user code                                                       |
-|  +-> omq (facade, picks one backend at build time):              |
+|  depends directly on one backend crate:                          |
 |         omq-tokio   (default, multi-thread, mio/epoll/kqueue)    |
 |         omq-compio  (single-thread io_uring/IOCP)                |
 +------------------------------------------------------------------+

--- a/doc/charts/compression/compio_2048.svg
+++ b/doc/charts/compression/compio_2048.svg
@@ -1,22 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 865 1304" font-family="system-ui, -apple-system, sans-serif">
   <rect width="865" height="1304" fill="white"/>
-  <text x="425.0" y="16" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">Compression transports: structured JSON, PUSH/PULL, 2-thread (omq-compio), dict 2 KiB</text>
-  <text x="425.0" y="30" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores</text>
+  <text x="425.0" y="16" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">Compression transports: structured JSON, PUSH/PULL, 2-process (omq-compio), dict 2 KiB</text>
+  <text x="425.0" y="30" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="425.0" y="59" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Gbps</text>
-  <line x1="90" y1="278.0" x2="760" y2="278.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="278.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
-  <line x1="90" y1="267.0" x2="760" y2="267.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="267.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400k</text>
-  <line x1="90" y1="256.0" x2="760" y2="256.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="256.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">600k</text>
-  <line x1="90" y1="245.0" x2="760" y2="245.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="245.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">800k</text>
-  <line x1="90" y1="197.2" x2="760" y2="197.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="197.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5M</text>
-  <line x1="90" y1="151.2" x2="760" y2="151.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="151.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
-  <line x1="90" y1="105.2" x2="760" y2="105.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="105.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">15M</text>
+  <line x1="90" y1="234.0" x2="760" y2="234.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="234.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="179.0" x2="760" y2="179.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="179.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="124.0" x2="760" y2="124.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="124.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="69.0" x2="760" y2="69.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="69.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="289.0" x2="760" y2="289.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="289.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">10 MB/s</text>
   <line x1="90" y1="263.5" x2="760" y2="263.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -52,8 +46,6 @@
   <line x1="90" y1="69" x2="90" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="69" x2="760" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="289" x2="760" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
-  <rect x="89.0" y="228.0" width="3" height="12" fill="white"/>
-  <path d="M 85.0,240.0 L 95.0,235.0 M 85.0,233.0 L 95.0,228.0" stroke="#9ca3af" stroke-width="1.5" fill="none"/>
   <text x="90.0" y="303" text-anchor="middle" fill="#374151" font-size="8">8 B</text>
   <text x="134.7" y="303" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="179.3" y="303" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
@@ -70,11 +62,11 @@
   <text x="670.7" y="303" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="303" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="303" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">msg/s</text>
-  <polyline points="90.0,91.7 134.7,97.8 179.3,120.4 224.0,164.7 268.7,184.1 313.3,202.0 358.0,220.7 402.7,232.0 447.3,255.4 492.0,272.2 536.7,280.6 581.3,284.8 626.0,286.9 670.7,288.0 715.3,288.5 760.0,288.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,208.2 134.7,208.5 179.3,209.0 224.0,200.6 268.7,205.5 313.3,216.6 358.0,259.9 402.7,271.1 447.3,278.7 492.0,283.3 536.7,285.7 581.3,287.2 626.0,288.1 670.7,288.6 715.3,288.8 760.0,288.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,208.0 134.7,208.4 179.3,209.5 224.0,216.7 268.7,231.4 313.3,231.5 358.0,232.3 402.7,232.8 447.3,261.0 492.0,281.4 536.7,285.7 581.3,287.4 626.0,288.2 670.7,288.7 715.3,288.8 760.0,288.9" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,213.7 134.7,214.0 179.3,216.1 224.0,281.0 268.7,281.0 313.3,281.0 358.0,281.0 402.7,281.1 447.3,281.6 492.0,284.5 536.7,287.3 581.3,288.3 626.0,288.7 670.7,288.9 715.3,288.9 760.0,289.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">CPU %</text>
+  <polyline points="90.0,206.4 134.7,205.8 179.3,208.0 224.0,186.7 268.7,192.6 313.3,194.0 358.0,217.0 402.7,235.8 447.3,245.5 492.0,251.6 536.7,254.3 581.3,255.6 626.0,262.7 670.7,261.5 715.3,266.5 760.0,267.8" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,210.5 134.7,210.0 179.3,207.2 224.0,186.2 268.7,181.7 313.3,189.1 358.0,219.3 402.7,220.9 447.3,222.5 492.0,222.9 536.7,222.4 581.3,221.8 626.0,221.5 670.7,222.0 715.3,224.1 760.0,225.2" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,182.0 134.7,181.6 179.3,179.4 224.0,199.1 268.7,213.7 313.3,213.5 358.0,214.0 402.7,212.2 447.3,211.9 492.0,221.0 536.7,222.4 581.3,222.5 626.0,222.9 670.7,224.0 715.3,224.9 760.0,225.6" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,184.7 134.7,185.7 179.3,187.1 224.0,216.4 268.7,216.4 313.3,216.1 358.0,216.2 402.7,209.0 447.3,206.7 492.0,192.5 536.7,212.3 581.3,220.9 626.0,222.9 670.7,224.7 715.3,225.8 760.0,226.9" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,194.3 134.7,170.4 179.3,151.1 224.0,142.1 268.7,127.1 313.3,114.9 358.0,111.7 402.7,111.7 447.3,111.7 492.0,111.7 536.7,111.7 581.3,111.7 626.0,111.7 670.7,111.7 715.3,111.7 760.0,111.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="194.3" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="170.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -144,20 +136,14 @@
   <circle cx="715.3" cy="186.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="190.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="369" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">1 Gbps</text>
-  <line x1="90" y1="588.0" x2="760" y2="588.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="588.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
-  <line x1="90" y1="577.0" x2="760" y2="577.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="577.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400k</text>
-  <line x1="90" y1="566.0" x2="760" y2="566.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="566.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">600k</text>
-  <line x1="90" y1="555.0" x2="760" y2="555.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="555.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">800k</text>
-  <line x1="90" y1="505.1" x2="760" y2="505.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="505.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5M</text>
-  <line x1="90" y1="456.5" x2="760" y2="456.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="456.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">10M</text>
-  <line x1="90" y1="407.9" x2="760" y2="407.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="407.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">15M</text>
+  <line x1="90" y1="544.0" x2="760" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="434.0" x2="760" y2="434.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="434.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="379.0" x2="760" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="599.0" x2="760" y2="599.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="599.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">5.0 MB/s</text>
   <line x1="90" y1="573.5" x2="760" y2="573.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -195,8 +181,6 @@
   <line x1="90" y1="379" x2="90" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="379" x2="760" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="599" x2="760" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
-  <rect x="89.0" y="538.0" width="3" height="12" fill="white"/>
-  <path d="M 85.0,550.0 L 95.0,545.0 M 85.0,543.0 L 95.0,538.0" stroke="#9ca3af" stroke-width="1.5" fill="none"/>
   <text x="90.0" y="613" text-anchor="middle" fill="#374151" font-size="8">8 B</text>
   <text x="134.7" y="613" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="179.3" y="613" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
@@ -213,11 +197,11 @@
   <text x="670.7" y="613" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="613" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="613" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">msg/s</text>
-  <polyline points="90.0,401.8 134.7,477.8 179.3,515.7 224.0,534.7 268.7,545.3 313.3,572.1 358.0,585.6 402.7,592.3 447.3,595.6 492.0,597.3 536.7,598.2 581.3,598.6 626.0,598.8 670.7,598.9 715.3,598.9 760.0,599.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,516.7 134.7,517.0 179.3,520.0 224.0,535.8 268.7,546.9 313.3,572.6 358.0,580.1 402.7,586.7 447.3,590.7 492.0,593.9 536.7,596.0 581.3,597.3 626.0,598.1 670.7,598.6 715.3,598.8 760.0,598.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,516.5 134.7,516.9 179.3,520.0 224.0,535.8 268.7,541.3 313.3,541.4 358.0,542.2 402.7,542.7 447.3,571.0 492.0,591.4 536.7,595.7 581.3,597.4 626.0,598.2 670.7,598.7 715.3,598.8 760.0,598.9" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,522.5 134.7,522.9 179.3,525.1 224.0,591.0 268.7,591.0 313.3,591.0 358.0,591.0 402.7,591.1 447.3,591.6 492.0,594.5 536.7,597.3 581.3,598.3 626.0,598.7 670.7,598.9 715.3,598.9 760.0,599.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">CPU %</text>
+  <polyline points="90.0,520.7 134.7,557.9 179.3,575.3 224.0,575.6 268.7,584.4 313.3,588.6 358.0,591.8 402.7,593.7 447.3,594.6 492.0,595.3 536.7,595.5 581.3,595.7 626.0,596.4 670.7,596.2 715.3,596.8 760.0,596.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,520.5 134.7,520.0 179.3,522.7 224.0,558.2 268.7,574.2 313.3,582.4 358.0,553.8 402.7,552.2 447.3,545.1 492.0,540.3 536.7,538.1 581.3,535.0 626.0,531.9 670.7,532.0 715.3,534.1 760.0,535.2" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,492.0 134.7,491.6 179.3,495.2 224.0,541.7 268.7,523.7 313.3,523.5 358.0,524.0 402.7,522.2 447.3,521.9 492.0,531.0 536.7,532.4 581.3,532.5 626.0,532.9 670.7,534.0 715.3,534.9 760.0,535.6" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,494.7 134.7,495.7 179.3,497.1 224.0,526.4 268.7,526.4 313.3,526.1 358.0,526.2 402.7,519.0 447.3,516.7 492.0,502.5 536.7,522.3 581.3,530.9 626.0,532.9 670.7,534.7 715.3,535.8 760.0,536.9" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,480.8 134.7,480.8 179.3,480.8 224.0,480.8 268.7,480.8 313.3,480.8 358.0,480.8 402.7,480.8 447.3,480.8 492.0,480.8 536.7,480.8 581.3,480.8 626.0,480.8 670.7,480.8 715.3,480.8 760.0,480.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="480.8" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="480.8" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -287,12 +271,14 @@
   <circle cx="715.3" cy="470.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="475.4" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="679" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">100 Mbps</text>
-  <line x1="90" y1="847.8" x2="760" y2="847.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="847.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500k</text>
-  <line x1="90" y1="786.6" x2="760" y2="786.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="786.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
-  <line x1="90" y1="725.3" x2="760" y2="725.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="725.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1.5M</text>
+  <line x1="90" y1="854.0" x2="760" y2="854.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="854.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="799.0" x2="760" y2="799.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="799.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="744.0" x2="760" y2="744.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="744.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="689.0" x2="760" y2="689.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="689.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="909.0" x2="760" y2="909.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1.0 MB/s</text>
   <line x1="90" y1="883.5" x2="760" y2="883.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -344,11 +330,11 @@
   <text x="670.7" y="923" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="923" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="923" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">msg/s</text>
-  <polyline points="90.0,717.7 134.7,813.3 179.3,861.2 224.0,885.1 268.7,897.0 313.3,903.0 358.0,906.0 402.7,907.5 447.3,908.3 492.0,908.6 536.7,908.8 581.3,908.9 626.0,909.0 670.7,909.0 715.3,909.0 760.0,909.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,886.5 268.7,897.4 313.3,903.1 358.0,904.8 402.7,906.3 447.3,907.1 492.0,907.9 536.7,908.3 581.3,908.6 626.0,908.8 670.7,908.9 715.3,908.9 760.0,909.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,886.5 268.7,865.3 313.3,865.3 358.0,866.5 402.7,868.7 447.3,900.2 492.0,906.8 536.7,908.1 581.3,908.5 626.0,908.8 670.7,908.9 715.3,908.9 760.0,909.0" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,891.1 268.7,891.1 313.3,891.1 358.0,891.2 402.7,891.4 447.3,898.3 492.0,906.2 536.7,907.8 581.3,908.4 626.0,908.7 670.7,908.8 715.3,908.9 760.0,909.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">CPU %</text>
+  <polyline points="90.0,901.2 134.7,904.9 179.3,906.6 224.0,906.7 268.7,907.5 313.3,908.0 358.0,908.3 402.7,908.5 447.3,908.6 492.0,908.6 536.7,908.7 581.3,908.7 626.0,908.7 670.7,908.7 715.3,908.8 760.0,908.8" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,887.5 134.7,895.9 179.3,901.4 224.0,904.9 268.7,906.5 313.3,907.3 358.0,904.5 402.7,904.3 447.3,903.6 492.0,903.1 536.7,902.9 581.3,902.6 626.0,902.3 670.7,901.8 715.3,900.6 760.0,899.4" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,879.9 134.7,891.3 179.3,898.6 224.0,903.3 268.7,888.0 313.3,887.8 358.0,887.0 402.7,886.7 447.3,898.1 492.0,900.2 536.7,900.6 581.3,900.7 626.0,900.3 670.7,899.6 715.3,899.0 760.0,898.3" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,875.2 134.7,888.6 179.3,897.0 224.0,836.4 268.7,836.4 313.3,836.1 358.0,836.2 402.7,829.0 447.3,855.4 492.0,881.9 536.7,885.7 581.3,882.3 626.0,878.2 670.7,877.0 715.3,875.5 760.0,871.9" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,816.3 134.7,816.3 179.3,816.3 224.0,816.3 268.7,816.3 313.3,816.3 358.0,816.3 402.7,816.3 447.3,816.3 492.0,816.3 536.7,816.3 581.3,816.3 626.0,816.3 670.7,816.3 715.3,816.3 760.0,816.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="816.3" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="816.3" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -418,12 +404,14 @@
   <circle cx="715.3" cy="745.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="745.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="989" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Mbps</text>
-  <line x1="90" y1="1157.8" x2="760" y2="1157.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1157.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50k</text>
-  <line x1="90" y1="1096.6" x2="760" y2="1096.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1096.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
-  <line x1="90" y1="1035.3" x2="760" y2="1035.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1035.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">150k</text>
+  <line x1="90" y1="1164.0" x2="760" y2="1164.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1164.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="1109.0" x2="760" y2="1109.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1109.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="1054.0" x2="760" y2="1054.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1054.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="999.0" x2="760" y2="999.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="999.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="1219.0" x2="760" y2="1219.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="1219.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1.0 MB/s</text>
   <line x1="90" y1="1177.7" x2="760" y2="1177.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -469,11 +457,11 @@
   <text x="670.7" y="1233" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="1233" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="1233" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="1109.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,1109.0)">msg/s</text>
-  <polyline points="90.0,1027.7 134.7,1123.3 179.3,1171.2 224.0,1195.1 268.7,1207.0 313.3,1213.0 358.0,1216.0 402.7,1217.5 447.3,1218.3 492.0,1218.6 536.7,1218.8 581.3,1218.9 626.0,1219.0 670.7,1219.0 715.3,1219.0 760.0,1219.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1196.5 268.7,1207.4 313.3,1213.1 358.0,1214.8 402.7,1216.3 447.3,1217.1 492.0,1217.9 536.7,1218.3 581.3,1218.6 626.0,1218.8 670.7,1218.9 715.3,1218.9 760.0,1219.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1196.5 268.7,1175.3 313.3,1175.3 358.0,1176.5 402.7,1178.7 447.3,1210.2 492.0,1216.8 536.7,1218.1 581.3,1218.5 626.0,1218.8 670.7,1218.9 715.3,1218.9 760.0,1219.0" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1157.8 268.7,1160.1 313.3,1162.3 358.0,1162.3 402.7,1162.3 447.3,1208.3 492.0,1216.2 536.7,1217.8 581.3,1218.4 626.0,1218.7 670.7,1218.8 715.3,1218.9 760.0,1219.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="1109.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,1109.0)">CPU %</text>
+  <polyline points="90.0,1218.2 134.7,1218.6 179.3,1218.8 224.0,1218.8 268.7,1218.9 313.3,1218.9 358.0,1218.9 402.7,1218.9 447.3,1219.0 492.0,1219.0 536.7,1219.0 581.3,1219.0 626.0,1219.0 670.7,1219.0 715.3,1219.0 760.0,1219.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1216.8 134.7,1217.7 179.3,1218.2 224.0,1218.6 268.7,1218.8 313.3,1218.8 358.0,1218.5 402.7,1218.5 447.3,1218.5 492.0,1218.4 536.7,1218.4 581.3,1218.4 626.0,1218.3 670.7,1218.3 715.3,1218.2 760.0,1218.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1216.1 134.7,1217.2 179.3,1218.0 224.0,1218.4 268.7,1216.9 313.3,1216.9 358.0,1216.8 402.7,1216.8 447.3,1217.9 492.0,1218.1 536.7,1218.2 581.3,1218.2 626.0,1218.1 670.7,1218.1 715.3,1218.0 760.0,1217.9" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1215.6 134.7,1217.0 179.3,1217.8 224.0,1194.1 268.7,1195.1 313.3,1195.9 358.0,1195.8 402.7,1193.2 447.3,1213.6 492.0,1216.3 536.7,1216.7 581.3,1216.3 626.0,1215.9 670.7,1215.8 715.3,1215.7 760.0,1215.3" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,1205.7 134.7,1205.7 179.3,1205.7 224.0,1205.7 268.7,1205.7 313.3,1205.7 358.0,1205.7 402.7,1205.7 447.3,1205.7 492.0,1205.7 536.7,1205.7 581.3,1205.7 626.0,1205.7 670.7,1205.7 715.3,1205.7 760.0,1205.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="1205.7" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="1205.7" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -554,5 +542,5 @@
   <line x1="592" y1="1251" x2="606" y2="1251" stroke="#f97316" stroke-width="1.5" stroke-dasharray="4,3"/>
   <line x1="592" y1="1263" x2="606" y2="1263" stroke="#f97316" stroke-width="2.5"/>
   <text x="610" y="1255" fill="#374151" font-size="10" font-weight="500">zstd</text>
-  <text x="425.0" y="1281" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = virtual throughput log (right)</text>
+  <text x="425.0" y="1281" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = CPU % (left) · solid = virtual throughput log (right)</text>
 </svg>

--- a/doc/charts/compression/tokio_2048.svg
+++ b/doc/charts/compression/tokio_2048.svg
@@ -1,26 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 865 1304" font-family="system-ui, -apple-system, sans-serif">
   <rect width="865" height="1304" fill="white"/>
   <text x="425.0" y="16" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">Compression transports: structured JSON, PUSH/PULL, 2-process (omq-tokio), dict 2 KiB</text>
-  <text x="425.0" y="30" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores</text>
+  <text x="425.0" y="30" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="425.0" y="59" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Gbps</text>
-  <line x1="90" y1="278.0" x2="760" y2="278.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="278.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
-  <line x1="90" y1="267.0" x2="760" y2="267.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="267.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400k</text>
-  <line x1="90" y1="256.0" x2="760" y2="256.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="256.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">600k</text>
-  <line x1="90" y1="245.0" x2="760" y2="245.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="245.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">800k</text>
   <line x1="90" y1="234.0" x2="760" y2="234.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="234.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
-  <line x1="90" y1="199.0" x2="760" y2="199.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="199.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2M</text>
-  <line x1="90" y1="164.0" x2="760" y2="164.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="164.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">3M</text>
-  <line x1="90" y1="129.0" x2="760" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">4M</text>
-  <line x1="90" y1="94.0" x2="760" y2="94.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="94.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">5M</text>
+  <text x="82" y="234.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="179.0" x2="760" y2="179.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="179.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="124.0" x2="760" y2="124.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="124.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="69.0" x2="760" y2="69.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="69.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="289.0" x2="760" y2="289.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="289.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">10 MB/s</text>
   <line x1="90" y1="263.5" x2="760" y2="263.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -56,8 +46,6 @@
   <line x1="90" y1="69" x2="90" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="69" x2="760" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="289" x2="760" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
-  <rect x="89.0" y="228.0" width="3" height="12" fill="white"/>
-  <path d="M 85.0,240.0 L 95.0,235.0 M 85.0,233.0 L 95.0,228.0" stroke="#9ca3af" stroke-width="1.5" fill="none"/>
   <text x="90.0" y="303" text-anchor="middle" fill="#374151" font-size="8">8 B</text>
   <text x="134.7" y="303" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="179.3" y="303" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
@@ -74,11 +62,11 @@
   <text x="670.7" y="303" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="303" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="303" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">msg/s</text>
-  <polyline points="90.0,130.3 134.7,119.7 179.3,95.1 224.0,125.0 268.7,151.7 313.3,159.8 358.0,183.5 402.7,226.3 447.3,255.4 492.0,272.2 536.7,280.6 581.3,284.8 626.0,286.9 670.7,288.0 715.3,288.5 760.0,288.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,185.5 134.7,185.6 179.3,186.5 224.0,180.3 268.7,181.8 313.3,191.6 358.0,254.1 402.7,262.9 447.3,270.3 492.0,277.4 536.7,282.0 581.3,284.8 626.0,286.6 670.7,287.8 715.3,288.5 760.0,288.8" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,218.9 134.7,218.8 179.3,219.3 224.0,222.8 268.7,241.4 313.3,242.6 358.0,246.6 402.7,245.6 447.3,261.3 492.0,275.1 536.7,281.9 581.3,285.2 626.0,287.0 670.7,287.8 715.3,288.2 760.0,288.7" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,223.0 134.7,223.3 179.3,223.5 224.0,281.1 268.7,281.1 313.3,281.1 358.0,281.1 402.7,281.2 447.3,282.1 492.0,283.2 536.7,285.0 581.3,287.3 626.0,288.1 670.7,288.4 715.3,288.6 760.0,288.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">CPU %</text>
+  <polyline points="90.0,168.3 134.7,169.9 179.3,180.2 224.0,182.3 268.7,195.1 313.3,185.4 358.0,191.1 402.7,217.0 447.3,249.3 492.0,255.9 536.7,251.3 581.3,227.5 626.0,219.3 670.7,245.6 715.3,256.4 760.0,258.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,179.8 134.7,187.5 179.3,192.1 224.0,183.4 268.7,188.5 313.3,189.1 358.0,202.6 402.7,201.8 447.3,203.4 492.0,206.3 536.7,198.2 581.3,191.6 626.0,179.6 670.7,163.4 715.3,160.9 760.0,156.5" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,179.4 134.7,178.5 179.3,178.6 224.0,189.8 268.7,199.6 313.3,200.2 358.0,202.8 402.7,199.8 447.3,196.5 492.0,200.6 536.7,196.1 581.3,190.7 626.0,181.4 670.7,147.0 715.3,88.0 760.0,135.4" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,185.0 134.7,185.0 179.3,184.9 224.0,218.9 268.7,219.3 313.3,218.2 358.0,218.2 402.7,217.7 447.3,210.3 492.0,194.9 536.7,174.7 581.3,189.7 626.0,181.8 670.7,152.8 715.3,111.3 760.0,129.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,246.6 134.7,218.5 179.3,187.4 224.0,168.9 268.7,151.0 313.3,128.2 358.0,111.7 402.7,111.7 447.3,111.7 492.0,111.7 536.7,111.7 581.3,111.7 626.0,111.7 670.7,111.7 715.3,111.7 760.0,111.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="246.6" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="218.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -148,22 +136,14 @@
   <circle cx="715.3" cy="125.8" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="131.6" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="369" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">1 Gbps</text>
-  <line x1="90" y1="588.0" x2="760" y2="588.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="588.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200k</text>
-  <line x1="90" y1="577.0" x2="760" y2="577.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="577.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400k</text>
-  <line x1="90" y1="566.0" x2="760" y2="566.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="566.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">600k</text>
-  <line x1="90" y1="555.0" x2="760" y2="555.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="555.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">800k</text>
   <line x1="90" y1="544.0" x2="760" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
-  <line x1="90" y1="501.7" x2="760" y2="501.7" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="501.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">2M</text>
-  <line x1="90" y1="459.5" x2="760" y2="459.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="459.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">3M</text>
-  <line x1="90" y1="417.2" x2="760" y2="417.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="417.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">4M</text>
+  <text x="82" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="434.0" x2="760" y2="434.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="434.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="379.0" x2="760" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="599.0" x2="760" y2="599.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="599.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">5.0 MB/s</text>
   <line x1="90" y1="573.5" x2="760" y2="573.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -201,8 +181,6 @@
   <line x1="90" y1="379" x2="90" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="379" x2="760" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="599" x2="760" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
-  <rect x="89.0" y="538.0" width="3" height="12" fill="white"/>
-  <path d="M 85.0,550.0 L 95.0,545.0 M 85.0,543.0 L 95.0,538.0" stroke="#9ca3af" stroke-width="1.5" fill="none"/>
   <text x="90.0" y="613" text-anchor="middle" fill="#374151" font-size="8">8 B</text>
   <text x="134.7" y="613" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="179.3" y="613" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
@@ -219,11 +197,11 @@
   <text x="670.7" y="613" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="613" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="613" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">msg/s</text>
-  <polyline points="90.0,418.8 134.7,406.0 179.3,421.2 224.0,503.7 268.7,545.3 313.3,572.1 358.0,585.6 402.7,592.3 447.3,595.6 492.0,597.3 536.7,598.2 581.3,598.6 626.0,598.8 670.7,598.9 715.3,598.9 760.0,599.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,485.4 134.7,485.6 179.3,486.7 224.0,508.6 268.7,546.9 313.3,572.6 358.0,580.1 402.7,586.7 447.3,590.7 492.0,593.9 536.7,596.0 581.3,597.3 626.0,598.1 670.7,598.5 715.3,598.8 760.0,598.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,525.8 134.7,525.6 179.3,526.2 224.0,530.5 268.7,551.4 313.3,552.6 358.0,556.6 402.7,555.6 447.3,571.3 492.0,589.2 536.7,594.8 581.3,597.0 626.0,598.0 670.7,598.5 715.3,598.8 760.0,598.9" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,530.7 134.7,531.1 179.3,531.3 224.0,591.1 268.7,591.1 313.3,591.1 358.0,591.1 402.7,591.2 447.3,592.1 492.0,593.2 536.7,595.0 581.3,597.3 626.0,598.1 670.7,598.4 715.3,598.6 760.0,598.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">CPU %</text>
+  <polyline points="90.0,478.3 134.7,479.9 179.3,513.5 224.0,548.3 268.7,571.7 313.3,582.8 358.0,589.2 402.7,591.8 447.3,595.0 492.0,595.7 536.7,595.2 581.3,592.8 626.0,592.0 670.7,594.7 715.3,595.7 760.0,595.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,489.8 134.7,497.5 179.3,502.1 224.0,522.4 268.7,560.8 313.3,577.3 358.0,552.2 402.7,557.8 447.3,560.8 492.0,562.7 536.7,559.7 581.3,559.5 626.0,557.6 670.7,551.5 715.3,531.6 760.0,529.8" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,489.4 134.7,488.5 179.3,488.6 224.0,499.8 268.7,509.6 313.3,510.2 358.0,512.8 402.7,509.8 447.3,506.5 492.0,536.9 536.7,543.9 581.3,547.2 626.0,546.2 670.7,539.1 715.3,539.1 760.0,536.6" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,495.0 134.7,495.0 179.3,494.9 224.0,528.9 268.7,529.3 313.3,528.2 358.0,528.2 402.7,527.7 447.3,520.3 492.0,504.9 536.7,484.7 581.3,499.7 626.0,491.8 670.7,462.8 715.3,421.3 760.0,439.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,531.2 134.7,503.0 179.3,480.8 224.0,480.8 268.7,480.8 313.3,480.8 358.0,480.8 402.7,480.8 447.3,480.8 492.0,480.8 536.7,480.8 581.3,480.8 626.0,480.8 670.7,480.8 715.3,480.8 760.0,480.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="531.2" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="503.0" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -293,12 +271,14 @@
   <circle cx="715.3" cy="410.3" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="416.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="679" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">100 Mbps</text>
-  <line x1="90" y1="847.8" x2="760" y2="847.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="847.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500k</text>
-  <line x1="90" y1="786.6" x2="760" y2="786.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="786.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1M</text>
-  <line x1="90" y1="725.3" x2="760" y2="725.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="725.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">1.5M</text>
+  <line x1="90" y1="854.0" x2="760" y2="854.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="854.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="799.0" x2="760" y2="799.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="799.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="744.0" x2="760" y2="744.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="744.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="689.0" x2="760" y2="689.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="689.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="909.0" x2="760" y2="909.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1.0 MB/s</text>
   <line x1="90" y1="883.5" x2="760" y2="883.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -350,11 +330,11 @@
   <text x="670.7" y="923" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="923" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="923" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">msg/s</text>
-  <polyline points="90.0,717.7 134.7,813.3 179.3,861.2 224.0,885.1 268.7,897.0 313.3,903.0 358.0,906.0 402.7,907.5 447.3,908.3 492.0,908.6 536.7,908.8 581.3,908.9 626.0,909.0 670.7,909.0 715.3,909.0 760.0,909.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,886.5 268.7,897.4 313.3,903.1 358.0,904.8 402.7,906.3 447.3,907.1 492.0,907.9 536.7,908.3 581.3,908.6 626.0,908.8 670.7,908.9 715.3,908.9 760.0,909.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,886.5 268.7,865.3 313.3,865.3 358.0,866.5 402.7,868.7 447.3,900.2 492.0,906.8 536.7,908.1 581.3,908.5 626.0,908.8 670.7,908.9 715.3,908.9 760.0,909.0" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,781.5 134.7,832.5 179.3,866.5 224.0,891.3 268.7,891.4 313.3,891.4 358.0,891.5 402.7,891.7 447.3,898.3 492.0,906.2 536.7,907.8 581.3,908.4 626.0,908.7 670.7,908.8 715.3,908.9 760.0,909.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">CPU %</text>
+  <polyline points="90.0,861.4 134.7,887.2 179.3,900.4 224.0,903.9 268.7,906.3 313.3,907.4 358.0,908.0 402.7,908.3 447.3,908.6 492.0,908.7 536.7,908.6 581.3,908.4 626.0,908.3 670.7,908.6 715.3,908.7 760.0,908.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,861.3 134.7,882.4 179.3,894.7 224.0,901.3 268.7,905.2 313.3,906.8 358.0,904.3 402.7,904.9 447.3,905.2 492.0,905.4 536.7,905.1 581.3,905.1 626.0,904.9 670.7,904.2 715.3,902.3 760.0,902.1" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,829.3 134.7,860.8 179.3,882.0 224.0,895.2 268.7,872.1 313.3,871.4 358.0,870.2 402.7,871.9 447.3,895.7 492.0,902.8 536.7,903.5 581.3,903.8 626.0,903.7 670.7,903.0 715.3,903.0 760.0,902.8" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,826.6 134.7,859.2 179.3,881.2 224.0,838.9 268.7,839.3 313.3,838.2 358.0,838.2 402.7,837.7 447.3,854.2 492.0,888.2 536.7,893.7 581.3,893.3 626.0,891.3 670.7,891.1 715.3,890.9 760.0,890.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,816.3 134.7,816.3 179.3,816.3 224.0,816.3 268.7,816.3 313.3,816.3 358.0,816.3 402.7,816.3 447.3,816.3 492.0,816.3 536.7,816.3 581.3,816.3 626.0,816.3 670.7,816.3 715.3,816.3 760.0,816.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="816.3" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="816.3" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -424,12 +404,14 @@
   <circle cx="715.3" cy="745.1" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="745.2" r="2.5" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="425.0" y="989" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Mbps</text>
-  <line x1="90" y1="1157.8" x2="760" y2="1157.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1157.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50k</text>
-  <line x1="90" y1="1096.6" x2="760" y2="1096.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1096.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100k</text>
-  <line x1="90" y1="1035.3" x2="760" y2="1035.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="1035.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">150k</text>
+  <line x1="90" y1="1164.0" x2="760" y2="1164.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1164.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="1109.0" x2="760" y2="1109.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1109.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="1054.0" x2="760" y2="1054.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="1054.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="999.0" x2="760" y2="999.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="999.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
   <line x1="90" y1="1219.0" x2="760" y2="1219.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="1219.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1.0 MB/s</text>
   <line x1="90" y1="1177.7" x2="760" y2="1177.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -475,11 +457,11 @@
   <text x="670.7" y="1233" text-anchor="middle" fill="#374151" font-size="8">64 KiB</text>
   <text x="715.3" y="1233" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="760.0" y="1233" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
-  <text x="40" y="1109.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,1109.0)">msg/s</text>
-  <polyline points="90.0,1027.7 134.7,1123.3 179.3,1171.2 224.0,1195.1 268.7,1207.0 313.3,1213.0 358.0,1216.0 402.7,1217.5 447.3,1218.3 492.0,1218.6 536.7,1218.8 581.3,1218.9 626.0,1219.0 670.7,1219.0 715.3,1219.0 760.0,1219.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1196.5 268.7,1207.4 313.3,1213.1 358.0,1214.8 402.7,1216.3 447.3,1217.1 492.0,1217.9 536.7,1218.3 581.3,1218.6 626.0,1218.8 670.7,1218.9 715.3,1218.9 760.0,1219.0" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1196.5 268.7,1175.3 313.3,1175.3 358.0,1176.5 402.7,1178.7 447.3,1210.2 492.0,1216.8 536.7,1218.1 581.3,1218.5 626.0,1218.8 670.7,1218.9 715.3,1218.9 760.0,1219.0" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,1091.5 134.7,1142.5 179.3,1176.5 224.0,1157.8 268.7,1160.1 313.3,1162.3 358.0,1162.3 402.7,1162.3 447.3,1208.3 492.0,1216.2 536.7,1217.8 581.3,1218.4 626.0,1218.7 670.7,1218.8 715.3,1218.9 760.0,1219.0" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="40" y="1109.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,1109.0)">CPU %</text>
+  <polyline points="90.0,1214.2 134.7,1216.8 179.3,1218.1 224.0,1218.5 268.7,1218.7 313.3,1218.8 358.0,1218.9 402.7,1218.9 447.3,1219.0 492.0,1219.0 536.7,1219.0 581.3,1218.9 626.0,1218.9 670.7,1219.0 715.3,1219.0 760.0,1219.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1214.2 134.7,1216.3 179.3,1217.6 224.0,1218.2 268.7,1218.6 313.3,1218.8 358.0,1218.5 402.7,1218.6 447.3,1218.6 492.0,1218.6 536.7,1218.6 581.3,1218.6 626.0,1218.6 670.7,1218.5 715.3,1218.3 760.0,1218.3" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1211.0 134.7,1214.2 179.3,1216.3 224.0,1217.6 268.7,1215.3 313.3,1215.2 358.0,1215.1 402.7,1215.3 447.3,1217.7 492.0,1218.4 536.7,1218.4 581.3,1218.5 626.0,1218.5 670.7,1218.4 715.3,1218.4 760.0,1218.4" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,1210.8 134.7,1214.0 179.3,1216.2 224.0,1194.7 268.7,1195.7 313.3,1196.3 358.0,1196.1 402.7,1195.6 447.3,1213.5 492.0,1216.9 536.7,1217.5 581.3,1217.4 626.0,1217.2 670.7,1217.2 715.3,1217.2 760.0,1217.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,1205.7 134.7,1205.7 179.3,1205.7 224.0,1205.7 268.7,1205.7 313.3,1205.7 358.0,1205.7 402.7,1205.7 447.3,1205.7 492.0,1205.7 536.7,1205.7 581.3,1205.7 626.0,1205.7 670.7,1205.7 715.3,1205.7 760.0,1205.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="1205.7" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="134.7" cy="1205.7" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -560,5 +542,5 @@
   <line x1="592" y1="1251" x2="606" y2="1251" stroke="#f97316" stroke-width="1.5" stroke-dasharray="4,3"/>
   <line x1="592" y1="1263" x2="606" y2="1263" stroke="#f97316" stroke-width="2.5"/>
   <text x="610" y="1255" fill="#374151" font-size="10" font-weight="500">zstd</text>
-  <text x="425.0" y="1281" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = virtual throughput log (right)</text>
+  <text x="425.0" y="1281" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = CPU % (left) · solid = virtual throughput log (right)</text>
 </svg>

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -439,7 +439,7 @@ def generate_svg(
 
 
 THREAD_MODELS = {
-    "compio": "2-thread",
+    "compio": "2-process",
     "tokio": "2-process",
 }
 


### PR DESCRIPTION
- Fix compression chart subtitle: `THREAD_MODELS["compio"]` was "2-thread", now "2-process" (both backends run 2-process for the compression bench)
- Regenerate both compression SVGs with the correct hw subtitle including "performance governor, turbo off"
- Put omq-tokio first throughout `BENCHMARKS.md` and `BENCHMARKS_COMPRESSION.md` (images, bench commands, chart gen commands)
- `doc/architecture.md`: remove omq facade crate from ASCII art; user code depends directly on a backend crate
- `ci.yml`: add `!**/*.svg` and `!**/*.py` to the doc-change filter so SVG and Python script edits don't trigger CI