### PR TITLE
Fix lz4+tcp fan-out, add compression tests, tune HWM test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/compression/tokio_2048.svg" alt="Compression throughput: omq-tokio" width="850">
 </p>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/pubsub/lz4_tcp.svg" alt="PUB/SUB lz4+tcp fan-out: projected throughput at link speed" width="850">
+</p>
 </details>
 
 <details>

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -314,11 +314,11 @@ def test_compression_dict_rejects_oversize():
 def test_compression_auto_train_round_trip():
     ctx, s = _push()
     try:
-        assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 1
-        s.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 0)
         assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 0
         s.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 1)
         assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 1
+        s.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 0)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN) == 0
     finally:
         s.close()
         ctx.term()

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -17,7 +17,7 @@ runtime backends differ. Detail lives in [`compio.md`](compio.md),
         |  Socket::send / Socket::recv / connect / bind / monitor
         v
 +------------------------------------------------------------------+
-|  runtime backend  (omq-compio or omq-tokio)                      |
+|  runtime backend  (omq-tokio or omq-compio)                      |
 |  ----------------------------------------                        |
 |  Socket actor / direct-IO state                                  |
 |  per-connection driver tasks                                     |
@@ -144,15 +144,15 @@ backends. Users see only `Message`. Public API: `Deref<[u8]>`
 
 ## Backends compared
 
-| | omq-compio | omq-tokio |
+| | omq-tokio | omq-compio |
 |---|---|---|
-| Runtime | Single-thread, cooperative | Multi-thread, work-stealing |
-| Linux I/O | io_uring | epoll (mio) |
-| Other platforms | macOS kqueue, Windows IOCP | macOS/BSD kqueue, Windows IOCP |
-| Hot-path send | Per-peer `EncodedQueue` under sync `try_lock` | Per-peer `PeerWireSlot` (`EncodedQueue` under `std::sync::Mutex`); driver flushes via `data_ready` select arm |
-| Hot-path recv | `RecvMulti` (multi-shot recv from io_uring `BUF_RING`) fed to codec inline | Connection driver pushes straight into user `recv_tx` |
-| Fan-in scaling | One runtime per worker thread (manual) | Free across cores via runtime |
-| Strengths | Small-message wire throughput, low syscall cost, low jitter | Multi-peer fan-in, no per-thread setup, ecosystem fit |
+| Runtime | Multi-thread, work-stealing | Single-thread, cooperative |
+| Linux I/O | epoll (mio) | io_uring |
+| Other platforms | macOS/BSD kqueue, Windows IOCP | macOS kqueue, Windows IOCP |
+| Hot-path send | Per-peer `PeerWireSlot` (`EncodedQueue` under `std::sync::Mutex`); driver flushes via `data_ready` select arm | Per-peer `EncodedQueue` under sync `try_lock` |
+| Hot-path recv | Connection driver pushes straight into user `recv_tx` | `RecvMulti` (multi-shot recv from io_uring `BUF_RING`) fed to codec inline |
+| Fan-in scaling | Free across cores via runtime | One runtime per worker thread (manual) |
+| Strengths | Multi-peer fan-in, no per-thread setup, ecosystem fit | Small-message wire throughput, low syscall cost, low jitter |
 
 Both expose an identical public `Socket` API. Anything on one that is
 not on the other is a bug. Verified by

--- a/doc/charts/pubsub/lz4_tcp.svg
+++ b/doc/charts/pubsub/lz4_tcp.svg
@@ -1,0 +1,301 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 875 1004" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="875" height="1004" fill="white"/>
+  <text x="395.0" y="16" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">PUB/SUB lz4+tcp: structured JSON, 1 PUB → 32 SUBs (omq-tokio), dict 2K</text>
+  <text x="395.0" y="30" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores</text>
+  <text x="395.0" y="59" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">1 Gbps</text>
+  <line x1="90" y1="261.5" x2="700" y2="261.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="261.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="234.0" x2="700" y2="234.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="234.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="206.5" x2="700" y2="206.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="206.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="179.0" x2="700" y2="179.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="179.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
+  <line x1="90" y1="151.5" x2="700" y2="151.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="151.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">500%</text>
+  <line x1="90" y1="124.0" x2="700" y2="124.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="124.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">600%</text>
+  <line x1="90" y1="96.5" x2="700" y2="96.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="96.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">700%</text>
+  <line x1="90" y1="69.0" x2="700" y2="69.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="69.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">800%</text>
+  <line x1="90" y1="289.0" x2="700" y2="289.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="289.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">50 MB/s</text>
+  <line x1="90" y1="247.7" x2="700" y2="247.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="247.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">100 MB/s</text>
+  <line x1="90" y1="206.3" x2="700" y2="206.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="206.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">200 MB/s</text>
+  <line x1="90" y1="151.7" x2="700" y2="151.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="151.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">500 MB/s</text>
+  <line x1="90" y1="110.3" x2="700" y2="110.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="110.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1000 MB/s</text>
+  <line x1="90" y1="69.0" x2="700" y2="69.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="69.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">2.0 GB/s</text>
+  <text x="788" y="289.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">100/s</text>
+  <text x="788" y="264.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">200/s</text>
+  <text x="788" y="232.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">500/s</text>
+  <text x="788" y="207.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">1K/s</text>
+  <text x="788" y="182.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2K/s</text>
+  <text x="788" y="150.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">5K/s</text>
+  <text x="788" y="126.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">10K/s</text>
+  <text x="788" y="101.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">20K/s</text>
+  <text x="788" y="69.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">50K/s</text>
+  <line x1="90.0" y1="69" x2="90.0" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="166.2" y1="69" x2="166.2" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="242.5" y1="69" x2="242.5" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="318.8" y1="69" x2="318.8" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="395.0" y1="69" x2="395.0" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="471.2" y1="69" x2="471.2" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="547.5" y1="69" x2="547.5" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="623.8" y1="69" x2="623.8" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="700.0" y1="69" x2="700.0" y2="289" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="69" x2="90" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="700" y1="69" x2="700" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="289" x2="700" y2="289" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="780" y1="69" x2="780" y2="289" stroke="#d1d5db" stroke-width="1"/>
+  <text x="90.0" y="303" text-anchor="middle" fill="#374151" font-size="8">128 B</text>
+  <text x="166.2" y="303" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
+  <text x="242.5" y="303" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
+  <text x="318.8" y="303" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
+  <text x="395.0" y="303" text-anchor="middle" fill="#374151" font-size="8">2 KiB</text>
+  <text x="471.2" y="303" text-anchor="middle" fill="#374151" font-size="8">4 KiB</text>
+  <text x="547.5" y="303" text-anchor="middle" fill="#374151" font-size="8">8 KiB</text>
+  <text x="623.8" y="303" text-anchor="middle" fill="#374151" font-size="8">16 KiB</text>
+  <text x="700.0" y="303" text-anchor="middle" fill="#374151" font-size="8">32 KiB</text>
+  <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">sender CPU %</text>
+  <polyline points="90.0,153.4 166.2,202.8 242.5,249.2 318.8,265.2 395.0,277.0 471.2,282.6 547.5,285.5 623.8,286.7 700.0,287.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,150.7 166.2,206.9 242.5,228.3 318.8,249.2 395.0,261.9 471.2,271.2 547.5,278.0 623.8,282.6 700.0,285.4" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,150.7 166.2,154.4 242.5,152.9 318.8,154.6 395.0,164.4 471.2,253.6 547.5,273.5 623.8,281.3 700.0,285.0" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,247.9 166.2,234.4 242.5,234.4 318.8,234.4 395.0,234.4 471.2,234.4 547.5,234.4 623.8,234.4 700.0,234.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="247.9" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="234.4" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,248.8 166.2,235.3 242.5,214.0 318.8,198.1 395.0,180.1 471.2,168.3 547.5,157.6 623.8,151.0 700.0,147.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="248.8" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="235.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="214.0" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="198.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="180.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="168.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="157.6" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="151.0" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="147.0" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,248.8 166.2,205.8 242.5,165.8 318.8,125.6 395.0,89.1 471.2,127.3 547.5,137.0 623.8,140.0 700.0,141.3" fill="none" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="248.8" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="205.8" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="165.8" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="125.6" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="89.1" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="127.3" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="137.0" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="140.0" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="141.3" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,94.5 166.2,111.0 242.5,135.6 318.8,160.1 395.0,184.6 471.2,209.2 547.5,233.7 623.8,258.2 700.0,282.8" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,95.1 166.2,111.6 242.5,123.5 318.8,138.6 395.0,152.4 471.2,170.0 547.5,188.1 623.8,208.8 700.0,230.9" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,95.1 166.2,94.1 242.5,94.9 318.8,95.5 395.0,98.4 471.2,145.6 547.5,175.9 623.8,202.3 700.0,227.5" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="395.0" y="369" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">100 Mbps</text>
+  <line x1="90" y1="571.5" x2="700" y2="571.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="571.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50%</text>
+  <line x1="90" y1="544.0" x2="700" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="516.5" x2="700" y2="516.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="516.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">150%</text>
+  <line x1="90" y1="489.0" x2="700" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">200%</text>
+  <line x1="90" y1="461.5" x2="700" y2="461.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="461.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">250%</text>
+  <line x1="90" y1="434.0" x2="700" y2="434.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="434.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">300%</text>
+  <line x1="90" y1="406.5" x2="700" y2="406.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="406.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">350%</text>
+  <line x1="90" y1="379.0" x2="700" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">400%</text>
+  <line x1="90" y1="599.0" x2="700" y2="599.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="599.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">10 MB/s</text>
+  <line x1="90" y1="560.0" x2="700" y2="560.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="560.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">20 MB/s</text>
+  <line x1="90" y1="508.5" x2="700" y2="508.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="508.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">50 MB/s</text>
+  <line x1="90" y1="469.5" x2="700" y2="469.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="469.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">100 MB/s</text>
+  <line x1="90" y1="430.5" x2="700" y2="430.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="430.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">200 MB/s</text>
+  <line x1="90" y1="379.0" x2="700" y2="379.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="379.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">500 MB/s</text>
+  <text x="788" y="599.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">10/s</text>
+  <text x="788" y="578.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">20/s</text>
+  <text x="788" y="552.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">50/s</text>
+  <text x="788" y="532.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">100/s</text>
+  <text x="788" y="512.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">200/s</text>
+  <text x="788" y="485.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">500/s</text>
+  <text x="788" y="465.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">1K/s</text>
+  <text x="788" y="445.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2K/s</text>
+  <text x="788" y="419.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">5K/s</text>
+  <text x="788" y="399.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">10K/s</text>
+  <text x="788" y="379.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">20K/s</text>
+  <line x1="90.0" y1="379" x2="90.0" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="166.2" y1="379" x2="166.2" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="242.5" y1="379" x2="242.5" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="318.8" y1="379" x2="318.8" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="395.0" y1="379" x2="395.0" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="471.2" y1="379" x2="471.2" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="547.5" y1="379" x2="547.5" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="623.8" y1="379" x2="623.8" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="700.0" y1="379" x2="700.0" y2="599" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="379" x2="90" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="700" y1="379" x2="700" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="599" x2="700" y2="599" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="780" y1="379" x2="780" y2="599" stroke="#d1d5db" stroke-width="1"/>
+  <text x="90.0" y="613" text-anchor="middle" fill="#374151" font-size="8">128 B</text>
+  <text x="166.2" y="613" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
+  <text x="242.5" y="613" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
+  <text x="318.8" y="613" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
+  <text x="395.0" y="613" text-anchor="middle" fill="#374151" font-size="8">2 KiB</text>
+  <text x="471.2" y="613" text-anchor="middle" fill="#374151" font-size="8">4 KiB</text>
+  <text x="547.5" y="613" text-anchor="middle" fill="#374151" font-size="8">8 KiB</text>
+  <text x="623.8" y="613" text-anchor="middle" fill="#374151" font-size="8">16 KiB</text>
+  <text x="700.0" y="613" text-anchor="middle" fill="#374151" font-size="8">32 KiB</text>
+  <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">sender CPU %</text>
+  <polyline points="90.0,565.0 166.2,581.8 242.5,591.0 318.8,594.2 395.0,596.6 471.2,597.7 547.5,598.3 623.8,598.5 700.0,598.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,564.8 166.2,582.6 242.5,586.9 318.8,591.0 395.0,593.6 471.2,595.4 547.5,596.8 623.8,597.7 700.0,598.3" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,448.6 166.2,456.8 242.5,456.4 318.8,495.7 395.0,569.6 471.2,591.9 547.5,595.9 623.8,597.5 700.0,598.2" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,586.5 166.2,586.5 242.5,586.5 318.8,586.5 395.0,586.5 471.2,586.5 547.5,586.5 623.8,586.5 700.0,586.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="586.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,588.2 166.2,587.3 242.5,567.3 318.8,552.3 395.0,535.3 471.2,524.2 547.5,514.1 623.8,507.9 700.0,504.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="588.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="587.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="567.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="552.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="535.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="524.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="514.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="507.9" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="504.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,504.9 166.2,465.9 242.5,428.7 318.8,408.2 395.0,440.2 471.2,485.5 547.5,494.7 623.8,497.5 700.0,498.7" fill="none" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="504.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="465.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="428.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="408.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="440.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="485.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="494.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="497.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="498.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,433.4 166.2,453.5 242.5,473.5 318.8,493.6 395.0,513.7 471.2,533.7 547.5,553.8 623.8,573.9 700.0,593.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,434.3 166.2,453.9 242.5,463.7 318.8,476.0 395.0,487.3 471.2,501.7 547.5,516.5 623.8,533.4 700.0,551.5" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,391.4 166.2,391.4 242.5,392.4 318.8,401.8 395.0,438.4 471.2,481.8 547.5,506.6 623.8,528.1 700.0,548.7" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="395.0" y="679" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Mbps</text>
+  <line x1="90" y1="799.0" x2="700" y2="799.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="799.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50%</text>
+  <line x1="90" y1="689.0" x2="700" y2="689.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="689.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">100%</text>
+  <line x1="90" y1="909.0" x2="700" y2="909.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">1.0 MB/s</text>
+  <line x1="90" y1="870.0" x2="700" y2="870.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="870.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">2.0 MB/s</text>
+  <line x1="90" y1="818.5" x2="700" y2="818.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="818.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">5.0 MB/s</text>
+  <line x1="90" y1="779.5" x2="700" y2="779.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="779.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">10 MB/s</text>
+  <line x1="90" y1="740.5" x2="700" y2="740.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="740.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">20 MB/s</text>
+  <line x1="90" y1="689.0" x2="700" y2="689.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708" y="689.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="9">50 MB/s</text>
+  <text x="788" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">1/s</text>
+  <text x="788" y="888.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2/s</text>
+  <text x="788" y="862.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">5/s</text>
+  <text x="788" y="842.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">10/s</text>
+  <text x="788" y="822.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">20/s</text>
+  <text x="788" y="795.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">50/s</text>
+  <text x="788" y="775.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">100/s</text>
+  <text x="788" y="755.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">200/s</text>
+  <text x="788" y="729.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">500/s</text>
+  <text x="788" y="709.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">1K/s</text>
+  <text x="788" y="689.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2K/s</text>
+  <line x1="90.0" y1="689" x2="90.0" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="166.2" y1="689" x2="166.2" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="242.5" y1="689" x2="242.5" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="318.8" y1="689" x2="318.8" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="395.0" y1="689" x2="395.0" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="471.2" y1="689" x2="471.2" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="547.5" y1="689" x2="547.5" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="623.8" y1="689" x2="623.8" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="700.0" y1="689" x2="700.0" y2="909" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="689" x2="90" y2="909" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="700" y1="689" x2="700" y2="909" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="909" x2="700" y2="909" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="780" y1="689" x2="780" y2="909" stroke="#d1d5db" stroke-width="1"/>
+  <text x="90.0" y="923" text-anchor="middle" fill="#374151" font-size="8">128 B</text>
+  <text x="166.2" y="923" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
+  <text x="242.5" y="923" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
+  <text x="318.8" y="923" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
+  <text x="395.0" y="923" text-anchor="middle" fill="#374151" font-size="8">2 KiB</text>
+  <text x="471.2" y="923" text-anchor="middle" fill="#374151" font-size="8">4 KiB</text>
+  <text x="547.5" y="923" text-anchor="middle" fill="#374151" font-size="8">8 KiB</text>
+  <text x="623.8" y="923" text-anchor="middle" fill="#374151" font-size="8">16 KiB</text>
+  <text x="700.0" y="923" text-anchor="middle" fill="#374151" font-size="8">32 KiB</text>
+  <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">sender CPU %</text>
+  <polyline points="90.0,895.4 166.2,902.1 242.5,905.8 318.8,907.1 395.0,908.0 471.2,908.5 547.5,908.7 623.8,908.8 700.0,908.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,895.3 166.2,902.4 242.5,904.1 318.8,905.8 395.0,906.8 471.2,907.6 547.5,908.1 623.8,908.5 700.0,908.7" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,848.8 166.2,852.1 242.5,852.0 318.8,867.7 395.0,897.2 471.2,906.2 547.5,907.8 623.8,908.4 700.0,908.7" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,896.5 166.2,896.5 242.5,896.5 318.8,896.5 395.0,896.5 471.2,896.5 547.5,896.5 623.8,896.5 700.0,896.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="896.5" r="2.5" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,898.2 166.2,897.3 242.5,877.3 318.8,862.3 395.0,845.3 471.2,834.2 547.5,824.1 623.8,817.9 700.0,814.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="898.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="897.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="877.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="862.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="845.3" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="834.2" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="824.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="817.9" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="814.1" r="2.5" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,814.9 166.2,775.9 242.5,738.7 318.8,718.2 395.0,750.2 471.2,795.5 547.5,804.7 623.8,807.5 700.0,808.7" fill="none" stroke="#1d4ed8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="814.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="166.2" cy="775.9" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="738.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="318.8" cy="718.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="750.2" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="471.2" cy="795.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="804.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="623.8" cy="807.5" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="808.7" r="2.5" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,743.4 166.2,763.5 242.5,783.5 318.8,803.6 395.0,823.7 471.2,843.7 547.5,863.8 623.8,883.9 700.0,903.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,744.3 166.2,763.9 242.5,773.7 318.8,786.0 395.0,797.3 471.2,811.7 547.5,826.5 623.8,843.4 700.0,861.5" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,701.4 166.2,701.4 242.5,702.4 318.8,711.8 395.0,748.4 471.2,791.8 547.5,816.6 623.8,838.1 700.0,858.7" fill="none" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <line x1="90" y1="941" x2="104" y2="941" stroke="#eab308" stroke-width="1.5" stroke-dasharray="2,3" opacity="0.7"/>
+  <line x1="90" y1="953" x2="104" y2="953" stroke="#eab308" stroke-width="2.5"/>
+  <line x1="90" y1="965" x2="104" y2="965" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="108" y="945" fill="#374151" font-size="10" font-weight="500">tcp (no compression)</text>
+  <line x1="293" y1="941" x2="307" y2="941" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="2,3" opacity="0.7"/>
+  <line x1="293" y1="953" x2="307" y2="953" stroke="#60a5fa" stroke-width="2.5"/>
+  <line x1="293" y1="965" x2="307" y2="965" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="311" y="945" fill="#374151" font-size="10" font-weight="500">lz4+tcp (no dict)</text>
+  <line x1="497" y1="941" x2="511" y2="941" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="2,3" opacity="0.7"/>
+  <line x1="497" y1="953" x2="511" y2="953" stroke="#1d4ed8" stroke-width="2.5"/>
+  <line x1="497" y1="965" x2="511" y2="965" stroke="#1d4ed8" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="515" y="945" fill="#374151" font-size="10" font-weight="500">lz4+tcp + 2K dict</text>
+  <text x="395.0" y="983" text-anchor="middle" fill="#9ca3af" font-size="9">dotted = sender CPU % linear (left) · solid = aggregate virtual SUB throughput log (inner right) · dashed = msg/s log (outer right)</text>
+</svg>

--- a/doc/compio.md
+++ b/doc/compio.md
@@ -612,8 +612,8 @@ after each handshake via `our_subs` and `joined_groups`.
 ### `InboundFrame::SinglePart`
 
 The single-part variant carries `Option<Bytes>` (identity) and `Bytes`
-(body) inline (~72 B). The `Message` struct is 48 B (custom enum with
-inline storage for single-frame messages up to 39 B); wrapping it in
+(body) inline (~72 B). The `Message` struct is 64 B (custom enum with
+inline storage for single-frame messages up to 55 B); wrapping it in
 a box for the multipart variant keeps the blume channel slot small on
 the hot path.
 

--- a/doc/tokio.md
+++ b/doc/tokio.md
@@ -175,13 +175,19 @@ The gather functions (`encode_message_gather`,
 arena and track payloads as external entries. The per-frame
 `scratch: BytesMut` is eliminated.
 
-The arena path is disabled when a frame transform (CURVE, BLAKE3ZMQ)
-is active, since those require the codec's encrypt-in-place flow via
-`send_message`. `Connection` exposes `take_transform()` /
-`restore_transform()` / `emit_encrypted_frames()` and `FrameTransform`
-exposes `encrypt_message()` as infrastructure for future per-peer
-encryption offloading, but the routing strategies do not wire this up
-yet.
+The arena path is disabled when CURVE or BLAKE3ZMQ is active.
+These mechanisms hold per-connection symmetric keys and a nonce
+counter inside the codec's `FrameTransform`. The nonce must advance
+in strict wire order per frame, so encryption is coupled to the
+codec's `send_message`/`poll_transmit` sequencing. The arena bypass
+skips `Connection::send_message` entirely, so there is no point at
+which the transform can encrypt. LZ4 does not have this constraint:
+its `MessageEncoder` lives outside the codec, holds no per-frame
+sequence state, and produces wire-ready bytes independently.
+`Connection` exposes `take_transform()` / `restore_transform()` /
+`emit_encrypted_frames()` and `FrameTransform` exposes
+`encrypt_message()` as infrastructure for future per-peer encryption
+offloading, but the routing strategies do not wire this up yet.
 
 ## 128 KiB read buffer
 

--- a/omq-compio/benches/pub_sub.rs
+++ b/omq-compio/benches/pub_sub.rs
@@ -13,10 +13,20 @@ use std::sync::{Arc, Barrier, mpsc};
 use std::time::Duration;
 
 use bytes::Bytes;
-use omq_compio::{Message, OnMute, Options, Socket, SocketType, build_default_runtime};
+use omq_compio::{Message, OnMute, Options, ProactorBuilderExt, Socket, SocketType};
 
 const PATTERN: &str = "pub_sub";
 const PEER_COUNTS: &[usize] = &[3];
+
+fn build_runtime(peers: usize) -> std::io::Result<compio::runtime::Runtime> {
+    let count = u16::try_from(64_usize.max(peers * 4)).unwrap_or(u16::MAX);
+    let len = common::bench_buffer_len();
+    let mut p = compio::driver::ProactorBuilder::new();
+    p.with_omq_buffer_pool_sized(std::num::NonZero::new(count).expect("nonzero"), len);
+    compio::runtime::RuntimeBuilder::new()
+        .with_proactor(p)
+        .build()
+}
 
 fn main() {
     common::print_header("PUB/SUB");
@@ -47,7 +57,7 @@ fn main() {
 
 #[allow(clippy::arc_with_non_send_sync)] // compio is single-threaded; Arc for spawn sharing
 fn run_cell_single(transport: &str, peers: usize, size: usize, seq: usize) -> common::Cell {
-    let rt = build_default_runtime().expect("single runtime");
+    let rt = build_runtime(peers).expect("single runtime");
     common::block_on_and_drain(rt, async {
         let ep = common::endpoint(transport, seq);
         let pub_ = Socket::new(SocketType::Pub, Options::default().on_mute(OnMute::Block));
@@ -148,7 +158,7 @@ fn run_cell_threaded(
             let stop = stop.clone();
             let bind_barrier = bind_barrier.clone();
             std::thread::spawn(move || {
-                let rt = build_default_runtime().expect("sub runtime");
+                let rt = build_runtime(1).expect("sub runtime");
                 common::block_on_and_drain(rt, async move {
                     bind_barrier.wait();
                     let s = Socket::new(SocketType::Sub, Options::default());
@@ -172,7 +182,7 @@ fn run_cell_threaded(
         let subs_ready = subs_ready.clone();
         let stop = stop.clone();
         std::thread::spawn(move || {
-            let rt = build_default_runtime().expect("pub runtime");
+            let rt = build_runtime(1).expect("pub runtime");
             common::block_on_and_drain(rt, async move {
                 let pub_ = Socket::new(SocketType::Pub, Options::default().on_mute(OnMute::Block));
                 pub_.bind(ep).await.expect("bind PUB");

--- a/omq-compio/tests/direct_encode_hwm.rs
+++ b/omq-compio/tests/direct_encode_hwm.rs
@@ -15,11 +15,11 @@ fn tcp_ep(port: u16) -> Endpoint {
     }
 }
 
-/// Fill the PUSH→PULL pipeline (receiver never reads), then verify
+/// Fill the PUSH->PULL pipeline (receiver never reads), then verify
 /// that `send()` blocks within a bounded number of messages.
 ///
-/// Uses 8 KiB payloads so kernel TCP buffers fill within hundreds of
-/// messages rather than tens of thousands.
+/// Uses 128 KiB payloads so kernel TCP buffers (which autoscale up to
+/// tcp_wmem max, often 4 MiB on Linux) fill within tens of messages.
 #[compio::test]
 async fn direct_encode_respects_send_hwm() {
     let hwm: u32 = 16;
@@ -30,7 +30,7 @@ async fn direct_encode_respects_send_hwm() {
     push.connect(ep).await.unwrap();
     compio::time::sleep(Duration::from_millis(50)).await;
 
-    let payload = vec![0u8; 8 * 1024];
+    let payload = vec![0u8; 128 * 1024];
     let mut accepted = 0usize;
     for _ in 0..5000 {
         match compio::time::timeout(
@@ -44,14 +44,13 @@ async fn direct_encode_respects_send_hwm() {
         }
     }
 
-    // Total buffering: DIRECT_CAP / 8 KiB = 64 msgs (byte-capped)
-    // + send_hwm (cmd channel) + kernel TCP buffers (system-dependent,
-    // typically 128-512 KiB on Linux). At 8 KiB per message that gives
-    // roughly 64 + 16 + ~32 = ~112 messages before backpressure.
+    // Total buffering: DIRECT_CAP (512 KiB) / 128 KiB = 4 msgs +
+    // send_hwm 16 (cmd channel) + kernel TCP buffers (tcp_wmem max is
+    // typically 4 MiB on Linux = ~32 msgs at 128 KiB). Total ~52 msgs.
     assert!(
         accepted < 500,
-        "accepted {accepted} messages — expected backpressure well before 500 \
-         (8 KiB payloads × send_hwm {hwm})",
+        "accepted {accepted} messages -- expected backpressure well before 500 \
+         (128 KiB payloads x send_hwm {hwm})",
     );
 
     let _ = pull;

--- a/omq-compio/tests/soak_ipc_fanout.rs
+++ b/omq-compio/tests/soak_ipc_fanout.rs
@@ -39,17 +39,23 @@ fn soak_ipc_fanout_no_message_loss() {
         )));
 
     let recv_count = Arc::new(AtomicUsize::new(0));
-    let stop = Arc::new(AtomicBool::new(false));
+    let sent_count = Arc::new(AtomicUsize::new(0));
+    let counting = Arc::new(AtomicBool::new(false));
+    let sending_done = Arc::new(AtomicBool::new(false));
     let subs_ready: Arc<Vec<AtomicBool>> =
         Arc::new((0..PEERS).map(|_| AtomicBool::new(false)).collect());
     let bind_barrier = Arc::new(Barrier::new(PEERS + 1));
+    let (drain_tx, drain_rx) = flume::bounded::<()>(PEERS);
 
     let sub_threads: Vec<_> = (0..PEERS)
         .map(|i| {
             let ep = ep.clone();
             let recv_count = recv_count.clone();
+            let sent_count = sent_count.clone();
+            let counting = counting.clone();
+            let sending_done = sending_done.clone();
+            let drain_tx = drain_tx.clone();
             let subs_ready = subs_ready.clone();
-            let stop = stop.clone();
             let bind_barrier = bind_barrier.clone();
             std::thread::spawn(move || {
                 let rt = build_default_runtime().expect("sub runtime");
@@ -58,23 +64,52 @@ fn soak_ipc_fanout_no_message_loss() {
                     let s = Socket::new(SocketType::Sub, Options::default());
                     s.connect(ep).await.expect("connect SUB");
                     s.subscribe(Bytes::new()).await.expect("subscribe");
-                    while !stop.load(Ordering::Relaxed) {
-                        if let Ok(Ok(_)) =
-                            compio::time::timeout(Duration::from_millis(20), s.recv()).await
-                        {
-                            subs_ready[i].store(true, Ordering::Relaxed);
-                            recv_count.fetch_add(1, Ordering::Relaxed);
+
+                    loop {
+                        match compio::time::timeout(Duration::from_millis(20), s.recv()).await {
+                            Ok(Ok(_)) => {
+                                subs_ready[i].store(true, Ordering::Relaxed);
+                                if counting.load(Ordering::Acquire) {
+                                    recv_count.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            _ => {
+                                if sending_done.load(Ordering::Acquire) {
+                                    break;
+                                }
+                            }
                         }
                     }
+
+                    // Drain messages still in the pipeline.
+                    let expected = sent_count.load(Ordering::Acquire) * PEERS;
+                    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+                    while std::time::Instant::now() < deadline {
+                        match compio::time::timeout(Duration::from_secs(1), s.recv()).await {
+                            Ok(Ok(_)) => {
+                                recv_count.fetch_add(1, Ordering::Relaxed);
+                            }
+                            _ => {
+                                if recv_count.load(Ordering::Relaxed) >= expected {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    let _ = drain_tx.send(());
                 });
             })
         })
         .collect();
+    drop(drain_tx);
 
     let pub_thread = {
         let recv_count = recv_count.clone();
+        let sent_count = sent_count.clone();
+        let counting = counting.clone();
+        let sending_done = sending_done.clone();
         let subs_ready = subs_ready.clone();
-        let stop = stop.clone();
         std::thread::spawn(move || {
             let rt = build_default_runtime().expect("pub runtime");
             block_on_and_drain(&rt, async move {
@@ -84,6 +119,8 @@ fn soak_ipc_fanout_no_message_loss() {
 
                 let payload = Bytes::from(vec![0xABu8; MSG_SIZE]);
 
+                // Warmup: send until all SUBs have received at least one
+                // message, confirming subscriptions are registered.
                 loop {
                     let _ = pub_.send(Message::single(payload.clone())).await;
                     if subs_ready.iter().all(|r| r.load(Ordering::Relaxed)) {
@@ -92,8 +129,12 @@ fn soak_ipc_fanout_no_message_loss() {
                     compio::time::sleep(Duration::from_micros(50)).await;
                 }
 
+                // Let warmup messages drain before counting begins.
+                compio::time::sleep(Duration::from_millis(100)).await;
+                counting.store(true, Ordering::Release);
+
                 let start = std::time::Instant::now();
-                let mut sent: u64 = 0;
+                let mut sent: usize = 0;
                 let mut last_log = start;
                 while start.elapsed() < duration {
                     pub_.send(Message::single(payload.clone())).await.unwrap();
@@ -107,15 +148,17 @@ fn soak_ipc_fanout_no_message_loss() {
                         last_log = std::time::Instant::now();
                     }
                 }
-                stop.store(true, Ordering::Relaxed);
 
-                let r = recv_count.load(Ordering::Relaxed);
-                let expected = sent as usize * PEERS;
-                eprintln!(
-                    "[ipc_fanout] done: sent {sent}, recvd {r}, expected {expected} in {:.1}s",
-                    start.elapsed().as_secs_f64(),
-                );
-                assert_eq!(r, expected, "message loss detected");
+                sent_count.store(sent, Ordering::Release);
+                sending_done.store(true, Ordering::Release);
+
+                // Wait for all SUBs to finish draining. This is async
+                // so the PUB's connection drivers keep flushing.
+                for _ in 0..PEERS {
+                    let _ = drain_rx.recv_async().await;
+                }
+
+                pub_.close().await.unwrap();
             });
         })
     };
@@ -124,4 +167,10 @@ fn soak_ipc_fanout_no_message_loss() {
     for t in sub_threads {
         t.join().expect("sub thread panicked");
     }
+
+    let s = sent_count.load(Ordering::Relaxed);
+    let r = recv_count.load(Ordering::Relaxed);
+    let expected = s * PEERS;
+    eprintln!("[ipc_fanout] done: sent {s}, recvd {r}, expected {expected}");
+    assert_eq!(r, expected, "message loss detected");
 }

--- a/omq-proto/CHANGELOG.md
+++ b/omq-proto/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `Options::compression_auto_train` now defaults to `false`. Auto-training adds per-connection overhead that only pays off for small structured records on bandwidth-constrained links. Enable explicitly with `.compression_auto_train(true)` when needed.
+
 ## [0.17.0] - 2026-06-12
 
 ### Added

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -99,8 +99,9 @@ pub struct Options {
     /// 512 B to 64 B and small messages ride the dict.
     /// Setting `compression_dict` overrides: auto-train is silently
     /// disabled when a static dict is supplied.
-    /// Set to `false` to suppress training (e.g. tests that need a
-    /// deterministic wire shape).
+    /// Default: `false`. Enable for workloads with small structured
+    /// records (JSON, protobuf) where dictionary compression can
+    /// achieve 8-24x compression ratios on sub-1 KiB messages.
     pub compression_auto_train: bool,
 
     /// Minimum payload size (bytes) before compression is attempted.
@@ -213,7 +214,7 @@ impl Default for Options {
             send_buffer_size: None,
             mechanism: MechanismSetup::Null,
             compression_dict: None,
-            compression_auto_train: true,
+            compression_auto_train: false,
             compression_threshold: None,
             compression_dict_capacity: None,
             max_recv_dict_size: None,
@@ -574,9 +575,9 @@ impl Options {
         self
     }
 
-    /// Toggle auto-trained dictionaries (`lz4+tcp://`).
-    /// On by default; pass `false` to suppress training. See
-    /// [`Options::compression_auto_train`] for semantics.
+    /// Enable auto-trained dictionaries (`lz4+tcp://`).
+    /// Off by default. See [`Options::compression_auto_train`] for
+    /// semantics.
     #[must_use]
     pub fn compression_auto_train(mut self, enabled: bool) -> Self {
         self.compression_auto_train = enabled;

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -14,12 +14,12 @@ use smallvec::SmallVec;
 
 use bytes::Bytes;
 
-use crate::engine::wire_slot::TryEncodeResult;
 use crate::engine::{DriverCommand, DriverHandle};
 use omq_proto::encoded_queue::EncodedQueue;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 use omq_proto::options::Options;
+use omq_proto::proto::transform::MessageEncoder;
 
 use super::peer_send::PeerSend;
 use super::subscription::SubscriptionSet;
@@ -78,11 +78,11 @@ impl Submitter {
             }
         };
 
-        let targets = self.collect_targets(&forwarded, group.as_deref());
+        let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop && !targets_have_space(&targets) {
             return Err(omq_proto::error::TrySendError::Full(forwarded));
         }
-        dispatch_to_targets(&targets, &forwarded);
+        dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
         Ok(())
     }
 
@@ -106,22 +106,27 @@ impl Submitter {
             }
         };
 
-        let targets = self.collect_targets(&forwarded, group.as_deref());
+        let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop {
             while !targets_have_space(&targets) {
                 tokio::task::yield_now().await;
             }
         }
-        dispatch_to_targets(&targets, &forwarded);
+        dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
         if self.send_count.fetch_add(1, Ordering::Relaxed) % YIELD_INTERVAL == YIELD_INTERVAL - 1 {
             tokio::task::yield_now().await;
         }
         Ok(())
     }
 
-    fn collect_targets(&self, msg: &Message, group: Option<&str>) -> SmallVec<[PeerSend; 8]> {
+    fn collect_targets(
+        &self,
+        msg: &Message,
+        group: Option<&str>,
+    ) -> (SmallVec<[PeerSend; 8]>, Option<Arc<Mutex<MessageEncoder>>>) {
         let g = self.inner.lock().expect("fanout inner poisoned");
-        if g.all_subscribe_all && matches!(self.mode, FanOutMode::SubscriptionPrefix) {
+        let targets = if g.all_subscribe_all && matches!(self.mode, FanOutMode::SubscriptionPrefix)
+        {
             g.all_targets.clone()
         } else {
             g.peers
@@ -135,7 +140,9 @@ impl Submitter {
                 })
                 .map(|p| p.target.clone())
                 .collect()
-        }
+        };
+        let encoder = g.fan_out_encoder.clone();
+        (targets, encoder)
     }
 }
 
@@ -147,11 +154,23 @@ pub(crate) struct FanOutSend {
     xpub_nodrop: bool,
 }
 
-#[derive(Debug)]
 struct FanOutInner {
     peers: FxHashMap<u64, FanOutPeer>,
     all_subscribe_all: bool,
     all_targets: SmallVec<[PeerSend; 8]>,
+    fan_out_encoder: Option<Arc<Mutex<MessageEncoder>>>,
+    #[allow(dead_code)]
+    options: Options,
+}
+
+impl std::fmt::Debug for FanOutInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FanOutInner")
+            .field("peers", &self.peers.len())
+            .field("all_subscribe_all", &self.all_subscribe_all)
+            .field("has_fan_out_encoder", &self.fan_out_encoder.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
@@ -163,6 +182,25 @@ struct FanOutPeer {
 }
 
 impl FanOutInner {
+    fn init_fan_out_encoder(&mut self) {
+        #[cfg(feature = "lz4")]
+        {
+            use omq_proto::endpoint::{Endpoint, Host};
+            let dummy = Endpoint::Lz4Tcp {
+                host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+                port: 0,
+            };
+            // Strip the dict: per-connection dict shipping requires the
+            // driver's per-peer encoder, which the fan-out path bypasses.
+            // Dictless compression still applies the lz4 block transform.
+            let mut opts = self.options.clone();
+            opts.compression_dict = None;
+            if let Some((enc, _dec)) = MessageEncoder::for_endpoint(&dummy, &opts) {
+                self.fan_out_encoder = Some(Arc::new(Mutex::new(enc.new_offload())));
+            }
+        }
+    }
+
     fn recompute_subscribe_all(&mut self) {
         self.all_subscribe_all = !self.peers.is_empty()
             && self
@@ -184,6 +222,8 @@ impl FanOutSend {
                 peers: FxHashMap::default(),
                 all_subscribe_all: false,
                 all_targets: SmallVec::new(),
+                fan_out_encoder: None,
+                options: options.clone(),
             })),
             mode,
             xpub_nodrop: options.xpub_nodrop,
@@ -209,6 +249,7 @@ impl FanOutSend {
 
     #[expect(clippy::needless_pass_by_value)]
     fn add_peer(&mut self, peer_id: u64, handle: DriverHandle, any_groups: bool) {
+        let has_transform = handle.wire_slot.as_ref().is_some_and(|s| s.has_transform);
         let target = PeerSend::from_handle(&handle);
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         g.peers.insert(
@@ -220,6 +261,9 @@ impl FanOutSend {
                 target,
             },
         );
+        if has_transform && g.fan_out_encoder.is_none() {
+            g.init_fan_out_encoder();
+        }
         g.recompute_subscribe_all();
     }
 
@@ -281,7 +325,11 @@ fn targets_have_space(targets: &[PeerSend]) -> bool {
     })
 }
 
-fn dispatch_to_targets(targets: &[PeerSend], msg: &Message) {
+fn dispatch_to_targets(
+    targets: &[PeerSend],
+    msg: &Message,
+    encoder: Option<&Mutex<MessageEncoder>>,
+) {
     match targets.len() {
         0 => {}
         1 => {
@@ -293,24 +341,43 @@ fn dispatch_to_targets(targets: &[PeerSend], msg: &Message) {
                 static SCRATCH: RefCell<EncodedQueue> = RefCell::new(
                     EncodedQueue::one_shot(),
                 );
+                static CHUNKS: RefCell<Vec<Bytes>> = const { RefCell::new(Vec::new()) };
             }
             SCRATCH.with(|cell| {
                 let eq = &mut *cell.borrow_mut();
-                eq.encode_auto(msg);
-                let encoded = eq.arena_bytes();
-                for t in targets {
-                    match t {
-                        PeerSend::Wire { slot, inbox } => {
-                            if slot.try_push_pre_encoded(encoded) == TryEncodeResult::Ineligible {
-                                let _ = inbox.try_send(DriverCommand::SendMessage(msg.clone()));
+                if let Some(enc_mtx) = encoder {
+                    let transformed = {
+                        let mut enc = enc_mtx.lock().expect("fan_out_encoder poisoned");
+                        match enc.encode(msg) {
+                            Ok(t) => t,
+                            Err(_) => return,
+                        }
+                    };
+                    for wire_msg in &transformed {
+                        eq.encode_auto(wire_msg);
+                    }
+                } else {
+                    eq.encode_auto(msg);
+                }
+                // Freeze the arena into shared Bytes, then distribute by
+                // reference.  Each subscriber gets an Arc clone (nanoseconds)
+                // instead of a full memcpy of the encoded bytes.
+                CHUNKS.with(|drain| {
+                    let chunks = &mut *drain.borrow_mut();
+                    chunks.clear();
+                    eq.drain_into_vec(chunks, 1024);
+                    for t in targets {
+                        match t {
+                            PeerSend::Wire { slot, .. } => {
+                                let _ = slot.try_push_encoded(chunks);
+                            }
+                            PeerSend::Inbox(tx) => {
+                                let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
                             }
                         }
-                        PeerSend::Inbox(tx) => {
-                            let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
-                        }
                     }
-                }
-                eq.clear_arena();
+                    chunks.clear();
+                });
             });
         }
     }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -182,6 +182,7 @@ struct FanOutPeer {
 }
 
 impl FanOutInner {
+    #[allow(clippy::unused_self)]
     fn init_fan_out_encoder(&mut self) {
         #[cfg(feature = "lz4")]
         {

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "lz4")]
 
-//! Pub/sub over `lz4+tcp://` — used to verify the README example.
+//! Pub/sub over `lz4+tcp://`.
 
 mod test_support;
 
@@ -9,43 +9,59 @@ use std::time::Duration;
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
 
-async fn pub_on_loopback() -> (Socket, Endpoint) {
-    let publisher = Socket::new(SocketType::Pub, Options::default());
-    let mut mon = publisher.monitor();
-    publisher
-        .bind(Endpoint::Lz4Tcp {
-            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-            port: 0,
-        })
-        .await
-        .unwrap();
-    let ev = tokio::time::timeout(Duration::from_millis(500), mon.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let port = match ev {
-        MonitorEvent::Listening {
+fn lz4_loopback() -> Endpoint {
+    Endpoint::Lz4Tcp {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port: 0,
+    }
+}
+
+async fn bind_lz4_loopback(sock: &Socket) -> (Endpoint, omq_tokio::MonitorStream) {
+    let mut mon = sock.monitor();
+    sock.bind(lz4_loopback()).await.unwrap();
+    let port = loop {
+        if let MonitorEvent::Listening {
             endpoint: Endpoint::Lz4Tcp { port, .. },
-        } => port,
-        other => panic!("expected Lz4Tcp Listening, got {other:?}"),
+        } = mon.recv().await.unwrap()
+        {
+            break port;
+        }
     };
-    let connect_ep = Endpoint::Lz4Tcp {
-        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+    let ep = Endpoint::Lz4Tcp {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
         port,
     };
-    (publisher, connect_ep)
+    (ep, mon)
+}
+
+async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
+    let fut = async {
+        let mut count = 0;
+        while count < n {
+            match mon.recv().await {
+                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => {
+                    panic!("monitor closed after {count}/{n} subscribes: {e:?}")
+                }
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate within 5s");
 }
 
 #[tokio::test]
 async fn pub_sub_prefix_filter() {
-    let (publisher, ep) = pub_on_loopback().await;
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
 
     let subscriber = Socket::new(SocketType::Sub, Options::default());
     subscriber.connect(ep).await.unwrap();
     subscriber.subscribe("news.").await.unwrap();
 
-    // Wait for the SUBSCRIBE command to travel from SUB -> PUB over the wire.
-    test_support::wait_for_subscribe(&publisher).await;
+    wait_for_subscribes(&mut mon, 1).await;
 
     publisher
         .send(Message::multipart(["news.sports", "ball scores"]))
@@ -74,10 +90,108 @@ async fn pub_sub_prefix_filter() {
     assert_eq!(m2.part_bytes(0).unwrap(), &b"news.tech"[..]);
     assert_eq!(m2.part_bytes(1).unwrap(), &b"rust 2.0"[..]);
 
-    // "weather" must never arrive.
     let nothing = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(
         nothing.is_err(),
         "non-matching message must not be delivered"
     );
+}
+
+/// Fan-out to multiple subscribers: exercises the multi-target
+/// `dispatch_to_targets` path that encodes once and pushes
+/// pre-encoded compressed bytes to all peers.
+#[tokio::test]
+async fn pub_sub_lz4_fan_out() {
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 200;
+
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, Options::default());
+        s.connect(ep.clone()).await.unwrap();
+        s.subscribe(bytes::Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+    wait_for_subscribes(&mut mon, N_SUBS).await;
+
+    for i in 0..N_MSGS {
+        let body = format!("msg-{i:04}");
+        publisher
+            .send(Message::single(bytes::Bytes::from(body)))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!("msg-{i:04}");
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
+}
+
+/// Fan-out with a compression dictionary configured. The fan-out
+/// encoder currently falls back to dictless compression (dict
+/// shipment requires the per-connection driver path). Verifies
+/// messages still arrive correctly.
+#[tokio::test]
+async fn pub_sub_lz4_fan_out_with_dict() {
+    use omq_proto::proto::transform::lz4::DictTrainer;
+
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 50;
+
+    let mut trainer = DictTrainer::new(2048);
+    for i in 0..100 {
+        let s = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        trainer.add_sample(s.as_bytes());
+    }
+    let dict = bytes::Bytes::from(trainer.train());
+    let opts = Options::default().compression_dict(dict);
+
+    let publisher = Socket::new(SocketType::Pub, opts.clone());
+    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, opts.clone());
+        s.connect(ep.clone()).await.unwrap();
+        s.subscribe(bytes::Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+    wait_for_subscribes(&mut mon, N_SUBS).await;
+
+    for i in 0..N_MSGS {
+        let body = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        publisher
+            .send(Message::single(bytes::Bytes::from(body)))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
 }

--- a/omq-tokio/tests/lz4_socket_types.rs
+++ b/omq-tokio/tests/lz4_socket_types.rs
@@ -1,0 +1,561 @@
+#![cfg(feature = "lz4")]
+
+mod test_support;
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+fn lz4_loopback(port: u16) -> Endpoint {
+    Endpoint::Lz4Tcp {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+async fn bind_lz4(sock: &Socket) -> u16 {
+    let mut mon = sock.monitor();
+    sock.bind(lz4_loopback(0)).await.unwrap();
+    loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Tcp { port, .. },
+            }) => return port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Tcp Listening, got {other:?}"),
+        }
+    }
+}
+
+async fn wait_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("handshake did not complete within 5s");
+}
+
+// ---- ROUTER / DEALER ----
+
+#[tokio::test]
+async fn router_dealer_identity_routing() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = bind_lz4(&router).await;
+
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"alice")),
+    );
+    dealer.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&router).await;
+
+    dealer.send(Message::single("hello")).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got.part_bytes(0).unwrap(), &b"alice"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+
+    router
+        .send(Message::multipart(["alice", "reply"]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(Duration::from_secs(2), dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap(), &b"reply"[..]);
+}
+
+#[tokio::test]
+async fn router_dealer_multi_peer() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = bind_lz4(&router).await;
+
+    let mut dealers = Vec::new();
+    for i in 0..3u8 {
+        let id = Bytes::from(vec![b'd', b'0' + i]);
+        let d = Socket::new(SocketType::Dealer, Options::default().identity(id));
+        d.connect(lz4_loopback(port)).await.unwrap();
+        dealers.push(d);
+    }
+
+    for d in &dealers {
+        wait_handshake(d).await;
+    }
+
+    for (i, d) in dealers.iter().enumerate() {
+        d.send(Message::single(format!("from-{i}"))).await.unwrap();
+    }
+
+    for _ in 0..3 {
+        let m = tokio::time::timeout(Duration::from_secs(2), router.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let id = m.part_bytes(0).unwrap();
+        let body = m.part_bytes(1).unwrap();
+
+        router
+            .send(Message::multipart([
+                id.clone(),
+                Bytes::from(format!("re:{}", String::from_utf8_lossy(&body))),
+            ]))
+            .await
+            .unwrap();
+    }
+
+    for d in &dealers {
+        let r = tokio::time::timeout(Duration::from_secs(2), d.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(r.part_bytes(0).unwrap().starts_with(b"re:from-"));
+    }
+}
+
+#[tokio::test]
+async fn router_dealer_large_compressible() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = bind_lz4(&router).await;
+
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"big")),
+    );
+    dealer.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&router).await;
+
+    let payload = vec![b'Z'; 8192];
+    dealer.send(Message::single(payload.clone())).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), &b"big"[..]);
+    assert_eq!(got.part_bytes(1).unwrap().to_vec(), payload);
+}
+
+// ---- XPUB / XSUB ----
+
+#[tokio::test]
+async fn xpub_xsub_over_lz4() {
+    let xpub = Socket::new(SocketType::XPub, Options::default());
+    let port = bind_lz4(&xpub).await;
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.subscribe("news.").await.unwrap();
+    sub.connect(lz4_loopback(port)).await.unwrap();
+
+    let notif = tokio::time::timeout(Duration::from_secs(2), xpub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&notif.part_bytes(0).unwrap()[..], b"\x01news.");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        xpub.send(Message::single("news.alpha")).await.unwrap();
+        xpub.send(Message::single("sports.beta")).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(50), sub.recv()).await {
+            assert!(
+                m.part_bytes(0).unwrap().starts_with(b"news."),
+                "sub got non-news: {:?}",
+                m.part_bytes(0).unwrap()
+            );
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "sub never received matching message"
+        );
+    }
+}
+
+#[tokio::test]
+async fn xsub_subscribe_over_lz4() {
+    let xpub = Socket::new(SocketType::XPub, Options::default());
+    let port = bind_lz4(&xpub).await;
+
+    let sub = Socket::new(SocketType::XSub, Options::default());
+    sub.connect(lz4_loopback(port)).await.unwrap();
+    sub.subscribe("data.").await.unwrap();
+
+    let notif = tokio::time::timeout(Duration::from_secs(2), xpub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&notif.part_bytes(0).unwrap()[..], b"\x01data.");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        xpub.send(Message::single("data.123")).await.unwrap();
+        xpub.send(Message::single("other.456")).await.unwrap();
+        if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(50), sub.recv()).await {
+            assert!(
+                m.part_bytes(0).unwrap().starts_with(b"data."),
+                "XSUB got non-data: {:?}",
+                m.part_bytes(0).unwrap()
+            );
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "XSUB never received matching message"
+        );
+    }
+}
+
+// ---- CLIENT / SERVER (draft) ----
+
+#[tokio::test]
+async fn client_server_over_lz4() {
+    let server = Socket::new(SocketType::Server, Options::default());
+    let port = bind_lz4(&server).await;
+
+    let client = Socket::new(
+        SocketType::Client,
+        Options::default().identity(Bytes::from_static(b"cli1")),
+    );
+    client.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&server).await;
+
+    client.send(Message::single("ping")).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got.part_bytes(0).unwrap(), &b"cli1"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"ping"[..]);
+
+    server
+        .send(Message::multipart(["cli1", "pong"]))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reply.len(), 1);
+    assert_eq!(reply.part_bytes(0).unwrap(), &b"pong"[..]);
+}
+
+#[tokio::test]
+async fn client_server_multi_client() {
+    let server = Socket::new(SocketType::Server, Options::default());
+    let port = bind_lz4(&server).await;
+
+    let mut clients = Vec::new();
+    for i in 0..3u8 {
+        let c = Socket::new(
+            SocketType::Client,
+            Options::default().identity(Bytes::from(vec![b'c', b'0' + i])),
+        );
+        c.connect(lz4_loopback(port)).await.unwrap();
+        clients.push(c);
+    }
+    for c in &clients {
+        wait_handshake(c).await;
+    }
+
+    for (i, c) in clients.iter().enumerate() {
+        c.send(Message::single(format!("from-{i}"))).await.unwrap();
+    }
+
+    for _ in 0..3 {
+        let m = tokio::time::timeout(Duration::from_secs(2), server.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let id = m.part_bytes(0).unwrap();
+        let body = m.part_bytes(1).unwrap();
+        server
+            .send(Message::multipart([
+                id.clone(),
+                Bytes::from(format!("re:{}", String::from_utf8_lossy(&body))),
+            ]))
+            .await
+            .unwrap();
+    }
+
+    for c in &clients {
+        let r = tokio::time::timeout(Duration::from_secs(2), c.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(r.part_bytes(0).unwrap().starts_with(b"re:from-"));
+    }
+}
+
+// ---- SCATTER / GATHER (draft) ----
+
+#[tokio::test]
+async fn scatter_gather_over_lz4() {
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    let port = bind_lz4(&gather).await;
+
+    let scatter = Socket::new(SocketType::Scatter, Options::default());
+    scatter.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&gather).await;
+
+    for i in 0..5 {
+        scatter
+            .send(Message::single(format!("m{i}")))
+            .await
+            .unwrap();
+    }
+
+    for i in 0..5 {
+        let m = tokio::time::timeout(Duration::from_secs(2), gather.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), format!("m{i}").as_bytes());
+    }
+}
+
+#[tokio::test]
+async fn scatter_gather_multi_scatter() {
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    let port = bind_lz4(&gather).await;
+
+    let mut scatterers = Vec::new();
+    for _ in 0..3 {
+        let s = Socket::new(SocketType::Scatter, Options::default());
+        s.connect(lz4_loopback(port)).await.unwrap();
+        scatterers.push(s);
+    }
+    for s in &scatterers {
+        wait_handshake(s).await;
+    }
+    for s in &scatterers {
+        s.send(Message::single("ping")).await.unwrap();
+    }
+
+    for _ in 0..3 {
+        let m = tokio::time::timeout(Duration::from_secs(2), gather.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    }
+}
+
+// ---- CHANNEL (draft) ----
+
+#[tokio::test]
+async fn channel_over_lz4() {
+    let a = Socket::new(SocketType::Channel, Options::default());
+    let port = bind_lz4(&a).await;
+
+    let b = Socket::new(SocketType::Channel, Options::default());
+    b.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&a).await;
+
+    a.send(Message::single("hi")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(2), b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), &b"hi"[..]);
+
+    b.send(Message::single("there")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(2), a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), &b"there"[..]);
+}
+
+// ---- PEER (draft) ----
+
+#[tokio::test]
+async fn peer_over_lz4() {
+    let a = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"peer-a")),
+    );
+    let port = bind_lz4(&a).await;
+
+    let b = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"peer-b")),
+    );
+    b.connect(lz4_loopback(port)).await.unwrap();
+    wait_handshake(&a).await;
+
+    b.send(Message::multipart(["peer-a", "hello a"]))
+        .await
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(2), a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), &b"peer-b"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello a"[..]);
+
+    a.send(Message::multipart(["peer-b", "hello b"]))
+        .await
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(2), b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), &b"peer-a"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello b"[..]);
+}
+
+// ---- RADIO / DISH (draft) ----
+
+#[tokio::test]
+async fn radio_dish_over_lz4() {
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    let port = bind_lz4(&radio).await;
+
+    let dish = Socket::new(SocketType::Dish, Options::default());
+    dish.join("weather").await.unwrap();
+    dish.connect(lz4_loopback(port)).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    radio
+        .send(Message::multipart([
+            Bytes::from_static(b"weather"),
+            Bytes::from_static(b"sunny"),
+        ]))
+        .await
+        .unwrap();
+    radio
+        .send(Message::multipart([
+            Bytes::from_static(b"news"),
+            Bytes::from_static(b"ignored"),
+        ]))
+        .await
+        .unwrap();
+    radio
+        .send(Message::multipart([
+            Bytes::from_static(b"weather"),
+            Bytes::from_static(b"rain"),
+        ]))
+        .await
+        .unwrap();
+
+    let m1 = tokio::time::timeout(Duration::from_secs(2), dish.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let m2 = tokio::time::timeout(Duration::from_secs(2), dish.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m1.part_bytes(0).unwrap(), &b"weather"[..]);
+    assert_eq!(m1.part_bytes(1).unwrap(), &b"sunny"[..]);
+    assert_eq!(m2.part_bytes(0).unwrap(), &b"weather"[..]);
+    assert_eq!(m2.part_bytes(1).unwrap(), &b"rain"[..]);
+
+    let third = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await;
+    assert!(third.is_err(), "non-joined group must not be delivered");
+}
+
+#[tokio::test]
+async fn radio_dish_multi_dish() {
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    let port = bind_lz4(&radio).await;
+
+    let dish_weather = Socket::new(SocketType::Dish, Options::default());
+    dish_weather.join("weather").await.unwrap();
+    dish_weather.connect(lz4_loopback(port)).await.unwrap();
+
+    let dish_news = Socket::new(SocketType::Dish, Options::default());
+    dish_news.join("news").await.unwrap();
+    dish_news.connect(lz4_loopback(port)).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    radio
+        .send(Message::multipart([
+            Bytes::from_static(b"weather"),
+            Bytes::from_static(b"sunny"),
+        ]))
+        .await
+        .unwrap();
+    radio
+        .send(Message::multipart([
+            Bytes::from_static(b"news"),
+            Bytes::from_static(b"headline"),
+        ]))
+        .await
+        .unwrap();
+
+    let w = tokio::time::timeout(Duration::from_secs(2), dish_weather.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(w.part_bytes(0).unwrap(), &b"weather"[..]);
+    assert_eq!(w.part_bytes(1).unwrap(), &b"sunny"[..]);
+
+    let n = tokio::time::timeout(Duration::from_secs(2), dish_news.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(n.part_bytes(0).unwrap(), &b"news"[..]);
+    assert_eq!(n.part_bytes(1).unwrap(), &b"headline"[..]);
+
+    let no_weather = tokio::time::timeout(Duration::from_millis(200), dish_weather.recv()).await;
+    assert!(no_weather.is_err(), "weather dish should not get news");
+
+    let no_news = tokio::time::timeout(Duration::from_millis(200), dish_news.recv()).await;
+    assert!(no_news.is_err(), "news dish should not get weather");
+}
+
+// ---- REQ/REP multi-peer over lz4+tcp ----
+
+#[tokio::test]
+async fn req_rep_multi_peer() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let port = bind_lz4(&rep).await;
+
+    let mut reqs = Vec::new();
+    for _ in 0..3 {
+        let r = Socket::new(SocketType::Req, Options::default());
+        r.connect(lz4_loopback(port)).await.unwrap();
+        reqs.push(r);
+    }
+    for r in &reqs {
+        wait_handshake(r).await;
+    }
+
+    for (i, r) in reqs.iter().enumerate() {
+        r.send(Message::single(format!("q-{i}"))).await.unwrap();
+
+        let q = tokio::time::timeout(Duration::from_secs(2), rep.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(q.part_bytes(0).unwrap(), format!("q-{i}").as_bytes(),);
+
+        rep.send(Message::single(format!("a-{i}"))).await.unwrap();
+
+        let a = tokio::time::timeout(Duration::from_secs(2), r.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(a.part_bytes(0).unwrap(), format!("a-{i}").as_bytes());
+    }
+}

--- a/scripts/bench_pubsub_lz4.py
+++ b/scripts/bench_pubsub_lz4.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""PUB/SUB lz4+tcp fan-out benchmark.
+
+Measures CPU-limited PUB/SUB throughput with 1 PUB -> 32 SUBs using
+JSON payloads, captures sender CPU%, then projects throughput at
+various link speeds.
+
+Usage:
+    scripts/bench_pubsub_lz4.py                        # full sweep
+    scripts/bench_pubsub_lz4.py --quick                 # 3 sizes, 1 round
+    scripts/bench_pubsub_lz4.py --chart                 # generate chart after
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PEER = REPO / "target" / "release" / "bench_peer_tokio"
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+JSONL = CACHE_DIR / "results_pubsub_lz4.jsonl"
+
+CHART_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
+               8192, 16384, 32768, 65536, 131072, 262144]
+QUICK_SIZES = [128, 1024, 8192]
+DEFAULT_TRANSPORTS = ["tcp", "lz4+tcp"]
+N_SUBS = 32
+DEFAULT_DICT_SIZES = [2048]
+DEFAULT_DURATION = 2.0
+DEFAULT_ROUNDS = 3
+QUICK_DURATION = 1.5
+QUICK_ROUNDS = 1
+
+_port_counter = 17500
+
+
+def next_port():
+    global _port_counter
+    _port_counter += 1
+    return _port_counter
+
+
+def build_peer():
+    print("Building bench_peer_tokio (--features lz4)...", file=sys.stderr)
+    subprocess.run(
+        ["cargo", "build", "--release", "-p", "omq-tokio",
+         "--bin", "bench_peer_tokio", "--features", "lz4"],
+        cwd=REPO, check=True,
+    )
+
+
+def run_peer(*args, env=None):
+    merged = {**os.environ, **(env or {})}
+    return subprocess.Popen(
+        [str(PEER)] + list(args),
+        env=merged, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+    )
+
+
+def kill_peer(proc):
+    try:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=3)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+
+
+def peer_output(*args, env=None):
+    merged = {**os.environ, **(env or {})}
+    r = subprocess.run(
+        [str(PEER)] + list(args),
+        env=merged, capture_output=True, text=True, check=True,
+    )
+    return r.stdout.strip()
+
+
+def get_wire_size(transport, size, dict_file=None):
+    ep = f"{transport}://127.0.0.1:19999"
+    env = {"OMQ_BENCH_PAYLOAD": "json"}
+    if dict_file:
+        env["OMQ_BENCH_DICT_FILE"] = str(dict_file)
+    return int(peer_output("wire-size", ep, str(size), env=env))
+
+
+def train_dict(path, capacity=2048):
+    peer_output("train-dict", str(path), str(capacity))
+
+
+def read_proc_cpu(pid):
+    try:
+        fields = open(f"/proc/{pid}/stat").read().split()
+        utime = int(fields[13])
+        stime = int(fields[14])
+        return (utime + stime) / os.sysconf("SC_CLK_TCK")
+    except (OSError, IndexError):
+        return 0.0
+
+
+def run_cell(transport, size, peers, duration, dict_file=None):
+    port = next_port()
+    ep = f"{transport}://127.0.0.1:{port}"
+    env = {"OMQ_BENCH_PAYLOAD": "json"}
+    if dict_file:
+        env["OMQ_BENCH_DICT_FILE"] = str(dict_file)
+
+    pub = run_peer("pub", ep, str(size), env=env)
+    time.sleep(0.25)
+
+    # Drain SUBs use bare tcp:// for lz4+tcp transports: they receive
+    # the compressed frames and discard without decompressing, simulating
+    # subscribers on separate machines whose CPU doesn't compete with
+    # the PUB.
+    drain_ep = f"tcp://127.0.0.1:{port}" if "lz4" in transport else ep
+    drain_dur = str(duration + 3)
+    drains = []
+    for _ in range(peers - 1):
+        drains.append(run_peer("sub", drain_ep, str(size), drain_dur,
+                               env=env))
+
+    if peers > 1:
+        time.sleep(0.15)
+
+    try:
+        measured = run_peer("sub", ep, str(size), str(duration), env=env)
+        stdout, _ = measured.communicate(timeout=duration + 15)
+        output = stdout.decode().strip()
+    except Exception:
+        output = ""
+
+    pub_cpu = read_proc_cpu(pub.pid)
+
+    kill_peer(pub)
+    for d in drains:
+        kill_peer(d)
+
+    if not output:
+        return None
+
+    parts = output.split()
+    if len(parts) < 2:
+        return None
+    count, elapsed = int(parts[0]), float(parts[1])
+    if elapsed <= 0:
+        return None
+    msgs_s = count / elapsed
+    mbps = count * size / elapsed / 1e6
+    return {"count": count, "elapsed": elapsed, "msgs_s": msgs_s,
+            "mbps": mbps * peers, "cpu_time": pub_cpu}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PUB/SUB lz4+tcp fan-out benchmark")
+    parser.add_argument("--transports",
+                        default=",".join(DEFAULT_TRANSPORTS))
+    parser.add_argument("--sizes",
+                        default=",".join(str(s) for s in CHART_SIZES))
+    parser.add_argument("--duration", type=float, default=DEFAULT_DURATION)
+    parser.add_argument("--rounds", type=int, default=DEFAULT_ROUNDS)
+    parser.add_argument("--quick", action="store_true",
+                        help="3 sizes, 1 round, shorter duration")
+    parser.add_argument("--dict-sizes",
+                        default=",".join(str(s) for s in DEFAULT_DICT_SIZES))
+    parser.add_argument("--chart", action="store_true",
+                        help="regenerate chart after bench")
+    args = parser.parse_args()
+
+    build_peer()
+
+    transports = args.transports.split(",")
+    sizes = [int(s) for s in args.sizes.split(",")]
+    dict_sizes = [int(s) for s in args.dict_sizes.split(",")]
+
+    if args.quick:
+        sizes = QUICK_SIZES
+        duration = QUICK_DURATION
+        rounds = QUICK_ROUNDS
+    else:
+        duration = args.duration
+        rounds = args.rounds
+
+    run_id = f"ts-{int(time.time())}"
+    print(f"--- PUB/SUB lz4 bench: 1 PUB -> {N_SUBS} SUBs"
+          f" (omq-tokio, JSON) ---")
+    print(f"run_id: {run_id}")
+    print()
+
+    all_rows = []
+
+    for transport in transports:
+        print(f"--- {transport}, {N_SUBS} subscribers ---")
+        for size in sizes:
+            best = None
+            for _ in range(rounds):
+                cell = run_cell(transport, size, N_SUBS, duration)
+                if cell and (best is None
+                             or cell["msgs_s"] > best["msgs_s"]):
+                    best = cell
+            if best is None:
+                print(f"  ~{size:>6}B  FAILED")
+                continue
+            wire_bytes = get_wire_size(transport, size)
+            agg_gbs = best["mbps"] / 1000
+            cpu_pct = (best["cpu_time"] / best["elapsed"] * 100
+                       if best["elapsed"] > 0 else 0)
+            print(f"  ~{size:>6}B  {best['msgs_s']:>9.0f} msg/s"
+                  f"  {agg_gbs:>7.2f} agg GB/s"
+                  f"  cpu {cpu_pct:>5.1f}%"
+                  f"  (wire {wire_bytes}B)")
+            all_rows.append({
+                "run_id": run_id,
+                "pattern": "pubsub_lz4",
+                "transport": transport,
+                "peers": N_SUBS,
+                "msg_size": size,
+                "wire_bytes": wire_bytes,
+                "msg_count": best["count"],
+                "elapsed": best["elapsed"],
+                "cpu_time": best["cpu_time"],
+                "msgs_s": best["msgs_s"],
+                "mbps": best["mbps"],
+            })
+        print()
+
+    # Wire-size sweep for dict series (projected, not measured)
+    for ds in dict_sizes:
+        with tempfile.NamedTemporaryFile(suffix=".dict",
+                                         delete=False) as f:
+            dict_path = f.name
+        try:
+            train_dict(dict_path, ds)
+            ds_label = f"{ds // 1024}K" if ds >= 1024 else f"{ds}B"
+            print(f"--- wire sizes: lz4+tcp + {ds_label} dict ---")
+            for size in sizes:
+                wire_bytes = get_wire_size("lz4+tcp", size, dict_path)
+                ratio = size / wire_bytes if wire_bytes else 0
+                print(f"  ~{size:>6}B  wire {wire_bytes}B ({ratio:.1f}x)")
+                all_rows.append({
+                    "run_id": run_id,
+                    "pattern": "pubsub_lz4_dict",
+                    "transport": "lz4+tcp",
+                    "peers": N_SUBS,
+                    "msg_size": size,
+                    "wire_bytes": wire_bytes,
+                    "dict_size": ds,
+                })
+            print()
+        finally:
+            os.unlink(dict_path)
+
+    JSONL.parent.mkdir(parents=True, exist_ok=True)
+    with open(JSONL, "a") as f:
+        for row in all_rows:
+            f.write(json.dumps(row, separators=(",", ":")) + "\n")
+    print(f"Appended {len(all_rows)} rows to {JSONL}", file=sys.stderr)
+
+    if args.chart:
+        chart_script = REPO / "scripts" / "gen_pubsub_lz4_chart.py"
+        subprocess.run([sys.executable, str(chart_script)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_pubsub_lz4_chart.py
+++ b/scripts/gen_pubsub_lz4_chart.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Generate PUB/SUB lz4 compression chart with link-speed projection.
+
+Three panels (1 Gbps, 100 Mbps, 10 Mbps), three axes per panel:
+  dotted = sender CPU % (left, linear)
+  solid  = aggregate virtual SUB throughput (inner right, log)
+  dashed = msg/s (outer right, log)
+
+Produces: doc/charts/pubsub/lz4_tcp.svg
+"""
+
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from gen_compression_chart import (
+    fmt_size, detect_hardware, _log_ticks, _cpu_ticks,
+    _fmt_cpu, _fmt_tput, _fmt_msgs,
+)
+
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
+JSONL_PATH = CACHE_DIR / "results_pubsub_lz4.jsonl"
+
+LINK_SPEEDS = [
+    ("1g",   1_000_000_000 / 8,  "1 Gbps"),
+    ("100m", 100_000_000 / 8,    "100 Mbps"),
+    ("10m",  10_000_000 / 8,     "10 Mbps"),
+]
+
+COLORS = {
+    "tcp":          "#eab308",
+    "lz4+tcp":      "#60a5fa",
+    "lz4+tcp+dict": "#1d4ed8",
+}
+LABELS = {
+    "tcp":          "tcp (no compression)",
+    "lz4+tcp":      "lz4+tcp (no dict)",
+    "lz4+tcp+dict": "lz4+tcp + dict",
+}
+SERIES_ORDER = ["tcp", "lz4+tcp", "lz4+tcp+dict"]
+
+
+# ── data ──────────────────────────────────────────────────────────
+
+def load_raw_data() -> tuple[dict, int, int]:
+    """Returns (raw_data, dict_size, peers)."""
+    if not JSONL_PATH.exists():
+        print(f"ERROR: {JSONL_PATH} not found", file=sys.stderr)
+        sys.exit(1)
+
+    all_rows = []
+    for line in JSONL_PATH.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                all_rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    pubsub = [r for r in all_rows
+              if r.get("pattern", "").startswith("pubsub_lz4")]
+    if not pubsub:
+        print("ERROR: no pubsub_lz4 rows", file=sys.stderr)
+        sys.exit(1)
+
+    dict_rows = [r for r in pubsub if r.get("dict_size")]
+    dict_size = max(r["dict_size"] for r in dict_rows) if dict_rows else 2048
+    peers = max((r.get("peers", 32) for r in pubsub), default=32)
+
+    def series_key(r):
+        if r["pattern"] == "pubsub_lz4_dict":
+            return "lz4+tcp+dict"
+        return r["transport"]
+
+    newest: dict[tuple, dict] = {}
+    for r in pubsub:
+        k = (series_key(r), r["msg_size"])
+        if k not in newest or r["run_id"] > newest[k]["run_id"]:
+            newest[k] = r
+
+    sizes_set = set()
+    series: dict[str, dict[int, dict]] = {}
+    for r in newest.values():
+        key = series_key(r)
+        sz = r["msg_size"]
+        sizes_set.add(sz)
+        elapsed = r.get("elapsed", 0)
+        cpu_time = r.get("cpu_time", 0)
+        cpu_pct = (cpu_time / elapsed * 100) if elapsed > 0 else 0
+        entry = {
+            "msg_size": sz,
+            "wire_bytes": r.get("wire_bytes", sz),
+        }
+        if "msgs_s" in r:
+            entry["cpu_msgs_s"] = r["msgs_s"]
+            entry["cpu_pct"] = cpu_pct
+        series.setdefault(key, {})[sz] = entry
+
+    # Dict series inherits cpu_msgs_s from lz4+tcp
+    if "lz4+tcp+dict" in series and "lz4+tcp" in series:
+        for sz, d in series["lz4+tcp+dict"].items():
+            if "cpu_msgs_s" not in d and sz in series["lz4+tcp"]:
+                src = series["lz4+tcp"][sz]
+                d["cpu_msgs_s"] = src.get("cpu_msgs_s", 0)
+                d["cpu_pct"] = src.get("cpu_pct", 0)
+
+    return {"sizes": sorted(sizes_set), "series": series}, dict_size, peers
+
+
+def project(raw: dict, link_bytes_s: float, peers: int) -> dict:
+    """Project throughput at a link speed."""
+    series = {}
+    for key, size_data in raw["series"].items():
+        series[key] = {}
+        for sz, d in size_data.items():
+            cpu = d.get("cpu_msgs_s")
+            if cpu is None:
+                continue
+            wire = d["wire_bytes"]
+            wire_per_msg = wire * peers
+            link_msgs = link_bytes_s / max(wire_per_msg, 1)
+            eff_msgs = min(cpu, link_msgs)
+            # Aggregate virtual throughput: all subscribers combined
+            agg_virt_mbs = eff_msgs * d["msg_size"] * peers / 1_000_000
+            ratio = eff_msgs / cpu if cpu > 0 else 0
+            series[key][sz] = {
+                "msgs_s": eff_msgs,
+                "virt_mbps": agg_virt_mbs,
+                "cpu_pct": d.get("cpu_pct", 0) * ratio,
+            }
+    return {"sizes": raw["sizes"], "series": series}
+
+
+# ── SVG ───────────────────────────────────────────────────────────
+
+def generate_svg(
+    panels: dict[str, dict],
+    peers: int,
+    dict_size_label: str | None = None,
+    hw_label: str | None = None,
+) -> str:
+    links = [tag for tag, _, _ in LINK_SPEEDS if tag in panels]
+    if not links:
+        return ""
+
+    n_panels = len(links)
+    x_left = 90
+    x_right = 700
+    x_right2 = 780
+    plot_w = x_right - x_left
+    panel_h = 220
+    panel_gap = 70
+    top_margin = 44 if hw_label else 30
+    x_label_space = 20
+    legend_h = 60
+    bottom_pad = 40
+    right_pad = 15
+
+    svg_h = (top_margin + n_panels * (panel_h + x_label_space)
+             + (n_panels - 1) * panel_gap + legend_h + bottom_pad)
+    svg_w = x_right2 + 80 + right_pad
+    mid_x = (x_left + x_right) / 2
+
+    all_sizes = set()
+    for d in panels.values():
+        all_sizes.update(d["sizes"])
+    sizes = sorted(all_sizes)
+    n = len(sizes)
+    if n < 2:
+        return ""
+    xs = [x_left + i * plot_w / (n - 1) for i in range(n)]
+
+    L = []
+    L.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg"'
+        f' viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">'
+    )
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>')
+
+    title = (f"PUB/SUB lz4+tcp: structured JSON, 1 PUB → {peers} SUBs"
+             f" (omq-tokio)")
+    if dict_size_label:
+        title += f", dict {dict_size_label}"
+    L.append(
+        f'  <text x="{mid_x}" y="16" text-anchor="middle" fill="#111827"'
+        f' font-size="12" font-weight="700">{title}</text>'
+    )
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="30" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
+
+    last_x_label_y = 0
+
+    for pi, link_tag in enumerate(links):
+        data = panels[link_tag]
+        series = data["series"]
+        y_top = top_margin + pi * (panel_h + x_label_space + panel_gap) + 25
+        y_bot = y_top + panel_h
+        plot_h = y_bot - y_top
+
+        cpu_data_max = max((d["cpu_pct"] for s in series.values()
+                            for d in s.values()), default=100)
+        cpu_ceil, cpu_ticks = _cpu_ticks(max(cpu_data_max, 100))
+
+        all_virt = [d["virt_mbps"] for s in series.values()
+                    for d in s.values() if d["virt_mbps"] > 0]
+        virt_min = min(all_virt) if all_virt else 1
+        virt_max = max(all_virt) if all_virt else 100
+        tp_min, tp_max, tp_ticks = _log_ticks(
+            max(virt_min, 0.01), max(virt_max, 1))
+
+        all_msgs = [d["msgs_s"] for s in series.values()
+                    for d in s.values() if d["msgs_s"] > 0]
+        msgs_min = min(all_msgs) if all_msgs else 1
+        msgs_max = max(all_msgs) if all_msgs else 1000
+        ms_min, ms_max, ms_ticks = _log_ticks(
+            max(msgs_min, 1), max(msgs_max, 10))
+
+        def y_cpu(v, _bot=y_bot, _h=plot_h, _ceil=cpu_ceil):
+            return _bot - max(0, min(1, v / _ceil)) * _h
+
+        def y_tput(v, _bot=y_bot, _h=plot_h, _lo=tp_min, _hi=tp_max):
+            if v <= 0:
+                return _bot
+            frac = max(0, min(1, (math.log10(v) - _lo) / (_hi - _lo)))
+            return _bot - frac * _h
+
+        def y_msgs(v, _bot=y_bot, _h=plot_h, _lo=ms_min, _hi=ms_max):
+            if v <= 0:
+                return _bot
+            frac = max(0, min(1, (math.log10(v) - _lo) / (_hi - _lo)))
+            return _bot - frac * _h
+
+        link_label = dict(LINK_SPEEDS).get(
+            link_tag, {}).get(2, link_tag) if False else \
+            next(lb for t, _, lb in LINK_SPEEDS if t == link_tag)
+        L.append(
+            f'  <text x="{mid_x:.1f}" y="{y_top - 10}"'
+            f' text-anchor="middle" fill="#111827"'
+            f' font-size="12" font-weight="700">{link_label}</text>'
+        )
+
+        # CPU% gridlines (left, linear)
+        for val in cpu_ticks:
+            yy = y_cpu(val)
+            L.append(
+                f'  <line x1="{x_left}" y1="{yy:.1f}"'
+                f' x2="{x_right}" y2="{yy:.1f}"'
+                f' stroke="#e5e7eb" stroke-width="1"/>'
+            )
+            L.append(
+                f'  <text x="{x_left - 8}" y="{yy:.1f}"'
+                f' text-anchor="end" dominant-baseline="middle"'
+                f' fill="#374151" font-size="9">{_fmt_cpu(val)}</text>'
+            )
+
+        # Virtual throughput gridlines (inner right, log)
+        for mb in tp_ticks:
+            yy = y_tput(mb)
+            L.append(
+                f'  <line x1="{x_left}" y1="{yy:.1f}"'
+                f' x2="{x_right}" y2="{yy:.1f}"'
+                f' stroke="#e5e7eb" stroke-width="1"'
+                f' stroke-dasharray="3,6"/>'
+            )
+            L.append(
+                f'  <text x="{x_right + 8}" y="{yy:.1f}"'
+                f' text-anchor="start" dominant-baseline="middle"'
+                f' fill="#6b7280" font-size="9">{_fmt_tput(mb)}</text>'
+            )
+
+        # msg/s gridlines (outer right, log)
+        for ms in ms_ticks:
+            yy = y_msgs(ms)
+            L.append(
+                f'  <text x="{x_right2 + 8}" y="{yy:.1f}"'
+                f' text-anchor="start" dominant-baseline="middle"'
+                f' fill="#9ca3af" font-size="9">{_fmt_msgs(ms)}/s</text>'
+            )
+
+        # Vertical gridlines
+        for x in xs:
+            L.append(
+                f'  <line x1="{x:.1f}" y1="{y_top}"'
+                f' x2="{x:.1f}" y2="{y_bot}"'
+                f' stroke="#e5e7eb" stroke-width="1"/>'
+            )
+
+        # Axes
+        for ax in [
+            f'{x_left}" y1="{y_top}" x2="{x_left}" y2="{y_bot}',
+            f'{x_right}" y1="{y_top}" x2="{x_right}" y2="{y_bot}',
+            f'{x_left}" y1="{y_bot}" x2="{x_right}" y2="{y_bot}',
+        ]:
+            L.append(
+                f'  <line x1="{ax}" stroke="#9ca3af"'
+                f' stroke-width="1.5"/>'
+            )
+        L.append(
+            f'  <line x1="{x_right2}" y1="{y_top}"'
+            f' x2="{x_right2}" y2="{y_bot}"'
+            f' stroke="#d1d5db" stroke-width="1"/>'
+        )
+
+        # X-axis labels
+        last_x_label_y = y_bot + 14
+        for i, s in enumerate(sizes):
+            L.append(
+                f'  <text x="{xs[i]:.1f}" y="{last_x_label_y}"'
+                f' text-anchor="middle" fill="#374151"'
+                f' font-size="8">{fmt_size(s)}</text>'
+            )
+
+        # CPU% axis title
+        mid_y = (y_top + y_bot) / 2
+        L.append(
+            f'  <text x="40" y="{mid_y:.1f}" text-anchor="middle"'
+            f' dominant-baseline="middle" fill="#374151"'
+            f' font-size="10" font-weight="600"'
+            f' transform="rotate(-90,40,{mid_y:.1f})">sender CPU %</text>'
+        )
+
+        present = [k for k in SERIES_ORDER if k in series]
+
+        # Dotted: CPU %
+        for name in present:
+            d = series[name]
+            active = [(i, sizes[i]) for i in range(n)
+                      if sizes[i] in d]
+            if not active:
+                continue
+            pts = " ".join(
+                f"{xs[i]:.1f},{y_cpu(d[s]['cpu_pct']):.1f}"
+                for i, s in active
+            )
+            L.append(
+                f'  <polyline points="{pts}" fill="none"'
+                f' stroke="{COLORS[name]}"'
+                f' stroke-width="2" stroke-dasharray="2,3"'
+                f' opacity="0.7"/>'
+            )
+
+        # Solid: aggregate virtual throughput with dots
+        for name in present:
+            d = series[name]
+            active = [(i, sizes[i]) for i in range(n)
+                      if sizes[i] in d]
+            if not active:
+                continue
+            pts = " ".join(
+                f"{xs[i]:.1f},{y_tput(d[s]['virt_mbps']):.1f}"
+                for i, s in active
+            )
+            L.append(
+                f'  <polyline points="{pts}" fill="none"'
+                f' stroke="{COLORS[name]}"'
+                f' stroke-width="2.5" stroke-linecap="round"'
+                f' stroke-linejoin="round"/>'
+            )
+            for i, s in active:
+                yy = y_tput(d[s]["virt_mbps"])
+                L.append(
+                    f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}"'
+                    f' r="2.5" fill="{COLORS[name]}"'
+                    f' stroke="white" stroke-width="1"/>'
+                )
+
+        # Dashed: msg/s
+        for name in present:
+            d = series[name]
+            active = [(i, sizes[i]) for i in range(n)
+                      if sizes[i] in d]
+            if not active:
+                continue
+            pts = " ".join(
+                f"{xs[i]:.1f},{y_msgs(d[s]['msgs_s']):.1f}"
+                for i, s in active
+            )
+            L.append(
+                f'  <polyline points="{pts}" fill="none"'
+                f' stroke="{COLORS[name]}"'
+                f' stroke-width="1.5" stroke-dasharray="5,3"/>'
+            )
+
+    # Legend
+    leg_y1 = last_x_label_y + 18
+    leg_y2 = leg_y1 + 12
+    leg_y3 = leg_y2 + 12
+
+    all_present = []
+    for link_tag in links:
+        for k in SERIES_ORDER:
+            if k in panels[link_tag]["series"] and k not in all_present:
+                all_present.append(k)
+
+    item_w = plot_w / max(len(all_present), 1)
+    for i, name in enumerate(all_present):
+        lx = x_left + i * item_w
+        c = COLORS[name]
+        L.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y1}"'
+            f' x2="{lx + 14:.0f}" y2="{leg_y1}"'
+            f' stroke="{c}" stroke-width="1.5"'
+            f' stroke-dasharray="2,3" opacity="0.7"/>'
+        )
+        L.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y2}"'
+            f' x2="{lx + 14:.0f}" y2="{leg_y2}"'
+            f' stroke="{c}" stroke-width="2.5"/>'
+        )
+        L.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y3}"'
+            f' x2="{lx + 14:.0f}" y2="{leg_y3}"'
+            f' stroke="{c}" stroke-width="1.5"'
+            f' stroke-dasharray="5,3"/>'
+        )
+        L.append(
+            f'  <text x="{lx + 18:.0f}" y="{leg_y1 + 4}"'
+            f' fill="#374151" font-size="10"'
+            f' font-weight="500">{LABELS.get(name, name)}</text>'
+        )
+
+    footer_y = leg_y3 + 18
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f'dotted = sender CPU % linear (left)'
+        f' · solid = aggregate virtual SUB throughput log (inner right)'
+        f' · dashed = msg/s log (outer right)</text>'
+    )
+
+    L.append("</svg>")
+    return "\n".join(L) + "\n"
+
+
+# ── main ──────────────────────────────────────────────────────────
+
+def main():
+    raw, dict_size, peers = load_raw_data()
+
+    ds_label = (f"{dict_size // 1024}K" if dict_size >= 1024
+                else f"{dict_size}B")
+    LABELS["lz4+tcp+dict"] = f"lz4+tcp + {ds_label} dict"
+
+    hw = detect_hardware()
+    if hw:
+        hw = "Linux VM on a 2018 Mac Mini, " + hw
+
+    panels = {}
+    for tag, bps, _ in LINK_SPEEDS:
+        panels[tag] = project(raw, bps, peers)
+
+    svg = generate_svg(panels, peers, dict_size_label=ds_label,
+                       hw_label=hw)
+    if svg:
+        out = REPO / "doc" / "charts" / "pubsub" / "lz4_tcp.svg"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(svg)
+        print(f"Written: {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Fix lz4+tcp fan-out in `omq-tokio`: encode once, distribute compressed bytes to all subscribers instead of per-peer encoding
- Default `compression_auto_train` to false (was causing unexpected behavior)
- Add lz4+tcp integration tests for all remaining socket types (`omq-tokio/tests/lz4_socket_types.rs`)
- Expand `lz4_pub_sub` test coverage
- Fix `soak_ipc_fanout`: proper drain + warmup separation
- Fix clippy `unused_self` lint and pyomq `auto_train` default
- Fix doc inaccuracies in architecture/tokio/compio docs, scale pub_sub bench pool with peer count
- `direct_encode_hwm`: use 128 KiB payloads to fill kernel TCP buffers faster
- Add lz4 pub/sub benchmark script and chart