### PR TITLE
feat: compressed WebSocket transports (lz4+ws://, lz4+wss://)

### DIFF
--- a/omq-compio/src/socket/bind.rs
+++ b/omq-compio/src/socket/bind.rs
@@ -313,7 +313,8 @@ impl Socket {
     async fn bind_ws(&self, endpoint: Endpoint) -> Result<Endpoint> {
         use crate::transport::ws as ws_transport;
 
-        let tls_acc = if matches!(endpoint, Endpoint::Wss { .. }) {
+        let plain = endpoint.underlying_ws();
+        let tls_acc = if matches!(plain, Endpoint::Wss { .. }) {
             let cert = self
                 .inner()
                 .options
@@ -340,9 +341,9 @@ impl Socket {
         } else {
             None
         };
-        let ws_listener = ws_transport::bind(&endpoint, tls_acc).await?;
+        let ws_listener = ws_transport::bind(&plain, tls_acc).await?;
         let local = ws_listener.local_addr;
-        let resolved = match &endpoint {
+        let resolved_plain = match &plain {
             Endpoint::Ws { path, .. } => Endpoint::Ws {
                 host: omq_proto::endpoint::Host::Ip(local.ip()),
                 port: local.port(),
@@ -355,6 +356,7 @@ impl Socket {
             },
             _ => unreachable!("checked above"),
         };
+        let resolved = endpoint.rewrap_ws(resolved_plain);
         self.inner().monitor.listening(resolved.clone());
         let inner = self.inner().clone();
         let ep_for_task = resolved.clone();

--- a/omq-compio/src/socket/connect.rs
+++ b/omq-compio/src/socket/connect.rs
@@ -51,7 +51,8 @@ impl Socket {
         }
         #[cfg(feature = "ws")]
         if endpoint.is_ws_family() {
-            match &endpoint {
+            let plain = endpoint.underlying_ws();
+            match &plain {
                 Endpoint::Ws {
                     host: Host::Name(name),
                     port,
@@ -72,7 +73,7 @@ impl Socket {
             let accept_invalid_certs = self.inner().options.wss_tls.accept_invalid_certs;
             compio::runtime::spawn(async move {
                 let Ok(upgraded) =
-                    crate::transport::ws::connect(&ep, &mechanism, accept_invalid_certs).await
+                    crate::transport::ws::connect(&plain, &mechanism, accept_invalid_certs).await
                 else {
                     return;
                 };

--- a/omq-compio/src/socket/dial.rs
+++ b/omq-compio/src/socket/dial.rs
@@ -219,6 +219,8 @@ async fn dial_supervisor<F, Fut>(
             #[cfg(feature = "ws")]
             None,
         );
+        #[cfg(feature = "ws")]
+        let is_ws = endpoint.is_ws_family();
         let state = DirectIoState::new(
             peer_io,
             peer.writer,
@@ -229,9 +231,9 @@ async fn dial_supervisor<F, Fut>(
             uses_crypto,
             inner.options.large_message_threshold.unwrap_or(0),
             #[cfg(feature = "ws")]
-            false,
+            is_ws,
             #[cfg(feature = "ws")]
-            false,
+            is_ws, // dialed peers are always clients → masked
         );
         install_and_run(
             &inner,

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -118,6 +118,11 @@ pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Re
         return Ok(false);
     }
     for wire in &wires {
+        #[cfg(feature = "ws")]
+        if state.is_ws {
+            eq.encode_ws(wire, state.ws_masked);
+            continue;
+        }
         eq.encode_auto(wire);
     }
     drop(eq);

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -78,7 +78,12 @@ pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Re
         return Ok(true);
     }
 
-    if let Some((ref sentinel, threshold)) = state.transform_passthrough
+    #[cfg(feature = "ws")]
+    let skip_passthrough = state.is_ws;
+    #[cfg(not(feature = "ws"))]
+    let skip_passthrough = false;
+    if !skip_passthrough
+        && let Some((ref sentinel, threshold)) = state.transform_passthrough
         && state.handshake_done.get()
         && msg.iter().all(|b| b.len() < threshold)
     {

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -200,6 +200,11 @@ impl DriverLoopState {
             let mut eq = state.encoded_queue.borrow_mut();
             let cr = eq.total_bytes() >= cap;
             for wire in &wires {
+                #[cfg(feature = "ws")]
+                if state.is_ws {
+                    eq.encode_ws(wire, state.ws_masked);
+                    continue;
+                }
                 eq.encode_auto(wire);
             }
             Ok(cr)
@@ -239,6 +244,11 @@ impl DriverLoopState {
                         drop(enc);
                         let mut eq = state.encoded_queue.borrow_mut();
                         for wire in &wires {
+                            #[cfg(feature = "ws")]
+                            if state.is_ws {
+                                eq.encode_ws(wire, state.ws_masked);
+                                continue;
+                            }
                             eq.encode_auto(wire);
                         }
                     } else if state.uses_crypto {

--- a/omq-compio/tests/fuzz_parsers.rs
+++ b/omq-compio/tests/fuzz_parsers.rs
@@ -389,6 +389,173 @@ fn fuzz_lz4_decode() {
     }
 }
 
+/// Random strings fed to `Endpoint::from_str()` — must never panic.
+#[test]
+fn fuzz_endpoint_parse() {
+    use omq_compio::Endpoint;
+    use std::str::FromStr;
+    let mut rng = rng();
+    let schemes = [
+        "tcp", "ipc", "inproc", "udp", "ws", "wss", "lz4+tcp", "lz4+ws", "lz4+wss", "bogus", "",
+    ];
+    for i in 0..iters() / 2 {
+        let input = if rng.random_range(0..4) == 0 {
+            let scheme = schemes[rng.random_range(0..schemes.len())];
+            let tail_len = rng.random_range(0..128);
+            let tail: String = (0..tail_len)
+                .map(|_| rng.random_range(0x20..0x7f_u8) as char)
+                .collect();
+            format!("{scheme}://{tail}")
+        } else {
+            let len = rng.random_range(0..256);
+            (0..len)
+                .map(|_| rng.random_range(0x20..0x7f_u8) as char)
+                .collect()
+        };
+        let _ = Endpoint::from_str(&input);
+        if i % 100_000 == 0 {
+            eprintln!("endpoint_parse iter {i}");
+        }
+    }
+}
+
+/// Valid endpoints must survive display → parse roundtrip.
+#[test]
+fn fuzz_endpoint_roundtrip() {
+    use omq_compio::Endpoint;
+    use omq_compio::endpoint::Host;
+    use std::str::FromStr;
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let host = match rng.random_range(0..3) {
+            0 => Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+            ))),
+            1 => Host::Ip(std::net::IpAddr::V6(std::net::Ipv6Addr::new(
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+            ))),
+            _ => Host::Name("example.com".to_string()),
+        };
+        let port: u16 = rng.random_range(1..=65535);
+        let path = format!("/{}", rng.random_range(0..100));
+        let ep = match rng.random_range(0..10) {
+            0 => Endpoint::Tcp {
+                host: host.clone(),
+                port,
+            },
+            #[cfg(feature = "lz4")]
+            1 => Endpoint::Lz4Tcp {
+                host: host.clone(),
+                port,
+            },
+            #[cfg(feature = "ws")]
+            3 => Endpoint::Ws {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(feature = "ws")]
+            4 => Endpoint::Wss {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            5 => Endpoint::Lz4Ws {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            6 => Endpoint::Lz4Wss {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            _ => Endpoint::Tcp {
+                host: host.clone(),
+                port,
+            },
+        };
+        let s = ep.to_string();
+        let parsed = Endpoint::from_str(&s).unwrap_or_else(|e| {
+            panic!("failed to parse roundtrip of {ep:?} → {s:?}: {e}");
+        });
+        assert_eq!(ep, parsed, "roundtrip mismatch for {s:?}");
+        if i % 50_000 == 0 {
+            eprintln!("endpoint_roundtrip iter {i}");
+        }
+    }
+}
+
+/// Compression transform encode→decode roundtrip with random messages.
+#[cfg(all(feature = "lz4", feature = "ws"))]
+#[test]
+fn fuzz_compress_ws_roundtrip() {
+    use omq_compio::Endpoint;
+    use omq_compio::endpoint::Host;
+    use omq_compio::options::Options;
+    use omq_compio::proto::transform::MessageEncoder;
+    let mut rng = rng();
+    let localhost = Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+    let endpoints: Vec<Endpoint> = vec![
+        Endpoint::Lz4Ws {
+            host: localhost.clone(),
+            port: 1,
+            path: "/".into(),
+        },
+        Endpoint::Lz4Wss {
+            host: localhost.clone(),
+            port: 1,
+            path: "/".into(),
+        },
+    ];
+    let opts = Options::default();
+    for i in 0..iters() / 4 {
+        let ep = &endpoints[rng.random_range(0..endpoints.len())];
+        let (mut enc, mut dec) =
+            MessageEncoder::for_endpoint(ep, &opts).expect("transform for compressed-ws");
+        let n_parts = rng.random_range(1..=4);
+        let mut parts: Vec<Bytes> = Vec::new();
+        for _ in 0..n_parts {
+            let len = rng.random_range(0..2048);
+            let part: Vec<u8> = (0..len).map(|_| rng.random()).collect();
+            parts.push(Bytes::from(part));
+        }
+        let msg = Message::multipart(parts.clone());
+        let wires = enc.encode(&msg).expect("encode failed");
+        let mut decoded_parts: Vec<Bytes> = Vec::new();
+        for wire in wires {
+            if let Some(decoded) = dec.decode(wire).expect("decode failed") {
+                for j in 0..decoded.len() {
+                    decoded_parts.push(decoded.part_bytes(j).unwrap().clone());
+                }
+            }
+        }
+        assert_eq!(
+            parts.len(),
+            decoded_parts.len(),
+            "part count mismatch at iter {i}"
+        );
+        for (j, (orig, got)) in parts.iter().zip(&decoded_parts).enumerate() {
+            assert_eq!(orig, got, "part {j} mismatch at iter {i}");
+        }
+        if i % 50_000 == 0 {
+            eprintln!("compress_ws_roundtrip iter {i}");
+        }
+    }
+}
+
 // ================================================================
 // Tier 2: RFC compliance + adversarial structured inputs
 // ================================================================

--- a/omq-compio/tests/lz4_ws.rs
+++ b/omq-compio/tests/lz4_ws.rs
@@ -6,41 +6,69 @@ use bytes::Bytes;
 use omq_compio::endpoint::Host;
 use omq_compio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
 
-async fn pull_on_loopback() -> (Socket, Endpoint) {
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    let mut mon = pull.monitor();
-    pull.bind(Endpoint::Lz4Ws {
-        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-        port: 0,
+fn lz4_ws_loopback(port: u16) -> Endpoint {
+    Endpoint::Lz4Ws {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
         path: "/".to_string(),
+    }
+}
+
+async fn bind_lz4_ws(sock: &Socket) -> (u16, omq_compio::MonitorStream) {
+    let mut mon = sock.monitor();
+    sock.bind(lz4_ws_loopback(0)).await.unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Ws { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Ws Listening, got {other:?}"),
+        }
+    };
+    (port, mon)
+}
+
+async fn wait_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    compio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
     })
     .await
-    .unwrap();
-    let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let port = match ev {
-        MonitorEvent::Listening {
-            endpoint: Endpoint::Lz4Ws { port, .. },
-        } => port,
-        other => panic!("expected Lz4Ws Listening, got {other:?}"),
-    };
-    (
-        pull,
-        Endpoint::Lz4Ws {
-            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-            port,
-            path: "/".to_string(),
-        },
-    )
+    .expect("handshake did not complete within 5s");
 }
+
+async fn wait_for_subscribes(mon: &mut omq_compio::MonitorStream, n: usize) {
+    let fut = async {
+        let mut count = 0;
+        while count < n {
+            match mon.recv().await {
+                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed after {count}/{n} subscribes: {e:?}"),
+            }
+        }
+    };
+    compio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate within 5s");
+}
+
+// ---- PUSH / PULL ----
 
 #[compio::test]
 async fn lz4_ws_small_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     push.send(Message::single("hello over lz4+ws"))
         .await
@@ -54,9 +82,11 @@ async fn lz4_ws_small_message_roundtrip() {
 
 #[compio::test]
 async fn lz4_ws_large_compressible_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     let payload = Bytes::from(vec![b'A'; 16 * 1024]);
     push.send(Message::single(payload.clone())).await.unwrap();
@@ -69,9 +99,11 @@ async fn lz4_ws_large_compressible_message_roundtrip() {
 
 #[compio::test]
 async fn lz4_ws_multipart_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     push.send(Message::multipart(["a", "bb", "ccc"]))
         .await
@@ -84,4 +116,439 @@ async fn lz4_ws_multipart_message_roundtrip() {
     assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
     assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
     assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+}
+
+#[compio::test]
+async fn lz4_ws_empty_message_roundtrip() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    push.send(Message::single(Bytes::new())).await.unwrap();
+    let m = compio::time::timeout(Duration::from_secs(1), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(m.part_bytes(0).unwrap().is_empty());
+}
+
+#[compio::test]
+async fn lz4_ws_incompressible_data_roundtrip() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    let mut random = vec![0u8; 8192];
+    rand::Rng::fill_bytes(&mut rand::rng(), &mut random);
+    push.send(Message::single(random.clone())).await.unwrap();
+
+    let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().to_vec(), random);
+}
+
+#[compio::test]
+async fn lz4_ws_many_messages_in_a_row() {
+    const N: usize = 200;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+    wait_handshake(&pull).await;
+
+    for i in 0..N {
+        push.send(Message::single(format!("m-{i}"))).await.unwrap();
+    }
+    for i in 0..N {
+        let m = compio::time::timeout(Duration::from_secs(5), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), format!("m-{i}").as_bytes());
+    }
+}
+
+// ---- REQ / REP ----
+
+#[compio::test]
+async fn lz4_ws_req_rep() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let (port, _mon) = bind_lz4_ws(&rep).await;
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    req.send(Message::single("question")).await.unwrap();
+    let q = compio::time::timeout(Duration::from_secs(2), rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(q.part_bytes(0).unwrap(), &b"question"[..]);
+
+    rep.send(Message::single("answer")).await.unwrap();
+    let a = compio::time::timeout(Duration::from_secs(2), req.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(a.part_bytes(0).unwrap(), &b"answer"[..]);
+}
+
+// ---- ROUTER / DEALER ----
+
+#[compio::test]
+async fn lz4_ws_router_dealer_identity_routing() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let (port, _mon) = bind_lz4_ws(&router).await;
+
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"alice")),
+    );
+    dealer.connect(lz4_ws_loopback(port)).await.unwrap();
+    wait_handshake(&router).await;
+
+    dealer.send(Message::single("hello")).await.unwrap();
+
+    let got = compio::time::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got.part_bytes(0).unwrap(), &b"alice"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+
+    router
+        .send(Message::multipart(["alice", "reply"]))
+        .await
+        .unwrap();
+    let r = compio::time::timeout(Duration::from_secs(2), dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap(), &b"reply"[..]);
+}
+
+// ---- PUB / SUB ----
+
+#[compio::test]
+async fn lz4_ws_pub_sub_prefix_filter() {
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+
+    let subscriber = Socket::new(SocketType::Sub, Options::default());
+    subscriber.connect(lz4_ws_loopback(port)).await.unwrap();
+    subscriber.subscribe("news.").await.unwrap();
+
+    wait_for_subscribes(&mut mon, 1).await;
+
+    publisher
+        .send(Message::multipart(["news.sports", "ball scores"]))
+        .await
+        .unwrap();
+    publisher
+        .send(Message::multipart(["weather", "sunny"]))
+        .await
+        .unwrap();
+    publisher
+        .send(Message::multipart(["news.tech", "rust 2.0"]))
+        .await
+        .unwrap();
+
+    let m1 = compio::time::timeout(Duration::from_secs(2), subscriber.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m1.part_bytes(0).unwrap(), &b"news.sports"[..]);
+    assert_eq!(m1.part_bytes(1).unwrap(), &b"ball scores"[..]);
+
+    let m2 = compio::time::timeout(Duration::from_secs(2), subscriber.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m2.part_bytes(0).unwrap(), &b"news.tech"[..]);
+    assert_eq!(m2.part_bytes(1).unwrap(), &b"rust 2.0"[..]);
+
+    let nothing = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
+    assert!(
+        nothing.is_err(),
+        "non-matching message must not be delivered"
+    );
+}
+
+#[compio::test]
+async fn lz4_ws_pub_sub_fan_out() {
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 50;
+
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, Options::default());
+        s.connect(lz4_ws_loopback(port)).await.unwrap();
+        s.subscribe(Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+    wait_for_subscribes(&mut mon, N_SUBS).await;
+
+    for i in 0..N_MSGS {
+        let body = format!("msg-{i:04}");
+        publisher
+            .send(Message::single(Bytes::from(body)))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = compio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!("msg-{i:04}");
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
+}
+
+// ---- Dict roundtrip ----
+
+#[compio::test]
+async fn lz4_ws_dict_roundtrip() {
+    let dict = Bytes::from_static(b"omq-omq-omq-omq-omq-omq-omq-omq-shared-prefix");
+    let opts = || Options::default().compression_dict(dict.clone());
+
+    let pull = Socket::new(SocketType::Pull, opts());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, opts());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    let plain = b"omq-".repeat(20); // 80 bytes, dict-friendly
+    for _ in 0..3 {
+        push.send(Message::single(plain.clone())).await.unwrap();
+        let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap().to_vec(), plain);
+    }
+}
+
+// ---- Auto-train dict over lz4+ws ----
+
+#[compio::test]
+async fn lz4_ws_auto_train_dict() {
+    use omq_proto::proto::transform::lz4::DictTrainer;
+
+    let mut trainer = DictTrainer::new(2048);
+    for i in 0..100 {
+        let s = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        trainer.add_sample(s.as_bytes());
+    }
+    let dict = Bytes::from(trainer.train());
+    let opts = Options::default().compression_dict(dict);
+
+    let pull = Socket::new(SocketType::Pull, opts.clone());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, opts);
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    for i in 0..20 {
+        let body = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        push.send(Message::single(Bytes::from(body.clone())))
+            .await
+            .unwrap();
+        let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), body.as_bytes());
+    }
+}
+
+// ---- Reconnect over lz4+ws ----
+
+#[compio::test]
+async fn lz4_ws_reconnect_after_server_restart() {
+    let pull1 = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull1).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+    compio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::single("before")).await.unwrap();
+    let msg = compio::time::timeout(Duration::from_secs(5), pull1.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"before"[..]);
+
+    drop(push);
+    pull1.close().await.unwrap();
+
+    let pull2 = Socket::new(SocketType::Pull, Options::default());
+    let mut rebound = false;
+    for _ in 0..40 {
+        if pull2.bind(lz4_ws_loopback(port)).await.is_ok() {
+            rebound = true;
+            break;
+        }
+        compio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(rebound, "pull2 failed to bind on same port");
+
+    let push2 = Socket::new(SocketType::Push, Options::default());
+    push2.connect(lz4_ws_loopback(port)).await.unwrap();
+    compio::time::sleep(Duration::from_millis(300)).await;
+
+    push2.send(Message::single("after")).await.unwrap();
+    let msg = compio::time::timeout(Duration::from_secs(5), pull2.recv())
+        .await
+        .expect("recv after restart timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"after"[..]);
+}
+
+// ---- lz4+wss (TLS) ----
+
+#[compio::test]
+async fn lz4_wss_push_pull() {
+    use omq_proto::options::WssTls;
+
+    let certified = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    let cert_pem = certified.cert.pem().into_bytes();
+    let key_pem = certified.signing_key.serialize_pem().into_bytes();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Wss { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Wss Listening, got {other:?}"),
+        }
+    };
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    compio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::single("hello over lz4+wss"))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+wss"[..]);
+}
+
+#[compio::test]
+async fn lz4_wss_large_compressible() {
+    use omq_proto::options::WssTls;
+
+    let certified = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    let cert_pem = certified.cert.pem().into_bytes();
+    let key_pem = certified.signing_key.serialize_pem().into_bytes();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Wss { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Wss Listening, got {other:?}"),
+        }
+    };
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    compio::time::sleep(Duration::from_millis(300)).await;
+
+    let payload = Bytes::from(vec![b'Z'; 16 * 1024]);
+    push.send(Message::single(payload.clone())).await.unwrap();
+    let m = compio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&m.part_bytes(0).unwrap()[..], &payload[..]);
 }

--- a/omq-compio/tests/lz4_ws.rs
+++ b/omq-compio/tests/lz4_ws.rs
@@ -1,0 +1,87 @@
+#![cfg(all(feature = "lz4", feature = "ws"))]
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_compio::endpoint::Host;
+use omq_compio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+async fn pull_on_loopback() -> (Socket, Endpoint) {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Ws {
+        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let ev = compio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let port = match ev {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::Lz4Ws { port, .. },
+        } => port,
+        other => panic!("expected Lz4Ws Listening, got {other:?}"),
+    };
+    (
+        pull,
+        Endpoint::Lz4Ws {
+            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+            port,
+            path: "/".to_string(),
+        },
+    )
+}
+
+#[compio::test]
+async fn lz4_ws_small_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::single("hello over lz4+ws"))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+ws"[..]);
+}
+
+#[compio::test]
+async fn lz4_ws_large_compressible_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    let payload = Bytes::from(vec![b'A'; 16 * 1024]);
+    push.send(Message::single(payload.clone())).await.unwrap();
+    let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&m.part_bytes(0).unwrap()[..], &payload[..]);
+}
+
+#[compio::test]
+async fn lz4_ws_multipart_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::multipart(["a", "bb", "ccc"]))
+        .await
+        .unwrap();
+    let m = compio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.len(), 3);
+    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
+    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+}

--- a/omq-compio/tests/ws_pub_sub.rs
+++ b/omq-compio/tests/ws_pub_sub.rs
@@ -79,3 +79,59 @@ async fn ws_pub_sub_unsubscribe() {
         "message should not arrive after unsubscribe"
     );
 }
+
+#[compio::test]
+async fn ws_pub_sub_fan_out() {
+    use bytes::Bytes;
+
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 50;
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let bound = pub_.bind(ws_endpoint(0)).await.unwrap();
+    let port = get_port(&bound);
+
+    let mut mon = pub_.monitor();
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, Options::default());
+        s.connect(ws_endpoint(port)).await.unwrap();
+        s.subscribe(Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+
+    let fut = async {
+        let mut count = 0;
+        while count < N_SUBS {
+            match mon.recv().await {
+                Ok(omq_compio::MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed after {count}/{N_SUBS} subscribes: {e:?}"),
+            }
+        }
+    };
+    compio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate");
+
+    for i in 0..N_MSGS {
+        pub_.send(Message::single(format!("msg-{i:04}")))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = compio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!("msg-{i:04}");
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
+}

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -441,7 +441,7 @@ fn parse_ws(rest: &str, tls: bool) -> Result<Endpoint> {
     }
 }
 
-#[cfg(feature = "ws")]
+#[cfg(all(feature = "lz4", feature = "ws"))]
 fn parse_compressed_ws(
     rest: &str,
     tls: bool,

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -46,6 +46,14 @@ pub enum Endpoint {
     /// `ws` feature.
     #[cfg(feature = "ws")]
     Wss { host: Host, port: u16, path: String },
+    /// `lz4+ws://host:port/path` LZ4-compressed WebSocket. Requires the
+    /// `lz4` and `ws` features.
+    #[cfg(all(feature = "lz4", feature = "ws"))]
+    Lz4Ws { host: Host, port: u16, path: String },
+    /// `lz4+wss://host:port/path` LZ4-compressed WebSocket with TLS.
+    /// Requires the `lz4` and `ws` features.
+    #[cfg(all(feature = "lz4", feature = "ws"))]
+    Lz4Wss { host: Host, port: u16, path: String },
 }
 
 /// TCP / UDP host specification: either an IP address or a DNS name.
@@ -121,6 +129,18 @@ impl FromStr for Endpoint {
             "ws" => parse_ws(rest, false),
             #[cfg(feature = "ws")]
             "wss" => parse_ws(rest, true),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            "lz4+ws" => parse_compressed_ws(rest, false, |h, p, pa| Endpoint::Lz4Ws {
+                host: h,
+                port: p,
+                path: pa,
+            }),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            "lz4+wss" => parse_compressed_ws(rest, true, |h, p, pa| Endpoint::Lz4Wss {
+                host: h,
+                port: p,
+                path: pa,
+            }),
             _ => Err(Error::UnsupportedScheme(scheme.to_string())),
         }
     }
@@ -143,6 +163,10 @@ impl fmt::Display for Endpoint {
             Self::Ws { host, port, path } => write!(f, "ws://{host}:{port}{path}"),
             #[cfg(feature = "ws")]
             Self::Wss { host, port, path } => write!(f, "wss://{host}:{port}{path}"),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Self::Lz4Ws { host, port, path } => write!(f, "lz4+ws://{host}:{port}{path}"),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Self::Lz4Wss { host, port, path } => write!(f, "lz4+wss://{host}:{port}{path}"),
         }
     }
 }
@@ -189,10 +213,58 @@ impl Endpoint {
         }
     }
 
+    /// Strip the compression scheme prefix so the underlying WS
+    /// transport sees a plain `ws://` or `wss://` endpoint. Identity
+    /// for plain `ws://` / `wss://` and all non-WS endpoints.
+    #[cfg(feature = "ws")]
+    #[must_use]
+    pub fn underlying_ws(&self) -> Endpoint {
+        match self {
+            #[cfg(feature = "lz4")]
+            Endpoint::Lz4Ws { host, port, path } => Endpoint::Ws {
+                host: host.clone(),
+                port: *port,
+                path: path.clone(),
+            },
+            #[cfg(feature = "lz4")]
+            Endpoint::Lz4Wss { host, port, path } => Endpoint::Wss {
+                host: host.clone(),
+                port: *port,
+                path: path.clone(),
+            },
+            other => other.clone(),
+        }
+    }
+
+    /// Re-attach the original endpoint's compression scheme to a
+    /// resolved WS address. Used after binding so the bound endpoint
+    /// surfaced to the user still says `lz4+ws://…` etc.
+    #[cfg(feature = "ws")]
+    #[must_use]
+    pub fn rewrap_ws(&self, resolved: Endpoint) -> Endpoint {
+        match (self, resolved) {
+            #[cfg(feature = "lz4")]
+            (Endpoint::Lz4Ws { .. }, Endpoint::Ws { host, port, path }) => {
+                Endpoint::Lz4Ws { host, port, path }
+            }
+            #[cfg(feature = "lz4")]
+            (Endpoint::Lz4Wss { .. }, Endpoint::Wss { host, port, path }) => {
+                Endpoint::Lz4Wss { host, port, path }
+            }
+            (_, resolved) => resolved,
+        }
+    }
+
     /// Whether this endpoint uses the WebSocket transport.
+    /// Includes the compression-wrapped variants.
     #[cfg(feature = "ws")]
     pub fn is_ws_family(&self) -> bool {
-        matches!(self, Endpoint::Ws { .. } | Endpoint::Wss { .. })
+        match self {
+            Endpoint::Ws { .. } | Endpoint::Wss { .. } => true,
+            #[cfg(feature = "lz4")]
+            Endpoint::Lz4Ws { .. } | Endpoint::Lz4Wss { .. } => true,
+            _ => false,
+        }
     }
 
     /// Short scheme tag suitable for monitor / log output.
@@ -209,6 +281,10 @@ impl Endpoint {
             Endpoint::Ws { .. } => "ws",
             #[cfg(feature = "ws")]
             Endpoint::Wss { .. } => "wss",
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Endpoint::Lz4Ws { .. } => "lz4+ws",
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Endpoint::Lz4Wss { .. } => "lz4+wss",
         }
     }
 }
@@ -362,6 +438,20 @@ fn parse_ws(rest: &str, tls: bool) -> Result<Endpoint> {
         Ok(Endpoint::Wss { host, port, path })
     } else {
         Ok(Endpoint::Ws { host, port, path })
+    }
+}
+
+#[cfg(feature = "ws")]
+fn parse_compressed_ws(
+    rest: &str,
+    tls: bool,
+    wrap: impl FnOnce(Host, u16, String) -> Endpoint,
+) -> Result<Endpoint> {
+    match parse_ws(rest, tls)? {
+        Endpoint::Ws { host, port, path } | Endpoint::Wss { host, port, path } => {
+            Ok(wrap(host, port, path))
+        }
+        _ => unreachable!(),
     }
 }
 

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -82,33 +82,38 @@ impl MessageEncoder {
     pub fn for_endpoint(endpoint: &Endpoint, options: &Options) -> Option<(Self, MessageDecoder)> {
         match endpoint {
             #[cfg(feature = "lz4")]
-            Endpoint::Lz4Tcp { .. } => {
-                use lz4::{Lz4Decoder, Lz4Encoder};
-                let mut enc = if let Some(d) = options.compression_dict.clone() {
-                    Lz4Encoder::with_send_dict(d)
-                        .expect("compression_dict validated at Options::compression_dict")
-                } else {
-                    let mut e = Lz4Encoder::new();
-                    if options.compression_auto_train {
-                        e = e.with_auto_train();
-                    }
-                    if let Some(c) = options.compression_dict_capacity {
-                        e = e.with_dict_capacity(c);
-                    }
-                    e
-                }
-                .with_max_message_size(options.max_message_size);
-                if let Some(t) = options.compression_threshold {
-                    enc = enc.with_threshold(t);
-                }
-                let mut dec = Lz4Decoder::new().with_max_message_size(options.max_message_size);
-                if let Some(m) = options.max_recv_dict_size {
-                    dec = dec.with_max_recv_dict_size(m);
-                }
-                Some((MessageEncoder::Lz4(Box::new(enc)), MessageDecoder::Lz4(dec)))
-            }
+            Endpoint::Lz4Tcp { .. } => Some(Self::build_lz4(options)),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Endpoint::Lz4Ws { .. } | Endpoint::Lz4Wss { .. } => Some(Self::build_lz4(options)),
             _ => None,
         }
+    }
+
+    #[cfg(feature = "lz4")]
+    fn build_lz4(options: &Options) -> (Self, MessageDecoder) {
+        use lz4::{Lz4Decoder, Lz4Encoder};
+        let mut enc = if let Some(d) = options.compression_dict.clone() {
+            Lz4Encoder::with_send_dict(d)
+                .expect("compression_dict validated at Options::compression_dict")
+        } else {
+            let mut e = Lz4Encoder::new();
+            if options.compression_auto_train {
+                e = e.with_auto_train();
+            }
+            if let Some(c) = options.compression_dict_capacity {
+                e = e.with_dict_capacity(c);
+            }
+            e
+        }
+        .with_max_message_size(options.max_message_size);
+        if let Some(t) = options.compression_threshold {
+            enc = enc.with_threshold(t);
+        }
+        let mut dec = Lz4Decoder::new().with_max_message_size(options.max_message_size);
+        if let Some(m) = options.max_recv_dict_size {
+            dec = dec.with_max_recv_dict_size(m);
+        }
+        (MessageEncoder::Lz4(Box::new(enc)), MessageDecoder::Lz4(dec))
     }
 
     /// Transform an outbound user message into 1+ wire messages.

--- a/omq-proto/src/proto/ws_handshake.rs
+++ b/omq-proto/src/proto/ws_handshake.rs
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn validate_accept_works() {
         let key = "dGhlIHNhbXBsZSBub25jZQ==";
-        assert!(validate_ws_accept(key, "SMKhevRK+OBO0OqLVjVnnQFNHvc="));
+        assert!(validate_ws_accept(key, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="));
         assert!(!validate_ws_accept(key, "wrong"));
     }
 

--- a/omq-proto/src/proto/ws_handshake.rs
+++ b/omq-proto/src/proto/ws_handshake.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{Error, Result};
 
-const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-5AB5B7C62A11";
+const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 /// Generate a random 16-byte `Sec-WebSocket-Key`, base64-encoded (24 chars).
 pub fn generate_ws_key() -> String {
@@ -329,7 +329,7 @@ mod tests {
         let key = "dGhlIHNhbXBsZSBub25jZQ==";
         let accept = compute_ws_accept(key);
         // Verified against Python: hashlib.sha1(key + GUID).digest() -> base64
-        assert_eq!(accept, "SMKhevRK+OBO0OqLVjVnnQFNHvc=");
+        assert_eq!(accept, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
     }
 
     #[test]

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1005,7 +1005,13 @@ fn encode_msg(
             codec.ws_role(),
             Some(omq_proto::proto::connection::WsRole::Client)
         );
-        eq.encode_ws(msg, masked);
+        if let Some(enc) = encoder.as_mut() {
+            for wire in enc.encode(msg)? {
+                eq.encode_ws(&wire, masked);
+            }
+        } else {
+            eq.encode_ws(msg, masked);
+        }
         return Ok(());
     }
     if codec.has_frame_transform() {

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -226,7 +226,7 @@ async fn batch_encode(
         }
     }
     if use_pipeline {
-        drain_pipeline(pipeline, pool, eq).await?;
+        drain_pipeline(pipeline, pool, codec, eq).await?;
     }
     Ok(count)
 }
@@ -621,7 +621,7 @@ where
                     use futures::StreamExt;
                     offload_pipeline.next().await
                 }, if !offload_pipeline.is_empty() => {
-                    drain_offload_result(pool_enc, frames, compression_pool.as_ref(), &mut eq)?;
+                    drain_offload_result(pool_enc, frames, compression_pool.as_ref(), &codec, &mut eq)?;
                     flush_all(&mut writer, &mut eq, &mut drain_buf, &mut codec).await?;
                 }
 
@@ -958,25 +958,40 @@ fn submit_to_pipeline(
 async fn drain_pipeline(
     pipeline: &mut OffloadPipeline,
     pool: Option<&Arc<CompressionPool>>,
+    codec: &Connection,
     eq: &mut EncodedQueue,
 ) -> Result<()> {
     use futures::StreamExt;
     while let Some((pool_enc, frames)) = pipeline.next().await {
-        drain_offload_result(pool_enc, frames, pool, eq)?;
+        drain_offload_result(pool_enc, frames, pool, codec, eq)?;
     }
     Ok(())
 }
 
+#[allow(unused_variables)]
 fn drain_offload_result(
     pool_enc: Option<MessageEncoder>,
     frames: Result<TransformedOut>,
     pool: Option<&Arc<CompressionPool>>,
+    codec: &Connection,
     eq: &mut EncodedQueue,
 ) -> Result<()> {
     if let (Some(enc), Some(pool)) = (pool_enc, pool) {
         pool.put(enc);
     }
+    #[cfg(feature = "ws")]
+    let ws = codec.is_ws().then(|| {
+        matches!(
+            codec.ws_role(),
+            Some(omq_proto::proto::connection::WsRole::Client)
+        )
+    });
     for wire in frames? {
+        #[cfg(feature = "ws")]
+        if let Some(masked) = ws {
+            eq.encode_ws(&wire, masked);
+            continue;
+        }
         eq.encode_auto(&wire);
     }
     Ok(())

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -87,6 +87,11 @@ impl PeerWireSlot {
         })
     }
 
+    #[cfg(feature = "ws")]
+    pub(crate) fn is_ws(&self) -> bool {
+        self.is_ws
+    }
+
     pub(crate) fn try_encode(&self, msg: &Message) -> TryEncodeResult {
         if self.dead.load(Ordering::Acquire) {
             return TryEncodeResult::Dead;

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -37,6 +37,10 @@ pub(crate) struct PeerWireSlot {
     pub(crate) has_transform: bool,
     #[allow(dead_code)]
     pub(crate) transform_passthrough: Option<(Bytes, usize)>,
+    #[cfg(feature = "ws")]
+    is_ws: bool,
+    #[cfg(feature = "ws")]
+    ws_masked: bool,
     pub(crate) dead: AtomicBool,
     pub(crate) peer_id: u64,
 }
@@ -62,6 +66,8 @@ impl PeerWireSlot {
         transform_passthrough: Option<(Bytes, usize)>,
         arena_threshold: usize,
         cap: usize,
+        #[cfg(feature = "ws")] is_ws: bool,
+        #[cfg(feature = "ws")] ws_masked: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
             eq: Mutex::new(EncodedQueue::with_arena_threshold(arena_threshold)),
@@ -72,6 +78,10 @@ impl PeerWireSlot {
             pending: AtomicBool::new(false),
             has_transform,
             transform_passthrough,
+            #[cfg(feature = "ws")]
+            is_ws,
+            #[cfg(feature = "ws")]
+            ws_masked,
             dead: AtomicBool::new(false),
             peer_id,
         })
@@ -83,6 +93,21 @@ impl PeerWireSlot {
         }
         if !self.handshake_done.load(Ordering::Acquire) {
             return TryEncodeResult::Ineligible;
+        }
+
+        #[cfg(feature = "ws")]
+        if self.is_ws {
+            if self.has_transform {
+                return TryEncodeResult::Ineligible;
+            }
+            let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
+            if eq.total_bytes() >= self.cap {
+                return TryEncodeResult::Full;
+            }
+            eq.encode_ws(msg, self.ws_masked);
+            drop(eq);
+            self.signal_encoded();
+            return TryEncodeResult::Ok;
         }
 
         if !self.has_transform {

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -214,6 +214,10 @@ impl Submitter {
                 cached.sole_wire = None;
                 let targets: Vec<PeerSend> = g.all_targets.to_vec();
                 cached.all_wire = targets.iter().all(|t| matches!(t, PeerSend::Wire { .. }));
+                #[cfg(feature = "ws")]
+                if cached.all_wire && targets.iter().any(PeerSend::is_ws) {
+                    cached.all_wire = false;
+                }
                 cached.all_targets = Some(Arc::new(targets));
                 cached.encoder.clone_from(&g.fan_out_encoder);
             } else {
@@ -578,13 +582,22 @@ fn dispatch_to_targets(
     msg: &Message,
     encoder: Option<&Mutex<MessageEncoder>>,
 ) {
+    use std::cell::RefCell;
+
     match targets.len() {
         0 => {}
         1 => {
             let _ = targets[0].try_encode(msg);
         }
         _ => {
-            use std::cell::RefCell;
+            #[cfg(feature = "ws")]
+            if targets.iter().any(PeerSend::is_ws) {
+                for t in targets {
+                    let _ = t.try_encode(msg);
+                }
+                return;
+            }
+
             thread_local! {
                 static ARENA: RefCell<EncodedQueue> = RefCell::new(
                     EncodedQueue::one_shot(),

--- a/omq-tokio/src/routing/peer_send.rs
+++ b/omq-tokio/src/routing/peer_send.rs
@@ -86,6 +86,14 @@ impl PeerSend {
         }
     }
 
+    #[cfg(feature = "ws")]
+    pub(crate) fn is_ws(&self) -> bool {
+        match self {
+            Self::Wire { slot, .. } => slot.is_ws(),
+            Self::Inbox(_) => false,
+        }
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         match self {
             Self::Wire { slot, .. } => slot.is_empty(),

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -271,7 +271,8 @@ impl SocketDriver {
                 AnyListener::Ws(l) => l.local_addr,
                 _ => unreachable!(),
             };
-            match &endpoint {
+            let plain = endpoint.underlying_ws();
+            let resolved_plain = match &plain {
                 Endpoint::Ws { path, .. } => Endpoint::Ws {
                     host: omq_proto::endpoint::Host::Ip(local.ip()),
                     port: local.port(),
@@ -283,7 +284,8 @@ impl SocketDriver {
                     path: path.clone(),
                 },
                 _ => unreachable!(),
-            }
+            };
+            endpoint.rewrap_ws(resolved_plain)
         } else {
             endpoint.rewrap_tcp(listener.local_endpoint().clone())
         };

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -258,7 +258,11 @@ impl SocketDriver {
             cfg = cfg.max_message_size(n);
         }
         #[cfg(feature = "ws")]
-        if matches!(&stream, AnyStream::Ws(_)) {
+        let is_ws = matches!(&stream, AnyStream::Ws(_));
+        #[cfg(feature = "ws")]
+        let ws_masked = is_ws && !is_server;
+        #[cfg(feature = "ws")]
+        if is_ws {
             let ws_role = if is_server {
                 omq_proto::proto::connection::WsRole::Server
             } else {
@@ -338,6 +342,10 @@ impl SocketDriver {
                 passthrough_info,
                 arena_threshold,
                 wire_slot_cap,
+                #[cfg(feature = "ws")]
+                is_ws,
+                #[cfg(feature = "ws")]
+                ws_masked,
             );
             Some(s)
         };

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -251,11 +251,12 @@ pub(super) async fn bind_any(
     }
     #[cfg(feature = "ws")]
     if endpoint.is_ws_family() {
-        let (host, port) = match endpoint {
+        let plain = endpoint.underlying_ws();
+        let (host, port) = match &plain {
             Endpoint::Ws { host, port, .. } | Endpoint::Wss { host, port, .. } => (host, *port),
             _ => unreachable!(),
         };
-        let tls_acc = if matches!(endpoint, Endpoint::Wss { .. }) {
+        let tls_acc = if matches!(plain, Endpoint::Wss { .. }) {
             let cert = wss_tls.server_cert_pem.as_deref().ok_or_else(|| {
                 Error::Protocol("wss:// bind requires server_cert_pem in WssTls options".into())
             })?;
@@ -301,7 +302,8 @@ pub(super) async fn connect_any(
     }
     #[cfg(feature = "ws")]
     if endpoint.is_ws_family() {
-        let (host, port, path) = match endpoint {
+        let plain = endpoint.underlying_ws();
+        let (host, port, path) = match &plain {
             Endpoint::Ws {
                 host, port, path, ..
             }
@@ -314,7 +316,7 @@ pub(super) async fn connect_any(
             host,
             port,
             path,
-            matches!(endpoint, Endpoint::Wss { .. }),
+            matches!(plain, Endpoint::Wss { .. }),
             accept_invalid_certs,
             mechanism,
         )

--- a/omq-tokio/tests/fuzz_parsers.rs
+++ b/omq-tokio/tests/fuzz_parsers.rs
@@ -389,6 +389,173 @@ fn fuzz_lz4_decode() {
     }
 }
 
+/// Random strings fed to `Endpoint::from_str()` — must never panic.
+#[test]
+fn fuzz_endpoint_parse() {
+    use omq_tokio::Endpoint;
+    use std::str::FromStr;
+    let mut rng = rng();
+    let schemes = [
+        "tcp", "ipc", "inproc", "udp", "ws", "wss", "lz4+tcp", "lz4+ws", "lz4+wss", "bogus", "",
+    ];
+    for i in 0..iters() / 2 {
+        let input = if rng.random_range(0..4) == 0 {
+            let scheme = schemes[rng.random_range(0..schemes.len())];
+            let tail_len = rng.random_range(0..128);
+            let tail: String = (0..tail_len)
+                .map(|_| rng.random_range(0x20..0x7f_u8) as char)
+                .collect();
+            format!("{scheme}://{tail}")
+        } else {
+            let len = rng.random_range(0..256);
+            (0..len)
+                .map(|_| rng.random_range(0x20..0x7f_u8) as char)
+                .collect()
+        };
+        let _ = Endpoint::from_str(&input);
+        if i % 100_000 == 0 {
+            eprintln!("endpoint_parse iter {i}");
+        }
+    }
+}
+
+/// Valid endpoints must survive display → parse roundtrip.
+#[test]
+fn fuzz_endpoint_roundtrip() {
+    use omq_tokio::Endpoint;
+    use omq_tokio::endpoint::Host;
+    use std::str::FromStr;
+    let mut rng = rng();
+    for i in 0..iters() / 4 {
+        let host = match rng.random_range(0..3) {
+            0 => Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+            ))),
+            1 => Host::Ip(std::net::IpAddr::V6(std::net::Ipv6Addr::new(
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+                rng.random(),
+            ))),
+            _ => Host::Name("example.com".to_string()),
+        };
+        let port: u16 = rng.random_range(1..=65535);
+        let path = format!("/{}", rng.random_range(0..100));
+        let ep = match rng.random_range(0..10) {
+            0 => Endpoint::Tcp {
+                host: host.clone(),
+                port,
+            },
+            #[cfg(feature = "lz4")]
+            1 => Endpoint::Lz4Tcp {
+                host: host.clone(),
+                port,
+            },
+            #[cfg(feature = "ws")]
+            3 => Endpoint::Ws {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(feature = "ws")]
+            4 => Endpoint::Wss {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            5 => Endpoint::Lz4Ws {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            6 => Endpoint::Lz4Wss {
+                host: host.clone(),
+                port,
+                path: path.clone(),
+            },
+            _ => Endpoint::Tcp {
+                host: host.clone(),
+                port,
+            },
+        };
+        let s = ep.to_string();
+        let parsed = Endpoint::from_str(&s).unwrap_or_else(|e| {
+            panic!("failed to parse roundtrip of {ep:?} → {s:?}: {e}");
+        });
+        assert_eq!(ep, parsed, "roundtrip mismatch for {s:?}");
+        if i % 50_000 == 0 {
+            eprintln!("endpoint_roundtrip iter {i}");
+        }
+    }
+}
+
+/// Compression transform encode→decode roundtrip with random messages.
+#[cfg(all(feature = "lz4", feature = "ws"))]
+#[test]
+fn fuzz_compress_ws_roundtrip() {
+    use omq_tokio::Endpoint;
+    use omq_tokio::endpoint::Host;
+    use omq_tokio::options::Options;
+    use omq_tokio::proto::transform::MessageEncoder;
+    let mut rng = rng();
+    let localhost = Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+    let endpoints: Vec<Endpoint> = vec![
+        Endpoint::Lz4Ws {
+            host: localhost.clone(),
+            port: 1,
+            path: "/".into(),
+        },
+        Endpoint::Lz4Wss {
+            host: localhost.clone(),
+            port: 1,
+            path: "/".into(),
+        },
+    ];
+    let opts = Options::default();
+    for i in 0..iters() / 4 {
+        let ep = &endpoints[rng.random_range(0..endpoints.len())];
+        let (mut enc, mut dec) =
+            MessageEncoder::for_endpoint(ep, &opts).expect("transform for compressed-ws");
+        let n_parts = rng.random_range(1..=4);
+        let mut parts: Vec<Bytes> = Vec::new();
+        for _ in 0..n_parts {
+            let len = rng.random_range(0..2048);
+            let part: Vec<u8> = (0..len).map(|_| rng.random()).collect();
+            parts.push(Bytes::from(part));
+        }
+        let msg = Message::multipart(parts.clone());
+        let wires = enc.encode(&msg).expect("encode failed");
+        let mut decoded_parts: Vec<Bytes> = Vec::new();
+        for wire in wires {
+            if let Some(decoded) = dec.decode(wire).expect("decode failed") {
+                for j in 0..decoded.len() {
+                    decoded_parts.push(decoded.part_bytes(j).unwrap().clone());
+                }
+            }
+        }
+        assert_eq!(
+            parts.len(),
+            decoded_parts.len(),
+            "part count mismatch at iter {i}"
+        );
+        for (j, (orig, got)) in parts.iter().zip(&decoded_parts).enumerate() {
+            assert_eq!(orig, got, "part {j} mismatch at iter {i}");
+        }
+        if i % 50_000 == 0 {
+            eprintln!("compress_ws_roundtrip iter {i}");
+        }
+    }
+}
+
 // ================================================================
 // Tier 2: RFC compliance + adversarial structured inputs
 // ================================================================

--- a/omq-tokio/tests/lz4_ws.rs
+++ b/omq-tokio/tests/lz4_ws.rs
@@ -1,0 +1,87 @@
+#![cfg(all(feature = "lz4", feature = "ws"))]
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+async fn pull_on_loopback() -> (Socket, Endpoint) {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Ws {
+        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let ev = tokio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let port = match ev {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::Lz4Ws { port, .. },
+        } => port,
+        other => panic!("expected Lz4Ws Listening, got {other:?}"),
+    };
+    (
+        pull,
+        Endpoint::Lz4Ws {
+            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+            port,
+            path: "/".to_string(),
+        },
+    )
+}
+
+#[tokio::test]
+async fn lz4_ws_small_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::single("hello over lz4+ws"))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+ws"[..]);
+}
+
+#[tokio::test]
+async fn lz4_ws_large_compressible_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    let payload = Bytes::from(vec![b'A'; 16 * 1024]);
+    push.send(Message::single(payload.clone())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&m.part_bytes(0).unwrap()[..], &payload[..]);
+}
+
+#[tokio::test]
+async fn lz4_ws_multipart_message_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::multipart(["a", "bb", "ccc"]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.len(), 3);
+    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
+    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+}

--- a/omq-tokio/tests/lz4_ws.rs
+++ b/omq-tokio/tests/lz4_ws.rs
@@ -6,41 +6,69 @@ use bytes::Bytes;
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
 
-async fn pull_on_loopback() -> (Socket, Endpoint) {
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    let mut mon = pull.monitor();
-    pull.bind(Endpoint::Lz4Ws {
-        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-        port: 0,
+fn lz4_ws_loopback(port: u16) -> Endpoint {
+    Endpoint::Lz4Ws {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
         path: "/".to_string(),
+    }
+}
+
+async fn bind_lz4_ws(sock: &Socket) -> (u16, omq_tokio::MonitorStream) {
+    let mut mon = sock.monitor();
+    sock.bind(lz4_ws_loopback(0)).await.unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Ws { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Ws Listening, got {other:?}"),
+        }
+    };
+    (port, mon)
+}
+
+async fn wait_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
     })
     .await
-    .unwrap();
-    let ev = tokio::time::timeout(Duration::from_millis(500), mon.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let port = match ev {
-        MonitorEvent::Listening {
-            endpoint: Endpoint::Lz4Ws { port, .. },
-        } => port,
-        other => panic!("expected Lz4Ws Listening, got {other:?}"),
-    };
-    (
-        pull,
-        Endpoint::Lz4Ws {
-            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-            port,
-            path: "/".to_string(),
-        },
-    )
+    .expect("handshake did not complete within 5s");
 }
+
+async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
+    let fut = async {
+        let mut count = 0;
+        while count < n {
+            match mon.recv().await {
+                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed after {count}/{n} subscribes: {e:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate within 5s");
+}
+
+// ---- PUSH / PULL ----
 
 #[tokio::test]
 async fn lz4_ws_small_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     push.send(Message::single("hello over lz4+ws"))
         .await
@@ -54,9 +82,11 @@ async fn lz4_ws_small_message_roundtrip() {
 
 #[tokio::test]
 async fn lz4_ws_large_compressible_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     let payload = Bytes::from(vec![b'A'; 16 * 1024]);
     push.send(Message::single(payload.clone())).await.unwrap();
@@ -69,9 +99,11 @@ async fn lz4_ws_large_compressible_message_roundtrip() {
 
 #[tokio::test]
 async fn lz4_ws_multipart_message_roundtrip() {
-    let (pull, ep) = pull_on_loopback().await;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
     let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
 
     push.send(Message::multipart(["a", "bb", "ccc"]))
         .await
@@ -84,4 +116,436 @@ async fn lz4_ws_multipart_message_roundtrip() {
     assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
     assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
     assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+}
+
+#[tokio::test]
+async fn lz4_ws_empty_message_roundtrip() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    push.send(Message::single(Bytes::new())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(1), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(m.part_bytes(0).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn lz4_ws_incompressible_data_roundtrip() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    let mut random = vec![0u8; 8192];
+    rand::Rng::fill_bytes(&mut rand::rng(), &mut random);
+    push.send(Message::single(random.clone())).await.unwrap();
+
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().to_vec(), random);
+}
+
+#[tokio::test]
+async fn lz4_ws_many_messages_in_a_row() {
+    const N: usize = 200;
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+    wait_handshake(&pull).await;
+
+    for i in 0..N {
+        push.send(Message::single(format!("m-{i}"))).await.unwrap();
+    }
+    for i in 0..N {
+        let m = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), format!("m-{i}").as_bytes());
+    }
+}
+
+// ---- REQ / REP ----
+
+#[tokio::test]
+async fn lz4_ws_req_rep() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let (port, _mon) = bind_lz4_ws(&rep).await;
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    req.send(Message::single("question")).await.unwrap();
+    let q = tokio::time::timeout(Duration::from_secs(2), rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(q.part_bytes(0).unwrap(), &b"question"[..]);
+
+    rep.send(Message::single("answer")).await.unwrap();
+    let a = tokio::time::timeout(Duration::from_secs(2), req.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(a.part_bytes(0).unwrap(), &b"answer"[..]);
+}
+
+// ---- ROUTER / DEALER ----
+
+#[tokio::test]
+async fn lz4_ws_router_dealer_identity_routing() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let (port, _mon) = bind_lz4_ws(&router).await;
+
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"alice")),
+    );
+    dealer.connect(lz4_ws_loopback(port)).await.unwrap();
+    wait_handshake(&router).await;
+
+    dealer.send(Message::single("hello")).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got.part_bytes(0).unwrap(), &b"alice"[..]);
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+
+    router
+        .send(Message::multipart(["alice", "reply"]))
+        .await
+        .unwrap();
+    let r = tokio::time::timeout(Duration::from_secs(2), dealer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.part_bytes(0).unwrap(), &b"reply"[..]);
+}
+
+// ---- PUB / SUB ----
+
+#[tokio::test]
+async fn lz4_ws_pub_sub_prefix_filter() {
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+
+    let subscriber = Socket::new(SocketType::Sub, Options::default());
+    subscriber.connect(lz4_ws_loopback(port)).await.unwrap();
+    subscriber.subscribe("news.").await.unwrap();
+
+    wait_for_subscribes(&mut mon, 1).await;
+
+    publisher
+        .send(Message::multipart(["news.sports", "ball scores"]))
+        .await
+        .unwrap();
+    publisher
+        .send(Message::multipart(["weather", "sunny"]))
+        .await
+        .unwrap();
+    publisher
+        .send(Message::multipart(["news.tech", "rust 2.0"]))
+        .await
+        .unwrap();
+
+    let m1 = tokio::time::timeout(Duration::from_secs(2), subscriber.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m1.part_bytes(0).unwrap(), &b"news.sports"[..]);
+    assert_eq!(m1.part_bytes(1).unwrap(), &b"ball scores"[..]);
+
+    let m2 = tokio::time::timeout(Duration::from_secs(2), subscriber.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m2.part_bytes(0).unwrap(), &b"news.tech"[..]);
+    assert_eq!(m2.part_bytes(1).unwrap(), &b"rust 2.0"[..]);
+
+    let nothing = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
+    assert!(
+        nothing.is_err(),
+        "non-matching message must not be delivered"
+    );
+}
+
+#[tokio::test]
+async fn lz4_ws_pub_sub_fan_out() {
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 50;
+
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, Options::default());
+        s.connect(lz4_ws_loopback(port)).await.unwrap();
+        s.subscribe(Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+    wait_for_subscribes(&mut mon, N_SUBS).await;
+
+    for i in 0..N_MSGS {
+        let body = format!("msg-{i:04}");
+        publisher
+            .send(Message::single(Bytes::from(body)))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!("msg-{i:04}");
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
+}
+
+// ---- Dict roundtrip ----
+
+#[tokio::test]
+async fn lz4_ws_dict_roundtrip() {
+    let dict = Bytes::from_static(b"omq-omq-omq-omq-omq-omq-omq-omq-shared-prefix");
+    let opts = || Options::default().compression_dict(dict.clone());
+
+    let pull = Socket::new(SocketType::Pull, opts());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, opts());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    let plain = b"omq-".repeat(20); // 80 bytes, dict-friendly
+    for _ in 0..3 {
+        push.send(Message::single(plain.clone())).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap().to_vec(), plain);
+    }
+}
+
+// ---- Auto-train dict over lz4+ws ----
+
+#[tokio::test]
+async fn lz4_ws_auto_train_dict() {
+    use omq_proto::proto::transform::lz4::DictTrainer;
+
+    let mut trainer = DictTrainer::new(2048);
+    for i in 0..100 {
+        let s = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        trainer.add_sample(s.as_bytes());
+    }
+    let dict = Bytes::from(trainer.train());
+    let opts = Options::default().compression_dict(dict);
+
+    let pull = Socket::new(SocketType::Pull, opts.clone());
+    let (port, _mon) = bind_lz4_ws(&pull).await;
+
+    let push = Socket::new(SocketType::Push, opts);
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+
+    for i in 0..20 {
+        let body = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);
+        push.send(Message::single(Bytes::from(body.clone())))
+            .await
+            .unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap(), body.as_bytes());
+    }
+}
+
+// ---- Reconnect over lz4+ws ----
+
+#[tokio::test]
+async fn lz4_ws_reconnect_after_server_restart() {
+    let pull1 = Socket::new(SocketType::Pull, Options::default());
+    let (port, _mon) = bind_lz4_ws(&pull1).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(lz4_ws_loopback(port)).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::single("before")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(5), pull1.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"before"[..]);
+
+    pull1.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let pull2 = Socket::new(SocketType::Pull, Options::default());
+    let mut bound = false;
+    for _ in 0..20 {
+        if pull2.bind(lz4_ws_loopback(port)).await.is_ok() {
+            bound = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(bound, "pull2 failed to bind after pull1 closed");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::single("after")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(5), pull2.recv())
+        .await
+        .expect("recv after restart timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"after"[..]);
+}
+
+// ---- lz4+wss (TLS) ----
+
+#[tokio::test]
+async fn lz4_wss_push_pull() {
+    use omq_proto::options::WssTls;
+
+    let certified = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    let cert_pem = certified.cert.pem().into_bytes();
+    let key_pem = certified.signing_key.serialize_pem().into_bytes();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Wss { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Wss Listening, got {other:?}"),
+        }
+    };
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    push.send(Message::single("hello over lz4+wss"))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+wss"[..]);
+}
+
+#[tokio::test]
+async fn lz4_wss_large_compressible() {
+    use omq_proto::options::WssTls;
+
+    let certified = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into()]).unwrap();
+    let cert_pem = certified.cert.pem().into_bytes();
+    let key_pem = certified.signing_key.serialize_pem().into_bytes();
+
+    let server_opts = Options {
+        wss_tls: WssTls {
+            server_cert_pem: Some(cert_pem),
+            server_key_pem: Some(key_pem),
+            accept_invalid_certs: false,
+        },
+        ..Options::default()
+    };
+
+    let pull = Socket::new(SocketType::Pull, server_opts);
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port: 0,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    let port = loop {
+        match mon.recv().await {
+            Ok(MonitorEvent::Listening {
+                endpoint: Endpoint::Lz4Wss { port, .. },
+            }) => break port,
+            Ok(_) => {}
+            other => panic!("expected Lz4Wss Listening, got {other:?}"),
+        }
+    };
+
+    let client_opts = Options {
+        wss_tls: WssTls {
+            accept_invalid_certs: true,
+            ..WssTls::default()
+        },
+        ..Options::default()
+    };
+
+    let push = Socket::new(SocketType::Push, client_opts);
+    push.connect(Endpoint::Lz4Wss {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+        path: "/".to_string(),
+    })
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let payload = Bytes::from(vec![b'Z'; 16 * 1024]);
+    push.send(Message::single(payload.clone())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(5), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&m.part_bytes(0).unwrap()[..], &payload[..]);
 }

--- a/omq-tokio/tests/ws_pub_sub.rs
+++ b/omq-tokio/tests/ws_pub_sub.rs
@@ -89,3 +89,57 @@ async fn ws_pub_sub_unsubscribe() {
         "message should not arrive after unsubscribe"
     );
 }
+
+#[tokio::test]
+async fn ws_pub_sub_fan_out() {
+    const N_SUBS: usize = 4;
+    const N_MSGS: usize = 50;
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let bound = pub_.bind(ws_endpoint(0)).await.unwrap();
+    let port = get_port(&bound);
+
+    let mut mon = pub_.monitor();
+    let mut subs = Vec::with_capacity(N_SUBS);
+    for _ in 0..N_SUBS {
+        let s = Socket::new(SocketType::Sub, Options::default());
+        s.connect(ws_endpoint(port)).await.unwrap();
+        s.subscribe(Bytes::new()).await.unwrap();
+        subs.push(s);
+    }
+
+    let fut = async {
+        let mut count = 0;
+        while count < N_SUBS {
+            match mon.recv().await {
+                Ok(omq_tokio::MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed after {count}/{N_SUBS} subscribes: {e:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate");
+
+    for i in 0..N_MSGS {
+        pub_.send(Message::single(format!("msg-{i:04}")))
+            .await
+            .unwrap();
+    }
+
+    for (si, sub) in subs.iter().enumerate() {
+        for i in 0..N_MSGS {
+            let m = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+                .await
+                .unwrap_or_else(|_| panic!("sub {si} timed out at msg {i}"))
+                .unwrap();
+            let expected = format!("msg-{i:04}");
+            assert_eq!(
+                m.part_bytes(0).unwrap(),
+                expected.as_bytes(),
+                "sub {si} msg {i}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Add `lz4+ws://` and `lz4+wss://` endpoint schemes: LZ4 compression layered on top of WebSocket transport
- Fix `FanOutSend::dispatch_to_targets` writing raw ZMTP frames to WS peers via the send bypass arena path. WS targets now fall back to per-peer `try_encode` which produces proper WS binary frames.
- Add `PeerWireSlot::is_ws()` / `PeerSend::is_ws()` accessors (`cfg(feature = "ws")`)
- 15 lz4+ws integration tests per backend: empty msg, incompressible data, many-in-a-row, REQ/REP, ROUTER/DEALER identity routing, PUB/SUB prefix filter, PUB/SUB fan-out, dict roundtrip, auto-train dict, reconnect, lz4+wss push/pull, lz4+wss large compressible
- `ws_pub_sub_fan_out` test in both backends covering plain WS multi-subscriber fan-out