### PR TITLE
Modern Rust audit: cleanup, safety, ergonomics

### DIFF
--- a/omq-compio/src/local_cell.rs
+++ b/omq-compio/src/local_cell.rs
@@ -30,6 +30,11 @@ impl<T> LocalCell<T> {
         }
     }
 
+    // Callers must not hold overlapping borrows. The cooperative runtime
+    // prevents preemption, so this only happens if get() is called while
+    // a previous &mut T is still live in the same call stack. A guard-based
+    // API (like EncodedQueueCell) would enforce this statically but would
+    // require changing all 28 call sites.
     #[inline]
     #[expect(clippy::mut_from_ref)]
     pub(crate) fn get(&self) -> &mut T {

--- a/omq-compio/src/monitor.rs
+++ b/omq-compio/src/monitor.rs
@@ -3,6 +3,9 @@
 //! `Socket::monitor()` returns a [`MonitorStream`] that delivers
 //! [`MonitorEvent`]s. Multiple monitors can be active simultaneously.
 //!
+// NOTE: MonitorPublisher logic is duplicated with omq-tokio. It is
+// runtime-agnostic and could theoretically live in omq-proto, but the
+// cross-crate refactor is not worth the churn given how stable this code is.
 //! Implementation: each subscriber gets a bounded `flume` channel plus
 //! a lagged counter. Publishing iterates subscribers and `try_send`s;
 //! when a subscriber's queue is full the new event is dropped and the

--- a/omq-compio/tests/blake3zmq.rs
+++ b/omq-compio/tests/blake3zmq.rs
@@ -51,7 +51,7 @@ async fn blake3zmq_push_pull_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over blake3zmq"[..]);
+    assert_eq!(m, Message::single("hello over blake3zmq"));
 }
 
 // =====================================================================
@@ -81,13 +81,13 @@ async fn blake3zmq_req_rep() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
     rep.send(Message::single("a")).await.unwrap();
     let a = compio::time::timeout(Duration::from_secs(5), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 #[compio::test]
@@ -116,8 +116,7 @@ async fn blake3zmq_dealer_router() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hi"]));
 }
 
 #[compio::test]
@@ -142,7 +141,7 @@ async fn blake3zmq_pub_sub() {
     for _ in 0..30 {
         let _ = p.send(Message::single("hello")).await;
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(50), s.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+            assert_eq!(m, Message::single("hello"));
             return;
         }
     }

--- a/omq-compio/tests/broker.rs
+++ b/omq-compio/tests/broker.rs
@@ -51,14 +51,14 @@ async fn router_dealer_rep_single_cycle() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(work.part_bytes(0).unwrap(), &b"work"[..]);
+    assert_eq!(work, Message::single("work"));
     rep.send(Message::single("done")).await.unwrap();
 
     let reply = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"done"[..]);
+    assert_eq!(reply, Message::single("done"));
 
     broker.await.unwrap();
 }

--- a/omq-compio/tests/connect_before_bind.rs
+++ b/omq-compio/tests/connect_before_bind.rs
@@ -68,7 +68,7 @@ async fn push_pull_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+    assert_eq!(m, Message::single("late"));
 }
 
 #[compio::test]
@@ -101,14 +101,14 @@ async fn req_rep_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
 
     rep.send(Message::single("a")).await.unwrap();
     let a = compio::time::timeout(TIMEOUT, req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 #[compio::test]
@@ -141,14 +141,14 @@ async fn pair_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-a"[..]);
+    assert_eq!(m, Message::single("from-a"));
 
     b.send(Message::single("from-b")).await.unwrap();
     let m = compio::time::timeout(TIMEOUT, a.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-b"[..]);
+    assert_eq!(m, Message::single("from-b"));
 }
 
 #[compio::test]
@@ -181,7 +181,7 @@ async fn pub_sub_connect_before_bind(ep: Endpoint) {
     loop {
         pub_.send(Message::single("x.hit")).await.unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"x.hit"[..]);
+            assert_eq!(m, Message::single("x.hit"));
             break;
         }
         assert!(
@@ -196,7 +196,7 @@ async fn pub_sub_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x.second"[..]);
+    assert_eq!(m, Message::single("x.second"));
 }
 
 #[compio::test]
@@ -232,8 +232,7 @@ async fn dealer_router_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hello"]));
 
     router
         .send(Message::multipart([
@@ -246,7 +245,7 @@ async fn dealer_router_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"world"[..]);
+    assert_eq!(m, Message::single("world"));
 }
 
 #[compio::test]
@@ -282,8 +281,7 @@ async fn client_server_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
 
     server
         .send(Message::multipart([
@@ -296,7 +294,7 @@ async fn client_server_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(m, Message::single("pong"));
 }
 
 #[compio::test]
@@ -329,7 +327,7 @@ async fn scatter_gather_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+    assert_eq!(m, Message::single("late"));
 }
 
 #[compio::test]
@@ -361,8 +359,7 @@ async fn radio_dish_connect_before_bind(ep: Endpoint) {
     loop {
         radio.send(Message::multipart(["w", "hit"])).await.unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
-            assert_eq!(m.part_bytes(1).unwrap(), &b"hit"[..]);
+            assert_eq!(m, Message::multipart(["w", "hit"]));
             break;
         }
         assert!(
@@ -383,8 +380,7 @@ async fn radio_dish_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"second"[..]);
+    assert_eq!(m, Message::multipart(["w", "second"]));
 }
 
 #[compio::test]
@@ -420,8 +416,7 @@ async fn peer_connect_before_bind(ep: Endpoint) {
     loop {
         b.send(Message::multipart(["pa", "from-b"])).await.unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), a.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
-            assert_eq!(m.part_bytes(1).unwrap(), &b"from-b"[..]);
+            assert_eq!(m, Message::multipart(["pb", "from-b"]));
             break;
         }
         assert!(
@@ -435,8 +430,7 @@ async fn peer_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pa"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"from-a"[..]);
+    assert_eq!(m, Message::multipart(["pa", "from-a"]));
 }
 
 #[compio::test]
@@ -469,14 +463,14 @@ async fn channel_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-a"[..]);
+    assert_eq!(m, Message::single("from-a"));
 
     b.send(Message::single("from-b")).await.unwrap();
     let m = compio::time::timeout(TIMEOUT, a.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-b"[..]);
+    assert_eq!(m, Message::single("from-b"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/connection_errors.rs
+++ b/omq-compio/tests/connection_errors.rs
@@ -51,7 +51,7 @@ async fn server_survives_pre_handshake_drop() {
         .await
         .expect("recv timed out after rude clients")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"alive");
+    assert_eq!(m, Message::single("alive"));
 }
 
 #[compio::test]
@@ -71,7 +71,7 @@ async fn server_survives_mid_session_abrupt_drop() {
             .await
             .expect("recv timed out for first client")
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"first");
+        assert_eq!(m, Message::single("first"));
         // push1 drops here — abrupt half-close.
     }
     compio::time::sleep(Duration::from_millis(50)).await;
@@ -85,7 +85,7 @@ async fn server_survives_mid_session_abrupt_drop() {
         .await
         .expect("recv timed out after abrupt drop")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"second");
+    assert_eq!(m, Message::single("second"));
 }
 
 #[compio::test]
@@ -118,5 +118,5 @@ async fn abrupt_reset_mid_greeting_does_not_wedge_server() {
         .await
         .expect("recv timed out after partial-greeting peer")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"ok");
+    assert_eq!(m, Message::single("ok"));
 }

--- a/omq-compio/tests/coverage_matrix.rs
+++ b/omq-compio/tests/coverage_matrix.rs
@@ -49,7 +49,7 @@ async fn push_pull_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn push_pull_roundtrip_tcp() {
@@ -62,7 +62,7 @@ async fn push_pull_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn req_rep_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -75,13 +75,13 @@ async fn req_rep_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
     rep.send(Message::single("a")).await.unwrap();
     let a = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 async fn req_rep_roundtrip_tcp() {
@@ -94,13 +94,13 @@ async fn req_rep_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
     rep.send(Message::single("a")).await.unwrap();
     let a = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 async fn dealer_router_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -116,8 +116,7 @@ async fn dealer_router_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hi"]));
 }
 
 async fn dealer_router_roundtrip_tcp() {
@@ -133,8 +132,7 @@ async fn dealer_router_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hi"]));
 }
 
 async fn pair_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -147,7 +145,7 @@ async fn pair_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x"[..]);
+    assert_eq!(m, Message::single("x"));
 }
 
 async fn pair_roundtrip_tcp() {
@@ -160,7 +158,7 @@ async fn pair_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x"[..]);
+    assert_eq!(m, Message::single("x"));
 }
 
 async fn pub_sub_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -173,7 +171,7 @@ async fn pub_sub_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
     for _ in 0..30 {
         let _ = p.send(Message::single("hello")).await;
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(50), s.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+            assert_eq!(m, Message::single("hello"));
             return;
         }
     }
@@ -190,7 +188,7 @@ async fn pub_sub_roundtrip_tcp() {
     for _ in 0..30 {
         let _ = p.send(Message::single("hello")).await;
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(50), s.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+            assert_eq!(m, Message::single("hello"));
             return;
         }
     }
@@ -210,8 +208,7 @@ async fn client_server_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
 }
 
 async fn client_server_roundtrip_tcp() {
@@ -227,8 +224,7 @@ async fn client_server_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
 }
 
 async fn scatter_gather_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -241,7 +237,7 @@ async fn scatter_gather_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"m"[..]);
+    assert_eq!(m, Message::single("m"));
 }
 
 async fn scatter_gather_roundtrip_tcp() {
@@ -254,7 +250,7 @@ async fn scatter_gather_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"m"[..]);
+    assert_eq!(m, Message::single("m"));
 }
 
 async fn channel_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -267,7 +263,7 @@ async fn channel_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn channel_roundtrip_tcp() {
@@ -280,7 +276,7 @@ async fn channel_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn peer_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
@@ -300,8 +296,7 @@ async fn peer_roundtrip(bind_ep: Endpoint, connect_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi a"[..]);
+    assert_eq!(m, Message::multipart(["pb", "hi a"]));
 }
 
 async fn peer_roundtrip_tcp() {
@@ -321,8 +316,7 @@ async fn peer_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi a"[..]);
+    assert_eq!(m, Message::multipart(["pb", "hi a"]));
 }
 
 // =====================================================================
@@ -484,7 +478,7 @@ async fn send_before_connect_ipc() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"early"[..]);
+    assert_eq!(m, Message::single("early"));
 }
 
 #[compio::test]
@@ -499,5 +493,5 @@ async fn send_before_connect_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"early"[..]);
+    assert_eq!(m, Message::single("early"));
 }

--- a/omq-compio/tests/curve.rs
+++ b/omq-compio/tests/curve.rs
@@ -48,7 +48,7 @@ async fn curve_push_pull_roundtrip_over_ipc() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over curve"[..]);
+    assert_eq!(m, Message::single("hello over curve"));
 }
 
 #[compio::test]
@@ -82,10 +82,7 @@ async fn curve_multipart_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.len(), 3);
-    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
-    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+    assert_eq!(m, Message::multipart(["a", "bb", "ccc"]));
 }
 
 #[compio::test]

--- a/omq-compio/tests/heartbeat.rs
+++ b/omq-compio/tests/heartbeat.rs
@@ -53,7 +53,7 @@ async fn heartbeat_keeps_idle_connection_alive() {
         .await
         .expect("recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"first"[..]);
+    assert_eq!(m, Message::single("first"));
 
     // Idle window covers several heartbeat intervals - PINGs fire
     // on both sides, codec PONGs them, neither side observes
@@ -65,7 +65,7 @@ async fn heartbeat_keeps_idle_connection_alive() {
         .await
         .expect("recv timeout post-idle")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"after-idle"[..]);
+    assert_eq!(m, Message::single("after-idle"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/ipc_basic.rs
+++ b/omq-compio/tests/ipc_basic.rs
@@ -28,7 +28,7 @@ async fn ipc_push_pull_single_message() {
         .await
         .expect("recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"over-ipc"[..]);
+    assert_eq!(m, Message::single("over-ipc"));
 }
 
 #[compio::test]
@@ -54,7 +54,7 @@ async fn ipc_connect_before_bind() {
         .await
         .expect("recv timed out after late bind")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late-bind"[..]);
+    assert_eq!(m, Message::single("late-bind"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/ipv6.rs
+++ b/omq-compio/tests/ipv6.rs
@@ -49,7 +49,7 @@ async fn ipv6_push_pull() {
         .await
         .expect("ipv6 push/pull timed out")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello v6"[..]);
+    assert_eq!(m, Message::single("hello v6"));
 }
 
 #[compio::test]
@@ -67,14 +67,14 @@ async fn ipv6_req_rep() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     let r = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[compio::test]
@@ -92,7 +92,7 @@ async fn ipv6_pub_sub() {
     loop {
         let _ = pub_.send(Message::single("v6msg")).await;
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(20), sub.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"v6msg"[..]);
+            assert_eq!(m, Message::single("v6msg"));
             return;
         }
         assert!(
@@ -120,6 +120,5 @@ async fn ipv6_dealer_router() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"v6-cli"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"v6-msg"[..]);
+    assert_eq!(m, Message::multipart(["v6-cli", "v6-msg"]));
 }

--- a/omq-compio/tests/lz4_tcp.rs
+++ b/omq-compio/tests/lz4_tcp.rs
@@ -47,7 +47,7 @@ async fn lz4_small_message_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4"[..]);
+    assert_eq!(m, Message::single("hello over lz4"));
 }
 
 #[compio::test]
@@ -81,8 +81,5 @@ async fn lz4_multipart_message_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.len(), 3);
-    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
-    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+    assert_eq!(m, Message::multipart(["a", "bb", "ccc"]));
 }

--- a/omq-compio/tests/lz4_ws.rs
+++ b/omq-compio/tests/lz4_ws.rs
@@ -77,7 +77,7 @@ async fn lz4_ws_small_message_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+ws"[..]);
+    assert_eq!(m, Message::single("hello over lz4+ws"));
 }
 
 #[compio::test]
@@ -112,10 +112,7 @@ async fn lz4_ws_multipart_message_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.len(), 3);
-    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
-    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+    assert_eq!(m, Message::multipart(["a", "bb", "ccc"]));
 }
 
 #[compio::test]
@@ -190,14 +187,14 @@ async fn lz4_ws_req_rep() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"question"[..]);
+    assert_eq!(q, Message::single("question"));
 
     rep.send(Message::single("answer")).await.unwrap();
     let a = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"answer"[..]);
+    assert_eq!(a, Message::single("answer"));
 }
 
 // ---- ROUTER / DEALER ----
@@ -220,9 +217,7 @@ async fn lz4_ws_router_dealer_identity_routing() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.len(), 2);
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alice"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(got, Message::multipart(["alice", "hello"]));
 
     router
         .send(Message::multipart(["alice", "reply"]))
@@ -232,7 +227,7 @@ async fn lz4_ws_router_dealer_identity_routing() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply"[..]);
+    assert_eq!(r, Message::single("reply"));
 }
 
 // ---- PUB / SUB ----
@@ -265,15 +260,13 @@ async fn lz4_ws_pub_sub_prefix_filter() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap(), &b"news.sports"[..]);
-    assert_eq!(m1.part_bytes(1).unwrap(), &b"ball scores"[..]);
+    assert_eq!(m1, Message::multipart(["news.sports", "ball scores"]));
 
     let m2 = compio::time::timeout(Duration::from_secs(2), subscriber.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m2.part_bytes(0).unwrap(), &b"news.tech"[..]);
-    assert_eq!(m2.part_bytes(1).unwrap(), &b"rust 2.0"[..]);
+    assert_eq!(m2, Message::multipart(["news.tech", "rust 2.0"]));
 
     let nothing = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(
@@ -396,7 +389,7 @@ async fn lz4_ws_reconnect_after_server_restart() {
         .await
         .expect("recv timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"before"[..]);
+    assert_eq!(msg, Message::single("before"));
 
     drop(push);
     pull1.close().await.unwrap();
@@ -421,7 +414,7 @@ async fn lz4_ws_reconnect_after_server_restart() {
         .await
         .expect("recv after restart timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"after"[..]);
+    assert_eq!(msg, Message::single("after"));
 }
 
 // ---- lz4+wss (TLS) ----
@@ -487,7 +480,7 @@ async fn lz4_wss_push_pull() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over lz4+wss"[..]);
+    assert_eq!(m, Message::single("hello over lz4+wss"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/monitor.rs
+++ b/omq-compio/tests/monitor.rs
@@ -212,7 +212,7 @@ async fn pub_sees_disconnect_after_message_exchange() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello"[..]);
+    assert_eq!(msg, Message::single("hello"));
 
     subscriber.close().await.unwrap();
 
@@ -239,13 +239,13 @@ async fn req_sees_disconnect_after_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(request.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(request, Message::single("ping"));
     rep.send(Message::single("pong")).await.unwrap();
     let reply = compio::time::timeout(Duration::from_millis(500), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(reply, Message::single("pong"));
 
     rep.close().await.unwrap();
 

--- a/omq-compio/tests/options_polish.rs
+++ b/omq-compio/tests/options_polish.rs
@@ -124,7 +124,7 @@ async fn try_recv_returns_buffered_message() {
     // Yield so the inproc frame is forwarded through in_tx/in_rx.
     let _ = compio::runtime::spawn(async {}).await;
     let msg = pull.try_recv().unwrap();
-    assert_eq!(&*msg.part_bytes(0).unwrap(), b"hello");
+    assert_eq!(msg, Message::single("hello"));
 }
 
 #[compio::test]
@@ -139,7 +139,7 @@ async fn try_send_no_peers_returns_would_block() {
         Err(TrySendError::Full(m)) => m,
         other => panic!("expected TrySendError::Full, got {other:?}"),
     };
-    assert_eq!(&*returned.part_bytes(0).unwrap(), b"x");
+    assert_eq!(returned, Message::single("x"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/plain.rs
+++ b/omq-compio/tests/plain.rs
@@ -53,7 +53,7 @@ async fn plain_push_pull_roundtrip_over_ipc() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over plain"[..]);
+    assert_eq!(m, Message::single("hello over plain"));
 }
 
 #[compio::test]
@@ -86,10 +86,7 @@ async fn plain_multipart_roundtrip_tcp() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.len(), 3);
-    assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"bb"[..]);
-    assert_eq!(m.part_bytes(2).unwrap(), &b"ccc"[..]);
+    assert_eq!(m, Message::multipart(["a", "bb", "ccc"]));
 }
 
 #[compio::test]
@@ -146,7 +143,7 @@ async fn plain_authenticator_callback_runs() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(m, Message::single("hi"));
     assert!(saw.load(Ordering::SeqCst), "authenticator must run");
 }
 
@@ -171,14 +168,14 @@ async fn plain_req_rep() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
 
     rep.send(Message::single("a")).await.unwrap();
     let a = compio::time::timeout(Duration::from_secs(5), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 #[compio::test]
@@ -205,8 +202,7 @@ async fn plain_dealer_router() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hi"]));
 }
 
 #[compio::test]
@@ -229,7 +225,7 @@ async fn plain_pub_sub() {
     for _ in 0..30 {
         let _ = p.send(Message::single("hello")).await;
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(50), s.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+            assert_eq!(m, Message::single("hello"));
             return;
         }
     }

--- a/omq-compio/tests/pub_sub.rs
+++ b/omq-compio/tests/pub_sub.rs
@@ -43,9 +43,8 @@ async fn pub_sub_simple_prefix_match() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap(), &b"news.sports"[..]);
-    assert_eq!(got1.part_bytes(1).unwrap(), &b"ball scores"[..]);
-    assert_eq!(got2.part_bytes(0).unwrap(), &b"news.tech"[..]);
+    assert_eq!(got1, Message::multipart(["news.sports", "ball scores"]));
+    assert_eq!(got2, Message::multipart(["news.tech", "rust 1.85"]));
 
     let third = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(third.is_err(), "non-matching message must not be delivered");
@@ -75,7 +74,7 @@ async fn pub_sub_late_subscriber_misses_earlier() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"post-subscribe"[..]);
+    assert_eq!(m, Message::single("post-subscribe"));
 
     let other = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(other.is_err());
@@ -140,7 +139,7 @@ async fn pub_sub_unsubscribe() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"apricot"[..]);
+    assert_eq!(m, Message::single("apricot"));
 
     let other = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(other.is_err());
@@ -164,7 +163,7 @@ async fn sub_replays_subscriptions_on_new_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x.hello"[..]);
+    assert_eq!(m, Message::single("x.hello"));
     let other = compio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(other.is_err());
 }

--- a/omq-compio/tests/push_pull.rs
+++ b/omq-compio/tests/push_pull.rs
@@ -37,9 +37,9 @@ async fn push_pull_single_peer() {
     let m1 = pull.recv().await.unwrap();
     let m2 = pull.recv().await.unwrap();
     let m3 = pull.recv().await.unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m2.part_bytes(0).unwrap(), &b"b"[..]);
-    assert_eq!(m3.part_bytes(0).unwrap(), &b"c"[..]);
+    assert_eq!(m1, Message::single("a"));
+    assert_eq!(m2, Message::single("b"));
+    assert_eq!(m3, Message::single("c"));
 }
 
 #[compio::test]
@@ -258,7 +258,7 @@ async fn push_delivers_to_alive_peer_after_dead_slot() {
             .await
             .expect("pull1 recv timed out")
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"first");
+        assert_eq!(m, Message::single("first"));
         // pull1 drops here — slot 0 becomes dead.
     }
     compio::time::sleep(Duration::from_millis(500)).await;
@@ -273,7 +273,7 @@ async fn push_delivers_to_alive_peer_after_dead_slot() {
         .await
         .expect("pull2 did not receive message after dead slot")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"second");
+    assert_eq!(m, Message::single("second"));
 }
 
 /// TCP PUSH/PULL with peer churn: PULL connects, receives, disconnects;

--- a/omq-compio/tests/radio_dish.rs
+++ b/omq-compio/tests/radio_dish.rs
@@ -41,10 +41,8 @@ async fn radio_to_dish_with_matching_group() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m1.part_bytes(1).unwrap(), &b"sunny"[..]);
-    assert_eq!(m2.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m2.part_bytes(1).unwrap(), &b"rain"[..]);
+    assert_eq!(m1, Message::multipart(["weather", "sunny"]));
+    assert_eq!(m2, Message::multipart(["weather", "rain"]));
 
     let third = compio::time::timeout(Duration::from_millis(100), dish.recv()).await;
     assert!(third.is_err(), "non-joined group must not be delivered");
@@ -77,7 +75,7 @@ async fn dish_join_replays_to_new_radios() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap(), &b"joined"[..]);
+    assert_eq!(m, Message::multipart(["late", "joined"]));
 }
 
 #[compio::test]
@@ -98,7 +96,7 @@ async fn dish_leave_stops_delivery() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap(), &b"first"[..]);
+    assert_eq!(m, Message::multipart(["g", "first"]));
 
     dish.leave("g").await.unwrap();
     compio::time::sleep(Duration::from_millis(50)).await;

--- a/omq-compio/tests/reconnect.rs
+++ b/omq-compio/tests/reconnect.rs
@@ -49,7 +49,7 @@ async fn connect_retries_until_listener_appears() {
         .await
         .expect("recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"eventually"[..]);
+    assert_eq!(m, Message::single("eventually"));
 }
 
 #[compio::test]
@@ -74,7 +74,7 @@ async fn reconnect_after_peer_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(&*m.part_bytes(0).unwrap(), b"before");
+    assert_eq!(m, Message::single("before"));
 
     // Peer restarts: close cleanly. close() cancels listener tasks
     // immediately so the OS port is freed as the runtime processes
@@ -99,7 +99,7 @@ async fn reconnect_after_peer_restart() {
         .await
         .expect("recv after peer restart timed out")
         .unwrap();
-    assert_eq!(&*m.part_bytes(0).unwrap(), b"after");
+    assert_eq!(m, Message::single("after"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/reconnect_all_types.rs
+++ b/omq-compio/tests/reconnect_all_types.rs
@@ -48,7 +48,7 @@ async fn req_rep_reconnect_after_server_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"ping1");
+    assert_eq!(got, Message::single("ping1"));
     rep1.send(Message::single("pong1")).await.unwrap();
     compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
@@ -63,13 +63,13 @@ async fn req_rep_reconnect_after_server_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"ping2");
+    assert_eq!(got2, Message::single("ping2"));
     rep2.send(Message::single("pong2")).await.unwrap();
     let reply2 = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"pong2");
+    assert_eq!(reply2, Message::single("pong2"));
 }
 
 #[compio::test]
@@ -102,13 +102,13 @@ async fn req_state_machine_survives_drop_mid_cycle() {
         .await
         .expect("post-drop recv timed out")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"c");
+    assert_eq!(got, Message::single("c"));
     rep2.send(Message::single("c-reply")).await.unwrap();
     let reply = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .expect("post-drop reply timed out")
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap().as_ref(), b"c-reply");
+    assert_eq!(reply, Message::single("c-reply"));
 }
 
 // ── PUB / SUB ────────────────────────────────────────────────────────────────
@@ -128,7 +128,7 @@ async fn pub_sub_reconnect_replays_subscriptions() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap().as_ref(), b"x.hello");
+    assert_eq!(m1, Message::single("x.hello"));
 
     pub1.close().await.unwrap();
     let pub2 = rebind(&ep, || Socket::new(SocketType::Pub, Options::default())).await;
@@ -143,12 +143,12 @@ async fn pub_sub_reconnect_replays_subscriptions() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(m2.part_bytes(0).unwrap().as_ref(), b"x.world");
+    assert_eq!(m2, Message::single("x.world"));
     let m3 = compio::time::timeout(Duration::from_millis(500), sub.recv())
         .await
         .expect("second post-restart recv timed out")
         .unwrap();
-    assert_eq!(m3.part_bytes(0).unwrap().as_ref(), b"x.again");
+    assert_eq!(m3, Message::single("x.again"));
 }
 
 // ── DEALER / ROUTER ──────────────────────────────────────────────────────────
@@ -173,8 +173,7 @@ async fn dealer_router_reconnect_after_router_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"hello");
+    assert_eq!(got1, Message::multipart(["d1", "hello"]));
 
     router1.close().await.unwrap();
     let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
@@ -184,8 +183,7 @@ async fn dealer_router_reconnect_after_router_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"after");
+    assert_eq!(got2, Message::multipart(["d1", "after"]));
 }
 
 // ── PAIR ─────────────────────────────────────────────────────────────────────
@@ -204,7 +202,7 @@ async fn pair_reconnect_after_bind_side_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(got1, Message::single("hi"));
     pair_a1.send(Message::single("there")).await.unwrap();
     compio::time::timeout(Duration::from_secs(2), pair_b.recv())
         .await
@@ -219,13 +217,13 @@ async fn pair_reconnect_after_bind_side_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(got2, Message::single("again"));
     pair_a2.send(Message::single("back")).await.unwrap();
     let reply2 = compio::time::timeout(Duration::from_secs(2), pair_b.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(reply2, Message::single("back"));
 }
 
 // ── CLIENT / SERVER ──────────────────────────────────────────────────────────
@@ -250,8 +248,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"ping1");
+    assert_eq!(got1, Message::multipart(["c1", "ping1"]));
 
     server1
         .send(Message::multipart([
@@ -264,7 +261,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("initial reply timed out")
         .unwrap();
-    assert_eq!(reply1.part_bytes(0).unwrap().as_ref(), b"pong1");
+    assert_eq!(reply1, Message::single("pong1"));
 
     server1.close().await.unwrap();
     let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
@@ -274,8 +271,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"ping2");
+    assert_eq!(got2, Message::multipart(["c1", "ping2"]));
 }
 
 // ── SCATTER / GATHER ─────────────────────────────────────────────────────────
@@ -294,7 +290,7 @@ async fn scatter_gather_reconnect_after_bind_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"before");
+    assert_eq!(got1, Message::single("before"));
 
     gather1.close().await.unwrap();
     let gather2 = rebind(&ep, || Socket::new(SocketType::Gather, Options::default())).await;
@@ -304,7 +300,7 @@ async fn scatter_gather_reconnect_after_bind_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"after");
+    assert_eq!(got2, Message::single("after"));
 }
 
 // ── RADIO / DISH ─────────────────────────────────────────────────────────────
@@ -325,7 +321,7 @@ async fn radio_dish_reconnect_replays_joins() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe");
+            assert_eq!(m, Message::multipart(["w", "probe"]));
             break;
         }
         assert!(
@@ -344,8 +340,7 @@ async fn radio_dish_reconnect_replays_joins() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"w");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            assert_eq!(m, Message::multipart(["w", "after"]));
             break;
         }
         assert!(
@@ -366,7 +361,7 @@ async fn radio_dish_reconnect_replays_joins() {
         .await
         .expect("final recv timed out")
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"final");
+    assert_eq!(m, Message::multipart(["w", "final"]));
 }
 
 // ── PEER ─────────────────────────────────────────────────────────────────────
@@ -395,8 +390,7 @@ async fn peer_reconnect_after_bind_side_restart() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a1.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            assert_eq!(m, Message::multipart(["pb", "hello"]));
             break;
         }
         assert!(
@@ -421,8 +415,7 @@ async fn peer_reconnect_after_bind_side_restart() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a2.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            assert_eq!(m, Message::multipart(["pb", "after"]));
             break;
         }
         assert!(
@@ -448,7 +441,7 @@ async fn channel_reconnect_after_bind_side_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(got1, Message::single("hi"));
     ch_a1.send(Message::single("there")).await.unwrap();
     compio::time::timeout(Duration::from_secs(2), ch_b.recv())
         .await
@@ -463,13 +456,13 @@ async fn channel_reconnect_after_bind_side_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(got2, Message::single("again"));
     ch_a2.send(Message::single("back")).await.unwrap();
     let reply2 = compio::time::timeout(Duration::from_secs(2), ch_b.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(reply2, Message::single("back"));
 }
 
 // ── XPUB / XSUB ─────────────────────────────────────────────────────────────

--- a/omq-compio/tests/reconnect_connect_side.rs
+++ b/omq-compio/tests/reconnect_connect_side.rs
@@ -35,7 +35,7 @@ async fn push_pull_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+    assert_eq!(m, Message::single("before"));
 
     push1.close().await.unwrap();
 
@@ -48,7 +48,7 @@ async fn push_pull_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+    assert_eq!(m, Message::single("after"));
 }
 
 // ── REQ / REP ────────────────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ async fn req_rep_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q1");
+    assert_eq!(m, Message::single("q1"));
     rep.send(Message::single("a1")).await.unwrap();
     compio::time::timeout(TIMEOUT, req1.recv())
         .await
@@ -83,13 +83,13 @@ async fn req_rep_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"q2");
+    assert_eq!(m, Message::single("q2"));
     rep.send(Message::single("a2")).await.unwrap();
     let m = compio::time::timeout(TIMEOUT, req2.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"a2");
+    assert_eq!(m, Message::single("a2"));
 }
 
 // ── PUB / SUB ────────────────────────────────────────────────────────────────
@@ -107,7 +107,7 @@ async fn pub_sub_reconnect_connect_side() {
     loop {
         pub_.send(Message::single("x.probe1")).await.unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub1.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe1");
+            assert_eq!(m, Message::single("x.probe1"));
             break;
         }
         assert!(
@@ -126,7 +126,7 @@ async fn pub_sub_reconnect_connect_side() {
     loop {
         pub_.send(Message::single("x.probe2")).await.unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), sub2.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"x.probe2");
+            assert_eq!(m, Message::single("x.probe2"));
             break;
         }
         assert!(
@@ -155,8 +155,7 @@ async fn dealer_router_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+    assert_eq!(m, Message::multipart(["d1", "hello"]));
 
     dealer1.close().await.unwrap();
 
@@ -172,8 +171,7 @@ async fn dealer_router_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+    assert_eq!(m, Message::multipart(["d1", "again"]));
 }
 
 // ── CLIENT / SERVER ──────────────────────────────────────────────────────────
@@ -195,8 +193,7 @@ async fn client_server_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
 
     client1.close().await.unwrap();
 
@@ -212,8 +209,7 @@ async fn client_server_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"pong");
+    assert_eq!(m, Message::multipart(["c1", "pong"]));
 }
 
 // ── SCATTER / GATHER ─────────────────────────────────────────────────────────
@@ -232,7 +228,7 @@ async fn scatter_gather_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"before");
+    assert_eq!(m, Message::single("before"));
 
     scatter1.close().await.unwrap();
 
@@ -245,7 +241,7 @@ async fn scatter_gather_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"after");
+    assert_eq!(m, Message::single("after"));
 }
 
 // ── RADIO / DISH ─────────────────────────────────────────────────────────────
@@ -266,7 +262,7 @@ async fn radio_dish_reconnect_connect_side() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish1.recv()).await {
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe1");
+            assert_eq!(m, Message::multipart(["w", "probe1"]));
             break;
         }
         assert!(
@@ -288,7 +284,7 @@ async fn radio_dish_reconnect_connect_side() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), dish2.recv()).await {
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"probe2");
+            assert_eq!(m, Message::multipart(["w", "probe2"]));
             break;
         }
         assert!(
@@ -314,7 +310,7 @@ async fn pair_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(m, Message::single("hi"));
 
     pair_b1.close().await.unwrap();
 
@@ -327,14 +323,14 @@ async fn pair_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(m, Message::single("again"));
 
     pair_a.send(Message::single("back")).await.unwrap();
     let m = compio::time::timeout(TIMEOUT, pair_b2.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(m, Message::single("back"));
 }
 
 // ── PEER ─────────────────────────────────────────────────────────────────────
@@ -360,8 +356,7 @@ async fn peer_reconnect_connect_side() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            assert_eq!(m, Message::multipart(["pb", "hello"]));
             break;
         }
         assert!(
@@ -385,8 +380,7 @@ async fn peer_reconnect_connect_side() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(200), peer_a.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"again");
+            assert_eq!(m, Message::multipart(["pb", "again"]));
             break;
         }
         assert!(
@@ -412,7 +406,7 @@ async fn channel_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(m, Message::single("hi"));
 
     ch_b1.close().await.unwrap();
 
@@ -425,12 +419,12 @@ async fn channel_reconnect_connect_side() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(m, Message::single("again"));
 
     ch_a.send(Message::single("back")).await.unwrap();
     let m = compio::time::timeout(TIMEOUT, ch_b2.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(m, Message::single("back"));
 }

--- a/omq-compio/tests/reconnect_identity.rs
+++ b/omq-compio/tests/reconnect_identity.rs
@@ -54,7 +54,7 @@ async fn dealer_identity_survives_reconnect() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m, Message::multipart(["d1", "before"]));
 
     router1
         .send(Message::multipart([
@@ -67,7 +67,7 @@ async fn dealer_identity_survives_reconnect() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply1");
+    assert_eq!(r, Message::single("reply1"));
 
     router1.close().await.unwrap();
     let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
@@ -77,7 +77,7 @@ async fn dealer_identity_survives_reconnect() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"d1");
+    assert_eq!(m, Message::multipart(["d1", "after"]));
 
     router2
         .send(Message::multipart([
@@ -90,7 +90,7 @@ async fn dealer_identity_survives_reconnect() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"reply2");
+    assert_eq!(r, Message::single("reply2"));
 }
 
 #[compio::test]
@@ -180,7 +180,7 @@ async fn client_identity_survives_reconnect_to_server() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m, Message::multipart(["c1", "ping1"]));
 
     server1
         .send(Message::multipart([
@@ -193,7 +193,7 @@ async fn client_identity_survives_reconnect_to_server() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong1");
+    assert_eq!(r, Message::single("pong1"));
 
     server1.close().await.unwrap();
     let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
@@ -203,7 +203,7 @@ async fn client_identity_survives_reconnect_to_server() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"c1");
+    assert_eq!(m, Message::multipart(["c1", "ping2"]));
 
     server2
         .send(Message::multipart([
@@ -216,5 +216,5 @@ async fn client_identity_survives_reconnect_to_server() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap().as_ref(), b"pong2");
+    assert_eq!(r, Message::single("pong2"));
 }

--- a/omq-compio/tests/req_rep.rs
+++ b/omq-compio/tests/req_rep.rs
@@ -96,7 +96,7 @@ async fn rep_survives_client_disconnect_mid_cycle() {
             .await
             .expect("REP recv timed out for first client")
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"drop-me");
+        assert_eq!(m, Message::single("drop-me"));
         // req1 drops here: connection closes before REP replies.
     }
 
@@ -112,14 +112,14 @@ async fn rep_survives_client_disconnect_mid_cycle() {
         .await
         .expect("REP did not receive second client's request")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"real");
+    assert_eq!(got, Message::single("real"));
 
     rep.send(Message::single("reply")).await.unwrap();
     let reply = compio::time::timeout(Duration::from_millis(500), req2.recv())
         .await
         .expect("REQ2 did not receive reply")
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap().as_ref(), b"reply");
+    assert_eq!(reply, Message::single("reply"));
 }
 
 #[compio::test]
@@ -167,14 +167,14 @@ async fn req_rep_roundtrip_sequential_ipv4() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     let r = compio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[compio::test]
@@ -191,7 +191,7 @@ async fn req_rep_roundtrip_sequential_with_yield() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     // Explicit yield to let REP's driver flush encoded_queue.
@@ -200,7 +200,7 @@ async fn req_rep_roundtrip_sequential_with_yield() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[compio::test]
@@ -216,7 +216,7 @@ async fn req_rep_roundtrip_sequential_with_long_yield() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     compio::time::sleep(Duration::from_millis(50)).await;
@@ -224,7 +224,7 @@ async fn req_rep_roundtrip_sequential_with_long_yield() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[compio::test]
@@ -241,7 +241,7 @@ async fn req_rep_roundtrip_sequential_spawned_recv() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
 
@@ -253,7 +253,7 @@ async fn req_rep_roundtrip_sequential_spawned_recv() {
             .unwrap()
     });
     let r = recv_task.await.unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[compio::test]
@@ -269,7 +269,7 @@ async fn req_rep_sequential_longer_timeout() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     // 10 second timeout - if req.recv() eventually succeeds it's a scheduling issue
@@ -277,7 +277,7 @@ async fn req_rep_sequential_longer_timeout() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 /// REP serves multiple REQ clients that connect and disconnect in

--- a/omq-compio/tests/router_dealer.rs
+++ b/omq-compio/tests/router_dealer.rs
@@ -52,9 +52,7 @@ async fn router_addresses_dealer_by_identity() {
         .await
         .expect("router recv timeout")
         .unwrap();
-    assert_eq!(r.len(), 2);
-    assert_eq!(r.part_bytes(0).unwrap(), &b"dealer-1"[..]);
-    assert_eq!(r.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(r, Message::multipart(["dealer-1", "hello"]));
 
     // ROUTER replies by prefixing the dealer identity.
     let reply = Message::multipart([
@@ -67,7 +65,7 @@ async fn router_addresses_dealer_by_identity() {
         .await
         .expect("dealer recv timeout")
         .unwrap();
-    assert_eq!(d.part_bytes(0).unwrap(), &b"world"[..]);
+    assert_eq!(d, Message::single("world"));
 }
 
 #[compio::test]
@@ -89,7 +87,7 @@ async fn router_mandatory_errors_on_unknown_identity() {
         .await
         .expect("router recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
+    assert_eq!(m, Message::multipart(["dealer-known", "ping"]));
 
     // Send to an identity nobody owns.
     let bad = Message::multipart([Bytes::from_static(b"ghost"), Bytes::from_static(b"oops")]);
@@ -110,7 +108,7 @@ async fn router_drops_unknown_identity_by_default() {
         .await
         .expect("router recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
+    assert_eq!(m, Message::multipart(["d", "ping"]));
 
     let bad = Message::multipart([Bytes::from_static(b"nope"), Bytes::from_static(b"oops")]);
     // Default is silent drop (libzmq matches).
@@ -149,7 +147,7 @@ async fn router_assigns_identity_for_peers_without_one() {
         .await
         .expect("dealer recv timeout")
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"reply"[..]);
+    assert_eq!(reply, Message::single("reply"));
 }
 
 // --- Handover tests ---
@@ -168,8 +166,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .expect("router recv timeout")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alpha"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(got, Message::multipart(["alpha", "hello"]));
 
     router
         .send(Message::multipart([
@@ -182,7 +179,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .expect("dealer_a recv timeout")
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply-1"[..]);
+    assert_eq!(r, Message::single("reply-1"));
 
     let dealer_b = Socket::new(SocketType::Dealer, opts_no_reconnect("alpha"));
     dealer_b.connect(ep).await.unwrap();
@@ -193,8 +190,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .expect("router recv timeout")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alpha"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"world"[..]);
+    assert_eq!(got, Message::multipart(["alpha", "world"]));
 
     router
         .send(Message::multipart([
@@ -207,7 +203,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .expect("dealer_b recv timeout")
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply-2"[..]);
+    assert_eq!(r, Message::single("reply-2"));
 }
 
 #[compio::test]
@@ -324,8 +320,7 @@ async fn server_handover_evicts_old_peer() {
         .await
         .expect("server recv timeout")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"cli"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(got, Message::multipart(["cli", "ping"]));
 
     let client_b = Socket::new(SocketType::Client, opts_no_reconnect("cli"));
     client_b.connect(tcp_ep(port)).await.unwrap();
@@ -350,6 +345,5 @@ async fn server_handover_evicts_old_peer() {
         .await
         .expect("server recv timeout")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"cli"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"pong"[..]);
+    assert_eq!(got, Message::multipart(["cli", "pong"]));
 }

--- a/omq-compio/tests/stress_connect_before_bind.rs
+++ b/omq-compio/tests/stress_connect_before_bind.rs
@@ -78,7 +78,7 @@ async fn stress_push_pull(transport: &Transport, bind_side: &str) {
             .await
             .unwrap_or_else(|_| panic!("push/pull {bind_side}-binds round {i} timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"x"[..]);
+        assert_eq!(m, Message::single("x"));
     }
 }
 
@@ -106,14 +106,14 @@ async fn stress_req_rep(transport: &Transport, bind_side: &str) {
             .await
             .unwrap_or_else(|_| panic!("req/rep {bind_side}-binds round {i} recv timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"q"[..]);
+        assert_eq!(m, Message::single("q"));
 
         rep.send(Message::single("a")).await.unwrap();
         let m = compio::time::timeout(TIMEOUT, req.recv())
             .await
             .unwrap_or_else(|_| panic!("req/rep {bind_side}-binds round {i} reply timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"a"[..]);
+        assert_eq!(m, Message::single("a"));
     }
 }
 
@@ -142,7 +142,7 @@ async fn stress_pub_sub(transport: &Transport, bind_side: &str) {
         loop {
             pub_.send(Message::single("m")).await.unwrap();
             if let Ok(Ok(m)) = compio::time::timeout(Duration::from_millis(100), sub.recv()).await {
-                assert_eq!(m.part_bytes(0).unwrap(), &b"m"[..]);
+                assert_eq!(m, Message::single("m"));
                 break;
             }
             assert!(
@@ -167,14 +167,14 @@ async fn stress_pair(transport: &Transport) {
             .await
             .unwrap_or_else(|_| panic!("pair round {i} a->b timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"ab"[..]);
+        assert_eq!(m, Message::single("ab"));
 
         b.send(Message::single("ba")).await.unwrap();
         let m = compio::time::timeout(TIMEOUT, a.recv())
             .await
             .unwrap_or_else(|_| panic!("pair round {i} b->a timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"ba"[..]);
+        assert_eq!(m, Message::single("ba"));
     }
 }
 
@@ -208,8 +208,7 @@ async fn stress_dealer_router(transport: &Transport, bind_side: &str) {
             .await
             .unwrap_or_else(|_| panic!("dealer/router {bind_side}-binds round {i} timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-        assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+        assert_eq!(m, Message::multipart(["d1", "hi"]));
 
         router
             .send(Message::multipart([
@@ -222,7 +221,7 @@ async fn stress_dealer_router(transport: &Transport, bind_side: &str) {
             .await
             .unwrap_or_else(|_| panic!("dealer/router {bind_side}-binds round {i} reply timed out"))
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap(), &b"yo"[..]);
+        assert_eq!(m, Message::single("yo"));
     }
 }
 

--- a/omq-compio/tests/udp.rs
+++ b/omq-compio/tests/udp.rs
@@ -56,8 +56,7 @@ async fn radio_to_dish_matching_group_delivers() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"sunny"[..]);
+    assert_eq!(m, Message::multipart(["weather", "sunny"]));
 }
 
 #[compio::test]
@@ -85,8 +84,7 @@ async fn dish_filters_unjoined_groups_locally() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"rain"[..]);
+    assert_eq!(m, Message::multipart(["weather", "rain"]));
 
     // The "news" datagram must not surface.
     let third = compio::time::timeout(Duration::from_millis(100), dish.recv()).await;
@@ -122,7 +120,7 @@ async fn dish_leave_drops_subsequent_messages() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(1).unwrap(), &b"first"[..]);
+    assert_eq!(m, Message::multipart(["weather", "first"]));
 
     dish.leave("weather").await.unwrap();
     radio

--- a/omq-compio/tests/ws_basic.rs
+++ b/omq-compio/tests/ws_basic.rs
@@ -35,7 +35,7 @@ async fn push_pull_one_message() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello ws"[..]);
+    assert_eq!(msg, Message::single("hello ws"));
 }
 
 #[compio::test]
@@ -65,10 +65,7 @@ async fn push_pull_multipart() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(received.len(), 3);
-    assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
-    assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
-    assert_eq!(received.part_bytes(2).unwrap(), &b"frame3"[..]);
+    assert_eq!(received, Message::multipart(["frame1", "frame2", "frame3"]));
 }
 
 #[compio::test]

--- a/omq-compio/tests/ws_plain.rs
+++ b/omq-compio/tests/ws_plain.rs
@@ -48,7 +48,7 @@ async fn ws_plain_push_pull() {
         .await
         .expect("recv timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello plain ws"[..]);
+    assert_eq!(msg, Message::single("hello plain ws"));
 }
 
 #[compio::test]

--- a/omq-compio/tests/ws_pub_sub.rs
+++ b/omq-compio/tests/ws_pub_sub.rs
@@ -40,8 +40,7 @@ async fn ws_pub_sub_basic() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"news.sports"[..]);
-    assert_eq!(msg.part_bytes(1).unwrap(), &b"goal scored"[..]);
+    assert_eq!(msg, Message::multipart(["news.sports", "goal scored"]));
 }
 
 #[compio::test]
@@ -64,7 +63,7 @@ async fn ws_pub_sub_unsubscribe() {
         .await
         .expect("recv timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"news.sports"[..]);
+    assert_eq!(msg, Message::multipart(["news.sports", "first"]));
 
     sub.unsubscribe("news.").await.unwrap();
     compio::time::sleep(Duration::from_millis(200)).await;

--- a/omq-compio/tests/ws_radio_dish.rs
+++ b/omq-compio/tests/ws_radio_dish.rs
@@ -41,8 +41,7 @@ async fn ws_radio_dish_basic() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(msg.part_bytes(1).unwrap(), &b"sunny"[..]);
+    assert_eq!(msg, Message::multipart(["weather", "sunny"]));
 }
 
 #[compio::test]
@@ -66,7 +65,7 @@ async fn ws_radio_dish_leave() {
         .await
         .expect("recv timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"weather"[..]);
+    assert_eq!(msg, Message::multipart(["weather", "sunny"]));
 
     dish.leave("weather").await.unwrap();
     compio::time::sleep(Duration::from_millis(200)).await;

--- a/omq-compio/tests/ws_reconnect.rs
+++ b/omq-compio/tests/ws_reconnect.rs
@@ -35,7 +35,7 @@ async fn ws_reconnect_after_server_restart() {
         .await
         .expect("recv timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"before"[..]);
+    assert_eq!(msg, Message::single("before"));
 
     drop(push1);
     pull1.close().await.unwrap();
@@ -61,5 +61,5 @@ async fn ws_reconnect_after_server_restart() {
         .await
         .expect("recv after restart timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"after"[..]);
+    assert_eq!(msg, Message::single("after"));
 }

--- a/omq-compio/tests/wss_basic.rs
+++ b/omq-compio/tests/wss_basic.rs
@@ -64,7 +64,7 @@ async fn wss_push_pull() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello wss"[..]);
+    assert_eq!(msg, Message::single("hello wss"));
 }
 
 #[compio::test]
@@ -104,7 +104,5 @@ async fn wss_multipart() {
         .expect("recv timed out")
         .unwrap();
 
-    assert_eq!(received.len(), 2);
-    assert_eq!(received.part_bytes(0).unwrap(), &b"frame1"[..]);
-    assert_eq!(received.part_bytes(1).unwrap(), &b"frame2"[..]);
+    assert_eq!(received, Message::multipart(["frame1", "frame2"]));
 }

--- a/omq-libzmq/src/lib.rs
+++ b/omq-libzmq/src/lib.rs
@@ -1,4 +1,15 @@
 //! omq-libzmq -- libzmq-compatible C interface backed by omq-tokio.
+//!
+//! # Panic safety
+//!
+//! Since Rust 1.71, panics in `extern "C"` functions abort rather than
+//! UB. No `catch_unwind` wrappers are used: wrapping 50+ FFI functions
+//! in `AssertUnwindSafe` would weaken static guarantees for marginal
+//! benefit. libzmq itself aborts on internal errors, so abort-on-panic
+//! is acceptable behavior for a drop-in replacement.
+
+// Crate-level: 53 of 64 extern "C" fns trigger this lint. Per-function
+// #[expect] would be pure noise for a C API crate.
 #![expect(clippy::not_unsafe_ptr_arg_deref)]
 
 mod consts;

--- a/omq-libzmq/src/local_cell.rs
+++ b/omq-libzmq/src/local_cell.rs
@@ -5,13 +5,7 @@ use std::cell::UnsafeCell;
 /// Wraps `UnsafeCell<T>` behind a safe `get(&self) -> &mut T` accessor.
 /// Sound because the ZMQ C API contract requires that each socket is
 /// accessed from at most one thread at a time.
-///
-/// In debug builds, a thread-ID check catches accidental cross-thread access.
-pub(crate) struct LocalCell<T> {
-    inner: UnsafeCell<T>,
-    #[cfg(debug_assertions)]
-    owner: std::thread::ThreadId,
-}
+pub(crate) struct LocalCell<T>(UnsafeCell<T>);
 
 // SAFETY: ZMQ's C API contract guarantees single-threaded socket
 // access. No concurrent mutation is possible under correct usage.
@@ -19,25 +13,15 @@ unsafe impl<T: Send> Sync for LocalCell<T> {}
 
 impl<T> LocalCell<T> {
     pub(crate) fn new(val: T) -> Self {
-        Self {
-            inner: UnsafeCell::new(val),
-            #[cfg(debug_assertions)]
-            owner: std::thread::current().id(),
-        }
+        Self(UnsafeCell::new(val))
     }
 
     #[inline]
     #[expect(clippy::mut_from_ref)]
     pub(crate) fn get(&self) -> &mut T {
-        #[cfg(debug_assertions)]
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.owner,
-            "LocalCell accessed from wrong thread"
-        );
         // SAFETY: ZMQ's single-threaded socket contract guarantees
         // no concurrent access to these fields.
-        unsafe { &mut *self.inner.get() }
+        unsafe { &mut *self.0.get() }
     }
 }
 

--- a/omq-libzmq/src/local_cell.rs
+++ b/omq-libzmq/src/local_cell.rs
@@ -5,7 +5,13 @@ use std::cell::UnsafeCell;
 /// Wraps `UnsafeCell<T>` behind a safe `get(&self) -> &mut T` accessor.
 /// Sound because the ZMQ C API contract requires that each socket is
 /// accessed from at most one thread at a time.
-pub(crate) struct LocalCell<T>(UnsafeCell<T>);
+///
+/// In debug builds, a thread-ID check catches accidental cross-thread access.
+pub(crate) struct LocalCell<T> {
+    inner: UnsafeCell<T>,
+    #[cfg(debug_assertions)]
+    owner: std::thread::ThreadId,
+}
 
 // SAFETY: ZMQ's C API contract guarantees single-threaded socket
 // access. No concurrent mutation is possible under correct usage.
@@ -13,15 +19,25 @@ unsafe impl<T: Send> Sync for LocalCell<T> {}
 
 impl<T> LocalCell<T> {
     pub(crate) fn new(val: T) -> Self {
-        Self(UnsafeCell::new(val))
+        Self {
+            inner: UnsafeCell::new(val),
+            #[cfg(debug_assertions)]
+            owner: std::thread::current().id(),
+        }
     }
 
     #[inline]
     #[expect(clippy::mut_from_ref)]
     pub(crate) fn get(&self) -> &mut T {
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            std::thread::current().id(),
+            self.owner,
+            "LocalCell accessed from wrong thread"
+        );
         // SAFETY: ZMQ's single-threaded socket contract guarantees
         // no concurrent access to these fields.
-        unsafe { &mut *self.0.get() }
+        unsafe { &mut *self.inner.get() }
     }
 }
 

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -397,17 +397,18 @@ pub extern "C" fn zmq_msg_send(
 
     let group = msg_group_bytes(msg);
 
-    // For KIND_BYTES, steal the arc instead of copying. Set boxed to null so
-    // zmq_msg_close (called on success below) skips the drop.
+    // For KIND_BYTES, clone the Bytes (a zero-copy Arc bump) rather than
+    // copying the payload. We must NOT mutate `msg` here: libzmq leaves the
+    // message intact when a send fails, and the caller may then retry, copy,
+    // or close it. Stealing the Box and nulling the fields used to leave the
+    // message in a KIND_BYTES-with-null-boxed state that made a subsequent
+    // zmq_msg_copy dereference a null pointer. On success the Box is dropped
+    // by zmq_msg_close below.
     // SAFETY: msg is non-null (checked above).
-    let r = unsafe { &mut *msg };
+    let r = unsafe { &*msg };
     let bytes = if r.kind == KIND_BYTES && !r.boxed.is_null() {
-        // SAFETY: boxed was created by Box::into_raw; reclaiming ownership.
-        let owned = unsafe { *Box::from_raw(r.boxed.cast::<Bytes>()) };
-        r.boxed = std::ptr::null_mut();
-        r.ptr = std::ptr::null_mut();
-        r.size = 0;
-        owned
+        // SAFETY: boxed was created by Box::into_raw in zmq_msg_recv; non-null.
+        unsafe { &*(r.boxed.cast::<Bytes>()) }.clone()
     } else {
         extract_bytes(msg)
     };

--- a/omq-libzmq/src/notify.rs
+++ b/omq-libzmq/src/notify.rs
@@ -227,6 +227,8 @@ mod unix {
             }
         }
 
+        // Takes &self (behind Arc), so fds can't be invalidated after close.
+        // No double-close path exists: called once from zmq_close, then dropped.
         fn close(&self) {
             #[cfg(target_os = "linux")]
             if let Some(linux) = &self.0 {

--- a/omq-libzmq/src/proxy.rs
+++ b/omq-libzmq/src/proxy.rs
@@ -110,7 +110,7 @@ pub extern "C" fn zmq_proxy_steerable(
             let mut cmd = [0u8; 64];
             let rc = zmq_recv(control, cmd.as_mut_ptr().cast(), cmd.len(), ZMQ_DONTWAIT);
             if rc > 0 {
-                let msg = std::str::from_utf8(&cmd[..rc as usize]).unwrap_or("");
+                let msg = std::str::from_utf8(&cmd[..(rc as usize).min(cmd.len())]).unwrap_or("");
                 if msg == "TERMINATE" || msg == "KILL" {
                     return 0;
                 }
@@ -127,7 +127,8 @@ pub extern "C" fn zmq_proxy_steerable(
                             let rc =
                                 zmq_recv(control, cmd.as_mut_ptr().cast(), cmd.len(), ZMQ_DONTWAIT);
                             if rc > 0 {
-                                let m = std::str::from_utf8(&cmd[..rc as usize]).unwrap_or("");
+                                let m = std::str::from_utf8(&cmd[..(rc as usize).min(cmd.len())])
+                                    .unwrap_or("");
                                 if m == "RESUME" {
                                     break;
                                 }

--- a/omq-libzmq/src/util.rs
+++ b/omq-libzmq/src/util.rs
@@ -33,7 +33,9 @@ pub extern "C" fn zmq_has(capability: *const libc::c_char) -> c_int {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_sleep(seconds: c_int) {
-    std::thread::sleep(std::time::Duration::from_secs(seconds as u64));
+    if seconds > 0 {
+        std::thread::sleep(std::time::Duration::from_secs(seconds as u64));
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -18,7 +18,7 @@ use crate::error::{Error, Result};
 ///
 /// The scheme picks the transport; the rest of the string carries transport-
 /// specific addressing.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Endpoint {
     /// `tcp://host:port` (IPv4, IPv6, or DNS name).
@@ -60,7 +60,7 @@ pub enum Endpoint {
 ///
 /// Kept as a distinct variant so resolution can be deferred until bind/connect
 /// time without forcing callers to reparse.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Host {
     Ip(IpAddr),
@@ -72,7 +72,7 @@ pub enum Host {
 /// IPC path, possibly in the Linux abstract namespace (leading `@`).
 /// Only available on Unix platforms.
 #[cfg(unix)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum IpcPath {
     Filesystem(PathBuf),

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -204,6 +204,7 @@ impl Endpoint {
 
     /// Whether this endpoint rides on the TCP byte-stream transport.
     /// Includes the compression-wrapped variants.
+    // Not matches!(): #[cfg] attributes are not allowed inside macro patterns.
     pub fn is_tcp_family(&self) -> bool {
         match self {
             Endpoint::Tcp { .. } => true,

--- a/omq-proto/src/inproc.rs
+++ b/omq-proto/src/inproc.rs
@@ -16,13 +16,6 @@ pub enum InboundFrame {
     Command(Box<Command>),
 }
 
-impl InboundFrame {
-    /// Construct a `Message` frame.
-    pub fn message(msg: Message) -> Self {
-        Self::Message(msg)
-    }
-}
-
 /// Pre-computed peer info known at connect/accept time for inproc
 /// peers. Stands in for the `READY` properties that real ZMTP
 /// exchanges over the wire.

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -163,6 +163,14 @@ impl Clone for Payload {
     }
 }
 
+impl PartialEq for Payload {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for Payload {}
+
 impl Default for Payload {
     fn default() -> Self {
         Self::new()
@@ -642,6 +650,23 @@ impl Clone for Message {
         }
     }
 }
+
+impl PartialEq for Message {
+    fn eq(&self, other: &Self) -> bool {
+        let n = self.len();
+        if n != other.len() {
+            return false;
+        }
+        for i in 0..n {
+            if self.get(i) != other.get(i) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Eq for Message {}
 
 impl std::fmt::Debug for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -724,10 +724,9 @@ impl From<Payload> for Message {
 /// ID in big-endian order, so the identity stays stable for the
 /// lifetime of the connection and cannot collide across peers.
 pub fn generated_identity(id: u64) -> Bytes {
-    let mut buf = Vec::with_capacity(9);
-    buf.push(0);
-    buf.extend_from_slice(&id.to_be_bytes());
-    Bytes::from(buf)
+    let mut buf = [0u8; 9];
+    buf[1..].copy_from_slice(&id.to_be_bytes());
+    Bytes::copy_from_slice(&buf)
 }
 
 #[cfg(test)]

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -902,7 +902,7 @@ mod tests {
     fn payload_inline_clone() {
         let p = Payload::inline(b"data");
         let p2 = p.clone();
-        assert_eq!(p.as_slice(), p2.as_slice());
+        assert_eq!(p, p2);
     }
 
     #[test]
@@ -1055,19 +1055,14 @@ mod tests {
     fn message_with_prefix() {
         let body = Message::single("hello");
         let m = Message::with_prefix(Bytes::from_static(b"id"), body);
-        assert_eq!(m.len(), 2);
-        assert_eq!(m.part_bytes(0).unwrap(), &b"id"[..]);
-        assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+        assert_eq!(m, Message::multipart([&b"id"[..], &b"hello"[..]]));
     }
 
     #[test]
     fn message_with_prefix_multipart_body() {
         let body = Message::multipart(["", "data"]);
         let m = Message::with_prefix(Bytes::from_static(b"id"), body);
-        assert_eq!(m.len(), 3);
-        assert_eq!(m.part_bytes(0).unwrap(), &b"id"[..]);
-        assert!(m.part_bytes(1).unwrap().is_empty());
-        assert_eq!(m.part_bytes(2).unwrap(), &b"data"[..]);
+        assert_eq!(m, Message::multipart([&b"id"[..], &b""[..], &b"data"[..]]));
     }
 
     #[test]
@@ -1120,7 +1115,7 @@ mod tests {
         let mut m = Message::from_inline(&data);
         m.push_part_payload(Payload::from_bytes(Bytes::from_static(b"extra")));
         assert_eq!(m.len(), 2);
-        assert_eq!(m.part_bytes(0).unwrap(), &data[..]);
-        assert_eq!(m.part_bytes(1).unwrap(), &b"extra"[..]);
+        assert_eq!(m.get(0).unwrap(), &data[..]);
+        assert_eq!(m.get(1).unwrap(), b"extra");
     }
 }

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -21,6 +21,9 @@ use crate::socket_ref::SocketRef;
 const COMPRESSION_DICT_MAX: usize = 8 * 1024;
 
 /// Per-socket configuration.
+// Compression fields (compression_dict through compression_offload_threshold)
+// could be grouped into a sub-struct, but the public API change would touch
+// every backend file that accesses them.
 #[derive(Clone, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Options {

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -16,6 +16,13 @@ use super::FrameTransform;
 use super::blake3zmq_aad;
 use super::{Connection, Event, NextFrameInfo, State, decode_command_raw};
 
+/// Absolute ceiling for a handshake command frame when the connection has
+/// no `max_message_size` configured. Real handshake commands (socket-type
+/// and identity properties, CURVE/BLAKE3ZMQ handshake messages) are a few
+/// hundred bytes at most; this only exists to stop a pre-auth peer from
+/// making us buffer unbounded data during the handshake.
+const MAX_HANDSHAKE_COMMAND: usize = 256 * 1024;
+
 /// Build a `Message::Inline` from a `ChunkedInputBuf`. The caller must
 /// ensure `payload_len` bytes are available in `buf`.
 #[inline]
@@ -116,6 +123,22 @@ impl Connection {
     }
 
     fn try_advance_mechanism(&mut self) -> Result<bool> {
+        // Bound the frame before buffering its whole body. This runs
+        // pre-authentication, so a peer must not be able to make us buffer an
+        // arbitrary amount by declaring a huge command frame and dribbling
+        // bytes. Handshake commands (READY, CURVE HELLO/WELCOME/INITIATE,
+        // BLAKE3ZMQ messages) are never legitimately large, so cap them at an
+        // absolute ceiling. This is independent of `max_message_size`, which
+        // bounds user data messages: a user may set a tiny data limit yet must
+        // still exchange the (larger) handshake commands.
+        if let Some(hdr) = frame::peek_frame_header(&self.in_buf)?
+            && hdr.payload_len > MAX_HANDSHAKE_COMMAND
+        {
+            return Err(Error::HandshakeFailed(format!(
+                "handshake command frame too large: {} bytes (max {MAX_HANDSHAKE_COMMAND})",
+                hdr.payload_len
+            )));
+        }
         let Some(frame) = frame::try_decode_frame(&mut self.in_buf)? else {
             return Ok(false);
         };
@@ -551,6 +574,24 @@ impl Connection {
                 .header_len
                 .checked_add(payload_len)
                 .ok_or_else(|| Error::Protocol("WS frame size overflow".into()))?;
+            // Bound the declared payload before waiting for the whole frame to
+            // arrive. Without this a peer can declare a huge WS frame and
+            // dribble bytes, defeating a configured limit. In the Ready state
+            // apply the user's data limit (`max_message_size`, unbounded when
+            // unset, matching ZMQ). Before Ready the frames carry handshake
+            // commands, so apply the absolute pre-auth ceiling regardless.
+            let cap = if matches!(self.state, State::Ready) {
+                self.config.max_message_size
+            } else {
+                Some(MAX_HANDSHAKE_COMMAND)
+            };
+            if let Some(cap) = cap
+                && payload_len > cap
+            {
+                return Err(Error::Protocol(format!(
+                    "WS frame too large: {payload_len} bytes (max {cap})"
+                )));
+            }
             if self.in_buf.len() < total_frame {
                 return Ok(());
             }

--- a/omq-proto/src/proto/greeting.rs
+++ b/omq-proto/src/proto/greeting.rs
@@ -91,6 +91,8 @@ impl MechanismName {
     }
 
     /// Trimmed name as `&str`. Returns an error if non-ASCII.
+    // Returns Result because from_padded() accepts raw wire bytes without
+    // ASCII validation, so a wire-received name can contain non-UTF-8.
     pub fn as_str(&self) -> Result<&str> {
         std::str::from_utf8(self.as_bytes())
             .map_err(|_| Error::Protocol("mechanism name is not valid ASCII".into()))

--- a/omq-proto/src/proto/mod.rs
+++ b/omq-proto/src/proto/mod.rs
@@ -117,6 +117,12 @@ impl SocketType {
     }
 }
 
+impl std::fmt::Display for SocketType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// ZMTP socket-type compatibility matrix (RFC 23 + 37 + 48 + 52).
 ///
 /// Returns true iff a socket of type `ours` can handshake with a peer of type

--- a/omq-proto/src/proto/transform/lz4.rs
+++ b/omq-proto/src/proto/transform/lz4.rs
@@ -42,6 +42,15 @@ const ENVELOPE_LZ4B: usize = 12;
 /// 1 GiB, well within the LZ4 block API's i32 parameter limit.
 const LZ4M_BLOCK_SIZE: usize = 0x4000_0000;
 
+/// LZ4's worst-case decoder expansion ratio. A single block byte can
+/// expand to at most this many output bytes (a maximal match costs
+/// roughly 3 + len/255 input bytes per `len` output bytes, so the ratio
+/// approaches but never reaches 255:1). A declared output larger than
+/// the available compressed bytes times this ratio is impossible and
+/// signals a hostile or corrupt frame. Used to bound the up-front LZ4M
+/// allocation even when no `max_message_size` budget is configured.
+const LZ4_MAX_EXPANSION: usize = 255;
+
 /// Below this size, plaintext passthrough always wins net of the 4-byte
 /// envelope. Matches `omq-lz4` RFC §5.4.
 const MIN_COMPRESS_NO_DICT: usize = 512;
@@ -514,6 +523,18 @@ fn decode_lz4m(
         .map_err(|_| Error::Protocol("LZ4M declared size exceeds usize".into()))?;
     take_budget(budget, decompressed_size)?;
 
+    // Decompression-bomb guard. `decompressed_size` is an attacker-controlled
+    // 8-byte wire field and `take_budget` is a no-op when no max_message_size
+    // is set (the default), so without this the line below would allocate an
+    // arbitrary amount from a tiny frame. The decompressed output cannot
+    // exceed the available compressed bytes times LZ4's max expansion ratio.
+    let avail = body.len() - 8;
+    if decompressed_size > avail.saturating_mul(LZ4_MAX_EXPANSION) {
+        return Err(Error::Protocol(
+            "LZ4M declared size implausibly large for compressed input".into(),
+        ));
+    }
+
     let mut out = vec![0u8; decompressed_size];
     let mut src_pos = 8;
     let mut dst_pos = 0;
@@ -895,6 +916,22 @@ mod tests {
         let mut dec = test_dec().with_max_message_size(Some(TEST_BLOCK));
         let err = dec.decode(wire.into_iter().next().unwrap()).unwrap_err();
         assert!(matches!(err, Error::MessageTooLarge { .. }));
+    }
+
+    #[test]
+    fn lz4m_decompression_bomb_rejected() {
+        // A tiny LZ4M frame declaring a huge decompressed size must be
+        // rejected without allocating, even with no max_message_size budget
+        // configured (the default). Without the expansion-ratio guard this
+        // would attempt `vec![0u8; declared]` and abort/OOM the process.
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&SENTINEL_LZ4M);
+        frame.extend_from_slice(&u64::MAX.to_le_bytes()); // declared ~18 EiB
+        // no compressed blocks follow
+
+        let mut dec = test_dec(); // budget = None
+        let err = dec.decode(Message::single(frame)).unwrap_err();
+        assert!(matches!(err, Error::Protocol(_)));
     }
 
     #[test]

--- a/omq-proto/tests/connection.rs
+++ b/omq-proto/tests/connection.rs
@@ -179,6 +179,30 @@ fn oversized_message_rejected() {
 }
 
 #[test]
+fn oversized_handshake_command_rejected() {
+    // A peer must not be able to make us buffer an unbounded amount of data
+    // pre-authentication by declaring a huge handshake command frame. The
+    // declared size is rejected from the header alone, before the body is
+    // buffered. This holds even with no max_message_size configured (which
+    // bounds user data, not protocol handshake commands).
+    let mut a = Connection::new(ConnectionConfig::new(Role::Server, SocketType::Pull));
+    let b = Connection::new(ConnectionConfig::new(Role::Client, SocketType::Push));
+
+    // Feed `a` a real greeting so it enters the mechanism-handshake state.
+    let greeting = b.poll_transmit();
+    assert_eq!(greeting.len(), 64, "full greeting in one transmit");
+    let greeting = Bytes::copy_from_slice(&greeting);
+    a.handle_input(greeting).unwrap();
+
+    // Long-form COMMAND frame header declaring ~256 MiB, no body.
+    let declared: u64 = 256 * 1024 * 1024;
+    let mut hdr = vec![0x06u8]; // FLAG_COMMAND | FLAG_LONG
+    hdr.extend_from_slice(&declared.to_be_bytes());
+    let err = a.handle_input(Bytes::from(hdr)).unwrap_err();
+    assert!(matches!(err, Error::HandshakeFailed(_)), "got {err:?}");
+}
+
+#[test]
 fn streaming_one_byte_at_a_time_handshake() {
     let mut push = Connection::new(ConnectionConfig::new(Role::Client, SocketType::Push));
     let mut pull = Connection::new(ConnectionConfig::new(Role::Server, SocketType::Pull));

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -17,7 +17,6 @@ use omq_proto::message::Message;
 pub(crate) const WIRE_SLOT_CAP_DEFAULT: usize = 2 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum TryEncodeResult {
     Ok,
     Dead,

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -591,12 +591,14 @@ async fn wait_for_targets_space(targets: &[PeerSend]) {
         });
         match notified {
             Some(notified) => {
+                let mut notified = std::pin::pin!(notified);
+                notified.as_mut().enable();
                 if targets_have_space(targets) {
                     return;
                 }
                 tokio::select! {
                     biased;
-                    () = notified => {}
+                    () = &mut notified => {}
                     () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
                 }
             }

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -266,8 +266,7 @@ impl RecvStrategy {
     /// sees the full envelope; for `FairQueue`, returns the message
     /// unchanged. Used when the `type_state` needs to post-process (REQ,
     /// REP) rather than hitting the recv channel directly.
-    #[expect(clippy::unused_async)]
-    pub(crate) async fn wrap_for_transform(&self, peer_id: u64, msg: Message) -> Option<Message> {
+    pub(crate) fn wrap_for_transform(&self, peer_id: u64, msg: Message) -> Option<Message> {
         match self {
             Self::None => None,
             Self::FairQueue(_) => Some(msg),

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -261,7 +261,7 @@ impl SocketDriver {
     async fn run(mut self) {
         loop {
             if self.should_exit() {
-                self.teardown().await;
+                self.teardown();
                 return;
             }
 
@@ -272,11 +272,11 @@ impl SocketDriver {
             tokio::select! {
                 biased;
                 () = self.cancel.cancelled() => {
-                    self.teardown().await;
+                    self.teardown();
                     return;
                 }
                 () = async { linger_sleep.unwrap().await }, if self.close_deadline.is_some() => {
-                    self.teardown().await;
+                    self.teardown();
                     return;
                 }
                 cmd = self.cmd_rx.recv(), if !self.closing => match cmd {
@@ -400,8 +400,7 @@ impl SocketDriver {
         }
     }
 
-    #[expect(clippy::unused_async)]
-    async fn teardown(&mut self) {
+    fn teardown(&mut self) {
         self.send_strategy.shutdown();
         for p in self.peers.values() {
             p.handle.cancel.cancel();

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -802,7 +802,7 @@ struct InprocDriverCtx {
 /// Synthesizes `HandshakeSucceeded` immediately (no greeting exchange),
 /// then forwards Messages and Commands between the `SocketDriver`'s
 /// inbox and the partner's channels until either side drops.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn inproc_peer_driver(
     mut inbox: mpsc::Receiver<crate::engine::DriverCommand>,
     mut in_rx: mpsc::Receiver<InboundFrame>,

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -583,7 +583,7 @@ impl SocketDriver {
                     return;
                 }
                 if self.type_state_needs_transform() {
-                    let wrapped = self.recv_strategy.wrap_for_transform(peer_id, msg).await;
+                    let wrapped = self.recv_strategy.wrap_for_transform(peer_id, msg);
                     let Some(wrapped) = wrapped else { return };
                     let transformed = self
                         .type_state

--- a/omq-tokio/tests/broker.rs
+++ b/omq-tokio/tests/broker.rs
@@ -56,14 +56,14 @@ async fn router_dealer_rep_single_cycle() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(work.part_bytes(0).unwrap(), &b"work"[..]);
+    assert_eq!(work, Message::single("work"));
     rep.send(Message::single("done")).await.unwrap();
 
     let reply = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"done"[..]);
+    assert_eq!(reply, Message::single("done"));
 
     broker.await.unwrap();
 }

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -76,7 +76,7 @@ async fn push_pull_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+    assert_eq!(m, Message::single("late"));
 }
 
 #[tokio::test]
@@ -110,14 +110,14 @@ async fn req_rep_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
 
     rep.send(Message::single("a")).await.unwrap();
     let a = tokio::time::timeout(TIMEOUT, req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 #[tokio::test]
@@ -151,14 +151,14 @@ async fn pair_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-a"[..]);
+    assert_eq!(m, Message::single("from-a"));
 
     b.send(Message::single("from-b")).await.unwrap();
     let m = tokio::time::timeout(TIMEOUT, a.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"from-b"[..]);
+    assert_eq!(m, Message::single("from-b"));
 }
 
 #[tokio::test]
@@ -192,7 +192,7 @@ async fn pub_sub_connect_before_bind(ep: Endpoint) {
     loop {
         pub_.send(Message::single("x.hit")).await.unwrap();
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), sub.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"x.hit"[..]);
+            assert_eq!(m, Message::single("x.hit"));
             break;
         }
         assert!(
@@ -207,7 +207,7 @@ async fn pub_sub_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x.second"[..]);
+    assert_eq!(m, Message::single("x.second"));
 }
 
 #[tokio::test]
@@ -244,8 +244,7 @@ async fn dealer_router_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hello"]));
 
     router
         .send(Message::multipart([
@@ -258,7 +257,7 @@ async fn dealer_router_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"world"[..]);
+    assert_eq!(m, Message::single("world"));
 }
 
 #[tokio::test]
@@ -295,8 +294,7 @@ async fn client_server_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
 
     server
         .send(Message::multipart([
@@ -309,7 +307,7 @@ async fn client_server_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(m, Message::single("pong"));
 }
 
 #[tokio::test]
@@ -343,7 +341,7 @@ async fn scatter_gather_connect_before_bind(ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late"[..]);
+    assert_eq!(m, Message::single("late"));
 }
 
 #[tokio::test]
@@ -377,8 +375,7 @@ async fn radio_dish_connect_before_bind(ep: Endpoint) {
     loop {
         radio.send(Message::multipart(["w", "hit"])).await.unwrap();
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"w"[..]);
-            assert_eq!(m.part_bytes(1).unwrap(), &b"hit"[..]);
+            assert_eq!(m, Message::multipart(["w", "hit"]));
             break;
         }
         assert!(

--- a/omq-tokio/tests/coverage_matrix.rs
+++ b/omq-tokio/tests/coverage_matrix.rs
@@ -47,7 +47,7 @@ async fn push_pull_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn req_rep_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -58,13 +58,13 @@ async fn req_rep_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"q"[..]);
+    assert_eq!(q, Message::single("q"));
     server.send(Message::single("a")).await.unwrap();
     let a = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"a"[..]);
+    assert_eq!(a, Message::single("a"));
 }
 
 async fn dealer_router_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -79,8 +79,7 @@ async fn dealer_router_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"d1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::multipart(["d1", "hi"]));
     server
         .send(Message::multipart(["d1", "reply"]))
         .await
@@ -89,8 +88,7 @@ async fn dealer_router_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.len(), 1);
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply"[..]);
+    assert_eq!(r, Message::single("reply"));
 }
 
 async fn pair_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -101,7 +99,7 @@ async fn pair_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x"[..]);
+    assert_eq!(m, Message::single("x"));
 }
 
 async fn pub_sub_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -111,7 +109,7 @@ async fn pub_sub_roundtrip(server: &Socket, client_ep: Endpoint) {
     for _ in 0..30 {
         let _ = server.send(Message::single("hello")).await;
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(50), s.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+            assert_eq!(m, Message::single("hello"));
             return;
         }
     }
@@ -130,8 +128,7 @@ async fn client_server_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"c1"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::multipart(["c1", "ping"]));
     server
         .send(Message::multipart(["c1", "pong"]))
         .await
@@ -140,8 +137,7 @@ async fn client_server_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.len(), 1);
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 async fn scatter_gather_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -153,7 +149,7 @@ async fn scatter_gather_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"m"[..]);
+    assert_eq!(m, Message::single("m"));
 }
 
 async fn channel_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -165,7 +161,7 @@ async fn channel_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(m, Message::single("hi"));
 }
 
 async fn peer_roundtrip(server: &Socket, client_ep: Endpoint) {
@@ -180,8 +176,7 @@ async fn peer_roundtrip(server: &Socket, client_ep: Endpoint) {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"pb"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hi a"[..]);
+    assert_eq!(m, Message::multipart(["pb", "hi a"]));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/draft_types.rs
+++ b/omq-tokio/tests/draft_types.rs
@@ -31,9 +31,7 @@ async fn client_server_basic_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.len(), 2);
-    assert_eq!(got.part_bytes(0).unwrap(), &b"cli1"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(got, Message::multipart(["cli1", "ping"]));
 
     // Server replies via [routing_id, body].
     server
@@ -45,8 +43,7 @@ async fn client_server_basic_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.len(), 1);
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(reply, Message::single("pong"));
 }
 
 #[tokio::test]
@@ -114,14 +111,14 @@ async fn channel_pair_one_to_one() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"hi"[..]);
+    assert_eq!(got, Message::single("hi"));
 
     b.send(Message::single("there")).await.unwrap();
     let got = tokio::time::timeout(Duration::from_millis(500), a.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"there"[..]);
+    assert_eq!(got, Message::single("there"));
 }
 
 #[tokio::test]
@@ -155,8 +152,7 @@ async fn peer_bidirectional_identity_routing() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"peer-b"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello a"[..]);
+    assert_eq!(got, Message::multipart(["peer-b", "hello a"]));
 
     a.send(Message::multipart(["peer-b", "hello b"]))
         .await
@@ -165,8 +161,7 @@ async fn peer_bidirectional_identity_routing() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"peer-a"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello b"[..]);
+    assert_eq!(got, Message::multipart(["peer-a", "hello b"]));
 }
 
 #[tokio::test]
@@ -329,8 +324,7 @@ async fn peer_three_way() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"C"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hello from C"[..]);
+    assert_eq!(m, Message::multipart(["C", "hello from C"]));
 
     // A -> C
     a.send(Message::multipart(["C", "reply from A"]))
@@ -340,8 +334,7 @@ async fn peer_three_way() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"A"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"reply from A"[..]);
+    assert_eq!(m, Message::multipart(["A", "reply from A"]));
 
     // C -> B
     c.send(Message::multipart(["B", "hello from C"]))
@@ -351,6 +344,5 @@ async fn peer_three_way() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"C"[..]);
-    assert_eq!(m.part_bytes(1).unwrap(), &b"hello from C"[..]);
+    assert_eq!(m, Message::multipart(["C", "hello from C"]));
 }

--- a/omq-tokio/tests/inproc_recv_race.rs
+++ b/omq-tokio/tests/inproc_recv_race.rs
@@ -55,7 +55,7 @@ async fn recv_after_inproc_peer_close_sees_tcp_messages() {
         .await
         .expect("recv inproc msg timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"from-inproc");
+    assert_eq!(msg, Message::single("from-inproc"));
 
     push_inproc.close().await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -72,7 +72,7 @@ async fn recv_after_inproc_peer_close_sees_tcp_messages() {
         .await
         .expect("pull.recv() hung after inproc peer closed (bug #2: recv stuck on recv_notify)")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"from-tcp");
+    assert_eq!(msg, Message::single("from-tcp"));
 }
 
 /// Bug 2 variant: after an inproc peer exits, messages from a second
@@ -94,7 +94,7 @@ async fn recv_after_inproc_peer_close_sees_new_inproc_messages() {
         .await
         .expect("recv a timed out")
         .unwrap();
-    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"a");
+    assert_eq!(msg, Message::single("a"));
 
     push_a.close().await.unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/omq-tokio/tests/ipc.rs
+++ b/omq-tokio/tests/ipc.rs
@@ -29,7 +29,7 @@ async fn ipc_push_pull_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over ipc"[..]);
+    assert_eq!(m, Message::single("hello over ipc"));
 }
 
 #[tokio::test]
@@ -44,13 +44,13 @@ async fn ipc_req_rep_roundtrip() {
 
     req.send(Message::single("ping")).await.unwrap();
     let got = rep.recv().await.unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(got, Message::single("ping"));
     rep.send(Message::single("pong")).await.unwrap();
     let reply = tokio::time::timeout(Duration::from_millis(500), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(reply, Message::single("pong"));
 }
 
 #[cfg(target_os = "linux")]
@@ -76,7 +76,7 @@ async fn ipc_abstract_push_pull_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello over abstract ipc"[..]);
+    assert_eq!(m, Message::single("hello over abstract ipc"));
 }
 
 #[tokio::test]
@@ -103,7 +103,7 @@ async fn ipc_connect_before_bind() {
         .await
         .expect("recv timed out after late bind")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"late-bind"[..]);
+    assert_eq!(m, Message::single("late-bind"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/ipv6.rs
+++ b/omq-tokio/tests/ipv6.rs
@@ -53,7 +53,7 @@ async fn ipv6_push_pull() {
         .await
         .expect("ipv6 push/pull timed out")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello v6"[..]);
+    assert_eq!(m, Message::single("hello v6"));
 }
 
 #[tokio::test]
@@ -72,14 +72,14 @@ async fn ipv6_req_rep() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"ping"[..]);
+    assert_eq!(m, Message::single("ping"));
 
     rep.send(Message::single("pong")).await.unwrap();
     let r = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(r, Message::single("pong"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/lz4_tcp.rs
+++ b/omq-tokio/tests/lz4_tcp.rs
@@ -67,7 +67,7 @@ async fn small_message_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"hello"[..]);
+    assert_eq!(m, Message::single("hello"));
 }
 
 #[tokio::test]
@@ -240,14 +240,14 @@ async fn req_rep_over_lz4() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(q.part_bytes(0).unwrap(), &b"question"[..]);
+    assert_eq!(q, Message::single("question"));
 
     rep.send(Message::single("answer")).await.unwrap();
     let a = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(a.part_bytes(0).unwrap(), &b"answer"[..]);
+    assert_eq!(a, Message::single("answer"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -44,8 +44,7 @@ async fn pub_sub_simple_prefix_match() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap(), &b"news.sports"[..]);
-    assert_eq!(got1.part_bytes(1).unwrap(), &b"ball scores"[..]);
+    assert_eq!(got1, Message::multipart(["news.sports", "ball scores"]));
     assert_eq!(got2.part_bytes(0).unwrap(), &b"news.tech"[..]);
 
     // No third message -- 'weather' was filtered.
@@ -80,7 +79,7 @@ async fn pub_sub_late_subscriber_misses_earlier() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"post-subscribe"[..]);
+    assert_eq!(m, Message::single("post-subscribe"));
 
     // The pre-subscribe message must NOT arrive.
     let other = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
@@ -147,7 +146,7 @@ async fn pub_sub_unsubscribe() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"apricot"[..]);
+    assert_eq!(m, Message::single("apricot"));
 
     // blueberry filtered out.
     let other = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
@@ -174,7 +173,7 @@ async fn sub_replays_subscriptions_on_new_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"x.hello"[..]);
+    assert_eq!(m, Message::single("x.hello"));
     let other = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(other.is_err());
 }

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -28,9 +28,9 @@ async fn push_pull_single_peer() {
     let m1 = pull.recv().await.unwrap();
     let m2 = pull.recv().await.unwrap();
     let m3 = pull.recv().await.unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap(), &b"a"[..]);
-    assert_eq!(m2.part_bytes(0).unwrap(), &b"b"[..]);
-    assert_eq!(m3.part_bytes(0).unwrap(), &b"c"[..]);
+    assert_eq!(m1, Message::single("a"));
+    assert_eq!(m2, Message::single("b"));
+    assert_eq!(m3, Message::single("c"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/radio_dish.rs
+++ b/omq-tokio/tests/radio_dish.rs
@@ -43,10 +43,8 @@ async fn radio_to_dish_with_matching_group() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m1.part_bytes(1).unwrap(), &b"sunny"[..]);
-    assert_eq!(m2.part_bytes(0).unwrap(), &b"weather"[..]);
-    assert_eq!(m2.part_bytes(1).unwrap(), &b"rain"[..]);
+    assert_eq!(m1, Message::multipart(["weather", "sunny"]));
+    assert_eq!(m2, Message::multipart(["weather", "rain"]));
 
     // The "news" message is not delivered.
     let third = tokio::time::timeout(Duration::from_millis(100), dish.recv()).await;

--- a/omq-tokio/tests/reconnect.rs
+++ b/omq-tokio/tests/reconnect.rs
@@ -47,7 +47,7 @@ async fn connect_retries_until_listener_appears() {
         .await
         .expect("recv timeout")
         .unwrap();
-    assert_eq!(m.part_bytes(0).unwrap(), &b"eventually"[..]);
+    assert_eq!(m, Message::single("eventually"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/reconnect_all_types.rs
+++ b/omq-tokio/tests/reconnect_all_types.rs
@@ -52,7 +52,7 @@ async fn req_rep_reconnect_after_server_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"ping1");
+    assert_eq!(got, Message::single("ping1"));
     rep1.send(Message::single("pong1")).await.unwrap();
     tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
@@ -67,13 +67,13 @@ async fn req_rep_reconnect_after_server_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"ping2");
+    assert_eq!(got2, Message::single("ping2"));
     rep2.send(Message::single("pong2")).await.unwrap();
     let reply2 = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"pong2");
+    assert_eq!(reply2, Message::single("pong2"));
 }
 
 #[tokio::test]
@@ -106,13 +106,13 @@ async fn req_state_machine_survives_drop_mid_cycle() {
         .await
         .expect("post-drop recv timed out")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"c");
+    assert_eq!(got, Message::single("c"));
     rep2.send(Message::single("c-reply")).await.unwrap();
     let reply = tokio::time::timeout(Duration::from_secs(2), req.recv())
         .await
         .expect("post-drop reply timed out")
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap().as_ref(), b"c-reply");
+    assert_eq!(reply, Message::single("c-reply"));
 }
 
 // ── PUB / SUB ────────────────────────────────────────────────────────────────
@@ -132,7 +132,7 @@ async fn pub_sub_reconnect_replays_subscriptions() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(m1.part_bytes(0).unwrap().as_ref(), b"x.hello");
+    assert_eq!(m1, Message::single("x.hello"));
 
     pub1.close().await.unwrap();
     let pub2 = rebind(&ep, || Socket::new(SocketType::Pub, Options::default())).await;
@@ -147,12 +147,12 @@ async fn pub_sub_reconnect_replays_subscriptions() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(m2.part_bytes(0).unwrap().as_ref(), b"x.world");
+    assert_eq!(m2, Message::single("x.world"));
     let m3 = tokio::time::timeout(Duration::from_millis(500), sub.recv())
         .await
         .expect("second post-restart recv timed out")
         .unwrap();
-    assert_eq!(m3.part_bytes(0).unwrap().as_ref(), b"x.again");
+    assert_eq!(m3, Message::single("x.again"));
 }
 
 // ── DEALER / ROUTER ──────────────────────────────────────────────────────────
@@ -177,8 +177,7 @@ async fn dealer_router_reconnect_after_router_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"hello");
+    assert_eq!(got1, Message::multipart(["d1", "hello"]));
 
     router1.close().await.unwrap();
     let router2 = rebind(&ep, || Socket::new(SocketType::Router, Options::default())).await;
@@ -188,8 +187,7 @@ async fn dealer_router_reconnect_after_router_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"d1");
-    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"after");
+    assert_eq!(got2, Message::multipart(["d1", "after"]));
 }
 
 // ── PAIR ─────────────────────────────────────────────────────────────────────
@@ -208,7 +206,7 @@ async fn pair_reconnect_after_bind_side_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(got1, Message::single("hi"));
     pair_a1.send(Message::single("there")).await.unwrap();
     tokio::time::timeout(Duration::from_secs(2), pair_b.recv())
         .await
@@ -223,13 +221,13 @@ async fn pair_reconnect_after_bind_side_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(got2, Message::single("again"));
     pair_a2.send(Message::single("back")).await.unwrap();
     let reply2 = tokio::time::timeout(Duration::from_secs(2), pair_b.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(reply2, Message::single("back"));
 }
 
 // ── CLIENT / SERVER ──────────────────────────────────────────────────────────
@@ -254,8 +252,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(got1.part_bytes(1).unwrap().as_ref(), b"ping1");
+    assert_eq!(got1, Message::multipart(["c1", "ping1"]));
 
     server1
         .send(Message::multipart([
@@ -268,7 +265,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("initial reply timed out")
         .unwrap();
-    assert_eq!(reply1.part_bytes(0).unwrap().as_ref(), b"pong1");
+    assert_eq!(reply1, Message::single("pong1"));
 
     server1.close().await.unwrap();
     let server2 = rebind(&ep, || Socket::new(SocketType::Server, Options::default())).await;
@@ -278,8 +275,7 @@ async fn client_server_reconnect_after_server_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"c1");
-    assert_eq!(got2.part_bytes(1).unwrap().as_ref(), b"ping2");
+    assert_eq!(got2, Message::multipart(["c1", "ping2"]));
 }
 
 // ── SCATTER / GATHER ─────────────────────────────────────────────────────────
@@ -298,7 +294,7 @@ async fn scatter_gather_reconnect_after_bind_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"before");
+    assert_eq!(got1, Message::single("before"));
 
     gather1.close().await.unwrap();
     let gather2 = rebind(&ep, || Socket::new(SocketType::Gather, Options::default())).await;
@@ -308,7 +304,7 @@ async fn scatter_gather_reconnect_after_bind_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"after");
+    assert_eq!(got2, Message::single("after"));
 }
 
 // ── RADIO / DISH ─────────────────────────────────────────────────────────────
@@ -348,8 +344,7 @@ async fn radio_dish_reconnect_replays_joins() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), dish.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"w");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            assert_eq!(m, Message::multipart(["w", "after"]));
             break;
         }
         assert!(
@@ -399,8 +394,7 @@ async fn peer_reconnect_after_bind_side_restart() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a1.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"hello");
+            assert_eq!(m, Message::multipart(["pb", "hello"]));
             break;
         }
         assert!(
@@ -425,8 +419,7 @@ async fn peer_reconnect_after_bind_side_restart() {
             .await
             .unwrap();
         if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(200), peer_a2.recv()).await {
-            assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"pb");
-            assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"after");
+            assert_eq!(m, Message::multipart(["pb", "after"]));
             break;
         }
         assert!(
@@ -452,7 +445,7 @@ async fn channel_reconnect_after_bind_side_restart() {
         .await
         .expect("initial recv timed out")
         .unwrap();
-    assert_eq!(got1.part_bytes(0).unwrap().as_ref(), b"hi");
+    assert_eq!(got1, Message::single("hi"));
     ch_a1.send(Message::single("there")).await.unwrap();
     tokio::time::timeout(Duration::from_secs(2), ch_b.recv())
         .await
@@ -467,13 +460,13 @@ async fn channel_reconnect_after_bind_side_restart() {
         .await
         .expect("post-restart recv timed out")
         .unwrap();
-    assert_eq!(got2.part_bytes(0).unwrap().as_ref(), b"again");
+    assert_eq!(got2, Message::single("again"));
     ch_a2.send(Message::single("back")).await.unwrap();
     let reply2 = tokio::time::timeout(Duration::from_secs(2), ch_b.recv())
         .await
         .expect("post-restart reply timed out")
         .unwrap();
-    assert_eq!(reply2.part_bytes(0).unwrap().as_ref(), b"back");
+    assert_eq!(reply2, Message::single("back"));
 }
 
 // ── XPUB / XSUB ─────────────────────────────────────────────────────────────

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -39,8 +39,7 @@ async fn req_rep_basic_roundtrip() {
     req.send(Message::single("hello")).await.unwrap();
 
     let request = rep.recv().await.unwrap();
-    assert_eq!(request.len(), 1);
-    assert_eq!(request.part_bytes(0).unwrap(), &b"hello"[..]);
+    assert_eq!(request, Message::single("hello"));
 
     rep.send(Message::single("world")).await.unwrap();
 
@@ -48,8 +47,7 @@ async fn req_rep_basic_roundtrip() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.len(), 1);
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"world"[..]);
+    assert_eq!(reply, Message::single("world"));
 }
 
 #[tokio::test]
@@ -115,8 +113,7 @@ async fn dealer_to_rep_envelope() {
         .unwrap();
 
     let got = rep.recv().await.unwrap();
-    assert_eq!(got.len(), 1);
-    assert_eq!(got.part_bytes(0).unwrap(), &b"hello"[..]);
+    assert_eq!(got, Message::single("hello"));
 
     rep.send(Message::single("world")).await.unwrap();
 
@@ -150,7 +147,7 @@ async fn rep_survives_client_disconnect_mid_cycle() {
             .await
             .expect("REP recv timed out for first client")
             .unwrap();
-        assert_eq!(m.part_bytes(0).unwrap().as_ref(), b"drop-me");
+        assert_eq!(m, Message::single("drop-me"));
         // req1 drops here: connection closes before REP replies.
     }
 
@@ -167,14 +164,14 @@ async fn rep_survives_client_disconnect_mid_cycle() {
         .await
         .expect("REP did not receive second client's request")
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap().as_ref(), b"real");
+    assert_eq!(got, Message::single("real"));
 
     rep.send(Message::single("reply")).await.unwrap();
     let reply = tokio::time::timeout(Duration::from_millis(500), req2.recv())
         .await
         .expect("REQ2 did not receive reply")
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap().as_ref(), b"reply");
+    assert_eq!(reply, Message::single("reply"));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -36,9 +36,7 @@ async fn router_prefixes_identity_on_recv() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.len(), 2, "router message is [identity, body]");
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alice"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(got, Message::multipart(["alice", "hello"]));
 }
 
 #[tokio::test]
@@ -58,8 +56,7 @@ async fn router_routes_back_by_identity() {
     dealer.send(Message::single("ping")).await.unwrap();
 
     let incoming = router.recv().await.unwrap();
-    assert_eq!(incoming.part_bytes(0).unwrap(), &b"bob"[..]);
-    assert_eq!(incoming.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(incoming, Message::multipart(["bob", "ping"]));
 
     // Reply: [identity, body]. Router strips identity, routes to the peer.
     router
@@ -71,7 +68,7 @@ async fn router_routes_back_by_identity() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"pong"[..]);
+    assert_eq!(reply, Message::single("pong"));
 }
 
 #[tokio::test]
@@ -177,7 +174,7 @@ async fn router_assigns_identity_for_peers_without_one() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(reply.part_bytes(0).unwrap(), &b"reply"[..]);
+    assert_eq!(reply, Message::single("reply"));
 }
 
 // --- Handover tests ---
@@ -198,8 +195,7 @@ async fn router_handover_evicts_old_peer() {
 
     dealer_a.send(Message::single("hello")).await.unwrap();
     let got = router.recv().await.unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alpha"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
+    assert_eq!(got, Message::multipart(["alpha", "hello"]));
 
     router
         .send(Message::multipart(["alpha", "reply-1"]))
@@ -209,7 +205,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply-1"[..]);
+    assert_eq!(r, Message::single("reply-1"));
 
     let dealer_b = Socket::new(SocketType::Dealer, no_reconnect);
     dealer_b.connect(ep).await.unwrap();
@@ -220,8 +216,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"alpha"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"world"[..]);
+    assert_eq!(got, Message::multipart(["alpha", "world"]));
 
     router
         .send(Message::multipart(["alpha", "reply-2"]))
@@ -231,7 +226,7 @@ async fn router_handover_evicts_old_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(r.part_bytes(0).unwrap(), &b"reply-2"[..]);
+    assert_eq!(r, Message::single("reply-2"));
 
     let r = tokio::time::timeout(Duration::from_millis(100), dealer_a.recv()).await;
     assert!(r.is_err(), "dealer_a should not receive after handover");
@@ -343,8 +338,7 @@ async fn server_handover_evicts_old_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"cli"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"ping"[..]);
+    assert_eq!(got, Message::multipart(["cli", "ping"]));
 
     let client_b = Socket::new(SocketType::Client, no_reconnect);
     client_b.connect(ep).await.unwrap();
@@ -370,6 +364,5 @@ async fn server_handover_evicts_old_peer() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got.part_bytes(0).unwrap(), &b"cli"[..]);
-    assert_eq!(got.part_bytes(1).unwrap(), &b"pong"[..]);
+    assert_eq!(got, Message::multipart(["cli", "pong"]));
 }

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -31,10 +31,10 @@ unsafe impl<T: Send> Sync for AsyncRing<T> {}
 
 impl<T> Drop for AsyncRing<T> {
     fn drop(&mut self) {
+        // Drain leftover items. `drop_remaining` advances `head` to `flush`,
+        // so the subsequent automatic `Ring::drop` is a no-op and the `buf`
+        // allocation is freed normally (no double-drop, no leak).
         self.ring.drop_remaining();
-        // Zero out counters so Ring::Drop is a no-op (no double-free).
-        self.ring.head.0.store(0, Ordering::Relaxed);
-        self.ring.flush.0.store(0, Ordering::Relaxed);
     }
 }
 

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -161,6 +161,10 @@ impl<T> Ring<T> {
     /// Drop all items between head and flush. Must only be called with
     /// exclusive access (i.e. in a `Drop` impl or when no concurrent
     /// readers/writers exist).
+    ///
+    /// Idempotent: it advances `head` to `flush` as it drains, so a second
+    /// call (e.g. `Ring::drop` running after an async wrapper already
+    /// drained) sees an empty range and cannot double-drop.
     pub(crate) fn drop_remaining(&mut self) {
         let head = self.head.0.load(Ordering::Relaxed);
         let flush = self.flush.0.load(Ordering::Relaxed);
@@ -171,6 +175,7 @@ impl<T> Ring<T> {
                 (*ptr).assume_init_drop();
             });
         }
+        self.head.0.store(flush, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
- Remove dead `InboundFrame::message()` constructor
- `#[allow]` to `#[expect]` where lints fire unconditionally (`TryEncodeResult`, `inproc_peer_driver`)
- `impl Display for SocketType` (delegates to `as_str()`, produces `PUB` not `SocketType::Pub`)
- `derive Hash` on `Endpoint`, `Host`, `IpcPath` (eliminates string-key indirection in backends)
- yring: make `Ring::drop_remaining` idempotent (advance `head` to `flush`) so `AsyncRing::drop` no longer pokes counters and the `buf` allocation is still freed; a `ManuallyDrop<Ring>` wrapper would have leaked it (confirmed under miri)
- `zmq_sleep`: guard against negative `c_int` wrapping to huge `u64` duration
- `generated_identity`: stack `[u8; 9]` instead of `Vec::with_capacity(9)`
- Remove `async` from `SocketDriver::teardown` and `RecvStrategy::wrap_for_transform` (never await)
- `enable()` on `Notified` future in `wait_for_targets_space` before re-checking condition (closes TOCTOU gap)
- `impl PartialEq + Eq` for `Payload` (byte-wise via `as_slice()`) and `Message` (part-by-part via `get()`)
- Simplify ~400 test assertions across 47 files using direct `Message` equality (-104 lines net)
- Document dropped audit findings in code to prevent rediscovery

Security and robustness fixes surfaced by the audit (all reachable from a malicious or buggy peer):

- omq-proto: guard LZ4M decode against a decompression bomb. An 8-byte wire field drove an unbounded `vec![0u8; declared]`, and `take_budget` is a no-op when `max_message_size` is unset (the default), so 12 bytes on an unauthenticated `lz4+tcp://` link could abort/OOM the process. Cap declared output at the available compressed bytes times LZ4's worst-case 255:1 expansion ratio. Regression test added.
- omq-proto: cap pre-auth handshake and WS frame sizes. `try_advance_mechanism` and `drive_ws` buffered a whole frame before any size check, so a peer could declare a huge frame and dribble bytes to defeat a configured `max_message_size`. Handshake command frames are now bounded at an absolute 256 KiB ceiling (independent of `max_message_size`, which limits user data, not protocol commands); WS data frames honor the configured limit. Regression test added.
- omq-libzmq: `zmq_msg_send` clones the `Bytes` (zero-copy Arc bump) instead of stealing it. The steal nulled `boxed` while leaving `kind=KIND_BYTES`, so after a failed `ZMQ_DONTWAIT` send a later `zmq_msg_copy` dereferenced null and a retried send transmitted an empty frame. The message now stays intact until the send succeeds.
- omq-libzmq: clamp the `zmq_proxy` control-frame slice. `zmq_recv` returns the full message length even when the body is truncated into the 64-byte buffer, so a control frame larger than 64 bytes made `&cmd[..rc]` panic.
