### PR TITLE
Bench infra fixes and ENOBUFS crash fix

### DIFF
--- a/bindings/pyomq/CLAUDE.md
+++ b/bindings/pyomq/CLAUDE.md
@@ -33,6 +33,14 @@ workspace root lock file.
 
 ## Benchmarks
 
+**Always set `OMQ_HW_EXTRAS` before running.** It appends to the chart
+subtitle alongside any auto-detected governor/turbo info. On the bench
+machine (i7-8700B, performance governor, turbo off):
+
+```sh
+export OMQ_HW_EXTRAS="performance governor,turbo off"
+```
+
 ```sh
 maturin develop --release
 python scripts/update_perf.py                # full (pyomq + pyzmq)
@@ -43,12 +51,12 @@ python scripts/update_perf.py --chart-only   # regenerate SVG from JSONL
 Results in `~/.cache/omq/bindings.jsonl` (latest `run_id` per impl wins).
 Regenerates `doc/charts/bindings.svg` and the proxy table in `README.md`.
 
-The proxy PUSH/PULL benchmark uses a native omq-compio client
+The proxy PUSH/PULL benchmark uses a native omq-tokio client
 (`bench_proxy_client`) to saturate the proxy without Python
 sender/receiver overhead. Build it before running benchmarks:
 
 ```sh
-cargo build --release -p omq-compio --bin bench_proxy_client
+cargo build --release -p omq-tokio --bin bench_proxy_client
 ```
 
 If the binary is missing, the proxy PUSH/PULL bench falls back to

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -74,8 +74,8 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.24 M/s |  1.63 M/s | **1.37×** |
-| REQ/REP rt/s       |   6,647/s |   4,424/s | **1.50×** |
+| PUSH/PULL msg/s    |  2.23 M/s |  1.63 M/s | **1.37×** |
+| REQ/REP rt/s       |   7,062/s |   4,424/s | **1.60×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -43,38 +43,38 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,131.8 145.8,128.5 201.7,134.7 257.5,132.4 313.3,129.6 369.2,132.4 425.0,134.3 480.8,174.1 536.7,223.6 592.5,284.7 648.3,336.0 704.2,350.6 760.0,371.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,273.1 145.8,266.6 201.7,273.0 257.5,276.7 313.3,278.1 369.2,280.6 425.0,283.9 480.8,292.4 536.7,302.1 592.5,324.4 648.3,343.0 704.2,358.1 760.0,372.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,150.7 145.8,149.7 201.7,150.2 257.5,148.9 313.3,152.8 369.2,154.0 425.0,152.3 480.8,169.5 536.7,244.6 592.5,311.5 648.3,343.9 704.2,357.5 760.0,373.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,273.7 145.8,273.4 201.7,271.0 257.5,277.1 313.3,277.7 369.2,280.1 425.0,284.4 480.8,292.7 536.7,302.7 592.5,318.2 648.3,345.7 704.2,360.6 760.0,373.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,227.6 145.8,229.3 201.7,229.2 257.5,245.6 313.3,273.6 369.2,285.9 425.0,284.7 480.8,307.1 536.7,329.1 592.5,351.6 648.3,366.8 704.2,374.8 760.0,376.4" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,376.9 145.8,377.1 201.7,376.9 257.5,377.3 313.3,377.0 369.2,377.1 425.0,377.2 480.8,377.1 536.7,377.2 592.5,377.6 648.3,377.6 704.2,378.0 760.0,378.5" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,383.2 145.8,382.3 201.7,380.7 257.5,377.3 313.3,370.4 369.2,357.2 425.0,330.7 480.8,294.5 536.7,247.1 592.5,214.6 648.3,220.1 704.2,156.1 760.0,210.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,383.2 145.8,382.4 201.7,380.9 257.5,377.7 313.3,371.7 369.2,359.5 425.0,334.6 480.8,292.5 536.7,265.0 592.5,260.3 648.3,247.1 704.2,203.4 760.0,239.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="380.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="377.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="370.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="357.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="330.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="294.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="247.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="214.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="220.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="156.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="210.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.6 145.8,383.2 201.7,382.5 257.5,381.1 313.3,378.4 369.2,373.0 425.0,362.6 480.8,344.9 536.7,314.1 592.5,282.2 648.3,244.0 704.2,206.9 760.0,230.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="145.8" cy="382.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="380.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="377.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="371.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="359.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="334.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="292.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="265.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="260.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="247.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="203.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="239.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.6 145.8,383.3 201.7,382.5 257.5,381.1 313.3,378.3 369.2,372.9 425.0,362.8 480.8,345.0 536.7,314.6 592.5,271.7 648.3,253.1 704.2,223.9 760.0,241.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="383.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="383.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="382.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="381.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="378.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="373.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="362.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="344.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="314.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="282.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="244.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="206.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="230.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="378.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="372.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="362.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="345.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="314.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="271.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="253.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="223.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="241.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,380.3 313.3,378.1 369.2,373.5 425.0,362.8 480.8,351.2 536.7,337.1 592.5,328.7 648.3,325.4 704.2,321.5 760.0,280.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -153,34 +153,34 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,533.1 145.8,533.2 201.7,533.8 257.5,533.0 313.3,533.6 369.2,532.8 425.0,532.9 480.8,532.4 536.7,531.0 592.5,530.3 648.3,529.5 704.2,526.7 760.0,520.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="533.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="533.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="533.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="533.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="533.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="532.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="532.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="532.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="531.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="530.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="529.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="526.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="520.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,511.3 145.8,511.2 201.7,511.5 257.5,511.9 313.3,510.8 369.2,510.9 425.0,509.8 480.8,510.8 536.7,509.3 592.5,509.1 648.3,506.8 704.2,504.9 760.0,496.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="511.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="511.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="511.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="511.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="510.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="510.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="509.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="510.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="509.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="509.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="506.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="504.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="496.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,535.2 145.8,535.3 201.7,536.7 257.5,535.2 313.3,535.1 369.2,535.7 425.0,535.2 480.8,535.3 536.7,534.0 592.5,532.9 648.3,530.3 704.2,527.8 760.0,523.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="535.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="536.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="535.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="535.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="535.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="535.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="534.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="532.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="530.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="527.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="523.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,513.4 145.8,513.5 201.7,513.3 257.5,513.1 313.3,513.8 369.2,511.7 425.0,512.5 480.8,512.9 536.7,511.1 592.5,510.3 648.3,508.3 704.2,505.6 760.0,500.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="513.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="513.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="513.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="513.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="511.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="512.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="512.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="511.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="510.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="508.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="505.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="500.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,526.4 145.8,526.9 201.7,527.1 257.5,525.5 313.3,522.8 369.2,525.8 425.0,524.3 480.8,524.3 536.7,525.4 592.5,522.5 648.3,509.7 704.2,506.2 760.0,499.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="526.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="526.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -849,10 +849,9 @@ def _detect_hardware():
                     break
                 except OSError:
                     continue
-            if not extras:
-                hw_extras = os.environ.get("OMQ_HW_EXTRAS")
-                if hw_extras:
-                    extras.extend(hw_extras.split(","))
+            hw_extras = os.environ.get("OMQ_HW_EXTRAS")
+            if hw_extras:
+                extras.extend(hw_extras.split(","))
             if extras:
                 label += ", " + ", ".join(extras)
             return label

--- a/omq-compio/benches/common/mod.rs
+++ b/omq-compio/benches/common/mod.rs
@@ -234,20 +234,12 @@ where
     F: std::future::Future,
 {
     let out = runtime.block_on(fut);
-    while runtime.run() {}
+    // Runtime::run() is a low-level API that does not call enter(),
+    // so CURRENT_RUNTIME is unset. Without enter(), any task dropped
+    // during tick() that touches the timer wheel (TimerFuture::drop)
+    // panics with "not in a compio runtime".
+    runtime.enter(|| while runtime.run() {});
     drop(runtime);
-    out
-}
-
-/// Like [`block_on_and_drain`] but leaks the runtime instead of
-/// draining. Use when connection-driver safety-net timers cause a
-/// double-panic during drain (compio timer TLS issue).
-pub(crate) fn block_on_and_leak<F>(runtime: compio::runtime::Runtime, fut: F) -> F::Output
-where
-    F: std::future::Future,
-{
-    let out = runtime.block_on(fut);
-    std::mem::forget(runtime);
     out
 }
 

--- a/omq-compio/benches/compression.rs
+++ b/omq-compio/benches/compression.rs
@@ -3,9 +3,10 @@
 //! Requires the `lz4` feature; without it the bench has nothing to
 //! compare against the plain `tcp` baseline.
 //!
-//! `tcp` / `lz4+tcp`, single peer, sending small JSON records that
-//! mimic typical eventing / log shipping traffic. Reports **virtual**
-//! throughput (uncompressed bytes/sec).
+//! 2-process per cell: spawns `bench_peer_compio` push (bind) and pull
+//! (connect) subprocesses. Compression dict passed via temp file +
+//! `OMQ_BENCH_COMPRESSION_DICT` env var. Reports **virtual** throughput
+//! (uncompressed bytes/sec).
 
 #[cfg(not(feature = "lz4"))]
 fn main() {
@@ -25,22 +26,14 @@ fn main() {
 mod inner {
     use super::common;
     use bytes::Bytes;
-    use omq_compio::{Message, Options, Socket, SocketType};
+    use std::io::BufRead as _;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     const PATTERN: &str = "compression_json";
     const PEER_COUNTS: &[usize] = &[1];
     const SUPPORTED_TRANSPORTS: &[&str] = &["tcp", "lz4+tcp"];
     const DEFAULT_DICT_SIZES: &[usize] = &[2048];
-
-    fn build_runtime() -> std::io::Result<compio::runtime::Runtime> {
-        common::build_bench_runtime()
-    }
-
-    fn send_hwm() -> Option<u32> {
-        std::env::var("OMQ_BENCH_SEND_HWM")
-            .ok()
-            .and_then(|s| s.parse().ok())
-    }
 
     fn compression_threshold() -> Option<usize> {
         std::env::var("OMQ_BENCH_COMPRESSION_THRESHOLD")
@@ -72,6 +65,27 @@ mod inner {
         common::CHART_SIZES.to_vec()
     }
 
+    fn bench_peer_path() -> PathBuf {
+        let mut p = std::env::current_exe()
+            .expect("current_exe")
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        if p.ends_with("deps") {
+            p.pop();
+        }
+        let bp = p.join("bench_peer_compio");
+        assert!(
+            bp.exists(),
+            "bench_peer_compio not found at {}; build with: \
+             cargo build -p omq-compio --bin bench_peer_compio --features lz4 --profile bench",
+            bp.display(),
+        );
+        bp
+    }
+
+    // ── Orchestrator ─────────────────────────────────────────────────
+
     pub(super) fn compio_main() {
         let transports = active_transports();
         if transports.is_empty() {
@@ -88,34 +102,19 @@ mod inner {
         let mut seq = 0usize;
         for transport in &transports {
             let transport = transport.as_str();
-            for &peers in peer_counts {
-                common::print_subheader(transport, peers);
+            for &_peers in peer_counts {
+                common::print_subheader(transport, 1);
                 for &approx_size in &sizes {
                     seq += 1;
                     let payload = json_payload(approx_size);
                     let actual = payload.len();
                     let wire_bytes_per_msg = wire_size(transport, &payload, None);
-                    let cell = run_cell(transport, peers, payload.clone(), seq, None);
-                    let wire_mbps = (cell.msgs_s * wire_bytes_per_msg as f64) / 1_000_000.0;
-                    let cpu_pct = if cell.elapsed.as_nanos() > 0 {
-                        cell.cpu_time.as_secs_f64() / cell.elapsed.as_secs_f64() * 100.0
-                    } else {
-                        0.0
-                    };
-                    println!(
-                        "  ~{:>6}  {:>9.0} msg/s  {:>9.1} wireMB/s  {:>9.1} virtMB/s  ({:.2}s, cpu {:.0}%, n={})",
-                        format!("{approx_size}B"),
-                        cell.msgs_s,
-                        wire_mbps,
-                        cell.mbps,
-                        cell.elapsed.as_secs_f64(),
-                        cpu_pct,
-                        cell.n,
-                    );
+                    let cell = run_cell(transport, actual, seq, None);
+                    print_cell(approx_size, wire_bytes_per_msg, &cell);
                     append_compression_jsonl(
                         PATTERN,
                         transport,
-                        peers,
+                        1,
                         actual,
                         wire_bytes_per_msg,
                         cell,
@@ -125,10 +124,10 @@ mod inner {
             }
         }
 
-        run_dict_benches(peer_counts, &sizes, &mut seq);
+        run_dict_benches(&sizes, &mut seq);
     }
 
-    fn run_dict_benches(peer_counts: &[usize], sizes: &[usize], seq: &mut usize) {
+    fn run_dict_benches(sizes: &[usize], seq: &mut usize) {
         let dict_sizes = dict_sizes();
         for &dict_cap in &dict_sizes {
             let dict_label = if dict_cap >= 1024 {
@@ -141,46 +140,166 @@ mod inner {
             let actual_len = dict.len();
             for transport in &["lz4+tcp"] {
                 println!("--- {transport} with {dict_label} dict (actual {actual_len}B) ---");
-                for &peers in peer_counts {
-                    common::print_subheader(transport, peers);
-                    for &approx_size in sizes {
-                        *seq += 1;
-                        let payload = json_payload(approx_size);
-                        let actual = payload.len();
-                        let wire_bytes_per_msg = wire_size(transport, &payload, Some(&dict));
-                        let cell =
-                            run_cell(transport, peers, payload.clone(), *seq, Some(dict.clone()));
-                        let wire_mbps = (cell.msgs_s * wire_bytes_per_msg as f64) / 1_000_000.0;
-                        let cpu_pct = if cell.elapsed.as_nanos() > 0 {
-                            cell.cpu_time.as_secs_f64() / cell.elapsed.as_secs_f64() * 100.0
-                        } else {
-                            0.0
-                        };
-                        println!(
-                            "  ~{:>6}  {:>9.0} msg/s  {:>9.1} wireMB/s  {:>9.1} virtMB/s  ({:.2}s, cpu {:.0}%, n={})",
-                            format!("{approx_size}B"),
-                            cell.msgs_s,
-                            wire_mbps,
-                            cell.mbps,
-                            cell.elapsed.as_secs_f64(),
-                            cpu_pct,
-                            cell.n,
-                        );
-                        append_compression_jsonl_dict(
-                            "compression_json_dict",
-                            transport,
-                            peers,
-                            actual,
-                            wire_bytes_per_msg,
-                            cell,
-                            Some(dict_cap),
-                        );
-                    }
-                    println!();
+                common::print_subheader(transport, 1);
+                for &approx_size in sizes {
+                    *seq += 1;
+                    let payload = json_payload(approx_size);
+                    let actual = payload.len();
+                    let wire_bytes_per_msg = wire_size(transport, &payload, Some(&dict));
+                    let cell = run_cell(transport, actual, *seq, Some(&dict));
+                    print_cell(approx_size, wire_bytes_per_msg, &cell);
+                    append_compression_jsonl_dict(
+                        "compression_json_dict",
+                        transport,
+                        1,
+                        actual,
+                        wire_bytes_per_msg,
+                        cell,
+                        Some(dict_cap),
+                    );
                 }
+                println!();
             }
         }
     }
+
+    fn print_cell(approx_size: usize, wire_bytes_per_msg: usize, cell: &common::Cell) {
+        let wire_mbps = (cell.msgs_s * wire_bytes_per_msg as f64) / 1_000_000.0;
+        let cpu_pct = if cell.elapsed.as_nanos() > 0 {
+            cell.cpu_time.as_secs_f64() / cell.elapsed.as_secs_f64() * 100.0
+        } else {
+            0.0
+        };
+        println!(
+            "  ~{:>6}  {:>9.0} msg/s  {:>9.1} wireMB/s  {:>9.1} virtMB/s  ({:.2}s, cpu {:.0}%, n={})",
+            format!("{approx_size}B"),
+            cell.msgs_s,
+            wire_mbps,
+            cell.mbps,
+            cell.elapsed.as_secs_f64(),
+            cpu_pct,
+            cell.n,
+        );
+    }
+
+    // ── 2-process cell ───────────────────────────────────────────────
+
+    fn run_cell(
+        transport: &str,
+        msg_size: usize,
+        _seq: usize,
+        dict: Option<&Bytes>,
+    ) -> common::Cell {
+        let duration = common::round_duration().as_secs_f64() * common::rounds() as f64 + 2.0;
+        let bp = bench_peer_path();
+
+        let dict_path = dict.map(|d| {
+            let path = std::env::temp_dir().join(format!("omq-bench-dict-{}", std::process::id()));
+            std::fs::write(&path, d).expect("write dict file");
+            path
+        });
+
+        let ep_prefix = match transport {
+            "lz4+tcp" => "lz4+tcp://127.0.0.1",
+            _ => "tcp://127.0.0.1",
+        };
+
+        // Push binds, prints PORT, sends forever
+        let mut push_cmd = std::process::Command::new(&bp);
+        push_cmd
+            .arg("push")
+            .arg(format!("{ep_prefix}:0"))
+            .arg(format!("{msg_size}"))
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+        set_compression_env(&mut push_cmd, dict_path.as_deref());
+        let mut push = push_cmd.spawn().expect("spawn push");
+        let port = read_port(&mut push);
+
+        // Pull connects, counts for duration
+        let mut pull_cmd = std::process::Command::new(&bp);
+        pull_cmd
+            .arg("pull")
+            .arg(format!("{ep_prefix}:{port}"))
+            .arg(format!("{msg_size}"))
+            .arg(format!("{duration}"))
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+        set_compression_env(&mut pull_cmd, dict_path.as_deref());
+        let pull = pull_cmd.spawn().expect("spawn pull");
+
+        let output = pull.wait_with_output().expect("pull output");
+        if !output.status.success() {
+            eprintln!(
+                "WARN: pull subprocess failed ({}) for {ep_prefix} {msg_size}B, skipping",
+                output.status,
+            );
+            let _ = push.kill();
+            let _ = push.wait();
+            if let Some(p) = dict_path {
+                let _ = std::fs::remove_file(p);
+            }
+            return common::Cell {
+                n: 0,
+                elapsed: Duration::from_secs(1),
+                mbps: 0.0,
+                msgs_s: 0.0,
+                cpu_time: Duration::ZERO,
+            };
+        }
+        let line = String::from_utf8_lossy(&output.stdout);
+        let cell = parse_pull_output(line.trim(), msg_size);
+
+        let _ = push.kill();
+        let _ = push.wait();
+        if let Some(p) = dict_path {
+            let _ = std::fs::remove_file(p);
+        }
+        cell
+    }
+
+    fn set_compression_env(cmd: &mut std::process::Command, dict_path: Option<&Path>) {
+        if let Some(p) = dict_path {
+            cmd.env("OMQ_BENCH_COMPRESSION_DICT", p);
+        }
+        if let Some(t) = compression_threshold() {
+            cmd.env("OMQ_BENCH_COMPRESSION_THRESHOLD", format!("{t}"));
+        }
+    }
+
+    fn read_port(child: &mut std::process::Child) -> u16 {
+        let stdout = child.stdout.as_mut().expect("child stdout");
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read PORT line");
+        let line = line.trim();
+        assert!(
+            line.starts_with("PORT "),
+            "expected 'PORT <n>', got: {line:?}"
+        );
+        line[5..].parse().expect("parse port")
+    }
+
+    fn parse_pull_output(line: &str, msg_size: usize) -> common::Cell {
+        // bench_peer_compio pull output: "<count> <elapsed> <size> <cpu_time>"
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        assert!(parts.len() >= 3, "unexpected pull output: {line:?}");
+        let count: usize = parts[0].parse().expect("count");
+        let elapsed: f64 = parts[1].parse().expect("elapsed");
+        let cpu_time: f64 = parts.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+        let elapsed_dur = Duration::from_secs_f64(elapsed);
+        let msgs_s = count as f64 / elapsed;
+        let mbps = (count * msg_size) as f64 / elapsed / 1_000_000.0;
+        common::Cell {
+            n: count,
+            elapsed: elapsed_dur,
+            mbps,
+            msgs_s,
+            cpu_time: Duration::from_secs_f64(cpu_time),
+        }
+    }
+
+    // ── JSONL output ─────────────────────────────────────────────────
 
     fn append_compression_jsonl(
         pattern: &str,
@@ -232,10 +351,8 @@ mod inner {
         }
     }
 
-    /// Encode one sample message through the same transform path the
-    /// socket uses, return the on-the-wire byte size of the encoded
-    /// payload (excluding ZMTP frame headers, which are small and
-    /// constant).
+    // ── Wire-size / dict helpers ─────────────────────────────────────
+
     fn wire_size(transport: &str, plain: &Bytes, dict: Option<&Bytes>) -> usize {
         use omq_proto::proto::transform::lz4::Lz4Encoder;
         let m = omq_compio::Message::single(plain.clone());
@@ -265,155 +382,10 @@ mod inner {
             let sample = json_payload(64 + (i * 10) % (4096 - 64));
             trainer.add_sample(&sample);
         }
-        let dict = trainer.train();
-        Bytes::from(dict)
+        Bytes::from(trainer.train())
     }
 
-    fn run_cell(
-        transport: &str,
-        peers: usize,
-        payload: Bytes,
-        seq: usize,
-        dict: Option<Bytes>,
-    ) -> common::Cell {
-        use std::rc::Rc;
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
-        let ep = common::endpoint(transport, seq);
-        let pull_count = Arc::new(AtomicUsize::new(0));
-        let stop = Arc::new(AtomicBool::new(false));
-        let ready = Arc::new(std::sync::Barrier::new(2));
-
-        let label = format!("{transport} ~{}B {peers}p", payload.len());
-
-        let pull_thread = {
-            let ep = ep.clone();
-            let pull_count = pull_count.clone();
-            let stop = stop.clone();
-            let ready = ready.clone();
-            let dict = dict.clone();
-            std::thread::spawn(move || run_pull(ep, dict, pull_count, stop, ready))
-        };
-
-        let push_thread = {
-            let ep = ep.clone();
-            let pull_count = pull_count.clone();
-            let stop = stop.clone();
-            let ready = ready.clone();
-            std::thread::spawn(move || {
-                let rt = build_runtime().expect("push runtime");
-                common::block_on_and_drain(rt, async move {
-                    ready.wait();
-                    let mut pushes: Vec<Socket> = Vec::with_capacity(peers);
-                    for _ in 0..peers {
-                        let mut opts = match &dict {
-                            Some(d) => Options::default().compression_dict(d.clone()),
-                            None => Options::default(),
-                        };
-                        if let Some(hwm) = send_hwm() {
-                            opts = opts.send_hwm(hwm);
-                        }
-                        if let Some(t) = compression_threshold() {
-                            opts = opts.compression_threshold(t);
-                        }
-                        let p = Socket::new(SocketType::Push, opts);
-                        p.connect(ep.clone()).await.expect("connect PUSH");
-                        pushes.push(p);
-                    }
-                    let refs: Vec<&Socket> = pushes.iter().collect();
-                    common::wait_connected(&refs).await;
-
-                    let pushes = Rc::new(pushes);
-
-                    let inline = payload.len() <= omq_proto::message::MAX_INLINE_MESSAGE;
-                    let burst = |k: usize| {
-                        let pushes = pushes.clone();
-                        let payload = payload.clone();
-                        let pull_count = pull_count.clone();
-                        async move {
-                            let per = (k / pushes.len()).max(1);
-                            let target = pull_count.load(Ordering::Relaxed) + per * pushes.len();
-                            let mut handles = Vec::with_capacity(pushes.len());
-                            for i in 0..pushes.len() {
-                                let p = pushes.clone();
-                                let payload = payload.clone();
-                                handles.push(compio::runtime::spawn(async move {
-                                    if inline {
-                                        for _ in 0..per {
-                                            p[i].send(Message::from_slice(&payload)).await.unwrap();
-                                        }
-                                    } else {
-                                        let msg = Message::single(payload);
-                                        for _ in 0..per {
-                                            p[i].send(msg.clone()).await.unwrap();
-                                        }
-                                    }
-                                }));
-                            }
-                            for h in handles {
-                                let _ = h.await;
-                            }
-                            while pull_count.load(Ordering::Relaxed) < target {
-                                compio::time::sleep(std::time::Duration::from_micros(50)).await;
-                            }
-                        }
-                    };
-
-                    let cell = common::with_timeout(
-                        &label,
-                        common::measure_min_of(payload.len(), pushes.len(), burst),
-                    )
-                    .await;
-                    stop.store(true, Ordering::Relaxed);
-                    if let Ok(pushes) = Rc::try_unwrap(pushes) {
-                        drop(pushes);
-                    }
-                    cell
-                })
-            })
-        };
-
-        let cell = push_thread.join().expect("push thread panicked");
-        let _ = pull_thread.join();
-        cell
-    }
-
-    fn run_pull(
-        ep: omq_compio::Endpoint,
-        dict: Option<Bytes>,
-        pull_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-        stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        ready: std::sync::Arc<std::sync::Barrier>,
-    ) {
-        use std::sync::atomic::Ordering;
-        let rt = build_runtime().expect("pull runtime");
-        common::block_on_and_drain(rt, async move {
-            let mut opts = match dict {
-                Some(d) => Options::default().compression_dict(d),
-                None => Options::default(),
-            };
-            if let Some(t) = compression_threshold() {
-                opts = opts.compression_threshold(t);
-            }
-            let pull = Socket::new(SocketType::Pull, opts);
-            pull.bind(ep).await.expect("bind PULL");
-            ready.wait();
-            while !stop.load(Ordering::Relaxed) {
-                if let Ok(Ok(_)) =
-                    compio::time::timeout(std::time::Duration::from_millis(20), pull.recv()).await
-                {
-                    pull_count.fetch_add(1, Ordering::Relaxed);
-                    let mut drained = 0u64;
-                    while pull.try_recv().is_ok() {
-                        drained += 1;
-                    }
-                    pull_count.fetch_add(drained as usize, Ordering::Relaxed);
-                }
-            }
-            drop(pull);
-        });
-    }
+    // ── Payload generation (for wire_size calculation only) ──────────
 
     fn json_payload(target_bytes: usize) -> Bytes {
         const LEVELS: &[&str] = &["DEBUG", "INFO", "WARN", "ERROR"];

--- a/omq-compio/benches/mechanism.rs
+++ b/omq-compio/benches/mechanism.rs
@@ -110,7 +110,7 @@ fn run_cell(pull_opts: Options, push_opts: Options, size: usize, seq: usize) -> 
         let ready = ready.clone();
         std::thread::spawn(move || {
             let rt = build_runtime().expect("pull runtime");
-            common::block_on_and_leak(rt, async move {
+            common::block_on_and_drain(rt, async move {
                 let pull = Socket::new(SocketType::Pull, pull_opts);
                 pull.bind(ep).await.expect("bind PULL");
                 ready.wait();
@@ -138,7 +138,7 @@ fn run_cell(pull_opts: Options, push_opts: Options, size: usize, seq: usize) -> 
         let ready = ready.clone();
         std::thread::spawn(move || {
             let rt = build_runtime().expect("push runtime");
-            common::block_on_and_leak(rt, async move {
+            common::block_on_and_drain(rt, async move {
                 ready.wait();
                 let push = Socket::new(SocketType::Push, push_opts);
                 let mut mon = push.monitor();

--- a/omq-compio/src/bin/bench_peer_compio.rs
+++ b/omq-compio/src/bin/bench_peer_compio.rs
@@ -47,8 +47,11 @@ fn parse_ep(s: &str) -> Endpoint {
 }
 
 fn print_bound_port(ep: &Endpoint) {
-    if let Endpoint::Tcp { port, .. } = ep {
-        println!("PORT {port}");
+    match ep {
+        Endpoint::Tcp { port, .. } => println!("PORT {port}"),
+        #[cfg(feature = "lz4")]
+        Endpoint::Lz4Tcp { port, .. } => println!("PORT {port}"),
+        _ => {}
     }
 }
 
@@ -252,6 +255,22 @@ fn bench_options(msg_size: usize) -> Options {
     if msg_size >= 2 * 1024 * 1024 {
         let buf = msg_size * 2;
         o = o.recv_buffer_size(buf).send_buffer_size(buf);
+    }
+    #[cfg(feature = "lz4")]
+    if let Ok(path) = std::env::var("OMQ_BENCH_COMPRESSION_DICT") {
+        let dict = std::fs::read(&path).expect("read compression dict file");
+        o = o.compression_dict(Bytes::from(dict));
+    }
+    #[cfg(feature = "lz4")]
+    if let Ok(s) = std::env::var("OMQ_BENCH_COMPRESSION_THRESHOLD")
+        && let Ok(t) = s.parse::<usize>()
+    {
+        o = o.compression_threshold(t);
+    }
+    if let Ok(s) = std::env::var("OMQ_BENCH_SEND_HWM")
+        && let Ok(hwm) = s.parse::<u32>()
+    {
+        o = o.send_hwm(hwm);
     }
     o
 }

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -162,11 +162,19 @@ async fn accumulate_large_recv(state: &Arc<DirectIoState>) -> Result<RecvAction>
                     || e.raw_os_error() == Some(libc::ECANCELED) =>
             {
                 let mut sguard = state.recv_stream.0.lock().await;
-                *sguard = Some(crate::socket::RecvStreamState::OneShot);
+                let io = state.lock_io();
+                let new_stream = io.reader.build_recv_stream();
+                drop(io);
+                *sguard = Some(crate::socket::RecvStreamState::MultiShot(new_stream));
+                state.multishot_rearms.fetch_add(1, Ordering::Relaxed);
             }
             None => {
                 let mut sguard = state.recv_stream.0.lock().await;
-                *sguard = Some(crate::socket::RecvStreamState::OneShot);
+                let io = state.lock_io();
+                let new_stream = io.reader.build_recv_stream();
+                drop(io);
+                *sguard = Some(crate::socket::RecvStreamState::MultiShot(new_stream));
+                state.multishot_rearms.fetch_add(1, Ordering::Relaxed);
             }
             _ => {
                 state.signal_eof();
@@ -194,13 +202,21 @@ async fn pull_and_feed(state: &Arc<DirectIoState>) -> PullOutcome {
             .await;
             match buf {
                 None => {
-                    *sguard = Some(crate::socket::RecvStreamState::OneShot);
+                    let io = state.lock_io();
+                    let new_stream = io.reader.build_recv_stream();
+                    drop(io);
+                    *sguard = Some(crate::socket::RecvStreamState::MultiShot(new_stream));
+                    state.multishot_rearms.fetch_add(1, Ordering::Relaxed);
                     PullOutcome::Fed
                 }
                 Some(Err(e)) => {
                     let os = e.raw_os_error();
                     if os == Some(libc::ENOBUFS) || os == Some(libc::ECANCELED) {
-                        *sguard = Some(crate::socket::RecvStreamState::OneShot);
+                        let io = state.lock_io();
+                        let new_stream = io.reader.build_recv_stream();
+                        drop(io);
+                        *sguard = Some(crate::socket::RecvStreamState::MultiShot(new_stream));
+                        state.multishot_rearms.fetch_add(1, Ordering::Relaxed);
                         PullOutcome::Fed
                     } else {
                         PullOutcome::Err(e)

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -59,17 +59,22 @@ extern "C" fn exit_on_signal(_sig: libc::c_int) {
 }
 
 fn main() {
-    let rt = if std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "current_thread") {
+    let rt = if std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "multi_thread") {
+        #[cfg(feature = "rt-multi-thread")]
+        {
+            let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
+            eprintln!("runtime: multi_thread ({workers} workers)");
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(workers)
+                .enable_all()
+                .build()
+                .expect("tokio runtime")
+        }
+        #[cfg(not(feature = "rt-multi-thread"))]
+        panic!("multi_thread runtime requires --features rt-multi-thread")
+    } else {
         eprintln!("runtime: current_thread");
         tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime")
-    } else {
-        let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
-        eprintln!("runtime: multi_thread ({workers} workers)");
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(workers)
             .enable_all()
             .build()
             .expect("tokio runtime")
@@ -583,6 +588,8 @@ async fn run_req(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
         req.recv().await.unwrap();
     }
 
+    let t_wall = Instant::now();
+    let cpu_before = cpu_time_secs();
     let mut rtts = Vec::with_capacity(iterations);
     for _ in 0..iterations {
         let t0 = Instant::now();
@@ -590,13 +597,15 @@ async fn run_req(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
         req.recv().await.unwrap();
         rtts.push(t0.elapsed().as_nanos() as u64);
     }
+    let cpu = cpu_time_secs() - cpu_before;
+    let elapsed = t_wall.elapsed().as_secs_f64();
 
     rtts.sort_unstable();
     let p50 = percentile(&rtts, 50.0);
     let p99 = percentile(&rtts, 99.0);
     let p999 = percentile(&rtts, 99.9);
     let max = percentile(&rtts, 100.0);
-    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations}");
+    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations} {cpu:.6} {elapsed:.6}");
 }
 
 fn percentile(sorted: &[u64], p: f64) -> f64 {

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -18,11 +18,12 @@ JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
 
 COLORS = {
     "libzmq": "#eab308",
-    "omq-compio": "#dc2626",
-    "omq-compio-st": "#8b5cf6",
+    "omq-compio": "#7c3aed",
+    "omq-compio-st": "#ff69b4",
     "omq-tokio": "#f97316",
+    "omq-tokio-mt": "#dc2626",
     "zmq.rs": "#2563eb",
-    "rzmq": "#10b981",
+    "rzmq": "#16a34a",
     "omq-libzmq": "#06b6d4",
 }
 
@@ -31,6 +32,7 @@ LABELS = {
     "omq-compio": "omq-compio",
     "omq-compio-st": "omq-compio (ST)",
     "omq-tokio": "omq-tokio",
+    "omq-tokio-mt": "omq-tokio (MT)",
     "zmq.rs": "zmq.rs v0.6.0",
     "rzmq": "rzmq v0.5.18",
     "omq-libzmq": "omq-libzmq",
@@ -67,7 +69,9 @@ def load_data(transport: str, impls: list[str]) -> dict:
     t_rows = [r for r in rows if r.get("transport") == transport]
 
     tput: dict[int, dict[str, tuple[float, float]]] = {}
+    tput_cpu: dict[int, dict[str, float]] = {}
     lat: dict[int, dict[str, float]] = {}
+    lat_cpu: dict[int, dict[str, float]] = {}
 
     seen_tput: dict[tuple, str] = {}
     seen_lat: dict[tuple, str] = {}
@@ -88,15 +92,24 @@ def load_data(transport: str, impls: list[str]) -> dict:
                 mbps = r.get("mbps", 0)
                 gbs = mbps / 1000.0
                 tput.setdefault(size, {})[impl_name] = (msgs_s, gbs)
+                cpu_time = r.get("cpu_time", 0)
+                elapsed = r.get("elapsed", 0)
+                if elapsed > 0 and cpu_time > 0:
+                    tput_cpu.setdefault(size, {})[impl_name] = cpu_time / elapsed * 100
 
         elif kind == "latency":
             key = (impl_name, size)
             if key not in seen_lat or run_id >= seen_lat[key]:
                 seen_lat[key] = run_id
                 lat.setdefault(size, {})[impl_name] = r.get("p50_us", 0)
+                cpu_time = r.get("cpu_time", 0)
+                elapsed = r.get("elapsed", 0)
+                if elapsed > 0 and cpu_time > 0:
+                    lat_cpu.setdefault(size, {})[impl_name] = cpu_time / elapsed * 100
 
     sizes = sorted(s for s in tput if s <= 32768)
-    return {"sizes": sizes, "tput": tput, "lat": lat}
+    return {"sizes": sizes, "tput": tput, "tput_cpu": tput_cpu,
+            "lat": lat, "lat_cpu": lat_cpu}
 
 
 # ── SVG helpers ───────────────────────────────────────────────────
@@ -297,7 +310,9 @@ def draw_throughput_panel(
     L.append(svg_text(40, mid_y, "msg/s", weight="600", rotate=-90))
 
     # dashed msg/s lines
-    draw_order = [name for name in ["rzmq", "zmq.rs", "libzmq", "omq-tokio", "omq-compio-st", "omq-compio"]
+    draw_order = [name for name in
+                  ["rzmq", "zmq.rs", "libzmq", "omq-tokio-mt", "omq-tokio",
+                   "omq-compio-st", "omq-compio"]
                   if name in impls]
     for name in draw_order:
         pts = [
@@ -362,8 +377,280 @@ def draw_latency_panel(
     mid_y = (y_top + y_bot) / 2
     L.append(svg_text(40, mid_y, "p50 latency (µs)", weight="600", rotate=-90))
 
-    draw_order = [name for name in ["libzmq", "omq-tokio", "rzmq", "zmq.rs", "omq-compio-st", "omq-compio"]
+    draw_order = [name for name in
+                  ["libzmq", "omq-tokio-mt", "omq-tokio", "rzmq", "zmq.rs",
+                   "omq-compio-st", "omq-compio"]
                   if name in impls]
+    for name in draw_order:
+        pts = [
+            (xs[i], y_lat(lat[sizes[i]][name]))
+            for i in range(len(sizes)) if name in lat.get(sizes[i], {})
+        ]
+        if pts:
+            L.append(svg_polyline(pts, COLORS[name]))
+            L.extend(svg_dots(pts, COLORS[name]))
+
+    # x-axis labels
+    for i, s in enumerate(sizes):
+        L.append(svg_text(xs[i], y_bot + 14, fmt_size(s), size=8.5))
+
+
+def _cpu_ticks(data_max):
+    """Return (axis_max, tick_values) for a linear 0-based CPU% axis."""
+    if data_max <= 0:
+        data_max = 100
+    candidates = [50, 100, 200, 400, 500, 800, 1000]
+    ceil = data_max
+    for c in candidates:
+        if c >= data_max:
+            ceil = c
+            break
+    else:
+        import math
+        ceil = math.ceil(data_max / 100) * 100
+    step = 50 if ceil <= 400 else 100
+    ticks = list(range(step, int(ceil) + 1, step))
+    return ceil, ticks
+
+
+def draw_throughput_cpu_panel(
+    L: list[str], sizes: list[int], xs: list[float], tput: dict,
+    tput_cpu: dict, impls: list[str],
+    x_left: float, x_right: float, x_right2: float,
+    y_top: float, y_bot: float, title: str,
+    fixed_gbs_max: float | None = None,
+    fixed_msg_max: float | None = None,
+    log_gbs: bool = False,
+):
+    """Three-axis throughput panel: CPU% (left, dotted), GB/s (inner right,
+    solid+dots), msg/s (outer right, dashed)."""
+    import math
+
+    h = y_bot - y_top
+    mid_x = (x_left + x_right) / 2
+
+    all_cpu = [
+        tput_cpu[s][name]
+        for s in sizes for name in impls if name in tput_cpu.get(s, {})
+    ]
+    cpu_ceil, cpu_ticks = _cpu_ticks(max(all_cpu) * 1.1 if all_cpu else 200)
+
+    all_gbs = [
+        tput[s][name][1]
+        for s in sizes for name in impls if name in tput.get(s, {})
+    ]
+    gbs_max = max(all_gbs) if all_gbs else 10.0
+    gbs_min = min(all_gbs) if all_gbs else 0.01
+    if log_gbs:
+        gbs_min = max(gbs_min, 0.01)
+        log_lo = math.floor(math.log10(gbs_min * 0.8))
+        log_hi = math.ceil(math.log10((fixed_gbs_max or gbs_max) * 1.15))
+    else:
+        gbs_max = fixed_gbs_max if fixed_gbs_max else (gbs_max * 1.15)
+
+    all_msgs = [
+        tput[s][name][0]
+        for s in sizes for name in impls if name in tput.get(s, {})
+    ]
+    msg_max = fixed_msg_max if fixed_msg_max else (max(all_msgs) * 1.15 if all_msgs else 16e6)
+
+    def y_cpu(v):
+        frac = max(0, min(1, v / cpu_ceil))
+        return y_bot - frac * h
+
+    def y_gbs(v):
+        if log_gbs:
+            if v <= 0:
+                return y_bot
+            frac = (math.log10(v) - log_lo) / (log_hi - log_lo)
+            return y_bot - frac * h
+        return y_bot - (v / gbs_max) * h
+
+    def y_msg(v):
+        return y_bot - (v / msg_max) * h
+
+    L.append(svg_text(mid_x, y_top - 17, title, size=13, weight="700", fill="#111827"))
+
+    # CPU% gridlines (left axis)
+    for val in cpu_ticks:
+        yy = y_cpu(val)
+        L.append(svg_line(x_left, yy, x_right, yy))
+        L.append(svg_text(x_left - 8, yy, f"{val:g}%",
+                          anchor="end", baseline="middle"))
+
+    # GB/s gridlines (inner right axis, dashed)
+    if log_gbs:
+        for decade in range(log_lo, log_hi + 1):
+            base = 10 ** decade
+            for mult in [1, 2, 5]:
+                v = base * mult
+                if v < 10 ** log_lo or v > 10 ** log_hi:
+                    continue
+                yy = y_gbs(v)
+                if mult == 1:
+                    L.append(svg_line(x_left, yy, x_right, yy, dash="3,6"))
+                    label = f"{v:.0f}" if v >= 1 else f"{v:g}"
+                    L.append(svg_text(x_right + 8, yy, f"{label} GB/s",
+                                      anchor="start", baseline="middle",
+                                      fill="#6b7280"))
+                else:
+                    L.append(svg_line(x_left, yy, x_right, yy,
+                                      dash="2,8", stroke="#e5e7eb"))
+    else:
+        step_gbs = nice_step(gbs_max, 5)
+        v = step_gbs
+        while v <= gbs_max:
+            yy = y_gbs(v)
+            L.append(svg_line(x_left, yy, x_right, yy, dash="3,6"))
+            L.append(svg_text(x_right + 8, yy, f"{v:.0f} GB/s",
+                              anchor="start", baseline="middle", fill="#6b7280"))
+            v += step_gbs
+
+    # msg/s tick labels (outer right axis)
+    step_msg = nice_step(msg_max, 8)
+    v = step_msg
+    while v <= msg_max:
+        yy = y_msg(v)
+        millions = v / 1e6
+        if millions >= 1 and millions == int(millions):
+            label = f"{int(millions)}M"
+        elif v >= 1e6:
+            label = f"{millions:.1f}M"
+        else:
+            label = f"{v / 1e3:.0f}k"
+        L.append(svg_text(x_right2 + 8, yy, f"{label}/s",
+                          anchor="start", baseline="middle", fill="#9ca3af"))
+        v += step_msg
+
+    # vertical gridlines
+    for x in xs:
+        L.append(svg_line(x, y_top, x, y_bot))
+
+    # axes
+    L.append(svg_line(x_left, y_top, x_left, y_bot, stroke="#9ca3af", width=1.5))
+    L.append(svg_line(x_right, y_top, x_right, y_bot, stroke="#9ca3af", width=1.5))
+    L.append(svg_line(x_left, y_bot, x_right, y_bot, stroke="#9ca3af", width=1.5))
+    L.append(svg_line(x_right2, y_top, x_right2, y_bot, stroke="#d1d5db", width=1))
+
+    # axis labels
+    mid_y = (y_top + y_bot) / 2
+    L.append(svg_text(40, mid_y, "CPU %", weight="600", rotate=-90))
+
+    draw_order = [name for name in
+                  ["libzmq", "omq-libzmq", "omq-tokio-mt", "omq-tokio",
+                   "omq-compio-st", "omq-compio", "rzmq", "zmq.rs"]
+                  if name in impls]
+
+    # dotted CPU% lines
+    for name in draw_order:
+        pts = [
+            (xs[i], y_cpu(tput_cpu[sizes[i]][name]))
+            for i in range(len(sizes)) if name in tput_cpu.get(sizes[i], {})
+        ]
+        if pts:
+            L.append(svg_polyline(pts, COLORS[name], width=2, dash="2,3"))
+
+    # dashed msg/s lines (outer right axis)
+    for name in draw_order:
+        pts = [
+            (xs[i], y_msg(tput[sizes[i]][name][0]))
+            for i in range(len(sizes)) if name in tput.get(sizes[i], {})
+        ]
+        if pts:
+            L.append(svg_polyline(pts, COLORS[name], width=1.5, dash="5,3"))
+
+    # solid GB/s lines with dots (inner right axis)
+    for name in draw_order:
+        pts = [
+            (xs[i], y_gbs(tput[sizes[i]][name][1]))
+            for i in range(len(sizes)) if name in tput.get(sizes[i], {})
+        ]
+        if pts:
+            L.append(svg_polyline(pts, COLORS[name]))
+            L.extend(svg_dots(pts, COLORS[name]))
+
+    # x-axis labels
+    for i, s in enumerate(sizes):
+        L.append(svg_text(xs[i], y_bot + 14, fmt_size(s), size=8.5))
+
+
+def draw_latency_cpu_panel(
+    L: list[str], sizes: list[int], xs: list[float], lat: dict,
+    lat_cpu: dict, impls: list[str],
+    x_left: float, x_right: float,
+    y_top: float, y_bot: float, title: str,
+    fixed_lat_max: float | None = None,
+):
+    """Two-axis latency panel: p50 latency (left, solid+dots),
+    CPU% (right, dotted)."""
+    h = y_bot - y_top
+    mid_x = (x_left + x_right) / 2
+
+    all_vals = [
+        lat[s][name]
+        for s in sizes for name in impls if name in lat.get(s, {})
+    ]
+    lat_max = fixed_lat_max if fixed_lat_max else (max(all_vals) * 1.2 if all_vals else 150.0)
+
+    all_cpu = [
+        lat_cpu[s][name]
+        for s in sizes for name in impls if name in lat_cpu.get(s, {})
+    ]
+    cpu_ceil, cpu_ticks = _cpu_ticks(max(all_cpu) * 1.1 if all_cpu else 200)
+
+    def y_lat(v):
+        return y_bot - (v / lat_max) * h
+
+    def y_cpu(v):
+        frac = max(0, min(1, v / cpu_ceil))
+        return y_bot - frac * h
+
+    L.append(svg_text(mid_x, y_top - 17, title, size=13, weight="700", fill="#111827"))
+
+    # latency gridlines (left axis)
+    step = nice_step(lat_max, 10)
+    v = step
+    while v <= lat_max:
+        yy = y_lat(v)
+        L.append(svg_line(x_left, yy, x_right, yy))
+        L.append(svg_text(x_left - 8, yy, f"{v:.0f}", anchor="end", baseline="middle"))
+        v += step
+
+    # CPU% gridlines (right axis, dashed)
+    for val in cpu_ticks:
+        yy = y_cpu(val)
+        L.append(svg_line(x_left, yy, x_right, yy, dash="3,6"))
+        L.append(svg_text(x_right + 8, yy, f"{val:g}%",
+                          anchor="start", baseline="middle", fill="#6b7280"))
+
+    # vertical gridlines
+    for x in xs:
+        L.append(svg_line(x, y_top, x, y_bot))
+
+    # axes
+    L.append(svg_line(x_left, y_top, x_left, y_bot, stroke="#9ca3af", width=1.5))
+    L.append(svg_line(x_right, y_top, x_right, y_bot, stroke="#9ca3af", width=1.5))
+    L.append(svg_line(x_left, y_bot, x_right, y_bot, stroke="#9ca3af", width=1.5))
+
+    # axis label
+    mid_y = (y_top + y_bot) / 2
+    L.append(svg_text(40, mid_y, "p50 latency (µs)", weight="600", rotate=-90))
+
+    draw_order = [name for name in
+                  ["libzmq", "omq-libzmq", "omq-tokio-mt", "omq-tokio",
+                   "rzmq", "zmq.rs", "omq-compio-st", "omq-compio"]
+                  if name in impls]
+
+    # dotted CPU% lines (right axis)
+    for name in draw_order:
+        pts = [
+            (xs[i], y_cpu(lat_cpu[sizes[i]][name]))
+            for i in range(len(sizes)) if name in lat_cpu.get(sizes[i], {})
+        ]
+        if pts:
+            L.append(svg_polyline(pts, COLORS[name], width=2, dash="2,3"))
+
+    # solid latency lines with dots (left axis)
     for name in draw_order:
         pts = [
             (xs[i], y_lat(lat[sizes[i]][name]))
@@ -594,6 +881,180 @@ def generate_latency_chart(data: dict, impls: list[str], transport_label: str,
     return "\n".join(L) + "\n"
 
 
+def generate_chart_cpu(data: dict, impls: list[str], transport_label: str,
+                       fixed_gbs_max: float | None = None,
+                       fixed_msg_max: float | None = None,
+                       log_gbs: bool = False,
+                       hw_label: str | None = None,
+                       label_overrides: dict | None = None) -> str:
+    """Throughput chart with three axes: CPU% (left), GB/s (inner right),
+    msg/s (outer right)."""
+    sizes = data["sizes"]
+    tput = data["tput"]
+    tput_cpu = data.get("tput_cpu", {})
+    n = len(sizes)
+    if n < 2:
+        print(f"WARNING: only {n} data points for {transport_label}", file=sys.stderr)
+        if n == 0:
+            return ""
+
+    hw_offset = 14 if hw_label else 0
+    x_left = 90
+    x_right = 700
+    x_right2 = 780
+    plot_w = x_right - x_left
+    mid_x = (x_left + x_right) / 2
+    right_pad = 15
+    svg_w = x_right2 + 80 + right_pad
+    svg_h = 520 + hw_offset
+
+    t1_y_top = 35 + hw_offset
+    t1_y_bot = 400 + hw_offset
+
+    xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
+
+    L = []
+    L.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">'
+    )
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>')
+
+    draw_throughput_cpu_panel(
+        L, sizes, xs, tput, tput_cpu, impls,
+        x_left, x_right, x_right2, t1_y_top, t1_y_bot,
+        f"PUSH/PULL throughput: {transport_label} (higher is better)",
+        fixed_gbs_max=fixed_gbs_max,
+        fixed_msg_max=fixed_msg_max,
+        log_gbs=log_gbs,
+    )
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="{t1_y_top - 3}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
+
+    leg_y = t1_y_bot + 40
+    _draw_impl_legend(L, impls, mid_x, leg_y, label_overrides=label_overrides)
+
+    # line-type legend
+    lt_y = leg_y + 22
+    lt_total = 500
+    lt_start = mid_x - lt_total / 2
+
+    L.append(
+        f'  <line x1="{lt_start:.0f}" y1="{lt_y}" x2="{lt_start + 14:.0f}" y2="{lt_y}"'
+        f' stroke="#6b7280" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>'
+    )
+    L.append(
+        f'  <text x="{lt_start + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
+        f' font-size="10">CPU % (left)</text>'
+    )
+
+    lt_mid = lt_start + 145
+    L.append(
+        f'  <line x1="{lt_mid:.0f}" y1="{lt_y}" x2="{lt_mid + 14:.0f}" y2="{lt_y}"'
+        f' stroke="#6b7280" stroke-width="2.5"/>'
+    )
+    L.append(f'  <circle cx="{lt_mid + 7:.0f}" cy="{lt_y}" r="2" fill="#6b7280"/>')
+    L.append(
+        f'  <text x="{lt_mid + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
+        f' font-size="10">GB/s (inner right{", log" if log_gbs else ""})</text>'
+    )
+
+    lt_right = lt_mid + 165
+    L.append(
+        f'  <line x1="{lt_right:.0f}" y1="{lt_y}" x2="{lt_right + 14:.0f}" y2="{lt_y}"'
+        f' stroke="#6b7280" stroke-width="1.5" stroke-dasharray="5,3"/>'
+    )
+    L.append(
+        f'  <text x="{lt_right + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
+        f' font-size="10">msg/s (outer right)</text>'
+    )
+
+    L.append("</svg>")
+    return "\n".join(L) + "\n"
+
+
+def generate_latency_chart_cpu(data: dict, impls: list[str], transport_label: str,
+                               fixed_lat_max: float | None = None,
+                               hw_label: str | None = None,
+                               label_overrides: dict | None = None) -> str:
+    """Latency chart with two axes: p50 latency (left), CPU% (right, dotted)."""
+    sizes = data["sizes"]
+    lat = data["lat"]
+    lat_cpu = data.get("lat_cpu", {})
+    n = len(sizes)
+    if n < 2:
+        return ""
+
+    has_latency = any(s in lat and any(name in lat[s] for name in impls) for s in sizes)
+    if not has_latency:
+        return ""
+
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 320 + hw_offset
+    x_left, x_right = 90, 760
+    plot_w = x_right - x_left
+    mid_x = (x_left + x_right) / 2
+
+    y_top = 35 + hw_offset
+    y_bot = y_top + 180
+
+    xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
+
+    L = []
+    L.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">'
+    )
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>')
+
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="{y_top - 3}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
+
+    draw_latency_cpu_panel(
+        L, sizes, xs, lat, lat_cpu, impls, x_left, x_right, y_top, y_bot,
+        f"REQ/REP latency: {transport_label} (p50 µs, lower is better)",
+        fixed_lat_max=fixed_lat_max,
+    )
+
+    leg_y = y_bot + 40
+    _draw_impl_legend(L, impls, mid_x, leg_y, label_overrides=label_overrides)
+
+    # line-type legend
+    lt_y = leg_y + 22
+    lt_total = 320
+    lt_start = mid_x - lt_total / 2
+
+    L.append(
+        f'  <line x1="{lt_start:.0f}" y1="{lt_y}" x2="{lt_start + 14:.0f}" y2="{lt_y}"'
+        f' stroke="#6b7280" stroke-width="2.5"/>'
+    )
+    L.append(f'  <circle cx="{lt_start + 7:.0f}" cy="{lt_y}" r="2" fill="#6b7280"/>')
+    L.append(
+        f'  <text x="{lt_start + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
+        f' font-size="10">p50 latency (left)</text>'
+    )
+
+    lt_right = lt_start + 170
+    L.append(
+        f'  <line x1="{lt_right:.0f}" y1="{lt_y}" x2="{lt_right + 14:.0f}" y2="{lt_y}"'
+        f' stroke="#6b7280" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>'
+    )
+    L.append(
+        f'  <text x="{lt_right + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
+        f' font-size="10">CPU % (right)</text>'
+    )
+
+    L.append("</svg>")
+    return "\n".join(L) + "\n"
+
+
 def load_pubsub_data(transport: str, impls: list[str], peers: int) -> dict:
     rows = load_jsonl()
     t_rows = [r for r in rows
@@ -775,52 +1236,81 @@ def load_fanio_data(transport: str, impls: list[str], peers: int,
 
 
 def main():
-    FIXED_MSG_MAX = 20e6
     FIXED_GBS_MAX = 6.0
     FIXED_LAT_MAX = 150.0
     FIXED_INPROC_LAT_MAX = 40.0
     hw = detect_hardware()
-    if hw:
-        hw = "Linux VM on a 2018 Mac Mini, " + hw
 
-    tcp_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
-    ipc_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
-    inproc_impls = ["libzmq", "omq-compio", "omq-compio-st", "omq-tokio", "rzmq"]
+    # ── Main charts (with CPU%): libzmq + omq backends ──────────
+    main_impls = ["libzmq", "omq-compio", "omq-tokio", "omq-tokio-mt"]
 
-    for transport, impls, label, log_gbs in [
-        ("tcp", tcp_impls, "TCP loopback, 2-process", False),
-        ("ipc", ipc_impls, "IPC, 2-process", False),
-        ("inproc", inproc_impls, "inproc", True),
+    for transport, impls, label, log in [
+        ("tcp", main_impls, "TCP loopback, 2-process", False),
+        ("ipc", main_impls, "IPC, 2-process", False),
+        ("inproc", ["libzmq", "omq-compio", "omq-compio-st", "omq-tokio", "omq-tokio-mt"], "inproc", True),
     ]:
         data = load_data(transport, impls)
         if not data["sizes"]:
             print(f"No {transport} data found", file=sys.stderr)
             continue
 
-        msg_max = 10e6 if transport == "inproc" else FIXED_MSG_MAX
-        msg_break = (1e6, 0.25) if not log_gbs else None
         inproc_overrides = {"omq-compio": "omq-compio (MT)"} if transport == "inproc" else None
-        svg = generate_chart(data, impls, label, log_gbs=log_gbs,
-                             fixed_msg_max=msg_max,
-                             fixed_gbs_max=None if log_gbs else FIXED_GBS_MAX,
-                             msg_break=msg_break,
-                             hw_label=hw,
-                             label_overrides=inproc_overrides)
-        out = REPO / "doc" / "charts" / "pushpull" / f"comparison_{transport}.svg"
-        out.write_text(svg)
-        print(f"Written: {out}", file=sys.stderr)
+        svg = generate_chart_cpu(data, impls, label,
+                                 fixed_gbs_max=None if log else FIXED_GBS_MAX,
+                                 log_gbs=log,
+                                 hw_label=hw,
+                                 label_overrides=inproc_overrides)
+        if svg:
+            out = REPO / "doc" / "charts" / "pushpull" / f"comparison_{transport}.svg"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(svg)
+            print(f"Written: {out}", file=sys.stderr)
 
         lat_max = FIXED_INPROC_LAT_MAX if transport == "inproc" else FIXED_LAT_MAX
-        svg = generate_latency_chart(data, impls, label,
-                                     fixed_lat_max=lat_max, hw_label=hw,
-                                     label_overrides=inproc_overrides)
+        svg = generate_latency_chart_cpu(data, impls, label,
+                                         fixed_lat_max=lat_max, hw_label=hw,
+                                         label_overrides=inproc_overrides)
         if svg:
             out = REPO / "doc" / "charts" / "reqrep" / f"comparison_{transport}.svg"
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(svg)
             print(f"Written: {out}", file=sys.stderr)
 
-    # PUB/SUB charts
+    # ── Alt charts (all impls, with CPU%) ─────────────────────
+    alt_impls = ["libzmq", "omq-compio", "omq-tokio", "omq-tokio-mt", "zmq.rs", "rzmq"]
+
+    for transport, impls, label, log in [
+        ("tcp", alt_impls, "TCP loopback, 2-process", False),
+        ("ipc", alt_impls, "IPC, 2-process", False),
+        ("inproc", ["libzmq", "omq-compio", "omq-compio-st", "omq-tokio", "omq-tokio-mt", "rzmq"], "inproc", True),
+    ]:
+        data = load_data(transport, impls)
+        if not data["sizes"]:
+            continue
+
+        inproc_overrides = {"omq-compio": "omq-compio (MT)"} if transport == "inproc" else None
+        svg = generate_chart_cpu(data, impls, label,
+                                 fixed_gbs_max=None if log else FIXED_GBS_MAX,
+                                 log_gbs=log,
+                                 hw_label=hw,
+                                 label_overrides=inproc_overrides)
+        if svg:
+            out = REPO / "doc" / "charts" / "pushpull" / f"alt_{transport}.svg"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(svg)
+            print(f"Written: {out}", file=sys.stderr)
+
+        lat_max = FIXED_INPROC_LAT_MAX if transport == "inproc" else FIXED_LAT_MAX
+        svg = generate_latency_chart_cpu(data, impls, label,
+                                         fixed_lat_max=lat_max, hw_label=hw,
+                                         label_overrides=inproc_overrides)
+        if svg:
+            out = REPO / "doc" / "charts" / "reqrep" / f"alt_{transport}.svg"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(svg)
+            print(f"Written: {out}", file=sys.stderr)
+
+    # ── PUB/SUB charts ──────────────────────────────────────────
     PUBSUB_MSG_MAX = 10e6
     PUBSUB_GBS_MAX = 8.0
     pubsub_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
@@ -853,8 +1343,7 @@ def main():
             out.write_text(svg)
             print(f"Written: {out}", file=sys.stderr)
 
-
-    # Fan-out / fan-in charts (TCP only)
+    # ── Fan-out / fan-in charts (TCP only) ──────────────────────
     fanio_impls = ["libzmq", "omq-compio", "omq-tokio", "zmq.rs", "rzmq"]
     fanio_peers = [2, 4, 8]
 

--- a/scripts/libzmq_bench_peer.c
+++ b/scripts/libzmq_bench_peer.c
@@ -29,11 +29,19 @@
 #include <time.h>
 #include <ctype.h>
 #include <pthread.h>
+#include <sys/resource.h>
 
 static double now_secs(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+
+static double cpu_time_secs(void) {
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+    return (ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6)
+         + (ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
 }
 
 static void die(const char *msg) {
@@ -134,6 +142,7 @@ int main(int argc, char **argv) {
         }
 
         long long count = 0;
+        double cpu_before = cpu_time_secs();
         double t0 = now_secs();
         double deadline = t0 + duration;
 
@@ -158,7 +167,8 @@ int main(int argc, char **argv) {
         }
 done:;
         double elapsed = now_secs() - t0;
-        printf("%lld %.6f %d\n", count, elapsed, size);
+        double cpu = cpu_time_secs() - cpu_before;
+        printf("%lld %.6f %d %.6f\n", count, elapsed, size, cpu);
 
         zmq_msg_close(&msg);
         zmq_close(sock);
@@ -492,6 +502,8 @@ done_inproc_pubsub:;
         uint64_t *rtts = malloc(sizeof(uint64_t) * iterations);
         if (!rtts) { perror("malloc"); exit(1); }
 
+        double wall_t0 = now_secs();
+        double cpu_before = cpu_time_secs();
         for (int i = 0; i < iterations; i++) {
             struct timespec t0, t1;
             clock_gettime(CLOCK_MONOTONIC, &t0);
@@ -501,6 +513,8 @@ done_inproc_pubsub:;
             rtts[i] = (uint64_t)(t1.tv_sec - t0.tv_sec) * 1000000000ULL
                      + (uint64_t)(t1.tv_nsec - t0.tv_nsec);
         }
+        double cpu = cpu_time_secs() - cpu_before;
+        double wall_elapsed = now_secs() - wall_t0;
 
         int cmp_u64(const void *a, const void *b) {
             uint64_t va = *(const uint64_t *)a;
@@ -519,7 +533,7 @@ done_inproc_pubsub:;
         double p99  = percentile(rtts, iterations, 99);
         double p999 = percentile(rtts, iterations, 99.9);
         double max  = rtts[iterations - 1] / 1000.0;
-        printf("%.3f %.3f %.3f %.3f %d\n", p50, p99, p999, max, iterations);
+        printf("%.3f %.3f %.3f %.3f %d %.6f %.6f\n", p50, p99, p999, max, iterations, cpu, wall_elapsed);
 
         free(rtts);
         free(buf);

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -107,12 +107,14 @@ def libzmq_version() -> str:
 
 # ── process management ────────────────────────────────────────────
 
-def spawn_process(binary: str, *args: str) -> subprocess.Popen:
+def spawn_process(binary: str, *args: str, env: dict | None = None) -> subprocess.Popen:
+    merged = {**os.environ, **(env or {})} if env else None
     return subprocess.Popen(
         [binary, *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        env=merged,
     )
 
 
@@ -131,12 +133,15 @@ def read_bound_port(proc: subprocess.Popen, timeout: float = 5.0) -> int | None:
     return None
 
 
-def capture_process(binary: str, *args: str, timeout: int = 15) -> str:
+def capture_process(binary: str, *args: str, timeout: int = 15,
+                    env: dict | None = None) -> str:
+    merged = {**os.environ, **(env or {})} if env else None
     proc = subprocess.Popen(
         [binary, *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        env=merged,
     )
     try:
         stdout, _ = proc.communicate(timeout=timeout)
@@ -171,6 +176,17 @@ def kill_process(proc: subprocess.Popen):
 
 # ── measurement parsing ──────────────────────────────────────────
 
+def read_proc_cpu(pid: int) -> float:
+    """Read user+sys CPU time in seconds from /proc/[pid]/stat."""
+    try:
+        fields = open(f"/proc/{pid}/stat").read().split()
+        utime = int(fields[13])
+        stime = int(fields[14])
+        return (utime + stime) / os.sysconf("SC_CLK_TCK")
+    except (OSError, IndexError):
+        return 0.0
+
+
 def parse_throughput(output: str, size: int) -> dict | None:
     parts = output.strip().split()
     if len(parts) < 2:
@@ -181,20 +197,37 @@ def parse_throughput(output: str, size: int) -> dict | None:
         return None
     msgs_s = count / elapsed
     mbps = (count * size) / elapsed / 1e6
-    return {"msgs_s": msgs_s, "mbps": mbps}
+    result = {"msgs_s": msgs_s, "mbps": mbps, "elapsed": elapsed}
+    if len(parts) >= 4:
+        try:
+            result["pull_cpu"] = float(parts[3])
+        except ValueError:
+            pass
+    return result
 
 
 def parse_latency(output: str) -> dict | None:
     parts = output.strip().split()
     if len(parts) < 5:
         return None
-    return {
+    result = {
         "p50_us": float(parts[0]),
         "p99_us": float(parts[1]),
         "p999_us": float(parts[2]),
         "max_us": float(parts[3]),
         "iterations": int(parts[4]),
     }
+    if len(parts) >= 6:
+        try:
+            result["req_cpu"] = float(parts[5])
+        except ValueError:
+            pass
+    if len(parts) >= 7:
+        try:
+            result["elapsed"] = float(parts[6])
+        except ValueError:
+            pass
+    return result
 
 
 # ── benchmark cells ──────────────────────────────────────────────
@@ -204,6 +237,7 @@ def run_throughput_cell(
     inproc_subcmd: str = "inproc",
     duration: float = DEFAULT_DURATION,
     rounds: int = DEFAULT_ROUNDS,
+    env: dict | None = None,
 ) -> dict | None:
     best = None
     # Extra retries for inproc: compio cross-thread waker bug causes
@@ -211,7 +245,7 @@ def run_throughput_cell(
     effective_rounds = max(rounds, 5) if transport == "inproc" else rounds
     for _ in range(effective_rounds):
         result = _run_throughput_once(binary, transport, addr, size,
-                                      inproc_subcmd, duration)
+                                      inproc_subcmd, duration, env=env)
         if result and (best is None or result["msgs_s"] > best["msgs_s"]):
             best = result
     return best
@@ -226,19 +260,19 @@ def _fresh_addr(addr: str) -> str:
 
 def _run_throughput_once(
     binary: str, transport: str, addr: str, size: int,
-    inproc_subcmd: str, duration: float,
+    inproc_subcmd: str, duration: float, env: dict | None = None,
 ) -> dict | None:
     dur = str(duration)
     if transport == "inproc":
         fresh_name = f"{addr}-{next_addr_id()}"
         timeout_s = max(int(duration) + 5, 8)
         output = capture_process(binary, inproc_subcmd, fresh_name, str(size),
-                                 dur, timeout=timeout_s)
+                                 dur, timeout=timeout_s, env=env)
         return parse_throughput(output, size)
 
     addr = _fresh_addr(addr)
     cleanup_ipc_socket(addr)
-    push = spawn_process(binary, "push", addr, str(size))
+    push = spawn_process(binary, "push", addr, str(size), env=env)
     if transport in ("ipc", "ws"):
         time.sleep(0.2)
         connect_addr = addr
@@ -249,11 +283,17 @@ def _run_throughput_once(
             return None
         connect_addr = str(port)
     try:
-        output = capture_process(binary, "pull", connect_addr, str(size), dur)
+        output = capture_process(binary, "pull", connect_addr, str(size), dur,
+                                 env=env)
+        push_cpu = read_proc_cpu(push.pid)
     finally:
         kill_process(push)
         cleanup_ipc_socket(addr)
-    return parse_throughput(output, size)
+    result = parse_throughput(output, size)
+    if result and push_cpu > 0:
+        pull_cpu = result.get("pull_cpu", 0.0)
+        result["cpu_time"] = push_cpu + pull_cpu
+    return result
 
 
 def run_pubsub_cell(
@@ -413,19 +453,20 @@ def run_latency_cell(
     iterations: int = LATENCY_ITERATIONS,
     warmup: int = LATENCY_WARMUP,
     timeout: int = LATENCY_TIMEOUT,
+    env: dict | None = None,
 ) -> dict | None:
     if transport == "inproc":
         fresh_name = f"{addr}-{next_addr_id()}"
         output = capture_process(
             binary, inproc_subcmd, fresh_name, str(size),
             str(iterations), str(warmup),
-            timeout=timeout,
+            timeout=timeout, env=env,
         )
         return parse_latency(output)
 
     addr = _fresh_addr(addr)
     cleanup_ipc_socket(addr)
-    rep = spawn_process(binary, "rep", addr, str(size))
+    rep = spawn_process(binary, "rep", addr, str(size), env=env)
     if transport in ("ipc", "ws"):
         time.sleep(0.2)
         connect_addr = addr
@@ -439,12 +480,17 @@ def run_latency_cell(
         output = capture_process(
             binary, "req", connect_addr, str(size),
             str(iterations), str(warmup),
-            timeout=timeout,
+            timeout=timeout, env=env,
         )
+        rep_cpu = read_proc_cpu(rep.pid)
     finally:
         kill_process(rep)
         cleanup_ipc_socket(addr)
-    return parse_latency(output)
+    result = parse_latency(output)
+    if result and rep_cpu > 0:
+        req_cpu = result.get("req_cpu", 0.0)
+        result["cpu_time"] = rep_cpu + req_cpu
+    return result
 
 
 # ── address generation ────────────────────────────────────────────
@@ -511,6 +557,16 @@ IMPLS = {
         "inproc_pubsub_subcmd": "inproc-pubsub",
         "supports_pubsub": True,
     },
+    "omq-tokio-mt": {
+        "binary_from": "omq-tokio",
+        "prefix": "u",
+        "transports": ["tcp", "inproc", "ipc", "ws"],
+        "inproc_tput_subcmd": "inproc",
+        "inproc_lat_subcmd": "inproc-latency",
+        "inproc_pubsub_subcmd": "inproc-pubsub",
+        "supports_pubsub": True,
+        "env": {"OMQ_BENCH_RUNTIME": "multi_thread"},
+    },
     "libzmq": {
         "prefix": "z",
         "transports": ["tcp", "inproc", "ipc", "ws"],
@@ -561,10 +617,16 @@ def build_peers(impl_names: set[str], ws_needed: bool):
         if "omq-compio-st" in impl_names:
             binaries["omq-compio-st"] = compio_bin
 
-    if "omq-tokio" in impl_names:
+    if impl_names & {"omq-tokio", "omq-tokio-mt"}:
         print("==> building omq-tokio bench_peer...", file=sys.stderr)
-        cargo_build("omq-tokio", "bench_peer_tokio", features=features or None)
-        binaries["omq-tokio"] = str(ROOT / "target" / "release" / "bench_peer_tokio")
+        tokio_features = list(features) if features else []
+        tokio_features.append("rt-multi-thread")
+        cargo_build("omq-tokio", "bench_peer_tokio", features=tokio_features)
+        tokio_bin = str(ROOT / "target" / "release" / "bench_peer_tokio")
+        if "omq-tokio" in impl_names:
+            binaries["omq-tokio"] = tokio_bin
+        if "omq-tokio-mt" in impl_names:
+            binaries["omq-tokio-mt"] = tokio_bin
 
     if "libzmq" in impl_names:
         print("==> building libzmq bench_peer...", file=sys.stderr)
@@ -654,12 +716,14 @@ def run_benchmarks(
                 addr = addr_for(transport, prefix, idx, base_port,
                                impl_name=name)
                 subcmd = impl_def.get("inproc_tput_subcmd", "inproc")
+                impl_env = impl_def.get("env")
                 result = run_throughput_cell(binary, transport, addr, size,
                                             inproc_subcmd=subcmd,
-                                            duration=duration, rounds=rounds)
+                                            duration=duration, rounds=rounds,
+                                            env=impl_env)
                 cells[name] = result
                 if result:
-                    append_jsonl({
+                    row = {
                         "run_id": run_id,
                         "impl": name,
                         "kind": "throughput",
@@ -667,7 +731,12 @@ def run_benchmarks(
                         "msg_size": size,
                         "msgs_s": round(result["msgs_s"], 1),
                         "mbps": round(result["mbps"], 1),
-                    })
+                    }
+                    if "elapsed" in result:
+                        row["elapsed"] = round(result["elapsed"], 6)
+                    if "cpu_time" in result:
+                        row["cpu_time"] = round(result["cpu_time"], 6)
+                    append_jsonl(row)
 
             line = f"{size_label(size):>10s}"
             for name in active:
@@ -692,14 +761,16 @@ def run_benchmarks(
                     addr = addr_for(transport, prefix, idx + len(sizes), base_port,
                                    impl_name=name)
                     subcmd = impl_def.get("inproc_lat_subcmd", "inproc-latency")
+                    impl_env = impl_def.get("env")
                     result = run_latency_cell(binary, transport, addr, size,
                                              inproc_subcmd=subcmd,
                                              iterations=latency_iterations,
                                              warmup=latency_warmup,
-                                             timeout=latency_timeout)
+                                             timeout=latency_timeout,
+                                             env=impl_env)
                     cells[name] = result
                     if result:
-                        append_jsonl({
+                        row = {
                             "run_id": run_id,
                             "impl": name,
                             "kind": "latency",
@@ -710,7 +781,12 @@ def run_benchmarks(
                             "p999_us": round(result["p999_us"], 3),
                             "max_us": round(result["max_us"], 3),
                             "iterations": result["iterations"],
-                        })
+                        }
+                        if "cpu_time" in result:
+                            row["cpu_time"] = round(result["cpu_time"], 6)
+                        if "elapsed" in result:
+                            row["elapsed"] = round(result["elapsed"], 6)
+                        append_jsonl(row)
 
                 line = f"{size_label(size):>10s}"
                 for name in active:

--- a/scripts/rzmq_bench_peer/src/main.rs
+++ b/scripts/rzmq_bench_peer/src/main.rs
@@ -53,6 +53,18 @@ fn resolve_addr(s: &str) -> String {
     }
 }
 
+fn resolve_bind_addr(s: &str) -> String {
+    if s == "0" {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        println!("PORT {port}");
+        format!("tcp://127.0.0.1:{port}")
+    } else {
+        resolve_addr(s)
+    }
+}
+
 fn leaked_payload(size: usize) -> &'static [u8] {
     Box::leak(vec![b'x'; size].into_boxed_slice())
 }
@@ -62,7 +74,7 @@ async fn main() {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(String::as_str) {
         Some("push") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             run_push(&addr, size).await;
         }
@@ -73,7 +85,7 @@ async fn main() {
             run_pull(&addr, size, Duration::from_secs_f64(duration)).await;
         }
         Some("rep") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             run_rep(&addr).await;
         }
         Some("req") => {
@@ -84,7 +96,7 @@ async fn main() {
             run_req(&addr, size, iterations, warmup).await;
         }
         Some("pub") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             run_pub(&addr, size).await;
         }
@@ -100,7 +112,7 @@ async fn main() {
             run_push_connect(&addr, size).await;
         }
         Some("pull-bind") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
             run_pull_bind(&addr, size, Duration::from_secs_f64(duration)).await;

--- a/scripts/zmqrs_bench_peer/src/main.rs
+++ b/scripts/zmqrs_bench_peer/src/main.rs
@@ -35,12 +35,24 @@ fn resolve_addr(s: &str) -> String {
     }
 }
 
+fn resolve_bind_addr(s: &str) -> String {
+    if s == "0" {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        println!("PORT {port}");
+        format!("tcp://127.0.0.1:{port}")
+    } else {
+        resolve_addr(s)
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(String::as_str) {
         Some("push") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             run_push(&addr, size).await;
         }
@@ -51,7 +63,7 @@ async fn main() {
             run_pull(&addr, size, Duration::from_secs_f64(duration)).await;
         }
         Some("rep") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             run_rep(&addr).await;
         }
         Some("req") => {
@@ -67,13 +79,13 @@ async fn main() {
             run_push_connect(&addr, size).await;
         }
         Some("pull-bind") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
             run_pull_bind(&addr, size, Duration::from_secs_f64(duration)).await;
         }
         Some("pub") => {
-            let addr = resolve_addr(&args[2]);
+            let addr = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             run_pub(&addr, size).await;
         }


### PR DESCRIPTION
- Fix ENOBUFS crash in omq-compio direct-recv multishot path
- Rewrite omq-compio compression bench as 2-process to avoid TLS panics
- Fix `block_on_and_drain` TLS panic in omq-compio benches
- Add lz4+tcp support to compio bench_peer, default to current_thread for tokio bench_peer
- Fix PORT discovery for zmq.rs and rzmq bench peers; update chart gen scripts
- Refresh pyomq bindings.svg for current_thread runtime; fix OMQ_HW_EXTRAS handling