### PR TITLE
pyomq: extract PeerInfo, fix send park_end, fix stale doc

### DIFF
--- a/bindings/pyomq/src/auth.rs
+++ b/bindings/pyomq/src/auth.rs
@@ -1,43 +1,13 @@
-//! CURVE client authentication: `PeerInfo` pyclass and authenticator
-//! bridge from Python callables / key lists to `omq_proto::Authenticator`.
+//! CURVE client authentication: authenticator bridge from Python
+//! callables / key lists to `omq_proto::Authenticator`.
 
 use std::collections::HashSet;
 use std::fmt;
 
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
 
+use crate::peer_info::PeerInfo;
 use crate::socket::SocketInner;
-
-/// Peer information passed to a Python authenticator callback.
-#[pyclass(frozen, module = "pyomq._native")]
-pub struct PeerInfo {
-    public_key: Py<PyBytes>,
-}
-
-#[pymethods]
-impl PeerInfo {
-    #[getter]
-    fn public_key(&self, py: Python<'_>) -> Py<PyBytes> {
-        self.public_key.clone_ref(py)
-    }
-}
-
-impl PeerInfo {
-    fn from_raw(py: Python<'_>, raw: &[u8; 32]) -> Self {
-        let pk = omq_proto::CurvePublicKey::from_bytes(*raw);
-        let z85 = pk.to_z85();
-        Self {
-            public_key: PyBytes::new_bound(py, z85.as_bytes()).unbind(),
-        }
-    }
-
-    pub(crate) fn from_raw_bytes(py: Python<'_>, raw: &[u8; 32]) -> Self {
-        Self {
-            public_key: PyBytes::new_bound(py, raw).unbind(),
-        }
-    }
-}
 
 /// Two modes of CURVE client authentication stored in the Overlay
 /// before socket materialization.

--- a/bindings/pyomq/src/blake3zmq_auth.rs
+++ b/bindings/pyomq/src/blake3zmq_auth.rs
@@ -44,7 +44,7 @@ pub(crate) fn build_authenticator(
                 Python::with_gil(|py| {
                     let info = Py::new(
                         py,
-                        crate::auth::PeerInfo::from_raw_bytes(py, &peer.public_key),
+                        crate::peer_info::PeerInfo::from_raw_bytes(py, &peer.public_key),
                     );
                     let info = match info {
                         Ok(i) => i,

--- a/bindings/pyomq/src/context.rs
+++ b/bindings/pyomq/src/context.rs
@@ -1,12 +1,14 @@
-//! Context: lightweight Socket factory. Most of the libzmq Context
-//! semantics (term, IO threads) don't apply to our model; we keep the
-//! type to satisfy `ctx = zmq.Context(); sock = ctx.socket(zmq.PUSH)`.
+//! Context: per-runtime Socket factory. Each Context owns a dedicated
+//! tokio runtime on a background thread. `term()` shuts it down.
+
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 use crate::constants;
 use crate::error::map_err;
+use crate::runtime::ContextInner;
 use crate::socket::Socket;
 use crate::socket_async::AsyncSocket;
 
@@ -41,27 +43,34 @@ fn map_socket_type(st: i32) -> PyResult<omq_tokio::SocketType> {
 }
 
 #[pyclass(module = "pyomq._native")]
-pub struct Context;
+pub struct Context {
+    pub(crate) ctx: Arc<ContextInner>,
+}
 
 #[pymethods]
 impl Context {
     #[new]
     #[pyo3(signature = (io_threads = 1))]
     fn new(io_threads: i32) -> Self {
-        crate::runtime::set_io_threads(io_threads.max(1) as u64);
-        Context
+        Context {
+            ctx: ContextInner::new(io_threads.max(1) as usize),
+        }
     }
 
     /// Construct a new socket of the given libzmq type code.
     #[pyo3(signature = (socket_type, /))]
     fn socket(&self, py: Python<'_>, socket_type: i32) -> PyResult<Socket> {
         let _ = py;
-        Ok(Socket::new(map_socket_type(socket_type)?))
+        Ok(Socket::new(self.ctx.clone(), map_socket_type(socket_type)?))
     }
 
     /// pyzmq calls this `term`; older code calls `destroy`.
-    fn term(&self) {}
-    fn destroy(&self) {}
+    fn term(&self) {
+        self.ctx.term();
+    }
+    fn destroy(&self) {
+        self.ctx.term();
+    }
 
     fn __enter__<'py>(slf: Bound<'py, Self>) -> Bound<'py, Self> {
         slf
@@ -74,33 +83,42 @@ impl Context {
         _exc_val: Option<Bound<'_, PyAny>>,
         _exc_tb: Option<Bound<'_, PyAny>>,
     ) -> bool {
+        self.ctx.term();
         false
     }
 }
 
-/// `pyomq.asyncio.Context`. Hands out `AsyncSocket` instances. The
-/// instance itself has no state - it's a factory the way `Context`
-/// is in pyzmq's `zmq.asyncio`.
+/// `pyomq.asyncio.Context`. Hands out `AsyncSocket` instances.
 #[pyclass(module = "pyomq._native")]
-pub struct AsyncContext;
+pub struct AsyncContext {
+    pub(crate) ctx: Arc<ContextInner>,
+}
 
 #[pymethods]
 impl AsyncContext {
     #[new]
     #[pyo3(signature = (io_threads = 1))]
     fn new(io_threads: i32) -> Self {
-        crate::runtime::set_io_threads(io_threads.max(1) as u64);
-        AsyncContext
+        AsyncContext {
+            ctx: ContextInner::new(io_threads.max(1) as usize),
+        }
     }
 
     #[pyo3(signature = (socket_type, /))]
     fn socket(&self, py: Python<'_>, socket_type: i32) -> PyResult<AsyncSocket> {
         let _ = py;
-        Ok(AsyncSocket::new(map_socket_type(socket_type)?))
+        Ok(AsyncSocket::new(
+            self.ctx.clone(),
+            map_socket_type(socket_type)?,
+        ))
     }
 
-    fn term(&self) {}
-    fn destroy(&self) {}
+    fn term(&self) {
+        self.ctx.term();
+    }
+    fn destroy(&self) {
+        self.ctx.term();
+    }
 
     fn __enter__<'py>(slf: Bound<'py, Self>) -> Bound<'py, Self> {
         slf
@@ -113,6 +131,7 @@ impl AsyncContext {
         _exc_val: Option<Bound<'_, PyAny>>,
         _exc_tb: Option<Bound<'_, PyAny>>,
     ) -> bool {
+        self.ctx.term();
         false
     }
 }

--- a/bindings/pyomq/src/dispatch.rs
+++ b/bindings/pyomq/src/dispatch.rs
@@ -10,7 +10,6 @@ use omq_tokio::Socket;
 use pyo3::prelude::*;
 
 use crate::error::map_err;
-use crate::runtime;
 use crate::socket::SocketInner;
 
 /// Sync version: spawn a `Result<()>`-returning op on the tokio
@@ -21,7 +20,8 @@ where
     Fut: Future<Output = Result<(), PError>> + Send + 'static,
 {
     let sock = inner.ensure_socket()?;
-    py.allow_threads(|| runtime::with_socket(&sock, op))
+    let ctx = inner.ctx.clone();
+    py.allow_threads(|| ctx.with_socket(&sock, op))
         .map_err(map_err)
 }
 
@@ -36,7 +36,8 @@ where
     Fut: Future<Output = Result<String, PError>> + Send + 'static,
 {
     let sock = inner.ensure_socket()?;
-    py.allow_threads(|| runtime::with_socket(&sock, op))
+    let ctx = inner.ctx.clone();
+    py.allow_threads(|| ctx.with_socket(&sock, op))
         .map_err(map_err)
 }
 
@@ -52,7 +53,8 @@ where
     Fut: Future<Output = Result<(), PError>> + Send + 'static,
 {
     let sock = inner.ensure_socket()?;
-    runtime::tokio_future_into_py(py, async move {
+    let ctx = inner.ctx.clone();
+    ctx.tokio_future_into_py(py, async move {
         op(sock).await.map_err(map_err)?;
         Python::with_gil(|py| Ok(py.None()))
     })
@@ -70,7 +72,8 @@ where
     Fut: Future<Output = Result<String, PError>> + Send + 'static,
 {
     let sock = inner.ensure_socket()?;
-    runtime::tokio_future_into_py(py, async move {
+    let ctx = inner.ctx.clone();
+    ctx.tokio_future_into_py(py, async move {
         let s = op(sock).await.map_err(map_err)?;
         Python::with_gil(|py| Ok(s.to_object(py)))
     })

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -123,7 +123,8 @@ fn native_proxy(
         }
         None => None,
     };
-    py.allow_threads(|| runtime::proxy(fe, be, cap, ctrl));
+    let ctx = fe.ctx.clone();
+    py.allow_threads(|| runtime::proxy(&ctx, fe, be, cap, ctrl));
     Ok(())
 }
 

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -25,6 +25,8 @@ mod conversions;
 mod dispatch;
 mod error;
 mod options;
+#[cfg(any(feature = "curve", feature = "blake3zmq"))]
+mod peer_info;
 mod runtime;
 mod socket;
 mod socket_async;
@@ -66,9 +68,10 @@ fn _native(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(wait_any, m)?)?;
     m.add_function(wrap_pyfunction!(native_proxy, m)?)?;
     m.add_function(wrap_pyfunction!(has_feature, m)?)?;
+    #[cfg(any(feature = "curve", feature = "blake3zmq"))]
+    m.add_class::<peer_info::PeerInfo>()?;
     #[cfg(feature = "curve")]
     {
-        m.add_class::<auth::PeerInfo>()?;
         m.add_function(wrap_pyfunction!(curve_keypair, m)?)?;
         m.add_function(wrap_pyfunction!(curve_public, m)?)?;
     }

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -347,20 +347,22 @@ pub fn setsockopt(
         constants::SUBSCRIBE => {
             let v: &[u8] = value.extract()?;
             let bytes = Bytes::copy_from_slice(v);
+            let ctx = sock.ctx.clone();
             drop(ov);
             let s = sock.ensure_socket()?;
             let r = py.allow_threads(|| {
-                crate::runtime::with_socket(&s, move |s| async move { s.subscribe(bytes).await })
+                ctx.with_socket(&s, move |s| async move { s.subscribe(bytes).await })
             });
             return r.map_err(map_err);
         }
         constants::UNSUBSCRIBE => {
             let v: &[u8] = value.extract()?;
             let bytes = Bytes::copy_from_slice(v);
+            let ctx = sock.ctx.clone();
             drop(ov);
             let s = sock.ensure_socket()?;
             let r = py.allow_threads(|| {
-                crate::runtime::with_socket(&s, move |s| async move { s.unsubscribe(bytes).await })
+                ctx.with_socket(&s, move |s| async move { s.unsubscribe(bytes).await })
             });
             return r.map_err(map_err);
         }

--- a/bindings/pyomq/src/peer_info.rs
+++ b/bindings/pyomq/src/peer_info.rs
@@ -1,0 +1,34 @@
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+/// Peer information passed to a Python authenticator callback.
+#[pyclass(frozen, module = "pyomq._native")]
+pub struct PeerInfo {
+    public_key: Py<PyBytes>,
+}
+
+#[pymethods]
+impl PeerInfo {
+    #[getter]
+    fn public_key(&self, py: Python<'_>) -> Py<PyBytes> {
+        self.public_key.clone_ref(py)
+    }
+}
+
+impl PeerInfo {
+    #[cfg(feature = "curve")]
+    pub(crate) fn from_raw(py: Python<'_>, raw: &[u8; 32]) -> Self {
+        let pk = omq_proto::CurvePublicKey::from_bytes(*raw);
+        let z85 = pk.to_z85();
+        Self {
+            public_key: PyBytes::new_bound(py, z85.as_bytes()).unbind(),
+        }
+    }
+
+    #[cfg(feature = "blake3zmq")]
+    pub(crate) fn from_raw_bytes(py: Python<'_>, raw: &[u8; 32]) -> Self {
+        Self {
+            public_key: PyBytes::new_bound(py, raw).unbind(),
+        }
+    }
+}

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -52,11 +52,18 @@ fn ensure_runtime() -> (Handle, flume::Sender<Job>, Arc<crate::socket::RecvNotif
     thread::Builder::new()
         .name("pyomq-tokio".into())
         .spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(n.max(1))
-                .enable_all()
-                .build()
-                .expect("pyomq: tokio runtime build");
+            let rt = if n <= 1 {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("pyomq: tokio runtime build")
+            } else {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(n)
+                    .enable_all()
+                    .build()
+                    .expect("pyomq: tokio runtime build")
+            };
             let _ = handle_tx.send(rt.handle().clone());
             rt.block_on(async move {
                 while let Ok(job) = rx.recv_async().await {

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -1,4 +1,7 @@
-//! Runtime: a single-threaded tokio runtime on a dedicated background thread.
+//! Per-context tokio runtime on a dedicated background thread.
+//!
+//! Each `ContextInner` owns one tokio runtime + background thread.
+//! `term()` shuts down that runtime (aborts all pumps, drops the handle).
 //!
 //! omq-tokio::Socket is Send + Sync, so Python-side wrappers hold an
 //! Arc<Socket> directly in SocketInner. However, the socket's internal
@@ -13,7 +16,7 @@
 //! actual socket.send()/recv().await calls.
 
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -29,87 +32,26 @@ struct RuntimeState {
     pid: u32,
     handle: Handle,
     submit: flume::Sender<Job>,
-    recv_ready: Arc<crate::socket::RecvNotify>,
 }
 
-static RUNTIME: Mutex<Option<RuntimeState>> = Mutex::new(None);
-static IO_THREADS: AtomicU64 = AtomicU64::new(1);
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-fn ensure_runtime() -> (Handle, flume::Sender<Job>, Arc<crate::socket::RecvNotify>) {
-    let mut guard = RUNTIME.lock().unwrap();
+static GLOBAL_RECV_READY: Mutex<Option<(u32, Arc<crate::socket::RecvNotify>)>> = Mutex::new(None);
+
+/// Process-global recv notification for `wait_any`. Recv pumps from all
+/// contexts signal this after pushing a message; `wait_any` parks on it.
+/// Recreated after fork (PID guard).
+pub(crate) fn global_recv_ready() -> Arc<crate::socket::RecvNotify> {
+    let mut guard = GLOBAL_RECV_READY.lock().unwrap();
     let pid = std::process::id();
-    if let Some(rt) = guard.as_ref()
-        && rt.pid == pid
+    if let Some((p, rr)) = guard.as_ref()
+        && *p == pid
     {
-        return (rt.handle.clone(), rt.submit.clone(), rt.recv_ready.clone());
+        return rr.clone();
     }
-    // First call, or child process after fork: (re)initialize.
-    let (tx, rx) = flume::unbounded::<Job>();
-    let recv_ready = Arc::new(crate::socket::RecvNotify::new());
-    let (handle_tx, handle_rx) = flume::bounded::<Handle>(1);
-    let n = IO_THREADS.load(Ordering::Relaxed) as usize;
-    thread::Builder::new()
-        .name("pyomq-tokio".into())
-        .spawn(move || {
-            let rt = if n <= 1 {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("pyomq: tokio runtime build")
-            } else {
-                tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(n)
-                    .enable_all()
-                    .build()
-                    .expect("pyomq: tokio runtime build")
-            };
-            let _ = handle_tx.send(rt.handle().clone());
-            rt.block_on(async move {
-                while let Ok(job) = rx.recv_async().await {
-                    job();
-                }
-            });
-        })
-        .expect("pyomq: spawn tokio thread");
-    let handle = handle_rx.recv().expect("pyomq: runtime handle");
-    let state = RuntimeState {
-        pid,
-        handle: handle.clone(),
-        submit: tx.clone(),
-        recv_ready: recv_ready.clone(),
-    };
-    *guard = Some(state);
-    (handle, tx, recv_ready)
-}
-
-/// Set the number of tokio worker threads. Only takes effect before the
-/// runtime starts (i.e. before the first socket is materialized). Later
-/// calls are silently ignored.
-pub(crate) fn set_io_threads(n: u64) {
-    let guard = RUNTIME.lock().unwrap();
-    if guard
-        .as_ref()
-        .is_some_and(|rt| rt.pid == std::process::id())
-    {
-        return;
-    }
-    drop(guard);
-    IO_THREADS.store(n.max(1), Ordering::Relaxed);
-}
-
-pub(crate) fn runtime_handle() -> Handle {
-    ensure_runtime().0
-}
-
-fn submit_tx() -> flume::Sender<Job> {
-    ensure_runtime().1
-}
-
-/// Global recv notification for the current process. Recv pumps signal
-/// this after pushing a message; `wait_any` parks on it.
-pub(crate) fn recv_ready() -> Arc<crate::socket::RecvNotify> {
-    ensure_runtime().2
+    let rr = Arc::new(crate::socket::RecvNotify::new());
+    *guard = Some((pid, rr.clone()));
+    rr
 }
 
 /// Allocate the next socket id. Strictly monotonic; never recycled.
@@ -117,146 +59,270 @@ fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-/// Spawn a Send future on the tokio runtime and block until it completes.
-pub fn spawn_blocking<F, T>(fut: F) -> T
-where
-    F: Future<Output = T> + Send + 'static,
-    T: Send + 'static,
-{
-    let handle = runtime_handle();
-    let (otx, orx) = flume::bounded::<T>(1);
-    handle.spawn(async move {
-        let out = fut.await;
-        let _ = otx.send(out);
-    });
-    pyo3::Python::with_gil(|py| {
-        py.allow_threads(|| orx.recv().expect("pyomq: runtime dropped result"))
-    })
+pub(crate) struct ContextInner {
+    io_threads: usize,
+    state: Mutex<Option<RuntimeState>>,
+    terminated: AtomicBool,
 }
 
-/// Build a socket on the tokio thread, spawn per-socket send/recv pumps,
-/// and return the socket Arc and its id.
-///
-/// The pumps relay between the yring rings and the socket's async
-/// send/recv. They must run on the tokio thread because socket
-/// operations need the runtime's scheduler and I/O driver.
-pub fn materialize(
-    socket_type: omq_tokio::SocketType,
-    options: omq_tokio::Options,
-    send_cons: yring::AsyncConsumer<omq_tokio::Message>,
-    mut recv_prod: yring::Producer<omq_tokio::Message>,
-    recv_notify: Arc<crate::socket::RecvNotify>,
-    send_notify: Arc<crate::socket::RecvNotify>,
-    recv_space: Arc<tokio::sync::Notify>,
-) -> (u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>) {
-    let (otx, orx) = flume::bounded(1);
-    let job: Job = Box::new(move || {
-        let id = next_id();
-        let sock = Arc::new(InnerSocket::new(socket_type, options));
+impl ContextInner {
+    pub fn new(io_threads: usize) -> Arc<Self> {
+        Arc::new(Self {
+            io_threads: io_threads.max(1),
+            state: Mutex::new(None),
+            terminated: AtomicBool::new(false),
+        })
+    }
 
-        // Send pump: drain Python-side yring into the omq Socket.
-        // Yield every N messages so the connection drivers get
-        // scheduled on this single-threaded tokio runtime.
-        // Signal send_notify after each drain so the Python thread
-        // can wake up from backpressure parking.
-        const SEND_YIELD_INTERVAL: u32 = 256;
-        let s = sock.clone();
-        let send_pump = tokio::spawn(async move {
-            futures::pin_mut!(send_cons);
-            let mut batch = 0u32;
-            while let Some(msg) = futures::StreamExt::next(&mut send_cons).await {
-                let _ = s.send(msg).await;
-                send_notify.notify();
-                batch += 1;
-                if batch >= SEND_YIELD_INTERVAL {
-                    batch = 0;
-                    tokio::task::yield_now().await;
-                }
-            }
-            send_notify.notify();
+    fn ensure_runtime(&self) -> pyo3::PyResult<(Handle, flume::Sender<Job>)> {
+        if self.terminated.load(Ordering::Acquire) {
+            return Err(crate::error::map_err(omq_proto::error::Error::Closed));
+        }
+        let mut guard = self.state.lock().unwrap();
+        let pid = std::process::id();
+        if let Some(rt) = guard.as_ref()
+            && rt.pid == pid
+        {
+            return Ok((rt.handle.clone(), rt.submit.clone()));
+        }
+        let (tx, rx) = flume::unbounded::<Job>();
+        let (handle_tx, handle_rx) = flume::bounded::<Handle>(1);
+        let n = self.io_threads;
+        thread::Builder::new()
+            .name("pyomq-tokio".into())
+            .spawn(move || {
+                let rt = if n <= 1 {
+                    tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("pyomq: tokio runtime build")
+                } else {
+                    tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(n)
+                        .enable_all()
+                        .build()
+                        .expect("pyomq: tokio runtime build")
+                };
+                let _ = handle_tx.send(rt.handle().clone());
+                rt.block_on(async move {
+                    while let Ok(job) = rx.recv_async().await {
+                        job();
+                    }
+                });
+            })
+            .expect("pyomq: spawn tokio thread");
+        let handle = handle_rx.recv().expect("pyomq: runtime handle");
+        *guard = Some(RuntimeState {
+            pid,
+            handle: handle.clone(),
+            submit: tx.clone(),
         });
+        Ok((handle, tx))
+    }
 
-        // Recv pump: drain the omq Socket into Python-side yring.
-        // When the ring is full, wait on recv_space (signaled by the
-        // Python consumer after draining) instead of spin-looping.
-        let s = sock.clone();
-        let global_recv_ready = recv_ready();
-        let recv_pump = tokio::spawn(async move {
-            while let Ok(msg) = s.recv().await {
-                let mut m = msg;
-                loop {
-                    match recv_prod.push(m) {
-                        Ok(()) => {
-                            recv_prod.flush();
-                            recv_notify.notify();
+    pub fn runtime_handle(&self) -> pyo3::PyResult<Handle> {
+        Ok(self.ensure_runtime()?.0)
+    }
 
-                            global_recv_ready.notify();
-                            break;
-                        }
-                        Err(returned) => {
-                            m = returned;
-                            let notified = recv_space.notified();
-                            tokio::pin!(notified);
-                            notified.as_mut().enable();
-                            match recv_prod.push(m) {
-                                Ok(()) => {
-                                    recv_prod.flush();
-                                    recv_notify.notify();
+    fn submit_tx(&self) -> pyo3::PyResult<flume::Sender<Job>> {
+        Ok(self.ensure_runtime()?.1)
+    }
 
-                                    global_recv_ready.notify();
-                                    break;
-                                }
-                                Err(returned2) => {
-                                    m = returned2;
-                                    notified.await;
+    /// Spawn a Send future on the tokio runtime and block until it completes.
+    pub fn spawn_blocking<F, T>(&self, fut: F) -> T
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let handle = self.runtime_handle().expect("pyomq: context terminated");
+        let (otx, orx) = flume::bounded::<T>(1);
+        handle.spawn(async move {
+            let out = fut.await;
+            let _ = otx.send(out);
+        });
+        pyo3::Python::with_gil(|py| {
+            py.allow_threads(|| orx.recv().expect("pyomq: runtime dropped result"))
+        })
+    }
+
+    /// Build a socket on the tokio thread, spawn per-socket send/recv pumps,
+    /// and return the socket Arc and its id.
+    #[expect(clippy::too_many_arguments, clippy::type_complexity)]
+    pub fn materialize(
+        &self,
+        socket_type: omq_tokio::SocketType,
+        options: omq_tokio::Options,
+        send_cons: yring::AsyncConsumer<omq_tokio::Message>,
+        mut recv_prod: yring::Producer<omq_tokio::Message>,
+        recv_notify: Arc<crate::socket::RecvNotify>,
+        send_notify: Arc<crate::socket::RecvNotify>,
+        recv_space: Arc<tokio::sync::Notify>,
+    ) -> pyo3::PyResult<(u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>)> {
+        let (otx, orx) = flume::bounded(1);
+        let grr = global_recv_ready();
+        let job: Job = Box::new(move || {
+            let id = next_id();
+            let sock = Arc::new(InnerSocket::new(socket_type, options));
+
+            const SEND_YIELD_INTERVAL: u32 = 256;
+            let s = sock.clone();
+            let send_pump = tokio::spawn(async move {
+                futures::pin_mut!(send_cons);
+                let mut batch = 0u32;
+                while let Some(msg) = futures::StreamExt::next(&mut send_cons).await {
+                    let _ = s.send(msg).await;
+                    send_notify.notify();
+                    batch += 1;
+                    if batch >= SEND_YIELD_INTERVAL {
+                        batch = 0;
+                        tokio::task::yield_now().await;
+                    }
+                }
+                send_notify.notify();
+            });
+
+            let s = sock.clone();
+            let recv_pump = tokio::spawn(async move {
+                while let Ok(msg) = s.recv().await {
+                    let mut m = msg;
+                    loop {
+                        match recv_prod.push(m) {
+                            Ok(()) => {
+                                recv_prod.flush();
+                                recv_notify.notify();
+                                grr.notify();
+                                break;
+                            }
+                            Err(returned) => {
+                                m = returned;
+                                let notified = recv_space.notified();
+                                tokio::pin!(notified);
+                                notified.as_mut().enable();
+                                match recv_prod.push(m) {
+                                    Ok(()) => {
+                                        recv_prod.flush();
+                                        recv_notify.notify();
+                                        grr.notify();
+                                        break;
+                                    }
+                                    Err(returned2) => {
+                                        m = returned2;
+                                        notified.await;
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
+            });
+
+            let _ = otx.send((id, sock, send_pump, recv_pump));
+        });
+        self.submit_tx()?
+            .send(job)
+            .expect("pyomq: tokio runtime gone");
+        pyo3::Python::with_gil(|py| {
+            Ok(py.allow_threads(|| orx.recv().expect("pyomq: runtime dropped result")))
+        })
+    }
+
+    /// Close a socket: drain the send yring, then close with linger.
+    ///
+    /// If the context is already terminated, the runtime is gone and
+    /// spawned tasks were aborted. Just drop the socket.
+    pub fn destroy_socket(
+        &self,
+        sock: Arc<InnerSocket>,
+        send_prod: Mutex<yring::AsyncProducer<omq_tokio::Message>>,
+        send_pump: JoinHandle<()>,
+        recv_pump: JoinHandle<()>,
+    ) {
+        recv_pump.abort();
+        drop(send_prod);
+        let handle = match self.runtime_handle() {
+            Ok(h) => h,
+            Err(_) => return,
+        };
+        let (otx, orx) = flume::bounded(1);
+        handle.spawn(async move {
+            let _ = tokio::time::timeout(Duration::from_secs(1), send_pump).await;
+            let s = Arc::try_unwrap(sock).unwrap_or_else(|arc| (*arc).clone());
+            let _ = tokio::time::timeout(Duration::from_secs(1), s.close()).await;
+            let _ = otx.send(());
+        });
+        let _ = orx.recv_timeout(Duration::from_secs(3));
+    }
+
+    /// Run an async op against a socket and return the result.
+    pub fn with_socket<F, Fut, T>(&self, sock: &Arc<InnerSocket>, op: F) -> T
+    where
+        F: FnOnce(Arc<InnerSocket>) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let s = sock.clone();
+        self.spawn_blocking(op(s))
+    }
+
+    /// Shut down this context's runtime. Drops the job channel, which
+    /// causes the background thread to exit (runtime drops, tasks abort).
+    /// The thread is detached, not joined, to avoid blocking.
+    pub fn term(&self) {
+        self.terminated.store(true, Ordering::Release);
+        let state = self.state.lock().unwrap().take();
+        if let Some(s) = state {
+            drop(s.submit);
+            drop(s.handle);
+        }
+    }
+
+    /// Bridge a Rust future to a Python `asyncio.Future`.
+    pub fn tokio_future_into_py<'py, F>(
+        &self,
+        py: pyo3::Python<'py>,
+        fut: F,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::PyAny>>
+    where
+        F: Future<Output = pyo3::PyResult<pyo3::PyObject>> + Send + 'static,
+    {
+        use pyo3::prelude::*;
+
+        let asyncio = py.import_bound("asyncio")?;
+        let event_loop = asyncio.call_method0("get_running_loop")?;
+        let py_future = event_loop.call_method0("create_future")?;
+        let loop_handle: PyObject = event_loop.clone().unbind().into_any();
+        let future_handle: PyObject = py_future.clone().unbind().into_any();
+
+        self.runtime_handle()?.spawn(async move {
+            let result = fut.await;
+            Python::with_gil(|gil| {
+                let loop_obj = loop_handle.bind(gil);
+                let fut_obj = future_handle.bind(gil);
+                let _ = match result {
+                    Ok(value) => {
+                        let setter = fut_obj.getattr("set_result")?;
+                        loop_obj.call_method1("call_soon_threadsafe", (setter, value))
+                    }
+                    Err(e) => {
+                        let setter = fut_obj.getattr("set_exception")?;
+                        loop_obj.call_method1("call_soon_threadsafe", (setter, e.into_value(gil)))
+                    }
+                };
+                PyResult::<()>::Ok(())
+            })
+            .ok();
         });
 
-        let _ = otx.send((id, sock, send_pump, recv_pump));
-    });
-    submit_tx().send(job).expect("pyomq: tokio runtime gone");
-    pyo3::Python::with_gil(|py| {
-        py.allow_threads(|| orx.recv().expect("pyomq: runtime dropped result"))
-    })
+        Ok(py_future)
+    }
 }
 
-/// Close a socket: drain the send yring, then close with linger.
-///
-/// Drops `send_prod` so the send pump's consumer stream ends after
-/// draining remaining messages. Awaits the pump (up to 1s) before
-/// closing the socket. The recv pump is aborted immediately.
-pub fn destroy_socket(
-    sock: Arc<InnerSocket>,
-    send_prod: Mutex<yring::AsyncProducer<omq_tokio::Message>>,
-    send_pump: JoinHandle<()>,
-    recv_pump: JoinHandle<()>,
-) {
-    recv_pump.abort();
-    // Drop the producer so the pump's consumer stream ends once drained.
-    drop(send_prod);
-    spawn_blocking(async move {
-        // Give the send pump time to drain remaining messages.
-        let _ = tokio::time::timeout(Duration::from_secs(1), send_pump).await;
-        let s = Arc::try_unwrap(sock).unwrap_or_else(|arc| (*arc).clone());
-        let _ = s.close().await;
-    });
-}
-
-/// Run an async op against a socket and return the result. The future
-/// is spawned on the tokio runtime. Blocks the calling thread.
-pub fn with_socket<F, Fut, T>(sock: &Arc<InnerSocket>, op: F) -> T
-where
-    F: FnOnce(Arc<InnerSocket>) -> Fut + Send + 'static,
-    Fut: Future<Output = T> + Send + 'static,
-    T: Send + 'static,
-{
-    let s = sock.clone();
-    spawn_blocking(op(s))
+impl Drop for ContextInner {
+    fn drop(&mut self) {
+        if let Some(s) = self.state.get_mut().unwrap().take() {
+            drop(s.submit);
+        }
+    }
 }
 
 fn drain_recv_ring(inner: &Arc<crate::socket::SocketInner>) -> Vec<omq_tokio::Message> {
@@ -283,16 +349,13 @@ fn push_to_capture(cap: &Arc<crate::socket::SocketInner>, msg: &omq_tokio::Messa
 }
 
 /// Run a forwarding proxy between two sockets on the tokio thread.
-///
-/// Stops the send/recv pumps on fe/be (and control, if any), then
-/// runs direct async forwarding loops. Capture stays ring-based.
 pub fn proxy(
+    ctx: &Arc<ContextInner>,
     fe_inner: Arc<crate::socket::SocketInner>,
     be_inner: Arc<crate::socket::SocketInner>,
     cap_inner: Option<Arc<crate::socket::SocketInner>>,
     ctrl_inner: Option<Arc<crate::socket::SocketInner>>,
 ) {
-    // Abort pumps so proxy gets exclusive socket access.
     let fe_mat = fe_inner.materialized.read().unwrap();
     let fe_m = fe_mat.as_ref().unwrap();
     fe_m.send_pump.abort();
@@ -318,7 +381,7 @@ pub fn proxy(
     let fe_drained = drain_recv_ring(&fe_inner);
     let be_drained = drain_recv_ring(&be_inner);
 
-    spawn_blocking(async move {
+    ctx.spawn_blocking(async move {
         for msg in fe_drained {
             if let Some(ref cap) = cap_inner {
                 push_to_capture(cap, &msg);
@@ -447,8 +510,7 @@ async fn proxy_loop(
 }
 
 /// Block the calling thread until at least one of the given sockets has
-/// an inbound message ready (or until `timeout_ms` elapses). Returns
-/// the list of socket IDs that are ready.
+/// an inbound message ready (or until `timeout_ms` elapses).
 pub fn wait_any(
     sockets: Vec<(u64, Arc<crate::socket::SocketInner>)>,
     timeout_ms: Option<u64>,
@@ -481,7 +543,7 @@ pub fn wait_any(
         return ready;
     }
 
-    let rr = recv_ready();
+    let rr = global_recv_ready();
     let deadline = timeout_ms.map(|ms| std::time::Instant::now() + Duration::from_millis(ms));
 
     rr.park_begin();
@@ -516,52 +578,4 @@ pub fn wait_any(
             return vec![];
         }
     }
-}
-
-/// Return an already-resolved `asyncio.Future`. Avoids the tokio
-/// spawn + `call_soon_threadsafe` round trip for fast-path results.
-/// Bridge a Rust future to a Python `asyncio.Future`.
-///
-/// 1. Acquires the running asyncio loop on the calling Python thread.
-/// 2. Creates a fresh `asyncio.Future` via `loop.create_future()`.
-/// 3. Spawns the future on the tokio runtime.
-/// 4. When it resolves, the tokio thread acquires the GIL and calls
-///    `loop.call_soon_threadsafe(future.set_result | set_exception, ...)`
-/// 5. Returns the Python `asyncio.Future` to the caller.
-pub fn tokio_future_into_py<F>(
-    py: pyo3::Python<'_>,
-    fut: F,
-) -> pyo3::PyResult<pyo3::Bound<'_, pyo3::PyAny>>
-where
-    F: Future<Output = pyo3::PyResult<pyo3::PyObject>> + Send + 'static,
-{
-    use pyo3::prelude::*;
-
-    let asyncio = py.import_bound("asyncio")?;
-    let event_loop = asyncio.call_method0("get_running_loop")?;
-    let py_future = event_loop.call_method0("create_future")?;
-    let loop_handle: PyObject = event_loop.clone().unbind().into_any();
-    let future_handle: PyObject = py_future.clone().unbind().into_any();
-
-    runtime_handle().spawn(async move {
-        let result = fut.await;
-        Python::with_gil(|gil| {
-            let loop_obj = loop_handle.bind(gil);
-            let fut_obj = future_handle.bind(gil);
-            let _ = match result {
-                Ok(value) => {
-                    let setter = fut_obj.getattr("set_result")?;
-                    loop_obj.call_method1("call_soon_threadsafe", (setter, value))
-                }
-                Err(e) => {
-                    let setter = fut_obj.getattr("set_exception")?;
-                    loop_obj.call_method1("call_soon_threadsafe", (setter, e.into_value(gil)))
-                }
-            };
-            PyResult::<()>::Ok(())
-        })
-        .ok();
-    });
-
-    Ok(py_future)
 }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -24,7 +24,7 @@ use crate::conversions;
 use crate::dispatch;
 use crate::error::{map_err, timeout_err};
 use crate::options;
-use crate::runtime;
+use crate::runtime::ContextInner;
 
 /// Per-socket scratchpad for SNDMORE-style multipart construction.
 #[derive(Default)]
@@ -164,6 +164,7 @@ pub(crate) struct Materialized {
 /// Both pyclasses hold an `Arc<SocketInner>` and route I/O through the
 /// helpers below.
 pub(crate) struct SocketInner {
+    pub ctx: Arc<ContextInner>,
     pub socket_type: omq_tokio::SocketType,
     pub overlay: Mutex<options::Overlay>,
     pub sndbuf: Mutex<SendBuffer>,
@@ -173,10 +174,11 @@ pub(crate) struct SocketInner {
 }
 
 impl SocketInner {
-    pub fn new(socket_type: omq_tokio::SocketType) -> Arc<Self> {
+    pub fn new(ctx: Arc<ContextInner>, socket_type: omq_tokio::SocketType) -> Arc<Self> {
         let opts = omq_tokio::Options::default();
         let overlay = options::Overlay::from_options(&opts);
         Arc::new(Self {
+            ctx,
             socket_type,
             overlay: Mutex::new(overlay),
             sndbuf: Mutex::new(SendBuffer::default()),
@@ -219,7 +221,7 @@ impl SocketInner {
         let send_notify = Arc::new(RecvNotify::new());
         let recv_space = Arc::new(tokio::sync::Notify::new());
         let st = self.socket_type;
-        let (id, socket, send_pump, recv_pump) = runtime::materialize(
+        let (id, socket, send_pump, recv_pump) = self.ctx.materialize(
             st,
             opts,
             send_cons,
@@ -227,7 +229,7 @@ impl SocketInner {
             recv_notify.clone(),
             send_notify.clone(),
             recv_space.clone(),
-        );
+        )?;
         *slot = Some(Materialized {
             id,
             fork_gen: fgen,
@@ -318,25 +320,30 @@ pub struct Monitor {
 }
 
 impl Monitor {
-    pub(crate) fn from_stream(mut stream: omq_tokio::MonitorStream) -> Self {
+    pub(crate) fn from_stream(
+        ctx: &Arc<ContextInner>,
+        mut stream: omq_tokio::MonitorStream,
+    ) -> Self {
         let (tx, rx) = flume::unbounded();
         let lagged = Arc::new(AtomicU64::new(0));
         let lagged2 = lagged.clone();
-        runtime::runtime_handle().spawn(async move {
-            loop {
-                match stream.recv().await {
-                    Ok(ev) => {
-                        if tx.send(ev).is_err() {
-                            break;
+        ctx.runtime_handle()
+            .expect("pyomq: context terminated")
+            .spawn(async move {
+                loop {
+                    match stream.recv().await {
+                        Ok(ev) => {
+                            if tx.send(ev).is_err() {
+                                break;
+                            }
                         }
+                        Err(omq_tokio::MonitorRecvError::Lagged(n)) => {
+                            lagged2.fetch_add(n, Ordering::Relaxed);
+                        }
+                        Err(_) => break,
                     }
-                    Err(omq_tokio::MonitorRecvError::Lagged(n)) => {
-                        lagged2.fetch_add(n, Ordering::Relaxed);
-                    }
-                    Err(_) => break,
                 }
-            }
-        });
+            });
         Self { rx, lagged }
     }
 }
@@ -473,9 +480,9 @@ pub struct Socket {
 }
 
 impl Socket {
-    pub fn new(socket_type: omq_tokio::SocketType) -> Self {
+    pub(crate) fn new(ctx: Arc<ContextInner>, socket_type: omq_tokio::SocketType) -> Self {
         Self {
-            inner: SocketInner::new(socket_type),
+            inner: SocketInner::new(ctx, socket_type),
         }
     }
 
@@ -595,8 +602,9 @@ impl Socket {
     /// Return a list of dicts describing every live peer connection.
     fn connections<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let sock = self.inner.ensure_socket()?;
+        let ctx = self.inner.ctx.clone();
         let statuses: Vec<omq_tokio::ConnectionStatus> = py.allow_threads(|| {
-            runtime::with_socket(&sock, |s| async move {
+            ctx.with_socket(&sock, |s| async move {
                 s.connections().await.unwrap_or_default()
             })
         });
@@ -611,8 +619,9 @@ impl Socket {
     /// `None` if no such peer is currently connected.
     fn connection_info<'py>(&self, py: Python<'py>, connection_id: u64) -> PyResult<PyObject> {
         let sock = self.inner.ensure_socket()?;
+        let ctx = self.inner.ctx.clone();
         let status: Option<omq_tokio::ConnectionStatus> = py.allow_threads(|| {
-            runtime::with_socket(&sock, move |s| async move {
+            ctx.with_socket(&sock, move |s| async move {
                 s.connection_info(connection_id).await.ok().flatten()
             })
         });
@@ -626,9 +635,9 @@ impl Socket {
     /// this socket. Multiple monitors can be active simultaneously.
     fn monitor(&self, py: Python<'_>) -> PyResult<Monitor> {
         let sock = self.inner.ensure_socket()?;
-        let stream =
-            py.allow_threads(|| runtime::with_socket(&sock, |s| async move { s.monitor() }));
-        Ok(Monitor::from_stream(stream))
+        let ctx = self.inner.ctx.clone();
+        let stream = py.allow_threads(|| ctx.with_socket(&sock, |s| async move { s.monitor() }));
+        Ok(Monitor::from_stream(&self.inner.ctx, stream))
     }
 
     fn setsockopt(&self, py: Python<'_>, option: i32, value: &Bound<'_, PyAny>) -> PyResult<()> {
@@ -655,8 +664,9 @@ impl Socket {
         let Some(m) = m else {
             return Ok(());
         };
+        let ctx = self.inner.ctx.clone();
         py.allow_threads(|| {
-            runtime::destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump)
+            ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump);
         });
         Ok(())
     }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -2,7 +2,7 @@
 //! the sync and async wrappers.
 //!
 //! Hot path is queue-relayed: every `send` / `recv` goes through a
-//! per-socket yring SPSC ring buffer. Two pump tasks on the compio
+//! per-socket yring SPSC ring buffer. Two pump tasks on the tokio
 //! thread bridge the rings to the actual `omq_tokio::Socket`'s async
 //! send/recv. The fast path (ring not full / not empty) does NOT call
 //! `Python::allow_threads`. The slow path (Full / Empty) releases the
@@ -712,7 +712,10 @@ impl Socket {
                     loop {
                         let push_result = {
                             let mat_guard = self.inner.materialized.read().unwrap();
-                            let mat = mat_guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
+                            let mat = mat_guard.as_ref().ok_or_else(|| {
+                                send_notify.park_end();
+                                map_err(PError::Closed)
+                            })?;
                             let mut prod = mat.send_prod.lock().unwrap();
                             prod.push_and_flush(msg)
                         };

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -25,7 +25,7 @@ use pyo3::types::{PyBytes, PyList, PyType};
 use crate::conversions;
 use crate::dispatch;
 use crate::error::map_err;
-use crate::runtime;
+use crate::runtime::ContextInner;
 use crate::socket::SocketInner;
 
 #[pyclass(module = "pyomq._native")]
@@ -34,9 +34,9 @@ pub struct AsyncSocket {
 }
 
 impl AsyncSocket {
-    pub fn new(socket_type: omq_tokio::SocketType) -> Self {
+    pub(crate) fn new(ctx: Arc<ContextInner>, socket_type: omq_tokio::SocketType) -> Self {
         Self {
-            inner: SocketInner::new(socket_type),
+            inner: SocketInner::new(ctx, socket_type),
         }
     }
 
@@ -209,8 +209,9 @@ impl AsyncSocket {
 
     fn connections<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let sock = self.inner.ensure_socket()?;
+        let ctx = self.inner.ctx.clone();
         let statuses: Vec<omq_tokio::ConnectionStatus> = py.allow_threads(|| {
-            runtime::with_socket(&sock, |s| async move {
+            ctx.with_socket(&sock, |s| async move {
                 s.connections().await.unwrap_or_default()
             })
         });
@@ -223,8 +224,9 @@ impl AsyncSocket {
 
     fn connection_info<'py>(&self, py: Python<'py>, connection_id: u64) -> PyResult<PyObject> {
         let sock = self.inner.ensure_socket()?;
+        let ctx = self.inner.ctx.clone();
         let status: Option<omq_tokio::ConnectionStatus> = py.allow_threads(|| {
-            runtime::with_socket(&sock, move |s| async move {
+            ctx.with_socket(&sock, move |s| async move {
                 s.connection_info(connection_id).await.ok().flatten()
             })
         });
@@ -236,9 +238,9 @@ impl AsyncSocket {
 
     fn monitor(&self, py: Python<'_>) -> PyResult<crate::socket::Monitor> {
         let sock = self.inner.ensure_socket()?;
-        let stream =
-            py.allow_threads(|| runtime::with_socket(&sock, |s| async move { s.monitor() }));
-        Ok(crate::socket::Monitor::from_stream(stream))
+        let ctx = self.inner.ctx.clone();
+        let stream = py.allow_threads(|| ctx.with_socket(&sock, |s| async move { s.monitor() }));
+        Ok(crate::socket::Monitor::from_stream(&self.inner.ctx, stream))
     }
 
     // ── Options ─────────────────────────────────────────────────────
@@ -269,8 +271,9 @@ impl AsyncSocket {
         let Some(m) = m else {
             return Ok(());
         };
+        let ctx = self.inner.ctx.clone();
         py.allow_threads(|| {
-            runtime::destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump)
+            ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump);
         });
         Ok(())
     }

--- a/bindings/pyomq/tests/soak/test_context_churn.py
+++ b/bindings/pyomq/tests/soak/test_context_churn.py
@@ -29,9 +29,8 @@ def test_context_churn():
         pull.bind(ep)
         push.connect(ep)
 
+        pull.setsockopt(zmq.RCVTIMEO, 5000)
         push.send(b"x")
-        push.setsockopt(zmq.RCVTIMEO, 1000)
-        pull.setsockopt(zmq.RCVTIMEO, 1000)
         msg = pull.recv()
         assert msg == b"x"
 

--- a/bindings/pyomq/tests/soak/test_fan_out.py
+++ b/bindings/pyomq/tests/soak/test_fan_out.py
@@ -1,0 +1,119 @@
+"""Soak: high fan-out PUB -> many SUBs (all-subscribe).
+
+One PUB with many connected SUBs all subscribed to everything. Exercises
+the fan-out multicast path (pre-encode once, distribute to N peers) and
+validates no corruption or message loss under N-way replication.
+"""
+
+import struct
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration, tcp_ep
+
+NUM_SUBS = 16
+MSG_SIZE = 128
+
+
+def test_fan_out():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = tcp_ep()
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.setsockopt(zmq.SNDHWM, 500)
+    pub.bind(ep)
+
+    subs = []
+    for _ in range(NUM_SUBS):
+        s = ctx.socket(zmq.SUB)
+        s.setsockopt(zmq.RCVTIMEO, 2000)
+        s.setsockopt(zmq.SUBSCRIBE, b"")
+        s.connect(ep)
+        subs.append(s)
+
+    time.sleep(0.3)
+
+    stop = False
+    sent = 0
+    recv_counts = [0] * NUM_SUBS
+
+    def publisher():
+        nonlocal sent, stop
+        seq = 0
+        while not stop:
+            msg = struct.pack("<Q", seq) + bytes([seq & 0xFF] * MSG_SIZE)
+            try:
+                pub.send(msg)
+                seq += 1
+                sent = seq
+            except zmq.Again:
+                pass
+
+    def subscriber(idx):
+        nonlocal stop
+        while not stop:
+            try:
+                msg = subs[idx].recv()
+                seq = struct.unpack("<Q", msg[:8])[0]
+                expected = bytes([seq & 0xFF] * MSG_SIZE)
+                assert msg[8:] == expected, (
+                    f"sub[{idx}] corruption at seq {seq}"
+                )
+                recv_counts[idx] += 1
+            except zmq.Again:
+                pass
+
+    t_pub = threading.Thread(target=publisher, daemon=True)
+    t_subs = [
+        threading.Thread(target=subscriber, args=(i,), daemon=True)
+        for i in range(NUM_SUBS)
+    ]
+    for t in t_subs:
+        t.start()
+    t_pub.start()
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        time.sleep(1)
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            total = sum(recv_counts)
+            lo = min(recv_counts)
+            hi = max(recv_counts)
+            print(
+                f"[fan_out] {elapsed:.0f}s, sent {sent}, "
+                f"total recvd {total}, range [{lo}, {hi}]"
+            )
+            last_log = now
+
+    stop = True
+    t_pub.join(timeout=5)
+    for t in t_subs:
+        t.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    total = sum(recv_counts)
+    lo = min(recv_counts)
+    hi = max(recv_counts)
+    print(
+        f"[fan_out] done: sent {sent}, total recvd {total} "
+        f"in {elapsed:.1f}s, range [{lo}, {hi}]"
+    )
+
+    for i, count in enumerate(recv_counts):
+        assert count > 0, f"sub[{i}] received nothing"
+
+    report = monitor.stop()
+    report.assert_no_leak("fan_out")
+
+    for s in subs:
+        s.close()
+    pub.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_inproc_throughput.py
+++ b/bindings/pyomq/tests/soak/test_inproc_throughput.py
@@ -1,0 +1,92 @@
+"""Soak: sustained PUSH/PULL over inproc.
+
+Exercises the yring SPSC relay path (no ZMTP, no kernel). Sender and
+receiver on separate threads. Validates message integrity and checks
+for RSS growth (leaks in the ring or PyO3 refcount path).
+"""
+
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, inproc_ep, soak_duration
+
+MSG_SIZE = 64
+
+
+def test_inproc_throughput():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = inproc_ep("throughput")
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    pull.bind(ep)
+    push.connect(ep)
+    push.setsockopt(zmq.SNDTIMEO, 5000)
+    pull.setsockopt(zmq.RCVTIMEO, 5000)
+
+    payload = bytes(range(MSG_SIZE))
+    stop = False
+    sent = 0
+    recvd = 0
+
+    def sender():
+        nonlocal sent, stop
+        while not stop:
+            try:
+                push.send(payload)
+                sent += 1
+            except zmq.Again:
+                pass
+
+    def receiver():
+        nonlocal recvd, stop
+        while not stop:
+            try:
+                msg = pull.recv()
+                assert len(msg) == MSG_SIZE
+                recvd += 1
+            except zmq.Again:
+                pass
+
+    t_send = threading.Thread(target=sender, daemon=True)
+    t_recv = threading.Thread(target=receiver, daemon=True)
+    t_recv.start()
+    t_send.start()
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        time.sleep(1)
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            print(
+                f"[inproc_throughput] {elapsed:.0f}s, "
+                f"sent {sent}, recvd {recvd}, "
+                f"{recvd / elapsed:.0f} msg/s"
+            )
+            last_log = now
+
+    stop = True
+    t_send.join(timeout=5)
+    t_recv.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[inproc_throughput] done: sent {sent}, recvd {recvd} "
+        f"in {elapsed:.1f}s ({recvd / elapsed:.0f} msg/s)"
+    )
+
+    assert recvd > 0, "no messages received"
+
+    report = monitor.stop()
+    report.assert_no_leak("inproc_throughput")
+
+    push.close()
+    pull.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_io_threads.py
+++ b/bindings/pyomq/tests/soak/test_io_threads.py
@@ -1,0 +1,152 @@
+"""Soak: validate behavior across different IO thread counts.
+
+Spawns subprocesses with io_threads=1 (current_thread runtime),
+io_threads=2, and io_threads=4 (multi_thread runtime). Each subprocess
+runs a PUSH/PULL throughput test and a REQ/REP latency test. Validates
+that all configurations work correctly and that multi-thread doesn't
+introduce races.
+
+Uses subprocess because io_threads is set once per process before the
+first socket materializes.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+from conftest import soak_duration
+
+WORKER_SCRIPT = '''
+import struct
+import sys
+import threading
+import time
+
+import pyomq as zmq
+
+IO_THREADS = int(sys.argv[1])
+DURATION = float(sys.argv[2])
+
+ctx = zmq.Context(io_threads=IO_THREADS)
+
+# --- PUSH/PULL throughput ---
+pull = ctx.socket(zmq.PULL)
+push = ctx.socket(zmq.PUSH)
+ep = pull.bind("tcp://127.0.0.1:0")
+push.connect(ep)
+push.setsockopt(zmq.SNDTIMEO, 5000)
+pull.setsockopt(zmq.RCVTIMEO, 5000)
+
+stop = False
+sent = 0
+recvd = 0
+corrupt = 0
+
+def sender():
+    global sent, stop
+    seq = 0
+    while not stop:
+        msg = struct.pack("<Q", seq) + b"X" * 56
+        try:
+            push.send(msg)
+            seq += 1
+            sent = seq
+        except Exception:
+            pass
+
+def receiver():
+    global recvd, corrupt, stop
+    while not stop:
+        try:
+            msg = pull.recv()
+            seq = struct.unpack("<Q", msg[:8])[0]
+            if msg[8:] != b"X" * 56:
+                corrupt += 1
+            recvd += 1
+        except Exception:
+            pass
+
+t_send = threading.Thread(target=sender, daemon=True)
+t_recv = threading.Thread(target=receiver, daemon=True)
+t_recv.start()
+t_send.start()
+
+start = time.monotonic()
+half = DURATION / 2
+while time.monotonic() - start < half:
+    time.sleep(0.5)
+
+stop = True
+t_send.join(timeout=3)
+t_recv.join(timeout=3)
+push.close()
+pull.close()
+
+throughput_ok = recvd > 0 and corrupt == 0
+elapsed = time.monotonic() - start
+tput = recvd / elapsed if elapsed > 0 else 0
+
+# --- REQ/REP latency ---
+rep = ctx.socket(zmq.REP)
+req = ctx.socket(zmq.REQ)
+ep2 = rep.bind("tcp://127.0.0.1:0")
+req.connect(ep2)
+rep.setsockopt(zmq.RCVTIMEO, 5000)
+rep.setsockopt(zmq.SNDTIMEO, 5000)
+req.setsockopt(zmq.RCVTIMEO, 5000)
+req.setsockopt(zmq.SNDTIMEO, 5000)
+time.sleep(0.1)
+
+cycles = 0
+start2 = time.monotonic()
+while time.monotonic() - start2 < half:
+    req.send(struct.pack("<Q", cycles))
+    msg = rep.recv()
+    rep.send(msg)
+    reply = req.recv()
+    seq = struct.unpack("<Q", reply[:8])[0]
+    assert seq == cycles, f"REQ/REP mismatch: {seq} != {cycles}"
+    cycles += 1
+
+latency_ok = cycles > 0
+elapsed2 = time.monotonic() - start2
+rtt = elapsed2 / cycles * 1e6 if cycles > 0 else 0
+
+req.close()
+rep.close()
+ctx.term()
+
+print(f"io_threads={IO_THREADS} throughput={tput:.0f}msg/s recvd={recvd} "
+      f"corrupt={corrupt} cycles={cycles} rtt={rtt:.0f}us "
+      f"ok={throughput_ok and latency_ok}")
+sys.exit(0 if throughput_ok and latency_ok else 1)
+'''
+
+
+def test_io_threads_variants():
+    duration = soak_duration()
+    per_variant = max(duration / 3, 10)
+
+    results = {}
+    for n_threads in [1, 2, 4]:
+        print(f"\n[io_threads] running with io_threads={n_threads}, "
+              f"duration={per_variant:.0f}s")
+        result = subprocess.run(
+            [sys.executable, "-c", WORKER_SCRIPT,
+             str(n_threads), str(per_variant)],
+            capture_output=True,
+            text=True,
+            timeout=per_variant + 30,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+        print(f"  stdout: {result.stdout.strip()}")
+        if result.stderr.strip():
+            print(f"  stderr: {result.stderr.strip()}")
+        assert result.returncode == 0, (
+            f"io_threads={n_threads} failed: "
+            f"rc={result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+        results[n_threads] = result.stdout.strip()
+
+    print(f"\n[io_threads] all variants passed: {list(results.keys())}")

--- a/bindings/pyomq/tests/soak/test_ipc_throughput.py
+++ b/bindings/pyomq/tests/soak/test_ipc_throughput.py
@@ -1,0 +1,98 @@
+"""Soak: sustained PUSH/PULL over IPC (Unix abstract socket).
+
+Same pattern as TCP throughput but over IPC transport. Exercises the
+IPC connection path and validates no message loss or corruption.
+"""
+
+import hashlib
+import os
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration
+
+MSG_SIZE = 512
+
+
+def ipc_ep() -> str:
+    tag = hashlib.sha1(f"soak-ipc-{os.getpid()}".encode()).hexdigest()[:16]
+    return f"ipc://@pyomq-soak-{tag}"
+
+
+def test_ipc_throughput():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = ipc_ep()
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    pull.bind(ep)
+    push.connect(ep)
+    push.setsockopt(zmq.SNDTIMEO, 5000)
+    pull.setsockopt(zmq.RCVTIMEO, 5000)
+
+    payload = bytes(i & 0xFF for i in range(MSG_SIZE))
+    stop = False
+    sent = 0
+    recvd = 0
+
+    def sender():
+        nonlocal sent, stop
+        while not stop:
+            try:
+                push.send(payload)
+                sent += 1
+            except zmq.Again:
+                pass
+
+    def receiver():
+        nonlocal recvd, stop
+        while not stop:
+            try:
+                msg = pull.recv()
+                assert len(msg) == MSG_SIZE
+                recvd += 1
+            except zmq.Again:
+                pass
+
+    t_send = threading.Thread(target=sender, daemon=True)
+    t_recv = threading.Thread(target=receiver, daemon=True)
+    t_recv.start()
+    t_send.start()
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        time.sleep(1)
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            print(
+                f"[ipc_throughput] {elapsed:.0f}s, "
+                f"sent {sent}, recvd {recvd}, "
+                f"{recvd / elapsed:.0f} msg/s"
+            )
+            last_log = now
+
+    stop = True
+    t_send.join(timeout=5)
+    t_recv.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[ipc_throughput] done: sent {sent}, recvd {recvd} "
+        f"in {elapsed:.1f}s ({recvd / elapsed:.0f} msg/s)"
+    )
+
+    assert recvd > 0, "no messages received"
+
+    report = monitor.stop()
+    report.assert_no_leak("ipc_throughput")
+
+    push.close()
+    pull.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_multipart.py
+++ b/bindings/pyomq/tests/soak/test_multipart.py
@@ -1,0 +1,195 @@
+"""Soak: multipart message integrity.
+
+PUSH/PULL over TCP with multi-frame messages. Validates multipart
+atomicity (all frames delivered together or not at all), frame count,
+frame sizes, content integrity, and monotonic sequencing. Sender and
+receiver on separate threads.
+
+Also tests DEALER/ROUTER identity routing with multipart in a
+single-threaded request-reply loop (pyomq sockets are not safe for
+concurrent send+recv from different threads).
+"""
+
+import struct
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration, tcp_ep
+
+FRAME_B = 128
+NUM_FRAMES = 3
+
+
+def build_multipart(seq: int) -> list[bytes]:
+    header = struct.pack("<Q", seq)
+    body = bytes((seq + i) & 0xFF for i in range(FRAME_B))
+    trailer = struct.pack("<Q", seq ^ 0xFFFFFFFFFFFFFFFF)
+    return [header, body, trailer]
+
+
+def validate_multipart(parts: list[bytes], min_seq: int) -> int:
+    assert len(parts) == NUM_FRAMES, (
+        f"frame count mismatch: got {len(parts)}, expected {NUM_FRAMES}"
+    )
+
+    seq = struct.unpack("<Q", parts[0])[0]
+    assert seq >= min_seq, (
+        f"sequence went backwards: got {seq}, expected >= {min_seq}"
+    )
+
+    assert len(parts[1]) == FRAME_B, (
+        f"body frame size: got {len(parts[1])}, expected {FRAME_B}"
+    )
+    expected_body = bytes((seq + i) & 0xFF for i in range(FRAME_B))
+    assert parts[1] == expected_body, (
+        f"body corruption at seq {seq}"
+    )
+
+    expected_trailer = struct.pack("<Q", seq ^ 0xFFFFFFFFFFFFFFFF)
+    assert parts[2] == expected_trailer, (
+        f"trailer corruption at seq {seq}"
+    )
+
+    return seq
+
+
+def test_multipart_push_pull():
+    """Sustained multipart over PUSH/PULL TCP (separate threads)."""
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = tcp_ep()
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    pull.bind(ep)
+    push.connect(ep)
+    push.setsockopt(zmq.SNDTIMEO, 5000)
+    pull.setsockopt(zmq.RCVTIMEO, 5000)
+
+    stop = False
+    sent = 0
+    recvd = 0
+
+    def sender():
+        nonlocal sent, stop
+        seq = 0
+        while not stop:
+            try:
+                push.send_multipart(build_multipart(seq))
+                seq += 1
+                sent = seq
+            except zmq.Again:
+                pass
+
+    def receiver():
+        nonlocal recvd, stop
+        last_seq = 0
+        while not stop:
+            try:
+                parts = pull.recv_multipart()
+                last_seq = validate_multipart(parts, last_seq)
+                recvd += 1
+            except zmq.Again:
+                pass
+
+    t_send = threading.Thread(target=sender, daemon=True)
+    t_recv = threading.Thread(target=receiver, daemon=True)
+    t_recv.start()
+    t_send.start()
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        time.sleep(1)
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            print(
+                f"[multipart_push_pull] {elapsed:.0f}s, "
+                f"sent {sent}, recvd {recvd}, "
+                f"{recvd / elapsed:.0f} msg/s"
+            )
+            last_log = now
+
+    stop = True
+    t_send.join(timeout=5)
+    t_recv.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[multipart_push_pull] done: sent {sent}, recvd {recvd} "
+        f"in {elapsed:.1f}s ({recvd / elapsed:.0f} msg/s)"
+    )
+
+    assert recvd > 0, "no messages received"
+
+    report = monitor.stop()
+    report.assert_no_leak("multipart_push_pull")
+
+    push.close()
+    pull.close()
+    ctx.term()
+
+
+def test_multipart_dealer_router():
+    """DEALER/ROUTER identity routing with multipart (single-threaded loop)."""
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = tcp_ep()
+    ctx = zmq.Context()
+    router = ctx.socket(zmq.ROUTER)
+    dealer = ctx.socket(zmq.DEALER)
+    router.bind(ep)
+    dealer.setsockopt(zmq.IDENTITY, b"soak-client")
+    dealer.connect(ep)
+    dealer.setsockopt(zmq.SNDTIMEO, 5000)
+    dealer.setsockopt(zmq.RCVTIMEO, 5000)
+    router.setsockopt(zmq.RCVTIMEO, 5000)
+    router.setsockopt(zmq.SNDTIMEO, 5000)
+
+    time.sleep(0.1)
+
+    start = time.monotonic()
+    last_log = start
+    cycles = 0
+    last_seq = 0
+
+    while time.monotonic() - start < duration:
+        dealer.send_multipart(build_multipart(cycles))
+
+        parts = router.recv_multipart()
+        assert parts[0] == b"soak-client", f"identity mismatch: {parts[0]!r}"
+        router.send_multipart(parts)
+
+        reply = dealer.recv_multipart()
+        last_seq = validate_multipart(reply, last_seq)
+        cycles += 1
+
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            print(
+                f"[multipart_dealer_router] {elapsed:.0f}s, "
+                f"{cycles} cycles, {cycles / elapsed:.0f} rtt/s"
+            )
+            last_log = now
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[multipart_dealer_router] done: {cycles} cycles "
+        f"in {elapsed:.1f}s ({cycles / elapsed:.0f} rtt/s)"
+    )
+
+    assert cycles > 0, "no round-trips completed"
+
+    report = monitor.stop()
+    report.assert_no_leak("multipart_dealer_router")
+
+    dealer.close()
+    router.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_pair.py
+++ b/bindings/pyomq/tests/soak/test_pair.py
@@ -1,0 +1,104 @@
+"""Soak: PAIR socket bidirectional traffic.
+
+Both sides send and receive concurrently over a single PAIR connection.
+Validates that messages flow in both directions without loss or
+corruption. PAIR is exclusive (1:1), so this exercises the simplest
+connection topology under sustained bidirectional load.
+"""
+
+import struct
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration, tcp_ep
+
+
+def test_pair_bidirectional():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = tcp_ep()
+    ctx = zmq.Context()
+    a = ctx.socket(zmq.PAIR)
+    b = ctx.socket(zmq.PAIR)
+    a.setsockopt(zmq.SNDTIMEO, 1000)
+    a.setsockopt(zmq.RCVTIMEO, 1)
+    b.setsockopt(zmq.SNDTIMEO, 1000)
+    b.setsockopt(zmq.RCVTIMEO, 1)
+    a.bind(ep)
+    b.connect(ep)
+
+    time.sleep(0.1)
+
+    start = time.monotonic()
+    last_log = start
+    a_sent = 0
+    b_sent = 0
+    a_recvd = 0
+    b_recvd = 0
+
+    while time.monotonic() - start < duration:
+        # Send burst A -> B
+        for _ in range(100):
+            msg_a = struct.pack("<Q", a_sent) + b"A" * 32
+            try:
+                a.send(msg_a)
+                a_sent += 1
+            except zmq.Again:
+                break
+
+        # Send burst B -> A
+        for _ in range(100):
+            msg_b = struct.pack("<Q", b_sent) + b"B" * 32
+            try:
+                b.send(msg_b)
+                b_sent += 1
+            except zmq.Again:
+                break
+
+        # Drain B
+        try:
+            while True:
+                got = b.recv()
+                seq = struct.unpack("<Q", got[:8])[0]
+                assert got[8:] == b"A" * 32, f"B got corrupt data at seq {seq}"
+                b_recvd += 1
+        except zmq.Again:
+            pass
+
+        # Drain A
+        try:
+            while True:
+                got = a.recv()
+                seq = struct.unpack("<Q", got[:8])[0]
+                assert got[8:] == b"B" * 32, f"A got corrupt data at seq {seq}"
+                a_recvd += 1
+        except zmq.Again:
+            pass
+
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            print(
+                f"[pair] {elapsed:.0f}s, "
+                f"A->B: {a_sent}/{b_recvd}, B->A: {b_sent}/{a_recvd}"
+            )
+            last_log = now
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[pair] done in {elapsed:.1f}s: "
+        f"A->B: sent {a_sent} recvd {b_recvd}, "
+        f"B->A: sent {b_sent} recvd {a_recvd}"
+    )
+
+    assert b_recvd > 0, "B received nothing from A"
+    assert a_recvd > 0, "A received nothing from B"
+
+    report = monitor.stop()
+    report.assert_no_leak("pair")
+
+    a.close()
+    b.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_poller.py
+++ b/bindings/pyomq/tests/soak/test_poller.py
@@ -1,0 +1,123 @@
+"""Soak: Poller under sustained load with multiple sockets.
+
+Exercises the poll/select path with multiple PULL sockets receiving
+from independent PUSH senders. Validates that the poller correctly
+identifies ready sockets and that no messages are lost.
+"""
+
+import struct
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration, tcp_ep
+
+NUM_CHANNELS = 4
+
+
+def test_poller_multi_socket():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ctx = zmq.Context()
+    pulls = []
+    pushes = []
+    eps = []
+
+    for _ in range(NUM_CHANNELS):
+        pull = ctx.socket(zmq.PULL)
+        push = ctx.socket(zmq.PUSH)
+        ep = pull.bind(tcp_ep())
+        push.connect(ep)
+        push.setsockopt(zmq.SNDTIMEO, 2000)
+        pulls.append(pull)
+        pushes.append(push)
+        eps.append(ep)
+
+    time.sleep(0.1)
+
+    stop = False
+    sent_counts = [0] * NUM_CHANNELS
+    recv_counts = [0] * NUM_CHANNELS
+
+    def sender(idx):
+        nonlocal stop
+        seq = 0
+        while not stop:
+            msg = struct.pack("<QI", seq, idx) + b"P" * 48
+            try:
+                pushes[idx].send(msg)
+                seq += 1
+                sent_counts[idx] = seq
+            except zmq.Again:
+                pass
+
+    threads = []
+    for i in range(NUM_CHANNELS):
+        t = threading.Thread(target=sender, args=(i,), daemon=True)
+        t.start()
+        threads.append(t)
+
+    poller = zmq.Poller()
+    for pull in pulls:
+        poller.register(pull, zmq.POLLIN)
+
+    sock_to_idx = {id(pull): i for i, pull in enumerate(pulls)}
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        events = poller.poll(timeout=100)
+        for sock, _ in events:
+            ch_idx = sock_to_idx.get(id(sock))
+            if ch_idx is None:
+                continue
+            try:
+                msg = sock.recv(flags=zmq.NOBLOCK)
+                seq = struct.unpack("<QI", msg[:12])
+                assert seq[1] == ch_idx, (
+                    f"channel mismatch: got {seq[1]}, "
+                    f"expected {ch_idx}"
+                )
+                assert msg[12:] == b"P" * 48, (
+                    f"corruption on channel {ch_idx}"
+                )
+                recv_counts[ch_idx] += 1
+            except zmq.Again:
+                pass
+
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            total = sum(recv_counts)
+            print(
+                f"[poller] {elapsed:.0f}s, "
+                f"total recvd {total}, per-ch: {recv_counts}"
+            )
+            last_log = now
+
+    stop = True
+    for t in threads:
+        t.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    total = sum(recv_counts)
+    print(
+        f"[poller] done: total recvd {total} in {elapsed:.1f}s, "
+        f"per-ch: {recv_counts}"
+    )
+
+    for i, count in enumerate(recv_counts):
+        assert count > 0, f"channel {i} received nothing via poller"
+
+    report = monitor.stop()
+    report.assert_no_leak("poller")
+
+    for pull in pulls:
+        poller.unregister(pull)
+        pull.close()
+    for push in pushes:
+        push.close()
+    ctx.term()

--- a/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
+++ b/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
@@ -1,0 +1,123 @@
+"""Soak: sustained PUB/SUB throughput with topic filtering.
+
+One PUB, multiple SUBs with different prefix filters. Validates that
+subscribers only receive messages matching their subscription and that
+content is intact. Exercises the fan-out path and subscription matching.
+"""
+
+import struct
+import threading
+import time
+
+import pyomq as zmq
+
+from conftest import ResourceMonitor, soak_duration, tcp_ep
+
+NUM_SUBS = 4
+TOPICS = [b"A:", b"B:", b"C:", b"D:"]
+BODY_SIZE = 256
+
+
+def test_pub_sub_throughput():
+    duration = soak_duration()
+    monitor = ResourceMonitor()
+
+    ep = tcp_ep()
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.setsockopt(zmq.SNDHWM, 1000)
+    pub.bind(ep)
+
+    subs = []
+    for i in range(NUM_SUBS):
+        s = ctx.socket(zmq.SUB)
+        s.setsockopt(zmq.RCVTIMEO, 2000)
+        s.setsockopt(zmq.SUBSCRIBE, TOPICS[i])
+        s.connect(ep)
+        subs.append(s)
+
+    time.sleep(0.2)
+
+    stop = False
+    sent = 0
+    recv_counts = [0] * NUM_SUBS
+
+    def publisher():
+        nonlocal sent, stop
+        seq = 0
+        while not stop:
+            topic_idx = seq % NUM_SUBS
+            header = TOPICS[topic_idx] + struct.pack("<Q", seq)
+            body = bytes((seq + i) & 0xFF for i in range(BODY_SIZE))
+            try:
+                pub.send(header + body)
+                seq += 1
+                sent = seq
+            except zmq.Again:
+                pass
+
+    def subscriber(idx):
+        nonlocal stop
+        topic = TOPICS[idx]
+        while not stop:
+            try:
+                msg = subs[idx].recv()
+                assert msg[:2] == topic, (
+                    f"sub[{idx}] got wrong topic: {msg[:2]!r} != {topic!r}"
+                )
+                seq = struct.unpack("<Q", msg[2:10])[0]
+                expected_body = bytes((seq + i) & 0xFF for i in range(BODY_SIZE))
+                assert msg[10:] == expected_body, (
+                    f"sub[{idx}] body corruption at seq {seq}"
+                )
+                recv_counts[idx] += 1
+            except zmq.Again:
+                pass
+
+    t_pub = threading.Thread(target=publisher, daemon=True)
+    t_subs = [
+        threading.Thread(target=subscriber, args=(i,), daemon=True)
+        for i in range(NUM_SUBS)
+    ]
+    for t in t_subs:
+        t.start()
+    t_pub.start()
+
+    start = time.monotonic()
+    last_log = start
+
+    while time.monotonic() - start < duration:
+        time.sleep(1)
+        now = time.monotonic()
+        if now - last_log >= 30:
+            elapsed = now - start
+            total_recv = sum(recv_counts)
+            print(
+                f"[pub_sub_throughput] {elapsed:.0f}s, "
+                f"sent {sent}, recvd {total_recv}, "
+                f"per-sub: {[r for r in recv_counts]}"
+            )
+            last_log = now
+
+    stop = True
+    t_pub.join(timeout=5)
+    for t in t_subs:
+        t.join(timeout=5)
+
+    elapsed = time.monotonic() - start
+    total_recv = sum(recv_counts)
+    print(
+        f"[pub_sub_throughput] done: sent {sent}, total recvd {total_recv} "
+        f"in {elapsed:.1f}s, per-sub: {recv_counts}"
+    )
+
+    for i, count in enumerate(recv_counts):
+        assert count > 0, f"sub[{i}] received nothing"
+
+    report = monitor.stop()
+    report.assert_no_leak("pub_sub_throughput")
+
+    for s in subs:
+        s.close()
+    pub.close()
+    ctx.term()

--- a/omq-proto/src/proto/frame.rs
+++ b/omq-proto/src/proto/frame.rs
@@ -247,6 +247,11 @@ pub(crate) fn peek_frame_header(buf: &ChunkedInputBuf) -> Result<Option<PeekedFr
         let size = u64::from_be_bytes(hdr[1..].try_into().expect("8 bytes"));
         let payload_len = usize::try_from(size)
             .map_err(|_| Error::Protocol(format!("frame size {size} exceeds platform usize")))?;
+        if payload_len > isize::MAX as usize {
+            return Err(Error::Protocol(format!(
+                "frame size {payload_len} exceeds maximum allocation"
+            )));
+        }
         (MAX_FRAME_HEADER_LEN, payload_len)
     } else {
         let Some(hdr) = buf.peek_array::<2>() else {

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -42,7 +42,7 @@ rand = "0.10"
 rustc-hash = "2.1.0"
 smallvec = { version = "1", features = ["const_generics", "union"] }
 thiserror = "2.0.18"
-tokio = { version = "1.52.0", features = ["rt", "rt-multi-thread", "net", "io-util", "sync", "macros", "time"] }
+tokio = { version = "1.52.0", features = ["rt", "net", "io-util", "sync", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 socket2 = "0.6"
 libc = "0.2"
@@ -55,7 +55,7 @@ omq-compio = { version = "0.12.0", path = "../omq-compio", optional = true, defa
 compio = { version = "0.19.0", git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.52.0", features = ["test-util"] }
+tokio = { version = "1.52.0", features = ["test-util", "rt-multi-thread"] }
 rcgen = "0.14"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -430,16 +430,25 @@ fn rustc_version_runtime() -> String {
         .to_string()
 }
 
-/// Tokio multi-thread runtime sized to keep the bench process honest:
-/// one worker for the receiver(s), one per sender, plus a bit of
-/// headroom. Defaults to the count of available CPUs.
+/// Build the benchmark runtime. Defaults to multi-thread with one
+/// worker per available CPU. Set `OMQ_BENCH_RUNTIME=current_thread`
+/// to use the single-threaded current-thread runtime instead.
 pub(crate) fn build_runtime() -> tokio::runtime::Runtime {
-    let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(workers)
-        .enable_all()
-        .build()
-        .expect("bench: tokio runtime")
+    if std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "current_thread") {
+        println!("runtime: current_thread\n");
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("bench: tokio runtime")
+    } else {
+        let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
+        println!("runtime: multi_thread ({workers} workers)\n");
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(workers)
+            .enable_all()
+            .build()
+            .expect("bench: tokio runtime")
+    }
 }
 
 /// Thin wrapper around `tokio::time::timeout` to enforce the per-cell

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -58,9 +58,27 @@ extern "C" fn exit_on_signal(_sig: libc::c_int) {
     unsafe { libc::_exit(0) };
 }
 
-#[tokio::main]
+fn main() {
+    let rt = if std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "current_thread") {
+        eprintln!("runtime: current_thread");
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+    } else {
+        let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
+        eprintln!("runtime: multi_thread ({workers} workers)");
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(workers)
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+    };
+    rt.block_on(async_main());
+}
+
 #[expect(clippy::too_many_lines)]
-async fn main() {
+async fn async_main() {
     unsafe {
         libc::signal(
             libc::SIGTERM,

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -557,6 +557,19 @@ where
                 slot.handshake_done.store(true, Ordering::Release);
             }
 
+            if let Some(ref slot) = wire_slot
+                && slot.handshake_done.load(Ordering::Acquire)
+                && slot.pending.load(Ordering::Acquire)
+            {
+                drain_buf.clear();
+                slot.drain_into_vec(&mut drain_buf, 1024);
+                if !drain_buf.is_empty() {
+                    eq.push_shared_chunks(&drain_buf);
+                    drain_buf.clear();
+                    slot.space_available.notify_one();
+                }
+            }
+
             let want_write = codec.has_pending_transmit() || !eq.is_empty();
             let hb_enabled = hb_interval.is_some() && codec.is_ready();
 

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1046,6 +1046,7 @@ where
         if drain_buf.is_empty() {
             return Ok(());
         }
+        let total: usize = drain_buf.iter().map(Bytes::len).sum();
         let iovecs: SmallVec<[io::IoSlice<'_>; 64]> =
             drain_buf.iter().map(|b| io::IoSlice::new(b)).collect();
         let n = writer.write_vectored(&iovecs).await?;
@@ -1053,7 +1054,6 @@ where
         if n == 0 {
             return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
         }
-        let total: usize = drain_buf.iter().map(Bytes::len).sum();
         if n < total {
             let drained = std::mem::take(drain_buf);
             eq.put_back_unwritten(drained, n);
@@ -1065,7 +1065,8 @@ async fn write_chunks<W>(writer: &mut W, chunks: &mut Vec<Bytes>) -> io::Result<
 where
     W: AsyncWrite + Unpin,
 {
-    while !chunks.is_empty() {
+    let mut remaining: usize = chunks.iter().map(Bytes::len).sum();
+    while remaining > 0 {
         let iovecs: SmallVec<[io::IoSlice<'_>; 64]> =
             chunks.iter().map(|b| io::IoSlice::new(b)).collect();
         let n = writer.write_vectored(&iovecs).await?;
@@ -1073,8 +1074,8 @@ where
         if n == 0 {
             return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
         }
-        let total: usize = chunks.iter().map(Bytes::len).sum();
-        if n >= total {
+        remaining -= n;
+        if remaining == 0 {
             chunks.clear();
         } else {
             let mut skip = n;

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -557,19 +557,6 @@ where
                 slot.handshake_done.store(true, Ordering::Release);
             }
 
-            if let Some(ref slot) = wire_slot
-                && slot.handshake_done.load(Ordering::Acquire)
-                && slot.pending.load(Ordering::Acquire)
-            {
-                drain_buf.clear();
-                slot.drain_into_vec(&mut drain_buf, 1024);
-                if !drain_buf.is_empty() {
-                    eq.push_shared_chunks(&drain_buf);
-                    drain_buf.clear();
-                    slot.space_available.notify_one();
-                }
-            }
-
             let want_write = codec.has_pending_transmit() || !eq.is_empty();
             let hb_enabled = hb_interval.is_some() && codec.is_ready();
 

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -26,7 +26,7 @@ pub(crate) struct PeerWireSlot {
     pub(crate) space_available: Notify,
     pub(crate) driver_in_select: AtomicBool,
     pub(crate) handshake_done: AtomicBool,
-    pending: AtomicBool,
+    pub(crate) pending: AtomicBool,
     #[allow(dead_code)]
     pub(crate) has_transform: bool,
     #[allow(dead_code)]
@@ -136,7 +136,9 @@ impl PeerWireSlot {
     }
 
     fn signal_encoded(&self) {
-        if !self.pending.swap(true, Ordering::Release) {
+        if !self.pending.swap(true, Ordering::Release)
+            && self.driver_in_select.load(Ordering::Acquire)
+        {
             self.data_ready.notify_one();
         }
     }

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -26,7 +26,7 @@ pub(crate) struct PeerWireSlot {
     pub(crate) space_available: Notify,
     pub(crate) driver_in_select: AtomicBool,
     pub(crate) handshake_done: AtomicBool,
-    pub(crate) pending: AtomicBool,
+    pending: AtomicBool,
     #[allow(dead_code)]
     pub(crate) has_transform: bool,
     #[allow(dead_code)]
@@ -136,9 +136,7 @@ impl PeerWireSlot {
     }
 
     fn signal_encoded(&self) {
-        if !self.pending.swap(true, Ordering::Release)
-            && self.driver_in_select.load(Ordering::Acquire)
-        {
+        if !self.pending.swap(true, Ordering::Release) {
             self.data_ready.notify_one();
         }
     }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -5,7 +5,7 @@
 //! (via `pre_encode`), then the pre-encoded chunks are pushed into
 //! each matching peer's `EncodedQueue`. The driver flushes to the wire.
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -38,18 +38,28 @@ const YIELD_INTERVAL: u32 = 256;
 #[derive(Debug)]
 pub(crate) struct Submitter {
     inner: Arc<Mutex<FanOutInner>>,
+    generation: Arc<AtomicU64>,
     mode: FanOutMode,
     send_count: Arc<AtomicU32>,
     xpub_nodrop: bool,
+    cached: Mutex<CachedFanOut>,
+}
+
+#[derive(Debug, Default)]
+struct CachedFanOut {
+    generation: u64,
+    sole_wire: Option<PeerSend>,
 }
 
 impl Clone for Submitter {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
+            generation: self.generation.clone(),
             mode: self.mode,
             send_count: self.send_count.clone(),
             xpub_nodrop: self.xpub_nodrop,
+            cached: Mutex::new(CachedFanOut::default()),
         }
     }
 }
@@ -78,6 +88,23 @@ impl Submitter {
         }
     }
 
+    fn try_sole_wire(&self, msg: &Message) -> Option<crate::engine::wire_slot::TryEncodeResult> {
+        let current = self.generation.load(Ordering::Acquire);
+        let mut cached = self.cached.lock().unwrap();
+        if cached.generation != current {
+            let g = self.inner.lock().expect("fanout inner poisoned");
+            cached.sole_wire =
+                if g.all_subscribe_all && g.all_targets.len() == 1 && g.fan_out_encoder.is_none() {
+                    Some(g.all_targets[0].clone())
+                } else {
+                    None
+                };
+            cached.generation = current;
+        }
+        let target = cached.sole_wire.as_ref()?;
+        Some(target.try_encode(msg))
+    }
+
     pub(crate) fn try_send(
         &self,
         msg: Message,
@@ -85,6 +112,19 @@ impl Submitter {
         let (forwarded, group) = self
             .prepare(msg)
             .map_err(omq_proto::error::TrySendError::Error)?;
+
+        if group.is_none()
+            && let Some(r) = self.try_sole_wire(&forwarded)
+        {
+            return match r {
+                crate::engine::wire_slot::TryEncodeResult::Ok
+                | crate::engine::wire_slot::TryEncodeResult::Dead
+                | crate::engine::wire_slot::TryEncodeResult::Ineligible => Ok(()),
+                crate::engine::wire_slot::TryEncodeResult::Full => {
+                    Err(omq_proto::error::TrySendError::Full(forwarded))
+                }
+            };
+        }
 
         let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop && !targets_have_space(&targets) {
@@ -96,6 +136,14 @@ impl Submitter {
 
     pub(crate) async fn send(&self, msg: Message) -> Result<()> {
         let (forwarded, group) = self.prepare(msg)?;
+
+        if group.is_none()
+            && self
+                .try_sole_wire(&forwarded)
+                .is_some_and(|r| r == crate::engine::wire_slot::TryEncodeResult::Ok)
+        {
+            return Ok(());
+        }
 
         let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop {
@@ -141,6 +189,7 @@ impl Submitter {
 #[derive(Debug)]
 pub(crate) struct FanOutSend {
     inner: Arc<Mutex<FanOutInner>>,
+    generation: Arc<AtomicU64>,
     mode: FanOutMode,
     xpub_nodrop: bool,
 }
@@ -217,17 +266,24 @@ impl FanOutSend {
                 fan_out_encoder: None,
                 options: options.clone(),
             })),
+            generation: Arc::new(AtomicU64::new(0)),
             mode,
             xpub_nodrop: options.xpub_nodrop,
         }
     }
 
+    fn bump_generation(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
     pub(crate) fn submitter(&self) -> Submitter {
         Submitter {
             inner: self.inner.clone(),
+            generation: self.generation.clone(),
             mode: self.mode,
             send_count: Arc::new(AtomicU32::new(0)),
             xpub_nodrop: self.xpub_nodrop,
+            cached: Mutex::new(CachedFanOut::default()),
         }
     }
 
@@ -257,12 +313,15 @@ impl FanOutSend {
             g.init_fan_out_encoder();
         }
         g.recompute_subscribe_all();
+        self.bump_generation();
     }
 
     pub(crate) fn connection_removed(&mut self, peer_id: u64) {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if g.peers.remove(&peer_id).is_some() {
             g.recompute_subscribe_all();
+            drop(g);
+            self.bump_generation();
         }
     }
 
@@ -272,6 +331,8 @@ impl FanOutSend {
         if let Some(p) = g.peers.get_mut(&peer_id) {
             p.subscriptions.add(&prefix);
             g.recompute_subscribe_all();
+            drop(g);
+            self.bump_generation();
         }
     }
 
@@ -280,6 +341,8 @@ impl FanOutSend {
         if let Some(p) = g.peers.get_mut(&peer_id) {
             p.subscriptions.remove(prefix);
             g.recompute_subscribe_all();
+            drop(g);
+            self.bump_generation();
         }
     }
 
@@ -289,6 +352,8 @@ impl FanOutSend {
             && let Ok(s) = std::str::from_utf8(group)
         {
             p.groups.insert(s.to_string());
+            drop(g);
+            self.bump_generation();
         }
     }
 
@@ -298,6 +363,8 @@ impl FanOutSend {
             && let Ok(s) = std::str::from_utf8(group)
         {
             p.groups.remove(s);
+            drop(g);
+            self.bump_generation();
         }
     }
 

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -514,6 +514,9 @@ impl SocketDriver {
         // Per-peer SPSC: always add to consumers Vec (recv side).
         if let Some(ref s) = spsc {
             self.spsc.consumers.write().unwrap().push(s.clone());
+            self.spsc
+                .consumer_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Release);
             if can_bypass_actor_recv(self.socket_type) {
                 s.recv_ready
                     .store(true, std::sync::atomic::Ordering::Release);

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -116,13 +116,15 @@ impl SpscAwareRecv {
             }
 
             if self.consumers.read().unwrap().is_empty() {
+                let activated = self.activated.notified();
+                tokio::pin!(activated);
+                activated.as_mut().enable();
                 tokio::select! {
                     biased;
                     res = self.rx.recv() => {
                         return res.map_err(|_| Error::Closed);
                     }
-                    () = self.activated.notified() => continue,
-                    () = tokio::time::sleep(std::time::Duration::from_millis(10)) => continue,
+                    () = activated => continue,
                 }
             } else {
                 let notified = self.recv_notify.notified();

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -1,6 +1,6 @@
 //! Public `Socket` handle.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::channel::oneshot;
@@ -45,9 +45,14 @@ pub(crate) type SpscActivated = Arc<tokio::sync::Notify>;
 /// Grouped handles for per-peer SPSC inproc fast path. Shared between
 /// the socket handle (recv side) and the actor (send-ring management,
 /// consumer registration).
+/// Bumped by the actor whenever the consumers Vec changes. Lets
+/// `SpscAwareRecv` skip re-cloning the Vec when nothing changed.
+pub(crate) type SpscConsumerGeneration = Arc<AtomicU64>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct SpscHandles {
     pub consumers: SpscConsumers,
+    pub consumer_generation: SpscConsumerGeneration,
     pub send_ring: SpscSendRing,
     pub send_ring_active: SpscSendRingActive,
     pub recv_notify: SpscRecvNotify,
@@ -61,6 +66,8 @@ struct SpscAwareRecv {
     rx: async_channel::Receiver<Message>,
     /// Per-peer SPSC rings (one per eligible inproc peer). Actor appends.
     consumers: Arc<std::sync::RwLock<Vec<Arc<InprocSpsc>>>>,
+    /// Generation counter. Bumped by the actor on consumer add/remove.
+    consumer_generation: SpscConsumerGeneration,
     /// Shared recv notification. All drivers/senders notify this.
     recv_notify: Arc<tokio::sync::Notify>,
     /// Notified when consumers Vec changes (new peer added).
@@ -71,6 +78,8 @@ struct SpscAwareRecv {
     send_ring_active: Arc<AtomicBool>,
     /// Batched inproc messages drained from consumers.
     inproc_cache: std::sync::Mutex<std::collections::VecDeque<Message>>,
+    /// Cached clone of the consumers Vec, refreshed when generation changes.
+    cached_consumers: Mutex<(u64, Vec<Arc<InprocSpsc>>)>,
 }
 
 impl SpscAwareRecv {
@@ -81,7 +90,14 @@ impl SpscAwareRecv {
                 return Some(msg);
             }
         }
-        let consumers = self.consumers.read().unwrap().clone();
+        let current_gen = self.consumer_generation.load(Ordering::Acquire);
+        let mut cached = self.cached_consumers.lock().unwrap();
+        if cached.0 != current_gen {
+            cached.1.clone_from(&self.consumers.read().unwrap());
+            cached.0 = current_gen;
+        }
+        let consumers = cached.1.clone();
+        drop(cached);
         let mut cache = self.inproc_cache.lock().unwrap();
         let mut has_disconnected = false;
         for p in &consumers {
@@ -104,6 +120,8 @@ impl SpscAwareRecv {
                 .write()
                 .unwrap()
                 .retain(|p| p.consumer.try_lock().map_or(true, |c| !c.is_disconnected()));
+            self.consumer_generation.fetch_add(1, Ordering::Release);
+            self.cached_consumers.lock().unwrap().0 = u64::MAX;
         }
         result
     }
@@ -244,6 +262,7 @@ impl Socket {
         let send_submitter = send_strategy.submitter();
         let spsc = SpscHandles {
             consumers: Arc::new(RwLock::new(Vec::new())),
+            consumer_generation: Arc::new(AtomicU64::new(0)),
             send_ring: Arc::new(RwLock::new(None)),
             send_ring_active: Arc::new(AtomicBool::new(false)),
             recv_notify: Arc::new(tokio::sync::Notify::new()),
@@ -274,11 +293,13 @@ impl Socket {
                 recv_rx: SpscAwareRecv {
                     rx: recv_rx,
                     consumers: spsc.consumers,
+                    consumer_generation: spsc.consumer_generation,
                     recv_notify: spsc.recv_notify,
                     activated: spsc.activated,
                     send_ring: spsc.send_ring,
                     send_ring_active: spsc.send_ring_active,
                     inproc_cache: std::sync::Mutex::new(std::collections::VecDeque::new()),
+                    cached_consumers: Mutex::new((u64::MAX, Vec::new())),
                 },
                 monitor,
                 root_cancel: cancel,

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -708,29 +708,23 @@ impl Socket {
     }
 
     async fn send_via_wire_slot(&self, msg: Message) -> Result<()> {
-        let fast = {
-            let guard = self.inner.wire_slot.lock().expect("wire_slot");
-            match guard.as_ref() {
-                Some(slot) => slot.try_encode(&msg),
-                None => TryEncodeResult::Ineligible,
-            }
+        let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
+        let Some(ref slot) = slot else {
+            return self.inner.send_submitter.send(msg).await;
         };
-        match fast {
+        match slot.try_encode(&msg) {
             TryEncodeResult::Ok => Ok(()),
             TryEncodeResult::Full => {
-                let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
-                if let Some(ref slot) = slot {
-                    loop {
-                        match slot.try_encode(&msg) {
-                            TryEncodeResult::Ok => return Ok(()),
-                            TryEncodeResult::Dead | TryEncodeResult::Ineligible => break,
-                            TryEncodeResult::Full => {
-                                let notified = slot.space_available.notified();
-                                if slot.try_encode(&msg) == TryEncodeResult::Ok {
-                                    return Ok(());
-                                }
-                                notified.await;
+                loop {
+                    match slot.try_encode(&msg) {
+                        TryEncodeResult::Ok => return Ok(()),
+                        TryEncodeResult::Dead | TryEncodeResult::Ineligible => break,
+                        TryEncodeResult::Full => {
+                            let notified = slot.space_available.notified();
+                            if slot.try_encode(&msg) == TryEncodeResult::Ok {
+                                return Ok(());
                             }
+                            notified.await;
                         }
                     }
                 }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -743,15 +743,6 @@ impl Socket {
     }
 
     async fn send_identity_routed(&self, msg: Message) -> Result<()> {
-        let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
-        if let Some(ref slot) = slot {
-            let mut stripped = msg.clone();
-            stripped.pop_front();
-            match slot.try_encode(&stripped) {
-                TryEncodeResult::Ok => return Ok(()),
-                TryEncodeResult::Dead | TryEncodeResult::Full | TryEncodeResult::Ineligible => {}
-            }
-        }
         self.inner.send_submitter.send(msg).await
     }
 

--- a/omq-tokio/tests/soak_large_throughput.rs
+++ b/omq-tokio/tests/soak_large_throughput.rs
@@ -12,6 +12,47 @@ use std::time::{Duration, Instant};
 use omq_tokio::{Message, Options, Socket, SocketType};
 
 const MSG_SIZE: usize = 1024 * 1024;
+const CANARY_MAGIC: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+fn build_payload(seq: u64) -> Vec<u8> {
+    let mut buf = vec![0u8; MSG_SIZE];
+    buf[..8].copy_from_slice(&CANARY_MAGIC.to_le_bytes());
+    buf[8..16].copy_from_slice(&seq.to_le_bytes());
+    for (i, slot) in buf.iter_mut().enumerate().skip(16) {
+        *slot = (i & 0xFF) as u8;
+    }
+    buf
+}
+
+fn validate_payload(data: &[u8], expected_min_seq: u64) -> u64 {
+    assert_eq!(data.len(), MSG_SIZE, "payload size mismatch");
+
+    let magic = u64::from_le_bytes(data[..8].try_into().unwrap());
+    let seq = u64::from_le_bytes(data[8..16].try_into().unwrap());
+
+    assert_eq!(
+        magic,
+        CANARY_MAGIC,
+        "CANARY CORRUPT: magic=0x{magic:016x}, seq={seq}, first 32 bytes: {:02x?}\n\
+         Receiver lost ZMTP frame sync: payload bytes parsed as frame headers.",
+        &data[..32]
+    );
+
+    assert!(
+        seq >= expected_min_seq,
+        "sequence went backwards: got {seq}, expected >= {expected_min_seq} \
+         (message reordering or duplication)"
+    );
+
+    for (i, &byte) in data.iter().enumerate().skip(16) {
+        assert_eq!(
+            byte,
+            (i & 0xFF) as u8,
+            "payload byte corruption at offset {i}: seq={seq}",
+        );
+    }
+    seq
+}
 
 #[test]
 fn soak_large_message_throughput() {
@@ -31,20 +72,21 @@ fn soak_large_message_throughput() {
         push.connect(ep).await.unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let payload: Vec<u8> = (0..MSG_SIZE).map(|i| (i & 0xFF) as u8).collect();
-
         let send_sent = sent.clone();
         let send_stop = stop.clone();
         let push_clone = push.clone();
         let send_task = tokio::spawn(async move {
+            let mut seq = 0u64;
             while !send_stop.load(Ordering::Relaxed) {
+                let payload = build_payload(seq);
                 if let Ok(Ok(())) = tokio::time::timeout(
                     Duration::from_secs(2),
-                    push_clone.send(Message::single(payload.clone())),
+                    push_clone.send(Message::single(payload)),
                 )
                 .await
                 {
-                    send_sent.fetch_add(1, Ordering::Relaxed);
+                    seq += 1;
+                    send_sent.store(seq, Ordering::Relaxed);
                 }
             }
         });
@@ -53,15 +95,13 @@ fn soak_large_message_throughput() {
         let recv_stop = stop.clone();
         let pull_clone = pull.clone();
         let recv_task = tokio::spawn(async move {
+            let mut last_seq = 0u64;
             while !recv_stop.load(Ordering::Relaxed) {
                 if let Ok(Ok(m)) =
                     tokio::time::timeout(Duration::from_secs(2), pull_clone.recv()).await
                 {
-                    assert_eq!(
-                        m.part_bytes(0).unwrap().len(),
-                        MSG_SIZE,
-                        "payload size mismatch"
-                    );
+                    let data = m.part_bytes(0).unwrap();
+                    last_seq = validate_payload(&data, last_seq);
                     recv_recvd.fetch_add(1, Ordering::Relaxed);
                 }
             }


### PR DESCRIPTION
**omq-tokio send/recv path optimizations:**
- Compute write total before `write_vectored`, not after
- Remove dead `wire_slot` attempt in `send_identity_routed`
- Clone `wire_slot` Arc once instead of locking twice
- Remove 10ms polling loop in recv no-consumers path
- Cache consumers `Vec` with generation counter
- Pre-drain `wire_slot` before select, gate signal on `driver_in_select`
- Cached single-peer fast path for `FanOut` send

**omq-proto:**
- Reject frame sizes exceeding `isize::MAX`

**omq-tokio misc:**
- Add canary validation to `soak_large_throughput`
- Drop `rt-multi-thread` from required tokio features

**pyomq:**
- Per-context tokio runtime (each `Context` owns its own runtime + background thread)
- Add soak tests for inproc, multipart, IPC, PAIR, fan-out, PUB/SUB, poller, and `io_threads`
- Extract `PeerInfo` pyclass to fix `--features blake3zmq` compilation without `curve`
- Fix missing `park_end()` in `Socket::send_message` slow path on close
- Fix stale doc comment referencing "compio thread"