### PR TITLE
Fix memory safety, correctness, and quality issues from code audit

### DIFF
--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -317,7 +317,7 @@ impl EncodedQueueCell {
 
     #[inline]
     pub(crate) fn borrow_mut(&self) -> EncodedQueueGuard<'_> {
-        debug_assert!(!self.borrowed.get(), "EncodedQueueCell: already borrowed");
+        assert!(!self.borrowed.get(), "EncodedQueueCell: already borrowed");
         self.borrowed.set(true);
         EncodedQueueGuard { cell: self }
     }

--- a/omq-compio/src/socket/send.rs
+++ b/omq-compio/src/socket/send.rs
@@ -898,14 +898,18 @@ impl Socket {
             let dgram = crate::transport::udp::encode_datagram(&group, &body)?;
             for sock in &udp_socks {
                 use std::os::fd::AsRawFd;
-                unsafe {
+                // SAFETY: sock is a valid connected UDP socket fd.
+                // dgram lives for the duration of the call.
+                // Best-effort: UDP send failures are silently ignored
+                // (matches ZMQ RADIO semantics for unreliable transport).
+                let _ = unsafe {
                     libc::send(
                         sock.as_raw_fd(),
                         dgram.as_ptr().cast::<libc::c_void>(),
                         dgram.len(),
                         libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL,
-                    );
-                }
+                    )
+                };
             }
         }
         let stream_targets: Vec<PeerOut> = {

--- a/omq-libzmq/src/inproc_bypass.rs
+++ b/omq-libzmq/src/inproc_bypass.rs
@@ -45,6 +45,15 @@ impl std::fmt::Debug for InprocPipe {
 
 const HEADER_SIZE: usize = 4;
 const WRAP_SENTINEL: u32 = u32::MAX;
+const ALIGN_MASK: usize = HEADER_SIZE - 1;
+
+/// Entry occupies `HEADER_SIZE + payload_len` bytes, rounded up to
+/// `HEADER_SIZE` alignment. Keeps `tail` 4-aligned so `cap - tail_offset`
+/// is always >= `HEADER_SIZE` (cap is a power of two).
+#[inline]
+const fn aligned_entry_size(payload_len: usize) -> usize {
+    (HEADER_SIZE + payload_len + ALIGN_MASK) & !ALIGN_MASK
+}
 
 struct RingBuf {
     buf: Box<[UnsafeCell<u8>]>,
@@ -135,7 +144,7 @@ impl RingProducer {
     /// Returns false if not enough space.
     #[inline]
     fn try_push(&mut self, data: &[u8]) -> bool {
-        let entry_size = HEADER_SIZE + data.len();
+        let entry_size = aligned_entry_size(data.len());
         let cap = self.ring.capacity;
         let mask = cap - 1;
         let tail = self.tail;
@@ -162,8 +171,9 @@ impl RingProducer {
                     return false;
                 }
             }
-            // SAFETY: tail_offset..tail_offset+4 is within buf (contiguous >= HEADER_SIZE
-            // because capacity is a power of two and entry_size >= HEADER_SIZE).
+            // SAFETY: tail_offset..tail_offset+4 is within buf. `contiguous >= HEADER_SIZE`
+            // because capacity is a power of two and tail is always HEADER_SIZE-aligned
+            // (aligned_entry_size rounds up all advances).
             unsafe {
                 let dst = self.ring.buf[tail_offset].get();
                 std::ptr::copy_nonoverlapping(
@@ -192,7 +202,7 @@ impl RingProducer {
             std::ptr::copy_nonoverlapping(len.to_ne_bytes().as_ptr(), base, HEADER_SIZE);
             std::ptr::copy_nonoverlapping(data.as_ptr(), base.add(HEADER_SIZE), data.len());
         }
-        self.tail += HEADER_SIZE + data.len();
+        self.tail += aligned_entry_size(data.len());
     }
 
     /// Publish all written entries to the consumer. Returns true if
@@ -267,7 +277,7 @@ impl RingConsumer {
     /// Advance past the last peeked entry and publish the new head.
     #[inline]
     fn advance_and_release(&mut self, len: usize) {
-        self.head += HEADER_SIZE + len;
+        self.head += aligned_entry_size(len);
         self.ring.head.store(self.head, Ordering::Release);
     }
 

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -35,10 +35,11 @@ pub struct OmqMsgRepr {
     reserved: [u8; 16],
 }
 
-// SAFETY: The pointer fields are either null or owned by exactly one
-// OmqMsgRepr instance; no concurrent access.
+// SAFETY: pointer fields are owned by exactly one OmqMsgRepr instance.
+// Send is needed for ownership transfer across threads.
+// Sync is intentionally omitted: concurrent &-access from multiple
+// threads (e.g. via Arc) would be unsound.
 unsafe impl Send for OmqMsgRepr {}
-unsafe impl Sync for OmqMsgRepr {}
 
 impl std::fmt::Debug for OmqMsgRepr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use omq_tokio::MechanismSetup;
 use omq_tokio::options::{KeepAlive, ReconnectPolicy};
 
+use crate::error::fail;
 use crate::socket::DEFAULT_HWM;
 
 macro_rules! lock_overlay {
@@ -1141,15 +1142,15 @@ fn write_string(optval: *mut libc::c_void, optvallen: *mut usize, data: &[u8]) -
     }
     // SAFETY: optvallen is non-null (checked above).
     let avail = unsafe { *optvallen };
-    let copy_len = data.len().min(avail);
-    // SAFETY: optval is non-null with at least copy_len bytes; null-terminator
-    // only written when buffer has room.
+    let needed = data.len() + 1;
+    if avail < needed {
+        return fail(libc::EINVAL);
+    }
+    // SAFETY: optval is non-null with at least `needed` bytes available.
     unsafe {
-        std::ptr::copy_nonoverlapping(data.as_ptr(), optval.cast::<u8>(), copy_len);
-        if copy_len < avail {
-            *optval.cast::<u8>().add(copy_len) = 0;
-        }
-        *optvallen = data.len() + 1;
+        std::ptr::copy_nonoverlapping(data.as_ptr(), optval.cast::<u8>(), data.len());
+        *optval.cast::<u8>().add(data.len()) = 0;
+        *optvallen = needed;
     }
     0
 }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -376,7 +376,7 @@ pub extern "C" fn zmq_setsockopt(
             lock_overlay!(sock_arc).handshake_ivl = if v <= 0 {
                 None
             } else {
-                Some(Duration::from_millis(v as u64 * 1000))
+                Some(Duration::from_secs(v as u64))
             };
         }
         ZMQ_MAXMSGSIZE => {

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -69,7 +69,7 @@ impl NotifyFd {
             return None;
         }
         // SAFETY: same as above.
-        let send_fd = unsafe { libc::eventfd(DEFAULT_HWM as u32, libc::EFD_NONBLOCK) };
+        let send_fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK) };
         if send_fd < 0 {
             // SAFETY: recv_fd is a valid open fd from the successful eventfd call above.
             unsafe { libc::close(recv_fd) };

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -570,10 +570,10 @@ pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
 ///
 /// `sock_ptr` must be a valid `*mut Arc<OmqSocket>` or null (returns EFAULT).
 /// `addr` must be a valid C string pointer or null (returns EFAULT).
-unsafe fn parse_endpoint_args(
+unsafe fn parse_endpoint_args<'a>(
     sock_ptr: *mut c_void,
     addr: *const c_char,
-) -> Result<(&'static Arc<OmqSocket>, String, Endpoint), c_int> {
+) -> Result<(&'a Arc<OmqSocket>, String, Endpoint), c_int> {
     if sock_ptr.is_null() || addr.is_null() {
         return Err(libc::EFAULT);
     }
@@ -601,10 +601,10 @@ unsafe fn parse_endpoint_args(
 ///
 /// `sock_ptr` must be a valid `*mut Arc<OmqSocket>` or null.
 /// `cstr` must be a valid C string pointer or null.
-unsafe fn parse_group_args(
+unsafe fn parse_group_args<'a>(
     sock_ptr: *mut c_void,
     cstr: *const c_char,
-) -> Result<(&'static Arc<OmqSocket>, Bytes), c_int> {
+) -> Result<(&'a Arc<OmqSocket>, Bytes), c_int> {
     if sock_ptr.is_null() || cstr.is_null() {
         return Err(libc::EFAULT);
     }

--- a/omq-proto/src/encoded_queue.rs
+++ b/omq-proto/src/encoded_queue.rs
@@ -90,6 +90,7 @@ impl EncodedQueue {
     /// `Entry::Arena`, if non-empty. Called before pushing `External`
     /// entries to preserve wire ordering.
     fn commit_arena_range(&mut self) {
+        debug_assert!(u32::try_from(self.arena.len()).is_ok());
         let end = self.arena.len() as u32;
         if end > self.arena_mark {
             self.entries.push_back(Entry::Arena {

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -30,7 +30,7 @@ fn inline_message_from_buf(
     payload_len: usize,
 ) -> Message {
     let mut data: [std::mem::MaybeUninit<u8>; crate::message::MAX_INLINE_MESSAGE] =
-        unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+        unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
     buf.read_into_uninit(payload_len, &mut data);
     Message {
         inner: crate::message::MessageInner::Inline {
@@ -648,7 +648,7 @@ impl Connection {
         // SAFETY: same pattern as try_advance_ready — MaybeUninit<u8> array
         // has no validity invariant.
         let mut data: [std::mem::MaybeUninit<u8>; crate::message::MAX_INLINE_MESSAGE] =
-            unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+            unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
 
         // Read ZWS flag + payload together, then split.
         // We use a small stack buffer for the ZWS flag byte.

--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -303,12 +303,12 @@ impl CurveClient {
         }
     }
 
-    fn next_out_counter(&mut self) -> u64 {
+    fn next_out_counter(&mut self) -> Result<u64> {
         self.out_counter = self
             .out_counter
             .checked_add(1)
-            .expect("CURVE handshake nonce counter exhausted");
-        self.out_counter
+            .ok_or_else(|| Error::Protocol("CURVE handshake nonce counter exhausted".into()))?;
+        Ok(self.out_counter)
     }
 
     fn start(&mut self, out: &mut Vec<Command>, our_props: PeerProperties) -> Result<()> {
@@ -386,7 +386,7 @@ impl CurveClient {
     }
 
     fn build_hello(&mut self) -> Result<Bytes> {
-        let counter = self.next_out_counter();
+        let counter = self.next_out_counter()?;
         let nonce = nonce_short(NONCE_HELLO, counter);
         let signature_box = SalsaBox::new(&self.peer_lt_public, self.eph_secret())
             .encrypt(&nonce.into(), &[0u8; 64][..])
@@ -443,7 +443,7 @@ impl CurveClient {
     }
 
     fn build_initiate(&mut self) -> Result<Bytes> {
-        let counter = self.next_out_counter();
+        let counter = self.next_out_counter()?;
 
         let Some(CurveClientState::AwaitingReady {
             ref our_eph_secret,
@@ -597,12 +597,12 @@ impl CurveServer {
         }
     }
 
-    fn next_out_counter(&mut self) -> u64 {
+    fn next_out_counter(&mut self) -> Result<u64> {
         self.out_counter = self
             .out_counter
             .checked_add(1)
-            .expect("CURVE handshake nonce counter exhausted");
-        self.out_counter
+            .ok_or_else(|| Error::Protocol("CURVE handshake nonce counter exhausted".into()))?;
+        Ok(self.out_counter)
     }
 
     fn start(&mut self, our_props: PeerProperties) {
@@ -709,7 +709,7 @@ impl CurveServer {
             .encrypt(&welcome_nonce.into(), welcome_pt.as_slice())
             .map_err(|_| Error::Protocol("CURVE WELCOME encrypt failed".into()))?;
 
-        let counter = self.next_out_counter();
+        let counter = self.next_out_counter()?;
         let _ = counter; // WELCOME doesn't carry a short nonce counter
 
         let mut body = BytesMut::with_capacity(160);
@@ -805,7 +805,7 @@ impl CurveServer {
     }
 
     fn build_ready(&mut self) -> Result<Bytes> {
-        let counter = self.next_out_counter();
+        let counter = self.next_out_counter()?;
         let CurveServerState::Done {
             ref our_eph_secret,
             ref peer_eph_public,

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -560,10 +560,6 @@ where
             let want_write = codec.has_pending_transmit() || !eq.is_empty();
             let hb_enabled = hb_interval.is_some() && codec.is_ready();
 
-            if let Some(ref slot) = wire_slot {
-                slot.driver_in_select.store(true, Ordering::Release);
-            }
-
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
@@ -769,10 +765,6 @@ where
                 // spurious polls/sec at 64 peers.
                 // () = tokio::time::sleep(Duration::from_millis(10)) => {}
             }
-
-            if let Some(ref slot) = wire_slot {
-                slot.driver_in_select.store(false, Ordering::Relaxed);
-            }
         }
     }
 }
@@ -862,6 +854,11 @@ async fn drain_wire_slot<W: AsyncWrite + Unpin>(
         write_chunks(writer, drain_buf).await?;
         slot.space_available.notify_one();
         if batch_bytes >= max_batch_bytes() {
+            // Data remains in the wire slot. Self-notify so the next
+            // select! iteration re-enters this arm instead of parking
+            // on a notification that signal_encoded will skip (pending
+            // is still true).
+            slot.data_ready.notify_one();
             break;
         }
     }

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -31,7 +31,6 @@ pub(crate) struct PeerWireSlot {
     cap: usize,
     pub(crate) data_ready: Notify,
     pub(crate) space_available: Notify,
-    pub(crate) driver_in_select: AtomicBool,
     pub(crate) handshake_done: AtomicBool,
     pending: AtomicBool,
     #[allow(dead_code)]
@@ -69,7 +68,6 @@ impl PeerWireSlot {
             cap,
             data_ready: Notify::new(),
             space_available: Notify::new(),
-            driver_in_select: AtomicBool::new(false),
             handshake_done: AtomicBool::new(false),
             pending: AtomicBool::new(false),
             has_transform,
@@ -151,7 +149,9 @@ impl PeerWireSlot {
     pub(crate) fn drain_into_vec(&self, buf: &mut Vec<Bytes>, max_chunks: usize) {
         let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
         eq.drain_into_vec(buf, max_chunks);
-        self.pending.store(false, Ordering::Relaxed);
+        if eq.is_empty() {
+            self.pending.store(false, Ordering::Relaxed);
+        }
     }
 
     pub(crate) fn has_space(&self) -> bool {

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -267,12 +267,8 @@ impl Submitter {
                 encoder,
                 all_wire,
             } => {
-                if all_wire {
+                if all_wire && !self.xpub_nodrop {
                     self.arena.encode_and_signal(&forwarded, encoder.as_deref());
-                    let interval = yield_interval(targets.len());
-                    if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
-                        tokio::task::yield_now().await;
-                    }
                 } else {
                     if self.xpub_nodrop {
                         while !targets_have_space(&targets) {
@@ -280,10 +276,10 @@ impl Submitter {
                         }
                     }
                     dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
-                    let interval = yield_interval(targets.len());
-                    if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
-                        tokio::task::yield_now().await;
-                    }
+                }
+                let interval = yield_interval(targets.len());
+                if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
+                    tokio::task::yield_now().await;
                 }
                 return Ok(());
             }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -361,24 +361,32 @@ impl Socket {
     pub async fn send(&self, msg: Message) -> Result<()> {
         match self.inner.socket_type {
             SocketType::Req => {
-                if self.inner.req_awaiting_reply.load(Ordering::Relaxed) {
-                    tokio::task::yield_now().await;
-                    if self.inner.req_awaiting_reply.load(Ordering::Relaxed) {
-                        if self.is_wire_slot_dead() {
-                            self.inner
-                                .req_awaiting_reply
-                                .store(false, Ordering::Relaxed);
-                        } else {
-                            return Err(Error::Protocol(
-                                "REQ socket must receive a reply before sending again".into(),
-                            ));
-                        }
+                loop {
+                    if self
+                        .inner
+                        .req_awaiting_reply
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        break;
                     }
+                    tokio::task::yield_now().await;
+                    if self.is_wire_slot_dead() {
+                        self.inner
+                            .req_awaiting_reply
+                            .store(false, Ordering::Release);
+                        continue;
+                    }
+                    return Err(Error::Protocol(
+                        "REQ socket must receive a reply before sending again".into(),
+                    ));
                 }
                 let msg = Message::with_prefix(Bytes::new(), msg);
                 let result = self.send_via_wire_slot(msg).await;
-                if result.is_ok() {
-                    self.inner.req_awaiting_reply.store(true, Ordering::Relaxed);
+                if result.is_err() {
+                    self.inner
+                        .req_awaiting_reply
+                        .store(false, Ordering::Release);
                 }
                 result
             }
@@ -413,15 +421,22 @@ impl Socket {
     pub fn try_send(&self, msg: Message) -> core::result::Result<(), TrySendError> {
         match self.inner.socket_type {
             SocketType::Req => {
-                if self.inner.req_awaiting_reply.load(Ordering::Relaxed) {
+                if self
+                    .inner
+                    .req_awaiting_reply
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+                {
                     return Err(TrySendError::Error(Error::Protocol(
                         "REQ socket must receive a reply before sending again".into(),
                     )));
                 }
                 let msg = Message::with_prefix(Bytes::new(), msg);
                 let result = self.inner.send_submitter.try_send(msg);
-                if result.is_ok() {
-                    self.inner.req_awaiting_reply.store(true, Ordering::Relaxed);
+                if result.is_err() {
+                    self.inner
+                        .req_awaiting_reply
+                        .store(false, Ordering::Release);
                 }
                 result
             }
@@ -464,7 +479,7 @@ impl Socket {
                 }
                 self.inner
                     .req_awaiting_reply
-                    .store(false, Ordering::Relaxed);
+                    .store(false, Ordering::Release);
                 return Ok(msg);
             },
             _ => self.inner.recv_rx.recv().await,
@@ -483,7 +498,7 @@ impl Socket {
                 {
                     self.inner
                         .req_awaiting_reply
-                        .store(false, Ordering::Relaxed);
+                        .store(false, Ordering::Release);
                     return Ok(msg);
                 }
             }


### PR DESCRIPTION
- Fix heap buffer overflow in inproc bypass `RingProducer::try_push` WRAP_SENTINEL write (non-4-aligned entries caused 1-3 byte heap overflow)
- Fix REQ send/recv alternation TOCTOU under concurrent senders (`Relaxed` load+store replaced with `compare_exchange`)
- Fix FanOut arena path bypassing `xpub_nodrop` backpressure (all-wire peers skipped the nodrop check)
- Narrow `parse_endpoint_args`/`parse_group_args` return lifetime from `'static` to `'a`
- Upgrade `EncodedQueueCell::borrow_mut` aliasing check from `debug_assert` to `assert`
- Use `MaybeUninit::zeroed()` for inline message buffers (indeterminate tail bytes)
- Replace CURVE handshake nonce counter `expect` panic with `Result`
- Add `debug_assert` for arena length `u32` overflow in `commit_arena_range`
- Remove dead `driver_in_select` field and stores from `PeerWireSlot`
- Remove unnecessary `unsafe impl Sync` for `OmqMsgRepr`
- Fix `write_string` to return `EINVAL` when buffer too small (was silently truncating and reporting untruncated length)
- Use `Duration::from_secs` for `ZMQ_HANDSHAKE_IVL`
- Only clear `pending` flag when `EncodedQueue` is actually empty after drain
- Initialize `send_fd` eventfd with 0 instead of `DEFAULT_HWM`
- Add SAFETY comment and capture `libc::send` return value in `try_send_radio`