### PR TITLE
add 8 soak tests + docs fix

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,13 +56,15 @@ OMQ_FUZZ_ITERS=500000000 cargo test -p omq-tokio  --features fuzz --release -- -
 
 ## Soak tests
 
-Long-running leak and stability scenarios. omq-tokio has 16
-scenarios; omq-compio has 11 (the five newest are tokio-only for
+Long-running leak and stability scenarios. omq-tokio has 21
+scenarios; omq-compio has 11 (the ten newest are tokio-only for
 now). Scenarios: peer churn, reconnect storm, reconnect all types,
-PUB/SUB churn, PUB/SUB churn TCP, ROUTER/DEALER churn,
-large-message throughput, compression (lz4), PLAIN auth, CURVE
-encryption, BLAKE3ZMQ encryption, multi-socket, inproc cross-thread,
-cancel safety, CURVE reconnect, BLAKE3ZMQ reconnect.
+PUB/SUB churn, PUB/SUB churn TCP, XPUB/XSUB churn,
+ROUTER/DEALER churn, HWM reconnect (drop + block), WebSocket
+throughput, WebSocket reconnect storm, large-message throughput,
+compression (lz4), PLAIN auth, CURVE encryption, BLAKE3ZMQ
+encryption, multi-socket, inproc cross-thread, cancel safety,
+CURVE reconnect, BLAKE3ZMQ reconnect.
 
 Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s).
 Enable all feature-gated scenarios with the full feature set.
@@ -72,7 +74,7 @@ sequentially. Launch scenarios in batches of 4 (8 processes) to
 keep peak RSS bounded while still running in parallel:
 
 ```sh
-FEATURES="soak lz4 plain curve blake3zmq"
+FEATURES="soak lz4 plain curve blake3zmq ws"
 
 # build first (avoid parallel compilation conflicts)
 cargo test -p omq-compio --features "$FEATURES" --release --no-run
@@ -80,10 +82,11 @@ cargo test -p omq-tokio  --features "$FEATURES" --release --no-run
 
 # run in batches of 4 scenarios (8 processes), 10 min each
 TESTS=(blake3zmq cancel_safety compression compression_lz4 curve
-       inproc_cross_thread large_throughput mechanism_reconnect
-       multi_socket peer_churn plain pub_sub_churn
-       pub_sub_churn_tcp reconnect_all_types reconnect_storm
-       router_dealer_churn)
+       hwm_reconnect inproc_cross_thread large_throughput
+       mechanism_reconnect multi_socket peer_churn plain
+       pub_sub_churn pub_sub_churn_tcp reconnect_all_types
+       reconnect_storm router_dealer_churn ws
+       xpub_xsub_churn)
 
 batch=()
 for test in "${TESTS[@]}"; do

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,12 +56,13 @@ OMQ_FUZZ_ITERS=500000000 cargo test -p omq-tokio  --features fuzz --release -- -
 
 ## Soak tests
 
-Long-running leak and stability scenarios. omq-tokio has 14
-scenarios; omq-compio has 11 (the three newest are tokio-only for
+Long-running leak and stability scenarios. omq-tokio has 16
+scenarios; omq-compio has 11 (the five newest are tokio-only for
 now). Scenarios: peer churn, reconnect storm, reconnect all types,
-PUB/SUB churn, large-message throughput, compression (lz4), PLAIN
-auth, CURVE encryption, BLAKE3ZMQ encryption, multi-socket, inproc
-cross-thread, cancel safety, CURVE reconnect, BLAKE3ZMQ reconnect.
+PUB/SUB churn, PUB/SUB churn TCP, ROUTER/DEALER churn,
+large-message throughput, compression (lz4), PLAIN auth, CURVE
+encryption, BLAKE3ZMQ encryption, multi-socket, inproc cross-thread,
+cancel safety, CURVE reconnect, BLAKE3ZMQ reconnect.
 
 Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s).
 Enable all feature-gated scenarios with the full feature set.
@@ -81,7 +82,8 @@ cargo test -p omq-tokio  --features "$FEATURES" --release --no-run
 TESTS=(blake3zmq cancel_safety compression compression_lz4 curve
        inproc_cross_thread large_throughput mechanism_reconnect
        multi_socket peer_churn plain pub_sub_churn
-       reconnect_all_types reconnect_storm)
+       pub_sub_churn_tcp reconnect_all_types reconnect_storm
+       router_dealer_churn)
 
 batch=()
 for test in "${TESTS[@]}"; do

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,11 +56,12 @@ OMQ_FUZZ_ITERS=500000000 cargo test -p omq-tokio  --features fuzz --release -- -
 
 ## Soak tests
 
-Long-running leak and stability scenarios. Both backends have
-identical suites (11 scenarios each): peer churn, reconnect storm,
+Long-running leak and stability scenarios. omq-tokio has 14
+scenarios; omq-compio has 11 (the three newest are tokio-only for
+now). Scenarios: peer churn, reconnect storm, reconnect all types,
 PUB/SUB churn, large-message throughput, compression (lz4), PLAIN
 auth, CURVE encryption, BLAKE3ZMQ encryption, multi-socket, inproc
-cross-thread.
+cross-thread, cancel safety, CURVE reconnect, BLAKE3ZMQ reconnect.
 
 Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s).
 Enable all feature-gated scenarios with the full feature set.
@@ -77,9 +78,10 @@ cargo test -p omq-compio --features "$FEATURES" --release --no-run
 cargo test -p omq-tokio  --features "$FEATURES" --release --no-run
 
 # run in batches of 4 scenarios (8 processes), 10 min each
-TESTS=(blake3zmq compression compression_lz4 curve
-       inproc_cross_thread large_throughput multi_socket peer_churn
-       plain pub_sub_churn reconnect_storm)
+TESTS=(blake3zmq cancel_safety compression compression_lz4 curve
+       inproc_cross_thread large_throughput mechanism_reconnect
+       multi_socket peer_churn plain pub_sub_churn
+       reconnect_all_types reconnect_storm)
 
 batch=()
 for test in "${TESTS[@]}"; do

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ covered by integration tests on both backends. The full suite:
   socket-type x transport x mechanism cell).
 - **Protocol fuzzing** (~10M iterations per suite): hand-rolled fuzz of
   the wire parser and the socket-action state machine.
-- **12 soak test scenarios** per backend: peer churn, reconnect storms,
+- **18 soak test scenarios** per backend: peer churn, reconnect storms,
   PUB/SUB churn, compression, PLAIN / CURVE / BLAKE3ZMQ auth
   large-message throughput, multi-socket. Each scenario samples
   RSS and file-descriptor counts to detect leaks.

--- a/omq-tokio/tests/soak_cancel_safety.rs
+++ b/omq-tokio/tests/soak_cancel_safety.rs
@@ -1,0 +1,248 @@
+#![cfg(feature = "soak")]
+//! Soak: cancel safety under sustained socket churn.
+//!
+//! Rapidly creates and drops sockets at every lifecycle phase —
+//! before bind, after connect, mid-recv, mid-send — without calling
+//! `close()`. Verifies the cancellation/cleanup path never panics,
+//! leaks FDs, or leaks memory.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Message, Options, Socket, SocketType};
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+const PAIRS: &[(SocketType, SocketType)] = &[
+    (SocketType::Push, SocketType::Pull),
+    (SocketType::Req, SocketType::Rep),
+    (SocketType::Pub, SocketType::Sub),
+    (SocketType::Dealer, SocketType::Router),
+    (SocketType::Pair, SocketType::Pair),
+    (SocketType::Client, SocketType::Server),
+    (SocketType::Scatter, SocketType::Gather),
+    (SocketType::Channel, SocketType::Channel),
+];
+
+fn random_pair(rng: &mut StdRng) -> (SocketType, SocketType) {
+    PAIRS[rng.random_range(0..PAIRS.len())]
+}
+
+fn no_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Disabled,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn soak_cancel_safety() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let mut rng = rand::make_rng::<StdRng>();
+        let start = Instant::now();
+        let mut iterations: u64 = 0;
+        let mut last_log = start;
+        let mut inproc_id: u64 = 0;
+
+        while start.elapsed() < duration {
+            let scenario = rng.random_range(0u8..9);
+            match scenario {
+                0 => drop_after_new(&mut rng),
+                1 => drop_after_bind(&mut rng).await,
+                2 => {
+                    inproc_id += 1;
+                    drop_after_connect_inproc(&mut rng, inproc_id).await;
+                }
+                3 => drop_after_connect_tcp(&mut rng).await,
+                4 => drop_server_while_connected(&mut rng).await,
+                5 => cancel_recv_then_drop(&mut rng).await,
+                6 => cancel_send_then_drop(&mut rng).await,
+                7 => {
+                    inproc_id += 1;
+                    drop_both_simultaneously(&mut rng, inproc_id).await;
+                }
+                8 => {
+                    inproc_id += 1;
+                    rapid_create_drop_burst(&mut rng, &mut inproc_id).await;
+                }
+                _ => unreachable!(),
+            }
+
+            iterations += 1;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[cancel_safety] {:.0}s, iterations {iterations}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        // Let internal cleanup tasks settle.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        eprintln!(
+            "[cancel_safety] done: {iterations} iterations in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("cancel_safety");
+}
+
+/// Drop sockets immediately after creation (no bind/connect).
+fn drop_after_new(rng: &mut StdRng) {
+    let (send_type, recv_type) = random_pair(rng);
+    drop(Socket::new(send_type, Options::default()));
+    drop(Socket::new(recv_type, Options::default()));
+}
+
+/// Bind a socket, then drop without close or any peer arriving.
+async fn drop_after_bind(rng: &mut StdRng) {
+    let (_, recv_type) = random_pair(rng);
+    let socket = Socket::new(recv_type, no_reconnect());
+    let _ = socket.bind(soak_common::tcp_ep(0)).await;
+}
+
+/// Connect via inproc (fast, no TCP overhead), drop immediately.
+/// Handshake is synchronous for inproc, so this tests post-handshake drop.
+async fn drop_after_connect_inproc(rng: &mut StdRng, id: u64) {
+    let (send_type, recv_type) = random_pair(rng);
+    let server = Socket::new(recv_type, no_reconnect());
+    let ep = server
+        .bind(soak_common::inproc_ep(&format!("cs-daci-{id}")))
+        .await
+        .unwrap();
+
+    let client = Socket::new(send_type, no_reconnect());
+    if send_type == SocketType::Sub {
+        client.subscribe("").await.unwrap();
+    }
+    client.connect(ep).await.unwrap();
+}
+
+/// Connect via TCP, drop immediately. ZMTP handshake may be in-flight.
+async fn drop_after_connect_tcp(rng: &mut StdRng) {
+    let (send_type, recv_type) = random_pair(rng);
+    let server = Socket::new(recv_type, no_reconnect());
+    let ep = server.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(send_type, no_reconnect());
+    if send_type == SocketType::Sub {
+        client.subscribe("").await.unwrap();
+    }
+    client.connect(ep).await.unwrap();
+    // Drop both while TCP handshake may still be in progress.
+}
+
+/// Drop the bind-side socket while the connect-side is still alive.
+/// The connect side observes a peer disconnect.
+async fn drop_server_while_connected(rng: &mut StdRng) {
+    let (send_type, recv_type) = random_pair(rng);
+    let server = Socket::new(recv_type, no_reconnect());
+    let ep = server.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+    let client = Socket::new(send_type, no_reconnect());
+    if send_type == SocketType::Sub {
+        client.subscribe("").await.unwrap();
+    }
+    client.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    drop(server);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    drop(client);
+}
+
+/// Start a `recv()` call, cancel it mid-await via select!, then drop
+/// the socket without close. Tests cancel safety of the recv future.
+async fn cancel_recv_then_drop(rng: &mut StdRng) {
+    let (_, recv_type) = random_pair(rng);
+    let socket = Socket::new(recv_type, no_reconnect());
+    let _ = socket.bind(soak_common::tcp_ep(0)).await;
+
+    if recv_type == SocketType::Sub {
+        let _ = socket.subscribe("").await;
+    }
+
+    tokio::select! {
+        biased;
+        () = tokio::time::sleep(Duration::from_millis(1)) => {}
+        _ = socket.recv() => {}
+    }
+}
+
+/// Start a `send()` call that blocks (no peer or HWM full), cancel it
+/// mid-await, then drop the socket. Tests cancel safety of the send future.
+async fn cancel_send_then_drop(rng: &mut StdRng) {
+    let (send_type, _) = random_pair(rng);
+    let socket = Socket::new(send_type, no_reconnect().send_hwm(1));
+    let _ = socket.bind(soak_common::tcp_ep(0)).await;
+
+    tokio::select! {
+        biased;
+        () = tokio::time::sleep(Duration::from_millis(1)) => {}
+        _ = socket.send(Message::single("cancel-me")) => {}
+    }
+}
+
+/// Connect via inproc, then drop both handles simultaneously.
+/// Both sides race to observe disconnection.
+async fn drop_both_simultaneously(rng: &mut StdRng, id: u64) {
+    let (send_type, recv_type) = random_pair(rng);
+    let server = Socket::new(recv_type, no_reconnect());
+    let ep = server
+        .bind(soak_common::inproc_ep(&format!("cs-dbs-{id}")))
+        .await
+        .unwrap();
+
+    let client = Socket::new(send_type, no_reconnect());
+    if send_type == SocketType::Sub {
+        client.subscribe("").await.unwrap();
+    }
+    client.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Drop both in the same task tick.
+    drop(client);
+    drop(server);
+}
+
+/// Rapid burst: create 20 inproc socket pairs and drop all at once.
+/// Stresses the spawn/cleanup path under high concurrency.
+async fn rapid_create_drop_burst(rng: &mut StdRng, id: &mut u64) {
+    let mut sockets = Vec::with_capacity(40);
+
+    for _ in 0..20 {
+        *id += 1;
+        let (send_type, recv_type) = random_pair(rng);
+        let server = Socket::new(recv_type, no_reconnect());
+        let ep = server
+            .bind(soak_common::inproc_ep(&format!("cs-burst-{id}")))
+            .await
+            .unwrap();
+
+        let client = Socket::new(send_type, no_reconnect());
+        if send_type == SocketType::Sub {
+            client.subscribe("").await.unwrap();
+        }
+        client.connect(ep).await.unwrap();
+
+        sockets.push(server);
+        sockets.push(client);
+    }
+
+    // Drop all 40 sockets at once.
+    drop(sockets);
+}

--- a/omq-tokio/tests/soak_hwm_reconnect.rs
+++ b/omq-tokio/tests/soak_hwm_reconnect.rs
@@ -1,0 +1,129 @@
+#![cfg(feature = "soak")]
+//! Soak: HWM pressure combined with reconnection.
+//!
+//! PUSH with a low HWM (4) sends to PULL over TCP. PULL periodically
+//! closes and rebinds. During the gap PUSH hits HWM. Two modes:
+//!
+//! 1. `OnMute::DropNewest`: send never blocks, messages are silently
+//!    dropped. Delivery resumes after reconnect.
+//! 2. `OnMute::Block`: send blocks until the peer returns. Delivery
+//!    resumes after reconnect with no message corruption.
+//!
+//! Verifies no hangs, no leaks, and that delivery resumes cleanly
+//! after each reconnect cycle.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use omq_tokio::options::{OnMute, ReconnectPolicy};
+use omq_tokio::{Message, Options, Socket, SocketType};
+
+fn fast_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(10)),
+        ..Default::default()
+    }
+}
+
+async fn rebind(ep: &omq_tokio::Endpoint) -> Option<Socket> {
+    for _ in 0..40 {
+        let s = Socket::new(SocketType::Pull, Options::default());
+        if s.bind(ep.clone()).await.is_ok() {
+            return Some(s);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    None
+}
+
+fn run_hwm_storm(name: &str, mute: OnMute) {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        // Probe for a port, then close so we can rebind.
+        let probe = Socket::new(SocketType::Pull, Options::default());
+        let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();
+        probe.close().await.unwrap();
+
+        let push = Socket::new(SocketType::Push, fast_reconnect().send_hwm(4).on_mute(mute));
+        push.connect(ep.clone()).await.unwrap();
+
+        let start = Instant::now();
+        let mut cycles: u64 = 0;
+        let mut delivered: u64 = 0;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let Some(pull) = rebind(&ep).await else {
+                eprintln!("[{name}] rebind failed at cycle {cycles}");
+                continue;
+            };
+
+            // Send a burst. With DropNewest some will be lost; with Block
+            // send will stall until the peer is back (but we just rebound).
+            let mut burst_ok = true;
+            for i in 0..8u32 {
+                let tag = format!("{name}-{cycles}-{i}");
+                if !matches!(
+                    tokio::time::timeout(Duration::from_secs(5), push.send(Message::single(tag)))
+                        .await,
+                    Ok(Ok(())),
+                ) {
+                    burst_ok = false;
+                    break;
+                }
+            }
+
+            if burst_ok {
+                while let Ok(Ok(_)) =
+                    tokio::time::timeout(Duration::from_millis(500), pull.recv()).await
+                {
+                    delivered += 1;
+                }
+            }
+
+            pull.close().await.unwrap();
+            cycles += 1;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[{name}] {:.0}s, cycles {cycles}, delivered {delivered}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        push.close().await.unwrap();
+
+        let pct = if cycles > 0 {
+            delivered as f64 / (cycles * 8) as f64 * 100.0
+        } else {
+            100.0
+        };
+        eprintln!(
+            "[{name}] done: {delivered}/{} delivered ({pct:.1}%) in {:.1}s",
+            cycles * 8,
+            start.elapsed().as_secs_f64(),
+        );
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak(name);
+}
+
+#[test]
+fn soak_hwm_reconnect_drop() {
+    run_hwm_storm("hwm_reconnect_drop", OnMute::DropNewest);
+}
+
+#[test]
+fn soak_hwm_reconnect_block() {
+    run_hwm_storm("hwm_reconnect_block", OnMute::Block);
+}

--- a/omq-tokio/tests/soak_mechanism_reconnect.rs
+++ b/omq-tokio/tests/soak_mechanism_reconnect.rs
@@ -101,7 +101,7 @@ fn run_mechanism_storm(
             "[{name}] done: {delivered}/{cycles} delivered ({pct:.1}%) in {:.1}s",
             start.elapsed().as_secs_f64(),
         );
-        assert!(pct >= 70.0, "[{name}] delivery rate too low: {pct:.1}%",);
+        assert!(pct >= 70.0, "[{name}] delivery rate too low: {pct:.1}%");
     });
 
     let report = monitor.stop();

--- a/omq-tokio/tests/soak_mechanism_reconnect.rs
+++ b/omq-tokio/tests/soak_mechanism_reconnect.rs
@@ -1,0 +1,167 @@
+#![cfg(feature = "soak")]
+//! Soak: mechanism re-handshake under bind-side restarts.
+//!
+//! Exercises the full greeting + mechanism state machine reset path
+//! hundreds of times per run. The server (PULL) binds with encryption
+//! keys, the client (PUSH) connects and sends. The server repeatedly
+//! crashes and rebinds with the same keypair; the client reconnects,
+//! re-handshakes, and resumes.
+//!
+//! Two sub-tests: CURVE (RFC 26) and BLAKE3ZMQ.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Message, Options, Socket, SocketType};
+
+fn fast_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(10)),
+        ..Default::default()
+    }
+}
+
+async fn rebind(ep: &omq_tokio::Endpoint, make: impl Fn() -> Socket) -> Option<Socket> {
+    for _ in 0..40 {
+        let s = make();
+        if s.bind(ep.clone()).await.is_ok() {
+            return Some(s);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    None
+}
+
+fn run_mechanism_storm(
+    name: &str,
+    make_server: impl Fn() -> Socket,
+    make_client: impl Fn(omq_tokio::Endpoint) -> Socket,
+) {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let probe = make_server();
+        let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();
+        probe.close().await.unwrap();
+
+        let push = make_client(ep.clone());
+        push.connect(ep.clone()).await.unwrap();
+
+        let start = Instant::now();
+        let mut cycles: u64 = 0;
+        let mut delivered: u64 = 0;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let Some(pull) = rebind(&ep, &make_server).await else {
+                eprintln!("[{name}] rebind failed at cycle {cycles}, retrying");
+                continue;
+            };
+
+            let tag = format!("{name}-{cycles}");
+            push.send(Message::single(tag.clone())).await.unwrap();
+
+            match tokio::time::timeout(Duration::from_secs(5), pull.recv()).await {
+                Ok(Ok(m)) => {
+                    assert_eq!(m.part_bytes(0).unwrap(), tag.as_bytes());
+                    delivered += 1;
+                }
+                other => {
+                    eprintln!("[{name}] MISS cycle {cycles}: {other:?}");
+                }
+            }
+
+            pull.close().await.unwrap();
+            cycles += 1;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[{name}] {:.0}s, cycles {cycles}, delivered {delivered}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        push.close().await.unwrap();
+
+        let pct = if cycles > 0 {
+            delivered as f64 / cycles as f64 * 100.0
+        } else {
+            100.0
+        };
+        eprintln!(
+            "[{name}] done: {delivered}/{cycles} delivered ({pct:.1}%) in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+        assert!(pct >= 70.0, "[{name}] delivery rate too low: {pct:.1}%",);
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak(name);
+}
+
+#[cfg(feature = "curve")]
+#[test]
+fn soak_curve_reconnect() {
+    use omq_tokio::CurveKeypair;
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub = server_kp.public;
+
+    run_mechanism_storm(
+        "curve_reconnect",
+        move || {
+            Socket::new(
+                SocketType::Pull,
+                Options::default().curve_server(server_kp.clone()),
+            )
+        },
+        move |_ep| {
+            Socket::new(
+                SocketType::Push,
+                fast_reconnect()
+                    .curve_client(client_kp.clone(), server_pub)
+                    .send_hwm(16)
+                    .linger(Duration::from_secs(5)),
+            )
+        },
+    );
+}
+
+#[cfg(feature = "blake3zmq")]
+#[test]
+fn soak_blake3zmq_reconnect() {
+    use omq_tokio::Blake3ZmqKeypair;
+
+    let server_kp = Blake3ZmqKeypair::generate();
+    let client_kp = Blake3ZmqKeypair::generate();
+    let server_pub = server_kp.public;
+
+    run_mechanism_storm(
+        "blake3zmq_reconnect",
+        move || {
+            Socket::new(
+                SocketType::Pull,
+                Options::default().blake3zmq_server(server_kp.clone()),
+            )
+        },
+        move |_ep| {
+            Socket::new(
+                SocketType::Push,
+                fast_reconnect()
+                    .blake3zmq_client(client_kp.clone(), server_pub)
+                    .send_hwm(16)
+                    .linger(Duration::from_secs(5)),
+            )
+        },
+    );
+}

--- a/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
+++ b/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "soak")]
+//! Soak: PUB/SUB churn over TCP.
+//!
+//! Same pattern as `soak_pub_sub_churn` (inproc) but over TCP,
+//! exercising the full ZMTP codec, wire-slot encoding, per-subscriber
+//! HWM, and subscription filter propagation over the network. SUB peers
+//! join and leave with different prefix subscriptions while PUB sends
+//! continuously.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+use omq_tokio::{Message, Options, ReconnectPolicy, Socket, SocketType};
+
+const TOPICS: &[&str] = &["fast.", "slow.", "all.", "rare."];
+
+fn no_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Disabled,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn soak_pub_sub_churn_tcp() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let publisher = Socket::new(SocketType::Pub, Options::default());
+        let ep = publisher.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+        let mut rng = rand::make_rng::<StdRng>();
+        let mut subs: Vec<Socket> = Vec::new();
+        let mut pub_count: u64 = 0;
+        let start = Instant::now();
+        let mut last_churn = start;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            for _ in 0..1_000 {
+                let topic = TOPICS[pub_count as usize % TOPICS.len()];
+                let msg = format!("{topic}{pub_count}");
+                if let Ok(Ok(())) = tokio::time::timeout(
+                    Duration::from_millis(1),
+                    publisher.send(Message::single(msg)),
+                )
+                .await
+                {
+                    pub_count += 1;
+                }
+            }
+
+            for sub in &subs {
+                while sub.try_recv().is_ok() {}
+            }
+
+            if last_churn.elapsed() >= Duration::from_millis(500) {
+                last_churn = Instant::now();
+
+                if !subs.is_empty() && rng.random_bool(0.5) {
+                    let idx = rng.random_range(0..subs.len());
+                    let sub = subs.swap_remove(idx);
+                    sub.close().await.unwrap();
+                }
+
+                if subs.len() < 10 {
+                    let sub = Socket::new(SocketType::Sub, no_reconnect().recv_hwm(32));
+                    sub.connect(ep.clone()).await.unwrap();
+                    let prefix = TOPICS[rng.random_range(0..TOPICS.len())];
+                    sub.subscribe(Bytes::from(prefix.to_string()))
+                        .await
+                        .unwrap();
+                    subs.push(sub);
+                }
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[pub_sub_churn_tcp] {:.0}s, pub_count {pub_count}, subs {}",
+                    start.elapsed().as_secs_f64(),
+                    subs.len(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        for sub in subs {
+            sub.close().await.unwrap();
+        }
+        publisher.close().await.unwrap();
+
+        eprintln!(
+            "[pub_sub_churn_tcp] done: {pub_count} published in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("pub_sub_churn_tcp");
+}

--- a/omq-tokio/tests/soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/soak_reconnect_all_types.rs
@@ -1,0 +1,425 @@
+#![cfg(feature = "soak")]
+//! Soak: bind-side restart storm across all socket-type pairs.
+//!
+//! Generalizes `soak_reconnect_storm` (PUSH/PULL only) to every
+//! socket-type pair: REQ/REP, PUB/SUB, DEALER/ROUTER, PAIR,
+//! CLIENT/SERVER, SCATTER/GATHER, CHANNEL. Each pair's bind-side
+//! socket is repeatedly closed and re-bound while the connect-side
+//! stays alive and reconnects. Verifies no hangs, no leaks, and that
+//! message delivery resumes after every restart.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Message, Options, Socket, SocketType};
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+fn fast_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(10)),
+        ..Default::default()
+    }
+}
+
+async fn rebind(ep: &omq_tokio::Endpoint, make: impl Fn() -> Socket) -> Option<Socket> {
+    for _ in 0..40 {
+        let s = make();
+        if s.bind(ep.clone()).await.is_ok() {
+            return Some(s);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    None
+}
+
+struct PairState {
+    name: &'static str,
+    ep: omq_tokio::Endpoint,
+    connector: Socket,
+    cycles: u64,
+    delivered: u64,
+}
+
+async fn make_pair(name: &'static str, bind_type: SocketType, connector: Socket) -> PairState {
+    let probe = Socket::new(bind_type, Options::default());
+    let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();
+    probe.close().await.unwrap();
+    connector.connect(ep.clone()).await.unwrap();
+    PairState {
+        name,
+        ep,
+        connector,
+        cycles: 0,
+        delivered: 0,
+    }
+}
+
+async fn create_all_pairs() -> Vec<PairState> {
+    let mut pairs = Vec::new();
+
+    pairs.push(
+        make_pair(
+            "push/pull",
+            SocketType::Pull,
+            Socket::new(SocketType::Push, fast_reconnect().send_hwm(16)),
+        )
+        .await,
+    );
+
+    pairs.push(
+        make_pair(
+            "req/rep",
+            SocketType::Rep,
+            Socket::new(SocketType::Req, fast_reconnect()),
+        )
+        .await,
+    );
+
+    {
+        let sub = Socket::new(SocketType::Sub, fast_reconnect());
+        sub.subscribe("x.").await.unwrap();
+        pairs.push(make_pair("pub/sub", SocketType::Pub, sub).await);
+    }
+
+    pairs.push(
+        make_pair(
+            "dealer/router",
+            SocketType::Router,
+            Socket::new(
+                SocketType::Dealer,
+                fast_reconnect().identity(Bytes::from_static(b"d1")),
+            ),
+        )
+        .await,
+    );
+
+    pairs.push(
+        make_pair(
+            "pair",
+            SocketType::Pair,
+            Socket::new(SocketType::Pair, fast_reconnect()),
+        )
+        .await,
+    );
+
+    pairs.push(
+        make_pair(
+            "client/server",
+            SocketType::Server,
+            Socket::new(
+                SocketType::Client,
+                fast_reconnect().identity(Bytes::from_static(b"c1")),
+            ),
+        )
+        .await,
+    );
+
+    pairs.push(
+        make_pair(
+            "scatter/gather",
+            SocketType::Gather,
+            Socket::new(SocketType::Scatter, fast_reconnect().send_hwm(16)),
+        )
+        .await,
+    );
+
+    pairs.push(
+        make_pair(
+            "channel",
+            SocketType::Channel,
+            Socket::new(SocketType::Channel, fast_reconnect()),
+        )
+        .await,
+    );
+
+    pairs
+}
+
+#[test]
+fn soak_reconnect_all_types() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let mut pairs = create_all_pairs().await;
+
+        let mut rng = rand::make_rng::<StdRng>();
+        let start = Instant::now();
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let idx = rng.random_range(0..pairs.len());
+            let pair = &mut pairs[idx];
+
+            let ok = match pair.name {
+                "push/pull" => cycle_push_pull(pair).await,
+                "req/rep" => cycle_req_rep(pair).await,
+                "pub/sub" => cycle_pub_sub(pair).await,
+                "dealer/router" => cycle_dealer_router(pair).await,
+                "pair" | "channel" => cycle_bidirectional(pair).await,
+                "client/server" => cycle_client_server(pair).await,
+                "scatter/gather" => cycle_scatter_gather(pair).await,
+                _ => unreachable!(),
+            };
+
+            pair.cycles += 1;
+            if ok {
+                pair.delivered += 1;
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[reconnect_all_types] {:.0}s:",
+                    start.elapsed().as_secs_f64()
+                );
+                for p in &pairs {
+                    let pct = if p.cycles > 0 {
+                        p.delivered as f64 / p.cycles as f64 * 100.0
+                    } else {
+                        100.0
+                    };
+                    eprintln!("  {}: {}/{} ({pct:.0}%)", p.name, p.delivered, p.cycles,);
+                }
+                last_log = Instant::now();
+            }
+        }
+
+        for pair in &pairs {
+            let pct = if pair.cycles > 0 {
+                pair.delivered as f64 / pair.cycles as f64 * 100.0
+            } else {
+                100.0
+            };
+            eprintln!(
+                "[reconnect_all_types] {}: {}/{} delivered ({pct:.1}%)",
+                pair.name, pair.delivered, pair.cycles,
+            );
+            assert!(
+                pct >= 70.0,
+                "{} delivery rate too low: {pct:.1}%",
+                pair.name,
+            );
+        }
+
+        for pair in pairs {
+            pair.connector.close().await.unwrap();
+        }
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("reconnect_all_types");
+}
+
+async fn try_send(connector: &Socket, msg: Message) -> bool {
+    matches!(
+        tokio::time::timeout(Duration::from_secs(5), connector.send(msg)).await,
+        Ok(Ok(())),
+    )
+}
+
+async fn cycle_push_pull(pair: &mut PairState) -> bool {
+    let Some(pull) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Pull, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("pp-{}", pair.cycles)),
+    )
+    .await
+    {
+        pull.close().await.unwrap();
+        return false;
+    }
+    let ok = matches!(
+        tokio::time::timeout(Duration::from_secs(5), pull.recv()).await,
+        Ok(Ok(_))
+    );
+    pull.close().await.unwrap();
+    ok
+}
+
+async fn cycle_req_rep(pair: &mut PairState) -> bool {
+    let Some(rep) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Rep, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("rr-{}", pair.cycles)),
+    )
+    .await
+    {
+        rep.close().await.unwrap();
+        return false;
+    }
+
+    if !matches!(
+        tokio::time::timeout(Duration::from_secs(5), rep.recv()).await,
+        Ok(Ok(_)),
+    ) {
+        rep.close().await.unwrap();
+        return false;
+    }
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), rep.send(Message::single("reply"))).await;
+    let _ = tokio::time::timeout(Duration::from_secs(2), pair.connector.recv()).await;
+
+    rep.close().await.unwrap();
+    true
+}
+
+async fn cycle_pub_sub(pair: &mut PairState) -> bool {
+    let Some(pub_) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Pub, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    // Wait for subscription to propagate, retry send until delivered.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if pub_
+            .send(Message::single(format!("x.{}", pair.cycles)))
+            .await
+            .is_err()
+        {
+            pub_.close().await.unwrap();
+            return false;
+        }
+        if let Ok(Ok(_)) =
+            tokio::time::timeout(Duration::from_millis(200), pair.connector.recv()).await
+        {
+            pub_.close().await.unwrap();
+            return true;
+        }
+        if Instant::now() >= deadline {
+            pub_.close().await.unwrap();
+            return false;
+        }
+    }
+}
+
+async fn cycle_dealer_router(pair: &mut PairState) -> bool {
+    let Some(router) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Router, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("dr-{}", pair.cycles)),
+    )
+    .await
+    {
+        router.close().await.unwrap();
+        return false;
+    }
+    let ok = match tokio::time::timeout(Duration::from_secs(5), router.recv()).await {
+        Ok(Ok(m)) => m.part_bytes(0).is_some_and(|id| id.as_ref() == b"d1"),
+        _ => false,
+    };
+    router.close().await.unwrap();
+    ok
+}
+
+async fn cycle_bidirectional(pair: &mut PairState) -> bool {
+    let bind_type = if pair.name == "pair" {
+        SocketType::Pair
+    } else {
+        SocketType::Channel
+    };
+    let Some(bind_side) = rebind(&pair.ep, || Socket::new(bind_type, Options::default())).await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("bi-{}", pair.cycles)),
+    )
+    .await
+    {
+        bind_side.close().await.unwrap();
+        return false;
+    }
+    let ok = matches!(
+        tokio::time::timeout(Duration::from_secs(5), bind_side.recv()).await,
+        Ok(Ok(_))
+    );
+    bind_side.close().await.unwrap();
+    ok
+}
+
+async fn cycle_client_server(pair: &mut PairState) -> bool {
+    let Some(server) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Server, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("cs-{}", pair.cycles)),
+    )
+    .await
+    {
+        server.close().await.unwrap();
+        return false;
+    }
+    let ok = match tokio::time::timeout(Duration::from_secs(5), server.recv()).await {
+        Ok(Ok(m)) => m.part_bytes(0).is_some_and(|id| id.as_ref() == b"c1"),
+        _ => false,
+    };
+    server.close().await.unwrap();
+    ok
+}
+
+async fn cycle_scatter_gather(pair: &mut PairState) -> bool {
+    let Some(gather) = rebind(&pair.ep, || {
+        Socket::new(SocketType::Gather, Options::default())
+    })
+    .await
+    else {
+        return false;
+    };
+
+    if !try_send(
+        &pair.connector,
+        Message::single(format!("sg-{}", pair.cycles)),
+    )
+    .await
+    {
+        gather.close().await.unwrap();
+        return false;
+    }
+    let ok = matches!(
+        tokio::time::timeout(Duration::from_secs(5), gather.recv()).await,
+        Ok(Ok(_))
+    );
+    gather.close().await.unwrap();
+    ok
+}

--- a/omq-tokio/tests/soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/soak_reconnect_all_types.rs
@@ -186,7 +186,7 @@ fn soak_reconnect_all_types() {
                     } else {
                         100.0
                     };
-                    eprintln!("  {}: {}/{} ({pct:.0}%)", p.name, p.delivered, p.cycles,);
+                    eprintln!("  {}: {}/{} ({pct:.0}%)", p.name, p.delivered, p.cycles);
                 }
                 last_log = Instant::now();
             }

--- a/omq-tokio/tests/soak_router_dealer_churn.rs
+++ b/omq-tokio/tests/soak_router_dealer_churn.rs
@@ -1,0 +1,187 @@
+#![cfg(feature = "soak")]
+//! Soak: ROUTER identity routing under DEALER peer churn.
+//!
+//! ROUTER binds TCP. 1-10 DEALER peers with unique identities join and
+//! leave randomly. ROUTER sends identity-addressed messages to known
+//! peers. Verifies:
+//! - Messages to live peers arrive.
+//! - Messages to recently-departed peers don't panic or hang
+//!   (`router_mandatory`=true: `Unroutable`).
+//! - Identity table doesn't grow unbounded (heap check).
+//! - New peer reusing a departed identity works correctly.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+use omq_tokio::{Message, Options, ReconnectPolicy, Socket, SocketType};
+
+struct Dealer {
+    identity: Bytes,
+    socket: Socket,
+}
+
+struct Stats {
+    sent: u64,
+    delivered: u64,
+    unroutable: u64,
+}
+
+fn dealer_opts(identity: &[u8]) -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Disabled,
+        ..Default::default()
+    }
+    .identity(Bytes::copy_from_slice(identity))
+}
+
+async fn churn_dealers(
+    dealers: &mut Vec<Dealer>,
+    next_id: &mut u64,
+    ep: &omq_tokio::Endpoint,
+    action: u8,
+    rng: &mut StdRng,
+) {
+    if action < 3 && dealers.len() < 10 {
+        let id = format!("d-{next_id}");
+        *next_id += 1;
+        let d = Socket::new(SocketType::Dealer, dealer_opts(id.as_bytes()));
+        d.connect(ep.clone()).await.unwrap();
+        dealers.push(Dealer {
+            identity: Bytes::from(id),
+            socket: d,
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    } else if action < 5 && dealers.len() > 1 {
+        let idx = rng.random_range(0..dealers.len());
+        let removed = dealers.swap_remove(idx);
+        removed.socket.close().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn exchange_messages(
+    router: &Socket,
+    dealers: &[Dealer],
+    stats: &mut Stats,
+    next_id: u64,
+    action: u8,
+    rng: &mut StdRng,
+) {
+    for dealer in dealers {
+        if let Ok(Ok(())) = tokio::time::timeout(
+            Duration::from_millis(5),
+            dealer.socket.send(Message::single("ping")),
+        )
+        .await
+        {
+            stats.sent += 1;
+        }
+    }
+
+    while let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_millis(1), router.recv()).await {
+        let id = msg.part_bytes(0).unwrap().clone();
+        match router
+            .send(Message::multipart([id, Bytes::from_static(b"pong")]))
+            .await
+        {
+            Ok(()) => stats.delivered += 1,
+            Err(omq_tokio::Error::Unroutable) => stats.unroutable += 1,
+            Err(e) => panic!("unexpected send error: {e}"),
+        }
+    }
+
+    for dealer in dealers {
+        while dealer.socket.try_recv().is_ok() {}
+    }
+
+    if action == 9 && next_id > 1 {
+        let stale = format!("d-{}", rng.random_range(0..next_id));
+        let is_live = dealers.iter().any(|d| d.identity == stale.as_bytes());
+        match router
+            .send(Message::multipart([
+                Bytes::from(stale),
+                Bytes::from_static(b"probe"),
+            ]))
+            .await
+        {
+            Ok(()) => {
+                if is_live {
+                    stats.delivered += 1;
+                }
+            }
+            Err(omq_tokio::Error::Unroutable) => stats.unroutable += 1,
+            Err(e) => panic!("unexpected send error: {e}"),
+        }
+    }
+}
+
+#[test]
+fn soak_router_dealer_churn() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let router = Socket::new(
+            SocketType::Router,
+            Options::default().router_mandatory(true),
+        );
+        let ep = router.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+        let mut rng = rand::make_rng::<StdRng>();
+        let mut dealers: Vec<Dealer> = Vec::new();
+        let mut next_id: u64 = 0;
+        let mut stats = Stats {
+            sent: 0,
+            delivered: 0,
+            unroutable: 0,
+        };
+        let start = Instant::now();
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let action = rng.random_range(0u8..10);
+            churn_dealers(&mut dealers, &mut next_id, &ep, action, &mut rng).await;
+            exchange_messages(&router, &dealers, &mut stats, next_id, action, &mut rng).await;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[router_dealer_churn] {:.0}s, sent {}, delivered {}, \
+                     unroutable {}, dealers {}",
+                    start.elapsed().as_secs_f64(),
+                    stats.sent,
+                    stats.delivered,
+                    stats.unroutable,
+                    dealers.len(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        for dealer in dealers {
+            dealer.socket.close().await.unwrap();
+        }
+        router.close().await.unwrap();
+
+        eprintln!(
+            "[router_dealer_churn] done: sent {}, delivered {}, \
+             unroutable {} in {:.1}s",
+            stats.sent,
+            stats.delivered,
+            stats.unroutable,
+            start.elapsed().as_secs_f64(),
+        );
+        assert!(stats.sent > 0, "no messages sent");
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("router_dealer_churn");
+}

--- a/omq-tokio/tests/soak_ws.rs
+++ b/omq-tokio/tests/soak_ws.rs
@@ -1,0 +1,182 @@
+#![cfg(all(feature = "soak", feature = "ws"))]
+//! Soak: WebSocket sustained throughput + bind-side restart storm.
+//!
+//! Exercises the HTTP upgrade handshake, WS framing, and reconnection
+//! over `ws://` under sustained load. Two sub-tests:
+//!
+//! 1. Sustained throughput: PUSH/PULL over WS for `soak_duration`.
+//! 2. Restart storm: bind-side closes and rebinds repeatedly while
+//!    the connect-side reconnects and resumes sending.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn ws_ep(port: u16) -> Endpoint {
+    format!("ws://127.0.0.1:{port}/").parse().unwrap()
+}
+
+fn get_port(ep: &Endpoint) -> u16 {
+    match ep {
+        Endpoint::Ws { port, .. } => *port,
+        other => panic!("expected Ws, got {other:?}"),
+    }
+}
+
+fn fast_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(10)),
+        ..Default::default()
+    }
+}
+
+async fn rebind_ws(port: u16) -> Option<Socket> {
+    for _ in 0..40 {
+        let s = Socket::new(SocketType::Pull, Options::default());
+        if s.bind(ws_ep(port)).await.is_ok() {
+            return Some(s);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    None
+}
+
+#[test]
+fn soak_ws_throughput() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        let ep = pull.bind(ws_ep(0)).await.unwrap();
+        let port = get_port(&ep);
+
+        let push = Socket::new(SocketType::Push, Options::default().send_hwm(1024));
+        push.connect(ws_ep(port)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut sent: u64 = 0;
+        let mut recvd: u64 = 0;
+        let start = Instant::now();
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            for _ in 0..100 {
+                if let Ok(Ok(())) = tokio::time::timeout(
+                    Duration::from_millis(1),
+                    push.send(Message::single(format!("ws-{sent}"))),
+                )
+                .await
+                {
+                    sent += 1;
+                }
+            }
+
+            while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_millis(1), pull.recv()).await
+            {
+                recvd += 1;
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[ws_throughput] {:.0}s, sent {sent}, recvd {recvd}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        push.close().await.unwrap();
+        pull.close().await.unwrap();
+
+        eprintln!(
+            "[ws_throughput] done: sent {sent}, recvd {recvd} in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+        assert!(recvd > 0, "no messages received");
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("ws_throughput");
+}
+
+#[test]
+fn soak_ws_reconnect_storm() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        // Probe for a port.
+        let probe = Socket::new(SocketType::Pull, Options::default());
+        let ep = probe.bind(ws_ep(0)).await.unwrap();
+        let port = get_port(&ep);
+        probe.close().await.unwrap();
+
+        let push = Socket::new(SocketType::Push, fast_reconnect().send_hwm(16));
+        push.connect(ws_ep(port)).await.unwrap();
+
+        let start = Instant::now();
+        let mut cycles: u64 = 0;
+        let mut delivered: u64 = 0;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let Some(pull) = rebind_ws(port).await else {
+                eprintln!("[ws_reconnect_storm] rebind failed at cycle {cycles}");
+                continue;
+            };
+
+            let tag = format!("ws-r-{cycles}");
+            if !matches!(
+                tokio::time::timeout(Duration::from_secs(5), push.send(Message::single(tag))).await,
+                Ok(Ok(())),
+            ) {
+                pull.close().await.unwrap();
+                cycles += 1;
+                continue;
+            }
+
+            if matches!(
+                tokio::time::timeout(Duration::from_secs(5), pull.recv()).await,
+                Ok(Ok(_)),
+            ) {
+                delivered += 1;
+            }
+
+            pull.close().await.unwrap();
+            cycles += 1;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[ws_reconnect_storm] {:.0}s, cycles {cycles}, delivered {delivered}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        push.close().await.unwrap();
+
+        let pct = if cycles > 0 {
+            delivered as f64 / cycles as f64 * 100.0
+        } else {
+            100.0
+        };
+        eprintln!(
+            "[ws_reconnect_storm] done: {delivered}/{cycles} ({pct:.1}%) in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+        assert!(pct >= 70.0, "delivery rate too low: {pct:.1}%");
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("ws_reconnect_storm");
+}

--- a/omq-tokio/tests/soak_xpub_xsub_churn.rs
+++ b/omq-tokio/tests/soak_xpub_xsub_churn.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "soak")]
+//! Soak: XPUB subscription forwarding under subscriber churn.
+//!
+//! XPUB binds TCP. SUB subscribers join and leave with different prefix
+//! subscriptions. Verifies:
+//! - XPUB surfaces subscribe/unsubscribe notifications.
+//! - No subscription leaks after subscriber departs (heap check).
+//! - Message delivery matches active subscriptions.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+use omq_tokio::{Message, Options, ReconnectPolicy, Socket, SocketType};
+
+const TOPICS: &[&str] = &["alpha.", "beta.", "gamma.", "delta."];
+
+fn no_reconnect() -> Options {
+    Options {
+        reconnect: ReconnectPolicy::Disabled,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn soak_xpub_xsub_churn() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let xpub = Socket::new(SocketType::XPub, Options::default());
+        let ep = xpub.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+        let mut rng = rand::make_rng::<StdRng>();
+        let mut subs: Vec<Socket> = Vec::new();
+        let mut pub_count: u64 = 0;
+        let mut sub_notifications: u64 = 0;
+        let start = Instant::now();
+        let mut last_churn = start;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            // Publish across all topics.
+            for _ in 0..1_000 {
+                let topic = TOPICS[pub_count as usize % TOPICS.len()];
+                let msg = format!("{topic}{pub_count}");
+                if let Ok(Ok(())) =
+                    tokio::time::timeout(Duration::from_millis(1), xpub.send(Message::single(msg)))
+                        .await
+                {
+                    pub_count += 1;
+                }
+            }
+
+            // Drain XPUB subscribe/unsubscribe notifications.
+            while let Ok(Ok(_notif)) =
+                tokio::time::timeout(Duration::from_millis(1), xpub.recv()).await
+            {
+                sub_notifications += 1;
+            }
+
+            // Drain subscriber recv queues.
+            for sub in &subs {
+                while sub.try_recv().is_ok() {}
+            }
+
+            // Churn subscribers every 500ms.
+            if last_churn.elapsed() >= Duration::from_millis(500) {
+                last_churn = Instant::now();
+                churn_subscribers(&mut subs, &ep, &mut rng).await;
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[xpub_xsub_churn] {:.0}s, published {pub_count}, \
+                     sub_notifications {sub_notifications}, subs {}",
+                    start.elapsed().as_secs_f64(),
+                    subs.len(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        for sub in subs {
+            sub.close().await.unwrap();
+        }
+        xpub.close().await.unwrap();
+
+        eprintln!(
+            "[xpub_xsub_churn] done: {pub_count} published, \
+             {sub_notifications} sub notifications in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+        assert!(
+            sub_notifications > 0,
+            "no subscription notifications received"
+        );
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("xpub_xsub_churn");
+}
+
+async fn churn_subscribers(subs: &mut Vec<Socket>, ep: &omq_tokio::Endpoint, rng: &mut StdRng) {
+    if !subs.is_empty() && rng.random_bool(0.5) {
+        let idx = rng.random_range(0..subs.len());
+        let sub = subs.swap_remove(idx);
+        sub.close().await.unwrap();
+    }
+
+    if subs.len() < 10 {
+        let sub = Socket::new(SocketType::Sub, no_reconnect().recv_hwm(32));
+        sub.connect(ep.clone()).await.unwrap();
+        let prefix = TOPICS[rng.random_range(0..TOPICS.len())];
+        sub.subscribe(Bytes::from(prefix.to_string()))
+            .await
+            .unwrap();
+        subs.push(sub);
+    }
+}


### PR DESCRIPTION
- `soak_cancel_safety`: concurrent send/recv cancel under load
- `soak_reconnect_all_types`: reconnect across all socket types and transports
- `soak_mechanism_reconnect`: reconnect after auth mechanism change (NULL/PLAIN/CURVE)
- `soak_router_dealer_churn`: ROUTER/DEALER peer churn under traffic
- `soak_pub_sub_churn_tcp`: PUB/SUB subscriber churn on TCP
- `soak_xpub_xsub_churn`: XPUB/XSUB peer churn
- `soak_hwm_reconnect`: HWM back-pressure + reconnect cycle
- `soak_ws`: WebSocket transport soak
- docs: clarify lz4 dict auto-training is off by default