### PR TITLE
release pyomq 0.12.5

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -291,9 +291,12 @@ crate must be configured as a trusted publisher on crates.io.
 4. **Merge the release PR.** release-plz tags and publishes to
    crates.io automatically.
 
-5. **pyomq** (if changed): bump version in
-   `bindings/pyomq/Cargo.toml` and `bindings/pyomq/pyproject.toml`,
-   push a `pyomq-v*` tag to trigger the wheel build/publish workflow.
+5. **pyomq** (if changed): bump version in **both**
+   `bindings/pyomq/Cargo.toml` and `bindings/pyomq/pyproject.toml`
+   (maturin reads `pyproject.toml` for the wheel version), run
+   `cargo update -p pyomq` to update `Cargo.lock`, add a changelog
+   entry in `bindings/pyomq/CHANGELOG.md`, then push a `pyomq-v*`
+   tag to trigger the wheel build/publish workflow.
 
 ### Crates to check
 

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-06-22
+
+### Fixed
+
+- `pyproject.toml` version was not bumped in 0.12.4, causing wheels to publish as 0.12.3.
+
 ## [0.12.4] - 2026-06-22
 
 ### Changed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.12.3"
+version = "0.12.5"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/examples/zguide-tokio/01_req_rep/Cargo.toml
+++ b/examples/zguide-tokio/01_req_rep/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/02_pub_sub/Cargo.toml
+++ b/examples/zguide-tokio/02_pub_sub/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/03_pipeline/Cargo.toml
+++ b/examples/zguide-tokio/03_pipeline/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
+++ b/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/05_heartbeat/Cargo.toml
+++ b/examples/zguide-tokio/05_heartbeat/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/06_last_value_cache/Cargo.toml
+++ b/examples/zguide-tokio/06_last_value_cache/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/07_clone/Cargo.toml
+++ b/examples/zguide-tokio/07_clone/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/08_majordomo/Cargo.toml
+++ b/examples/zguide-tokio/08_majordomo/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/09_titanic/Cargo.toml
+++ b/examples/zguide-tokio/09_titanic/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/10_binary_star/Cargo.toml
+++ b/examples/zguide-tokio/10_binary_star/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 

--- a/examples/zguide-tokio/11_freelance/Cargo.toml
+++ b/examples/zguide-tokio/11_freelance/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.14.3", path = "../../../omq-tokio" }
+omq-tokio = { version = "0.14.4", path = "../../../omq-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 bytes = "1"
 


### PR DESCRIPTION
- Fix pyproject.toml version (was stuck at 0.12.3, caused 0.12.4 wheels to publish wrong version)
- Document full pyomq release checklist in DEVELOPMENT.md (both Cargo.toml + pyproject.toml, Cargo.lock, changelog)
- Bump zguide-tokio examples to omq-tokio 0.14.4