### PR TITLE
release pyomq 0.12.4

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4] - 2026-06-22
+
+### Changed
+
+- *(deps)* Bump `omq-tokio` to 0.14.4, `lz4rip` to 0.8.
+
 ## [0.12.3] - 2026-06-17
 
 ### Changed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "blake3",
  "bytes",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "async-channel",
  "bytes",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"


### PR DESCRIPTION
- Bump omq-tokio to 0.14.4 (fan-out perf, bug fixes)
- Bump lz4rip to 0.8
- Update Cargo.lock