### PR TITLE
Fan-out performance optimizations

### DIFF
--- a/doc/charts/pubsub/alt_tcp.svg
+++ b/doc/charts/pubsub/alt_tcp.svg
@@ -18,14 +18,14 @@
   <text x="82.0" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="49.0" x2="700.0" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="255.4" x2="700.0" y2="255.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="255.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90.0" y1="201.8" x2="700.0" y2="201.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="201.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="148.2" x2="700.0" y2="148.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="148.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90.0" y1="94.6" x2="700.0" y2="94.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="94.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="250.5" x2="700.0" y2="250.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="250.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90.0" y1="192.0" x2="700.0" y2="192.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="192.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="133.5" x2="700.0" y2="133.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="133.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
+  <line x1="90.0" y1="75.0" x2="700.0" y2="75.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="75.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
   <text x="788.0" y="275.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
   <text x="788.0" y="241.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
   <text x="788.0" y="207.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
@@ -52,69 +52,69 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="309.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="179.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,179.0)">CPU %</text>
   <polyline points="90.0,153.3 140.8,146.8 191.7,145.9 242.5,146.2 293.3,166.0 344.2,177.7 395.0,190.7 445.8,198.8 496.7,217.4 547.5,220.6 598.3,216.1 649.2,218.0 700.0,212.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,226.5 140.8,226.5 191.7,226.1 242.5,226.5 293.3,226.1 344.2,226.5 395.0,226.5 445.8,226.8 496.7,226.5 547.5,226.2 598.3,226.8 649.2,227.4 700.0,226.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,226.8 140.8,226.5 191.7,226.5 242.5,226.5 293.3,226.1 344.2,226.5 395.0,226.1 445.8,226.5 496.7,226.5 547.5,226.8 598.3,226.5 649.2,226.5 700.0,226.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,91.0 140.8,96.8 191.7,100.8 242.5,103.9 293.3,100.5 344.2,97.8 395.0,111.1 445.8,122.4 496.7,135.5 547.5,145.2 598.3,151.7 649.2,151.1 700.0,155.1" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,227.8 140.8,234.6 191.7,235.9 242.5,239.1 293.3,240.8 344.2,241.8 395.0,242.4 445.8,242.4 496.7,242.4 547.5,242.4 598.3,242.7 649.2,242.7 700.0,257.7" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,90.8 140.8,82.9 191.7,83.1 242.5,163.6 293.3,239.6 344.2,244.2 395.0,259.2 445.8,279.2 496.7,292.0 547.5,299.7 598.3,302.8 649.2,306.6 700.0,307.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,148.6 140.8,151.0 191.7,153.6 242.5,186.1 293.3,189.5 344.2,214.0 395.0,215.1 445.8,239.7 496.7,258.3 547.5,279.6 598.3,295.5 649.2,301.8 700.0,304.7" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,154.8 140.8,155.1 191.7,154.7 242.5,184.5 293.3,190.5 344.2,213.7 395.0,215.4 445.8,243.7 496.7,263.0 547.5,282.8 598.3,296.8 649.2,301.7 700.0,305.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,262.5 140.8,260.6 191.7,255.7 242.5,258.8 293.3,258.0 344.2,255.7 395.0,263.0 445.8,268.4 496.7,275.7 547.5,285.6 598.3,295.7 649.2,301.2 700.0,305.0" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,295.9 140.8,298.1 191.7,299.0 242.5,299.9 293.3,300.6 344.2,301.4 395.0,301.5 445.8,302.2 496.7,302.7 547.5,303.0 598.3,303.6 649.2,304.3 700.0,305.7" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,306.2 140.8,303.2 191.7,297.5 242.5,294.2 293.3,294.9 344.2,282.6 395.0,268.5 445.8,260.5 496.7,253.8 547.5,248.5 598.3,228.8 649.2,245.9 700.0,206.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="306.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="303.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="297.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="294.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="294.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="282.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="268.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="260.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="253.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="248.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="228.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="245.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="206.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.0 140.8,305.0 191.7,301.1 242.5,296.5 293.3,284.7 344.2,270.4 395.0,232.6 445.8,196.2 496.7,143.9 547.5,117.7 598.3,132.8 649.2,122.2 700.0,82.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="305.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="301.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="296.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="284.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="270.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="232.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="196.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="143.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="117.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="132.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="122.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="82.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,308.4 140.8,307.8 191.7,306.3 242.5,303.9 293.3,298.6 344.2,287.3 395.0,271.6 445.8,242.9 496.7,200.4 547.5,156.5 598.3,135.5 649.2,105.7 700.0,101.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,306.0 140.8,302.7 191.7,296.5 242.5,292.9 293.3,293.6 344.2,280.2 395.0,264.8 445.8,256.1 496.7,248.7 547.5,243.0 598.3,221.5 649.2,240.1 700.0,196.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="306.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="302.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="292.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="293.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="280.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="264.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="256.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="248.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="243.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="221.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="240.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="196.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,306.9 140.8,304.7 191.7,300.4 242.5,295.2 293.3,282.7 344.2,266.7 395.0,225.9 445.8,193.0 496.7,145.5 547.5,122.8 598.3,136.1 649.2,100.3 700.0,95.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="306.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="304.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="300.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="295.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="282.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="266.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="225.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="193.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="145.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="122.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="136.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="100.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="95.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,308.4 140.8,307.7 191.7,306.0 242.5,303.4 293.3,297.7 344.2,285.3 395.0,268.2 445.8,236.9 496.7,190.5 547.5,142.6 598.3,119.7 649.2,87.1 700.0,82.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="308.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="307.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="306.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="303.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="298.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="287.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="271.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="242.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="200.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="156.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="135.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="105.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="101.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,308.8 140.8,308.7 191.7,308.5 242.5,308.1 293.3,307.3 344.2,305.9 395.0,302.9 445.8,297.9 496.7,288.5 547.5,270.3 598.3,238.2 649.2,187.0 700.0,138.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="140.8" cy="307.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="306.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="303.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="297.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="285.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="268.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="236.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="190.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="142.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="119.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="87.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="82.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,308.8 140.8,308.7 191.7,308.4 242.5,308.0 293.3,307.1 344.2,305.6 395.0,302.4 445.8,296.9 496.7,286.6 547.5,266.7 598.3,231.7 649.2,175.8 700.0,123.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="308.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="308.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="308.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="308.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="307.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="305.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="302.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="297.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="288.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="270.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="238.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="187.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="138.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="308.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="308.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="307.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="305.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="302.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="296.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="286.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="266.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="231.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="175.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="123.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -145,20 +145,18 @@
   <text x="82.0" y="411.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="379.0" x2="700.0" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="569.0" x2="700.0" y2="569.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="569.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="499.0" x2="700.0" y2="499.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="499.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="429.0" x2="700.0" y2="429.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="429.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
-  <text x="788.0" y="607.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="575.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
-  <text x="788.0" y="543.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">600k/s</text>
-  <text x="788.0" y="511.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">800k/s</text>
-  <text x="788.0" y="479.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
-  <text x="788.0" y="447.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.2M/s</text>
-  <text x="788.0" y="415.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.4M/s</text>
-  <text x="788.0" y="383.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.6M/s</text>
+  <line x1="90.0" y1="567.3" x2="700.0" y2="567.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="567.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="495.6" x2="700.0" y2="495.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="495.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="424.0" x2="700.0" y2="424.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="424.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
+  <text x="788.0" y="598.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500k/s</text>
+  <text x="788.0" y="558.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
+  <text x="788.0" y="517.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5M/s</text>
+  <text x="788.0" y="477.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
+  <text x="788.0" y="436.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5M/s</text>
+  <text x="788.0" y="396.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
   <line x1="90.0" y1="379.0" x2="90.0" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="379.0" x2="140.8" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="379.0" x2="191.7" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -178,56 +176,56 @@
   <line x1="780.0" y1="379.0" x2="780.0" y2="639.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="509.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,509.0)">CPU %</text>
   <polyline points="90.0,506.1 140.8,512.6 191.7,516.5 242.5,521.0 293.3,529.8 344.2,539.2 395.0,550.0 445.8,552.5 496.7,559.4 547.5,558.1 598.3,556.8 649.2,556.5 700.0,554.2" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,559.4 140.8,557.8 191.7,558.1 242.5,556.1 293.3,556.5 344.2,556.1 395.0,560.4 445.8,556.5 496.7,558.1 547.5,556.5 598.3,556.1 649.2,556.1 700.0,556.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,558.4 140.8,558.7 191.7,557.8 242.5,562.6 293.3,557.4 344.2,556.8 395.0,556.5 445.8,556.1 496.7,556.5 547.5,556.5 598.3,556.1 649.2,556.8 700.0,556.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,565.6 140.8,554.2 191.7,552.9 242.5,570.8 293.3,542.3 344.2,542.5 395.0,558.4 445.8,549.2 496.7,561.7 547.5,558.1 598.3,548.7 649.2,527.5 700.0,531.4" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,557.8 140.8,558.4 191.7,560.4 242.5,564.3 293.3,567.9 344.2,569.9 395.0,571.1 445.8,571.4 496.7,571.7 547.5,572.8 598.3,573.1 649.2,573.7 700.0,574.0" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,412.9 140.8,430.3 191.7,446.4 242.5,501.3 293.3,547.7 344.2,578.8 395.0,604.3 445.8,618.8 496.7,628.7 547.5,633.7 598.3,636.3 649.2,637.5 700.0,637.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,516.7 140.8,530.5 191.7,540.8 242.5,542.8 293.3,551.7 344.2,559.2 395.0,572.6 445.8,581.8 496.7,602.6 547.5,614.3 598.3,625.1 649.2,631.3 700.0,635.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,620.1 140.8,623.5 191.7,622.0 242.5,621.7 293.3,623.8 344.2,623.1 395.0,622.5 445.8,622.8 496.7,625.0 547.5,628.6 598.3,631.7 649.2,634.3 700.0,636.2" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,632.0 140.8,632.1 191.7,632.6 242.5,633.5 293.3,634.1 344.2,634.6 395.0,634.9 445.8,635.1 496.7,635.2 547.5,635.5 598.3,635.8 649.2,636.3 700.0,636.9" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,635.8 140.8,633.1 191.7,628.2 242.5,623.5 293.3,618.5 344.2,611.9 395.0,607.8 445.8,602.7 496.7,602.0 547.5,600.6 598.3,599.7 649.2,596.6 700.0,563.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="635.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="633.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="628.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="623.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="618.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="611.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="607.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="602.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="602.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="600.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="599.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="596.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="563.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,637.3 140.8,636.0 191.7,633.5 242.5,628.2 293.3,619.4 344.2,603.1 395.0,579.3 445.8,536.2 496.7,508.2 547.5,461.5 598.3,438.8 649.2,416.9 700.0,412.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="637.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="636.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="633.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="628.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="619.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="603.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="579.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="536.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="508.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="461.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="438.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="416.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,524.2 140.8,533.0 191.7,541.2 242.5,569.1 293.3,592.7 344.2,608.4 395.0,621.4 445.8,628.7 496.7,633.8 547.5,636.3 598.3,637.6 649.2,638.3 700.0,638.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,412.9 140.8,435.9 191.7,458.1 242.5,460.2 293.3,477.4 344.2,535.0 395.0,563.9 445.8,591.5 496.7,611.8 547.5,624.5 598.3,631.4 649.2,635.2 700.0,637.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,629.4 140.8,631.1 191.7,630.4 242.5,630.2 293.3,631.3 344.2,630.9 395.0,630.6 445.8,630.8 496.7,631.9 547.5,633.7 598.3,635.3 649.2,636.6 700.0,637.6" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,635.4 140.8,635.5 191.7,635.7 242.5,636.2 293.3,636.5 344.2,636.8 395.0,636.9 445.8,637.0 496.7,637.1 547.5,637.2 598.3,637.4 649.2,637.6 700.0,637.9" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,635.7 140.8,633.0 191.7,627.9 242.5,623.2 293.3,618.0 344.2,611.3 395.0,607.0 445.8,601.8 496.7,601.1 547.5,599.7 598.3,598.8 649.2,595.6 700.0,561.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="635.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="633.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="627.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="623.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="618.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="611.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="607.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="601.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="601.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="599.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="598.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="595.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="561.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,632.6 140.8,627.5 191.7,618.5 242.5,598.5 293.3,565.8 344.2,544.7 395.0,502.8 445.8,466.7 496.7,441.8 547.5,428.2 598.3,418.9 649.2,418.8 700.0,412.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="632.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="627.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="618.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="598.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="565.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="544.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="502.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="466.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="441.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="428.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="418.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="418.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="412.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,638.7 140.8,638.6 191.7,638.0 242.5,637.1 293.3,635.6 344.2,631.9 395.0,624.1 445.8,609.8 496.7,588.7 547.5,564.4 598.3,533.6 649.2,503.7 700.0,477.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,638.7 140.8,638.6 191.7,638.0 242.5,637.0 293.3,635.5 344.2,631.7 395.0,623.8 445.8,609.1 496.7,587.4 547.5,562.6 598.3,531.0 649.2,500.5 700.0,473.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="638.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="638.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="191.7" cy="638.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="637.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="635.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="631.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="624.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="609.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="588.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="564.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="533.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="503.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="477.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,638.9 140.8,638.8 191.7,638.6 242.5,638.4 293.3,637.9 344.2,637.0 395.0,635.3 445.8,631.9 496.7,625.5 547.5,613.5 598.3,593.3 649.2,560.5 700.0,518.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="242.5" cy="637.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="635.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="631.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="623.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="609.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="587.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="562.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="531.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="500.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="473.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,638.9 140.8,638.8 191.7,638.6 242.5,638.4 293.3,637.9 344.2,637.0 395.0,635.3 445.8,631.8 496.7,625.2 547.5,612.9 598.3,592.2 649.2,558.6 700.0,515.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="638.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="638.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="191.7" cy="638.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -235,12 +233,12 @@
   <circle cx="293.3" cy="637.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="344.2" cy="637.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="395.0" cy="635.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="631.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="625.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="613.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="593.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="560.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="518.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="631.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="625.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="612.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="592.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="558.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="515.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -273,13 +271,10 @@
   <text x="708.0" y="774.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">8 GB/s</text>
   <line x1="90.0" y1="725.5" x2="700.0" y2="725.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="708.0" y="725.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
-  <text x="788.0" y="933.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">50k/s</text>
-  <text x="788.0" y="897.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
-  <text x="788.0" y="861.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">150k/s</text>
-  <text x="788.0" y="825.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="789.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">250k/s</text>
-  <text x="788.0" y="754.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
-  <text x="788.0" y="718.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">350k/s</text>
+  <text x="788.0" y="913.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
+  <text x="788.0" y="858.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
+  <text x="788.0" y="802.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
+  <text x="788.0" y="747.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
   <line x1="90.0" y1="709.0" x2="90.0" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="709.0" x2="140.8" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="709.0" x2="191.7" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -299,13 +294,13 @@
   <line x1="780.0" y1="709.0" x2="780.0" y2="969.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="839.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,839.0)">CPU %</text>
   <polyline points="90.0,755.1 140.8,766.9 191.7,759.7 242.5,776.0 293.3,807.8 344.2,823.4 395.0,832.5 445.8,834.5 496.7,831.2 547.5,834.5 598.3,841.0 649.2,824.7 700.0,824.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,810.4 140.8,807.8 191.7,813.0 242.5,815.0 293.3,812.4 344.2,807.8 395.0,808.5 445.8,810.4 496.7,807.8 547.5,806.5 598.3,806.0 649.2,800.0 700.0,805.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,916.7 140.8,897.5 191.7,874.8 242.5,872.8 293.3,860.5 344.2,839.0 395.0,814.3 445.8,802.0 496.7,802.6 547.5,802.7 598.3,800.7 649.2,802.0 700.0,802.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,916.4 140.8,915.7 191.7,912.5 242.5,907.3 293.3,906.6 344.2,903.4 395.0,900.1 445.8,894.3 496.7,887.8 547.5,872.8 598.3,863.7 649.2,857.2 700.0,872.2" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,815.7 140.8,809.8 191.7,811.1 242.5,812.6 293.3,811.1 344.2,816.6 395.0,814.4 445.8,829.3 496.7,834.5 547.5,838.4 598.3,837.1 649.2,835.8 700.0,837.1" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,742.9 140.8,773.2 191.7,779.3 242.5,824.1 293.3,891.9 344.2,910.9 395.0,930.1 445.8,944.1 496.7,955.4 547.5,961.3 598.3,965.5 649.2,967.1 700.0,967.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,940.7 140.8,919.0 191.7,912.9 242.5,907.8 293.3,917.2 344.2,915.1 395.0,915.4 445.8,935.7 496.7,947.9 547.5,955.6 598.3,960.8 649.2,962.8 700.0,966.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,940.2 140.8,942.5 191.7,936.5 242.5,944.1 293.3,945.1 344.2,935.7 395.0,942.9 445.8,946.2 496.7,948.0 547.5,950.7 598.3,958.2 649.2,962.7 700.0,966.3" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,964.4 140.8,963.9 191.7,964.3 242.5,962.5 293.3,962.7 344.2,962.3 395.0,963.6 445.8,964.1 496.7,964.0 547.5,964.8 598.3,964.8 649.2,966.9 700.0,967.2" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,793.9 140.8,817.3 191.7,822.1 242.5,856.7 293.3,909.3 344.2,924.0 395.0,938.9 445.8,949.7 496.7,958.5 547.5,963.1 598.3,966.3 649.2,967.5 700.0,967.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,742.9 140.8,756.7 191.7,787.9 242.5,818.4 293.3,842.9 344.2,855.9 395.0,879.8 445.8,909.8 496.7,934.7 547.5,950.3 598.3,960.5 649.2,964.5 700.0,966.9" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,946.7 140.8,948.5 191.7,943.9 242.5,949.7 293.3,950.5 344.2,943.2 395.0,948.8 445.8,951.4 496.7,952.7 547.5,954.8 598.3,960.7 649.2,964.1 700.0,966.9" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,965.4 140.8,965.0 191.7,965.3 242.5,963.9 293.3,964.1 344.2,963.8 395.0,964.8 445.8,965.2 496.7,965.1 547.5,965.7 598.3,965.7 649.2,967.4 700.0,967.6" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,965.1 140.8,962.2 191.7,955.8 242.5,948.8 293.3,947.5 344.2,936.7 395.0,925.7 445.8,913.5 496.7,908.4 547.5,900.6 598.3,905.8 649.2,901.8 700.0,850.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="965.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="962.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -320,20 +315,20 @@
   <circle cx="598.3" cy="905.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="901.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="850.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,968.5 140.8,967.3 191.7,965.1 242.5,960.5 293.3,954.6 344.2,939.0 395.0,909.3 445.8,894.7 496.7,875.0 547.5,849.7 598.3,823.4 649.2,749.8 700.0,762.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="968.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="967.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="965.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="960.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="954.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="939.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="909.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="894.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="875.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="849.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="823.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="749.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="762.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,963.9 140.8,959.5 191.7,952.7 242.5,941.9 293.3,923.7 344.2,887.7 395.0,840.8 445.8,798.9 496.7,771.5 547.5,753.7 598.3,773.6 649.2,761.1 700.0,772.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="963.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="959.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="952.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="941.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="923.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="887.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="840.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="798.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="771.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="753.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="773.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="761.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="772.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,968.5 140.8,968.1 191.7,966.7 242.5,965.5 293.3,962.3 344.2,950.5 395.0,939.9 445.8,918.3 496.7,875.4 547.5,805.8 598.3,777.3 649.2,742.9 700.0,775.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="968.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="968.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pubsub/omq_ipc.svg
+++ b/doc/charts/pubsub/omq_ipc.svg
@@ -18,16 +18,12 @@
   <text x="82.0" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="49.0" x2="700.0" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="262.4" x2="700.0" y2="262.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="262.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90.0" y1="215.7" x2="700.0" y2="215.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="215.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="169.1" x2="700.0" y2="169.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="169.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90.0" y1="122.4" x2="700.0" y2="122.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="122.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="75.8" x2="700.0" y2="75.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="75.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="229.6" x2="700.0" y2="229.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="229.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90.0" y1="150.2" x2="700.0" y2="150.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="150.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="70.8" x2="700.0" y2="70.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="70.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
   <text x="788.0" y="272.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
   <text x="788.0" y="236.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
   <text x="788.0" y="200.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
@@ -54,69 +50,69 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="309.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="179.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,179.0)">CPU %</text>
   <polyline points="90.0,150.4 140.8,145.9 191.7,162.4 242.5,139.7 293.3,151.4 344.2,157.6 395.0,168.9 445.8,194.0 496.7,214.1 547.5,221.2 598.3,221.3 649.2,215.7 700.0,202.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,220.0 140.8,220.0 191.7,220.0 242.5,220.0 293.3,220.0 344.2,220.0 395.0,220.0 445.8,220.0 496.7,220.0 547.5,220.0 598.3,219.6 649.2,219.6 700.0,220.0" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,220.0 140.8,220.0 191.7,220.0 242.5,220.3 293.3,219.7 344.2,220.0 395.0,220.0 445.8,220.0 496.7,220.0 547.5,220.0 598.3,220.0 649.2,220.0 700.0,220.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,220.0 140.8,220.0 191.7,220.0 242.5,220.1 293.3,219.7 344.2,220.0 395.0,220.0 445.8,219.6 496.7,220.0 547.5,220.0 598.3,220.4 649.2,219.6 700.0,220.0" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,220.0 140.8,220.0 191.7,220.0 242.5,220.0 293.3,220.0 344.2,220.0 395.0,220.0 445.8,219.6 496.7,220.0 547.5,219.6 598.3,220.0 649.2,220.0 700.0,219.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,235.9 140.8,235.9 191.7,236.2 242.5,235.9 293.3,236.2 344.2,236.2 395.0,236.2 445.8,235.9 496.7,235.9 547.5,235.9 598.3,235.6 649.2,235.6 700.0,234.9" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,91.5 140.8,92.3 191.7,82.9 242.5,170.2 293.3,234.2 344.2,236.4 395.0,246.1 445.8,270.4 496.7,287.3 547.5,296.8 598.3,302.2 649.2,305.2 700.0,305.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,208.6 140.8,210.5 191.7,209.9 242.5,227.4 293.3,229.4 344.2,237.7 395.0,254.9 445.8,276.3 496.7,288.1 547.5,292.3 598.3,296.7 649.2,298.6 700.0,303.7" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,207.4 140.8,210.3 191.7,211.1 242.5,228.5 293.3,229.8 344.2,237.8 395.0,254.4 445.8,276.6 496.7,288.1 547.5,292.7 598.3,298.2 649.2,298.9 700.0,303.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,203.0 140.8,206.0 191.7,205.1 242.5,221.8 293.3,225.1 344.2,235.0 395.0,256.9 445.8,275.0 496.7,285.1 547.5,296.8 598.3,302.3 649.2,305.7 700.0,307.3" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,203.1 140.8,205.2 191.7,205.7 242.5,222.5 293.3,224.9 344.2,235.4 395.0,256.9 445.8,275.4 496.7,285.5 547.5,296.7 598.3,302.9 649.2,305.5 700.0,307.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,173.4 140.8,174.8 191.7,177.5 242.5,210.0 293.3,217.4 344.2,225.1 395.0,236.7 445.8,254.7 496.7,270.0 547.5,286.2 598.3,298.1 649.2,303.1 700.0,305.9" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,306.8 140.8,304.5 191.7,299.7 242.5,297.5 293.3,296.6 344.2,285.0 395.0,267.4 445.8,258.0 496.7,251.7 547.5,244.6 598.3,236.8 649.2,227.8 700.0,178.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="306.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="304.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="299.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="297.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="296.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="285.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="267.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="258.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="251.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="244.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="236.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="227.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="178.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,308.0 140.8,307.0 191.7,304.9 242.5,302.3 293.3,295.8 344.2,285.4 395.0,273.2 445.8,265.8 496.7,253.8 547.5,220.8 598.3,178.9 649.2,88.9 700.0,82.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="308.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="307.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="304.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="302.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="295.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="285.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="273.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="265.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="253.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="220.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="178.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="88.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="82.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,308.0 140.8,307.0 191.7,305.0 242.5,302.4 293.3,295.9 344.2,285.4 395.0,272.9 445.8,266.1 496.7,253.6 547.5,222.9 598.3,194.8 649.2,96.2 700.0,88.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="308.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="307.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="305.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="302.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="295.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="285.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="272.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="266.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="253.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="222.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="194.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="96.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="88.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.6 140.8,306.2 191.7,303.6 242.5,300.8 293.3,293.9 344.2,281.3 395.0,261.2 445.8,237.2 496.7,205.9 547.5,188.4 598.3,193.6 649.2,184.9 700.0,176.2" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="306.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="303.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="300.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="293.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="281.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="261.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="237.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="205.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="188.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="193.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="184.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="176.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,305.2 140.8,301.4 191.7,293.1 242.5,289.5 293.3,287.9 344.2,268.1 395.0,238.2 445.8,222.2 496.7,211.4 547.5,199.4 598.3,186.0 649.2,170.8 700.0,86.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="305.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="301.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="293.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="289.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="287.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="268.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="238.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="222.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="211.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="199.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="186.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="170.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="86.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,307.1 140.8,305.4 191.7,301.7 242.5,296.7 293.3,285.4 344.2,267.4 395.0,250.3 445.8,232.5 496.7,201.6 547.5,199.1 598.3,188.9 649.2,191.9 700.0,186.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="307.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="305.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="301.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="296.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="285.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="267.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="250.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="232.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="201.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="199.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="188.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="191.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="186.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,307.1 140.8,305.3 191.7,301.7 242.5,296.8 293.3,285.3 344.2,267.6 395.0,250.4 445.8,233.4 496.7,203.4 547.5,197.9 598.3,198.5 649.2,183.1 700.0,180.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="307.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="305.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="301.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="296.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="285.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="250.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="233.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="203.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="197.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="198.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="183.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="180.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,306.6 140.8,304.3 191.7,299.7 242.5,295.1 293.3,283.2 344.2,261.8 395.0,227.7 445.8,186.8 496.7,133.5 547.5,103.8 598.3,112.6 649.2,97.7 700.0,82.9" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="306.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="304.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="299.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="295.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="283.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="261.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="227.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="186.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="133.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="103.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="112.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="97.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="82.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -147,20 +143,19 @@
   <text x="82.0" y="411.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="379.0" x2="700.0" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="571.4" x2="700.0" y2="571.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="571.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="503.7" x2="700.0" y2="503.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="503.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="436.1" x2="700.0" y2="436.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="436.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
-  <text x="788.0" y="608.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="577.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
-  <text x="788.0" y="546.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">600k/s</text>
-  <text x="788.0" y="515.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">800k/s</text>
-  <text x="788.0" y="485.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
-  <text x="788.0" y="454.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.2M/s</text>
-  <text x="788.0" y="423.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.4M/s</text>
-  <text x="788.0" y="392.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.6M/s</text>
+  <line x1="90.0" y1="569.2" x2="700.0" y2="569.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="569.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="499.5" x2="700.0" y2="499.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="499.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="429.7" x2="700.0" y2="429.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="429.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
+  <text x="788.0" y="603.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500k/s</text>
+  <text x="788.0" y="568.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
+  <text x="788.0" y="532.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5M/s</text>
+  <text x="788.0" y="497.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
+  <text x="788.0" y="462.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5M/s</text>
+  <text x="788.0" y="426.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
+  <text x="788.0" y="391.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5M/s</text>
   <line x1="90.0" y1="379.0" x2="90.0" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="379.0" x2="140.8" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="379.0" x2="191.7" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -180,69 +175,69 @@
   <line x1="780.0" y1="379.0" x2="780.0" y2="639.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="509.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,509.0)">CPU %</text>
   <polyline points="90.0,506.7 140.8,504.8 191.7,513.6 242.5,515.5 293.3,519.7 344.2,538.6 395.0,550.9 445.8,555.2 496.7,557.4 547.5,557.4 598.3,557.1 649.2,552.6 700.0,550.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,551.7 140.8,550.3 191.7,551.6 242.5,551.3 293.3,552.0 344.2,551.3 395.0,550.3 445.8,550.0 496.7,550.3 547.5,550.0 598.3,549.6 649.2,552.2 700.0,549.6" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,551.9 140.8,550.9 191.7,550.9 242.5,550.6 293.3,551.9 344.2,549.7 395.0,551.3 445.8,549.6 496.7,550.3 547.5,550.3 598.3,549.6 649.2,549.6 700.0,550.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,554.5 140.8,551.9 191.7,554.2 242.5,554.5 293.3,554.2 344.2,551.3 395.0,550.0 445.8,549.6 496.7,550.0 547.5,549.6 598.3,549.6 649.2,550.0 700.0,550.0" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,555.1 140.8,551.6 191.7,552.9 242.5,553.5 293.3,553.5 344.2,551.6 395.0,550.3 445.8,549.7 496.7,549.6 547.5,550.0 598.3,549.6 649.2,550.0 700.0,550.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,564.6 140.8,564.3 191.7,564.3 242.5,563.3 293.3,564.3 344.2,565.6 395.0,565.6 445.8,565.2 496.7,565.2 547.5,564.9 598.3,564.3 649.2,563.6 700.0,561.7" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,412.9 140.8,427.4 191.7,446.1 242.5,488.4 293.3,532.8 344.2,565.6 395.0,594.5 445.8,612.7 496.7,624.9 547.5,631.3 598.3,634.8 649.2,636.8 700.0,637.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,517.2 140.8,516.3 191.7,524.9 242.5,526.2 293.3,537.6 344.2,546.1 395.0,555.7 445.8,573.4 496.7,594.7 547.5,610.7 598.3,624.0 649.2,631.1 700.0,635.1" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,517.3 140.8,519.1 191.7,522.5 242.5,525.6 293.3,536.1 344.2,542.2 395.0,556.1 445.8,572.9 496.7,595.3 547.5,610.9 598.3,623.8 649.2,631.3 700.0,635.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,482.8 140.8,484.7 191.7,489.4 242.5,504.1 293.3,513.5 344.2,527.7 395.0,546.5 445.8,588.9 496.7,613.4 547.5,623.7 598.3,631.2 649.2,634.6 700.0,636.9" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,635.8 140.8,633.1 191.7,628.2 242.5,622.1 293.3,615.1 344.2,606.0 395.0,598.9 445.8,591.7 496.7,588.4 547.5,583.5 598.3,578.7 649.2,576.3 700.0,538.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="635.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="633.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="628.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="622.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="615.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="606.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="598.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="591.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="588.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="583.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="578.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="576.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="538.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,637.3 140.8,635.6 191.7,632.6 242.5,626.3 293.3,616.2 344.2,597.2 395.0,564.1 445.8,521.0 496.7,479.7 547.5,435.2 598.3,423.7 649.2,412.9 700.0,416.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="637.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="635.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="632.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="626.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="616.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="597.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="564.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="521.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="479.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="435.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="423.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="412.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="416.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,637.3 140.8,635.6 191.7,632.4 242.5,626.3 293.3,615.9 344.2,595.5 395.0,564.4 445.8,520.2 496.7,482.0 547.5,436.6 598.3,420.7 649.2,416.0 700.0,421.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="637.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="635.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="632.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="626.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="615.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="595.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="564.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="520.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="482.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="436.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="420.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="416.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="421.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,636.8 140.8,634.7 191.7,630.6 242.5,623.8 293.3,610.8 344.2,588.9 395.0,555.8 445.8,548.8 496.7,546.9 547.5,528.7 598.3,526.6 649.2,513.7 700.0,516.2" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="636.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="634.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="630.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="623.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="610.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="588.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="555.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="548.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="546.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="528.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="526.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="513.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="516.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,535.2 140.8,541.8 191.7,550.4 242.5,569.8 293.3,590.2 344.2,605.3 395.0,618.5 445.8,626.9 496.7,632.5 547.5,635.5 598.3,637.1 649.2,638.0 700.0,638.2" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,412.9 140.8,431.3 191.7,474.8 242.5,494.9 293.3,496.9 344.2,524.2 395.0,562.8 445.8,589.3 496.7,614.0 547.5,626.6 598.3,633.7 649.2,635.6 700.0,637.5" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,425.5 140.8,459.8 191.7,458.8 242.5,500.0 293.3,494.9 344.2,527.8 395.0,562.3 445.8,590.5 496.7,615.8 547.5,626.8 598.3,632.5 649.2,635.8 700.0,637.3" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,567.3 140.8,568.1 191.7,570.3 242.5,577.0 293.3,581.4 344.2,587.9 395.0,596.5 445.8,616.0 496.7,627.2 547.5,632.0 598.3,635.4 649.2,637.0 700.0,638.0" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,635.7 140.8,632.9 191.7,627.8 242.5,621.5 293.3,614.4 344.2,605.0 395.0,597.7 445.8,590.2 496.7,586.8 547.5,581.7 598.3,576.8 649.2,574.3 700.0,535.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="635.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="632.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="627.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="621.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="614.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="605.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="597.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="590.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="586.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="581.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="576.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="574.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="535.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,631.9 140.8,625.9 191.7,618.3 242.5,602.6 293.3,567.2 344.2,523.0 395.0,485.0 445.8,438.3 496.7,436.9 547.5,438.5 598.3,467.7 649.2,421.4 700.0,447.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="631.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="625.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="618.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="602.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="567.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="523.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="485.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="438.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="436.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="438.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="467.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="421.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="447.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,632.3 140.8,627.7 191.7,616.3 242.5,603.9 293.3,566.2 344.2,526.7 395.0,484.1 445.8,443.0 496.7,451.2 547.5,441.7 598.3,429.9 649.2,430.4 700.0,412.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="632.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="627.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="616.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="603.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="566.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="526.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="484.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="443.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="451.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="441.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="429.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="430.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="412.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,636.7 140.8,634.5 191.7,630.3 242.5,623.4 293.3,609.9 344.2,587.4 395.0,553.2 445.8,546.0 496.7,544.0 547.5,525.2 598.3,523.1 649.2,509.7 700.0,512.4" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="636.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="634.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="630.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="623.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="609.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="587.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="553.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="546.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="544.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="525.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="523.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="509.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="512.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -265,22 +260,22 @@
   <text x="82.0" y="774.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">150%</text>
   <line x1="90.0" y1="709.0" x2="700.0" y2="709.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="709.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200%</text>
-  <line x1="90.0" y1="923.0" x2="700.0" y2="923.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="923.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="877.0" x2="700.0" y2="877.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="877.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="830.9" x2="700.0" y2="830.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="830.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
-  <line x1="90.0" y1="784.9" x2="700.0" y2="784.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="784.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">8 GB/s</text>
-  <line x1="90.0" y1="738.9" x2="700.0" y2="738.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="738.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
-  <text x="788.0" y="931.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">50k/s</text>
-  <text x="788.0" y="893.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
-  <text x="788.0" y="856.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">150k/s</text>
-  <text x="788.0" y="818.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="781.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">250k/s</text>
-  <text x="788.0" y="743.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
+  <line x1="90.0" y1="916.9" x2="700.0" y2="916.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="916.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="864.7" x2="700.0" y2="864.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="864.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="812.6" x2="700.0" y2="812.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="812.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
+  <line x1="90.0" y1="760.4" x2="700.0" y2="760.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="760.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">8 GB/s</text>
+  <text x="788.0" y="939.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">50k/s</text>
+  <text x="788.0" y="910.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
+  <text x="788.0" y="881.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">150k/s</text>
+  <text x="788.0" y="852.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
+  <text x="788.0" y="823.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">250k/s</text>
+  <text x="788.0" y="794.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
+  <text x="788.0" y="765.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">350k/s</text>
+  <text x="788.0" y="736.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
   <line x1="90.0" y1="709.0" x2="90.0" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="709.0" x2="140.8" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="709.0" x2="191.7" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -300,69 +295,69 @@
   <line x1="780.0" y1="709.0" x2="780.0" y2="969.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="839.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,839.0)">CPU %</text>
   <polyline points="90.0,748.0 140.8,765.5 191.7,761.6 242.5,791.6 293.3,811.7 344.2,833.1 395.0,843.6 445.8,846.2 496.7,854.0 547.5,858.5 598.3,852.0 649.2,839.7 700.0,828.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,789.6 140.8,789.6 191.7,801.4 242.5,796.8 293.3,800.0 344.2,811.1 395.0,813.9 445.8,809.1 496.7,813.7 547.5,796.8 598.3,793.5 649.2,791.6 700.0,794.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,789.0 140.8,789.6 191.7,788.3 242.5,800.0 293.3,803.3 344.2,811.2 395.0,816.3 445.8,809.1 496.7,803.9 547.5,798.7 598.3,794.2 649.2,796.1 700.0,798.7" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,887.7 140.8,882.1 191.7,873.5 242.5,870.2 293.3,858.5 344.2,843.0 395.0,834.5 445.8,826.0 496.7,803.3 547.5,796.1 598.3,789.7 649.2,789.6 700.0,792.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,884.5 140.8,879.6 191.7,868.0 242.5,867.6 293.3,856.7 344.2,844.2 395.0,827.3 445.8,815.0 496.7,802.0 547.5,794.9 598.3,791.6 649.2,793.8 700.0,795.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,795.5 140.8,795.5 191.7,798.1 242.5,804.6 293.3,805.2 344.2,815.6 395.0,816.3 445.8,816.3 496.7,815.0 547.5,813.0 598.3,806.5 649.2,793.5 700.0,792.2" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,742.9 140.8,752.4 191.7,760.3 242.5,817.7 293.3,879.3 344.2,900.9 395.0,919.6 445.8,936.5 496.7,952.1 547.5,960.4 598.3,963.4 649.2,965.9 700.0,966.8" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,944.6 140.8,937.8 191.7,941.8 242.5,919.1 293.3,917.4 344.2,926.9 395.0,936.7 445.8,944.7 496.7,951.6 547.5,956.1 598.3,960.9 649.2,962.0 700.0,965.5" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,951.7 140.8,944.9 191.7,911.3 242.5,916.1 293.3,918.4 344.2,926.9 395.0,937.6 445.8,945.3 496.7,951.4 547.5,956.6 598.3,960.6 649.2,962.4 700.0,965.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,800.0 140.8,801.3 191.7,791.8 242.5,830.6 293.3,838.0 344.2,853.4 395.0,876.0 445.8,909.1 496.7,934.8 547.5,951.5 598.3,959.6 649.2,964.4 700.0,967.2" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,965.5 140.8,962.2 191.7,955.9 242.5,950.0 293.3,946.5 344.2,934.8 395.0,919.4 445.8,903.8 496.7,901.4 547.5,899.8 598.3,878.5 649.2,870.2 700.0,830.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="965.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="962.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="955.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="950.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="946.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="934.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="919.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="903.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="901.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="899.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="878.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="870.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="830.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,968.6 140.8,968.0 191.7,967.3 242.5,962.7 293.3,956.1 344.2,947.9 395.0,936.6 445.8,920.3 496.7,899.0 547.5,865.2 598.3,838.7 649.2,742.9 700.0,746.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="968.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="968.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="967.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="962.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="956.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="947.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="936.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="920.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="899.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="865.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="838.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,794.1 140.8,801.4 191.7,807.6 242.5,851.9 293.3,899.6 344.2,916.3 395.0,930.8 445.8,943.8 496.7,956.0 547.5,962.3 598.3,964.6 649.2,966.6 700.0,967.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,761.1 140.8,780.6 191.7,792.3 242.5,816.8 293.3,825.4 344.2,856.3 395.0,890.0 445.8,918.0 496.7,939.2 547.5,955.1 598.3,959.5 649.2,964.2 700.0,967.0" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,742.9 140.8,770.3 191.7,782.9 242.5,809.8 293.3,824.0 344.2,861.0 395.0,883.7 445.8,914.1 496.7,937.1 547.5,952.1 598.3,960.6 649.2,964.4 700.0,966.7" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,838.3 140.8,839.2 191.7,831.9 242.5,861.9 293.3,867.7 344.2,879.6 395.0,897.1 445.8,922.6 496.7,942.5 547.5,955.4 598.3,961.7 649.2,965.4 700.0,967.6" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,965.0 140.8,961.3 191.7,954.2 242.5,947.5 293.3,943.5 344.2,930.3 395.0,912.8 445.8,895.1 496.7,892.4 547.5,890.6 598.3,866.5 649.2,857.1 700.0,812.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="965.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="961.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="954.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="947.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="943.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="930.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="912.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="895.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="892.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="890.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="866.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="857.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="812.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,964.2 140.8,960.4 191.7,952.8 242.5,941.1 293.3,916.3 344.2,886.2 395.0,852.9 445.8,819.3 496.7,794.2 547.5,805.2 598.3,745.0 649.2,742.9 700.0,779.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="964.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="960.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="952.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="941.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="916.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="886.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="852.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="819.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="794.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="805.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="745.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="742.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="746.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,968.7 140.8,968.2 191.7,965.4 242.5,962.4 293.3,956.3 344.2,947.9 395.0,937.5 445.8,921.5 496.7,898.5 547.5,869.2 598.3,834.0 649.2,758.6 700.0,765.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="968.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="968.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="965.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="962.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="956.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="947.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="937.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="921.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="898.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="869.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="834.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="758.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="765.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,966.4 140.8,963.7 191.7,957.9 242.5,951.7 293.3,936.2 344.2,911.0 395.0,875.8 445.8,848.7 496.7,831.7 547.5,828.4 598.3,818.4 649.2,821.5 700.0,853.2" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="966.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="963.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="957.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="951.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="936.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="911.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="875.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="848.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="831.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="828.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="818.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="821.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="853.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="779.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,963.8 140.8,959.9 191.7,951.9 242.5,939.8 293.3,915.8 344.2,889.7 395.0,843.8 445.8,807.6 496.7,781.6 547.5,770.4 598.3,771.6 649.2,752.2 700.0,756.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="963.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="959.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="951.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="939.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="915.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="889.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="843.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="807.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="781.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="770.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="771.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="752.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="756.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,966.0 140.8,963.0 191.7,956.4 242.5,949.3 293.3,931.8 344.2,903.3 395.0,863.4 445.8,832.7 496.7,813.4 547.5,809.7 598.3,798.4 649.2,801.9 700.0,837.8" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="966.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="963.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="956.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="949.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="931.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="903.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="863.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="832.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="813.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="809.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="798.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="801.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="837.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/pubsub/omq_tcp.svg
+++ b/doc/charts/pubsub/omq_tcp.svg
@@ -18,14 +18,14 @@
   <text x="82.0" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="49.0" x2="700.0" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="255.4" x2="700.0" y2="255.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="255.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90.0" y1="201.8" x2="700.0" y2="201.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="201.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="148.2" x2="700.0" y2="148.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="148.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90.0" y1="94.6" x2="700.0" y2="94.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="94.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="247.9" x2="700.0" y2="247.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="247.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90.0" y1="186.8" x2="700.0" y2="186.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="186.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="125.7" x2="700.0" y2="125.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="125.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
+  <line x1="90.0" y1="64.6" x2="700.0" y2="64.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="64.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
   <text x="788.0" y="275.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
   <text x="788.0" y="241.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
   <text x="788.0" y="207.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
@@ -52,69 +52,69 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="309.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="179.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,179.0)">CPU %</text>
   <polyline points="90.0,153.3 140.8,146.8 191.7,145.9 242.5,146.2 293.3,166.0 344.2,177.7 395.0,190.7 445.8,198.8 496.7,217.4 547.5,220.6 598.3,216.1 649.2,218.0 700.0,212.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,226.5 140.8,226.1 191.7,226.5 242.5,226.5 293.3,226.5 344.2,226.5 395.0,226.5 445.8,226.8 496.7,226.5 547.5,226.5 598.3,226.5 649.2,226.1 700.0,226.1" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,226.5 140.8,226.5 191.7,226.1 242.5,226.5 293.3,226.1 344.2,226.5 395.0,226.5 445.8,226.8 496.7,226.5 547.5,226.2 598.3,226.8 649.2,227.4 700.0,226.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,226.8 140.8,226.5 191.7,226.5 242.5,226.1 293.3,226.5 344.2,226.1 395.0,226.5 445.8,226.5 496.7,226.5 547.5,226.1 598.3,226.5 649.2,226.5 700.0,226.1" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,226.8 140.8,226.5 191.7,226.5 242.5,226.5 293.3,226.1 344.2,226.5 395.0,226.1 445.8,226.5 496.7,226.5 547.5,226.8 598.3,226.5 649.2,226.5 700.0,226.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,236.9 140.8,239.8 191.7,240.8 242.5,241.1 293.3,241.7 344.2,242.1 395.0,242.1 445.8,242.1 496.7,242.4 547.5,242.1 598.3,241.7 649.2,241.7 700.0,241.4" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,90.8 140.8,82.9 191.7,83.1 242.5,163.6 293.3,239.6 344.2,244.2 395.0,259.2 445.8,279.2 496.7,292.0 547.5,299.7 598.3,302.8 649.2,306.6 700.0,307.0" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,152.7 140.8,154.1 191.7,153.5 242.5,187.7 293.3,189.5 344.2,214.5 395.0,214.3 445.8,237.4 496.7,258.3 547.5,279.7 598.3,295.4 649.2,301.9 700.0,305.4" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,148.6 140.8,151.0 191.7,153.6 242.5,186.1 293.3,189.5 344.2,214.0 395.0,215.1 445.8,239.7 496.7,258.3 547.5,279.6 598.3,295.5 649.2,301.8 700.0,304.7" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,152.1 140.8,155.0 191.7,155.9 242.5,184.7 293.3,190.2 344.2,214.0 395.0,211.8 445.8,243.1 496.7,262.7 547.5,282.6 598.3,296.9 649.2,301.5 700.0,305.2" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,154.8 140.8,155.1 191.7,154.7 242.5,184.5 293.3,190.5 344.2,213.7 395.0,215.4 445.8,243.7 496.7,263.0 547.5,282.8 598.3,296.8 649.2,301.7 700.0,305.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,177.1 140.8,182.3 191.7,190.3 242.5,220.3 293.3,227.9 344.2,235.1 395.0,243.1 445.8,261.4 496.7,276.4 547.5,289.9 598.3,299.8 649.2,304.2 700.0,306.5" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,306.2 140.8,303.2 191.7,297.5 242.5,294.2 293.3,294.9 344.2,282.6 395.0,268.5 445.8,260.5 496.7,253.8 547.5,248.5 598.3,228.8 649.2,245.9 700.0,206.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="306.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="303.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="297.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="294.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="294.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="282.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="268.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="260.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="253.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="248.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="228.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="245.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="206.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.0 140.8,305.1 191.7,301.1 242.5,296.7 293.3,284.7 344.2,270.5 395.0,231.9 445.8,192.4 496.7,143.8 547.5,118.5 598.3,132.3 649.2,124.0 700.0,122.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="305.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="301.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="296.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="284.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="270.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="231.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="192.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="143.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="118.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="132.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="124.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="122.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.0 140.8,305.0 191.7,301.1 242.5,296.5 293.3,284.7 344.2,270.4 395.0,232.6 445.8,196.2 496.7,143.9 547.5,117.7 598.3,132.8 649.2,122.2 700.0,82.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="305.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="301.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="296.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="284.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="270.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="232.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="196.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="143.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="117.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="132.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="122.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="82.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.3 140.8,305.8 191.7,303.0 242.5,300.0 293.3,292.5 344.2,278.9 395.0,255.4 445.8,231.5 496.7,202.7 547.5,184.7 598.3,189.7 649.2,185.1 700.0,178.3" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="305.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="303.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="300.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="292.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="278.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="255.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="231.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="202.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="184.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="189.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="185.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="178.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,305.8 140.8,302.4 191.7,295.9 242.5,292.1 293.3,292.9 344.2,278.9 395.0,262.8 445.8,253.7 496.7,246.1 547.5,240.1 598.3,217.6 649.2,237.1 700.0,191.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="305.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="302.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="295.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="292.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="292.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="278.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="262.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="253.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="246.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="240.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="217.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="237.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="191.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,306.7 140.8,304.5 191.7,300.1 242.5,294.6 293.3,281.5 344.2,264.9 395.0,218.9 445.8,186.8 496.7,137.2 547.5,113.4 598.3,129.6 649.2,87.1 700.0,82.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="306.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="304.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="300.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="294.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="281.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="264.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="218.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="186.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="137.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="113.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="129.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="87.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="82.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,306.8 140.8,304.5 191.7,300.1 242.5,294.6 293.3,281.5 344.2,264.8 395.0,222.2 445.8,187.8 496.7,138.3 547.5,114.6 598.3,128.4 649.2,91.1 700.0,85.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="306.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="304.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="300.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="294.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="281.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="264.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="222.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="187.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="138.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="114.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="128.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="91.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="85.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,307.1 140.8,305.3 191.7,302.1 242.5,298.7 293.3,290.2 344.2,274.7 395.0,247.9 445.8,220.7 496.7,187.9 547.5,167.4 598.3,173.1 649.2,167.8 700.0,160.1" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="307.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="305.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="302.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="298.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="290.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="274.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="247.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="220.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="187.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="167.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="173.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="167.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="160.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="323.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -145,20 +145,18 @@
   <text x="82.0" y="411.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">350%</text>
   <line x1="90.0" y1="379.0" x2="700.0" y2="379.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="379.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400%</text>
-  <line x1="90.0" y1="569.7" x2="700.0" y2="569.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="569.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="500.4" x2="700.0" y2="500.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="500.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="431.0" x2="700.0" y2="431.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="431.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
-  <text x="788.0" y="607.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="575.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
-  <text x="788.0" y="543.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">600k/s</text>
-  <text x="788.0" y="511.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">800k/s</text>
-  <text x="788.0" y="479.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
-  <text x="788.0" y="447.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.2M/s</text>
-  <text x="788.0" y="415.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.4M/s</text>
-  <text x="788.0" y="383.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.6M/s</text>
+  <line x1="90.0" y1="567.3" x2="700.0" y2="567.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="567.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="495.6" x2="700.0" y2="495.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="495.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="424.0" x2="700.0" y2="424.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="424.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
+  <text x="788.0" y="599.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500k/s</text>
+  <text x="788.0" y="560.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1M/s</text>
+  <text x="788.0" y="521.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5M/s</text>
+  <text x="788.0" y="481.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2M/s</text>
+  <text x="788.0" y="442.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5M/s</text>
+  <text x="788.0" y="403.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3M/s</text>
   <line x1="90.0" y1="379.0" x2="90.0" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="379.0" x2="140.8" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="379.0" x2="191.7" y2="639.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -178,69 +176,69 @@
   <line x1="780.0" y1="379.0" x2="780.0" y2="639.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="509.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,509.0)">CPU %</text>
   <polyline points="90.0,506.1 140.8,512.6 191.7,516.5 242.5,521.0 293.3,529.8 344.2,539.2 395.0,550.0 445.8,552.5 496.7,559.4 547.5,558.1 598.3,556.8 649.2,556.5 700.0,554.2" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,563.0 140.8,557.4 191.7,557.4 242.5,556.1 293.3,562.0 344.2,556.1 395.0,556.5 445.8,563.9 496.7,556.8 547.5,556.5 598.3,556.5 649.2,556.1 700.0,556.1" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,559.4 140.8,557.8 191.7,558.1 242.5,556.1 293.3,556.5 344.2,556.1 395.0,560.4 445.8,556.5 496.7,558.1 547.5,556.5 598.3,556.1 649.2,556.1 700.0,556.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,559.4 140.8,559.4 191.7,557.8 242.5,560.7 293.3,557.4 344.2,557.8 395.0,556.5 445.8,556.5 496.7,556.5 547.5,556.5 598.3,557.1 649.2,556.5 700.0,556.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,558.4 140.8,558.7 191.7,557.8 242.5,562.6 293.3,557.4 344.2,556.8 395.0,556.5 445.8,556.1 496.7,556.5 547.5,556.5 598.3,556.1 649.2,556.8 700.0,556.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,560.4 140.8,562.6 191.7,564.6 242.5,566.9 293.3,567.8 344.2,569.5 395.0,570.1 445.8,570.8 496.7,570.8 547.5,571.1 598.3,570.1 649.2,569.1 700.0,567.2" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,412.9 140.8,430.3 191.7,446.4 242.5,501.3 293.3,547.7 344.2,578.8 395.0,604.3 445.8,618.8 496.7,628.7 547.5,633.7 598.3,636.3 649.2,637.5 700.0,637.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,525.8 140.8,529.8 191.7,538.4 242.5,543.9 293.3,559.3 344.2,558.5 395.0,567.9 445.8,589.1 496.7,601.6 547.5,614.6 598.3,625.0 649.2,631.2 700.0,635.0" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,516.7 140.8,530.5 191.7,540.8 242.5,542.8 293.3,551.7 344.2,559.2 395.0,572.6 445.8,581.8 496.7,602.6 547.5,614.3 598.3,625.1 649.2,631.3 700.0,635.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,469.6 140.8,480.2 191.7,490.1 242.5,504.9 293.3,514.0 344.2,535.3 395.0,552.1 445.8,576.3 496.7,599.3 547.5,622.2 598.3,631.0 649.2,634.9 700.0,636.9" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,635.9 140.8,633.2 191.7,628.3 242.5,623.7 293.3,618.7 344.2,612.2 395.0,608.1 445.8,603.0 496.7,602.3 547.5,601.0 598.3,600.1 649.2,597.0 700.0,564.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="635.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="633.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="628.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="623.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="618.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="612.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="608.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="603.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="602.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="601.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="600.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="597.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="564.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,637.4 140.8,636.0 191.7,633.4 242.5,628.4 293.3,621.3 344.2,603.2 395.0,575.7 445.8,550.2 496.7,505.7 547.5,465.2 598.3,440.0 649.2,416.7 700.0,412.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="637.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="636.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="633.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="628.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="621.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="603.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="575.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="550.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="505.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="465.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="440.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="416.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="412.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,637.3 140.8,636.0 191.7,633.5 242.5,628.3 293.3,619.6 344.2,603.5 395.0,579.9 445.8,537.2 496.7,509.5 547.5,463.3 598.3,440.7 649.2,419.0 700.0,415.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="637.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="636.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="633.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="628.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="619.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="603.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="579.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="537.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="509.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="463.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="440.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="419.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="415.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,636.6 140.8,634.6 191.7,630.7 242.5,624.1 293.3,611.2 344.2,592.8 395.0,561.6 445.8,527.3 496.7,497.8 547.5,519.1 598.3,524.4 649.2,522.4 700.0,519.2" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,527.7 140.8,536.2 191.7,544.1 242.5,571.2 293.3,594.1 344.2,609.4 395.0,621.9 445.8,629.1 496.7,633.9 547.5,636.4 598.3,637.7 649.2,638.3 700.0,638.4" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,412.9 140.8,430.1 191.7,457.6 242.5,466.5 293.3,495.5 344.2,539.5 395.0,564.4 445.8,592.8 496.7,611.9 547.5,625.1 598.3,632.2 649.2,635.3 700.0,637.1" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,419.7 140.8,442.0 191.7,463.6 242.5,465.6 293.3,482.3 344.2,538.2 395.0,566.1 445.8,592.9 496.7,612.6 547.5,624.9 598.3,631.6 649.2,635.3 700.0,637.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,555.6 140.8,560.8 191.7,565.7 242.5,572.9 293.3,577.4 344.2,587.9 395.0,596.2 445.8,608.1 496.7,619.5 547.5,630.7 598.3,635.0 649.2,637.0 700.0,638.0" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,635.7 140.8,633.0 191.7,627.9 242.5,623.2 293.3,618.0 344.2,611.3 395.0,607.0 445.8,601.8 496.7,601.1 547.5,599.7 598.3,598.8 649.2,595.6 700.0,561.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="635.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="633.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="627.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="623.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="618.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="611.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="607.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="601.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="601.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="599.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="598.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="595.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="561.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,632.4 140.8,626.8 191.7,617.8 242.5,598.7 293.3,571.9 344.2,546.0 395.0,499.5 445.8,466.3 496.7,436.3 547.5,431.7 598.3,435.3 649.2,419.4 700.0,414.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="632.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="626.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="617.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="598.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="571.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="546.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="499.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="466.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="436.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="431.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="435.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="419.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="414.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,632.6 140.8,627.5 191.7,618.5 242.5,598.5 293.3,565.8 344.2,544.7 395.0,502.8 445.8,466.7 496.7,441.8 547.5,428.2 598.3,418.9 649.2,418.8 700.0,412.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="632.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="627.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="618.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="598.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="565.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="544.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="502.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="466.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="441.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="428.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="418.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="418.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="412.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,636.6 140.8,634.4 191.7,630.4 242.5,623.6 293.3,610.2 344.2,591.3 395.0,559.0 445.8,523.5 496.7,493.0 547.5,515.1 598.3,520.5 649.2,518.4 700.0,515.1" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="636.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="634.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="630.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="624.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="611.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="592.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="561.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="527.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="497.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="519.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="524.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="522.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="519.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="634.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="630.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="623.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="610.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="591.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="559.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="523.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="493.0" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="515.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="520.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="518.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="515.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="653.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -263,23 +261,21 @@
   <text x="82.0" y="774.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">150%</text>
   <line x1="90.0" y1="709.0" x2="700.0" y2="709.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="709.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200%</text>
-  <line x1="90.0" y1="919.4" x2="700.0" y2="919.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="919.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90.0" y1="869.8" x2="700.0" y2="869.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="869.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90.0" y1="820.2" x2="700.0" y2="820.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="820.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
-  <line x1="90.0" y1="770.6" x2="700.0" y2="770.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="770.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">8 GB/s</text>
-  <line x1="90.0" y1="721.1" x2="700.0" y2="721.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="708.0" y="721.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
-  <text x="788.0" y="933.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">50k/s</text>
-  <text x="788.0" y="897.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
-  <text x="788.0" y="861.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">150k/s</text>
-  <text x="788.0" y="825.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
-  <text x="788.0" y="789.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">250k/s</text>
-  <text x="788.0" y="754.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
-  <text x="788.0" y="718.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">350k/s</text>
+  <line x1="90.0" y1="921.6" x2="700.0" y2="921.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="921.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90.0" y1="874.2" x2="700.0" y2="874.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="874.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90.0" y1="826.7" x2="700.0" y2="826.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="826.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">6 GB/s</text>
+  <line x1="90.0" y1="779.3" x2="700.0" y2="779.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="779.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">8 GB/s</text>
+  <line x1="90.0" y1="731.9" x2="700.0" y2="731.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="708.0" y="731.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
+  <text x="788.0" y="923.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">100k/s</text>
+  <text x="788.0" y="877.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">200k/s</text>
+  <text x="788.0" y="831.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">300k/s</text>
+  <text x="788.0" y="785.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">400k/s</text>
+  <text x="788.0" y="740.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500k/s</text>
   <line x1="90.0" y1="709.0" x2="90.0" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="140.8" y1="709.0" x2="140.8" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="191.7" y1="709.0" x2="191.7" y2="969.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -299,69 +295,69 @@
   <line x1="780.0" y1="709.0" x2="780.0" y2="969.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="839.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,839.0)">CPU %</text>
   <polyline points="90.0,755.1 140.8,766.9 191.7,759.7 242.5,776.0 293.3,807.8 344.2,823.4 395.0,832.5 445.8,834.5 496.7,831.2 547.5,834.5 598.3,841.0 649.2,824.7 700.0,824.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,813.0 140.8,808.5 191.7,809.8 242.5,810.4 293.3,812.4 344.2,809.1 395.0,807.2 445.8,810.4 496.7,804.6 547.5,806.5 598.3,806.5 649.2,802.0 700.0,805.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,810.4 140.8,807.8 191.7,813.0 242.5,815.0 293.3,812.4 344.2,807.8 395.0,808.5 445.8,810.4 496.7,807.8 547.5,806.5 598.3,806.0 649.2,800.0 700.0,805.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,914.4 140.8,905.4 191.7,878.0 242.5,873.5 293.3,861.8 344.2,841.6 395.0,815.6 445.8,803.3 496.7,803.3 547.5,803.3 598.3,803.9 649.2,802.0 700.0,801.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,916.7 140.8,897.5 191.7,874.8 242.5,872.8 293.3,860.5 344.2,839.0 395.0,814.3 445.8,802.0 496.7,802.6 547.5,802.7 598.3,800.7 649.2,802.0 700.0,802.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,803.3 140.8,801.3 191.7,802.0 242.5,800.7 293.3,806.5 344.2,813.0 395.0,811.7 445.8,818.2 496.7,820.8 547.5,822.8 598.3,822.8 649.2,811.7 700.0,802.6" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,742.9 140.8,773.2 191.7,779.3 242.5,824.1 293.3,891.9 344.2,910.9 395.0,930.1 445.8,944.1 496.7,955.4 547.5,961.3 598.3,965.5 649.2,967.1 700.0,967.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,942.2 140.8,916.1 191.7,911.9 242.5,900.9 293.3,909.0 344.2,915.2 395.0,923.7 445.8,934.6 496.7,943.2 547.5,956.3 598.3,961.0 649.2,962.8 700.0,965.9" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,940.7 140.8,919.0 191.7,912.9 242.5,907.8 293.3,917.2 344.2,915.1 395.0,915.4 445.8,935.7 496.7,947.9 547.5,955.6 598.3,960.8 649.2,962.8 700.0,966.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,805.2 140.8,801.2 191.7,820.2 242.5,818.3 293.3,853.2 344.2,875.6 395.0,893.7 445.8,911.2 496.7,935.1 547.5,952.8 598.3,962.3 649.2,965.6 700.0,967.8" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,965.0 140.8,962.1 191.7,955.6 242.5,948.5 293.3,947.2 344.2,936.1 395.0,924.9 445.8,912.5 496.7,907.3 547.5,899.4 598.3,904.7 649.2,900.5 700.0,848.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="965.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="962.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="955.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="948.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="947.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="936.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="924.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="912.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="907.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="899.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="904.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="900.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="848.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,968.5 140.8,967.1 191.7,965.0 242.5,959.4 293.3,952.0 344.2,938.5 395.0,917.6 445.8,891.0 496.7,852.2 547.5,853.8 598.3,823.7 649.2,742.9 700.0,746.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="968.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="967.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="965.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="959.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="952.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="938.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="917.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="891.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="852.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="853.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="823.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="742.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="746.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,968.5 140.8,967.2 191.7,965.0 242.5,960.3 293.3,954.3 344.2,938.4 395.0,908.2 445.8,893.4 496.7,873.3 547.5,847.6 598.3,820.7 649.2,745.8 700.0,758.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="968.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="967.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="965.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="960.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="954.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="938.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="908.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="893.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="873.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="847.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="820.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="745.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="758.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,966.1 140.8,963.1 191.7,958.5 242.5,947.6 293.3,936.2 344.2,916.1 395.0,883.6 445.8,837.9 496.7,815.4 547.5,822.2 598.3,848.3 649.2,846.5 700.0,879.3" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="966.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="963.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="958.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="947.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="936.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="916.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="883.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="837.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="815.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="822.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="848.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="846.5" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="879.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,824.6 140.8,843.9 191.7,847.8 242.5,876.4 293.3,919.8 344.2,931.9 395.0,944.2 445.8,953.1 496.7,960.3 547.5,964.1 598.3,966.7 649.2,967.8 700.0,967.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,742.9 140.8,773.4 191.7,821.6 242.5,844.7 293.3,866.2 344.2,881.8 395.0,898.5 445.8,921.7 496.7,940.3 547.5,953.7 598.3,961.7 649.2,965.2 700.0,966.9" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,782.5 140.8,793.9 191.7,819.7 242.5,844.8 293.3,865.0 344.2,875.7 395.0,895.5 445.8,920.2 496.7,940.7 547.5,953.6 598.3,962.0 649.2,965.3 700.0,967.2" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,864.4 140.8,861.8 191.7,874.0 242.5,872.7 293.3,895.0 344.2,909.4 395.0,920.9 445.8,932.1 496.7,947.4 547.5,958.7 598.3,964.7 649.2,966.8 700.0,968.2" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,965.2 140.8,962.4 191.7,956.1 242.5,949.4 293.3,948.1 344.2,937.5 395.0,926.8 445.8,915.0 496.7,910.0 547.5,902.5 598.3,907.5 649.2,903.5 700.0,853.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="965.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="962.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="956.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="949.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="948.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="937.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="926.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="915.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="910.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="902.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="907.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="903.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="853.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,963.0 140.8,958.6 191.7,953.4 242.5,942.6 293.3,925.4 344.2,895.0 395.0,849.4 445.8,808.6 496.7,773.9 547.5,761.5 598.3,770.8 649.2,761.9 700.0,742.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="963.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="958.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="953.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="942.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="925.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="895.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="849.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="808.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="773.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="761.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="770.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="761.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="742.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,964.1 140.8,959.7 191.7,953.2 242.5,942.7 293.3,924.9 344.2,889.8 395.0,844.2 445.8,803.4 496.7,776.7 547.5,759.4 598.3,778.7 649.2,766.6 700.0,778.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="964.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="959.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="953.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="942.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="924.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="889.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="844.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="803.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="776.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="759.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="778.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="766.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="778.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,966.2 140.8,963.3 191.7,958.9 242.5,948.6 293.3,937.6 344.2,918.4 395.0,887.3 445.8,843.6 496.7,822.1 547.5,828.6 598.3,853.6 649.2,851.9 700.0,883.2" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="966.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="963.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="958.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="948.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="937.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="918.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="887.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="843.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="822.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="828.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="853.6" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="851.9" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="883.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <text x="90.0" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="140.8" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="191.7" y="983.0" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/doc/charts/pushpull/alt_inproc.svg
+++ b/doc/charts/pushpull/alt_inproc.svg
@@ -60,10 +60,10 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,238.1 140.8,237.3 191.7,236.2 242.5,232.6 293.3,245.0 344.2,242.1 395.0,240.6 445.8,237.7 496.7,238.8 547.5,240.3 598.3,245.4 649.2,246.8 700.0,247.6" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,341.0 140.8,341.4 191.7,341.0 242.5,341.4 293.3,341.0 344.2,341.0 395.0,341.0 445.8,341.4 496.7,341.0 547.5,341.0 598.3,341.0 649.2,341.0 700.0,341.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,341.0 140.8,341.0 191.7,341.0 242.5,341.4 293.3,341.4 344.2,341.4 395.0,341.0 445.8,341.0 496.7,341.0 547.5,341.0 598.3,341.4 649.2,341.0 700.0,341.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,105.7 140.8,100.5 191.7,109.5 242.5,120.2 293.3,127.6 344.2,100.7 395.0,118.2 445.8,105.3 496.7,95.1 547.5,152.8 598.3,161.5 649.2,180.9 700.0,179.1" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,107.7 140.8,101.7 191.7,96.6 242.5,231.3 293.3,328.1 344.2,330.9 395.0,335.2 445.8,350.5 496.7,358.8 547.5,370.3 598.3,363.6 649.2,377.3 700.0,390.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,155.2 140.8,151.9 191.7,152.9 242.5,163.2 293.3,163.3 344.2,166.6 395.0,165.0 445.8,163.3 496.7,163.5 547.5,164.0 598.3,165.9 649.2,163.4 700.0,163.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,157.1 140.8,151.1 191.7,150.4 242.5,163.6 293.3,164.9 344.2,165.4 395.0,163.5 445.8,165.0 496.7,163.9 547.5,164.9 598.3,161.5 649.2,162.5 700.0,160.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,359.9 140.8,358.1 191.7,361.6 242.5,360.9 293.3,361.7 344.2,360.7 395.0,364.5 445.8,365.6 496.7,373.7 547.5,392.1 598.3,400.6 649.2,408.9 700.0,410.8" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,303.2 140.8,284.4 191.7,265.6 242.5,261.9 293.3,263.5 344.2,246.1 395.0,229.2 445.8,216.6 496.7,202.0 547.5,189.8 598.3,167.8 649.2,157.8 700.0,151.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="303.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -79,20 +79,20 @@
   <circle cx="598.3" cy="167.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="157.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="151.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,307.7 140.8,289.0 191.7,270.8 242.5,253.5 293.3,235.2 344.2,217.3 395.0,198.8 445.8,180.3 496.7,162.0 547.5,143.7 598.3,125.6 649.2,107.1 700.0,88.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="307.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="289.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="270.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="253.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="235.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="217.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="198.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="180.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="162.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="143.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="125.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="107.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="88.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,307.8 140.8,288.9 191.7,270.5 242.5,253.6 293.3,235.4 344.2,217.2 395.0,198.6 445.8,180.5 496.7,162.1 547.5,143.8 598.3,125.2 649.2,107.0 700.0,88.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="307.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="288.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="270.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="253.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="235.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="217.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="198.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="180.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="162.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="143.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="125.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="107.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="88.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,349.0 140.8,329.8 191.7,313.2 242.5,294.5 293.3,276.6 344.2,257.8 395.0,241.5 445.8,223.8 496.7,210.3 547.5,208.1 598.3,202.8 649.2,209.7 700.0,204.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="349.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="329.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/alt_ipc.svg
+++ b/doc/charts/pushpull/alt_ipc.svg
@@ -50,11 +50,11 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,146.1 140.8,129.4 191.7,132.2 242.5,110.0 293.3,163.4 344.2,146.6 395.0,151.3 445.8,171.8 496.7,188.5 547.5,189.9 598.3,182.3 649.2,182.3 700.0,192.6" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,335.0 140.8,335.2 191.7,334.8 242.5,333.6 293.3,332.1 344.2,328.7 395.0,326.1 445.8,320.5 496.7,314.6 547.5,308.6 598.3,294.7 649.2,295.8 700.0,294.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,333.8 140.8,333.7 191.7,333.5 242.5,332.3 293.3,320.8 344.2,325.2 395.0,321.7 445.8,310.2 496.7,294.0 547.5,296.3 598.3,292.4 649.2,295.5 700.0,294.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,202.1 140.8,200.2 191.7,204.2 242.5,202.3 293.3,203.9 344.2,204.6 395.0,204.6 445.8,217.7 496.7,230.5 547.5,255.7 598.3,228.3 649.2,267.3 700.0,236.6" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,301.6 140.8,300.9 191.7,302.0 242.5,299.8 293.3,300.1 344.2,299.8 395.0,302.7 445.8,299.8 496.7,296.8 547.5,322.1 598.3,320.2 649.2,344.3 700.0,352.0" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,112.5 140.8,96.6 191.7,123.6 242.5,218.2 293.3,314.9 344.2,318.1 395.0,336.3 445.8,368.3 496.7,388.2 547.5,399.7 598.3,405.7 649.2,409.6 700.0,410.5" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,283.9 140.8,282.3 191.7,286.3 242.5,305.9 293.3,312.2 344.2,321.7 395.0,332.0 445.8,347.5 496.7,367.3 547.5,387.1 598.3,390.6 649.2,401.4 700.0,407.7" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,281.3 140.8,281.2 191.7,282.4 242.5,302.4 293.3,308.6 344.2,315.5 395.0,327.0 445.8,336.7 496.7,354.5 547.5,381.9 598.3,390.2 649.2,401.8 700.0,407.8" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,357.1 140.8,358.8 191.7,360.0 242.5,357.5 293.3,357.4 344.2,354.9 395.0,356.7 445.8,363.2 496.7,378.2 547.5,394.9 598.3,394.3 649.2,408.3 700.0,408.5" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,390.2 140.8,390.0 191.7,390.1 242.5,390.1 293.3,390.1 344.2,390.8 395.0,391.0 445.8,392.1 496.7,394.0 547.5,398.7 598.3,401.8 649.2,406.4 700.0,409.6" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,410.6 140.8,406.8 191.7,400.9 242.5,396.3 293.3,396.1 344.2,379.3 395.0,357.9 445.8,348.0 496.7,339.3 547.5,331.5 598.3,318.3 649.2,311.2 700.0,249.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -71,20 +71,20 @@
   <circle cx="598.3" cy="318.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="311.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="249.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,412.5 140.8,411.0 191.7,408.2 242.5,404.2 293.3,395.6 344.2,380.7 395.0,354.7 445.8,317.9 496.7,279.2 547.5,258.4 598.3,143.9 649.2,123.8 700.0,123.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,412.5 140.8,411.0 191.7,408.1 242.5,403.9 293.3,395.0 344.2,378.4 395.0,351.1 445.8,302.3 496.7,242.1 547.5,228.4 598.3,138.5 649.2,132.7 700.0,127.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="412.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="411.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="408.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="404.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="395.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="380.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="354.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="317.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="279.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="258.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="143.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="123.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="123.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="408.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="403.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="395.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="378.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="351.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="302.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="242.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="228.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="138.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="132.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="127.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,413.4 140.8,412.8 191.7,411.6 242.5,408.9 293.3,403.8 344.2,392.7 395.0,372.6 445.8,340.6 496.7,310.5 547.5,303.8 598.3,186.3 649.2,281.2 700.0,158.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="413.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="412.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/alt_tcp.svg
+++ b/doc/charts/pushpull/alt_tcp.svg
@@ -50,11 +50,11 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,126.4 140.8,112.1 191.7,118.4 242.5,109.3 293.3,176.6 344.2,162.0 395.0,178.9 445.8,184.6 496.7,195.8 547.5,187.2 598.3,197.3 649.2,206.7 700.0,200.2" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,291.1 140.8,293.2 191.7,291.4 242.5,299.5 293.3,291.0 344.2,299.4 395.0,286.6 445.8,272.8 496.7,268.1 547.5,272.5 598.3,295.4 649.2,295.5 700.0,294.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,291.8 140.8,290.1 191.7,293.6 242.5,299.6 293.3,296.5 344.2,299.1 395.0,287.0 445.8,273.5 496.7,269.3 547.5,269.1 598.3,296.4 649.2,296.7 700.0,295.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,175.0 140.8,179.0 191.7,179.8 242.5,185.2 293.3,184.2 344.2,187.4 395.0,194.7 445.8,203.8 496.7,221.1 547.5,226.8 598.3,242.0 649.2,263.6 700.0,246.1" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,327.2 140.8,329.0 191.7,334.8 242.5,338.1 293.3,339.6 344.2,340.7 395.0,341.0 445.8,341.0 496.7,341.4 547.5,341.0 598.3,341.0 649.2,351.3 700.0,359.6" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,121.8 140.8,96.6 191.7,103.4 242.5,210.5 293.3,311.5 344.2,318.9 395.0,347.7 445.8,373.6 496.7,390.5 547.5,399.4 598.3,407.5 649.2,410.7 700.0,411.3" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,203.2 140.8,204.7 191.7,202.0 242.5,247.5 293.3,254.2 344.2,288.9 395.0,287.0 445.8,307.9 496.7,345.5 547.5,376.6 598.3,392.5 649.2,402.9 700.0,408.3" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,205.1 140.8,204.2 191.7,212.4 242.5,250.7 293.3,252.7 344.2,289.8 395.0,288.5 445.8,310.4 496.7,346.8 547.5,376.2 598.3,393.7 649.2,403.2 700.0,408.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,341.9 140.8,341.0 191.7,341.1 242.5,338.4 293.3,341.2 344.2,341.8 395.0,344.7 445.8,351.9 496.7,366.5 547.5,381.7 598.3,395.5 649.2,406.3 700.0,408.6" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,395.3 140.8,396.4 191.7,399.6 242.5,401.2 293.3,402.0 344.2,402.6 395.0,403.0 445.8,403.5 496.7,404.5 547.5,405.0 598.3,406.2 649.2,405.3 700.0,409.5" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,410.9 140.8,407.2 191.7,400.7 242.5,396.6 293.3,396.4 344.2,381.4 395.0,368.6 445.8,358.7 496.7,349.7 547.5,334.2 598.3,342.5 649.2,342.1 700.0,297.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -71,20 +71,20 @@
   <circle cx="598.3" cy="342.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="342.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="297.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,411.7 140.8,409.5 191.7,404.9 242.5,399.7 293.3,386.6 344.2,371.2 395.0,327.0 445.8,268.7 496.7,226.3 547.5,209.1 598.3,178.7 649.2,170.5 700.0,164.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="411.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,411.8 140.8,409.5 191.7,405.4 242.5,400.0 293.3,386.4 344.2,371.5 395.0,328.0 445.8,272.1 496.7,229.8 547.5,207.1 598.3,191.9 649.2,176.8 700.0,170.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="411.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="409.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="404.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="399.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="386.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="371.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="327.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="268.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="226.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="209.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="178.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="164.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="405.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="400.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="386.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="371.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="328.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="272.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="229.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="207.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="191.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="176.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="170.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,413.2 140.8,412.4 191.7,410.9 242.5,407.5 293.3,401.5 344.2,389.3 395.0,366.6 445.8,329.0 496.7,284.0 547.5,237.1 598.3,211.2 649.2,244.2 700.0,178.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="413.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="412.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/omq_inproc.svg
+++ b/doc/charts/pushpull/omq_inproc.svg
@@ -62,13 +62,13 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,194.1 140.8,193.2 191.7,191.8 242.5,187.2 293.3,202.8 344.2,199.1 395.0,197.3 445.8,193.6 496.7,195.0 547.5,196.8 598.3,203.2 649.2,205.0 700.0,206.0" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,231.5 140.8,239.7 191.7,231.6 242.5,231.5 293.3,231.5 344.2,232.1 395.0,231.6 445.8,231.6 496.7,231.2 547.5,231.4 598.3,231.5 649.2,231.2 700.0,231.1" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,322.8 140.8,323.2 191.7,322.8 242.5,323.2 293.3,322.8 344.2,322.8 395.0,322.8 445.8,323.2 496.7,322.8 547.5,322.8 598.3,322.8 649.2,322.8 700.0,322.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,232.0 140.8,231.5 191.7,231.7 242.5,239.8 293.3,231.1 344.2,231.2 395.0,231.2 445.8,229.0 496.7,231.1 547.5,231.6 598.3,231.3 649.2,231.5 700.0,231.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,322.8 140.8,322.8 191.7,322.8 242.5,323.2 293.3,323.2 344.2,323.2 395.0,322.8 445.8,322.8 496.7,322.8 547.5,322.8 598.3,323.2 649.2,322.8 700.0,322.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,323.2 140.8,323.2 191.7,323.2 242.5,323.2 293.3,322.8 344.2,323.2 395.0,322.8 445.8,323.2 496.7,323.2 547.5,323.2 598.3,323.2 649.2,323.2 700.0,323.2" fill="none" stroke="#ff69b4" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,241.5 140.8,242.9 191.7,237.9 242.5,246.1 293.3,242.0 344.2,241.5 395.0,237.0 445.8,236.5 496.7,240.2 547.5,238.8 598.3,239.7 649.2,241.5 700.0,241.1" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,107.7 140.8,101.7 191.7,96.6 242.5,231.3 293.3,328.1 344.2,330.9 395.0,335.2 445.8,350.5 496.7,358.8 547.5,370.3 598.3,363.6 649.2,377.3 700.0,390.7" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,302.7 140.8,279.4 191.7,262.5 242.5,274.9 293.3,278.2 344.2,257.4 395.0,279.6 445.8,274.8 496.7,274.3 547.5,280.0 598.3,275.1 649.2,261.9 700.0,275.5" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,155.2 140.8,151.9 191.7,152.9 242.5,163.2 293.3,163.3 344.2,166.6 395.0,165.0 445.8,163.3 496.7,163.5 547.5,164.0 598.3,165.9 649.2,163.4 700.0,163.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,302.6 140.8,272.0 191.7,267.0 242.5,266.2 293.3,254.2 344.2,273.1 395.0,273.3 445.8,267.1 496.7,252.9 547.5,266.7 598.3,265.4 649.2,257.7 700.0,267.4" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,157.1 140.8,151.1 191.7,150.4 242.5,163.6 293.3,164.9 344.2,165.4 395.0,163.5 445.8,165.0 496.7,163.9 547.5,164.9 598.3,161.5 649.2,162.5 700.0,160.4" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,249.1 140.8,247.4 191.7,248.1 242.5,254.6 293.3,254.7 344.2,254.8 395.0,255.2 445.8,253.8 496.7,255.3 547.5,255.4 598.3,255.2 649.2,255.1 700.0,254.9" fill="none" stroke="#ff69b4" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,300.4 140.8,298.5 191.7,298.6 242.5,283.2 293.3,290.2 344.2,292.9 395.0,297.9 445.8,290.8 496.7,295.8 547.5,298.7 598.3,297.7 649.2,294.9 700.0,294.5" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,354.0 140.8,331.4 191.7,309.0 242.5,304.5 293.3,306.4 344.2,285.5 395.0,265.2 445.8,250.1 496.7,232.6 547.5,218.0 598.3,191.5 649.2,179.6 700.0,172.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -85,34 +85,34 @@
   <circle cx="598.3" cy="191.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="179.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="172.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,386.1 140.8,358.1 191.7,332.4 242.5,313.2 293.3,291.9 344.2,265.4 395.0,248.3 445.8,225.2 496.7,203.1 547.5,182.5 598.3,159.4 649.2,134.5 700.0,115.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,386.1 140.8,356.4 191.7,333.4 242.5,311.2 293.3,286.8 344.2,268.8 395.0,246.8 445.8,223.5 496.7,198.6 547.5,179.5 598.3,157.2 649.2,133.6 700.0,113.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="386.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="358.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="332.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="313.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="291.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="265.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="248.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="225.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="203.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="182.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="159.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="134.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="115.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,359.4 140.8,337.0 191.7,315.2 242.5,294.4 293.3,272.5 344.2,250.9 395.0,228.8 445.8,206.6 496.7,184.6 547.5,162.7 598.3,141.0 649.2,118.7 700.0,96.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="359.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="337.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="315.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="294.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="272.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="250.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="228.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="206.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="184.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="162.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="141.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="118.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="96.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="356.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="333.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="311.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="286.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="268.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="246.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="223.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="198.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="179.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="157.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="133.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="113.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,359.6 140.8,336.9 191.7,314.8 242.5,294.5 293.3,272.7 344.2,250.8 395.0,228.6 445.8,206.8 496.7,184.7 547.5,162.8 598.3,140.4 649.2,118.6 700.0,96.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="359.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="336.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="314.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="294.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="272.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="250.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="228.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="206.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="184.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="162.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="140.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="118.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="96.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,373.7 140.8,351.4 191.7,329.5 242.5,308.8 293.3,286.9 344.2,264.9 395.0,243.0 445.8,220.8 496.7,199.1 547.5,177.1 598.3,155.1 649.2,133.1 700.0,111.1" fill="none" stroke="#ff69b4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="373.7" r="3" fill="#ff69b4" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="351.4" r="3" fill="#ff69b4" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/omq_ipc.svg
+++ b/doc/charts/pushpull/omq_ipc.svg
@@ -45,12 +45,12 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,146.1 140.8,129.4 191.7,132.2 242.5,110.0 293.3,163.4 344.2,146.6 395.0,151.3 445.8,171.8 496.7,188.5 547.5,189.9 598.3,182.3 649.2,182.3 700.0,192.6" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,211.0 140.8,214.4 191.7,212.1 242.5,233.5 293.3,233.2 344.2,232.9 395.0,227.4 445.8,217.0 496.7,214.7 547.5,212.5 598.3,219.5 649.2,209.6 700.0,209.6" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,335.0 140.8,335.2 191.7,334.8 242.5,333.6 293.3,332.1 344.2,328.7 395.0,326.1 445.8,320.5 496.7,314.6 547.5,308.6 598.3,294.7 649.2,295.8 700.0,294.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,208.1 140.8,213.8 191.7,209.7 242.5,226.8 293.3,223.5 344.2,221.2 395.0,206.6 445.8,209.7 496.7,192.3 547.5,198.0 598.3,204.6 649.2,202.4 700.0,203.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,333.8 140.8,333.7 191.7,333.5 242.5,332.3 293.3,320.8 344.2,325.2 395.0,321.7 445.8,310.2 496.7,294.0 547.5,296.3 598.3,292.4 649.2,295.5 700.0,294.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,309.5 140.8,308.8 191.7,312.6 242.5,278.3 293.3,293.6 344.2,294.6 395.0,286.8 445.8,287.0 496.7,277.9 547.5,273.4 598.3,270.4 649.2,269.5 700.0,279.5" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,275.0 140.8,267.7 191.7,280.1 242.5,323.7 293.3,368.3 344.2,369.8 395.0,378.2 445.8,392.9 496.7,402.1 547.5,407.4 598.3,410.2 649.2,411.9 700.0,412.4" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,284.1 140.8,295.7 191.7,297.2 242.5,316.1 293.3,317.3 344.2,328.1 395.0,340.5 445.8,359.6 496.7,374.6 547.5,389.2 598.3,400.1 649.2,406.2 700.0,410.4" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,354.0 140.8,353.3 191.7,355.1 242.5,364.2 293.3,367.0 344.2,371.5 395.0,376.2 445.8,383.3 496.7,392.5 547.5,401.6 598.3,403.2 649.2,408.2 700.0,411.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,273.0 140.8,284.3 191.7,285.6 242.5,303.6 293.3,306.2 344.2,320.8 395.0,334.0 445.8,358.1 496.7,372.6 547.5,386.1 598.3,398.7 649.2,406.4 700.0,410.1" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,352.8 140.8,352.8 191.7,353.3 242.5,362.5 293.3,365.4 344.2,368.6 395.0,373.9 445.8,378.4 496.7,386.6 547.5,399.2 598.3,403.0 649.2,408.4 700.0,411.1" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,96.6 140.8,112.4 191.7,176.5 242.5,239.1 293.3,295.3 344.2,330.6 395.0,344.9 445.8,366.8 496.7,381.1 547.5,395.4 598.3,404.1 649.2,408.8 700.0,411.4" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,410.6 140.8,406.8 191.7,400.9 242.5,396.3 293.3,396.1 344.2,379.3 395.0,357.9 445.8,348.0 496.7,339.3 547.5,331.5 598.3,318.3 649.2,311.2 700.0,249.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="410.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -66,34 +66,34 @@
   <circle cx="598.3" cy="318.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="311.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="249.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,410.8 140.8,408.2 191.7,402.6 242.5,394.8 293.3,376.1 344.2,346.7 395.0,298.8 445.8,243.6 496.7,166.8 547.5,103.6 598.3,66.4 649.2,23.1 700.0,50.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="410.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="408.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="402.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="394.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="376.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="346.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="298.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="243.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="166.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="103.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="66.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="23.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="50.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,412.5 140.8,411.0 191.7,408.2 242.5,404.2 293.3,395.6 344.2,380.7 395.0,354.7 445.8,317.9 496.7,279.2 547.5,258.4 598.3,143.9 649.2,123.8 700.0,123.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,410.6 140.8,407.6 191.7,401.4 242.5,392.4 293.3,371.8 344.2,341.0 395.0,288.6 445.8,239.0 496.7,154.8 547.5,64.7 598.3,30.9 649.2,32.4 700.0,22.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="410.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="407.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="401.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="392.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="371.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="341.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="288.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="239.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="154.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="64.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="30.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="32.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="22.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,412.5 140.8,411.0 191.7,408.1 242.5,403.9 293.3,395.0 344.2,378.4 395.0,351.1 445.8,302.3 496.7,242.1 547.5,228.4 598.3,138.5 649.2,132.7 700.0,127.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="412.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="411.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="408.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="404.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="395.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="380.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="354.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="317.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="279.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="258.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="143.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="123.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="123.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="408.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="403.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="395.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="378.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="351.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="302.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="242.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="228.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="138.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="132.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="127.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,406.2 140.8,399.2 191.7,390.7 242.5,379.8 293.3,367.5 344.2,348.6 395.0,305.8 445.8,265.9 496.7,207.6 547.5,180.4 598.3,166.5 649.2,153.7 700.0,156.5" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="406.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="399.2" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/omq_tcp.svg
+++ b/doc/charts/pushpull/omq_tcp.svg
@@ -45,12 +45,12 @@
   <line x1="780.0" y1="49.0" x2="780.0" y2="414.0" stroke="#d1d5db" stroke-width="1"/>
   <text x="40.0" y="231.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,231.5)">CPU %</text>
   <polyline points="90.0,126.4 140.8,112.1 191.7,118.4 242.5,109.3 293.3,176.6 344.2,162.0 395.0,178.9 445.8,184.6 496.7,195.8 547.5,187.2 598.3,197.3 649.2,206.7 700.0,200.2" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,120.7 140.8,127.7 191.7,110.9 242.5,145.9 293.3,160.1 344.2,228.7 395.0,190.3 445.8,186.0 496.7,183.9 547.5,195.2 598.3,200.6 649.2,211.3 700.0,208.9" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,291.1 140.8,293.2 191.7,291.4 242.5,299.5 293.3,291.0 344.2,299.4 395.0,286.6 445.8,272.8 496.7,268.1 547.5,272.5 598.3,295.4 649.2,295.5 700.0,294.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,124.4 140.8,108.7 191.7,176.6 242.5,146.1 293.3,171.5 344.2,198.7 395.0,191.8 445.8,191.5 496.7,186.0 547.5,184.9 598.3,201.6 649.2,212.1 700.0,218.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,291.8 140.8,290.1 191.7,293.6 242.5,299.6 293.3,296.5 344.2,299.1 395.0,287.0 445.8,273.5 496.7,269.3 547.5,269.1 598.3,296.4 649.2,296.7 700.0,295.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,304.3 140.8,305.8 191.7,309.2 242.5,278.4 293.3,289.9 344.2,292.1 395.0,289.8 445.8,291.1 496.7,281.8 547.5,280.7 598.3,278.1 649.2,276.0 700.0,267.5" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,292.5 140.8,282.0 191.7,284.9 242.5,329.4 293.3,371.4 344.2,374.5 395.0,386.4 445.8,397.2 496.7,404.2 547.5,407.9 598.3,411.3 649.2,412.6 700.0,412.9" fill="none" stroke="#eab308" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,287.0 140.8,297.9 191.7,291.7 242.5,315.0 293.3,314.8 344.2,331.1 395.0,344.0 445.8,359.8 496.7,377.8 547.5,389.8 598.3,400.5 649.2,407.6 700.0,410.7" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <polyline points="90.0,326.4 140.8,327.0 191.7,325.9 242.5,344.8 293.3,347.5 344.2,362.0 395.0,361.2 445.8,369.9 496.7,385.5 547.5,398.4 598.3,405.1 649.2,409.4 700.0,411.6" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,290.7 140.8,284.4 191.7,302.9 242.5,312.4 293.3,315.4 344.2,331.4 395.0,344.1 445.8,360.4 496.7,377.9 547.5,390.5 598.3,401.4 649.2,407.9 700.0,411.0" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polyline points="90.0,327.2 140.8,326.8 191.7,330.2 242.5,346.1 293.3,346.9 344.2,362.4 395.0,361.8 445.8,370.9 496.7,386.0 547.5,398.3 598.3,405.6 649.2,409.5 700.0,411.7" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,96.6 140.8,116.3 191.7,179.6 242.5,250.9 293.3,301.1 344.2,336.6 395.0,353.7 445.8,374.5 496.7,387.0 547.5,399.6 598.3,406.4 649.2,409.9 700.0,411.6" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="5,3"/>
   <polyline points="90.0,410.9 140.8,407.2 191.7,400.7 242.5,396.6 293.3,396.4 344.2,381.4 395.0,368.6 445.8,358.7 496.7,349.7 547.5,334.2 598.3,342.5 649.2,342.1 700.0,297.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="410.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -66,34 +66,34 @@
   <circle cx="598.3" cy="342.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="649.2" cy="342.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="297.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,410.7 140.8,408.0 191.7,401.4 242.5,393.6 293.3,373.2 344.2,345.7 395.0,298.6 445.8,235.4 496.7,175.2 547.5,95.1 598.3,58.8 649.2,78.4 700.0,68.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="410.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="140.8" cy="408.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="401.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="393.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="373.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="345.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="298.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="235.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="175.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="95.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="58.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="78.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="68.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,411.7 140.8,409.5 191.7,404.9 242.5,399.7 293.3,386.6 344.2,371.2 395.0,327.0 445.8,268.7 496.7,226.3 547.5,209.1 598.3,178.7 649.2,170.5 700.0,164.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="411.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,410.8 140.8,407.3 191.7,402.6 242.5,393.1 293.3,373.4 344.2,346.0 395.0,298.8 445.8,237.3 496.7,176.4 547.5,104.5 598.3,81.0 649.2,91.0 700.0,97.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="410.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="140.8" cy="407.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="402.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="393.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="373.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="346.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="298.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="237.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="176.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="104.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="81.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="91.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="97.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,411.8 140.8,409.5 191.7,405.4 242.5,400.0 293.3,386.4 344.2,371.5 395.0,328.0 445.8,272.1 496.7,229.8 547.5,207.1 598.3,191.9 649.2,176.8 700.0,170.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="411.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="409.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="191.7" cy="404.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="242.5" cy="399.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="386.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="344.2" cy="371.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="395.0" cy="327.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="445.8" cy="268.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="226.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="547.5" cy="209.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="598.3" cy="178.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="649.2" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="164.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="191.7" cy="405.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="242.5" cy="400.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="386.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="344.2" cy="371.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="395.0" cy="328.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="445.8" cy="272.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="229.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="547.5" cy="207.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="598.3" cy="191.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="649.2" cy="176.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="170.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,405.8 140.8,398.7 191.7,389.9 242.5,380.4 293.3,367.5 344.2,350.3 395.0,314.8 445.8,284.0 496.7,235.9 547.5,223.8 598.3,213.8 649.2,196.6 700.0,158.4" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="405.8" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <circle cx="140.8" cy="398.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/alt_inproc.svg
+++ b/doc/charts/reqrep/alt_inproc.svg
@@ -52,7 +52,7 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,175.8 145.8,178.4 201.7,179.3 257.5,178.5 313.3,179.1 369.2,179.3 425.0,175.6 480.8,177.1 536.7,181.5 592.5,177.2 648.3,176.3 704.2,178.8 760.0,179.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,199.9 145.8,185.2 201.7,199.9 257.5,199.1 313.3,184.5 369.2,185.6 425.0,185.3 480.8,184.9 536.7,199.5 592.5,184.7 648.3,184.3 704.2,184.4 760.0,184.8" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,200.4 145.8,186.0 201.7,186.5 257.5,199.9 313.3,185.9 369.2,185.6 425.0,199.9 480.8,185.4 536.7,186.1 592.5,185.6 648.3,185.4 704.2,185.7 760.0,185.7" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,120.4 145.8,114.9 201.7,125.4 257.5,116.7 313.3,113.9 369.2,118.5 425.0,119.9 480.8,112.9 536.7,121.4 592.5,120.8 648.3,116.1 704.2,115.6 760.0,117.8" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,115.5 145.8,99.9 201.7,116.2 257.5,100.9 313.3,104.8 369.2,99.7 425.0,109.7 480.8,97.1 536.7,111.7 592.5,104.4 648.3,109.2 704.2,86.5 760.0,81.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="115.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -68,20 +68,20 @@
   <circle cx="648.3" cy="109.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="86.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="81.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,201.6 145.8,201.6 201.7,201.6 257.5,202.3 313.3,202.2 369.2,201.5 425.0,202.2 480.8,201.9 536.7,201.9 592.5,201.9 648.3,202.2 704.2,202.1 760.0,201.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="202.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="202.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,201.0 145.8,201.1 201.7,200.7 257.5,201.5 313.3,201.2 369.2,201.3 425.0,201.7 480.8,201.5 536.7,201.0 592.5,201.4 648.3,201.5 704.2,201.3 760.0,201.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="201.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="200.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="201.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="201.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="201.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,81.6 145.8,75.9 201.7,83.3 257.5,78.2 313.3,91.7 369.2,89.5 425.0,75.0 480.8,85.9 536.7,94.1 592.5,75.6 648.3,80.2 704.2,60.1 760.0,40.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="81.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="75.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/alt_ipc.svg
+++ b/doc/charts/reqrep/alt_ipc.svg
@@ -44,7 +44,7 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,190.3 145.8,188.6 201.7,189.2 257.5,189.0 313.3,187.3 369.2,203.4 425.0,193.3 480.8,189.8 536.7,189.2 592.5,188.1 648.3,186.3 704.2,185.0 760.0,187.8" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,180.2 145.8,183.0 201.7,184.6 257.5,181.4 313.3,181.5 369.2,183.8 425.0,207.4 480.8,181.2 536.7,185.6 592.5,184.3 648.3,181.3 704.2,181.6 760.0,184.2" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,181.5 145.8,182.8 201.7,183.4 257.5,183.0 313.3,180.6 369.2,188.0 425.0,184.4 480.8,179.6 536.7,178.5 592.5,184.1 648.3,181.0 704.2,181.4 760.0,182.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,84.1 145.8,71.9 201.7,74.8 257.5,72.4 313.3,84.2 369.2,74.5 425.0,77.2 480.8,92.2 536.7,86.9 592.5,77.6 648.3,76.2 704.2,93.0 760.0,80.7" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,186.9 145.8,188.2 201.7,188.1 257.5,183.4 313.3,183.7 369.2,186.7 425.0,183.6 480.8,181.9 536.7,188.2 592.5,186.4 648.3,184.0 704.2,187.9 760.0,187.4" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,135.8 145.8,135.8 201.7,131.5 257.5,141.7 313.3,143.1 369.2,126.4 425.0,125.6 480.8,125.2 536.7,131.8 592.5,118.6 648.3,101.0 704.2,114.1 760.0,106.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -61,20 +61,20 @@
   <circle cx="648.3" cy="101.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="114.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="106.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,183.7 145.8,184.2 201.7,178.9 257.5,184.4 313.3,183.8 369.2,183.9 425.0,166.8 480.8,182.7 536.7,180.9 592.5,176.5 648.3,174.9 704.2,167.9 760.0,159.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="183.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="184.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="178.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="184.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="183.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="183.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="166.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="182.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="180.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="176.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="167.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="159.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,182.0 145.8,182.3 201.7,181.6 257.5,182.6 313.3,181.9 369.2,181.4 425.0,180.5 480.8,185.9 536.7,185.0 592.5,176.9 648.3,171.5 704.2,169.3 760.0,158.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="182.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="182.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="181.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="182.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="181.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="181.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="180.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="185.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="185.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="176.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="171.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="169.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="158.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,109.4 145.8,123.1 201.7,112.1 257.5,123.1 313.3,117.4 369.2,118.8 425.0,107.4 480.8,119.1 536.7,121.2 592.5,106.3 648.3,112.9 704.2,105.2 760.0,98.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="109.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="123.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/alt_tcp.svg
+++ b/doc/charts/reqrep/alt_tcp.svg
@@ -44,7 +44,7 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,187.1 145.8,186.9 201.7,188.9 257.5,187.7 313.3,187.9 369.2,187.5 425.0,187.4 480.8,187.4 536.7,186.9 592.5,187.5 648.3,184.9 704.2,184.4 760.0,184.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,189.1 145.8,188.8 201.7,187.7 257.5,188.4 313.3,188.0 369.2,188.4 425.0,187.2 480.8,189.1 536.7,187.5 592.5,188.2 648.3,187.8 704.2,189.3 760.0,188.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,190.1 145.8,189.4 201.7,189.3 257.5,190.3 313.3,188.0 369.2,188.0 425.0,190.6 480.8,189.2 536.7,190.2 592.5,188.8 648.3,188.9 704.2,188.6 760.0,189.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,93.2 145.8,100.2 201.7,94.0 257.5,96.5 313.3,97.9 369.2,97.5 425.0,94.2 480.8,92.9 536.7,93.3 592.5,99.1 648.3,94.1 704.2,100.1 760.0,100.5" fill="none" stroke="#16a34a" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,188.8 145.8,190.0 201.7,189.6 257.5,190.0 313.3,189.4 369.2,188.2 425.0,189.9 480.8,190.1 536.7,187.6 592.5,188.4 648.3,189.3 704.2,190.4 760.0,190.5" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,119.5 145.8,125.0 201.7,119.8 257.5,131.6 313.3,124.2 369.2,115.8 425.0,121.9 480.8,121.7 536.7,119.1 592.5,112.3 648.3,93.2 704.2,93.0 760.0,72.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -61,20 +61,20 @@
   <circle cx="648.3" cy="93.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="93.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="72.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,169.5 145.8,169.5 201.7,169.3 257.5,170.5 313.3,170.0 369.2,170.2 425.0,169.1 480.8,168.6 536.7,168.9 592.5,166.3 648.3,163.1 704.2,159.3 760.0,149.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="169.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="169.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="169.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="170.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,168.9 145.8,168.1 201.7,170.0 257.5,169.0 313.3,170.1 369.2,170.2 425.0,169.2 480.8,168.3 536.7,168.1 592.5,163.1 648.3,164.3 704.2,157.0 760.0,149.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="168.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="168.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="170.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="169.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="170.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="170.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="169.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="168.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="168.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="166.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="163.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="159.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="149.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="169.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="168.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="168.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="163.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="164.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="157.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="149.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,101.2 145.8,115.6 201.7,121.5 257.5,106.4 313.3,120.1 369.2,101.9 425.0,108.6 480.8,105.7 536.7,106.8 592.5,105.0 648.3,105.8 704.2,106.7 760.0,86.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="101.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="115.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/omq_inproc.svg
+++ b/doc/charts/reqrep/omq_inproc.svg
@@ -44,8 +44,8 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,122.6 145.8,127.8 201.7,129.5 257.5,128.0 313.3,129.1 369.2,129.6 425.0,122.2 480.8,125.3 536.7,133.9 592.5,125.4 648.3,123.6 704.2,128.5 760.0,130.8" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,68.1 145.8,75.8 201.7,85.0 257.5,79.2 313.3,75.8 369.2,76.4 425.0,70.7 480.8,73.9 536.7,78.6 592.5,84.0 648.3,99.5 704.2,81.2 760.0,78.7" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,170.8 145.8,141.5 201.7,170.8 257.5,169.2 313.3,140.1 369.2,142.2 425.0,141.7 480.8,140.7 536.7,170.1 592.5,140.5 648.3,139.6 704.2,139.8 760.0,140.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,79.0 145.8,80.4 201.7,85.6 257.5,72.9 313.3,100.1 369.2,75.9 425.0,78.7 480.8,66.8 536.7,77.2 592.5,81.2 648.3,70.8 704.2,82.9 760.0,69.0" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,171.9 145.8,142.9 201.7,144.0 257.5,170.9 313.3,142.7 369.2,142.3 425.0,170.8 480.8,141.8 536.7,143.2 592.5,142.1 648.3,141.9 704.2,142.3 760.0,142.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,171.9 145.8,173.5 201.7,173.2 257.5,172.1 313.3,171.9 369.2,172.1 425.0,172.6 480.8,172.7 536.7,172.7 592.5,174.2 648.3,171.8 704.2,171.7 760.0,172.8" fill="none" stroke="#ff69b4" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,127.6 145.8,128.0 201.7,128.7 257.5,133.7 313.3,123.9 369.2,136.6 425.0,135.8 480.8,132.5 536.7,134.9 592.5,129.8 648.3,130.7 704.2,129.4 760.0,135.7" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,115.5 145.8,99.9 201.7,116.2 257.5,100.9 313.3,104.8 369.2,99.7 425.0,109.7 480.8,97.1 536.7,111.7 592.5,104.4 648.3,109.2 704.2,86.5 760.0,81.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -62,34 +62,34 @@
   <circle cx="648.3" cy="109.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="86.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="81.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,137.6 145.8,132.3 201.7,128.6 257.5,140.4 313.3,133.6 369.2,133.1 425.0,134.7 480.8,137.8 536.7,125.9 592.5,126.0 648.3,120.6 704.2,135.1 760.0,137.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="137.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="132.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="128.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="140.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="133.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="133.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="134.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="137.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="125.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="126.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="120.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="135.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="137.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,201.6 145.8,201.6 201.7,201.6 257.5,202.3 313.3,202.2 369.2,201.5 425.0,202.2 480.8,201.9 536.7,201.9 592.5,201.9 648.3,202.2 704.2,202.1 760.0,201.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="202.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="202.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="202.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="201.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,134.1 145.8,132.1 201.7,122.1 257.5,136.9 313.3,129.7 369.2,112.0 425.0,136.6 480.8,138.0 536.7,135.2 592.5,135.8 648.3,135.3 704.2,135.8 760.0,136.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="134.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="132.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="122.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="136.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="129.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="112.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="136.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="138.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="135.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="135.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="135.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="135.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="136.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,201.0 145.8,201.1 201.7,200.7 257.5,201.5 313.3,201.2 369.2,201.3 425.0,201.7 480.8,201.5 536.7,201.0 592.5,201.4 648.3,201.5 704.2,201.3 760.0,201.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="201.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="200.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="201.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="201.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="201.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="201.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,215.1 145.8,215.0 201.7,215.0 257.5,215.0 313.3,215.1 369.2,215.0 425.0,214.9 480.8,214.9 536.7,214.9 592.5,214.5 648.3,215.1 704.2,215.1 760.0,214.9" fill="none" stroke="#ff69b4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="215.1" r="3" fill="#ff69b4" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="215.0" r="3" fill="#ff69b4" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/omq_ipc.svg
+++ b/doc/charts/reqrep/omq_ipc.svg
@@ -42,8 +42,8 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,132.2 145.8,128.1 201.7,129.6 257.5,129.0 313.3,124.8 369.2,165.0 425.0,139.7 480.8,130.9 536.7,129.4 592.5,126.7 648.3,122.3 704.2,119.0 760.0,125.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,109.9 145.8,105.4 201.7,110.8 257.5,100.6 313.3,104.0 369.2,168.6 425.0,142.3 480.8,121.9 536.7,99.9 592.5,98.1 648.3,97.6 704.2,97.5 760.0,112.7" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,107.1 145.8,114.1 201.7,117.9 257.5,109.9 313.3,110.3 369.2,116.0 425.0,175.1 480.8,109.6 536.7,120.5 592.5,117.2 648.3,109.8 704.2,110.5 760.0,116.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,105.1 145.8,97.6 201.7,98.1 257.5,97.0 313.3,98.9 369.2,95.9 425.0,99.5 480.8,95.9 536.7,100.6 592.5,99.8 648.3,95.7 704.2,99.6 760.0,101.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,110.2 145.8,113.5 201.7,115.0 257.5,113.9 313.3,107.9 369.2,126.6 425.0,117.6 480.8,105.5 536.7,102.6 592.5,116.7 648.3,109.1 704.2,109.9 760.0,112.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,122.9 145.8,127.2 201.7,123.8 257.5,122.8 313.3,118.1 369.2,121.5 425.0,121.2 480.8,130.4 536.7,127.3 592.5,124.2 648.3,128.6 704.2,123.9 760.0,128.5" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,135.8 145.8,135.8 201.7,131.5 257.5,141.7 313.3,143.1 369.2,126.4 425.0,125.6 480.8,125.2 536.7,131.8 592.5,118.6 648.3,101.0 704.2,114.1 760.0,106.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="135.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -59,34 +59,34 @@
   <circle cx="648.3" cy="101.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="114.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="106.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,125.4 145.8,131.7 201.7,129.6 257.5,125.6 313.3,128.7 369.2,112.8 425.0,105.2 480.8,117.2 536.7,116.9 592.5,122.1 648.3,110.4 704.2,102.8 760.0,99.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="125.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="131.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="129.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="125.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="128.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="112.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="105.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="117.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="116.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="122.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="110.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="102.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="99.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,183.7 145.8,184.2 201.7,178.9 257.5,184.4 313.3,183.8 369.2,183.9 425.0,166.8 480.8,182.7 536.7,180.9 592.5,176.5 648.3,174.9 704.2,167.9 760.0,159.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="183.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="184.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="178.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="184.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="183.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="183.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="166.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="182.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="180.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="176.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="167.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="159.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,117.4 145.8,133.1 201.7,129.1 257.5,130.6 313.3,133.8 369.2,131.1 425.0,126.8 480.8,130.3 536.7,123.8 592.5,118.2 648.3,108.7 704.2,116.9 760.0,103.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="117.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="133.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="129.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="130.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="133.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="131.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="126.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="130.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="123.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="118.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="108.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="116.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="103.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,182.0 145.8,182.3 201.7,181.6 257.5,182.6 313.3,181.9 369.2,181.4 425.0,180.5 480.8,185.9 536.7,185.0 592.5,176.9 648.3,171.5 704.2,169.3 760.0,158.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="182.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="182.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="181.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="182.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="181.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="181.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="180.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="185.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="185.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="176.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="171.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="169.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="158.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,181.4 145.8,181.3 201.7,181.3 257.5,181.0 313.3,181.4 369.2,180.8 425.0,180.3 480.8,178.6 536.7,178.4 592.5,175.0 648.3,171.6 704.2,165.5 760.0,156.3" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="181.4" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="181.3" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/omq_tcp.svg
+++ b/doc/charts/reqrep/omq_tcp.svg
@@ -42,8 +42,8 @@
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,124.2 145.8,123.8 201.7,128.7 257.5,125.8 313.3,126.2 369.2,125.3 425.0,125.1 480.8,125.0 536.7,123.7 592.5,125.3 648.3,118.8 704.2,117.6 760.0,117.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,93.5 145.8,92.0 201.7,90.0 257.5,95.9 313.3,103.6 369.2,95.7 425.0,100.5 480.8,87.6 536.7,93.5 592.5,94.8 648.3,94.6 704.2,94.6 760.0,104.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
-  <polyline points="90.0,129.2 145.8,128.5 201.7,125.8 257.5,127.6 313.3,126.5 369.2,127.4 425.0,124.5 480.8,129.3 536.7,125.2 592.5,127.1 648.3,126.1 704.2,129.9 760.0,127.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,104.2 145.8,104.9 201.7,100.8 257.5,102.9 313.3,102.0 369.2,110.8 425.0,102.3 480.8,104.3 536.7,103.4 592.5,112.7 648.3,106.2 704.2,107.0 760.0,108.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="2,3"/>
+  <polyline points="90.0,131.7 145.8,130.0 201.7,129.8 257.5,132.2 313.3,126.6 369.2,126.5 425.0,133.0 480.8,129.5 536.7,132.0 592.5,128.6 648.3,128.6 704.2,128.1 760.0,129.3" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,121.1 145.8,120.2 201.7,121.9 257.5,118.0 313.3,120.3 369.2,121.2 425.0,121.8 480.8,118.0 536.7,119.5 592.5,119.5 648.3,120.6 704.2,120.5 760.0,124.2" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="2,3"/>
   <polyline points="90.0,119.5 145.8,125.0 201.7,119.8 257.5,131.6 313.3,124.2 369.2,115.8 425.0,121.9 480.8,121.7 536.7,119.1 592.5,112.3 648.3,93.2 704.2,93.0 760.0,72.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="119.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -59,34 +59,34 @@
   <circle cx="648.3" cy="93.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="704.2" cy="93.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="72.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,126.5 145.8,121.4 201.7,121.2 257.5,112.2 313.3,106.3 369.2,110.4 425.0,112.1 480.8,120.0 536.7,112.1 592.5,106.8 648.3,103.1 704.2,109.2 760.0,93.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="126.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="121.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="121.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="112.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="106.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="110.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="112.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="120.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="112.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="106.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="103.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="109.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="93.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,169.5 145.8,169.5 201.7,169.3 257.5,170.5 313.3,170.0 369.2,170.2 425.0,169.1 480.8,168.6 536.7,168.9 592.5,166.3 648.3,163.1 704.2,159.3 760.0,149.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="169.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="169.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="169.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="170.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,108.5 145.8,117.7 201.7,118.2 257.5,115.1 313.3,119.3 369.2,123.6 425.0,125.7 480.8,108.6 536.7,116.6 592.5,111.5 648.3,100.0 704.2,97.7 760.0,96.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="108.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="117.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="118.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="115.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="119.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="123.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="125.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="108.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="116.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="111.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="100.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="97.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="96.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,168.9 145.8,168.1 201.7,170.0 257.5,169.0 313.3,170.1 369.2,170.2 425.0,169.2 480.8,168.3 536.7,168.1 592.5,163.1 648.3,164.3 704.2,157.0 760.0,149.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="168.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="168.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="170.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="169.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="170.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="170.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="169.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="168.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="168.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="166.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="163.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="159.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="149.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="169.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="168.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="168.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="163.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="164.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="157.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="149.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,170.7 145.8,169.1 201.7,169.9 257.5,169.5 313.3,169.1 369.2,170.3 425.0,169.3 480.8,168.2 536.7,167.5 592.5,165.3 648.3,162.4 704.2,158.5 760.0,143.8" fill="none" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="170.7" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="169.1" r="3" fill="#7c3aed" stroke="white" stroke-width="1"/>

--- a/omq-proto/src/encoded_queue.rs
+++ b/omq-proto/src/encoded_queue.rs
@@ -81,6 +81,21 @@ impl EncodedQueue {
         self.total_bytes = 0;
     }
 
+    pub fn has_arena_only(&self) -> bool {
+        self.entries.is_empty() && !self.arena.is_empty()
+    }
+
+    pub fn uncommitted_arena(&self) -> &[u8] {
+        &self.arena[self.arena_mark as usize..]
+    }
+
+    pub fn take_arena_bytes(&mut self) -> Bytes {
+        let frozen = self.arena.split().freeze();
+        self.arena_mark = 0;
+        self.total_bytes = 0;
+        frozen
+    }
+
     pub fn push_pre_encoded(&mut self, data: &[u8]) {
         self.arena.extend_from_slice(data);
         self.total_bytes += data.len();
@@ -350,5 +365,66 @@ mod tests {
         let mut buf = Vec::new();
         eq.drain_into_vec(&mut buf, 1024);
         assert!(eq.is_empty());
+    }
+
+    #[test]
+    fn has_arena_only_small_message() {
+        let mut eq = EncodedQueue::one_shot();
+        assert!(!eq.has_arena_only());
+
+        let msg = Message::from(Bytes::from_static(&[0xAA; 64]));
+        eq.encode_auto(&msg);
+        assert!(eq.has_arena_only());
+
+        let raw = eq.uncommitted_arena();
+        assert_eq!(raw.len(), eq.total_bytes());
+        assert!(!raw.is_empty());
+    }
+
+    #[test]
+    fn has_arena_only_false_for_gather() {
+        let mut eq = EncodedQueue::one_shot();
+        let large = Message::from(Bytes::from(vec![0xBB; 128 * 1024]));
+        eq.encode_auto(&large);
+        assert!(!eq.has_arena_only());
+    }
+
+    #[test]
+    fn take_arena_bytes_round_trip() {
+        let mut eq = EncodedQueue::one_shot();
+        let msg = Message::from(Bytes::from_static(&[0xCC; 32]));
+        eq.encode_auto(&msg);
+        assert!(eq.has_arena_only());
+
+        let frozen = eq.take_arena_bytes();
+        assert!(!frozen.is_empty());
+        assert!(eq.is_empty());
+        assert_eq!(eq.total_bytes(), 0);
+
+        let mut eq2 = EncodedQueue::new();
+        eq2.push_pre_encoded(&frozen);
+        let mut buf = Vec::new();
+        eq2.drain_into_vec(&mut buf, 1024);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0], frozen);
+    }
+
+    #[test]
+    fn arena_only_matches_drain_output() {
+        let mut eq1 = EncodedQueue::one_shot();
+        let mut eq2 = EncodedQueue::one_shot();
+        let msg = Message::from(Bytes::from_static(&[0xDD; 100]));
+
+        eq1.encode_auto(&msg);
+        eq2.encode_auto(&msg);
+
+        let raw = eq1.uncommitted_arena().to_vec();
+        eq1.clear_arena();
+
+        let mut chunks = Vec::new();
+        eq2.drain_into_vec(&mut chunks, 1024);
+
+        let drained: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(raw, drained);
     }
 }

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -523,6 +523,7 @@ where
             .unwrap_or(0);
         let hb_sleep = tokio::time::sleep(hb_interval.unwrap_or(Duration::MAX));
         tokio::pin!(hb_sleep);
+        let mut hb_ping_sent = false;
         loop {
             if handshake_deadline.is_some() && codec.is_ready() {
                 handshake_deadline = None;
@@ -679,22 +680,13 @@ where
                     }
                 },
 
-                // Wire-slot arm: the socket handle encoded ZMTP frames
-                // into the per-peer PeerWireSlot. Drain and write
-                // directly, bypassing the local EncodedQueue.
-                () = async {
-                    wire_slot.as_ref().unwrap().data_ready.notified().await;
-                }, if wire_slot.as_ref().is_some_and(|s| {
-                    s.handshake_done.load(Ordering::Acquire)
-                }) => {
-                    drain_wire_slot(
-                        wire_slot.as_ref().unwrap(), &mut drain_buf, &mut writer,
-                    ).await?;
-                },
-
                 // Shared-queue arm: batch-encodes up to
                 // SHARED_MAX_BATCH_MSGS messages per wakeup then flushes
                 // them all in one or a few write_vectored calls.
+                //
+                // Higher priority than wire_slot: messages queued before
+                // the wire-slot fast path was enabled (pre-handshake or
+                // post-reconnect) must drain first to preserve ordering.
                 msg = async {
                     if let Some(ref rx) = shared_msg_rx {
                         rx.recv().await
@@ -742,11 +734,29 @@ where
                     }
                 },
 
+                // Wire-slot arm: the socket handle encoded ZMTP frames
+                // into the per-peer PeerWireSlot. Drain and write
+                // directly, bypassing the local EncodedQueue.
+                () = async {
+                    wire_slot.as_ref().unwrap().data_ready.notified().await;
+                }, if wire_slot.as_ref().is_some_and(|s| {
+                    s.handshake_done.load(Ordering::Acquire)
+                }) => {
+                    drain_wire_slot(
+                        wire_slot.as_ref().unwrap(), &mut drain_buf, &mut writer,
+                    ).await?;
+                },
+
                 // Heartbeat tick: enabled only post-handshake when
                 // `heartbeat_interval` is set. Uses a persistent pinned
                 // sleep so the safety-net timeout doesn't reset it.
+                //
+                // Only check the timeout after at least one PING has
+                // been sent: on unidirectional sockets (PUSH, PUB) the
+                // peer has no data to send, so last_input stays at
+                // handshake time until the first PONG arrives.
                 () = &mut hb_sleep, if hb_enabled => {
-                    if last_input.elapsed() > hb_timeout {
+                    if hb_ping_sent && last_input.elapsed() > hb_timeout {
                         return Err(Error::Timeout);
                     }
                     let ping = Command::Ping {
@@ -754,6 +764,7 @@ where
                         context: Bytes::new(),
                     };
                     let _ = codec.send_command(&ping);
+                    hb_ping_sent = true;
                     hb_sleep.as_mut().reset(
                         tokio::time::Instant::now() + hb_interval.unwrap(),
                     );

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -140,7 +140,19 @@ impl PeerWireSlot {
         TryEncodeResult::Ok
     }
 
-    fn signal_encoded(&self) {
+    pub(crate) fn try_push_pre_encoded_no_signal(&self, data: &[u8]) -> TryEncodeResult {
+        if self.dead.load(Ordering::Acquire) {
+            return TryEncodeResult::Dead;
+        }
+        let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
+        if eq.total_bytes() >= self.cap {
+            return TryEncodeResult::Full;
+        }
+        eq.push_pre_encoded(data);
+        TryEncodeResult::Ok
+    }
+
+    pub(crate) fn signal_encoded(&self) {
         if !self.pending.swap(true, Ordering::Release) {
             self.data_ready.notify_one();
         }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -36,9 +36,13 @@ pub(crate) enum FanOutMode {
     Group,
 }
 
+const ARENA_YIELD_BYTES: usize = 2 * 1024 * 1024;
+
+const FAN_OUT_COPY_BUDGET: usize = 128 * 1024;
+
 fn yield_interval(peer_count: usize) -> u32 {
     let n = (peer_count as u32).max(1);
-    (256 / n).max(4)
+    (512 / n.isqrt()).max(16)
 }
 
 enum CachedResult {
@@ -95,13 +99,20 @@ impl FanOutArena {
             self.pending.store(false, Ordering::Relaxed);
             return;
         }
-        if eq.has_arena_only() {
+        if eq.has_arena_only()
+            && eq.uncommitted_arena().len() * targets.len() <= FAN_OUT_COPY_BUDGET
+        {
             let frozen = eq.take_arena_bytes();
             self.pending.store(false, Ordering::Relaxed);
             drop(eq);
             for t in targets {
                 if let PeerSend::Wire { slot, .. } = t {
-                    let _ = slot.try_push_pre_encoded(&frozen);
+                    let _ = slot.try_push_pre_encoded_no_signal(&frozen);
+                }
+            }
+            for t in targets {
+                if let PeerSend::Wire { slot, .. } = t {
+                    slot.signal_encoded();
                 }
             }
         } else {
@@ -278,8 +289,11 @@ impl Submitter {
                 encoder,
                 all_wire,
             } => {
+                let interval;
                 if all_wire && !self.xpub_nodrop {
                     self.arena.encode_and_signal(&forwarded, encoder.as_deref());
+                    let wire_size = forwarded.byte_len() + 10;
+                    interval = (ARENA_YIELD_BYTES / wire_size.max(1)).clamp(16, 256) as u32;
                 } else {
                     if self.xpub_nodrop {
                         while !targets_have_space(&targets) {
@@ -287,8 +301,8 @@ impl Submitter {
                         }
                     }
                     dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+                    interval = yield_interval(targets.len());
                 }
-                let interval = yield_interval(targets.len());
                 if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
                     tokio::task::yield_now().await;
                 }
@@ -593,16 +607,23 @@ fn dispatch_to_targets(
                 } else {
                     eq.encode_auto(msg);
                 }
-                if eq.has_arena_only() {
+                if eq.has_arena_only()
+                    && eq.uncommitted_arena().len() * targets.len() <= FAN_OUT_COPY_BUDGET
+                {
                     let raw = eq.uncommitted_arena();
                     for t in targets {
                         match t {
                             PeerSend::Wire { slot, .. } => {
-                                let _ = slot.try_push_pre_encoded(raw);
+                                let _ = slot.try_push_pre_encoded_no_signal(raw);
                             }
                             PeerSend::Inbox(tx) => {
                                 let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
                             }
+                        }
+                    }
+                    for t in targets {
+                        if let PeerSend::Wire { slot, .. } = t {
+                            slot.signal_encoded();
                         }
                     }
                     eq.clear_arena();

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -90,18 +90,29 @@ impl FanOutArena {
     }
 
     fn drain_to(&self, targets: &[PeerSend], chunks: &mut Vec<Bytes>) {
-        chunks.clear();
-        {
-            let mut eq = self.eq.lock().unwrap();
-            eq.drain_into_vec(chunks, 1024);
+        let mut eq = self.eq.lock().unwrap();
+        if eq.is_empty() {
             self.pending.store(false, Ordering::Relaxed);
-        }
-        if chunks.is_empty() {
             return;
         }
-        for t in targets {
-            if let PeerSend::Wire { slot, .. } = t {
-                let _ = slot.try_push_encoded(chunks);
+        if eq.has_arena_only() {
+            let frozen = eq.take_arena_bytes();
+            self.pending.store(false, Ordering::Relaxed);
+            drop(eq);
+            for t in targets {
+                if let PeerSend::Wire { slot, .. } = t {
+                    let _ = slot.try_push_pre_encoded(&frozen);
+                }
+            }
+        } else {
+            chunks.clear();
+            eq.drain_into_vec(chunks, 1024);
+            self.pending.store(false, Ordering::Relaxed);
+            drop(eq);
+            for t in targets {
+                if let PeerSend::Wire { slot, .. } = t {
+                    let _ = slot.try_push_encoded(chunks);
+                }
             }
         }
     }
@@ -582,22 +593,37 @@ fn dispatch_to_targets(
                 } else {
                     eq.encode_auto(msg);
                 }
-                CHUNKS.with(|drain| {
-                    let chunks = &mut *drain.borrow_mut();
-                    chunks.clear();
-                    eq.drain_into_vec(chunks, 1024);
+                if eq.has_arena_only() {
+                    let raw = eq.uncommitted_arena();
                     for t in targets {
                         match t {
                             PeerSend::Wire { slot, .. } => {
-                                let _ = slot.try_push_encoded(chunks);
+                                let _ = slot.try_push_pre_encoded(raw);
                             }
                             PeerSend::Inbox(tx) => {
                                 let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
                             }
                         }
                     }
-                    chunks.clear();
-                });
+                    eq.clear_arena();
+                } else {
+                    CHUNKS.with(|drain| {
+                        let chunks = &mut *drain.borrow_mut();
+                        chunks.clear();
+                        eq.drain_into_vec(chunks, 1024);
+                        for t in targets {
+                            match t {
+                                PeerSend::Wire { slot, .. } => {
+                                    let _ = slot.try_push_encoded(chunks);
+                                }
+                                PeerSend::Inbox(tx) => {
+                                    let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
+                                }
+                            }
+                        }
+                        chunks.clear();
+                    });
+                }
             });
         }
     }

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -7,6 +7,7 @@
 //! entry points the socket actor calls from its bind / dial paths.
 
 use std::io;
+use std::io::IoSlice;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -85,6 +86,30 @@ impl AsyncWrite for AnyStream {
             Self::Ipc(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "ws")]
             Self::Ws(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(unix)]
+            Self::Ipc(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(feature = "ws")]
+            Self::Ws(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            Self::Tcp(s) => s.is_write_vectored(),
+            #[cfg(unix)]
+            Self::Ipc(s) => s.is_write_vectored(),
+            #[cfg(feature = "ws")]
+            Self::Ws(s) => s.is_write_vectored(),
         }
     }
 
@@ -340,3 +365,46 @@ pub(super) fn peer_ident_socket_addr(ident: &PeerIdent) -> Option<std::net::Sock
 }
 
 pub(super) use omq_proto::message::generated_identity;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWrite;
+
+    #[test]
+    fn any_stream_tcp_reports_write_vectored() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let tcp = TcpStream::connect(addr).await.unwrap();
+            assert!(tcp.is_write_vectored());
+            let any = AnyStream::Tcp(tcp);
+            assert!(any.is_write_vectored());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn any_stream_ipc_reports_write_vectored() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let dir = std::env::temp_dir();
+            let path = dir.join(format!("omq-test-writev-{}.sock", std::process::id()));
+            let _ = std::fs::remove_file(&path);
+            let listener = tokio::net::UnixListener::bind(&path).unwrap();
+            let client = UnixStream::connect(&path).await.unwrap();
+            let _ = listener.accept().await.unwrap();
+            assert!(client.is_write_vectored());
+            let any = AnyStream::Ipc(client);
+            assert!(any.is_write_vectored());
+            let _ = std::fs::remove_file(&path);
+        });
+    }
+}

--- a/omq-tokio/src/transport/ipc.rs
+++ b/omq-tokio/src/transport/ipc.rs
@@ -42,13 +42,17 @@ impl Transport for IpcTransport {
     }
 
     async fn connect(endpoint: &Endpoint) -> Result<Self::Stream> {
-        match endpoint {
-            Endpoint::Ipc(IpcPath::Filesystem(p)) => Ok(UnixStream::connect(p).await?),
-            Endpoint::Ipc(IpcPath::Abstract(name)) => connect_abstract(name),
-            other => Err(Error::InvalidEndpoint(format!(
-                "ipc transport got non-ipc endpoint: {other}"
-            ))),
-        }
+        let stream = match endpoint {
+            Endpoint::Ipc(IpcPath::Filesystem(p)) => UnixStream::connect(p).await?,
+            Endpoint::Ipc(IpcPath::Abstract(name)) => connect_abstract(name)?,
+            other => {
+                return Err(Error::InvalidEndpoint(format!(
+                    "ipc transport got non-ipc endpoint: {other}"
+                )));
+            }
+        };
+        tune_unix_buffers(&stream);
+        Ok(stream)
     }
 }
 
@@ -111,6 +115,32 @@ fn connect_abstract(_name: &str) -> Result<UnixStream> {
     ))
 }
 
+const IPC_BUF_SIZE: u32 = 1024 * 1024;
+
+fn tune_unix_buffers(stream: &UnixStream) {
+    use std::os::fd::AsRawFd;
+    let fd = stream.as_raw_fd();
+    // SAFETY: fd is valid, SOL_SOCKET + SO_SNDBUF/SO_RCVBUF are
+    // standard. The kernel clamps to wmem_max / rmem_max silently.
+    let val = IPC_BUF_SIZE;
+    unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            (&raw const val).cast::<libc::c_void>(),
+            std::mem::size_of::<u32>() as libc::socklen_t,
+        );
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            (&raw const val).cast::<libc::c_void>(),
+            std::mem::size_of::<u32>() as libc::socklen_t,
+        );
+    }
+}
+
 /// Bound IPC listener. For filesystem-path binds, removes the socket
 /// file on drop; abstract-namespace binds carry no filesystem entry
 /// and need no cleanup.
@@ -133,8 +163,7 @@ impl Listener for IpcListener {
 
     async fn accept(&mut self) -> Result<(Self::Stream, PeerIdent)> {
         let (stream, _addr) = self.inner.accept().await?;
-        // Accepted peer addresses on Unix are usually anonymous; surface
-        // the bound address for monitor events instead.
+        tune_unix_buffers(&stream);
         Ok((stream, self.ident.clone()))
     }
 }

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -55,6 +55,26 @@ impl tokio::io::AsyncWrite for WsTransport {
         }
     }
 
+    fn poll_write_vectored(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Self::Plain(s) => std::pin::Pin::new(s).poll_write_vectored(cx, bufs),
+            Self::Tls(s) => std::pin::Pin::new(s).poll_write_vectored(cx, bufs),
+            Self::TlsServer(s) => std::pin::Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            Self::Plain(s) => s.is_write_vectored(),
+            Self::Tls(s) => s.is_write_vectored(),
+            Self::TlsServer(s) => s.is_write_vectored(),
+        }
+    }
+
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,


### PR DESCRIPTION
- `EncodedQueue`: add `take_arena_bytes()`, `uncommitted_arena()`, `push_pre_encoded()`, `clear_arena()` for arena-only encode-once-distribute-many fan-out
- `FanOutSend`: arena-only dispatch path with `FanOutArena` and `fan_out_pump` task bypasses per-peer encode; `dispatch_to_targets` uses thread-local EQ with `FAN_OUT_COPY_BUDGET` (128 KiB) threshold for memcpy vs `Bytes::clone`
- `PeerWireSlot`: add `try_push_pre_encoded_no_signal()` and make `signal_encoded()` `pub(crate)` for batched signal after fan-out push loop
- `FanOutSend::send()`: adaptive `ARENA_YIELD_BYTES` (2 MiB) capped at 256 msgs replaces flat `ARENA_YIELD_INTERVAL`; `yield_interval()` scales with `sqrt(peer_count)`
- `SocketDispatch`: `writev_iov_max()` delegates to per-transport values; IPC send/recv buffers raised to 2 MiB / 4 MiB
- Driver `select!`: swap `shared_msg_rx` above `wire_slot` so pre-handshake queued messages drain first, preserving ordering
- Driver heartbeat: add `hb_ping_sent` flag so unidirectional sockets (PUSH/PUB) don't false-timeout on the first tick before any PING is sent
- Regenerate all comparison charts (pushpull, pubsub, reqrep) with fresh omq-tokio + omq-tokio-mt benchmark data

PUB/SUB 64p TCP 8B: 37K → 494K msg/s (omq-tokio-mt), 407K msg/s (omq-tokio current_thread). PUSH/PULL TCP 8B: 4.6M msg/s. soak_large_throughput: 0 reorders across repeated runs.