### PR TITLE
fix(yring): panic-safe drop, 128-byte padding, naming cleanup

### DIFF
--- a/yring/Cargo.toml
+++ b/yring/Cargo.toml
@@ -27,6 +27,7 @@ futures-lite = "2"
 loom = "0.7"
 rtrb = "0.3"
 crossbeam-channel = "0.5"
+flume = "0.11"
 
 [[bench]]
 name = "throughput"

--- a/yring/README.md
+++ b/yring/README.md
@@ -65,14 +65,15 @@ cap=1024, batch=64:
 
 | Channel | API | u64 (8 B) | [u8; 32] | [u8; 64] | [u8; 128] |
 |---------|-----|----------:|----------:|----------:|----------:|
-| **yring** | per-item, batch=1 | 265 | 134 | 66 | 49 |
-| **yring** | per-item, batch=64 | **595** | **386** | **192** | **111** |
+| **yring** | per-item, batch=1 | 427 | 208 | 99 | 48 |
+| **yring** | per-item, batch=64 | 569 | 394 | 210 | 109 |
 | rtrb | per-item | 32 | 32 | 32 | 32 |
-| rtrb | chunk, batch=64 | 2083 | 486 | 293 | 194 |
-| crossbeam | bounded | 15 | 15 | 15 | 14 |
+| rtrb | chunk, batch=64 | **1937** | **603** | **313** | **171** |
+| crossbeam | bounded | 15 | 15 | 14 | 13 |
+| flume | bounded | 4 | 5 | 5 | 5 |
 
-yring vs rtrb per-item (the natural API comparison): **6x** at 64
-bytes, **12x** at 32 bytes. rtrb's chunk API is faster in raw
+yring vs rtrb per-item (the natural API comparison): **3x** at 64
+bytes, **6x** at 32 bytes. rtrb's chunk API is faster in raw
 throughput because it copies contiguous slices in bulk, but requires
 restructuring code around upfront chunk sizes.
 

--- a/yring/benches/comparison.rs
+++ b/yring/benches/comparison.rs
@@ -134,6 +134,33 @@ fn crossbeam_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     received as f64 / start.elapsed().as_secs_f64()
 }
 
+fn flume_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
+    let stop = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = flume::bounded::<T>(cap);
+
+    let stop2 = stop.clone();
+    let sender = thread::spawn(move || {
+        while !stop2.load(Ordering::Relaxed) {
+            if tx.try_send(val).is_err() {
+                thread::yield_now();
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut received = 0u64;
+    while start.elapsed() < DURATION {
+        match rx.try_recv() {
+            Ok(_) => received += 1,
+            Err(_) => thread::yield_now(),
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+    sender.join().unwrap();
+
+    received as f64 / start.elapsed().as_secs_f64()
+}
+
 fn run_suite<T: Copy + Send + 'static>(label: &str, cap: usize, batch: usize, val: T) {
     println!("--- {label} ---");
 
@@ -159,6 +186,9 @@ fn run_suite<T: Copy + Send + 'static>(label: &str, cap: usize, batch: usize, va
 
     let r = crossbeam_bounded(cap, val);
     println!("  crossbeam bounded          {:>7.1}M items/s", m(r));
+
+    let r = flume_bounded(cap, val);
+    println!("  flume bounded              {:>7.1}M items/s", m(r));
 
     println!();
 }

--- a/yring/doc/spsc_comparison.svg
+++ b/yring/doc/spsc_comparison.svg
@@ -3,49 +3,57 @@
   <text x="350.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">SPSC channel throughput (M items/s, higher is better)</text>
   <text x="350.0" y="38" text-anchor="middle" fill="#7d8590" font-size="10">cap=1024, 2s per config. Linux VM, i7-8700B @ 3.20 GHz, 6 cores, performance governor, turbo off</text>
   <text x="22" y="180.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,180.0)">M items/s</text>
-  <line x1="70" y1="260.3" x2="680" y2="260.3" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="260.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">100</text>
-  <line x1="70" y1="215.6" x2="680" y2="215.6" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="215.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
-  <line x1="70" y1="170.9" x2="680" y2="170.9" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="170.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">300</text>
-  <line x1="70" y1="126.2" x2="680" y2="126.2" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="126.2" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
-  <line x1="70" y1="81.5" x2="680" y2="81.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="81.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">500</text>
+  <line x1="70" y1="268.9" x2="680" y2="268.9" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="268.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">100</text>
+  <line x1="70" y1="232.8" x2="680" y2="232.8" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="232.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
+  <line x1="70" y1="196.8" x2="680" y2="196.8" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="196.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">300</text>
+  <line x1="70" y1="160.7" x2="680" y2="160.7" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="160.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
+  <line x1="70" y1="124.6" x2="680" y2="124.6" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="124.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">500</text>
+  <line x1="70" y1="88.5" x2="680" y2="88.5" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="88.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">600</text>
   <line x1="70" y1="305" x2="680" y2="305" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="92.0" y="245.1" width="28.5" height="59.9" fill="#e85d04" rx="1"/>
-  <text x="106.2" y="240.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">134</text>
-  <rect x="124.7" y="132.7" width="28.5" height="172.3" fill="#dc2626" rx="1"/>
-  <text x="138.9" y="127.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">386</text>
-  <rect x="157.4" y="290.8" width="28.5" height="14.2" fill="#2563eb" rx="1"/>
-  <text x="171.7" y="285.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.7</text>
-  <rect x="190.2" y="87.6" width="28.5" height="217.4" fill="#7c3aed" rx="1"/>
-  <text x="204.4" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">486</text>
-  <rect x="222.9" y="298.3" width="28.5" height="6.7" fill="#525c68" rx="1"/>
-  <text x="237.1" y="293.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.9</text>
+  <rect x="91.6" y="230.1" width="23.7" height="74.9" fill="#e85d04" rx="1"/>
+  <text x="103.5" y="225.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">208</text>
+  <rect x="118.9" y="163.0" width="23.7" height="142.0" fill="#dc2626" rx="1"/>
+  <text x="130.7" y="158.0" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">394</text>
+  <rect x="146.2" y="293.3" width="23.7" height="11.7" fill="#2563eb" rx="1"/>
+  <text x="158.0" y="288.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.3</text>
+  <rect x="173.4" y="87.6" width="23.7" height="217.4" fill="#7c3aed" rx="1"/>
+  <text x="185.3" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">602</text>
+  <rect x="200.7" y="299.7" width="23.7" height="5.3" fill="#525c68" rx="1"/>
+  <text x="212.6" y="294.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.8</text>
+  <rect x="228.0" y="303.3" width="23.7" height="1.7" fill="#16a34a" rx="1"/>
+  <text x="239.9" y="298.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">4.8</text>
   <text x="171.7" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 32]</text>
-  <rect x="295.3" y="275.7" width="28.5" height="29.3" fill="#e85d04" rx="1"/>
-  <text x="309.5" y="270.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">65.6</text>
-  <rect x="328.0" y="219.2" width="28.5" height="85.8" fill="#dc2626" rx="1"/>
-  <text x="342.3" y="214.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">192</text>
-  <rect x="360.8" y="290.8" width="28.5" height="14.2" fill="#2563eb" rx="1"/>
-  <text x="375.0" y="285.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.7</text>
-  <rect x="393.5" y="174.0" width="28.5" height="131.0" fill="#7c3aed" rx="1"/>
-  <text x="407.7" y="169.0" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">293</text>
-  <rect x="426.2" y="298.5" width="28.5" height="6.5" fill="#525c68" rx="1"/>
-  <text x="440.5" y="293.5" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.6</text>
+  <rect x="294.9" y="269.2" width="23.7" height="35.8" fill="#e85d04" rx="1"/>
+  <text x="306.8" y="264.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">99.2</text>
+  <rect x="322.2" y="229.3" width="23.7" height="75.7" fill="#dc2626" rx="1"/>
+  <text x="334.1" y="224.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">210</text>
+  <rect x="349.5" y="293.4" width="23.7" height="11.6" fill="#2563eb" rx="1"/>
+  <text x="361.4" y="288.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.1</text>
+  <rect x="376.8" y="192.1" width="23.7" height="112.9" fill="#7c3aed" rx="1"/>
+  <text x="388.6" y="187.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">313</text>
+  <rect x="404.1" y="299.9" width="23.7" height="5.1" fill="#525c68" rx="1"/>
+  <text x="415.9" y="294.9" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.2</text>
+  <rect x="431.3" y="303.2" width="23.7" height="1.8" fill="#16a34a" rx="1"/>
+  <text x="443.2" y="298.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">5.0</text>
   <text x="375.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 64]</text>
-  <rect x="498.6" y="283.1" width="28.5" height="21.9" fill="#e85d04" rx="1"/>
-  <text x="512.9" y="278.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">48.9</text>
-  <rect x="531.4" y="255.3" width="28.5" height="49.7" fill="#dc2626" rx="1"/>
-  <text x="545.6" y="250.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">111</text>
-  <rect x="564.1" y="290.7" width="28.5" height="14.3" fill="#2563eb" rx="1"/>
-  <text x="578.3" y="285.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
-  <rect x="596.8" y="218.3" width="28.5" height="86.7" fill="#7c3aed" rx="1"/>
-  <text x="611.1" y="213.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">194</text>
-  <rect x="629.6" y="298.8" width="28.5" height="6.2" fill="#525c68" rx="1"/>
-  <text x="643.8" y="293.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">13.9</text>
+  <rect x="498.3" y="287.8" width="23.7" height="17.2" fill="#e85d04" rx="1"/>
+  <text x="510.1" y="282.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">47.7</text>
+  <rect x="525.6" y="265.6" width="23.7" height="39.4" fill="#dc2626" rx="1"/>
+  <text x="537.4" y="260.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">109</text>
+  <rect x="552.8" y="293.5" width="23.7" height="11.5" fill="#2563eb" rx="1"/>
+  <text x="564.7" y="288.5" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
+  <rect x="580.1" y="243.2" width="23.7" height="61.8" fill="#7c3aed" rx="1"/>
+  <text x="592.0" y="238.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">171</text>
+  <rect x="607.4" y="300.2" width="23.7" height="4.8" fill="#525c68" rx="1"/>
+  <text x="619.3" y="295.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">13.3</text>
+  <rect x="634.7" y="303.4" width="23.7" height="1.6" fill="#16a34a" rx="1"/>
+  <text x="646.5" y="298.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">4.5</text>
   <text x="578.3" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 128]</text>
   <rect x="130" y="338" width="12" height="12" fill="#e85d04" rx="2"/>
   <text x="148" y="348" fill="#e6edf3" font-size="10" font-weight="500">yring (per-item, no batching)</text>
@@ -57,4 +65,6 @@
   <text x="398" y="348" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (chunk API, batch=64)</text>
   <rect x="380" y="356" width="12" height="12" fill="#525c68" rx="2"/>
   <text x="398" y="366" fill="#e6edf3" font-size="10" font-weight="500">crossbeam-channel v0.5 (bounded MPMC)</text>
+  <rect x="380" y="374" width="12" height="12" fill="#16a34a" rx="2"/>
+  <text x="398" y="384" fill="#e6edf3" font-size="10" font-weight="500">flume v0.11 (bounded MPMC)</text>
 </svg>

--- a/yring/scripts/gen_chart.py
+++ b/yring/scripts/gen_chart.py
@@ -14,6 +14,7 @@ CHANNEL_ORDER = [
     "rtrb per-item",
     "rtrb chunked",
     "crossbeam bounded",
+    "flume bounded",
 ]
 
 COLORS = {
@@ -22,6 +23,7 @@ COLORS = {
     "rtrb per-item":      ("#2563eb", "#1d4ed8"),
     "rtrb chunked":       ("#7c3aed", "#6d28d9"),
     "crossbeam bounded":  ("#525c68", "#3d454f"),
+    "flume bounded":      ("#16a34a", "#15803d"),
 }
 
 LABELS = {
@@ -30,29 +32,33 @@ LABELS = {
     "rtrb per-item":      "rtrb v0.3 (per-item)",
     "rtrb chunked":       "rtrb v0.3 (chunk API, batch=64)",
     "crossbeam bounded":  "crossbeam-channel v0.5 (bounded MPMC)",
+    "flume bounded":      "flume v0.11 (bounded MPMC)",
 }
 
 RESULTS = {
     "[u8; 32]": {
-        "yring (batch=1)": 134.0,
-        "yring (batch=64)": 385.6,
-        "rtrb per-item": 31.7,
-        "rtrb chunked": 486.4,
-        "crossbeam bounded": 14.9,
+        "yring (batch=1)": 207.6,
+        "yring (batch=64)": 393.6,
+        "rtrb per-item": 32.3,
+        "rtrb chunked": 602.5,
+        "crossbeam bounded": 14.8,
+        "flume bounded": 4.8,
     },
     "[u8; 64]": {
-        "yring (batch=1)": 65.6,
-        "yring (batch=64)": 192.0,
-        "rtrb per-item": 31.7,
-        "rtrb chunked": 293.2,
-        "crossbeam bounded": 14.6,
+        "yring (batch=1)": 99.2,
+        "yring (batch=64)": 209.7,
+        "rtrb per-item": 32.1,
+        "rtrb chunked": 312.8,
+        "crossbeam bounded": 14.2,
+        "flume bounded": 5.0,
     },
     "[u8; 128]": {
-        "yring (batch=1)": 48.9,
-        "yring (batch=64)": 111.2,
+        "yring (batch=1)": 47.7,
+        "yring (batch=64)": 109.3,
         "rtrb per-item": 31.9,
-        "rtrb chunked": 193.9,
-        "crossbeam bounded": 13.9,
+        "rtrb chunked": 171.2,
+        "crossbeam bounded": 13.3,
+        "flume bounded": 4.5,
     },
 }
 

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -31,7 +31,7 @@ unsafe impl<T: Send> Sync for AsyncRing<T> {}
 
 impl<T> Drop for AsyncRing<T> {
     fn drop(&mut self) {
-        // Drain leftover items. `drop_remaining` advances `head` to `flush`,
+        // Drain leftover items. `drop_remaining` advances `head` to `tail`,
         // so the subsequent automatic `Ring::drop` is a no-op and the `buf`
         // allocation is freed normally (no double-drop, no leak).
         self.ring.drop_remaining();
@@ -41,7 +41,7 @@ impl<T> Drop for AsyncRing<T> {
 /// Async sending half. Wakes the consumer on flush when the ring was empty.
 pub struct AsyncProducer<T> {
     ring: Arc<AsyncRing<T>>,
-    tail: usize,
+    cursor: usize,
     cached_head: usize,
 }
 
@@ -53,7 +53,7 @@ unsafe impl<T: Send> Send for AsyncProducer<T> {}
 pub struct AsyncConsumer<T> {
     ring: Arc<AsyncRing<T>>,
     head: usize,
-    cached_flush: usize,
+    cached_tail: usize,
 }
 
 // SAFETY: AsyncConsumer<T> is Send because it is single-owner (not Sync) and
@@ -71,13 +71,13 @@ pub fn async_spsc<T>(capacity: usize) -> (AsyncProducer<T>, AsyncConsumer<T>) {
     (
         AsyncProducer {
             ring: ring.clone(),
-            tail: 0,
+            cursor: 0,
             cached_head: 0,
         },
         AsyncConsumer {
             ring,
             head: 0,
-            cached_flush: 0,
+            cached_tail: 0,
         },
     )
 }
@@ -88,7 +88,7 @@ impl<T> AsyncProducer<T> {
     pub fn push(&mut self, val: T) -> Result<(), T> {
         self.ring
             .ring
-            .push(&mut self.tail, &mut self.cached_head, val)
+            .push(&mut self.cursor, &mut self.cached_head, val)
     }
 
     /// Make all pushed items visible and wake the consumer unconditionally.
@@ -101,7 +101,7 @@ impl<T> AsyncProducer<T> {
     /// (a no-op when no waker is registered) but is race-free.
     #[inline]
     pub fn flush(&mut self) {
-        self.ring.ring.flush.0.store(self.tail, Ordering::Release);
+        self.ring.ring.tail.0.store(self.cursor, Ordering::Release);
         self.ring.consumer_waker.0.wake();
     }
 
@@ -128,7 +128,7 @@ impl<T> AsyncProducer<T> {
 
     #[inline]
     pub fn is_full(&mut self) -> bool {
-        self.ring.ring.is_full(self.tail, &mut self.cached_head)
+        self.ring.ring.is_full(self.cursor, &mut self.cached_head)
     }
 
     #[inline]
@@ -138,12 +138,12 @@ impl<T> AsyncProducer<T> {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.ring.ring.producer_len(self.tail)
+        self.ring.ring.producer_len(self.cursor)
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.ring.ring.producer_is_empty(self.tail)
+        self.ring.ring.producer_is_empty(self.cursor)
     }
 }
 
@@ -202,7 +202,7 @@ impl<T> AsyncConsumer<T> {
     /// Call [`release`](Self::release) after draining a batch.
     #[inline]
     pub fn pop(&mut self) -> Option<T> {
-        self.ring.ring.pop(&mut self.head, self.cached_flush)
+        self.ring.ring.pop(&mut self.head, self.cached_tail)
     }
 
     /// Publish consumed position so the producer can reuse slots,
@@ -216,13 +216,13 @@ impl<T> AsyncConsumer<T> {
     /// Load all items flushed since the last prefetch. One Acquire load.
     #[inline]
     pub fn prefetch(&mut self) -> usize {
-        self.ring.ring.prefetch(&mut self.cached_flush)
+        self.ring.ring.prefetch(&mut self.cached_tail)
     }
 
     /// Prefetch + pop + release in one call.
     #[inline]
     pub fn prefetch_and_pop(&mut self) -> Option<T> {
-        if self.head == self.cached_flush {
+        if self.head == self.cached_tail {
             self.prefetch();
         }
         let val = self.pop();
@@ -236,7 +236,7 @@ impl<T> AsyncConsumer<T> {
     pub fn is_empty(&self) -> bool {
         self.ring
             .ring
-            .consumer_is_empty(self.head, self.cached_flush)
+            .consumer_is_empty(self.head, self.cached_tail)
     }
 
     #[inline]
@@ -256,7 +256,7 @@ impl<T> Stream for AsyncConsumer<T> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        if this.head == this.cached_flush {
+        if this.head == this.cached_tail {
             this.prefetch();
         }
         if let Some(val) = this.pop() {
@@ -272,7 +272,7 @@ impl<T> Stream for AsyncConsumer<T> {
         this.ring.consumer_waker.0.register(cx.waker());
 
         // Re-check after registering to avoid lost wakes.
-        if this.head == this.cached_flush {
+        if this.head == this.cached_tail {
             this.prefetch();
         }
         if let Some(val) = this.pop() {

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -15,6 +15,9 @@ mod r#async;
 #[cfg(feature = "async")]
 pub use r#async::{AsyncConsumer, AsyncProducer, async_spsc};
 
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("yring requires a 64-bit target (AtomicUsize must not wrap in practice)");
+
 mod compat;
 
 use std::mem::MaybeUninit;

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -23,7 +23,7 @@ use std::mem::MaybeUninit;
 use compat::UnsafeCellExt;
 use compat::{Arc, AtomicBool, AtomicUsize, Ordering, UnsafeCell};
 
-#[repr(align(64))]
+#[repr(align(128))]
 pub(crate) struct Padded<T>(pub(crate) T);
 
 pub(crate) struct Ring<T> {

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Three pointers:
 //! - `head`: consumer read position (`AtomicUsize`, consumer-owned)
-//! - `tail`: writer position (plain usize, producer-only, no atomic)
-//! - `flush`: last flushed position (`AtomicUsize`, producer writes, consumer reads)
+//! - `cursor`: writer position (plain usize, producer-only, no atomic)
+//! - `tail`: last flushed position (`AtomicUsize`, producer writes, consumer reads)
 //!
 //! `push` writes to the ring with zero atomics. `flush` makes all
 //! pending writes visible with one Release store. `pop` reads with
@@ -35,7 +35,7 @@ pub(crate) struct Ring<T> {
     /// Consumer read position. Written by consumer, read by producer.
     pub(crate) head: Padded<AtomicUsize>,
     /// Last flushed position. Written by producer, read by consumer.
-    pub(crate) flush: Padded<AtomicUsize>,
+    pub(crate) tail: Padded<AtomicUsize>,
     /// Set by `Producer::drop`. Lets the consumer detect that no more
     /// data will ever arrive.
     pub(crate) producer_dropped: AtomicBool,
@@ -47,8 +47,8 @@ pub(crate) struct Ring<T> {
 }
 
 // SAFETY: Ring<T> is Send because all shared mutable state is accessed through
-// atomics (head, flush) and UnsafeCell slots follow the SPSC protocol: the
-// producer writes tail..flush, the consumer reads head..flush, non-overlapping.
+// atomics (head, tail) and UnsafeCell slots follow the SPSC protocol: the
+// producer writes cursor..tail, the consumer reads head..tail, non-overlapping.
 unsafe impl<T: Send> Send for Ring<T> {}
 // SAFETY: Ring<T> is Sync for the same reason: concurrent access is mediated
 // by atomics and the SPSC single-producer/single-consumer invariant.
@@ -65,7 +65,7 @@ impl<T> Ring<T> {
             buf: buf.into_boxed_slice(),
             mask: cap - 1,
             head: Padded(AtomicUsize::new(0)),
-            flush: Padded(AtomicUsize::new(0)),
+            tail: Padded(AtomicUsize::new(0)),
             producer_dropped: AtomicBool::new(false),
             #[cfg(feature = "async")]
             consumer_dropped: AtomicBool::new(false),
@@ -77,61 +77,66 @@ impl<T> Ring<T> {
     }
 
     #[inline]
-    pub(crate) fn push(&self, tail: &mut usize, cached_head: &mut usize, val: T) -> Result<(), T> {
-        if *tail - *cached_head >= self.capacity() {
+    pub(crate) fn push(
+        &self,
+        cursor: &mut usize,
+        cached_head: &mut usize,
+        val: T,
+    ) -> Result<(), T> {
+        if *cursor - *cached_head >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            if *tail - *cached_head >= self.capacity() {
+            if *cursor - *cached_head >= self.capacity() {
                 return Err(val);
             }
         }
         // SAFETY: capacity check above guarantees this slot is not
-        // visible to the consumer (tail < head + capacity).
-        self.buf[*tail & self.mask].with_mut(|ptr| unsafe {
+        // visible to the consumer (cursor < head + capacity).
+        self.buf[*cursor & self.mask].with_mut(|ptr| unsafe {
             (*ptr).write(val);
         });
-        *tail += 1;
+        *cursor += 1;
         Ok(())
     }
 
     #[inline]
-    pub(crate) fn flush_to(&self, tail: usize, cached_head: &mut usize) -> FlushResult {
-        let prev_flush = self.flush.0.load(Ordering::Relaxed);
-        if tail == prev_flush {
+    pub(crate) fn flush_to(&self, cursor: usize, cached_head: &mut usize) -> FlushResult {
+        let prev_tail = self.tail.0.load(Ordering::Relaxed);
+        if cursor == prev_tail {
             return FlushResult::NothingToFlush;
         }
-        let count = tail - prev_flush;
+        let count = cursor - prev_tail;
         *cached_head = self.head.0.load(Ordering::Acquire);
-        let was_empty = prev_flush == *cached_head;
-        self.flush.0.store(tail, Ordering::Release);
+        let was_empty = prev_tail == *cached_head;
+        self.tail.0.store(cursor, Ordering::Release);
         FlushResult::Flushed { count, was_empty }
     }
 
     #[inline]
-    pub(crate) fn is_full(&self, tail: usize, cached_head: &mut usize) -> bool {
-        if tail - *cached_head >= self.capacity() {
+    pub(crate) fn is_full(&self, cursor: usize, cached_head: &mut usize) -> bool {
+        if cursor - *cached_head >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            tail - *cached_head >= self.capacity()
+            cursor - *cached_head >= self.capacity()
         } else {
             false
         }
     }
 
     #[inline]
-    pub(crate) fn producer_len(&self, tail: usize) -> usize {
-        tail.wrapping_sub(self.head.0.load(Ordering::Acquire))
+    pub(crate) fn producer_len(&self, cursor: usize) -> usize {
+        cursor.wrapping_sub(self.head.0.load(Ordering::Acquire))
     }
 
     #[inline]
-    pub(crate) fn producer_is_empty(&self, tail: usize) -> bool {
-        tail == self.head.0.load(Ordering::Acquire)
+    pub(crate) fn producer_is_empty(&self, cursor: usize) -> bool {
+        cursor == self.head.0.load(Ordering::Acquire)
     }
 
     #[inline]
-    pub(crate) fn pop(&self, head: &mut usize, cached_flush: usize) -> Option<T> {
-        if *head == cached_flush {
+    pub(crate) fn pop(&self, head: &mut usize, cached_tail: usize) -> Option<T> {
+        if *head == cached_tail {
             return None;
         }
-        // SAFETY: head < cached_flush, so this slot was written by the
+        // SAFETY: head < cached_tail, so this slot was written by the
         // producer and made visible via flush (Release store).
         let val = self.buf[*head & self.mask].with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
         *head += 1;
@@ -144,41 +149,41 @@ impl<T> Ring<T> {
     }
 
     #[inline]
-    pub(crate) fn prefetch(&self, cached_flush: &mut usize) -> usize {
-        let new_flush = self.flush.0.load(Ordering::Acquire);
-        let count = new_flush.wrapping_sub(*cached_flush);
-        *cached_flush = new_flush;
+    pub(crate) fn prefetch(&self, cached_tail: &mut usize) -> usize {
+        let new_tail = self.tail.0.load(Ordering::Acquire);
+        let count = new_tail.wrapping_sub(*cached_tail);
+        *cached_tail = new_tail;
         count
     }
 
     #[inline]
-    pub(crate) fn consumer_is_empty(&self, head: usize, cached_flush: usize) -> bool {
-        head == cached_flush && self.flush.0.load(Ordering::Acquire) == head
+    pub(crate) fn consumer_is_empty(&self, head: usize, cached_tail: usize) -> bool {
+        head == cached_tail && self.tail.0.load(Ordering::Acquire) == head
     }
 
     #[inline]
     pub(crate) fn consumer_len(&self, head: usize) -> usize {
-        self.flush.0.load(Ordering::Acquire).wrapping_sub(head)
+        self.tail.0.load(Ordering::Acquire).wrapping_sub(head)
     }
 
-    /// Drop all items between head and flush. Must only be called with
+    /// Drop all items between head and tail. Must only be called with
     /// exclusive access (i.e. in a `Drop` impl or when no concurrent
     /// readers/writers exist).
     ///
-    /// Idempotent: it advances `head` to `flush` before draining, so a
+    /// Idempotent: it advances `head` to `tail` before draining, so a
     /// second call (e.g. `Ring::drop` running after an async wrapper
     /// already drained) sees an empty range and cannot double-drop.
     /// If a `T::drop` panics mid-loop, items past the panicking one are
     /// leaked rather than double-dropped.
     pub(crate) fn drop_remaining(&mut self) {
         let head = self.head.0.load(Ordering::Relaxed);
-        let flush = self.flush.0.load(Ordering::Relaxed);
+        let tail = self.tail.0.load(Ordering::Relaxed);
         // Advance head before the loop so a panicking T::drop cannot
         // cause a second call to re-drop the same items.
-        self.head.0.store(flush, Ordering::Relaxed);
-        for i in head..flush {
+        self.head.0.store(tail, Ordering::Relaxed);
+        for i in head..tail {
             // SAFETY: &mut self guarantees exclusive access. Slots
-            // [head..flush] were written by the producer and flushed.
+            // [head..tail] were written by the producer and flushed.
             self.buf[i & self.mask].with_mut(|ptr| unsafe {
                 (*ptr).assume_init_drop();
             });
@@ -197,7 +202,7 @@ impl<T> Drop for Ring<T> {
 pub enum FlushResult {
     /// Items were flushed. The consumer may have been idle and needs waking.
     Flushed { count: usize, was_empty: bool },
-    /// Nothing to flush (tail == flush already).
+    /// Nothing to flush (cursor == tail already).
     NothingToFlush,
 }
 
@@ -205,7 +210,7 @@ pub enum FlushResult {
 pub struct Producer<T> {
     ring: Arc<Ring<T>>,
     /// Private write position. No atomic; only the producer touches it.
-    tail: usize,
+    cursor: usize,
     /// Cached copy of the consumer's `head` to avoid Acquire loads.
     cached_head: usize,
 }
@@ -220,7 +225,7 @@ impl<T> Producer<T> {
 
 impl<T> Drop for Producer<T> {
     fn drop(&mut self) {
-        self.ring.flush.0.store(self.tail, Ordering::Release);
+        self.ring.tail.0.store(self.cursor, Ordering::Release);
         self.ring.producer_dropped.store(true, Ordering::Release);
     }
 }
@@ -234,8 +239,8 @@ pub struct Consumer<T> {
     ring: Arc<Ring<T>>,
     /// Private read position. Only the consumer touches it.
     head: usize,
-    /// Cached copy of `flush`. Updated by `prefetch()`.
-    cached_flush: usize,
+    /// Cached copy of `tail`. Updated by `prefetch()`.
+    cached_tail: usize,
 }
 
 impl<T> Consumer<T> {
@@ -257,13 +262,13 @@ pub fn spsc<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
     (
         Producer {
             ring: ring.clone(),
-            tail: 0,
+            cursor: 0,
             cached_head: 0,
         },
         Consumer {
             ring,
             head: 0,
-            cached_flush: 0,
+            cached_tail: 0,
         },
     )
 }
@@ -273,7 +278,7 @@ impl<T> Producer<T> {
     /// The value is NOT visible to the consumer until [`flush`](Self::flush).
     #[inline]
     pub fn push(&mut self, val: T) -> Result<(), T> {
-        self.ring.push(&mut self.tail, &mut self.cached_head, val)
+        self.ring.push(&mut self.cursor, &mut self.cached_head, val)
     }
 
     /// Make all pushed items visible to the consumer. One Release store.
@@ -281,7 +286,7 @@ impl<T> Producer<T> {
     /// when the ring appears full.
     #[inline]
     pub fn flush(&mut self) {
-        self.ring.flush.0.store(self.tail, Ordering::Release);
+        self.ring.tail.0.store(self.cursor, Ordering::Release);
     }
 
     /// Flush and report whether the ring was empty (consumer fully caught
@@ -289,7 +294,7 @@ impl<T> Producer<T> {
     /// Only needed when the caller uses `was_empty` for wakeup decisions.
     #[inline]
     pub fn flush_and_check(&mut self) -> FlushResult {
-        self.ring.flush_to(self.tail, &mut self.cached_head)
+        self.ring.flush_to(self.cursor, &mut self.cached_head)
     }
 
     /// Push + flush in one call (convenience for single-item sends).
@@ -302,7 +307,7 @@ impl<T> Producer<T> {
 
     #[inline]
     pub fn is_full(&mut self) -> bool {
-        self.ring.is_full(self.tail, &mut self.cached_head)
+        self.ring.is_full(self.cursor, &mut self.cached_head)
     }
 
     #[inline]
@@ -312,12 +317,12 @@ impl<T> Producer<T> {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.ring.producer_len(self.tail)
+        self.ring.producer_len(self.cursor)
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.ring.producer_is_empty(self.tail)
+        self.ring.producer_is_empty(self.cursor)
     }
 }
 
@@ -329,7 +334,7 @@ impl<T> Consumer<T> {
     /// producer.
     #[inline]
     pub fn pop(&mut self) -> Option<T> {
-        self.ring.pop(&mut self.head, self.cached_flush)
+        self.ring.pop(&mut self.head, self.cached_tail)
     }
 
     /// Publish consumed position so the producer can reuse slots.
@@ -343,14 +348,14 @@ impl<T> Consumer<T> {
     /// Returns the count of newly available items.
     #[inline]
     pub fn prefetch(&mut self) -> usize {
-        self.ring.prefetch(&mut self.cached_flush)
+        self.ring.prefetch(&mut self.cached_tail)
     }
 
     /// Convenience: prefetch + pop + release. For callers that don't
     /// need batching.
     #[inline]
     pub fn prefetch_and_pop(&mut self) -> Option<T> {
-        if self.head == self.cached_flush {
+        if self.head == self.cached_tail {
             self.prefetch();
         }
         let val = self.pop();
@@ -362,7 +367,7 @@ impl<T> Consumer<T> {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.ring.consumer_is_empty(self.head, self.cached_flush)
+        self.ring.consumer_is_empty(self.head, self.cached_tail)
     }
 
     /// The producer has been dropped and all flushed items have been
@@ -370,7 +375,7 @@ impl<T> Consumer<T> {
     #[inline]
     pub fn is_disconnected(&self) -> bool {
         self.ring.producer_dropped.load(Ordering::Acquire)
-            && self.head == self.ring.flush.0.load(Ordering::Acquire)
+            && self.head == self.ring.tail.0.load(Ordering::Acquire)
     }
 
     #[inline]

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -162,12 +162,17 @@ impl<T> Ring<T> {
     /// exclusive access (i.e. in a `Drop` impl or when no concurrent
     /// readers/writers exist).
     ///
-    /// Idempotent: it advances `head` to `flush` as it drains, so a second
-    /// call (e.g. `Ring::drop` running after an async wrapper already
-    /// drained) sees an empty range and cannot double-drop.
+    /// Idempotent: it advances `head` to `flush` before draining, so a
+    /// second call (e.g. `Ring::drop` running after an async wrapper
+    /// already drained) sees an empty range and cannot double-drop.
+    /// If a `T::drop` panics mid-loop, items past the panicking one are
+    /// leaked rather than double-dropped.
     pub(crate) fn drop_remaining(&mut self) {
         let head = self.head.0.load(Ordering::Relaxed);
         let flush = self.flush.0.load(Ordering::Relaxed);
+        // Advance head before the loop so a panicking T::drop cannot
+        // cause a second call to re-drop the same items.
+        self.head.0.store(flush, Ordering::Relaxed);
         for i in head..flush {
             // SAFETY: &mut self guarantees exclusive access. Slots
             // [head..flush] were written by the producer and flushed.
@@ -175,7 +180,6 @@ impl<T> Ring<T> {
                 (*ptr).assume_init_drop();
             });
         }
-        self.head.0.store(flush, Ordering::Relaxed);
     }
 }
 
@@ -528,6 +532,39 @@ mod tests {
         drop(p);
         drop(c);
         assert_eq!(DROPS.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn drop_remaining_panicking_drop() {
+        use std::sync::atomic::AtomicUsize;
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        #[derive(Debug)]
+        struct PanicOnDrop(bool);
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::Relaxed);
+                if self.0 {
+                    self.0 = false;
+                    panic!("intentional panic in drop");
+                }
+            }
+        }
+
+        DROPS.store(0, Ordering::Relaxed);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let (mut p, _c) = spsc::<PanicOnDrop>(4);
+            p.push(PanicOnDrop(false)).unwrap();
+            p.push(PanicOnDrop(true)).unwrap(); // this one panics
+            p.push(PanicOnDrop(false)).unwrap();
+            p.flush();
+            // Ring::drop runs, calls drop_remaining. Item 1 panics.
+            // Items 0 and 1 are dropped. Item 2 is leaked (not double-dropped).
+        }));
+        assert!(result.is_err());
+        // Item 0 dropped normally, item 1's Drop panicked (but incremented
+        // before panicking), item 2 leaked. Exactly 2 drops.
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
     }
 
     #[test]


### PR DESCRIPTION
- Make `drop_remaining` panic-safe by advancing head before the drop loop (pre-poop pattern), preventing double-drop if `T::drop` panics
- Widen `Padded` alignment from 64 to 128 bytes to prevent false sharing from Intel adjacent-line prefetch between head and tail
- Add `compile_error!` on non-64-bit targets to guard against `AtomicUsize` wrap
- Rename `Ring::flush` -> `Ring::tail`, `Producer::tail` -> `Producer::cursor`, `Consumer::cached_flush` -> `Consumer::cached_tail` for conventional head/tail naming