### PR TITLE
Fix imprecise dependency requirements, bump lz4rip to 0.3.1

### DIFF
--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -52,7 +52,7 @@ libc = "0.2"
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "std"] }
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pemfile = { version = "2.2", optional = true }
-rustls-pki-types = { version = "1", optional = true }
+rustls-pki-types = { version = "1.14", optional = true }
 compio-tls = { git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, default-features = false, features = ["rustls"] }
 
 

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 omq-tokio = { path = "../omq-tokio", version = "0.14.0", features = ["plain", "curve", "lz4", "zstd"] }
 yring = { path = "../yring", version = "0.3.0" }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "sync", "time"] }
 bytes = "1.11.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -40,9 +40,9 @@ bytes = "1.11.0"
 chacha20-blake3 = { version = "0.10.0", optional = true }
 crypto_box = { version = "0.9", features = ["std"], optional = true }
 crypto_secretbox = { version = "0.1", optional = true }
-subtle = { version = "2", optional = true }
+subtle = { version = "2.6", optional = true }
 x25519-dalek = { version = "2", features = ["static_secrets", "getrandom"], optional = true }
-lz4rip = { version = "0.2.0", default-features = false, optional = true }
+lz4rip = { version = "0.3.1", default-features = false, optional = true }
 rand = "0.10"
 zstd-safe = { version = "7", default-features = false, features = ["std", "zdict_builder"], optional = true }
 patricia_tree = "0.10"

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -50,7 +50,7 @@ libc = "0.2"
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "std"] }
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pemfile = { version = "2.2", optional = true }
-rustls-pki-types = { version = "1", optional = true }
+rustls-pki-types = { version = "1.14", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 omq-compio = { version = "0.12.0", path = "../omq-compio", optional = true, default-features = false, features = ["ws"] }
 compio = { version = "0.19.0", git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }


### PR DESCRIPTION
- Tighten `rustls-pki-types` from `"1"` to `"1.14"` in `omq-tokio` and `omq-compio`
- Tighten `subtle` from `"2"` to `"2.6"` in `omq-proto`
- Tighten `tokio` from `"1"` to `"1.52"` in `omq-libzmq`
- Bump `lz4rip` from `0.2.0` to `0.3.1` in `omq-proto` (removed APIs not used by omq)