### PR TITLE
Remove dead is_draft(), add STREAM socket test

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -43,7 +43,7 @@ await sock.close()
 
 Sync and `asyncio` APIs both ship in this release. All 19 ZMTP socket types are wired:
 
-- **Standard (RFC 28 + 47)**: PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH, XPUB, XSUB.
+- **Standard (RFC 28 + 47)**: PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH, XPUB, XSUB, STREAM.
 - **Draft**: SERVER, CLIENT (RFC 41), RADIO, DISH (RFC 48), GATHER, SCATTER (RFC 49), PEER, CHANNEL (RFC 51).
 
 Transports: `tcp://`, `ipc://`, `inproc://`, and `udp://` (RADIO/DISH only).

--- a/bindings/pyomq/tests/test_socket_types.py
+++ b/bindings/pyomq/tests/test_socket_types.py
@@ -1,4 +1,4 @@
-"""Coverage for all 19 ZMTP socket types (11 standard + 8 draft).
+"""Coverage for all 19 ZMTP socket types.
 
 Each test constructs a real omq socket pair and exchanges at least one
 message. The point is not perf or edge cases - those live in the
@@ -13,7 +13,7 @@ import pytest
 
 import pyomq
 
-STANDARD = [
+ALL_TYPES = [
     pyomq.PAIR,
     pyomq.PUB,
     pyomq.SUB,
@@ -25,9 +25,7 @@ STANDARD = [
     pyomq.PUSH,
     pyomq.XPUB,
     pyomq.XSUB,
-]
-
-DRAFT = [
+    pyomq.STREAM,
     pyomq.SERVER,
     pyomq.CLIENT,
     pyomq.RADIO,
@@ -51,7 +49,7 @@ def _inproc(name: str) -> str:
     return f"inproc://socket-types-{name}-{time.monotonic_ns()}"
 
 
-@pytest.mark.parametrize("kind", STANDARD + DRAFT)
+@pytest.mark.parametrize("kind", ALL_TYPES)
 def test_construct_each_type(kind):
     """Every constant maps through Context.socket without erroring."""
     ctx = pyomq.Context()
@@ -260,3 +258,36 @@ def test_radio_dish_udp_with_groups():
 
     dish.leave(b"weather")
     radio.close(); dish.close(); ctx.term()
+
+
+def test_stream_raw_tcp():
+    """STREAM socket accepts raw TCP and echoes data back."""
+    ep = _free_tcp()
+    ctx = pyomq.Context()
+    stream = ctx.socket(pyomq.STREAM)
+    stream.bind(ep)
+    stream.setsockopt(pyomq.RCVTIMEO, 1000)
+
+    raw = stdsocket.socket(stdsocket.AF_INET, stdsocket.SOCK_STREAM)
+    host, port = ep.replace("tcp://", "").split(":")
+    raw.connect((host, int(port)))
+    raw.sendall(b"hello")
+
+    # Connect notification: [identity, b""]
+    parts = stream.recv_multipart()
+    assert len(parts) == 2
+    identity = parts[0]
+    assert len(identity) > 0
+    assert parts[1] == b""
+
+    # Data: [identity, payload]
+    parts = stream.recv_multipart()
+    assert parts == [identity, b"hello"]
+
+    # Echo back via [identity, payload]
+    stream.send_multipart([identity, b"world"])
+    echoed = raw.recv(1024)
+    assert echoed == b"world"
+
+    raw.close()
+    stream.close(); ctx.term()

--- a/omq-proto/src/proto/mod.rs
+++ b/omq-proto/src/proto/mod.rs
@@ -34,13 +34,12 @@ pub use connection::{Connection, ConnectionConfig, Event, Role};
 pub use frame::{MAX_FRAME_HEADER_LEN, MAX_SHORT_FRAME_SIZE};
 pub use greeting::{Greeting, MechanismName, VERSION_SNIFF_LEN, ZMTP_MAJOR, ZMTP_MINOR};
 
-/// All 19 ZMTP socket types (11 standard + 8 draft).
+/// All 19 ZMTP socket types.
 ///
 /// The value carries the wire-level ASCII name returned by [`Self::as_str`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum SocketType {
-    // Standard
     Req,
     Rep,
     Pub,
@@ -52,7 +51,6 @@ pub enum SocketType {
     Dealer,
     Router,
     Pair,
-    // Draft
     Client,
     Server,
     Radio,
@@ -89,22 +87,6 @@ impl SocketType {
             Self::Peer => "PEER",
             Self::Stream => "STREAM",
         }
-    }
-
-    /// Whether the type is a draft RFC (CLIENT/SERVER, RADIO/DISH, etc.).
-    pub const fn is_draft(self) -> bool {
-        matches!(
-            self,
-            Self::Client
-                | Self::Server
-                | Self::Radio
-                | Self::Dish
-                | Self::Scatter
-                | Self::Gather
-                | Self::Channel
-                | Self::Peer
-                | Self::Stream
-        )
     }
 
     /// Parse a wire-level socket-type name. Case-sensitive.
@@ -233,15 +215,6 @@ mod tests {
         assert!(is_compatible(Scatter, Gather));
         assert!(is_compatible(Channel, Channel));
         assert!(is_compatible(Peer, Peer));
-    }
-
-    #[test]
-    fn draft_flag() {
-        assert!(!SocketType::Req.is_draft());
-        assert!(!SocketType::Pair.is_draft());
-        assert!(SocketType::Radio.is_draft());
-        assert!(SocketType::Peer.is_draft());
-        assert!(SocketType::Stream.is_draft());
     }
 
     #[test]


### PR DESCRIPTION
- Remove `SocketType::is_draft()` and its test from `omq-proto` (zero callers outside its own test)
- STREAM was incorrectly classified as draft; it's a standard libzmq socket type with no ZMQ RFC
- Remove `Standard`/`Draft` comments from `SocketType` enum
- Merge `STANDARD` + `DRAFT` test lists into `ALL_TYPES` in pyomq `test_socket_types.py`, add `STREAM`
- Add `test_stream_raw_tcp`: bind STREAM, connect raw TCP client, verify connect notification, data recv, and echo-back
- Mention STREAM in `bindings/pyomq/README.md` socket type list