### PR TITLE
Add Context.shadow() to pyomq

### DIFF
--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -831,8 +831,13 @@ class Context:
     _instance_lock = threading.Lock()
     _socket_class = None  # set after Socket is defined
 
-    def __init__(self, io_threads=1):
-        self._ctx = _native.Context(io_threads)
+    def __init__(self, io_threads=1, *, _shadow_ctx=None):
+        if _shadow_ctx is not None:
+            self._ctx = _shadow_ctx._ctx
+            self._is_shadow = True
+        else:
+            self._ctx = _native.Context(io_threads)
+            self._is_shadow = False
         self._closed = False
         self._sockets = weakref.WeakSet()
         self._ctx_id = next(_next_ctx_id)
@@ -879,6 +884,14 @@ class Context:
         return s
 
     @classmethod
+    def shadow(cls, address):
+        if isinstance(address, Context):
+            return cls(_shadow_ctx=address)
+        if isinstance(address, int):
+            return cls(_shadow_ctx=Context.instance())
+        raise TypeError(f"expected Context or int, got {type(address).__name__}")
+
+    @classmethod
     def instance(cls, io_threads=1):
         with cls._instance_lock:
             if cls._instance is None or cls._instance._closed:
@@ -891,7 +904,8 @@ class Context:
             if not s.closed:
                 s.close()
         self._sockets.clear()
-        self._ctx.term()
+        if not self._is_shadow:
+            self._ctx.term()
 
     def destroy(self, linger=None):
         for s in list(self._sockets):

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -526,8 +526,13 @@ class Poller:
 class Context(_SyncContext):
     _socket_class = None
 
-    def __init__(self, io_threads=1):
-        self._ctx = _native.AsyncContext(io_threads)
+    def __init__(self, io_threads=1, *, _shadow_ctx=None):
+        if _shadow_ctx is not None:
+            self._ctx = _shadow_ctx._ctx
+            self._is_shadow = True
+        else:
+            self._ctx = _native.AsyncContext(io_threads)
+            self._is_shadow = False
         self._closed = False
         self._sockets = weakref.WeakSet()
         self._ctx_id = next(_next_ctx_id)

--- a/bindings/pyomq/tests/test_shadow.py
+++ b/bindings/pyomq/tests/test_shadow.py
@@ -1,9 +1,54 @@
-"""_ShadowSocket and Socket.shadow() tests."""
+"""_ShadowSocket, Socket.shadow(), and Context.shadow() tests."""
 
 import pytest
 
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
+
+
+# ── Context.shadow ──────────────────────────────────────────────────
+
+
+def test_context_shadow_shares_native():
+    ctx = zmq.Context()
+    try:
+        shadow = zmq.Context.shadow(ctx)
+        assert shadow is not ctx
+        assert shadow._ctx is ctx._ctx
+    finally:
+        shadow.term()
+        ctx.term()
+
+
+def test_context_shadow_creates_sockets():
+    ctx = zmq.Context()
+    try:
+        shadow = zmq.Context.shadow(ctx)
+        sock = shadow.socket(zmq.PUSH)
+        assert sock.socket_type == zmq.PUSH
+        sock.close()
+    finally:
+        shadow.term()
+        ctx.term()
+
+
+def test_context_shadow_term_does_not_destroy_original():
+    ctx = zmq.Context()
+    shadow = zmq.Context.shadow(ctx)
+    shadow.term()
+    assert shadow.closed
+    sock = ctx.socket(zmq.PUSH)
+    sock.close()
+    ctx.term()
+
+
+def test_context_shadow_int_uses_instance():
+    shadow = zmq.Context.shadow(0)
+    assert shadow._ctx is zmq.Context.instance()._ctx
+    shadow.term()
+
+
+# ── Socket.shadow ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Implement `Context.shadow(ctx_or_int)` on both sync and async `Context` classes, matching pyzmq's API
- Shadow contexts share the native handle but skip `term()` on cleanup
- Integer addresses fall back to the singleton instance
- `Socket.bind_to_random_port()` already existed

Closes #111