### PR TITLE
yring: add photon-ring to SPSC comparison bench and chart

### DIFF
--- a/yring/Cargo.toml
+++ b/yring/Cargo.toml
@@ -25,6 +25,7 @@ loom = "0.7"
 [dev-dependencies]
 futures-lite = "2"
 loom = "0.7"
+photon-ring = "2.5.0"
 rtrb = "0.3"
 crossbeam-channel = "0.5"
 

--- a/yring/benches/comparison.rs
+++ b/yring/benches/comparison.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use photon_ring::Pod;
+
 const DURATION: Duration = Duration::from_secs(2);
 
 fn yring_bench<T: Copy + Send + 'static>(cap: usize, batch_size: usize, val: T) -> f64 {
@@ -107,6 +109,38 @@ fn rtrb_chunked<T: Copy + Send + 'static>(cap: usize, batch_size: usize, val: T)
     received as f64 / start.elapsed().as_secs_f64()
 }
 
+fn photon_ring_bench<T: Pod + Send + Sync + 'static>(cap: usize, val: T) -> f64 {
+    let stop = Arc::new(AtomicBool::new(false));
+    let (mut publ, sub) = photon_ring::channel::<T>(cap);
+    let reader = sub.subscribe_tracked();
+    let barrier = photon_ring::DependencyBarrier::from_subscribers(&[&reader]);
+
+    let stop2 = stop.clone();
+    let sender = thread::spawn(move || {
+        while !stop2.load(Ordering::Relaxed) {
+            if publ.sequence().wrapping_sub(barrier.slowest()) >= cap as u64 {
+                thread::yield_now();
+            } else {
+                publ.publish(val);
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut reader = reader;
+    let mut received = 0u64;
+    while start.elapsed() < DURATION {
+        match reader.try_recv() {
+            Ok(_) => received += 1,
+            Err(_) => thread::yield_now(),
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+    sender.join().unwrap();
+
+    received as f64 / start.elapsed().as_secs_f64()
+}
+
 fn crossbeam_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     let stop = Arc::new(AtomicBool::new(false));
     let (tx, rx) = crossbeam_channel::bounded::<T>(cap);
@@ -134,7 +168,7 @@ fn crossbeam_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     received as f64 / start.elapsed().as_secs_f64()
 }
 
-fn run_suite<T: Copy + Send + 'static>(label: &str, cap: usize, batch: usize, val: T) {
+fn run_suite<T: Pod + Send + Sync + 'static>(label: &str, cap: usize, batch: usize, val: T) {
     println!("--- {label} ---");
 
     let m = |x: f64| x / 1_000_000.0;
@@ -156,6 +190,9 @@ fn run_suite<T: Copy + Send + 'static>(label: &str, cap: usize, batch: usize, va
         "  rtrb chunked   (batch={batch:<3})  {:>7.1}M items/s",
         m(r)
     );
+
+    let r = photon_ring_bench(cap, val);
+    println!("  photon-ring                {:>7.1}M items/s", m(r));
 
     let r = crossbeam_bounded(cap, val);
     println!("  crossbeam bounded          {:>7.1}M items/s", m(r));

--- a/yring/doc/spsc_comparison.svg
+++ b/yring/doc/spsc_comparison.svg
@@ -1,60 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 419" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="700" height="419" fill="#0d1117"/>
-  <text x="350.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">SPSC channel throughput (M items/s, higher is better)</text>
-  <text x="350.0" y="38" text-anchor="middle" fill="#7d8590" font-size="10">cap=1024, 2s per config. Linux VM, i7-8700B @ 3.20 GHz, 6 cores, performance governor, turbo off</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 401" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="800" height="401" fill="#0d1117"/>
+  <text x="400.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">SPSC channel throughput (M items/s, higher is better)</text>
+  <text x="400.0" y="38" text-anchor="middle" fill="#7d8590" font-size="10">cap=1024, 2s per config. Linux VM, i7-8700B @ 3.20 GHz, 6 cores, performance governor, turbo off</text>
   <text x="22" y="180.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,180.0)">M items/s</text>
-  <line x1="70" y1="260.3" x2="680" y2="260.3" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="260.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">100</text>
-  <line x1="70" y1="215.6" x2="680" y2="215.6" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="215.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
-  <line x1="70" y1="170.9" x2="680" y2="170.9" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="170.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">300</text>
-  <line x1="70" y1="126.2" x2="680" y2="126.2" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="126.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
-  <line x1="70" y1="81.5" x2="680" y2="81.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">500</text>
-  <line x1="70" y1="305" x2="680" y2="305" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="92.0" y="245.1" width="28.5" height="59.9" fill="#e85d04" rx="1"/>
-  <text x="106.2" y="240.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">134</text>
-  <rect x="124.7" y="132.7" width="28.5" height="172.3" fill="#dc2626" rx="1"/>
-  <text x="138.9" y="127.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">386</text>
-  <rect x="157.4" y="290.8" width="28.5" height="14.2" fill="#2563eb" rx="1"/>
-  <text x="171.7" y="285.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.7</text>
-  <rect x="190.2" y="87.6" width="28.5" height="217.4" fill="#7c3aed" rx="1"/>
-  <text x="204.4" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">486</text>
-  <rect x="222.9" y="298.3" width="28.5" height="6.7" fill="#525c68" rx="1"/>
-  <text x="237.1" y="293.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.9</text>
-  <text x="171.7" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 32]</text>
-  <rect x="295.3" y="275.7" width="28.5" height="29.3" fill="#e85d04" rx="1"/>
-  <text x="309.5" y="270.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">65.6</text>
-  <rect x="328.0" y="219.2" width="28.5" height="85.8" fill="#dc2626" rx="1"/>
-  <text x="342.3" y="214.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">192</text>
-  <rect x="360.8" y="290.8" width="28.5" height="14.2" fill="#2563eb" rx="1"/>
-  <text x="375.0" y="285.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.7</text>
-  <rect x="393.5" y="174.0" width="28.5" height="131.0" fill="#7c3aed" rx="1"/>
-  <text x="407.7" y="169.0" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">293</text>
-  <rect x="426.2" y="298.5" width="28.5" height="6.5" fill="#525c68" rx="1"/>
-  <text x="440.5" y="293.5" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.6</text>
-  <text x="375.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 64]</text>
-  <rect x="498.6" y="283.1" width="28.5" height="21.9" fill="#e85d04" rx="1"/>
-  <text x="512.9" y="278.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">48.9</text>
-  <rect x="531.4" y="255.3" width="28.5" height="49.7" fill="#dc2626" rx="1"/>
-  <text x="545.6" y="250.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">111</text>
-  <rect x="564.1" y="290.7" width="28.5" height="14.3" fill="#2563eb" rx="1"/>
-  <text x="578.3" y="285.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
-  <rect x="596.8" y="218.3" width="28.5" height="86.7" fill="#7c3aed" rx="1"/>
-  <text x="611.1" y="213.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">194</text>
-  <rect x="629.6" y="298.8" width="28.5" height="6.2" fill="#525c68" rx="1"/>
-  <text x="643.8" y="293.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">13.9</text>
-  <text x="578.3" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 128]</text>
-  <rect x="130" y="338" width="12" height="12" fill="#e85d04" rx="2"/>
-  <text x="148" y="348" fill="#e6edf3" font-size="10" font-weight="500">yring (per-item, no batching)</text>
-  <rect x="130" y="356" width="12" height="12" fill="#dc2626" rx="2"/>
-  <text x="148" y="366" fill="#e6edf3" font-size="10" font-weight="500">yring (batch=64)</text>
-  <rect x="130" y="374" width="12" height="12" fill="#2563eb" rx="2"/>
-  <text x="148" y="384" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (per-item)</text>
-  <rect x="380" y="338" width="12" height="12" fill="#7c3aed" rx="2"/>
-  <text x="398" y="348" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (chunk API, batch=64)</text>
-  <rect x="380" y="356" width="12" height="12" fill="#525c68" rx="2"/>
-  <text x="398" y="366" fill="#e6edf3" font-size="10" font-weight="500">crossbeam-channel v0.5 (bounded MPMC)</text>
+  <line x1="70" y1="266.3" x2="780" y2="266.3" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="266.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">100</text>
+  <line x1="70" y1="227.6" x2="780" y2="227.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="227.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
+  <line x1="70" y1="188.9" x2="780" y2="188.9" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="188.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">300</text>
+  <line x1="70" y1="150.2" x2="780" y2="150.2" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="150.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
+  <line x1="70" y1="111.6" x2="780" y2="111.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="111.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">500</text>
+  <line x1="70" y1="72.9" x2="780" y2="72.9" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="72.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">600</text>
+  <line x1="70" y1="305" x2="780" y2="305" stroke="#30363d" stroke-width="1.5"/>
+  <rect x="95.1" y="269.3" width="27.6" height="35.7" fill="#e85d04" rx="1"/>
+  <text x="109.0" y="264.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">92.3</text>
+  <rect x="126.9" y="153.7" width="27.6" height="151.3" fill="#dc2626" rx="1"/>
+  <text x="140.7" y="148.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">391</text>
+  <rect x="158.7" y="292.7" width="27.6" height="12.3" fill="#2563eb" rx="1"/>
+  <text x="172.5" y="287.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
+  <rect x="190.4" y="87.6" width="27.6" height="217.4" fill="#7c3aed" rx="1"/>
+  <text x="204.2" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">562</text>
+  <rect x="222.2" y="295.7" width="27.6" height="9.3" fill="#16a34a" rx="1"/>
+  <text x="236.0" y="290.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">24.0</text>
+  <rect x="253.9" y="299.4" width="27.6" height="5.6" fill="#525c68" rx="1"/>
+  <text x="267.7" y="294.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.4</text>
+  <text x="188.3" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 32]</text>
+  <rect x="331.8" y="286.6" width="27.6" height="18.4" fill="#e85d04" rx="1"/>
+  <text x="345.6" y="281.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">47.6</text>
+  <rect x="363.6" y="257.2" width="27.6" height="47.8" fill="#dc2626" rx="1"/>
+  <text x="377.4" y="252.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">124</text>
+  <rect x="395.3" y="292.8" width="27.6" height="12.2" fill="#2563eb" rx="1"/>
+  <text x="409.1" y="287.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.6</text>
+  <rect x="427.1" y="191.8" width="27.6" height="113.2" fill="#7c3aed" rx="1"/>
+  <text x="440.9" y="186.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">293</text>
+  <rect x="458.8" y="296.7" width="27.6" height="8.3" fill="#16a34a" rx="1"/>
+  <text x="472.6" y="291.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">21.5</text>
+  <rect x="490.6" y="299.6" width="27.6" height="5.4" fill="#525c68" rx="1"/>
+  <text x="504.4" y="294.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.0</text>
+  <text x="425.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 64]</text>
+  <rect x="568.5" y="292.7" width="27.6" height="12.3" fill="#e85d04" rx="1"/>
+  <text x="582.3" y="287.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.7</text>
+  <rect x="600.2" y="263.8" width="27.6" height="41.2" fill="#dc2626" rx="1"/>
+  <text x="614.0" y="258.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">106</text>
+  <rect x="632.0" y="292.7" width="27.6" height="12.3" fill="#2563eb" rx="1"/>
+  <text x="645.8" y="287.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
+  <rect x="663.7" y="233.2" width="27.6" height="71.8" fill="#7c3aed" rx="1"/>
+  <text x="677.5" y="228.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">186</text>
+  <rect x="695.5" y="298.3" width="27.6" height="6.7" fill="#16a34a" rx="1"/>
+  <text x="709.3" y="293.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">17.2</text>
+  <rect x="727.2" y="299.4" width="27.6" height="5.6" fill="#525c68" rx="1"/>
+  <text x="741.0" y="294.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.4</text>
+  <text x="661.7" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 128]</text>
+  <rect x="70" y="338" width="12" height="12" fill="#e85d04" rx="2"/>
+  <text x="88" y="348" fill="#e6edf3" font-size="10" font-weight="500">yring (per-item, no batching)</text>
+  <rect x="70" y="356" width="12" height="12" fill="#dc2626" rx="2"/>
+  <text x="88" y="366" fill="#e6edf3" font-size="10" font-weight="500">yring (batch=64)</text>
+  <rect x="300" y="338" width="12" height="12" fill="#2563eb" rx="2"/>
+  <text x="318" y="348" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (per-item)</text>
+  <rect x="300" y="356" width="12" height="12" fill="#7c3aed" rx="2"/>
+  <text x="318" y="366" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (chunk API, batch=64)</text>
+  <rect x="530" y="338" width="12" height="12" fill="#16a34a" rx="2"/>
+  <text x="548" y="348" fill="#e6edf3" font-size="10" font-weight="500">photon-ring v2.5 (seqlock SPMC, per-item)</text>
+  <rect x="530" y="356" width="12" height="12" fill="#525c68" rx="2"/>
+  <text x="548" y="366" fill="#e6edf3" font-size="10" font-weight="500">crossbeam-channel v0.5 (bounded MPMC)</text>
 </svg>

--- a/yring/scripts/gen_chart.py
+++ b/yring/scripts/gen_chart.py
@@ -13,6 +13,7 @@ CHANNEL_ORDER = [
     "yring (batch=64)",
     "rtrb per-item",
     "rtrb chunked",
+    "photon-ring",
     "crossbeam bounded",
 ]
 
@@ -21,6 +22,7 @@ COLORS = {
     "yring (batch=64)":   ("#dc2626", "#a81e1e"),
     "rtrb per-item":      ("#2563eb", "#1d4ed8"),
     "rtrb chunked":       ("#7c3aed", "#6d28d9"),
+    "photon-ring":        ("#16a34a", "#15803d"),
     "crossbeam bounded":  ("#525c68", "#3d454f"),
 }
 
@@ -29,30 +31,34 @@ LABELS = {
     "yring (batch=64)":   "yring (batch=64)",
     "rtrb per-item":      "rtrb v0.3 (per-item)",
     "rtrb chunked":       "rtrb v0.3 (chunk API, batch=64)",
+    "photon-ring":        "photon-ring v2.5 (seqlock SPMC, per-item)",
     "crossbeam bounded":  "crossbeam-channel v0.5 (bounded MPMC)",
 }
 
 RESULTS = {
     "[u8; 32]": {
-        "yring (batch=1)": 134.0,
-        "yring (batch=64)": 385.6,
-        "rtrb per-item": 31.7,
-        "rtrb chunked": 486.4,
-        "crossbeam bounded": 14.9,
+        "yring (batch=1)": 92.3,
+        "yring (batch=64)": 391.2,
+        "rtrb per-item": 31.9,
+        "rtrb chunked": 561.9,
+        "photon-ring": 24.0,
+        "crossbeam bounded": 14.4,
     },
     "[u8; 64]": {
-        "yring (batch=1)": 65.6,
-        "yring (batch=64)": 192.0,
-        "rtrb per-item": 31.7,
-        "rtrb chunked": 293.2,
-        "crossbeam bounded": 14.6,
+        "yring (batch=1)": 47.6,
+        "yring (batch=64)": 123.5,
+        "rtrb per-item": 31.6,
+        "rtrb chunked": 292.6,
+        "photon-ring": 21.5,
+        "crossbeam bounded": 14.0,
     },
     "[u8; 128]": {
-        "yring (batch=1)": 48.9,
-        "yring (batch=64)": 111.2,
+        "yring (batch=1)": 31.7,
+        "yring (batch=64)": 106.4,
         "rtrb per-item": 31.9,
-        "rtrb chunked": 193.9,
-        "crossbeam bounded": 13.9,
+        "rtrb chunked": 185.6,
+        "photon-ring": 17.2,
+        "crossbeam bounded": 14.4,
     },
 }
 
@@ -75,8 +81,8 @@ def generate_chart():
     n_groups = len(GROUPS)
     n_bars = len(CHANNEL_ORDER)
 
-    svg_w = 700
-    x_left, x_right = 70, 680
+    svg_w = 800
+    x_left, x_right = 70, 780
     plot_w = x_right - x_left
 
     top_margin = 55
@@ -99,7 +105,7 @@ def generate_chart():
 
     legend_items = [(k, LABELS[k]) for k in CHANNEL_ORDER]
     leg_row_h = 18
-    leg_cols = 2
+    leg_cols = 3
     leg_rows = math.ceil(len(legend_items) / leg_cols)
 
     svg_h = int(p_bot + 40 + leg_rows * leg_row_h + 20)
@@ -193,7 +199,7 @@ def generate_chart():
 
     # legend
     leg_y = p_bot + 38
-    leg_col_x = [mid_x - 220, mid_x + 30]
+    leg_col_x = [mid_x - 330, mid_x - 100, mid_x + 130]
     for i, (key, label) in enumerate(legend_items):
         col = i // leg_rows
         row = i % leg_rows


### PR DESCRIPTION
- Add photon-ring v2.5 (seqlock SPMC) to `yring/benches/comparison.rs` with `DependencyBarrier` backpressure to prevent lapping
- Add photon-ring to `yring/scripts/gen_chart.py` (green bars, 3-column legend, wider SVG)
- Refresh all chart numbers from a single bench run