### PR TITLE
fix audit findings: correctness, safety, docs

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -41,7 +41,7 @@ await sock.close()
 
 ## Status
 
-Sync and `asyncio` APIs both ship in this release. All 19 ZMTP socket types are wired:
+Sync and `asyncio` APIs both ship in this release. All 20 ZMTP socket types are wired:
 
 - **Standard (RFC 28 + 47)**: PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH, XPUB, XSUB, STREAM.
 - **Draft**: SERVER, CLIENT (RFC 41), RADIO, DISH (RFC 48), GATHER, SCATTER (RFC 49), PEER, CHANNEL (RFC 51).

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -47,7 +47,7 @@ Sync and `asyncio` APIs both ship in this release. All 19 ZMTP socket types are 
 - **Draft**: SERVER, CLIENT (RFC 41), RADIO, DISH (RFC 48), GATHER, SCATTER (RFC 49), PEER, CHANNEL (RFC 51).
 
 Transports: `tcp://`, `ipc://`, `inproc://`, and `udp://` (RADIO/DISH only).
-Optional features built into the wheel: `plain`, `curve`, `lz4`.
+Optional features built into the wheel: `plain`, `curve`, `blake3zmq`, `lz4`.
 
 DISH groups: use `socket.join(b"group")` / `socket.leave(b"group")` to manage
 subscriptions; messages are sent as multipart `[group, body]`.

--- a/omq-compio/Cargo.toml
+++ b/omq-compio/Cargo.toml
@@ -36,7 +36,7 @@ soak = []
 omq-proto = { path = "../omq-proto", version = "0.18.0", default-features = false }
 blume = { path = "../blume", version = "0.4.2" }
 yring = { path = "../yring", version = "0.3.2" }
-bytes = "1.11.0"
+bytes = "1.12.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"
 concurrent-queue = "2.5.0"

--- a/omq-compio/src/local_cell.rs
+++ b/omq-compio/src/local_cell.rs
@@ -14,7 +14,11 @@ pub(crate) struct LocalCell<T> {
 }
 
 // SAFETY: compio is single-threaded cooperative. All access happens on
-// the runtime thread that created the cell. No concurrent access.
+// the runtime thread that created the cell, so no concurrent mutation is
+// possible. In debug builds, every `get()` call asserts the current thread
+// matches the creating thread. In release builds this assertion is compiled
+// out for zero overhead. The type is `pub(crate)` and only used inside
+// compio driver internals. Callers must not move a LocalCell to another thread.
 unsafe impl<T: Send> Sync for LocalCell<T> {}
 
 impl<T> LocalCell<T> {

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -47,6 +47,10 @@ impl std::fmt::Debug for Socket {
 
 impl Drop for Socket {
     fn drop(&mut self) {
+        // SAFETY: Arc::strong_count is racy under concurrent access, but
+        // compio is single-threaded cooperative. No other task executes
+        // between the read and the cleanup below, so the count cannot
+        // change underneath us.
         if Arc::strong_count(&self.user_life) == 1 {
             if let Ok(mut d) = self.inner.endpoints.dialers.write() {
                 d.clear();

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 omq-tokio = { path = "../omq-tokio", version = "0.14.5", features = ["plain", "curve", "lz4"] }
 yring = { path = "../yring", version = "0.3.2" }
 tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "sync", "time"] }
-bytes = "1.11.0"
+bytes = "1.12.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"
 crypto_box = "0.9"

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -405,6 +405,8 @@ pub extern "C" fn zmq_msg_send(
         // SAFETY: boxed was created by Box::into_raw; reclaiming ownership.
         let owned = unsafe { *Box::from_raw(r.boxed.cast::<Bytes>()) };
         r.boxed = std::ptr::null_mut();
+        r.ptr = std::ptr::null_mut();
+        r.size = 0;
         owned
     } else {
         extract_bytes(msg)

--- a/omq-libzmq/src/notify.rs
+++ b/omq-libzmq/src/notify.rs
@@ -417,6 +417,7 @@ mod unix {
             }
 
             let mut ready_count = 0i32;
+            let mut counted = vec![false; items.len()];
             for (pfd_idx, pfd) in self.pfds.iter().enumerate() {
                 if pfd.revents == 0 {
                     continue;
@@ -442,9 +443,8 @@ mod unix {
                     items[item_idx].revents |= zmq_event;
                 }
 
-                if items[item_idx].revents != 0 && ready_count == 0 {
-                    ready_count = 1;
-                } else if items[item_idx].revents != 0 {
+                if items[item_idx].revents != 0 && !counted[item_idx] {
+                    counted[item_idx] = true;
                     ready_count += 1;
                 }
             }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -298,27 +298,37 @@ pub extern "C" fn zmq_setsockopt(
 
     match option {
         ZMQ_SNDTIMEO => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             sock_arc
                 .sndtimeo_ms
                 .store(i64::from(v), std::sync::atomic::Ordering::Relaxed);
         }
         ZMQ_RCVTIMEO => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             sock_arc
                 .rcvtimeo_ms
                 .store(i64::from(v), std::sync::atomic::Ordering::Relaxed);
         }
         ZMQ_SNDHWM => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).send_hwm = if v <= 0 { None } else { Some(v as u32) };
         }
         ZMQ_RCVHWM => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).recv_hwm = if v <= 0 { None } else { Some(v as u32) };
         }
         ZMQ_LINGER => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).linger = if v < 0 {
                 None
             } else {
@@ -334,7 +344,9 @@ pub extern "C" fn zmq_setsockopt(
             lock_overlay!(sock_arc).identity = Bytes::copy_from_slice(bytes);
         }
         ZMQ_RECONNECT_IVL => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).reconnect_ivl = if v <= 0 {
                 None
             } else {
@@ -342,7 +354,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_RECONNECT_IVL_MAX => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).reconnect_ivl_max = if v <= 0 {
                 None
             } else {
@@ -350,7 +364,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_HEARTBEAT_IVL => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).heartbeat_ivl = if v <= 0 {
                 None
             } else {
@@ -358,7 +374,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_HEARTBEAT_TTL => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).heartbeat_ttl = if v <= 0 {
                 None
             } else {
@@ -366,7 +384,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_HEARTBEAT_TIMEOUT => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).heartbeat_timeout = if v <= 0 {
                 None
             } else {
@@ -374,7 +394,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_HANDSHAKE_IVL => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).handshake_ivl = if v <= 0 {
                 None
             } else {
@@ -382,27 +404,39 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_MAXMSGSIZE => {
-            let v = read_i64(optval, optvallen);
+            let Some(v) = read_i64(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).max_message_size = if v < 0 { None } else { Some(v as usize) };
         }
         ZMQ_ROUTER_MANDATORY => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).router_mandatory = v != 0;
         }
         ZMQ_CONFLATE => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).conflate = v != 0;
         }
         ZMQ_TCP_KEEPALIVE => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).tcp_keepalive = v;
         }
         ZMQ_TCP_KEEPALIVE_CNT => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).tcp_keepalive_cnt = if v <= 0 { None } else { Some(v as u32) };
         }
         ZMQ_TCP_KEEPALIVE_IDLE => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).tcp_keepalive_idle = if v <= 0 {
                 None
             } else {
@@ -410,7 +444,9 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_TCP_KEEPALIVE_INTVL => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).tcp_keepalive_intvl = if v <= 0 {
                 None
             } else {
@@ -418,15 +454,21 @@ pub extern "C" fn zmq_setsockopt(
             };
         }
         ZMQ_SNDBUF => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).sndbuf = if v <= 0 { None } else { Some(v as usize) };
         }
         ZMQ_RCVBUF => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).rcvbuf = if v <= 0 { None } else { Some(v as usize) };
         }
         ZMQ_XPUB_VERBOSE => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             lock_overlay!(sock_arc).xpub_verbose = v != 0;
         }
         ZMQ_SUBSCRIBE => {
@@ -436,7 +478,9 @@ pub extern "C" fn zmq_setsockopt(
             return do_subscribe(sock_arc, optval, optvallen, false);
         }
         ZMQ_PLAIN_SERVER => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             if v != 0 {
                 ov.mechanism = MechanismOverlay::PlainServer;
@@ -445,7 +489,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_PLAIN_USERNAME => {
-            let s = read_string(optval, optvallen);
+            let Some(s) = read_string(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             match &mut ov.mechanism {
                 MechanismOverlay::PlainClient { username, .. } => *username = s,
@@ -458,7 +504,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_PLAIN_PASSWORD => {
-            let s = read_string(optval, optvallen);
+            let Some(s) = read_string(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             match &mut ov.mechanism {
                 MechanismOverlay::PlainClient { password, .. } => *password = s,
@@ -471,7 +519,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_CURVE_SERVER => {
-            let v = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             if v != 0 {
                 if !matches!(ov.mechanism, MechanismOverlay::CurveServer { .. }) {
@@ -484,7 +534,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_CURVE_PUBLICKEY => {
-            let key = read_key(optval, optvallen);
+            let Some(key) = read_key(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             match &mut ov.mechanism {
                 MechanismOverlay::CurveClient { public_key, .. } => *public_key = key,
@@ -498,7 +550,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_CURVE_SECRETKEY => {
-            let key = read_key(optval, optvallen);
+            let Some(key) = read_key(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             match &mut ov.mechanism {
                 MechanismOverlay::CurveServer { secret_key, .. }
@@ -513,7 +567,9 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_CURVE_SERVERKEY => {
-            let key = read_key(optval, optvallen);
+            let Some(key) = read_key(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
             let mut ov = lock_overlay!(sock_arc);
             match &mut ov.mechanism {
                 MechanismOverlay::CurveClient { server_key, .. } => *server_key = key,
@@ -527,34 +583,61 @@ pub extern "C" fn zmq_setsockopt(
             }
         }
         ZMQ_IPV6 => {
-            lock_overlay!(sock_arc).ipv6 = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).ipv6 = v != 0;
         }
         ZMQ_IPV4ONLY => {
-            lock_overlay!(sock_arc).ipv6 = read_i32(optval, optvallen) == 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).ipv6 = v == 0;
         }
         // Always-on in omq; accept silently.
         #[expect(clippy::match_same_arms)]
         ZMQ_ROUTER_HANDOVER => {}
         ZMQ_BACKLOG => {
-            lock_overlay!(sock_arc).backlog = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).backlog = v;
         }
         ZMQ_IMMEDIATE => {
-            lock_overlay!(sock_arc).immediate = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).immediate = v != 0;
         }
         ZMQ_CONNECT_TIMEOUT => {
-            lock_overlay!(sock_arc).connect_timeout = read_i32(optval, optvallen);
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).connect_timeout = v;
         }
         ZMQ_PROBE_ROUTER => {
-            lock_overlay!(sock_arc).probe_router = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).probe_router = v != 0;
         }
         ZMQ_REQ_CORRELATE => {
-            lock_overlay!(sock_arc).req_correlate = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).req_correlate = v != 0;
         }
         ZMQ_REQ_RELAXED => {
-            lock_overlay!(sock_arc).req_relaxed = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).req_relaxed = v != 0;
         }
         ZMQ_XPUB_NODROP => {
-            lock_overlay!(sock_arc).xpub_nodrop = read_i32(optval, optvallen) != 0;
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).xpub_nodrop = v != 0;
         }
         #[expect(clippy::match_same_arms)]
         ZMQ_AFFINITY
@@ -1044,34 +1127,37 @@ pub extern "C" fn zmq_getsockopt(
     }
 }
 
-fn read_i32(optval: *const libc::c_void, optvallen: usize) -> i32 {
+fn read_i32(optval: *const libc::c_void, optvallen: usize) -> Option<i32> {
     if optval.is_null() || optvallen < 4 {
-        return 0;
+        return None;
     }
     // SAFETY: optval is non-null (checked above) and points to at least 4 readable bytes.
-    unsafe { std::ptr::read_unaligned(optval.cast::<i32>()) }
+    Some(unsafe { std::ptr::read_unaligned(optval.cast::<i32>()) })
 }
 
-fn read_i64(optval: *const libc::c_void, optvallen: usize) -> i64 {
+fn read_i64(optval: *const libc::c_void, optvallen: usize) -> Option<i64> {
     if optval.is_null() || optvallen < 8 {
-        return 0;
+        return None;
     }
     // SAFETY: optval is non-null (checked above) and points to at least 8 readable bytes.
-    unsafe { std::ptr::read_unaligned(optval.cast::<i64>()) }
+    Some(unsafe { std::ptr::read_unaligned(optval.cast::<i64>()) })
 }
 
-fn read_string(optval: *const libc::c_void, optvallen: usize) -> String {
-    if optval.is_null() || optvallen == 0 {
-        return String::new();
+fn read_string(optval: *const libc::c_void, optvallen: usize) -> Option<String> {
+    if optval.is_null() {
+        return None;
+    }
+    if optvallen == 0 {
+        return Some(String::new());
     }
     // SAFETY: optval is non-null with optvallen > 0 (checked above).
     let slice = unsafe { std::slice::from_raw_parts(optval.cast::<u8>(), optvallen) };
-    String::from_utf8_lossy(slice).into_owned()
+    Some(String::from_utf8_lossy(slice).into_owned())
 }
 
-fn read_key(optval: *const libc::c_void, optvallen: usize) -> [u8; 32] {
+fn read_key(optval: *const libc::c_void, optvallen: usize) -> Option<[u8; 32]> {
     if optval.is_null() {
-        return [0; 32];
+        return None;
     }
     let mut key = [0u8; 32];
     if optvallen == 32 {
@@ -1082,7 +1168,7 @@ fn read_key(optval: *const libc::c_void, optvallen: usize) -> [u8; 32] {
         // SAFETY: optval is non-null (checked above) and optvallen >= 40.
         let slice = unsafe { std::slice::from_raw_parts(optval.cast::<u8>(), 40) };
         let Ok(s) = std::str::from_utf8(slice) else {
-            return key;
+            return Some(key);
         };
         if let Ok(decoded) = omq_tokio::proto::z85::decode(s)
             && decoded.len() == 32
@@ -1090,7 +1176,7 @@ fn read_key(optval: *const libc::c_void, optvallen: usize) -> [u8; 32] {
             key.copy_from_slice(&decoded);
         }
     }
-    key
+    Some(key)
 }
 
 fn write_i32(optval: *mut libc::c_void, optvallen: *mut usize, val: i32) -> c_int {

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -673,3 +673,21 @@ fn curve_key_non_utf8_does_not_crash() {
     zmq_close(s);
     zmq_ctx_term(ctx);
 }
+
+#[test]
+fn setsockopt_null_optval_returns_einval() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_PUSH);
+
+    let rc = zmq_setsockopt(s, ZMQ_SNDHWM, std::ptr::null(), size_of::<i32>());
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    let v: i32 = 100;
+    let rc = zmq_setsockopt(s, ZMQ_SNDHWM, (&v as *const i32).cast(), 2);
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}

--- a/omq-libzmq/tests/poll.rs
+++ b/omq-libzmq/tests/poll.rs
@@ -468,3 +468,52 @@ fn poll_128_sockets_fairness() {
     }
     zmq_ctx_term(ctx);
 }
+
+#[test]
+#[serial]
+fn poll_both_events_counts_as_one_item() {
+    let ctx = zmq_ctx_new();
+    let a = zmq_socket(ctx, ZMQ_PAIR);
+    let b = zmq_socket(ctx, ZMQ_PAIR);
+    set_timeo(a, 1000);
+    set_timeo(b, 1000);
+
+    let addr = CString::new("tcp://127.0.0.1:*").unwrap();
+    zmq_bind(a, addr.as_ptr());
+
+    let mut ep_buf = [0u8; 256];
+    let mut ep_sz = ep_buf.len();
+    const ZMQ_LAST_ENDPOINT: i32 = 32;
+    omq_zmq::zmq_getsockopt(a, ZMQ_LAST_ENDPOINT, ep_buf.as_mut_ptr().cast(), &mut ep_sz);
+    let ep_end = if ep_sz > 0 && ep_buf[ep_sz - 1] == 0 {
+        ep_sz - 1
+    } else {
+        ep_sz
+    };
+    let ep = CString::new(&ep_buf[..ep_end]).unwrap();
+    zmq_connect(b, ep.as_ptr());
+
+    std::thread::sleep(Duration::from_millis(50));
+
+    zmq_send(b, b"hi".as_ptr().cast(), 2, 0);
+    std::thread::sleep(Duration::from_millis(50));
+
+    let mut items = [PollItem {
+        socket: a,
+        fd: -1,
+        events: ZMQ_POLLIN | ZMQ_POLLOUT,
+        revents: 0,
+    }];
+
+    let rc = zmq_poll(items.as_mut_ptr().cast(), 1, 1000);
+    assert_ne!(items[0].revents & ZMQ_POLLIN, 0, "should be readable");
+    assert_ne!(items[0].revents & ZMQ_POLLOUT, 0, "should be writable");
+    assert_eq!(rc, 1, "ready_count should count items, not event types");
+
+    let mut buf = [0u8; 16];
+    zmq_recv(a, buf.as_mut_ptr().cast(), buf.len(), 0);
+
+    zmq_close(a);
+    zmq_close(b);
+    zmq_ctx_term(ctx);
+}

--- a/omq-libzmq/tests/poll.rs
+++ b/omq-libzmq/tests/poll.rs
@@ -472,6 +472,8 @@ fn poll_128_sockets_fairness() {
 #[test]
 #[serial]
 fn poll_both_events_counts_as_one_item() {
+    const ZMQ_LAST_ENDPOINT: i32 = 32;
+
     let ctx = zmq_ctx_new();
     let a = zmq_socket(ctx, ZMQ_PAIR);
     let b = zmq_socket(ctx, ZMQ_PAIR);
@@ -483,7 +485,6 @@ fn poll_both_events_counts_as_one_item() {
 
     let mut ep_buf = [0u8; 256];
     let mut ep_sz = ep_buf.len();
-    const ZMQ_LAST_ENDPOINT: i32 = 32;
     omq_zmq::zmq_getsockopt(a, ZMQ_LAST_ENDPOINT, ep_buf.as_mut_ptr().cast(), &mut ep_sz);
     let ep_end = if ep_sz > 0 && ep_buf[ep_sz - 1] == 0 {
         ep_sz - 1

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -35,13 +35,13 @@ soak = []
 
 [dependencies]
 blake3 = { version = "1.8", optional = true }
-bytes = "1.11.0"
+bytes = "1.12.0"
 chacha20-blake3 = { version = "0.10.0", optional = true }
 crypto_box = { version = "0.9", features = ["std"], optional = true }
 crypto_secretbox = { version = "0.1", optional = true }
 subtle = { version = "2.6", optional = true }
 x25519-dalek = { version = "2", features = ["static_secrets", "getrandom"], optional = true }
-lz4rip = { version = "0.8", default-features = false, features = ["std"], optional = true }
+lz4rip = { version = "0.9", default-features = false, features = ["std"], optional = true }
 rand = "0.10"
 patricia_tree = "0.10"
 smallvec = { version = "1", features = ["const_generics", "union"] }

--- a/omq-proto/src/proto/mechanism/mod.rs
+++ b/omq-proto/src/proto/mechanism/mod.rs
@@ -368,10 +368,7 @@ impl SecurityMechanism {
             #[cfg(feature = "blake3zmq")]
             Self::Blake3Zmq(m) => m.start(out, our_props, our_greeting, peer_greeting),
             #[cfg(feature = "plain")]
-            Self::Plain(m) => {
-                m.start(out, our_props);
-                Ok(())
-            }
+            Self::Plain(m) => m.start(out, our_props),
         }
     }
 

--- a/omq-proto/src/proto/mechanism/plain.rs
+++ b/omq-proto/src/proto/mechanism/plain.rs
@@ -69,10 +69,17 @@ impl PlainMechanism {
         })
     }
 
-    pub(crate) fn start(&mut self, out: &mut Vec<Command>, our_props: PeerProperties) {
+    pub(crate) fn start(
+        &mut self,
+        out: &mut Vec<Command>,
+        our_props: PeerProperties,
+    ) -> Result<()> {
         match self {
             Self::Client(c) => c.start(out, our_props),
-            Self::Server(s) => s.start(our_props),
+            Self::Server(s) => {
+                s.start(our_props);
+                Ok(())
+            }
         }
     }
 
@@ -92,13 +99,14 @@ impl PlainMechanism {
 }
 
 impl PlainClient {
-    fn start(&mut self, out: &mut Vec<Command>, our_props: PeerProperties) {
+    fn start(&mut self, out: &mut Vec<Command>, our_props: PeerProperties) -> Result<()> {
         self.our_props = our_props;
         out.push(Command::Unknown {
             name: Bytes::from_static(b"HELLO"),
-            body: encode_hello(&self.username, &self.password),
+            body: encode_hello(&self.username, &self.password)?,
         });
         self.state = PlainClientState::AwaitingWelcome;
+        Ok(())
     }
 
     fn on_command(&mut self, cmd: Command, out: &mut Vec<Command>) -> Result<MechanismStep> {
@@ -182,7 +190,17 @@ impl PlainServer {
     }
 }
 
-fn encode_hello(username: &str, password: &str) -> Bytes {
+fn encode_hello(username: &str, password: &str) -> Result<Bytes> {
+    if username.len() > 255 {
+        return Err(Error::HandshakeFailed(
+            "PLAIN username exceeds 255 bytes".into(),
+        ));
+    }
+    if password.len() > 255 {
+        return Err(Error::HandshakeFailed(
+            "PLAIN password exceeds 255 bytes".into(),
+        ));
+    }
     let u = username.as_bytes();
     let p = password.as_bytes();
     let mut buf = BytesMut::with_capacity(2 + u.len() + p.len());
@@ -190,7 +208,7 @@ fn encode_hello(username: &str, password: &str) -> Bytes {
     buf.put_slice(u);
     buf.put_u8(p.len() as u8);
     buf.put_slice(p);
-    buf.freeze()
+    Ok(buf.freeze())
 }
 
 fn decode_hello(body: &[u8]) -> Result<(String, String)> {
@@ -226,7 +244,7 @@ mod tests {
 
     #[test]
     fn hello_encode_decode_roundtrip() {
-        let wire = encode_hello("alice", "s3cret");
+        let wire = encode_hello("alice", "s3cret").unwrap();
         let (u, p) = decode_hello(&wire).unwrap();
         assert_eq!(u, "alice");
         assert_eq!(p, "s3cret");
@@ -234,7 +252,7 @@ mod tests {
 
     #[test]
     fn hello_empty_credentials() {
-        let wire = encode_hello("", "");
+        let wire = encode_hello("", "").unwrap();
         let (u, p) = decode_hello(&wire).unwrap();
         assert!(u.is_empty());
         assert!(p.is_empty());
@@ -262,7 +280,8 @@ mod tests {
         m.start(
             &mut out,
             PeerProperties::default().with_socket_type(SocketType::Push),
-        );
+        )
+        .unwrap();
         assert_eq!(out.len(), 1);
         match &out[0] {
             Command::Unknown { name, body } => {
@@ -282,7 +301,8 @@ mod tests {
         m.start(
             &mut out,
             PeerProperties::default().with_socket_type(SocketType::Pull),
-        );
+        )
+        .unwrap();
         assert!(out.is_empty());
     }
 
@@ -296,14 +316,18 @@ mod tests {
         let mut c_out = Vec::new();
         let mut s_out = Vec::new();
 
-        client.start(
-            &mut c_out,
-            PeerProperties::default().with_socket_type(SocketType::Push),
-        );
-        server.start(
-            &mut s_out,
-            PeerProperties::default().with_socket_type(SocketType::Pull),
-        );
+        client
+            .start(
+                &mut c_out,
+                PeerProperties::default().with_socket_type(SocketType::Push),
+            )
+            .unwrap();
+        server
+            .start(
+                &mut s_out,
+                PeerProperties::default().with_socket_type(SocketType::Pull),
+            )
+            .unwrap();
         assert_eq!(c_out.len(), 1); // HELLO
         assert!(s_out.is_empty());
 
@@ -341,14 +365,16 @@ mod tests {
     fn auth_reject_sends_error() {
         let mut server = PlainMechanism::new_server(Authenticator::new(|_| false));
         let mut s_out = Vec::new();
-        server.start(
-            &mut s_out,
-            PeerProperties::default().with_socket_type(SocketType::Pull),
-        );
+        server
+            .start(
+                &mut s_out,
+                PeerProperties::default().with_socket_type(SocketType::Pull),
+            )
+            .unwrap();
 
         let hello = Command::Unknown {
             name: Bytes::from_static(b"HELLO"),
-            body: encode_hello("bad", "creds"),
+            body: encode_hello("bad", "creds").unwrap(),
         };
         let err = server.on_command(hello, &mut s_out).unwrap_err();
         assert!(matches!(err, Error::HandshakeFailed(_)));
@@ -357,13 +383,33 @@ mod tests {
     }
 
     #[test]
+    fn encode_hello_rejects_overlong_username() {
+        let long = "x".repeat(256);
+        assert!(encode_hello(&long, "ok").is_err());
+    }
+
+    #[test]
+    fn encode_hello_rejects_overlong_password() {
+        let long = "x".repeat(256);
+        assert!(encode_hello("ok", &long).is_err());
+    }
+
+    #[test]
+    fn encode_hello_accepts_max_length() {
+        let max = "x".repeat(255);
+        assert!(encode_hello(&max, &max).is_ok());
+    }
+
+    #[test]
     fn unexpected_command_rejected() {
         let mut client = PlainMechanism::new_client("u".into(), "p".into());
         let mut out = Vec::new();
-        client.start(
-            &mut out,
-            PeerProperties::default().with_socket_type(SocketType::Push),
-        );
+        client
+            .start(
+                &mut out,
+                PeerProperties::default().with_socket_type(SocketType::Push),
+            )
+            .unwrap();
         out.clear();
 
         let bogus = Command::Unknown {

--- a/omq-proto/src/proto/transform/lz4.rs
+++ b/omq-proto/src/proto/transform/lz4.rs
@@ -1064,8 +1064,8 @@ mod tests {
         assert_eq!(out.part_bytes(0).unwrap().len(), size);
         assert_eq!(&out.part_bytes(0).unwrap()[..8], &plain[..8]);
         assert_eq!(
-            &out.part_bytes(0).unwrap()[LZ4M_BLOCK_SIZE..LZ4M_BLOCK_SIZE + 8],
-            &plain[LZ4M_BLOCK_SIZE..LZ4M_BLOCK_SIZE + 8],
+            &out.part_bytes(0).unwrap()[LZ4M_BLOCK_SIZE..size],
+            &plain[LZ4M_BLOCK_SIZE..size],
         );
     }
 
@@ -1094,8 +1094,8 @@ mod tests {
         assert_eq!(out.part_bytes(0).unwrap().len(), size);
         assert_eq!(&out.part_bytes(0).unwrap()[..8], &plain[..8]);
         assert_eq!(
-            &out.part_bytes(0).unwrap()[LZ4M_BLOCK_SIZE..LZ4M_BLOCK_SIZE + 8],
-            &plain[LZ4M_BLOCK_SIZE..LZ4M_BLOCK_SIZE + 8],
+            &out.part_bytes(0).unwrap()[LZ4M_BLOCK_SIZE..size],
+            &plain[LZ4M_BLOCK_SIZE..size],
         );
     }
 

--- a/omq-proto/src/proto/ws_handshake.rs
+++ b/omq-proto/src/proto/ws_handshake.rs
@@ -212,7 +212,7 @@ fn sha1(data: &[u8]) -> [u8; 20] {
     }
     padded.extend_from_slice(&bit_len.to_be_bytes());
 
-    for chunk in padded.chunks_exact(64) {
+    for chunk in padded.as_chunks::<64>().0 {
         let mut w = [0u32; 80];
         for (i, word) in w[..16].iter_mut().enumerate() {
             *word = u32::from_be_bytes(chunk[i * 4..i * 4 + 4].try_into().unwrap());

--- a/omq-proto/src/proto/z85.rs
+++ b/omq-proto/src/proto/z85.rs
@@ -36,7 +36,7 @@ pub fn encode(data: &[u8]) -> Result<String> {
     }
     let out_len = data.len() / 4 * 5;
     let mut out = Vec::with_capacity(out_len);
-    for chunk in data.chunks_exact(4) {
+    for chunk in data.as_chunks::<4>().0 {
         let value = u64::from(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
         // 5 base-85 digits, most-significant first.
         let d4 = (value / 85u64.pow(4)) % 85;
@@ -68,7 +68,7 @@ pub fn decode(s: &str) -> Result<Vec<u8>> {
     }
     let out_len = bytes.len() / 5 * 4;
     let mut out = Vec::with_capacity(out_len);
-    for chunk in bytes.chunks_exact(5) {
+    for chunk in bytes.as_chunks::<5>().0 {
         let mut value: u64 = 0;
         for &c in chunk {
             let d = DECODER[c as usize];

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -35,7 +35,7 @@ soak = []
 omq-proto = { path = "../omq-proto", version = "0.18.0", default-features = false }
 yring = { path = "../yring", version = "0.3.2" }
 async-channel = "2.5.0"
-bytes = "1.11.0"
+bytes = "1.12.0"
 concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 rand = "0.10"

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -306,9 +306,7 @@ impl Submitter {
                     interval = (ARENA_YIELD_BYTES / wire_size.max(1)).clamp(16, 256) as u32;
                 } else {
                     if self.xpub_nodrop {
-                        while !targets_have_space(&targets) {
-                            tokio::task::yield_now().await;
-                        }
+                        wait_for_targets_space(&targets).await;
                     }
                     dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
                     interval = yield_interval(targets.len());
@@ -323,9 +321,7 @@ impl Submitter {
 
         let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop {
-            while !targets_have_space(&targets) {
-                tokio::task::yield_now().await;
-            }
+            wait_for_targets_space(&targets).await;
         }
         dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
         let interval = yield_interval(targets.len());
@@ -578,9 +574,35 @@ impl FanOutSend {
 
 fn targets_have_space(targets: &[PeerSend]) -> bool {
     targets.iter().all(|t| match t {
-        PeerSend::Wire { slot, .. } => slot.has_space(),
+        PeerSend::Wire { slot, .. } => slot.has_space() || slot.dead.load(Ordering::Acquire),
         PeerSend::Inbox(_) => true,
     })
+}
+
+async fn wait_for_targets_space(targets: &[PeerSend]) {
+    while !targets_have_space(targets) {
+        let notified = targets.iter().find_map(|t| match t {
+            PeerSend::Wire { slot, .. }
+                if !slot.has_space() && !slot.dead.load(Ordering::Acquire) =>
+            {
+                Some(slot.space_available.notified())
+            }
+            _ => None,
+        });
+        match notified {
+            Some(notified) => {
+                if targets_have_space(targets) {
+                    return;
+                }
+                tokio::select! {
+                    biased;
+                    () = notified => {}
+                    () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+                }
+            }
+            None => return,
+        }
+    }
 }
 
 fn dispatch_encoded(

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -249,3 +249,39 @@ async fn pub_tcp_subscriber_churn() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
+
+#[tokio::test]
+async fn xpub_nodrop_delivers_all_under_backpressure() {
+    let mut opts = Options::default().send_hwm(2);
+    opts.xpub_nodrop = true;
+    let pub_ = Socket::new(SocketType::XPub, opts);
+    let port = test_support::bind_loopback(&pub_).await;
+
+    let sub = Socket::new(SocketType::Sub, Options::default().recv_hwm(2));
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    sub.connect(test_support::tcp_loopback(port)).await.unwrap();
+    test_support::wait_for_subscribe(&pub_).await;
+
+    let count = 10u32;
+    let sender = tokio::spawn({
+        let pub_ = pub_.clone();
+        async move {
+            for i in 0..count {
+                pub_.send(Message::single(i.to_le_bytes().to_vec()))
+                    .await
+                    .unwrap();
+            }
+        }
+    });
+
+    for i in 0..count {
+        let m = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+            .await
+            .expect("recv timed out")
+            .unwrap();
+        let body = m.part_bytes(0).unwrap();
+        assert_eq!(u32::from_le_bytes(body[..4].try_into().unwrap()), i);
+    }
+
+    sender.await.unwrap();
+}

--- a/tests/interop/Cargo.toml
+++ b/tests/interop/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 omq-proto = { path = "../../omq-proto" }
 omq-tokio = { path = "../../omq-tokio" }
 omq-compio = { path = "../../omq-compio", default-features = false }
-bytes = "1.11.0"
+bytes = "1.12.0"
 tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 compio = { version = "0.19.1", features = ["macros", "net", "io", "bytes", "runtime", "io-uring", "time", "sync"] }
 


### PR DESCRIPTION
- validate PLAIN username/password length in `encode_hello` (reject >255 bytes instead of silent `as u8` truncation)
- return EINVAL for null/short optval in `zmq_setsockopt` (`read_i32`/`read_i64`/`read_string`/`read_key` now return `Option<T>`)
- fix `PollWaiter` ready_count to count items, not event types (latent bug, unreachable due to `check_immediate` early return)
- replace xpub_nodrop `yield_now()` spin with notify-based wait (mirrors `PeerSend::send` pattern); fix `targets_have_space` to treat dead slots as ready
- add SAFETY comment on compio `Socket::Drop` `Arc::strong_count` check
- strengthen `LocalCell` `unsafe impl Sync` safety documentation
- null dangling `r.ptr`/`r.size` in `zmq_msg_send` after `Box::from_raw` reclaim
- fix LZ4M 2 GiB test slice bounds (test indexed 8 bytes past end of 1-byte second block)
- fix pyomq README: add missing `blake3zmq` feature, correct socket type count (20, not 19)