### PR TITLE
Fix fan-out fairness and send-path correctness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,42 +86,37 @@ reconnections, framing, and multiplexing internally. The transport
 (TCP, IPC, inproc, UDP) is chosen by endpoint URI and is transparent
 to the application.
 
-**Reliability is non-negotiable.** ZMQ users expect the library to
-Just Work. No errors from peer failures. No hangs. No stuck states.
-Connections self-heal automatically. Back-pressure is applied silently.
-The library must always take the optimal performance path and recover
-from any transient failure without user intervention. A ZMQ library
-that surfaces transport-level errors to the user, requires manual
-reconnection, or gets stuck in a degraded state is broken. Never
-propose a fix that weakens self-healing, adds user-visible failure
-modes, or trades reliability for convenience.
+**Reliability is non-negotiable.** Self-healing, silent
+back-pressure, no user-visible errors from peer failures. Never
+propose a fix that weakens self-healing or trades reliability for
+convenience. Core guarantees:
 
-Core guarantees that omq must uphold:
-
-- **Send/recv never fail due to peers.** A peer disconnecting, a TCP
-  connection dropping, or a slow consumer does not cause `send` or
-  `recv` to return an error. The socket reconnects automatically and
-  resumes delivery. The only user-visible send errors are protocol
-  violations (e.g. REQ sending twice without recv) or socket closed.
-- **Connect-before-bind works.** `connect()` queues internally and
-  waits for the bind to appear. Never suggest connection ordering as
-  a cause for failures or hangs.
-- **Automatic reconnection.** ZMTP peers reconnect on disconnect
-  with configurable backoff. The application does not manage
-  connection lifecycle.
-- **Messages are atomic.** A multipart message is delivered in full
-  or not at all. No partial delivery.
+- **Send/recv never fail due to peers.** Peer disconnects,
+  TCP drops, slow consumers: no errors. Reconnects automatically.
+  Only user-visible send errors: protocol violations or socket closed.
+- **Connect-before-bind works.** `connect()` retries until the
+  remote `bind()` appears. Never blame connection ordering.
+- **Automatic reconnection.** Configurable backoff. The
+  application does not manage connection lifecycle.
+- **Heartbeats detect dead peers, not slow ones.** A slow peer
+  that still responds to PINGs is alive. Heartbeat timeout only
+  fires when a peer stops responding entirely. Never assume
+  heartbeat will resolve a slow-consumer backpressure situation.
+- **Messages are atomic.** Delivered in full or not at all.
 - **HWM back-pressure, not errors.** When the outbound queue is
   full, the socket either drops (PUB default) or blocks (PUSH
   default, configurable via OnMute). It does not return an error.
-- **Transport-agnostic.** The same socket can bind on TCP and IPC
-  simultaneously. Inproc is in-process (no kernel, no serialization).
-- **Subscriptions are prefix-matched.** SUB subscribes to byte
-  prefixes. Empty prefix = all messages. PUB filters per subscriber.
-- **Thread safety contract.** A single socket must not be used from
-  multiple threads concurrently (ZMQ's rule). omq-tokio relaxes this
-  for async (send/recv serialize internally), but the principle holds
-  for omq-libzmq's C API.
+- **No peer starvation.** A slow peer must never be permanently
+  starved. Round-robin (PUSH) waits for a full peer's slot to
+  drain rather than skipping it indefinitely. A slow peer must
+  also never block fast peers from making progress.
+- **Fair fan-in.** Consumer fair-queues across all connections.
+- **Transport-agnostic.** Bind TCP and IPC simultaneously. Inproc
+  is in-process (no kernel, no serialization).
+- **Subscriptions are prefix-matched.** Empty prefix = all
+  messages. PUB filters per subscriber.
+- **Thread safety.** One socket, one thread. omq-tokio relaxes
+  this for async; omq-libzmq does not.
 
 ## Performance invariants
 

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +386,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +531,19 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lz4rip"
@@ -538,6 +581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +612,15 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys",
 ]
 
@@ -790,6 +851,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +896,12 @@ checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -872,6 +956,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -955,6 +1048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1097,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1178,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1097,6 +1254,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1215,10 +1381,11 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "atomic-waker",
  "futures-core",
+ "loom",
 ]
 
 [[package]]

--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -34,6 +34,13 @@ pub(crate) struct DirectIoState {
     pub(crate) encoder: async_lock::Mutex<Option<MessageEncoder>>,
     pub(crate) encoded_queue: EncodedQueueCell,
     pub(crate) driver_in_select: Cell<bool>,
+    /// Set when a sender has already issued a `transmit_ready` notify for
+    /// the driver's current park. Coalesces the per-message notify: while
+    /// the cooperative driver is parked, a sender burst would otherwise
+    /// call `Event::notify` (an internal-lock op) on every message even
+    /// though the first wakeup already arms the driver. Reset by the
+    /// driver at the top of its loop once it is running again.
+    pub(crate) transmit_notified: Cell<bool>,
     pub(crate) direct_msg_count: Cell<usize>,
     pub(crate) socket_closing: Cell<bool>,
     pub(crate) large_recv_pending: AtomicUsize,
@@ -222,7 +229,12 @@ impl DirectIoState {
     #[inline]
     pub(crate) fn signal_encoded(&self) {
         self.direct_msg_count.set(self.direct_msg_count.get() + 1);
-        if self.driver_in_select.get() {
+        // Coalesce: only the first sender after the driver parks needs to
+        // wake it. Subsequent messages in the same cooperative burst skip
+        // the event_listener notify (an internal-lock op, ~16% of the
+        // small-message fan-out send path per perf). The driver resets
+        // `transmit_notified` when it resumes.
+        if self.driver_in_select.get() && !self.transmit_notified.replace(true) {
             self.transmit_ready.notify(1);
         }
     }
@@ -274,6 +286,7 @@ impl DirectIoState {
             encoder: async_lock::Mutex::new(encoder),
             encoded_queue: EncodedQueueCell::new(),
             driver_in_select: Cell::new(false),
+            transmit_notified: Cell::new(false),
             direct_msg_count: Cell::new(0),
             socket_closing: Cell::new(false),
             large_recv_pending: AtomicUsize::new(0),

--- a/omq-compio/src/socket/handle.rs
+++ b/omq-compio/src/socket/handle.rs
@@ -419,6 +419,9 @@ impl Socket {
             .cached_route
             .lock()
             .expect("cached_route") = None;
+        // Drop cached round-robin direct targets so their
+        // `Arc<DirectIoState>` refs release with the socket.
+        *self.inner.routing.cached_rr_targets.get() = None;
 
         // Close the inbound channel so drivers blocked on
         // peer_in_tx.send_async() get unblocked with SendError.

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -181,6 +181,15 @@ pub(super) struct PeerRouting {
     /// Cached route for the common single-peer case. Invalidated
     /// when `generation` advances past the stored generation.
     pub(super) cached_route: Mutex<Option<CachedPeerRoute>>,
+    /// Cached round-robin direct-encode targets for the multi-peer
+    /// wire-only case, with the generation they were built at. Lets the
+    /// hot path index a `Vec<Arc<DirectIoState>>` instead of re-acquiring
+    /// the `peers` / `peer_keys` / per-peer `direct_io` RwLocks on every
+    /// send. Readiness (handshake) is a live `Cell` inside each
+    /// `DirectIoState`, so cached entries stay valid across handshake
+    /// completion; only peer add/remove (which bumps `generation`)
+    /// invalidates the cache.
+    pub(super) cached_rr_targets: Mutex<Option<(u64, Vec<Arc<DirectIoState>>)>>,
     /// Identity -> slot index for ROUTER outbound.
     pub(super) identity_to_slot: RwLock<FxHashMap<Bytes, usize>>,
     /// `connection_id` -> peer identity for the recv path.
@@ -357,6 +366,7 @@ impl SocketInner {
                 peer_count: out_peer_count.clone(),
                 inproc_count: AtomicUsize::new(0),
                 cached_route: Mutex::new(None),
+                cached_rr_targets: Mutex::new(None),
                 identity_to_slot: RwLock::new(FxHashMap::default()),
                 conn_id_to_identity: RwLock::new(FxHashMap::default()),
                 rr_index: AtomicUsize::new(0),

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -184,7 +184,7 @@ pub(super) struct PeerRouting {
     /// Cached round-robin direct-encode targets for the multi-peer
     /// wire-only case, with the generation they were built at. Lets the
     /// hot path index a `Vec<Arc<DirectIoState>>` instead of re-acquiring
-    /// the `peers` / `peer_keys` / per-peer `direct_io` RwLocks on every
+    /// the `peers` / `peer_keys` / per-peer `direct_io` `RwLock`s on every
     /// send. Readiness (handshake) is a live `Cell` inside each
     /// `DirectIoState`, so cached entries stay valid across handshake
     /// completion; only peer add/remove (which bumps `generation`)

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -195,7 +195,8 @@ pub(super) struct PeerRouting {
     /// the runtime thread, exactly like `DirectIoCache::send`. Dropping
     /// the `Mutex` removes a lock/unlock pair from every multi-peer
     /// PUSH send (it dominated the profile after the target cache landed).
-    pub(super) cached_rr_targets: LocalCell<Option<(u64, Vec<Arc<DirectIoState>>)>>,
+    #[expect(clippy::type_complexity)]
+    pub(super) cached_rr_targets: LocalCell<Option<(u64, Vec<Arc<DirectIoState>>, usize)>>,
     /// Identity -> slot index for ROUTER outbound.
     pub(super) identity_to_slot: RwLock<FxHashMap<Bytes, usize>>,
     /// `connection_id` -> peer identity for the recv path.

--- a/omq-compio/src/socket/inner.rs
+++ b/omq-compio/src/socket/inner.rs
@@ -189,7 +189,13 @@ pub(super) struct PeerRouting {
     /// `DirectIoState`, so cached entries stay valid across handshake
     /// completion; only peer add/remove (which bumps `generation`)
     /// invalidates the cache.
-    pub(super) cached_rr_targets: Mutex<Option<(u64, Vec<Arc<DirectIoState>>)>>,
+    ///
+    /// A `LocalCell` (not a `Mutex`): the multi-peer round-robin send
+    /// fast path is inlined into `Socket::send` and only ever runs on
+    /// the runtime thread, exactly like `DirectIoCache::send`. Dropping
+    /// the `Mutex` removes a lock/unlock pair from every multi-peer
+    /// PUSH send (it dominated the profile after the target cache landed).
+    pub(super) cached_rr_targets: LocalCell<Option<(u64, Vec<Arc<DirectIoState>>)>>,
     /// Identity -> slot index for ROUTER outbound.
     pub(super) identity_to_slot: RwLock<FxHashMap<Bytes, usize>>,
     /// `connection_id` -> peer identity for the recv path.
@@ -366,7 +372,7 @@ impl SocketInner {
                 peer_count: out_peer_count.clone(),
                 inproc_count: AtomicUsize::new(0),
                 cached_route: Mutex::new(None),
-                cached_rr_targets: Mutex::new(None),
+                cached_rr_targets: LocalCell::new(None),
                 identity_to_slot: RwLock::new(FxHashMap::default()),
                 conn_id_to_identity: RwLock::new(FxHashMap::default()),
                 rr_index: AtomicUsize::new(0),

--- a/omq-compio/src/socket/send/fan_out.rs
+++ b/omq-compio/src/socket/send/fan_out.rs
@@ -90,9 +90,13 @@ impl Socket {
                         fan_out_encode_dispatch(dio_cache, targets, &msg);
                     } else if !try_direct_encode(&msg, &dio_cache[0])? {
                         let _ = targets[0].send(msg.clone()).await;
-                    } else if dio_cache[0].direct_msg_count.get()
-                        >= super::DIRECT_ENCODE_YIELD_BACKLOG
+                    } else if dio_cache[0].direct_msg_count.get() >= super::DIRECT_ENCODE_YIELD_MSGS
+                        || dio_cache[0]
+                            .encoded_queue
+                            .try_borrow_mut()
+                            .is_some_and(|eq| eq.total_bytes() >= super::DIRECT_ENCODE_YIELD_BYTES)
                     {
+                        dio_cache[0].direct_msg_count.set(0);
                         crate::yield_now().await;
                     }
                     if count.is_multiple_of(yield_interval(&msg)) {

--- a/omq-compio/src/socket/send/fan_out.rs
+++ b/omq-compio/src/socket/send/fan_out.rs
@@ -88,16 +88,15 @@ impl Socket {
                             crate::yield_now().await;
                         }
                         fan_out_encode_dispatch(dio_cache, targets, &msg);
-                    } else if !try_direct_encode(&msg, &dio_cache[0])? {
+                    } else if let Some(qbytes) = try_direct_encode(&msg, &dio_cache[0])? {
+                        if dio_cache[0].direct_msg_count.get() >= super::DIRECT_ENCODE_YIELD_MSGS
+                            || qbytes >= super::DIRECT_ENCODE_YIELD_BYTES
+                        {
+                            dio_cache[0].direct_msg_count.set(0);
+                            crate::yield_now().await;
+                        }
+                    } else {
                         let _ = targets[0].send(msg.clone()).await;
-                    } else if dio_cache[0].direct_msg_count.get() >= super::DIRECT_ENCODE_YIELD_MSGS
-                        || dio_cache[0]
-                            .encoded_queue
-                            .try_borrow_mut()
-                            .is_some_and(|eq| eq.total_bytes() >= super::DIRECT_ENCODE_YIELD_BYTES)
-                    {
-                        dio_cache[0].direct_msg_count.set(0);
-                        crate::yield_now().await;
                     }
                     if count.is_multiple_of(yield_interval(&msg)) {
                         crate::yield_now().await;
@@ -158,7 +157,11 @@ impl Socket {
                 if dio_cache.len() == targets.len() {
                     if targets.len() > 1 {
                         fan_out_encode_dispatch(dio_cache, targets, msg);
-                    } else if !try_direct_encode(msg, &dio_cache[0]).unwrap_or(false) {
+                    } else if try_direct_encode(msg, &dio_cache[0])
+                        .ok()
+                        .flatten()
+                        .is_none()
+                    {
                         let _ = targets[0].try_send_immediate(msg.clone());
                     }
                     return;

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -276,6 +276,34 @@ impl Socket {
                 return Ok(());
             }
         }
+        // Multi-peer wire round-robin fast path: round-robin
+        // direct-encode across the cached wire targets, mirroring the
+        // single-peer fast path above. Uses a `LocalCell` target cache
+        // (no Mutex) and stays inline in `send` (no async
+        // `send_round_robin` frame). Conflate and any inproc peer fall
+        // through to the general dispatch. On `None` (every peer at HWM
+        // or mid-handshake) we hand off to the shared work-stealing
+        // queue, which preserves `send_hwm` backpressure.
+        if matches!(
+            st,
+            SocketType::Push | SocketType::Dealer | SocketType::Channel
+        ) && !pre_send_needs_type_state(st)
+            && !self.inner().options.conflate
+        {
+            let inner = self.inner();
+            if inner.routing.peer_count.load(Ordering::Acquire) > 1
+                && inner.routing.inproc_count.load(Ordering::Relaxed) == 0
+            {
+                match self.try_direct_round_robin(&msg)? {
+                    Some(true) => {
+                        crate::yield_now().await;
+                        return Ok(());
+                    }
+                    Some(false) => return Ok(()),
+                    None => return self.send_rr_shared(msg).await,
+                }
+            }
+        }
         // TypeState's pre_send is a no-op for round-robin / fan-out
         // socket types - only REQ / REP / draft single-frame types
         // touch it. Skip the mutex acquisition entirely when not

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -49,14 +49,12 @@ use super::handle::Socket;
 pub(super) const DIRECT_CAP: usize = 512 * 1024;
 pub(super) const DIRECT_MSG_CAP: usize = DIRECT_CAP / 16;
 
-/// Yield to the runtime when this many direct-encodes have accumulated
-/// without the driver fully flushing the `EncodedQueue`. Prevents
-/// driver starvation under sustained single-peer send bursts: the
-/// driver only runs when the sender yields, so a tight encode loop
-/// can starve the flush path. The threshold is per-peer, so with N
-/// peers each hitting this limit, the runtime gets N yield points per
-/// pass through the send loop.
-const DIRECT_ENCODE_YIELD_BACKLOG: usize = 4;
+/// Yield to the runtime when unflushed direct-encodes exceed these
+/// thresholds. Prevents driver starvation under sustained single-peer
+/// send bursts: the driver only runs when the sender yields, so a
+/// tight encode loop can starve the flush path.
+pub(super) const DIRECT_ENCODE_YIELD_BYTES: usize = 2 * 1024 * 1024;
+pub(super) const DIRECT_ENCODE_YIELD_MSGS: usize = 256;
 
 pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> {
     // Crypto connections must go through the codec's send_message.
@@ -266,7 +264,13 @@ impl Socket {
                 && *cached_gen == inner.routing.generation.load(Ordering::Acquire)
                 && try_direct_encode(&msg, state)?
             {
-                if state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_BACKLOG {
+                if state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
+                    || state
+                        .encoded_queue
+                        .try_borrow_mut()
+                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES)
+                {
+                    state.direct_msg_count.set(0);
                     crate::yield_now().await;
                 }
                 return Ok(());

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -56,33 +56,48 @@ pub(super) const DIRECT_MSG_CAP: usize = DIRECT_CAP / 16;
 pub(super) const DIRECT_ENCODE_YIELD_BYTES: usize = 2 * 1024 * 1024;
 pub(super) const DIRECT_ENCODE_YIELD_MSGS: usize = 256;
 
-pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Result<bool> {
+/// Encode `msg` directly into the peer's `EncodedQueue`, bypassing the
+/// flume channel. Returns `Some(total_bytes)` (the queue's post-encode
+/// byte count) on success, `None` when the peer can't take the direct
+/// path (crypto, mid-handshake, queue borrowed, or at the capacity cap).
+///
+/// The returned byte count lets the caller make the
+/// `DIRECT_ENCODE_YIELD_BYTES` backlog decision without re-borrowing the
+/// queue: we already hold the borrow here, so reading `total_bytes()`
+/// once and returning it removes a second `try_borrow_mut()` from every
+/// direct send on the hot path.
+pub(super) fn try_direct_encode(
+    msg: &Message,
+    state: &Arc<DirectIoState>,
+) -> Result<Option<usize>> {
     // Crypto connections must go through the codec's send_message.
     if state.uses_crypto {
-        return Ok(false);
+        return Ok(None);
     }
 
     if !state.has_transform {
         if !state.handshake_done.get() {
-            return Ok(false);
+            return Ok(None);
         }
         let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
-            return Ok(false);
+            return Ok(None);
         };
         if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
-            return Ok(false);
+            return Ok(None);
         }
         #[cfg(feature = "ws")]
         if state.is_ws {
             eq.encode_ws(msg, state.ws_masked);
+            let qbytes = eq.total_bytes();
             drop(eq);
             state.signal_encoded();
-            return Ok(true);
+            return Ok(Some(qbytes));
         }
         eq.encode_auto(msg);
+        let qbytes = eq.total_bytes();
         drop(eq);
         state.signal_encoded();
-        return Ok(true);
+        return Ok(Some(qbytes));
     }
 
     #[cfg(feature = "ws")]
@@ -95,22 +110,23 @@ pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Re
         && msg.iter().all(|b| b.len() < threshold)
     {
         let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
-            return Ok(false);
+            return Ok(None);
         };
         if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
-            return Ok(false);
+            return Ok(None);
         }
         eq.encode_prefixed_auto(sentinel, msg);
+        let qbytes = eq.total_bytes();
         drop(eq);
         state.signal_encoded();
-        return Ok(true);
+        return Ok(Some(qbytes));
     }
 
     let Some(mut enc_guard) = state.encoder.try_lock() else {
-        return Ok(false);
+        return Ok(None);
     };
     if !state.handshake_done.get() {
-        return Ok(false);
+        return Ok(None);
     }
     let enc = enc_guard
         .as_mut()
@@ -119,10 +135,10 @@ pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Re
     drop(enc_guard);
 
     let Some(mut eq) = state.encoded_queue.try_borrow_mut() else {
-        return Ok(false);
+        return Ok(None);
     };
     if eq.total_bytes() >= DIRECT_CAP || state.direct_msg_count.get() >= DIRECT_MSG_CAP {
-        return Ok(false);
+        return Ok(None);
     }
     for wire in &wires {
         #[cfg(feature = "ws")]
@@ -132,9 +148,10 @@ pub(super) fn try_direct_encode(msg: &Message, state: &Arc<DirectIoState>) -> Re
         }
         eq.encode_auto(wire);
     }
+    let qbytes = eq.total_bytes();
     drop(eq);
     state.signal_encoded();
-    Ok(true)
+    Ok(Some(qbytes))
 }
 
 /// Push pre-encoded ZMTP chunks directly into a peer's `EncodedQueue`,
@@ -262,13 +279,10 @@ impl Socket {
             let dio = inner.direct_io.send.get();
             if let Some((state, cached_gen)) = dio
                 && *cached_gen == inner.routing.generation.load(Ordering::Acquire)
-                && try_direct_encode(&msg, state)?
+                && let Some(qbytes) = try_direct_encode(&msg, state)?
             {
                 if state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
-                    || state
-                        .encoded_queue
-                        .try_borrow_mut()
-                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES)
+                    || qbytes >= DIRECT_ENCODE_YIELD_BYTES
                 {
                     state.direct_msg_count.set(0);
                     crate::yield_now().await;

--- a/omq-compio/src/socket/send/mod.rs
+++ b/omq-compio/src/socket/send/mod.rs
@@ -66,6 +66,7 @@ pub(super) const DIRECT_ENCODE_YIELD_MSGS: usize = 256;
 /// queue: we already hold the borrow here, so reading `total_bytes()`
 /// once and returning it removes a second `try_borrow_mut()` from every
 /// direct send on the hot path.
+#[inline]
 pub(super) fn try_direct_encode(
     msg: &Message,
     state: &Arc<DirectIoState>,

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -84,6 +84,38 @@ impl Socket {
         })
     }
 
+    /// Encode `msg` directly into the next available peer's `EncodedQueue`,
+    /// scanning round-robin from `rr_index`. Returns the chosen peer's
+    /// [`DirectIoState`] on success (so the caller can do backlog/yield
+    /// accounting), or `None` if no wire peer could accept it directly
+    /// (queue full, codec busy, or handshake not yet complete).
+    ///
+    /// Holds only the `peers`/`peer_keys` read locks; `try_direct_encode`
+    /// is synchronous, so no `.await` happens while the locks are held.
+    fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<Arc<DirectIoState>>> {
+        let inner = self.inner();
+        let peers = inner.routing.peers.read().expect("peers lock");
+        let keys = inner.routing.peer_keys.read().expect("peer_keys lock");
+        let n = keys.len();
+        if n == 0 {
+            return Ok(None);
+        }
+        for _ in 0..n {
+            let idx = keys[inner.routing.rr_index.fetch_add(1, Ordering::Relaxed) % n];
+            let p = &peers[idx];
+            let PeerOut::Wire(_) = &p.out else { continue };
+            let Some(handle) = &p.direct_io else { continue };
+            let guard = handle.read().expect("direct_io handle lock");
+            let Some(state) = guard.as_ref() else {
+                continue;
+            };
+            if try_direct_encode(msg, state)? {
+                return Ok(Some(state.clone()));
+            }
+        }
+        Ok(None)
+    }
+
     pub(super) async fn send_round_robin(&self, msg: Message) -> Result<()> {
         let inner = self.inner();
         // Fast path: reuse cached route when the peer set hasn't changed.
@@ -103,7 +135,7 @@ impl Socket {
         }
 
         // Multi-peer wire-only fast path: skip select_peer entirely.
-        // Wire drivers work-steal from the shared queue; inproc peers
+        // Wire drivers can work-steal from the shared queue; inproc peers
         // don't, so we can only bypass when there are no inproc peers.
         // Gate on total > 1 so single-peer wire still bootstraps the
         // direct_send_io cache via select_peer -> slow_round_robin.
@@ -112,6 +144,26 @@ impl Socket {
         {
             if inner.options.conflate {
                 return self.conflate_shared_queue_send(msg);
+            }
+            // Per-peer round-robin direct-encode: pick the next peer via
+            // `rr_index` and encode straight into its `EncodedQueue`,
+            // skipping peers whose queue is full or busy. This keeps the
+            // single-peer direct path's throughput for multi-peer PUSH and
+            // gives strict round-robin distribution (libzmq `lb_t`
+            // semantics). Only when no peer can take the message directly
+            // (all at HWM or mid-handshake) do we fall back to the shared
+            // work-stealing queue, which preserves `send_hwm` backpressure.
+            if let Some(state) = self.try_direct_round_robin(&msg)? {
+                let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
+                    || state
+                        .encoded_queue
+                        .try_borrow_mut()
+                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
+                if backlogged {
+                    state.direct_msg_count.set(0);
+                    crate::yield_now().await;
+                }
+                return Ok(());
             }
             let stx = inner
                 .shared_send_tx

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -8,7 +8,7 @@ use crate::socket::handle::Socket;
 use crate::socket::inner::{CachedPeerRoute, DirectIoState, PeerOut};
 use crate::transport::driver::DriverCommand;
 
-use super::{DIRECT_ENCODE_YIELD_BACKLOG, try_direct_encode};
+use super::{DIRECT_ENCODE_YIELD_BYTES, DIRECT_ENCODE_YIELD_MSGS, try_direct_encode};
 
 struct PeerSelection {
     out: PeerOut,
@@ -241,7 +241,14 @@ impl Socket {
                 if let Some(state) = direct
                     && try_direct_encode(&msg, &state)?
                 {
-                    let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_BACKLOG;
+                    let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
+                        || state
+                            .encoded_queue
+                            .try_borrow_mut()
+                            .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
+                    if backlogged {
+                        state.direct_msg_count.set(0);
+                    }
                     let cur_gen = self.inner().routing.generation.load(Ordering::Acquire);
                     *self.inner().direct_io.send.get() = Some((state, cur_gen));
                     if backlogged {

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -85,32 +85,59 @@ impl Socket {
     }
 
     /// Encode `msg` directly into the next available peer's `EncodedQueue`,
-    /// scanning round-robin from `rr_index`. Returns the chosen peer's
-    /// [`DirectIoState`] on success (so the caller can do backlog/yield
-    /// accounting), or `None` if no wire peer could accept it directly
-    /// (queue full, codec busy, or handshake not yet complete).
+    /// scanning round-robin from `rr_index`. Returns `Some(should_yield)`
+    /// when a peer accepted the message (`should_yield` true when that
+    /// peer's unflushed backlog crossed the yield threshold), or `None`
+    /// when no wire peer could accept it directly (queue full, codec busy,
+    /// or handshake not yet complete).
     ///
-    /// Holds only the `peers`/`peer_keys` read locks; `try_direct_encode`
-    /// is synchronous, so no `.await` happens while the locks are held.
-    fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<Arc<DirectIoState>>> {
+    /// The wire target list is cached by `generation` so the hot path
+    /// avoids re-acquiring the `peers` / `peer_keys` / per-peer `direct_io`
+    /// RwLocks on every send (that re-locking dominated the profile -
+    /// ~34% of PUSH CPU). Per-peer handshake readiness is a live `Cell`
+    /// inside each `DirectIoState`, checked by `try_direct_encode`, so the
+    /// cache stays correct across handshake completion; only peer
+    /// add/remove (which bumps `generation`) rebuilds it.
+    fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<bool>> {
         let inner = self.inner();
-        let peers = inner.routing.peers.read().expect("peers lock");
-        let keys = inner.routing.peer_keys.read().expect("peer_keys lock");
-        let n = keys.len();
+        let cur_gen = inner.routing.generation.load(Ordering::Acquire);
+        let mut cache = inner
+            .routing
+            .cached_rr_targets
+            .lock()
+            .expect("cached_rr_targets lock");
+        if cache.as_ref().map(|(g, _)| *g) != Some(cur_gen) {
+            let peers = inner.routing.peers.read().expect("peers lock");
+            let keys = inner.routing.peer_keys.read().expect("peer_keys lock");
+            let mut targets = Vec::with_capacity(keys.len());
+            for &idx in keys.iter() {
+                let p = &peers[idx];
+                let PeerOut::Wire(_) = &p.out else { continue };
+                let Some(handle) = &p.direct_io else { continue };
+                if let Some(state) = handle.read().expect("direct_io handle lock").as_ref() {
+                    targets.push(state.clone());
+                }
+            }
+            *cache = Some((cur_gen, targets));
+        }
+        let targets = &cache.as_ref().expect("just populated").1;
+        let n = targets.len();
         if n == 0 {
             return Ok(None);
         }
         for _ in 0..n {
-            let idx = keys[inner.routing.rr_index.fetch_add(1, Ordering::Relaxed) % n];
-            let p = &peers[idx];
-            let PeerOut::Wire(_) = &p.out else { continue };
-            let Some(handle) = &p.direct_io else { continue };
-            let guard = handle.read().expect("direct_io handle lock");
-            let Some(state) = guard.as_ref() else {
-                continue;
-            };
+            let i = inner.routing.rr_index.fetch_add(1, Ordering::Relaxed) % n;
+            let state = &targets[i];
             if try_direct_encode(msg, state)? {
-                return Ok(Some(state.clone()));
+                let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
+                    || state
+                        .encoded_queue
+                        .try_borrow_mut()
+                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
+                if backlogged {
+                    state.direct_msg_count.set(0);
+                }
+                return Ok(Some(backlogged));
             }
         }
         Ok(None)
@@ -118,27 +145,12 @@ impl Socket {
 
     pub(super) async fn send_round_robin(&self, msg: Message) -> Result<()> {
         let inner = self.inner();
-        // Fast path: reuse cached route when the peer set hasn't changed.
-        let cur_gen = inner.routing.generation.load(Ordering::Acquire);
-        let cached = {
-            let cache = inner.routing.cached_route.lock().expect("cached_route");
-            if let Some(ref cr) = *cache
-                && cr.generation == cur_gen
-            {
-                Some((cr.out.clone(), cr.direct.clone(), cr.slot_idx))
-            } else {
-                None
-            }
-        };
-        if let Some((out, direct, slot_idx)) = cached {
-            return self.slow_round_robin(out, msg, 1, direct, slot_idx).await;
-        }
 
-        // Multi-peer wire-only fast path: skip select_peer entirely.
-        // Wire drivers can work-steal from the shared queue; inproc peers
-        // don't, so we can only bypass when there are no inproc peers.
-        // Gate on total > 1 so single-peer wire still bootstraps the
-        // direct_send_io cache via select_peer -> slow_round_robin.
+        // Multi-peer wire-only fast path, checked FIRST so it skips the
+        // single-peer `cached_route` Mutex (that lock is only ever
+        // populated when peer_count == 1). Wire drivers can work-steal
+        // from the shared queue; inproc peers don't, so we only bypass
+        // when there are no inproc peers.
         if inner.routing.peer_count.load(Ordering::Acquire) > 1
             && inner.routing.inproc_count.load(Ordering::Relaxed) == 0
         {
@@ -153,17 +165,13 @@ impl Socket {
             // semantics). Only when no peer can take the message directly
             // (all at HWM or mid-handshake) do we fall back to the shared
             // work-stealing queue, which preserves `send_hwm` backpressure.
-            if let Some(state) = self.try_direct_round_robin(&msg)? {
-                let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
-                    || state
-                        .encoded_queue
-                        .try_borrow_mut()
-                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
-                if backlogged {
-                    state.direct_msg_count.set(0);
+            match self.try_direct_round_robin(&msg)? {
+                Some(true) => {
                     crate::yield_now().await;
+                    return Ok(());
                 }
-                return Ok(());
+                Some(false) => return Ok(()),
+                None => {}
             }
             let stx = inner
                 .shared_send_tx
@@ -172,6 +180,23 @@ impl Socket {
                 .clone()
                 .ok_or(Error::Closed)?;
             return stx.send_async(msg).await;
+        }
+
+        // Single-peer / inproc path: reuse the cached route when the peer
+        // set hasn't changed.
+        let cur_gen = inner.routing.generation.load(Ordering::Acquire);
+        let cached = {
+            let cache = inner.routing.cached_route.lock().expect("cached_route");
+            if let Some(ref cr) = *cache
+                && cr.generation == cur_gen
+            {
+                Some((cr.out.clone(), cr.direct.clone(), cr.slot_idx))
+            } else {
+                None
+            }
+        };
+        if let Some((out, direct, slot_idx)) = cached {
+            return self.slow_round_robin(out, msg, 1, direct, slot_idx).await;
         }
 
         loop {

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -98,15 +98,12 @@ impl Socket {
     /// inside each `DirectIoState`, checked by `try_direct_encode`, so the
     /// cache stays correct across handshake completion; only peer
     /// add/remove (which bumps `generation`) rebuilds it.
+    #[inline]
     pub(super) fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<bool>> {
         let inner = self.inner();
         let cur_gen = inner.routing.generation.load(Ordering::Acquire);
-        // `LocalCell`: single-thread interior mutability, no lock. The
-        // `&mut` borrow lives only for this sync function (no `.await`
-        // inside), so the exclusive access is sound; the caller does any
-        // `yield_now` after we return.
         let cache = inner.routing.cached_rr_targets.get();
-        if cache.as_ref().map(|(g, _)| *g) != Some(cur_gen) {
+        if cache.as_ref().map(|(g, _, _)| *g) != Some(cur_gen) {
             let peers = inner.routing.peers.read().expect("peers lock");
             let keys = inner.routing.peer_keys.read().expect("peer_keys lock");
             let mut targets = Vec::with_capacity(keys.len());
@@ -118,15 +115,16 @@ impl Socket {
                     targets.push(state.clone());
                 }
             }
-            *cache = Some((cur_gen, targets));
+            *cache = Some((cur_gen, targets, 0));
         }
-        let targets = &cache.as_ref().expect("just populated").1;
+        let (_, targets, cursor) = cache.as_mut().expect("just populated");
         let n = targets.len();
         if n == 0 {
             return Ok(None);
         }
         for _ in 0..n {
-            let i = inner.routing.rr_index.fetch_add(1, Ordering::Relaxed) % n;
+            let i = *cursor;
+            *cursor = if i + 1 >= n { 0 } else { i + 1 };
             let state = &targets[i];
             if let Some(qbytes) = try_direct_encode(msg, state)? {
                 let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -98,14 +98,14 @@ impl Socket {
     /// inside each `DirectIoState`, checked by `try_direct_encode`, so the
     /// cache stays correct across handshake completion; only peer
     /// add/remove (which bumps `generation`) rebuilds it.
-    fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<bool>> {
+    pub(super) fn try_direct_round_robin(&self, msg: &Message) -> Result<Option<bool>> {
         let inner = self.inner();
         let cur_gen = inner.routing.generation.load(Ordering::Acquire);
-        let mut cache = inner
-            .routing
-            .cached_rr_targets
-            .lock()
-            .expect("cached_rr_targets lock");
+        // `LocalCell`: single-thread interior mutability, no lock. The
+        // `&mut` borrow lives only for this sync function (no `.await`
+        // inside), so the exclusive access is sound; the caller does any
+        // `yield_now` after we return.
+        let cache = inner.routing.cached_rr_targets.get();
         if cache.as_ref().map(|(g, _)| *g) != Some(cur_gen) {
             let peers = inner.routing.peers.read().expect("peers lock");
             let keys = inner.routing.peer_keys.read().expect("peer_keys lock");
@@ -173,13 +173,7 @@ impl Socket {
                 Some(false) => return Ok(()),
                 None => {}
             }
-            let stx = inner
-                .shared_send_tx
-                .read()
-                .expect("shared_send_tx lock")
-                .clone()
-                .ok_or(Error::Closed)?;
-            return stx.send_async(msg).await;
+            return self.send_rr_shared(msg).await;
         }
 
         // Single-peer / inproc path: reuse the cached route when the peer
@@ -245,6 +239,20 @@ impl Socket {
     /// so `try_send` always has room after the drain. Safe without locks
     /// in compio's cooperative single-threaded runtime: no `.await`
     /// between the drain and the send means no other task can interpose.
+    /// Submit `msg` to the shared work-stealing queue (the multi-peer
+    /// round-robin fallback when no peer accepted a direct-encode). Async
+    /// because the queue applies `send_hwm` backpressure when full.
+    pub(super) async fn send_rr_shared(&self, msg: Message) -> Result<()> {
+        let stx = self
+            .inner()
+            .shared_send_tx
+            .read()
+            .expect("shared_send_tx lock")
+            .clone()
+            .ok_or(Error::Closed)?;
+        stx.send_async(msg).await
+    }
+
     fn conflate_shared_queue_send(&self, msg: Message) -> Result<()> {
         let inner = self.inner();
         let stx = inner

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -128,12 +128,9 @@ impl Socket {
         for _ in 0..n {
             let i = inner.routing.rr_index.fetch_add(1, Ordering::Relaxed) % n;
             let state = &targets[i];
-            if try_direct_encode(msg, state)? {
+            if let Some(qbytes) = try_direct_encode(msg, state)? {
                 let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
-                    || state
-                        .encoded_queue
-                        .try_borrow_mut()
-                        .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
+                    || qbytes >= DIRECT_ENCODE_YIELD_BYTES;
                 if backlogged {
                     state.direct_msg_count.set(0);
                 }
@@ -324,13 +321,10 @@ impl Socket {
             PeerOut::Wire(handle) if peer_count == 1 => {
                 // Fast path: encode directly into the codec buffer.
                 if let Some(state) = direct
-                    && try_direct_encode(&msg, &state)?
+                    && let Some(qbytes) = try_direct_encode(&msg, &state)?
                 {
                     let backlogged = state.direct_msg_count.get() >= DIRECT_ENCODE_YIELD_MSGS
-                        || state
-                            .encoded_queue
-                            .try_borrow_mut()
-                            .is_some_and(|eq| eq.total_bytes() >= DIRECT_ENCODE_YIELD_BYTES);
+                        || qbytes >= DIRECT_ENCODE_YIELD_BYTES;
                     if backlogged {
                         state.direct_msg_count.set(0);
                     }

--- a/omq-compio/src/socket/send/round_robin.rs
+++ b/omq-compio/src/socket/send/round_robin.rs
@@ -93,7 +93,7 @@ impl Socket {
     ///
     /// The wire target list is cached by `generation` so the hot path
     /// avoids re-acquiring the `peers` / `peer_keys` / per-peer `direct_io`
-    /// RwLocks on every send (that re-locking dominated the profile -
+    /// `RwLock`s on every send (that re-locking dominated the profile -
     /// ~34% of PUSH CPU). Per-peer handshake readiness is a live `Cell`
     /// inside each `DirectIoState`, checked by `try_direct_encode`, so the
     /// cache stays correct across handshake completion; only peer

--- a/omq-compio/src/socket/shared_queue.rs
+++ b/omq-compio/src/socket/shared_queue.rs
@@ -123,10 +123,7 @@ impl SharedQueueReceiver {
     /// others, but always at least 1.
     pub(crate) fn batch_limit(&self) -> usize {
         let peers = self.peer_count.load(std::sync::atomic::Ordering::Relaxed);
-        if peers <= 1 {
-            return MAX_DRAIN;
-        }
-        (self.inner.queue.len() / peers).clamp(1, MAX_DRAIN)
+        omq_proto::flow::fair_share(self.inner.queue.len(), peers, MAX_DRAIN)
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -30,6 +30,7 @@ use smallvec::SmallVec;
 
 use omq_proto::encoded_queue::EncodedQueue;
 use omq_proto::error::{Error, Result};
+use omq_proto::flow::max_batch_bytes;
 use omq_proto::message::{Message, generated_identity};
 use omq_proto::options::Options;
 use omq_proto::proto::command::PeerProperties;
@@ -42,25 +43,6 @@ use crate::socket::TaggedFrame;
 use crate::transport::dispatch::{Drained, MonitorCtx, SnapshotSink, dispatch_drained_events};
 use crate::transport::peer_io::{PeerIo, SharedPeerIo, WireReader};
 use crate::transport::recv_stream::{StreamArmOutcome, pull_stream};
-
-/// Per-flush byte cap. Once a single drain has buffered this many
-/// bytes we stop pulling more from the inbox and let writev flush.
-/// 1 MiB folds large messages into bigger writev calls without
-/// outgrowing typical kernel TCP send buffers. Smaller caps (e.g.
-/// 256 KiB) under-utilize writev for 32 KiB+ messages and let the
-/// per-syscall overhead dominate; larger caps add latency without
-/// extra throughput once the kernel send buffer is the bottleneck.
-/// Override at runtime via `OMQ_BATCH_BYTES`.
-fn max_batch_bytes() -> usize {
-    use std::sync::OnceLock;
-    static CAP: OnceLock<usize> = OnceLock::new();
-    *CAP.get_or_init(|| {
-        std::env::var("OMQ_BATCH_BYTES")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1024 * 1024)
-    })
-}
 
 /// Sleep until `deadline`, or hang forever when `None`. Lets the
 /// driver loop unconditionally include the timeout / heartbeat

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -404,8 +404,11 @@ pub(crate) async fn run_connection(
         // Clear the driver_in_select flag at the top of every iteration.
         // The flag is set again just before we park in select_biased!
         // so the fast-path sender can tell whether a transmit_ready
-        // notification is worth issuing.
+        // notification is worth issuing. Also clear transmit_notified so
+        // the next park cycle accepts one fresh notify (the coalescing
+        // flag in signal_encoded).
         state.driver_in_select.set(false);
+        state.transmit_notified.set(false);
 
         if !ls.closing && state.socket_closing.get() {
             ls.closing = true;

--- a/omq-compio/tests/multi_peer.rs
+++ b/omq-compio/tests/multi_peer.rs
@@ -1,7 +1,10 @@
 //! Multi-peer routing tests for omq-compio:
 //! - PUSH→3 PULLs work-stealing distribution.
+//! - PUSH→3 PULLs round-robin fairness over TCP (wire path).
 //! - 3 PUSHes→PULL fair-queue.
 //! - PUB→3 SUBs fan-out with subscription filtering.
+
+mod test_support;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -64,6 +67,64 @@ async fn push_distributes_across_three_pulls() {
         assert!(
             n > N / 20,
             "pull got only {n} / {N}; distribution too skewed"
+        );
+    }
+}
+
+#[compio::test]
+async fn push_distributes_fairly_over_tcp() {
+    // Regression guard for multi-peer PUSH round-robin on the WIRE path.
+    // The inproc test above never exercised it: previously every wire
+    // peer work-stole from a single shared queue, which let one
+    // connection driver monopolize the stream and starve the others.
+    // Use TCP so the wire send path (direct round-robin) is hit.
+    const N: usize = 3;
+    const M: usize = 600;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    let port = test_support::bind_loopback(&push).await;
+
+    let pulls: Vec<Socket> = (0..N)
+        .map(|_| Socket::new(SocketType::Pull, Options::default()))
+        .collect();
+    for p in &pulls {
+        p.connect(test_support::tcp_loopback(port)).await.unwrap();
+        test_support::wait_for_handshake(p).await;
+    }
+
+    for i in 0..M {
+        push.send(Message::single(format!("m{i}"))).await.unwrap();
+    }
+
+    let counts: Vec<Arc<AtomicUsize>> = (0..N).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+    let mut handles = Vec::new();
+    for (p, c) in pulls.into_iter().zip(counts.iter().cloned()) {
+        handles.push(compio::runtime::spawn(async move {
+            loop {
+                match compio::time::timeout(Duration::from_millis(300), p.recv()).await {
+                    Ok(Ok(_)) => {
+                        c.fetch_add(1, Ordering::SeqCst);
+                    }
+                    _ => return,
+                }
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let total: usize = counts.iter().map(|c| c.load(Ordering::SeqCst)).sum();
+    assert_eq!(total, M, "every message must reach exactly one pull");
+    // No peer may be starved: direct round-robin splits evenly, a shared-
+    // queue regression would let one driver monopolize. A 1/4 fair-share
+    // floor catches starvation without flaking on scheduling jitter.
+    let fair_share = M / N;
+    for (i, c) in counts.iter().enumerate() {
+        let n = c.load(Ordering::SeqCst);
+        assert!(
+            n >= fair_share / 4,
+            "pull {i} got {n} / {M} (fair share {fair_share}); a peer is being starved"
         );
     }
 }

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -215,6 +215,9 @@ pub extern "C" fn zmq_msg_move(dst: *mut OmqMsgRepr, src: *mut OmqMsgRepr) -> c_
     if dst.is_null() || src.is_null() {
         return crate::error::fail(libc::EFAULT);
     }
+    if dst == src {
+        return 0;
+    }
     // Close dst first.
     zmq_msg_close(dst);
     // SAFETY: src and dst are non-null (checked above) and don't overlap
@@ -230,6 +233,9 @@ pub extern "C" fn zmq_msg_move(dst: *mut OmqMsgRepr, src: *mut OmqMsgRepr) -> c_
 pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> c_int {
     if dst.is_null() || src.is_null() {
         return crate::error::fail(libc::EFAULT);
+    }
+    if std::ptr::addr_eq(dst.cast_const(), src) {
+        return 0;
     }
     zmq_msg_close(dst);
     // SAFETY: src is non-null (checked above).
@@ -501,9 +507,9 @@ pub extern "C" fn zmq_msg_recv(
             r.hint = std::ptr::null_mut();
             r.boxed = Box::into_raw(boxed).cast::<libc::c_void>();
             r.reserved = [0; 16];
-            #[expect(clippy::cast_possible_wrap)]
-            {
-                sz as c_int
+            match c_int::try_from(sz) {
+                Ok(n) => n,
+                Err(_) => crate::error::fail(libc::EMSGSIZE),
             }
         }
         Err(e) => crate::error::fail(e),

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -2,8 +2,6 @@
 //!
 //! Send: direct `Handle::block_on(socket.send())`, no relay.
 //! Recv: bypass ring -> yring consumers -> block on `RecvNotify`.
-#![expect(clippy::cast_possible_wrap)]
-
 use std::ffi::c_int;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,6 +12,10 @@ use crate::consts::{ZMQ_DONTWAIT, ZMQ_SNDMORE};
 use crate::error::{ETERM, fail};
 use crate::notify::NotifyHandle;
 use crate::socket::OmqSocket;
+
+fn checked_c_int_len(n: usize) -> Result<c_int, c_int> {
+    c_int::try_from(n).map_err(|_| libc::EMSGSIZE)
+}
 
 /// Clear a bypass option if the peer has closed the pipe.
 ///
@@ -72,6 +74,35 @@ fn block_recv<T>(
     }
 }
 
+fn block_recv_result<T>(
+    sock: &OmqSocket,
+    rcvtimeo: i64,
+    mut try_pop: impl FnMut() -> Result<Option<T>, c_int>,
+) -> Result<T, c_int> {
+    if rcvtimeo > 0 {
+        let deadline = std::time::Instant::now() + Duration::from_millis(rcvtimeo as u64);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(libc::EAGAIN);
+            }
+            let ms = remaining.as_millis().min(i32::MAX as u128) as c_int;
+            let recv_notify = sock.notify.recv_notifier();
+            let _ = recv_notify.wait_for_readable(ms);
+            if let Some(val) = try_pop()? {
+                return Ok(val);
+            }
+        }
+    }
+    loop {
+        let recv_notify = sock.notify.recv_notifier();
+        let _ = recv_notify.wait_for_readable(-1);
+        if let Some(val) = try_pop()? {
+            return Ok(val);
+        }
+    }
+}
+
 /// Core send dispatch. Takes a raw slice to avoid heap-allocating a `Bytes`
 /// on the hot path: single-part messages ≤55 bytes use `Message`'s inline
 /// storage (zero alloc). Only SNDMORE accumulation and XSUB subscription
@@ -79,6 +110,9 @@ fn block_recv<T>(
 #[expect(clippy::too_many_lines)]
 pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_int {
     let len = data.len();
+    let Ok(ret_len) = checked_c_int_len(len) else {
+        return fail(libc::EMSGSIZE);
+    };
 
     let max = sock
         .ctx
@@ -109,7 +143,7 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
                 }
             });
         return match result {
-            Ok(Ok(())) => len as c_int,
+            Ok(Ok(())) => ret_len,
             Ok(Err(ref e)) => fail(crate::error::map_omq_err(e)),
             Err(()) => fail(ETERM),
         };
@@ -131,13 +165,13 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
             let dontwait = (flags & ZMQ_DONTWAIT) != 0 || sndtimeo == 0;
             if dontwait {
                 return if bypass.push(data) {
-                    len as c_int
+                    ret_len
                 } else {
                     fail(libc::EAGAIN)
                 };
             }
             bypass.push_blocking(data);
-            return len as c_int;
+            return ret_len;
         }
     }
 
@@ -147,7 +181,7 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
     // If SNDMORE: buffer and return immediately.
     if flags & ZMQ_SNDMORE != 0 {
         accum.push(Bytes::copy_from_slice(data));
-        return len as c_int;
+        return ret_len;
     }
 
     // Drain accumulated parts + current frame into one message.
@@ -176,7 +210,7 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
                 *bytes = 0;
                 std::thread::yield_now();
             }
-            len as c_int
+            ret_len
         }
         Err(omq_tokio::TrySendError::Closed | omq_tokio::TrySendError::Error(_)) => fail(ETERM),
         Err(omq_tokio::TrySendError::Full(_)) if dontwait => fail(libc::EAGAIN),
@@ -186,7 +220,7 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
             for _ in 0..64 {
                 std::thread::yield_now();
                 match inner.try_send(msg) {
-                    Ok(()) => return len as c_int,
+                    Ok(()) => return ret_len,
                     Err(omq_tokio::TrySendError::Closed | omq_tokio::TrySendError::Error(_)) => {
                         return fail(ETERM);
                     }
@@ -198,13 +232,13 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
             if sndtimeo > 0 {
                 let timeout = Duration::from_millis(sndtimeo as u64);
                 match handle.block_on(async { tokio::time::timeout(timeout, s.send(msg)).await }) {
-                    Ok(Ok(())) => len as c_int,
+                    Ok(Ok(())) => ret_len,
                     Ok(Err(_)) => fail(ETERM),
                     Err(_elapsed) => fail(libc::EAGAIN),
                 }
             } else {
                 match handle.block_on(s.send(msg)) {
-                    Ok(()) => len as c_int,
+                    Ok(()) => ret_len,
                     Err(_) => fail(ETERM),
                 }
             }
@@ -290,7 +324,10 @@ fn zmq_recv_impl(sock: &OmqSocket, buf: *mut libc::c_void, buf_len: usize, flags
         Ok((frame, _more)) => {
             let frame_len = frame.len();
             copy_to_buf(buf, buf_len, &frame);
-            frame_len as c_int
+            match checked_c_int_len(frame_len) {
+                Ok(n) => n,
+                Err(e) => fail(e),
+            }
         }
         Err(e) => fail(e),
     }
@@ -401,8 +438,7 @@ fn recv_bypass_direct(
             }
             let frame_len = frame.len();
             copy_to_buf(buf, buf_len, &frame);
-            #[expect(clippy::cast_possible_wrap)]
-            return Ok(frame_len as c_int);
+            return checked_c_int_len(frame_len);
         }
         sock.drain_nonempty.store(false, Ordering::Relaxed);
     }
@@ -423,7 +459,7 @@ fn recv_bypass_direct(
     let rcvtimeo = sock.rcvtimeo_ms.load(Ordering::Relaxed);
     let dontwait = (flags & ZMQ_DONTWAIT) != 0 || rcvtimeo == 0;
 
-    if let Some(n) = try_recv_bypass_or_yring(sock, bypass, buf, buf_len) {
+    if let Some(n) = try_recv_bypass_or_yring(sock, bypass, buf, buf_len)? {
         return Ok(n);
     }
 
@@ -431,7 +467,7 @@ fn recv_bypass_direct(
         return Err(libc::EAGAIN);
     }
 
-    let n = block_recv(sock, rcvtimeo, || {
+    let n = block_recv_result(sock, rcvtimeo, || {
         try_recv_bypass_or_yring(sock, bypass, buf, buf_len)
     })?;
     Ok(n)
@@ -444,7 +480,7 @@ fn try_recv_bypass_or_yring(
     bypass: &mut crate::inproc_bypass::BypassRecv,
     buf: *mut libc::c_void,
     buf_len: usize,
-) -> Option<c_int> {
+) -> Result<Option<c_int>, c_int> {
     if let Some((ptr, len)) = bypass.peek() {
         let copy_len = len.min(buf_len);
         if !buf.is_null() && copy_len > 0 {
@@ -454,8 +490,7 @@ fn try_recv_bypass_or_yring(
             }
         }
         bypass.advance(len);
-        #[expect(clippy::cast_possible_wrap)]
-        return Some(len as c_int);
+        return checked_c_int_len(len).map(Some);
     }
     // SAFETY: zmq contract guarantees single-threaded access per socket.
     if let Some(cons) = sock.recv_cons.get()
@@ -469,10 +504,9 @@ fn try_recv_bypass_or_yring(
             let _ = decompose_message(sock, &m);
         }
         copy_to_buf(buf, buf_len, &frame);
-        #[expect(clippy::cast_possible_wrap)]
-        return Some(frame_len as c_int);
+        return checked_c_int_len(frame_len).map(Some);
     }
-    None
+    Ok(None)
 }
 
 #[inline]

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -68,6 +68,40 @@ fn msg_init_size() {
     zmq_msg_close(m.0.as_mut_ptr().cast());
 }
 
+#[test]
+fn msg_move_and_copy_self_alias_are_noops() {
+    let payload = b"alias";
+    let mut m = ZmqMsg([0u8; 64]);
+    assert_eq!(
+        zmq_msg_init_buffer(
+            m.0.as_mut_ptr().cast(),
+            payload.as_ptr().cast(),
+            payload.len()
+        ),
+        0
+    );
+
+    assert_eq!(
+        zmq_msg_move(m.0.as_mut_ptr().cast(), m.0.as_mut_ptr().cast()),
+        0
+    );
+    assert_eq!(zmq_msg_size(m.0.as_ptr().cast()), payload.len());
+    let data = zmq_msg_data(m.0.as_mut_ptr().cast());
+    let slice = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), payload.len()) };
+    assert_eq!(slice, payload);
+
+    assert_eq!(
+        zmq_msg_copy(m.0.as_mut_ptr().cast(), m.0.as_ptr().cast()),
+        0
+    );
+    assert_eq!(zmq_msg_size(m.0.as_ptr().cast()), payload.len());
+    let data = zmq_msg_data(m.0.as_mut_ptr().cast());
+    let slice = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), payload.len()) };
+    assert_eq!(slice, payload);
+
+    zmq_msg_close(m.0.as_mut_ptr().cast());
+}
+
 /// `zmq_msg_init_buffer` copies the buffer
 #[test]
 fn msg_init_buffer() {

--- a/omq-proto/src/encoded_queue.rs
+++ b/omq-proto/src/encoded_queue.rs
@@ -120,6 +120,7 @@ impl EncodedQueue {
         }
     }
 
+    #[inline]
     pub fn encode_arena(&mut self, msg: &Message) {
         let before = self.arena.len();
         frame::encode_message_flat(msg, &mut self.arena);
@@ -159,6 +160,7 @@ impl EncodedQueue {
         self.total_bytes += self.arena.len() - before;
     }
 
+    #[inline]
     pub fn encode_auto(&mut self, msg: &Message) {
         if msg.byte_len() < self.arena_threshold {
             self.encode_arena(msg);

--- a/omq-proto/src/flow.rs
+++ b/omq-proto/src/flow.rs
@@ -1,0 +1,71 @@
+//! Shared outbound flow-control knobs.
+//!
+//! Both backends drain a shared outbound queue in batches and flush via
+//! a single writev. Two caps bound each batch so one busy consumer can
+//! never starve its siblings:
+//!
+//! - a **message cap** ([`fair_share`]): each driver takes at most its
+//!   fair share of the queued messages, leaving the rest for the other
+//!   peers draining the same queue.
+//! - a **byte cap** ([`max_batch_bytes`]): independent of message count,
+//!   stop pulling once the batch has buffered this many bytes so a few
+//!   large messages don't monopolize the writev or outgrow the kernel
+//!   send buffer.
+//!
+//! Per-peer yield intervals and direct-encode admission caps stay in the
+//! backends: those are tuned to each runtime (multi-thread tokio vs.
+//! single-thread compio) and don't share a formula.
+
+use std::sync::OnceLock;
+
+/// Max bytes one shared-queue batch buffers before flushing.
+///
+/// 1 MiB folds large messages into bigger writev calls without
+/// outgrowing typical kernel TCP send buffers. Smaller caps (e.g.
+/// 256 KiB) under-utilize writev for 32 KiB+ messages and let the
+/// per-syscall overhead dominate; larger caps add latency without extra
+/// throughput once the kernel send buffer is the bottleneck.
+///
+/// Override at runtime via `OMQ_BATCH_BYTES`. Read once and cached.
+#[must_use]
+pub fn max_batch_bytes() -> usize {
+    static CAP: OnceLock<usize> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        std::env::var("OMQ_BATCH_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1024 * 1024)
+    })
+}
+
+/// Fair share of the current queue for one consumer.
+///
+/// Single peer: full batch (`cap`), no competition. Multiple peers: each
+/// consumer takes at most `queue_len / peers` to leave work for the
+/// others, but always at least 1 and never more than `cap`.
+#[must_use]
+pub fn fair_share(queue_len: usize, peers: usize, cap: usize) -> usize {
+    if peers <= 1 {
+        return cap;
+    }
+    (queue_len / peers).clamp(1, cap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_peer_gets_full_cap() {
+        assert_eq!(fair_share(0, 1, 256), 256);
+        assert_eq!(fair_share(1000, 0, 256), 256);
+        assert_eq!(fair_share(5, 1, 64), 64);
+    }
+
+    #[test]
+    fn multi_peer_splits_with_floor_and_cap() {
+        assert_eq!(fair_share(100, 4, 256), 25);
+        assert_eq!(fair_share(3, 8, 256), 1); // floor of 1
+        assert_eq!(fair_share(10_000, 2, 256), 256); // capped
+    }
+}

--- a/omq-proto/src/lib.rs
+++ b/omq-proto/src/lib.rs
@@ -12,6 +12,7 @@ pub mod backoff;
 pub mod encoded_queue;
 pub mod endpoint;
 pub mod error;
+pub mod flow;
 pub mod inproc;
 pub mod message;
 pub mod monitor;

--- a/omq-proto/src/proto/frame.rs
+++ b/omq-proto/src/proto/frame.rs
@@ -180,6 +180,7 @@ pub fn encode_message_flat_ws_masked(msg: &Message, buf: &mut BytesMut) {
 
 /// Encode all frames of `msg` into a flat contiguous buffer (header + payload
 /// concatenated). Used by the compio fast send path for small messages.
+#[inline]
 pub fn encode_message_flat(msg: &Message, buf: &mut BytesMut) {
     let n = msg.len();
     let mut i = 0;

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -242,19 +242,7 @@ async fn batch_encode(
 const READ_BUF_SIZE: usize = 128 * 1024;
 
 use crate::routing::SHARED_MAX_BATCH_MSGS;
-
-/// Max bytes one shared-queue batch encodes before flushing.
-/// Override at runtime via `OMQ_BATCH_BYTES`.
-fn max_batch_bytes() -> usize {
-    use std::sync::OnceLock;
-    static CAP: OnceLock<usize> = OnceLock::new();
-    *CAP.get_or_init(|| {
-        std::env::var("OMQ_BATCH_BYTES")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1024 * 1024)
-    })
-}
+use omq_proto::flow::max_batch_bytes;
 
 /// Driver-level timing configuration: handshake deadline, heartbeat
 /// cadence, idle-close timeout.

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -859,10 +859,6 @@ async fn drain_wire_slot<W: AsyncWrite + Unpin>(
         write_chunks(writer, drain_buf).await?;
         slot.space_available.notify_one();
         if batch_bytes >= max_batch_bytes() {
-            // Data remains in the wire slot. Self-notify so the next
-            // select! iteration re-enters this arm instead of parking
-            // on a notification that signal_encoded will skip (pending
-            // is still true).
             slot.data_ready.notify_one();
             break;
         }

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -234,6 +234,10 @@ mod tests {
             None,
             omq_proto::encoded_queue::ARENA_THRESHOLD,
             WIRE_SLOT_CAP_DEFAULT,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
         );
         slot.handshake_done.store(true, Ordering::Release);
         let msg = Message::from("x");

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -5,7 +5,7 @@
 // in-flight message may still be in the inbox while the next message
 // takes the wire slot fast path and reaches the wire first.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -15,6 +15,7 @@ use omq_proto::encoded_queue::EncodedQueue;
 use omq_proto::message::Message;
 
 pub(crate) const WIRE_SLOT_CAP_DEFAULT: usize = 2 * 1024 * 1024;
+pub(crate) const WIRE_SLOT_MSG_CAP_DEFAULT: usize = crate::routing::SHARED_MAX_BATCH_MSGS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TryEncodeResult {
@@ -42,6 +43,8 @@ pub(crate) struct PeerWireSlot {
     ws_masked: bool,
     pub(crate) dead: AtomicBool,
     pub(crate) peer_id: u64,
+    pub(crate) consecutive_full: AtomicU32,
+    queued_msgs: AtomicUsize,
 }
 
 impl std::fmt::Debug for PeerWireSlot {
@@ -82,6 +85,8 @@ impl PeerWireSlot {
             ws_masked,
             dead: AtomicBool::new(false),
             peer_id,
+            consecutive_full: AtomicU32::new(0),
+            queued_msgs: AtomicUsize::new(0),
         })
     }
 
@@ -90,6 +95,7 @@ impl PeerWireSlot {
         self.is_ws
     }
 
+    #[inline]
     pub(crate) fn try_encode(&self, msg: &Message) -> TryEncodeResult {
         if self.dead.load(Ordering::Acquire) {
             return TryEncodeResult::Dead;
@@ -104,10 +110,11 @@ impl PeerWireSlot {
                 return TryEncodeResult::Ineligible;
             }
             let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
-            if eq.total_bytes() >= self.cap {
+            if self.is_full(&eq) {
                 return TryEncodeResult::Full;
             }
             eq.encode_ws(msg, self.ws_masked);
+            self.queued_msgs.fetch_add(1, Ordering::Relaxed);
             drop(eq);
             self.signal_encoded();
             return TryEncodeResult::Ok;
@@ -115,10 +122,11 @@ impl PeerWireSlot {
 
         if !self.has_transform {
             let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
-            if eq.total_bytes() >= self.cap {
+            if self.is_full(&eq) {
                 return TryEncodeResult::Full;
             }
             eq.encode_auto(msg);
+            self.queued_msgs.fetch_add(1, Ordering::Relaxed);
             drop(eq);
             self.signal_encoded();
             return TryEncodeResult::Ok;
@@ -128,10 +136,11 @@ impl PeerWireSlot {
             && msg.iter().all(|part| part.len() < threshold)
         {
             let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
-            if eq.total_bytes() >= self.cap {
+            if self.is_full(&eq) {
                 return TryEncodeResult::Full;
             }
             eq.encode_prefixed_auto(sentinel, msg);
+            self.queued_msgs.fetch_add(1, Ordering::Relaxed);
             drop(eq);
             self.signal_encoded();
             return TryEncodeResult::Ok;
@@ -145,10 +154,11 @@ impl PeerWireSlot {
             return TryEncodeResult::Dead;
         }
         let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
-        if eq.total_bytes() >= self.cap {
+        if self.is_full(&eq) {
             return TryEncodeResult::Full;
         }
         eq.push_shared_chunks(chunks);
+        self.queued_msgs.fetch_add(1, Ordering::Relaxed);
         drop(eq);
         self.signal_encoded();
         TryEncodeResult::Ok
@@ -159,10 +169,11 @@ impl PeerWireSlot {
             return TryEncodeResult::Dead;
         }
         let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
-        if eq.total_bytes() >= self.cap {
+        if self.is_full(&eq) {
             return TryEncodeResult::Full;
         }
         eq.push_pre_encoded(data);
+        self.queued_msgs.fetch_add(1, Ordering::Relaxed);
         TryEncodeResult::Ok
     }
 
@@ -177,6 +188,13 @@ impl PeerWireSlot {
         eq.drain_into_vec(buf, max_chunks);
         if eq.is_empty() {
             self.pending.store(false, Ordering::Relaxed);
+            self.queued_msgs.store(0, Ordering::Relaxed);
+        } else if !buf.is_empty() {
+            self.queued_msgs
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                    Some(n.saturating_sub(max_chunks))
+                })
+                .ok();
         }
     }
 
@@ -185,7 +203,7 @@ impl PeerWireSlot {
             return false;
         }
         let eq = self.eq.lock().expect("wire_slot eq poisoned");
-        eq.total_bytes() < self.cap
+        !self.is_full(&eq)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -196,5 +214,37 @@ impl PeerWireSlot {
     pub(crate) fn mark_dead(&self) {
         self.dead.store(true, Ordering::Release);
         self.space_available.notify_waiters();
+    }
+
+    fn is_full(&self, eq: &EncodedQueue) -> bool {
+        eq.total_bytes() >= self.cap
+            || self.queued_msgs.load(Ordering::Relaxed) >= WIRE_SLOT_MSG_CAP_DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_slot_caps_queued_messages_independent_of_bytes() {
+        let slot = PeerWireSlot::new(
+            1,
+            false,
+            None,
+            omq_proto::encoded_queue::ARENA_THRESHOLD,
+            WIRE_SLOT_CAP_DEFAULT,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+        let msg = Message::from("x");
+
+        for _ in 0..WIRE_SLOT_MSG_CAP_DEFAULT {
+            assert_eq!(slot.try_encode(&msg), TryEncodeResult::Ok);
+        }
+        assert_eq!(slot.try_encode(&msg), TryEncodeResult::Full);
+
+        let mut chunks = Vec::new();
+        slot.drain_into_vec(&mut chunks, 1024);
+        assert_eq!(slot.try_encode(&msg), TryEncodeResult::Ok);
     }
 }

--- a/omq-tokio/src/routing/drop_queue.rs
+++ b/omq-tokio/src/routing/drop_queue.rs
@@ -182,10 +182,7 @@ impl QueueReceiver {
     /// others, but always at least 1.
     pub(crate) fn batch_limit(&self) -> usize {
         let peers = self.peer_count.load(std::sync::atomic::Ordering::Relaxed);
-        if peers <= 1 {
-            return super::SHARED_MAX_BATCH_MSGS;
-        }
-        (self.inner.queue.len() / peers).clamp(1, super::SHARED_MAX_BATCH_MSGS)
+        omq_proto::flow::fair_share(self.inner.queue.len(), peers, super::SHARED_MAX_BATCH_MSGS)
     }
 
     pub(crate) fn set_peer_count(&self, n: usize) {

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -54,6 +54,12 @@ enum CachedResult {
     Miss,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchStatus {
+    Ok,
+    Full,
+}
+
 #[derive(Debug)]
 pub(crate) struct Submitter {
     inner: Arc<Mutex<FanOutInner>>,
@@ -174,7 +180,13 @@ impl Submitter {
                 if self.xpub_nodrop && !targets_have_space(&targets) {
                     return Err(omq_proto::error::TrySendError::Full(forwarded));
                 }
-                dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+                if dispatch_to_targets(&targets, &forwarded, encoder.as_deref())
+                    .map_err(omq_proto::error::TrySendError::Error)?
+                    == DispatchStatus::Full
+                    && self.xpub_nodrop
+                {
+                    return Err(omq_proto::error::TrySendError::Full(forwarded));
+                }
                 return Ok(());
             }
             CachedResult::Miss => {}
@@ -184,7 +196,13 @@ impl Submitter {
         if self.xpub_nodrop && !targets_have_space(&targets) {
             return Err(omq_proto::error::TrySendError::Full(forwarded));
         }
-        dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+        if dispatch_to_targets(&targets, &forwarded, encoder.as_deref())
+            .map_err(omq_proto::error::TrySendError::Error)?
+            == DispatchStatus::Full
+            && self.xpub_nodrop
+        {
+            return Err(omq_proto::error::TrySendError::Full(forwarded));
+        }
         Ok(())
     }
 
@@ -204,9 +222,10 @@ impl Submitter {
                 // CPU without adding parallelism (distribution stays serial
                 // on the one pump). Inline dispatch removes both hops.
                 if self.xpub_nodrop {
-                    wait_for_targets_space(&targets).await;
+                    send_to_targets_nodrop(&targets, forwarded.clone()).await?;
+                    return Ok(());
                 }
-                dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+                dispatch_to_targets(&targets, &forwarded, encoder.as_deref())?;
                 let interval = yield_interval(targets.len());
                 if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
                     tokio::task::yield_now().await;
@@ -218,9 +237,10 @@ impl Submitter {
 
         let (targets, encoder) = self.collect_targets(&forwarded, group.as_deref());
         if self.xpub_nodrop {
-            wait_for_targets_space(&targets).await;
+            send_to_targets_nodrop(&targets, forwarded.clone()).await?;
+            return Ok(());
         }
-        dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+        dispatch_to_targets(&targets, &forwarded, encoder.as_deref())?;
         let interval = yield_interval(targets.len());
         if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
             tokio::task::yield_now().await;
@@ -456,32 +476,11 @@ fn targets_have_space(targets: &[PeerSend]) -> bool {
     })
 }
 
-async fn wait_for_targets_space(targets: &[PeerSend]) {
-    while !targets_have_space(targets) {
-        let notified = targets.iter().find_map(|t| match t {
-            PeerSend::Wire { slot, .. }
-                if !slot.has_space() && !slot.dead.load(Ordering::Acquire) =>
-            {
-                Some(slot.space_available.notified())
-            }
-            _ => None,
-        });
-        match notified {
-            Some(notified) => {
-                let mut notified = std::pin::pin!(notified);
-                notified.as_mut().enable();
-                if targets_have_space(targets) {
-                    return;
-                }
-                tokio::select! {
-                    biased;
-                    () = &mut notified => {}
-                    () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
-                }
-            }
-            None => return,
-        }
+async fn send_to_targets_nodrop(targets: &[PeerSend], msg: Message) -> Result<()> {
+    for target in targets {
+        target.send(msg.clone()).await?;
     }
+    Ok(())
 }
 
 fn dispatch_encoded(
@@ -489,16 +488,19 @@ fn dispatch_encoded(
     targets: &[PeerSend],
     msg: &Message,
     chunks: &mut Vec<Bytes>,
-) {
+) -> DispatchStatus {
+    let mut full = false;
     if eq.has_arena_only() && eq.uncommitted_arena().len() * targets.len() <= FAN_OUT_COPY_BUDGET {
         let raw = eq.uncommitted_arena();
         for t in targets {
             match t {
                 PeerSend::Wire { slot, .. } => {
-                    let _ = slot.try_push_pre_encoded_no_signal(raw);
+                    full |= slot.try_push_pre_encoded_no_signal(raw) == TryEncodeResult::Full;
                 }
                 PeerSend::Inbox(tx) => {
-                    let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
+                    full |= tx
+                        .try_send(DriverCommand::SendMessage(msg.clone()))
+                        .is_err();
                 }
             }
         }
@@ -514,14 +516,21 @@ fn dispatch_encoded(
         for t in targets {
             match t {
                 PeerSend::Wire { slot, .. } => {
-                    let _ = slot.try_push_encoded(chunks);
+                    full |= slot.try_push_encoded(chunks) == TryEncodeResult::Full;
                 }
                 PeerSend::Inbox(tx) => {
-                    let _ = tx.try_send(DriverCommand::SendMessage(msg.clone()));
+                    full |= tx
+                        .try_send(DriverCommand::SendMessage(msg.clone()))
+                        .is_err();
                 }
             }
         }
         chunks.clear();
+    }
+    if full {
+        DispatchStatus::Full
+    } else {
+        DispatchStatus::Ok
     }
 }
 
@@ -529,21 +538,27 @@ fn dispatch_to_targets(
     targets: &[PeerSend],
     msg: &Message,
     encoder: Option<&Mutex<MessageEncoder>>,
-) {
+) -> Result<DispatchStatus> {
     use std::cell::RefCell;
 
     match targets.len() {
-        0 => {}
-        1 => {
-            let _ = targets[0].try_encode(msg);
-        }
+        0 => Ok(DispatchStatus::Ok),
+        1 => match targets[0].try_encode(msg) {
+            TryEncodeResult::Full => Ok(DispatchStatus::Full),
+            _ => Ok(DispatchStatus::Ok),
+        },
         _ => {
             #[cfg(feature = "ws")]
             if targets.iter().any(PeerSend::is_ws) {
+                let mut full = false;
                 for t in targets {
-                    let _ = t.try_encode(msg);
+                    full |= t.try_encode(msg) == TryEncodeResult::Full;
                 }
-                return;
+                return Ok(if full {
+                    DispatchStatus::Full
+                } else {
+                    DispatchStatus::Ok
+                });
             }
 
             thread_local! {
@@ -557,10 +572,7 @@ fn dispatch_to_targets(
                 if let Some(enc_mtx) = encoder {
                     let transformed = {
                         let mut enc = enc_mtx.lock().expect("fan_out_encoder poisoned");
-                        match enc.encode(msg) {
-                            Ok(t) => t,
-                            Err(_) => return,
-                        }
+                        enc.encode(msg)?
                     };
                     for wire_msg in &transformed {
                         eq.encode_auto(wire_msg);
@@ -568,10 +580,8 @@ fn dispatch_to_targets(
                 } else {
                     eq.encode_auto(msg);
                 }
-                CHUNKS.with(|drain| {
-                    dispatch_encoded(eq, targets, msg, &mut drain.borrow_mut());
-                });
-            });
+                CHUNKS.with(|drain| Ok(dispatch_encoded(eq, targets, msg, &mut drain.borrow_mut())))
+            })
         }
     }
 }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -36,10 +36,6 @@ pub(crate) enum FanOutMode {
     Group,
 }
 
-/// Yield to the runtime after encoding this many arena bytes, so a large
-/// fan-out does not starve other tasks on the same thread.
-const ARENA_YIELD_BYTES: usize = 2 * 1024 * 1024;
-
 /// Per-peer copy budget for pre-encoded bytes before yielding.
 const FAN_OUT_COPY_BUDGET: usize = 128 * 1024;
 
@@ -74,28 +70,6 @@ impl FanOutArena {
             eq: Mutex::new(EncodedQueue::one_shot()),
             data_ready: Notify::new(),
             pending: AtomicBool::new(false),
-        }
-    }
-
-    fn encode_and_signal(&self, msg: &Message, encoder: Option<&Mutex<MessageEncoder>>) {
-        let mut eq = self.eq.lock().unwrap();
-        if let Some(enc_mtx) = encoder {
-            let transformed = {
-                let mut enc = enc_mtx.lock().expect("fan_out_encoder poisoned");
-                match enc.encode(msg) {
-                    Ok(t) => t,
-                    Err(_) => return,
-                }
-            };
-            for wire_msg in &transformed {
-                eq.encode_auto(wire_msg);
-            }
-        } else {
-            eq.encode_auto(msg);
-        }
-        drop(eq);
-        if !self.pending.swap(true, Ordering::Release) {
-            self.data_ready.notify_one();
         }
     }
 
@@ -297,20 +271,22 @@ impl Submitter {
             CachedResult::Cached {
                 targets,
                 encoder,
-                all_wire,
+                all_wire: _,
             } => {
-                let interval;
-                if all_wire && !self.xpub_nodrop {
-                    self.arena.encode_and_signal(&forwarded, encoder.as_deref());
-                    let wire_size = forwarded.byte_len() + 10;
-                    interval = (ARENA_YIELD_BYTES / wire_size.max(1)).clamp(16, 256) as u32;
-                } else {
-                    if self.xpub_nodrop {
-                        wait_for_targets_space(&targets).await;
-                    }
-                    dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
-                    interval = yield_interval(targets.len());
+                // Encode once and distribute synchronously on this task via
+                // the thread-local arena (`dispatch_to_targets`), the same
+                // path `try_send` uses. The earlier all-wire fast path
+                // handed the message to a single `fan_out_pump` task through
+                // `FanOutArena.eq`; under the multi-thread runtime that put
+                // the send task and the pump task in a per-message ping-pong
+                // on that mutex plus a cross-thread `Notify` wakeup, burning
+                // CPU without adding parallelism (distribution stays serial
+                // on the one pump). Inline dispatch removes both hops.
+                if self.xpub_nodrop {
+                    wait_for_targets_space(&targets).await;
                 }
+                dispatch_to_targets(&targets, &forwarded, encoder.as_deref());
+                let interval = yield_interval(targets.len());
                 if self.send_count.fetch_add(1, Ordering::Relaxed) % interval == interval - 1 {
                     tokio::task::yield_now().await;
                 }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -5,12 +5,10 @@
 //! into the fan-out arena, then the pre-encoded bytes are pushed into
 //! each matching peer's `EncodedQueue`. The driver flushes to the wire.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use tokio::sync::Notify;
-use tokio_util::sync::CancellationToken;
 
 use smallvec::SmallVec;
 
@@ -52,66 +50,8 @@ enum CachedResult {
     Cached {
         targets: Arc<Vec<PeerSend>>,
         encoder: Option<Arc<Mutex<MessageEncoder>>>,
-        all_wire: bool,
     },
     Miss,
-}
-
-#[derive(Debug)]
-pub(crate) struct FanOutArena {
-    eq: Mutex<EncodedQueue>,
-    data_ready: Notify,
-    pending: AtomicBool,
-}
-
-impl FanOutArena {
-    fn new() -> Self {
-        Self {
-            eq: Mutex::new(EncodedQueue::one_shot()),
-            data_ready: Notify::new(),
-            pending: AtomicBool::new(false),
-        }
-    }
-
-    fn drain_to(&self, targets: &[PeerSend], chunks: &mut Vec<Bytes>) {
-        let mut eq = self.eq.lock().unwrap();
-        if eq.is_empty() {
-            self.pending.store(false, Ordering::Relaxed);
-            return;
-        }
-        if eq.has_arena_only()
-            && eq.uncommitted_arena().len() * targets.len() <= FAN_OUT_COPY_BUDGET
-        {
-            let frozen = eq.take_arena_bytes();
-            self.pending.store(false, Ordering::Relaxed);
-            drop(eq);
-            for t in targets {
-                if let PeerSend::Wire { slot, .. } = t {
-                    let _ = slot.try_push_pre_encoded_no_signal(&frozen);
-                }
-            }
-            for t in targets {
-                if let PeerSend::Wire { slot, .. } = t {
-                    slot.signal_encoded();
-                }
-            }
-        } else {
-            chunks.clear();
-            eq.drain_into_vec(chunks, 1024);
-            self.pending.store(false, Ordering::Relaxed);
-            drop(eq);
-            for t in targets {
-                if let PeerSend::Wire { slot, .. } = t {
-                    let _ = slot.try_push_encoded(chunks);
-                }
-            }
-        }
-    }
-
-    fn drain_to_targets(&self, targets: &[PeerSend]) {
-        let mut chunks = Vec::new();
-        self.drain_to(targets, &mut chunks);
-    }
 }
 
 #[derive(Debug)]
@@ -122,7 +62,6 @@ pub(crate) struct Submitter {
     send_count: Arc<AtomicU32>,
     xpub_nodrop: bool,
     cached: Mutex<CachedFanOut>,
-    arena: Arc<FanOutArena>,
 }
 
 #[derive(Debug, Default)]
@@ -143,7 +82,6 @@ impl Clone for Submitter {
             send_count: self.send_count.clone(),
             xpub_nodrop: self.xpub_nodrop,
             cached: Mutex::new(CachedFanOut::default()),
-            arena: self.arena.clone(),
         }
     }
 }
@@ -179,11 +117,6 @@ impl Submitter {
         let current = self.generation.load(Ordering::Acquire);
         let mut cached = self.cached.lock().unwrap();
         if cached.generation != current {
-            if cached.all_wire
-                && let Some(ref targets) = cached.all_targets
-            {
-                self.arena.drain_to_targets(targets);
-            }
             let g = self.inner.lock().expect("fanout inner poisoned");
             if g.all_subscribe_all && g.all_targets.len() == 1 && g.fan_out_encoder.is_none() {
                 cached.sole_wire = Some(g.all_targets[0].clone());
@@ -215,7 +148,6 @@ impl Submitter {
             return CachedResult::Cached {
                 targets: targets.clone(),
                 encoder: cached.encoder.clone(),
-                all_wire: cached.all_wire,
             };
         }
         CachedResult::Miss
@@ -238,14 +170,7 @@ impl Submitter {
                     TryEncodeResult::Full => Err(omq_proto::error::TrySendError::Full(forwarded)),
                 };
             }
-            CachedResult::Cached {
-                targets,
-                encoder,
-                all_wire,
-            } => {
-                if all_wire {
-                    self.arena.drain_to_targets(&targets);
-                }
+            CachedResult::Cached { targets, encoder } => {
                 if self.xpub_nodrop && !targets_have_space(&targets) {
                     return Err(omq_proto::error::TrySendError::Full(forwarded));
                 }
@@ -268,11 +193,7 @@ impl Submitter {
 
         match self.try_cached(&forwarded, group.as_deref()) {
             CachedResult::SoleWire(TryEncodeResult::Ok) => return Ok(()),
-            CachedResult::Cached {
-                targets,
-                encoder,
-                all_wire: _,
-            } => {
+            CachedResult::Cached { targets, encoder } => {
                 // Encode once and distribute synchronously on this task via
                 // the thread-local arena (`dispatch_to_targets`), the same
                 // path `try_send` uses. The earlier all-wire fast path
@@ -341,9 +262,6 @@ pub(crate) struct FanOutSend {
     generation: Arc<AtomicU64>,
     mode: FanOutMode,
     xpub_nodrop: bool,
-    arena: Arc<FanOutArena>,
-    pump_cancel: CancellationToken,
-    pump_spawned: bool,
 }
 
 struct FanOutInner {
@@ -421,9 +339,6 @@ impl FanOutSend {
             generation: Arc::new(AtomicU64::new(0)),
             mode,
             xpub_nodrop: options.xpub_nodrop,
-            arena: Arc::new(FanOutArena::new()),
-            pump_cancel: CancellationToken::new(),
-            pump_spawned: false,
         }
     }
 
@@ -439,7 +354,6 @@ impl FanOutSend {
             send_count: Arc::new(AtomicU32::new(0)),
             xpub_nodrop: self.xpub_nodrop,
             cached: Mutex::new(CachedFanOut::default()),
-            arena: self.arena.clone(),
         }
     }
 
@@ -453,15 +367,6 @@ impl FanOutSend {
 
     #[expect(clippy::needless_pass_by_value)]
     fn add_peer(&mut self, peer_id: u64, handle: DriverHandle, any_groups: bool) {
-        if !self.pump_spawned {
-            self.pump_spawned = true;
-            tokio::spawn(fan_out_pump(
-                self.arena.clone(),
-                self.inner.clone(),
-                self.generation.clone(),
-                self.pump_cancel.child_token(),
-            ));
-        }
         let has_transform = handle.wire_slot.as_ref().is_some_and(|s| s.has_transform);
         let target = PeerSend::from_handle(&handle);
         let mut g = self.inner.lock().expect("fanout inner poisoned");
@@ -533,16 +438,12 @@ impl FanOutSend {
         }
     }
 
-    pub(crate) fn shutdown(&self) {
-        self.pump_cancel.cancel();
-    }
+    // Kept for the SendStrategy enum dispatch; fan-out has no pump task
+    // to cancel since dispatch is inline on the sending task.
+    #[expect(clippy::unused_self)]
+    pub(crate) fn shutdown(&self) {}
 
     pub(crate) fn is_drained(&self) -> bool {
-        let eq = self.arena.eq.lock().unwrap();
-        if !eq.is_empty() {
-            return false;
-        }
-        drop(eq);
         let g = self.inner.lock().expect("fanout inner poisoned");
         g.peers.values().all(|p| p.target.is_empty())
     }
@@ -677,44 +578,4 @@ fn dispatch_to_targets(
 
 fn first_frame_bytes(msg: &Message) -> Bytes {
     msg.part_bytes(0).unwrap_or_default()
-}
-
-async fn fan_out_pump(
-    arena: Arc<FanOutArena>,
-    inner: Arc<Mutex<FanOutInner>>,
-    generation: Arc<AtomicU64>,
-    cancel: CancellationToken,
-) {
-    let mut chunks = Vec::new();
-    let mut cached_gen = 0u64;
-    let mut targets: Vec<PeerSend> = Vec::new();
-    loop {
-        tokio::select! {
-            biased;
-            () = cancel.cancelled() => {
-                refresh_pump_targets(&inner, &generation, &mut cached_gen, &mut targets);
-                arena.drain_to(&targets, &mut chunks);
-                return;
-            }
-            () = async { arena.data_ready.notified().await } => {
-                let current = generation.load(Ordering::Acquire);
-                if cached_gen != current {
-                    refresh_pump_targets(&inner, &generation, &mut cached_gen, &mut targets);
-                }
-                arena.drain_to(&targets, &mut chunks);
-            }
-        }
-    }
-}
-
-fn refresh_pump_targets(
-    inner: &Mutex<FanOutInner>,
-    generation: &AtomicU64,
-    cached_gen: &mut u64,
-    targets: &mut Vec<PeerSend>,
-) {
-    let g = inner.lock().expect("fanout inner poisoned");
-    targets.clear();
-    targets.extend_from_slice(&g.all_targets);
-    *cached_gen = generation.load(Ordering::Acquire);
 }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -202,6 +202,7 @@ pub(crate) struct SocketDriver {
     close_ack: Option<oneshot::Sender<Result<()>>>,
     spsc: super::handle::SpscHandles,
     wire_slot: super::handle::WireSlotHolder,
+    rr_slots: super::handle::RrSlots,
     compression_pool: Option<Arc<crate::engine::compression_pool::CompressionPool>>,
     recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
 }
@@ -220,6 +221,7 @@ impl SocketDriver {
         type_state: Arc<Mutex<TypeState>>,
         req_awaiting_reply: Arc<AtomicBool>,
         wire_slot: super::handle::WireSlotHolder,
+        rr_slots: super::handle::RrSlots,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
     ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(128);
@@ -253,6 +255,7 @@ impl SocketDriver {
             close_ack: None,
             spsc,
             wire_slot,
+            rr_slots,
             compression_pool: None,
             recv_sink_config,
         }

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -148,6 +148,8 @@ impl SocketDriver {
             return;
         }
         let mut guard = self.wire_slot.lock().expect("wire_slot");
+        let mut rr = self.rr_slots.slots.lock().expect("rr_slots");
+        rr.clear();
         if self.peers.len() == 1 {
             let peer = self.peers.values().next().unwrap();
             if let Some(ref slot) = peer.handle.wire_slot {
@@ -156,6 +158,21 @@ impl SocketDriver {
             }
         }
         *guard = None;
+        // Multi-peer round-robin: populate per-peer wire slots so the handle
+        // dispatches directly to one peer at a time. Only when every peer is
+        // a wire peer (no inproc) - inproc peers have no wire slot and would
+        // be starved if the round-robin only cycled wire slots. Mixed or
+        // inproc-only sets fall back to the shared queue (rr left empty).
+        if matches!(cat, SendCategory::RoundRobin)
+            && self.peers.len() > 1
+            && self.peers.values().all(|p| p.handle.wire_slot.is_some())
+        {
+            for p in self.peers.values() {
+                if let Some(ref slot) = p.handle.wire_slot {
+                    rr.push(slot.clone());
+                }
+            }
+        }
     }
 
     fn evict_peer_for_handover(&mut self, peer_id: u64) {

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use super::{
     AnyConn, AnyStream, ConnectionConfig, ConnectionDriver, DisconnectReason, DriverConfig,
@@ -152,7 +153,9 @@ impl SocketDriver {
         rr.clear();
         if self.peers.len() == 1 {
             let peer = self.peers.values().next().unwrap();
-            if let Some(ref slot) = peer.handle.wire_slot {
+            if let Some(ref slot) = peer.handle.wire_slot
+                && slot.handshake_done.load(Ordering::Acquire)
+            {
                 *guard = Some(slot.clone());
                 return;
             }
@@ -165,7 +168,12 @@ impl SocketDriver {
         // inproc-only sets fall back to the shared queue (rr left empty).
         if matches!(cat, SendCategory::RoundRobin)
             && self.peers.len() > 1
-            && self.peers.values().all(|p| p.handle.wire_slot.is_some())
+            && self.peers.values().all(|p| {
+                p.handle
+                    .wire_slot
+                    .as_ref()
+                    .is_some_and(|slot| slot.handshake_done.load(Ordering::Acquire))
+            })
         {
             for p in self.peers.values() {
                 if let Some(ref slot) = p.handle.wire_slot {

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -378,16 +378,37 @@ impl SocketDriver {
         // skipping the actor's event loop.
         let driver = if can_bypass_actor_recv(self.socket_type) {
             let can_use_yring = !matches!(self.socket_type, SocketType::Req);
-            let from_slot = if can_use_yring {
-                self.recv_sink_config
+            if can_use_yring {
+                let from_slot = self
+                    .recv_sink_config
                     .as_ref()
-                    .and_then(|cfg| cfg.slot.lock().unwrap().take())
+                    .and_then(|cfg| cfg.slot.lock().unwrap().take());
+                if let Some(sink) = from_slot {
+                    driver.with_recv_sink(sink)
+                } else {
+                    let cap = self.options.recv_hwm.unwrap_or(1024).max(16) as usize;
+                    let (prod, cons) = yring::spsc(cap);
+                    let recv_notify = self.spsc.recv_notify.clone();
+                    let space = std::sync::Arc::new(tokio::sync::Notify::new());
+                    let sink = crate::engine::RecvSink::Yring(crate::engine::YringSink {
+                        producer: prod,
+                        signal: Box::new(move || recv_notify.notify_one()),
+                        space: space.clone(),
+                    });
+                    let entry = std::sync::Arc::new(crate::socket::handle::TcpYringConsumer {
+                        consumer: std::sync::Mutex::new(cons),
+                        space,
+                        peer_id,
+                    });
+                    self.spsc.tcp_consumers.write().unwrap().push(entry);
+                    self.spsc
+                        .consumer_generation
+                        .fetch_add(1, std::sync::atomic::Ordering::Release);
+                    self.spsc.activated.notify_one();
+                    driver.with_recv_sink(sink)
+                }
             } else {
-                None
-            };
-            match from_slot {
-                Some(sink) => driver.with_recv_sink(sink),
-                None => driver.with_recv_direct(self.recv_tx.clone()),
+                driver.with_recv_direct(self.recv_tx.clone())
             }
         } else {
             driver

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -556,7 +556,11 @@ impl Socket {
                     )));
                 }
                 let msg = Message::with_prefix(Bytes::new(), msg);
-                let result = self.inner.send_submitter.try_send(msg);
+                let result = match self.try_send_single_wire(&msg) {
+                    Ok(true) => Ok(()),
+                    Ok(false) => self.inner.send_submitter.try_send(msg),
+                    Err(e) => Err(e),
+                };
                 if result.is_err() {
                     self.inner
                         .req_awaiting_reply

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -586,7 +586,7 @@ impl Socket {
                     Ok(()) => return Ok(()),
                     Err(msg) => msg,
                 };
-                if self.try_send_wire(&msg) {
+                if self.try_send_single_wire(&msg)? {
                     return Ok(());
                 }
                 self.inner.send_submitter.try_send(msg)
@@ -876,8 +876,7 @@ impl Socket {
     /// the message was encoded into the peer's `EncodedQueue`.
     #[inline]
     fn try_send_wire(&self, msg: &Message) -> bool {
-        let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
-        if let Some(ref slot) = slot {
+        if let Some(ref slot) = self.single_wire_slot() {
             return slot.try_encode(msg) == TryEncodeResult::Ok;
         }
         false
@@ -935,7 +934,7 @@ impl Socket {
     /// Single-peer async slow path: handles backpressure (Full → wait
     /// for space) and falls back to the shared queue for ineligible peers.
     async fn send_wire_slow(&self, msg: Message) -> Result<()> {
-        let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
+        let slot = self.single_wire_slot();
         if let Some(ref slot) = slot {
             loop {
                 match slot.try_encode(&msg) {
@@ -952,6 +951,21 @@ impl Socket {
             }
         }
         self.inner.send_submitter.send(msg).await
+    }
+
+    fn try_send_single_wire(&self, msg: &Message) -> core::result::Result<bool, TrySendError> {
+        let Some(slot) = self.single_wire_slot() else {
+            return Ok(false);
+        };
+        match slot.try_encode(msg) {
+            TryEncodeResult::Ok => Ok(true),
+            TryEncodeResult::Full => Err(TrySendError::Full(msg.clone())),
+            TryEncodeResult::Dead | TryEncodeResult::Ineligible => Ok(false),
+        }
+    }
+
+    fn single_wire_slot(&self) -> Option<Arc<PeerWireSlot>> {
+        self.inner.wire_slot.lock().expect("wire_slot").clone()
     }
 
     async fn send_identity_routed(&self, msg: Message) -> Result<()> {

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -1,6 +1,6 @@
 //! Public `Socket` handle.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::channel::oneshot;
@@ -65,6 +65,24 @@ pub(crate) type SpscActivated = Arc<tokio::sync::Notify>;
 /// `SpscAwareRecv` skip re-cloning the Vec when nothing changed.
 pub(crate) type SpscConsumerGeneration = Arc<AtomicU64>;
 
+/// Per-TCP-peer yring consumer entry. The driver pushes decoded messages
+/// into its yring producer; the recv side drains the consumer here.
+pub(crate) struct TcpYringConsumer {
+    pub consumer: Mutex<yring::Consumer<Message>>,
+    pub space: Arc<tokio::sync::Notify>,
+    pub peer_id: u64,
+}
+
+impl std::fmt::Debug for TcpYringConsumer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TcpYringConsumer")
+            .field("peer_id", &self.peer_id)
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) type TcpConsumers = Arc<RwLock<Vec<Arc<TcpYringConsumer>>>>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct SpscHandles {
     pub consumers: SpscConsumers,
@@ -73,16 +91,21 @@ pub(crate) struct SpscHandles {
     pub send_ring_active: SpscSendRingActive,
     pub recv_notify: SpscRecvNotify,
     pub activated: SpscActivated,
+    pub tcp_consumers: TcpConsumers,
 }
 
 /// Recv channel that integrates per-peer SPSC awareness. Fair-queues
-/// across per-peer consumers, then falls back to the `async_channel`.
+/// across per-peer yring consumers (inproc + TCP), then falls back to
+/// the `async_channel`.
 #[derive(Debug)]
 struct SpscAwareRecv {
     rx: async_channel::Receiver<Message>,
     /// Per-peer SPSC rings (one per eligible inproc peer). Actor appends.
     consumers: Arc<std::sync::RwLock<Vec<Arc<InprocSpsc>>>>,
-    /// Generation counter. Bumped by the actor on consumer add/remove.
+    /// Per-TCP-peer yring consumers. Actor appends on handshake.
+    tcp_consumers: TcpConsumers,
+    /// Generation counter. Bumped by the actor on any consumer add/remove
+    /// (inproc or TCP).
     consumer_generation: SpscConsumerGeneration,
     /// Shared recv notification. All drivers/senders notify this.
     recv_notify: Arc<tokio::sync::Notify>,
@@ -92,14 +115,33 @@ struct SpscAwareRecv {
     send_ring: Arc<std::sync::RwLock<Option<Arc<InprocSpsc>>>>,
     /// True when `send_ring` is `Some`. Lets the hot path skip the `RwLock`.
     send_ring_active: Arc<AtomicBool>,
-    /// Batched inproc messages drained from consumers.
+    /// Batched messages drained from consumers (inproc + TCP).
     inproc_cache: std::sync::Mutex<std::collections::VecDeque<Message>>,
-    /// Cached clone of the consumers Vec, refreshed when generation changes.
-    cached_consumers: Mutex<(u64, Vec<Arc<InprocSpsc>>)>,
+    /// Cached clone of consumers Vecs, refreshed when generation changes.
+    cached_consumers: Mutex<CachedConsumers>,
+}
+
+struct CachedConsumers {
+    generation: u64,
+    inproc: Vec<Arc<InprocSpsc>>,
+    tcp: Vec<Arc<TcpYringConsumer>>,
+}
+
+impl std::fmt::Debug for CachedConsumers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedConsumers")
+            .field("generation", &self.generation)
+            .field("inproc_count", &self.inproc.len())
+            .field("tcp_count", &self.tcp.len())
+            .finish()
+    }
 }
 
 impl SpscAwareRecv {
     fn try_drain_consumers(&self) -> Option<Message> {
+        if self.consumer_generation.load(Ordering::Relaxed) == 0 {
+            return None;
+        }
         {
             let mut cache = self.inproc_cache.lock().unwrap();
             if let Some(msg) = cache.pop_front() {
@@ -108,15 +150,17 @@ impl SpscAwareRecv {
         }
         let current_gen = self.consumer_generation.load(Ordering::Acquire);
         let mut cached = self.cached_consumers.lock().unwrap();
-        if cached.0 != current_gen {
-            cached.1.clone_from(&self.consumers.read().unwrap());
-            cached.0 = current_gen;
+        if cached.generation != current_gen {
+            cached.inproc.clone_from(&self.consumers.read().unwrap());
+            cached.tcp.clone_from(&self.tcp_consumers.read().unwrap());
+            cached.generation = current_gen;
         }
-        let consumers = cached.1.clone();
+        let inproc = cached.inproc.clone();
+        let tcp = cached.tcp.clone();
         drop(cached);
         let mut cache = self.inproc_cache.lock().unwrap();
         let mut has_disconnected = false;
-        for p in &consumers {
+        for p in &inproc {
             if let Ok(mut consumer) = p.consumer.try_lock() {
                 let got = consumer.prefetch();
                 if got > 0 {
@@ -129,6 +173,20 @@ impl SpscAwareRecv {
                 }
             }
         }
+        for tc in &tcp {
+            if let Ok(mut consumer) = tc.consumer.try_lock() {
+                let got = consumer.prefetch();
+                if got > 0 {
+                    while let Some(msg) = consumer.pop() {
+                        cache.push_back(msg);
+                    }
+                    consumer.release();
+                    tc.space.notify_one();
+                } else if consumer.is_disconnected() {
+                    has_disconnected = true;
+                }
+            }
+        }
         let result = cache.pop_front();
         drop(cache);
         if has_disconnected {
@@ -136,8 +194,13 @@ impl SpscAwareRecv {
                 .write()
                 .unwrap()
                 .retain(|p| p.consumer.try_lock().map_or(true, |c| !c.is_disconnected()));
+            self.tcp_consumers.write().unwrap().retain(|tc| {
+                tc.consumer
+                    .try_lock()
+                    .map_or(true, |c| !c.is_disconnected())
+            });
             self.consumer_generation.fetch_add(1, Ordering::Release);
-            self.cached_consumers.lock().unwrap().0 = u64::MAX;
+            self.cached_consumers.lock().unwrap().generation = u64::MAX;
         }
         result
     }
@@ -149,18 +212,7 @@ impl SpscAwareRecv {
                 return Ok(msg);
             }
 
-            if self.consumers.read().unwrap().is_empty() {
-                let activated = self.activated.notified();
-                tokio::pin!(activated);
-                activated.as_mut().enable();
-                tokio::select! {
-                    biased;
-                    res = self.rx.recv() => {
-                        return res.map_err(|_| Error::Closed);
-                    }
-                    () = activated => continue,
-                }
-            } else {
+            if self.consumer_generation.load(Ordering::Acquire) > 0 {
                 let notified = self.recv_notify.notified();
                 tokio::pin!(notified);
                 notified.as_mut().enable();
@@ -174,6 +226,17 @@ impl SpscAwareRecv {
                         return res.map_err(|_| Error::Closed);
                     }
                     () = self.activated.notified() => continue,
+                }
+            } else {
+                let activated = self.activated.notified();
+                tokio::pin!(activated);
+                activated.as_mut().enable();
+                tokio::select! {
+                    biased;
+                    res = self.rx.recv() => {
+                        return res.map_err(|_| Error::Closed);
+                    }
+                    () = activated => continue,
                 }
             }
         }
@@ -232,10 +295,18 @@ struct Inner {
     /// `send_via_wire_slot` to dispatch directly to one peer at a time
     /// instead of funneling every message through the shared queue.
     rr_slots: RrSlots,
+    /// Cooperative yield counter. Every `SEND_YIELD_INTERVAL` successful
+    /// synchronous sends, `send()` yields to the runtime so driver tasks
+    /// on the same worker thread can drain and flush.
+    send_ops: AtomicU32,
     last_bound_endpoint: RwLock<Option<Endpoint>>,
 }
 
+const SEND_YIELD_INTERVAL: u32 = 4096;
+
 impl Socket {
+    const STARVATION_THRESHOLD: u32 = 2;
+
     /// Create a new socket of the given type with the given options. Spawns
     /// the driver task on the current tokio runtime.
     ///
@@ -287,6 +358,7 @@ impl Socket {
             send_ring_active: Arc::new(AtomicBool::new(false)),
             recv_notify: Arc::new(tokio::sync::Notify::new()),
             activated: Arc::new(tokio::sync::Notify::new()),
+            tcp_consumers: Arc::new(RwLock::new(Vec::new())),
         };
         let type_state = Arc::new(Mutex::new(TypeState::new()));
         let req_awaiting_reply = Arc::new(AtomicBool::new(false));
@@ -315,13 +387,18 @@ impl Socket {
                 recv_rx: SpscAwareRecv {
                     rx: recv_rx,
                     consumers: spsc.consumers,
+                    tcp_consumers: spsc.tcp_consumers,
                     consumer_generation: spsc.consumer_generation,
                     recv_notify: spsc.recv_notify,
                     activated: spsc.activated,
                     send_ring: spsc.send_ring,
                     send_ring_active: spsc.send_ring_active,
                     inproc_cache: std::sync::Mutex::new(std::collections::VecDeque::new()),
-                    cached_consumers: Mutex::new((u64::MAX, Vec::new())),
+                    cached_consumers: Mutex::new(CachedConsumers {
+                        generation: u64::MAX,
+                        inproc: Vec::new(),
+                        tcp: Vec::new(),
+                    }),
                 },
                 monitor,
                 root_cancel: cancel,
@@ -330,6 +407,7 @@ impl Socket {
                 req_awaiting_reply,
                 wire_slot,
                 rr_slots,
+                send_ops: AtomicU32::new(0),
                 last_bound_endpoint: RwLock::new(None),
             }),
         }
@@ -382,6 +460,14 @@ impl Socket {
     /// Send a message. Awaits until the message has been accepted by a ready
     /// peer's driver inbox (not waited-on-wire).
     pub async fn send(&self, msg: Message) -> Result<()> {
+        if self
+            .inner
+            .send_ops
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(SEND_YIELD_INTERVAL)
+        {
+            tokio::task::yield_now().await;
+        }
         match self.inner.socket_type {
             SocketType::Req => {
                 // CAS loop with yield guards against a TOCTOU race: between
@@ -410,7 +496,10 @@ impl Socket {
                     ));
                 }
                 let msg = Message::with_prefix(Bytes::new(), msg);
-                let result = self.send_via_wire_slot(msg).await;
+                if self.try_send_wire(&msg) {
+                    return Ok(());
+                }
+                let result = self.send_wire_slow(msg).await;
                 if result.is_err() {
                     self.inner
                         .req_awaiting_reply
@@ -437,7 +526,10 @@ impl Socket {
                     Ok(()) => return Ok(()),
                     Err(msg) => msg,
                 };
-                self.send_via_wire_slot(msg).await
+                if self.try_send_wire(&msg) {
+                    return Ok(());
+                }
+                self.send_round_robin_wire(msg).await
             }
         }
     }
@@ -490,6 +582,9 @@ impl Socket {
                     Ok(()) => return Ok(()),
                     Err(msg) => msg,
                 };
+                if self.try_send_wire(&msg) {
+                    return Ok(());
+                }
                 self.inner.send_submitter.try_send(msg)
             }
         }
@@ -773,59 +868,85 @@ impl Socket {
         Ok(())
     }
 
-    async fn send_via_wire_slot(&self, msg: Message) -> Result<()> {
+    /// Synchronous single-peer wire encode fast path. Returns true if
+    /// the message was encoded into the peer's `EncodedQueue`.
+    #[inline]
+    fn try_send_wire(&self, msg: &Message) -> bool {
         let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
-        let Some(ref slot) = slot else {
-            return self.send_round_robin_wire(msg).await;
-        };
-        match slot.try_encode(&msg) {
-            TryEncodeResult::Ok => Ok(()),
-            TryEncodeResult::Full => {
-                loop {
-                    match slot.try_encode(&msg) {
-                        TryEncodeResult::Ok => return Ok(()),
-                        TryEncodeResult::Dead | TryEncodeResult::Ineligible => break,
-                        TryEncodeResult::Full => {
-                            let notified = slot.space_available.notified();
-                            if slot.try_encode(&msg) == TryEncodeResult::Ok {
-                                return Ok(());
-                            }
-                            notified.await;
-                        }
-                    }
-                }
-                self.inner.send_submitter.send(msg).await
-            }
-            TryEncodeResult::Dead | TryEncodeResult::Ineligible => {
-                self.inner.send_submitter.send(msg).await
-            }
+        if let Some(ref slot) = slot {
+            return slot.try_encode(msg) == TryEncodeResult::Ok;
         }
+        false
     }
 
-    /// Multi-peer round-robin over per-peer wire slots. Picks the next
-    /// slot via `rr_slots.cursor` and encodes directly into it, skipping
-    /// peers that are full or dead. This keeps the single-peer direct
-    /// path's throughput for multi-peer PUSH and gives strict round-robin
-    /// distribution (libzmq `lb_t` semantics), instead of funneling every
-    /// message through the shared work-stealing queue where one driver
-    /// could monopolize the stream and starve the others.
+    /// Multi-peer round-robin with anti-starvation.
     ///
-    /// Falls back to the shared queue (which enforces `send_hwm`
-    /// backpressure and serves inproc / transform / pre-handshake peers)
-    /// only when no wire slot can take the message directly.
+    /// Normal path: try all slots, skip Full, encode into the first Ok.
+    /// Anti-starvation: when any slot has been skipped more than
+    /// `STARVATION_THRESHOLD` consecutive times, wait briefly for
+    /// that slot's driver to drain (bounded by timeout). This
+    /// breaks the TCP flow-control feedback loop that otherwise
+    /// causes permanent starvation under MT scheduling.
     async fn send_round_robin_wire(&self, msg: Message) -> Result<()> {
-        {
+        let starved = {
             let slots = self.inner.rr_slots.slots.lock().expect("rr_slots");
             let n = slots.len();
+            let mut starved_slot = None;
             for _ in 0..n {
                 let i = self.inner.rr_slots.cursor.fetch_add(1, Ordering::Relaxed) % n;
-                if slots[i].try_encode(&msg) == TryEncodeResult::Ok {
-                    return Ok(());
+                match slots[i].try_encode(&msg) {
+                    TryEncodeResult::Ok => {
+                        slots[i].consecutive_full.store(0, Ordering::Relaxed);
+                        return Ok(());
+                    }
+                    TryEncodeResult::Full => {
+                        let prev = slots[i].consecutive_full.fetch_add(1, Ordering::Relaxed);
+                        if prev >= Self::STARVATION_THRESHOLD {
+                            starved_slot = Some(slots[i].clone());
+                            break;
+                        }
+                    }
+                    TryEncodeResult::Dead | TryEncodeResult::Ineligible => {}
+                }
+            }
+            starved_slot
+        };
+
+        if let Some(slot) = starved {
+            let notified = slot.space_available.notified();
+            if slot.try_encode(&msg) == TryEncodeResult::Ok {
+                slot.consecutive_full.store(0, Ordering::Relaxed);
+                return Ok(());
+            }
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(1), notified).await;
+            if slot.try_encode(&msg) == TryEncodeResult::Ok {
+                slot.consecutive_full.store(0, Ordering::Relaxed);
+                return Ok(());
+            }
+        }
+
+        self.inner.send_submitter.send(msg).await
+    }
+
+    /// Single-peer async slow path: handles backpressure (Full → wait
+    /// for space) and falls back to the shared queue for ineligible peers.
+    async fn send_wire_slow(&self, msg: Message) -> Result<()> {
+        let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
+        if let Some(ref slot) = slot {
+            loop {
+                match slot.try_encode(&msg) {
+                    TryEncodeResult::Ok => return Ok(()),
+                    TryEncodeResult::Dead | TryEncodeResult::Ineligible => break,
+                    TryEncodeResult::Full => {
+                        let notified = slot.space_available.notified();
+                        if slot.try_encode(&msg) == TryEncodeResult::Ok {
+                            return Ok(());
+                        }
+                        notified.await;
+                    }
                 }
             }
         }
-        // No peer slot accepted directly (none registered, all at HWM, dead,
-        // or ineligible for direct encode): fall back to the shared queue.
         self.inner.send_submitter.send(msg).await
     }
 

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -23,6 +23,22 @@ use crate::transport::inproc::InprocSpsc;
 
 pub(crate) type WireSlotHolder = Arc<Mutex<Option<Arc<PeerWireSlot>>>>;
 
+/// Multi-peer round-robin wire slots, shared between the handle (reads)
+/// and the actor (writes on peer add/remove). When more than one wire
+/// peer is active on a round-robin socket and none are inproc, the actor
+/// fills `slots` with every peer's [`PeerWireSlot`]; the handle picks the
+/// next one per send via `cursor`, giving strict round-robin distribution
+/// over the per-peer direct-encode fast path. Empty for single-peer /
+/// inproc-mixed / identity-routed sockets (those fall back to the shared
+/// work-stealing queue).
+pub(crate) type RrSlots = Arc<RrSlotsInner>;
+
+#[derive(Debug, Default)]
+pub(crate) struct RrSlotsInner {
+    pub(crate) slots: Mutex<Vec<Arc<PeerWireSlot>>>,
+    pub(crate) cursor: std::sync::atomic::AtomicUsize,
+}
+
 pub use omq_proto::error::TrySendError;
 
 /// Per-peer SPSC consumers Vec. Actor appends; recv fair-queues.
@@ -212,6 +228,10 @@ struct Inner {
     /// driver flushes them to the wire. Set by the actor when exactly
     /// one wire peer is active; cleared on multi-peer or disconnect.
     wire_slot: WireSlotHolder,
+    /// Multi-peer round-robin wire slots (see [`RrSlots`]). Used by
+    /// `send_via_wire_slot` to dispatch directly to one peer at a time
+    /// instead of funneling every message through the shared queue.
+    rr_slots: RrSlots,
     last_bound_endpoint: RwLock<Option<Endpoint>>,
 }
 
@@ -271,6 +291,7 @@ impl Socket {
         let type_state = Arc::new(Mutex::new(TypeState::new()));
         let req_awaiting_reply = Arc::new(AtomicBool::new(false));
         let wire_slot: WireSlotHolder = Arc::new(Mutex::new(None));
+        let rr_slots: RrSlots = Arc::new(RrSlotsInner::default());
         let driver = SocketDriver::new(
             socket_type,
             options,
@@ -283,6 +304,7 @@ impl Socket {
             type_state.clone(),
             req_awaiting_reply.clone(),
             wire_slot.clone(),
+            rr_slots.clone(),
             recv_sink_config,
         );
         spawn_driver(driver);
@@ -307,6 +329,7 @@ impl Socket {
                 type_state,
                 req_awaiting_reply,
                 wire_slot,
+                rr_slots,
                 last_bound_endpoint: RwLock::new(None),
             }),
         }
@@ -753,7 +776,7 @@ impl Socket {
     async fn send_via_wire_slot(&self, msg: Message) -> Result<()> {
         let slot = self.inner.wire_slot.lock().expect("wire_slot").clone();
         let Some(ref slot) = slot else {
-            return self.inner.send_submitter.send(msg).await;
+            return self.send_round_robin_wire(msg).await;
         };
         match slot.try_encode(&msg) {
             TryEncodeResult::Ok => Ok(()),
@@ -777,6 +800,33 @@ impl Socket {
                 self.inner.send_submitter.send(msg).await
             }
         }
+    }
+
+    /// Multi-peer round-robin over per-peer wire slots. Picks the next
+    /// slot via `rr_slots.cursor` and encodes directly into it, skipping
+    /// peers that are full or dead. This keeps the single-peer direct
+    /// path's throughput for multi-peer PUSH and gives strict round-robin
+    /// distribution (libzmq `lb_t` semantics), instead of funneling every
+    /// message through the shared work-stealing queue where one driver
+    /// could monopolize the stream and starve the others.
+    ///
+    /// Falls back to the shared queue (which enforces `send_hwm`
+    /// backpressure and serves inproc / transform / pre-handshake peers)
+    /// only when no wire slot can take the message directly.
+    async fn send_round_robin_wire(&self, msg: Message) -> Result<()> {
+        {
+            let slots = self.inner.rr_slots.slots.lock().expect("rr_slots");
+            let n = slots.len();
+            for _ in 0..n {
+                let i = self.inner.rr_slots.cursor.fetch_add(1, Ordering::Relaxed) % n;
+                if slots[i].try_encode(&msg) == TryEncodeResult::Ok {
+                    return Ok(());
+                }
+            }
+        }
+        // No peer slot accepted directly (none registered, all at HWM, dead,
+        // or ineligible for direct encode): fall back to the shared queue.
+        self.inner.send_submitter.send(msg).await
     }
 
     async fn send_identity_routed(&self, msg: Message) -> Result<()> {

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -529,7 +529,11 @@ impl Socket {
                 if self.try_send_wire(&msg) {
                     return Ok(());
                 }
-                self.send_round_robin_wire(msg).await
+                if self.inner.wire_slot.lock().expect("wire_slot").is_some() {
+                    self.send_wire_slow(msg).await
+                } else {
+                    self.send_round_robin_wire(msg).await
+                }
             }
         }
     }

--- a/omq-tokio/tests/multi_peer.rs
+++ b/omq-tokio/tests/multi_peer.rs
@@ -1,7 +1,10 @@
 //! Multi-peer routing tests for omq-tokio:
 //! - PUSH→3 PULLs work-stealing distribution.
+//! - PUSH→3 PULLs round-robin fairness over TCP (wire path).
 //! - 3 PUSHes→PULL fair-queue.
 //! - PUB→3 SUBs fan-out with subscription filtering.
+
+mod test_support;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -59,6 +62,70 @@ async fn push_distributes_across_three_pulls() {
         assert!(
             n > N / 20,
             "pull got only {n} / {N}; distribution too skewed"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn push_distributes_fairly_over_tcp() {
+    // Regression guard for multi-peer PUSH round-robin on the WIRE path.
+    // The inproc test above never exercised it: previously every wire
+    // peer drained a single shared queue, which let one connection driver
+    // monopolize the stream and starve the others (a 0/100 split).
+    //
+    // The starvation only appears under SUSTAINED load with peers draining
+    // CONCURRENTLY (so PUSH drivers never block on a full TCP buffer).
+    // Drain first, then send, on a multi-threaded runtime.
+    const N: usize = 3;
+    const M: usize = 60_000;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    let port = test_support::bind_loopback(&push).await;
+
+    let pulls: Vec<Socket> = (0..N)
+        .map(|_| Socket::new(SocketType::Pull, Options::default()))
+        .collect();
+    for p in &pulls {
+        p.connect(test_support::tcp_loopback(port)).await.unwrap();
+        test_support::wait_for_handshake(p).await;
+    }
+
+    // Spawn concurrent drainers BEFORE sending so the push side stays hot.
+    let counts: Vec<Arc<AtomicUsize>> = (0..N).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+    let mut handles = Vec::new();
+    for (p, c) in pulls.into_iter().zip(counts.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            loop {
+                match tokio::time::timeout(Duration::from_millis(500), p.recv()).await {
+                    Ok(Ok(_)) => {
+                        c.fetch_add(1, Ordering::SeqCst);
+                    }
+                    _ => return,
+                }
+            }
+        }));
+    }
+
+    for i in 0..M {
+        push.send(Message::single(format!("m{i}"))).await.unwrap();
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let total: usize = counts.iter().map(|c| c.load(Ordering::SeqCst)).sum();
+    assert_eq!(total, M, "every message must reach exactly one pull");
+    // No peer may be starved. With direct round-robin the split is even
+    // (~M/N each); the shared-queue regression let one connection driver
+    // monopolize the stream, starving the others toward zero. A 1/4
+    // fair-share floor catches that without flaking on the skip-on-full
+    // jitter that CPU contention (parallel tests) adds to the even split.
+    let fair_share = M / N;
+    for (i, c) in counts.iter().enumerate() {
+        let n = c.load(Ordering::SeqCst);
+        assert!(
+            n >= fair_share / 4,
+            "pull {i} got {n} / {M} (fair share {fair_share}); a peer is being starved"
         );
     }
 }

--- a/omq-tokio/tests/multi_peer.rs
+++ b/omq-tokio/tests/multi_peer.rs
@@ -85,9 +85,12 @@ async fn push_distributes_fairly_over_tcp() {
     let pulls: Vec<Socket> = (0..N)
         .map(|_| Socket::new(SocketType::Pull, Options::default()))
         .collect();
+    let mut monitors: Vec<_> = pulls.iter().map(Socket::monitor).collect();
     for p in &pulls {
         p.connect(test_support::tcp_loopback(port)).await.unwrap();
-        test_support::wait_for_handshake(p).await;
+    }
+    for mon in &mut monitors {
+        test_support::wait_for_handshake_on(mon).await;
     }
 
     // Spawn concurrent drainers BEFORE sending so the push side stays hot.

--- a/omq-tokio/tests/test_support/mod.rs
+++ b/omq-tokio/tests/test_support/mod.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Endpoint, MonitorEvent, Socket};
+use omq_tokio::{Endpoint, MonitorEvent, MonitorStream, Socket};
 
 pub fn tcp_loopback(port: u16) -> Endpoint {
     Endpoint::Tcp {
@@ -28,6 +28,10 @@ pub async fn bind_loopback(sock: &Socket) -> u16 {
 
 pub async fn wait_for_handshake(sock: &Socket) {
     let mut mon = sock.monitor();
+    wait_for_handshake_on(&mut mon).await;
+}
+
+pub async fn wait_for_handshake_on(mon: &mut MonitorStream) {
     let fut = async {
         loop {
             match mon.recv().await {

--- a/omq-tokio/tests/wire_slot_stress.rs
+++ b/omq-tokio/tests/wire_slot_stress.rs
@@ -73,6 +73,24 @@ async fn try_send_single_peer_full_wire_slot_preserves_fifo() {
     assert_eq!(&second.part_bytes(0).unwrap()[..], b"second");
 }
 
+#[tokio::test]
+async fn req_try_send_uses_single_peer_wire_slot() {
+    let ep = tcp_ep(free_port());
+    let req = Socket::new(SocketType::Req, Options::default().wire_slot_cap(1));
+    let rep = Socket::new(SocketType::Rep, opts());
+    rep.bind(ep.clone()).await.unwrap();
+    req.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    req.try_send(Message::single("first")).unwrap();
+
+    let first = tokio::time::timeout(TIMEOUT, rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&first.part_bytes(0).unwrap()[..], b"first");
+}
+
 /// PUSH/PULL: peer churn. Encode slot must re-enable after 2->1.
 #[tokio::test]
 async fn push_pull_peer_churn_wire_slot() {

--- a/omq-tokio/tests/wire_slot_stress.rs
+++ b/omq-tokio/tests/wire_slot_stress.rs
@@ -1,5 +1,6 @@
 //! Stress tests for `PeerWireSlot` refactor edge cases.
 use bytes::Bytes;
+use omq_proto::error::TrySendError;
 use omq_proto::message::Message;
 use omq_proto::options::Options;
 use omq_proto::proto::SocketType;
@@ -42,6 +43,34 @@ async fn push_pull_burst_single_peer() {
         let got = u32::from_be_bytes(m.part_bytes(0).unwrap()[..4].try_into().unwrap());
         assert_eq!(got, i, "message ordering broken at {i}");
     }
+}
+
+#[tokio::test]
+async fn try_send_single_peer_full_wire_slot_preserves_fifo() {
+    let ep = tcp_ep(free_port());
+    let push = Socket::new(SocketType::Push, Options::default().wire_slot_cap(1));
+    let pull = Socket::new(SocketType::Pull, opts());
+    pull.bind(ep.clone()).await.unwrap();
+    push.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push.try_send(Message::single("first")).unwrap();
+    let returned = match push.try_send(Message::single("second")) {
+        Err(TrySendError::Full(msg)) => msg,
+        other => panic!("expected full wire slot, got {other:?}"),
+    };
+    push.send(returned).await.unwrap();
+
+    let first = tokio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let second = tokio::time::timeout(TIMEOUT, pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&first.part_bytes(0).unwrap()[..], b"first");
+    assert_eq!(&second.part_bytes(0).unwrap()[..], b"second");
 }
 
 /// PUSH/PULL: peer churn. Encode slot must re-enable after 2->1.


### PR DESCRIPTION
## Summary
- fix multi-peer direct-send fairness and preserve FIFO ordering under full wire slots
- bound wire-slot backlog and make fan-out report compression/backpressure errors correctly
- harden libzmq FFI edge cases, checked message length returns, and REQ try_send routing
- refresh pyomq Cargo.lock after the dependency resolution update

## Tests
- scripts/test-all.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --check
