### PR TITLE
omq-compio: fix inproc deadlock, bump compio to 0.19.1

### DIFF
--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -41,7 +41,7 @@ flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"
 concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-compio = { git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync", "async-fd"] }
+compio = { version = "0.19.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync", "async-fd"] }
 slab = "0.4"
 event-listener = "5.4.0"
 async-lock = "3.4.0"
@@ -52,7 +52,7 @@ rustls = { version = "0.23", optional = true, default-features = false, features
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pemfile = { version = "2.2", optional = true }
 rustls-pki-types = { version = "1.14", optional = true }
-compio-tls = { git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, default-features = false, features = ["rustls"] }
+compio-tls = { version = "0.10", optional = true, default-features = false, features = ["rustls"] }
 
 
 [dev-dependencies]

--- a/omq-compio/src/bin/bench_peer_compio.rs
+++ b/omq-compio/src/bin/bench_peer_compio.rs
@@ -322,12 +322,6 @@ fn bench_b3_client_keypair() -> omq_compio::Blake3ZmqKeypair {
     omq_compio::Blake3ZmqKeypair::from_secret(omq_compio::Blake3ZmqSecretKey([0x04; 32]))
 }
 
-// FIXME: uses channel signaling instead of a Barrier because compio's
-// single-threaded runtime intermittently loses cross-thread wakeups
-// (flume send → Waker::wake → eventfd write not picked up by
-// io_uring_enter). Reproduces ~25% of the time with the old Barrier
-// approach. Root cause is upstream in compio's driver; not yet isolated
-// into a minimal repro outside omq.
 async fn run_inproc(name: String, size: usize, duration: Duration) {
     use std::sync::{
         Arc,
@@ -393,6 +387,7 @@ async fn run_pull(ep: Endpoint, size: usize, duration: Duration) {
 
     compio::time::sleep(Duration::from_millis(500)).await;
 
+    let cpu_before = cpu_time_secs();
     let t0 = Instant::now();
     let deadline = t0 + duration;
     let mut count: u64 = 0;
@@ -407,7 +402,8 @@ async fn run_pull(ep: Endpoint, size: usize, duration: Duration) {
         }
     }
     let elapsed = t0.elapsed().as_secs_f64();
-    println!("{count} {elapsed:.6} {size}");
+    let cpu = cpu_time_secs() - cpu_before;
+    println!("{count} {elapsed:.6} {size} {cpu:.6}");
     eprint_pull_summary(&ep, count, elapsed, size);
 }
 
@@ -482,6 +478,8 @@ async fn run_req(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
         req.recv().await.unwrap();
     }
 
+    let t_wall = Instant::now();
+    let cpu_before = cpu_time_secs();
     let mut rtts = Vec::with_capacity(iterations);
     for _ in 0..iterations {
         let t0 = Instant::now();
@@ -489,13 +487,15 @@ async fn run_req(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
         req.recv().await.unwrap();
         rtts.push(t0.elapsed().as_nanos() as u64);
     }
+    let cpu = cpu_time_secs() - cpu_before;
+    let elapsed = t_wall.elapsed().as_secs_f64();
 
     rtts.sort_unstable();
     let p50 = percentile(&rtts, 50.0);
     let p99 = percentile(&rtts, 99.0);
     let p999 = percentile(&rtts, 99.9);
     let max = percentile(&rtts, 100.0);
-    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations}");
+    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations} {cpu:.6} {elapsed:.6}");
 }
 
 fn percentile(sorted: &[u64], p: f64) -> f64 {
@@ -750,6 +750,18 @@ async fn run_inproc_pubsub(name: String, size: usize, duration: Duration, peers:
     let elapsed = t0.elapsed().as_secs_f64();
     println!("{count} {elapsed:.6} {size}");
     std::process::exit(0);
+}
+
+#[expect(clippy::cast_precision_loss)]
+fn cpu_time_secs() -> f64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    unsafe {
+        libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr());
+        let usage = usage.assume_init();
+        let user = usage.ru_utime.tv_sec as f64 + usage.ru_utime.tv_usec as f64 / 1e6;
+        let sys = usage.ru_stime.tv_sec as f64 + usage.ru_stime.tv_usec as f64 / 1e6;
+        user + sys
+    }
 }
 
 async fn run_inproc_same_thread(name: String, size: usize, duration: Duration) {

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -554,6 +554,7 @@ impl Socket {
                         cache.push_back(msg);
                     }
                     c.release();
+                    recv_state.space_events[idx].notify(usize::MAX);
                 }
                 if !cache.is_empty() {
                     recv_state.fq_index = idx + 1;

--- a/omq-compio/tests/inproc_mt.rs
+++ b/omq-compio/tests/inproc_mt.rs
@@ -153,6 +153,67 @@ fn spsc_preserves_ordering() {
     pull_thread.join().unwrap();
 }
 
+/// Regression: try_recv() must notify space_events after releasing
+/// yring slots, otherwise the producer blocks on a full ring forever.
+///
+/// The yring has capacity 1024. We let the push fill it, then the
+/// pull uses recv()+try_recv() to drain. try_recv() must notify the
+/// producer's space_event, otherwise the producer stays blocked on
+/// the full ring and the next recv() deadlocks.
+#[test]
+fn try_recv_notifies_space_event() {
+    const N: usize = 50_000;
+    let ep = inproc_ep("try-recv-space");
+    let count = Arc::new(AtomicUsize::new(0));
+    let (bound_tx, bound_rx) = flume::bounded::<()>(1);
+    let (connected_tx, connected_rx) = flume::bounded::<()>(1);
+
+    let pull_count = count.clone();
+    let pull_ep = ep.clone();
+    let pull_thread = std::thread::spawn(move || {
+        let rt = compio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let pull = Socket::new(SocketType::Pull, Options::default());
+            pull.bind(pull_ep).await.unwrap();
+            let _ = bound_tx.send(());
+            let _ = connected_rx.recv_async().await;
+            compio::time::sleep(Duration::from_millis(100)).await;
+
+            let mut got = 0;
+            while got < N {
+                let r = compio::time::timeout(Duration::from_secs(5), pull.recv()).await;
+                r.expect("recv timed out (deadlock: producer stuck on full ring)")
+                    .unwrap();
+                got += 1;
+                while got < N {
+                    match pull.try_recv() {
+                        Ok(_) => got += 1,
+                        Err(_) => break,
+                    }
+                }
+            }
+            pull_count.store(got, Ordering::Relaxed);
+        });
+    });
+
+    let push_thread = std::thread::spawn(move || {
+        let rt = compio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let _ = bound_rx.recv_async().await;
+            let push = Socket::new(SocketType::Push, Options::default());
+            push.connect(ep).await.unwrap();
+            let _ = connected_tx.send(());
+            for _ in 0..N {
+                push.send(Message::single(b"x" as &[u8])).await.unwrap();
+            }
+        });
+    });
+
+    push_thread.join().unwrap();
+    pull_thread.join().unwrap();
+    assert_eq!(count.load(Ordering::Relaxed), N);
+}
+
 /// Multi-PUSH cross-thread to one PULL.
 #[test]
 fn multi_push_cross_thread() {

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -27,6 +27,7 @@ ws = ["omq-proto/ws", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfi
 # Enables the fuzz test suites (`tests/fuzz_*.rs`). Off by default -
 # those targets do ~1 M iterations each and dominate runtime of
 # `cargo test`. Run with `cargo test --features fuzz`.
+rt-multi-thread = ["tokio/rt-multi-thread"]
 fuzz = []
 soak = []
 compio-interop = ["dep:omq-compio", "dep:compio"]
@@ -52,7 +53,7 @@ rustls-pemfile = { version = "2.2", optional = true }
 rustls-pki-types = { version = "1.14", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 omq-compio = { version = "0.12.0", path = "../omq-compio", optional = true, default-features = false, features = ["ws"] }
-compio = { version = "0.19.0", git = "https://github.com/compio-rs/compio.git", rev = "cf746eb8", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
+compio = { version = "0.19.1", optional = true, features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.52.0", features = ["test-util", "rt-multi-thread"] }


### PR DESCRIPTION
- `Socket::try_recv()` called `Consumer::release()` after draining the yring but did not call `space_events[idx].notify()`, deadlocking push+pull when the ring filled up (~30% repro rate in the inproc bench)
- Add regression test in `inproc_mt.rs` (`try_recv_notifies_space_event`)
- Remove stale FIXME that blamed compio's driver
- Bump compio dep from git rev pin (0.19.0 @ 594ea2e) to crates.io 0.19.1 (includes compio-rs/compio#949 Remote::schedule fix)