### PR TITLE
Fix tokio send teardown leaks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,6 +68,10 @@ CURVE reconnect, BLAKE3ZMQ reconnect.
 
 Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s).
 Enable all feature-gated scenarios with the full feature set.
+For omq-tokio, `OMQ_SOAK_TOKIO_RUNTIME=multi_thread` (default) or
+`OMQ_SOAK_TOKIO_RUNTIME=current_thread` selects the runtime flavor used
+by each soak binary. Run both flavors when validating scheduler-sensitive
+changes.
 
 Each soak test is a separate binary, so `cargo test` runs them
 sequentially. Launch scenarios in batches of 4 (8 processes) to

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -28,6 +28,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,13 @@ dependencies = [
  "constant_time_eq 0.4.2",
  "cpufeatures 0.3.0",
  "zeroize",
+]
+
+[[package]]
+name = "blume"
+version = "0.4.2"
+dependencies = [
+ "event-listener",
 ]
 
 [[package]]
@@ -648,7 +664,9 @@ dependencies = [
 name = "omq-tokio"
 version = "0.14.6"
 dependencies = [
+ "arc-swap",
  "async-channel",
+ "blume",
  "bytes",
  "concurrent-queue",
  "futures",

--- a/blume/src/receiver.rs
+++ b/blume/src/receiver.rs
@@ -91,6 +91,45 @@ impl<T> Receiver<T> {
         }
     }
 
+    /// Drain all pending values into `out` through a mutable receiver
+    /// reference. This avoids holding `&Receiver` across `.await` in
+    /// `Send` futures while preserving the single-consumer contract.
+    pub async fn recv_batch_mut(&mut self, out: &mut Vec<T>) -> Result<usize, RecvError> {
+        let before = out.len();
+        {
+            let cache = self.cache.get_mut();
+            if Self::drain_cache_into(cache, out) > 0 {
+                return Ok(out.len() - before);
+            }
+            match self.shared.try_drain(cache) {
+                Ok(true) => {
+                    Self::drain_cache_into(cache, out);
+                    return Ok(out.len() - before);
+                }
+                Ok(false) => {}
+                Err(RecvError) => return Err(RecvError),
+            }
+        }
+
+        loop {
+            let listener = self.shared.recv_event.listen();
+
+            {
+                let cache = self.cache.get_mut();
+                match self.shared.try_drain(cache) {
+                    Ok(true) => {
+                        Self::drain_cache_into(cache, out);
+                        return Ok(out.len() - before);
+                    }
+                    Ok(false) => {}
+                    Err(RecvError) => return Err(RecvError),
+                }
+            }
+
+            listener.await;
+        }
+    }
+
     /// Whether both the local cache and the shared queue are empty.
     pub fn is_empty(&self) -> bool {
         let cache = self.cache.borrow();
@@ -100,12 +139,18 @@ impl<T> Receiver<T> {
     /// Signal senders that the receiver is closed. Subsequent and
     /// in-flight `send_async` calls will return `SendError`.
     pub fn close(&self) {
+        self.cache.borrow_mut().clear();
         let mut inner = self
             .shared
             .inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         inner.closed_recv = true;
+        let drained = inner.queue.len();
+        inner.queue.clear();
+        self.shared
+            .queued
+            .fetch_sub(drained, std::sync::atomic::Ordering::Release);
         drop(inner);
         self.shared.send_event.notify(usize::MAX);
     }

--- a/blume/src/sender.rs
+++ b/blume/src/sender.rs
@@ -39,6 +39,30 @@ impl<T> Sender<T> {
     pub fn is_empty(&self) -> bool {
         self.shared.is_send_empty()
     }
+
+    /// Current number of values queued on the send side.
+    pub fn len(&self) -> usize {
+        self.shared.send_len()
+    }
+
+    /// Close the channel from the send side and drop queued values.
+    ///
+    /// Used by socket teardown when the receiver task may still be alive but
+    /// its queued payloads are no longer deliverable.
+    pub fn close(&self) {
+        let mut inner = self
+            .shared
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        inner.closed_recv = true;
+        let drained = inner.queue.len();
+        inner.queue.clear();
+        self.shared.queued.fetch_sub(drained, Ordering::Release);
+        drop(inner);
+        self.shared.send_event.notify(usize::MAX);
+        self.shared.recv_event.notify(usize::MAX);
+    }
 }
 
 impl<T> Clone for Sender<T> {

--- a/blume/src/shared.rs
+++ b/blume/src/shared.rs
@@ -16,6 +16,7 @@ pub(crate) struct Inner<T> {
 pub(crate) struct Shared<T> {
     pub(crate) inner: Mutex<Inner<T>>,
     pub(crate) capacity: usize,
+    pub(crate) queued: AtomicUsize,
     pub(crate) sender_count: AtomicUsize,
     pub(crate) recv_event: Event,
     pub(crate) send_event: Event,
@@ -29,6 +30,7 @@ impl<T> Shared<T> {
                 closed_recv: false,
             }),
             capacity,
+            queued: AtomicUsize::new(0),
             sender_count: AtomicUsize::new(1),
             recv_event: Event::new(),
             send_event: Event::new(),
@@ -45,6 +47,7 @@ impl<T> Shared<T> {
         }
         let was_empty = inner.queue.is_empty();
         inner.queue.push_back(val);
+        self.queued.fetch_add(1, Ordering::Release);
         drop(inner);
         if was_empty {
             self.recv_event.notify(1);
@@ -99,7 +102,9 @@ impl<T> Shared<T> {
             };
         }
         let was_full = inner.queue.len() >= self.capacity;
+        let drained = inner.queue.len();
         std::mem::swap(cache, &mut inner.queue);
+        self.queued.fetch_sub(drained, Ordering::Release);
         drop(inner);
         if was_full {
             self.send_event.notify(usize::MAX);
@@ -123,8 +128,11 @@ impl<T> Shared<T> {
     }
 
     pub(crate) fn is_send_empty(&self) -> bool {
-        let inner = self.inner.lock().expect("blume: poisoned");
-        inner.queue.is_empty()
+        self.queued.load(Ordering::Acquire) == 0
+    }
+
+    pub(crate) fn send_len(&self) -> usize {
+        self.queued.load(Ordering::Acquire)
     }
 
     pub(crate) fn is_recv_disconnected(&self) -> bool {

--- a/doc/tokio.md
+++ b/doc/tokio.md
@@ -11,8 +11,11 @@ header scratch) are described from the compio side in
 `omq-tokio` is the multi-thread backend. Its structure differs from
 compio's because tokio's runtime is preemptive and work-stealing across
 cores. The same high-level shape applies: per-connection driver tasks
-push into one socket-wide inbound queue and pull from one socket-wide
-outbound queue.
+push into one socket-wide inbound queue. Send-side routing depends on
+socket type: single-peer round-robin uses a direct wire slot, multi-peer
+round-robin uses active per-peer pipes, fan-out/identity/exclusive use
+per-peer targets, and a shared fallback queue remains for no-peer and
+inproc paths.
 
 ## Top-level shape
 
@@ -56,8 +59,8 @@ common message flow around it.
 ## State the actor owns
 
 - `HashMap<PeerId, PeerInfo>` -- every connected peer (TCP/IPC/inproc/
-  UDP), including each peer's outbound flume `Sender`, monitor handle,
-  codec config.
+  UDP), including each peer's driver handle, monitor handle, codec
+  config.
 - `TypeState` -- REQ/REP alternation flag, ROUTER identity-prefix
   table, DISH group memberships, XPUB subscription trie, conflate flag.
 - `SendStrategy` + `RecvStrategy` -- round-robin, fan-out,
@@ -91,7 +94,7 @@ actor state actually mutates per-message.
 For PUSH/DEALER/PUB/PAIR/CLIENT/SCATTER/CHANNEL send, `TypeState::pre_
 send` is identity or a stateless frame-count assert. Routing those
 messages through the actor would mean `cmd_tx.send(...).await` +
-per-message `tokio::spawn` + oneshot ack + flume push (~3 context
+per-message `tokio::spawn` + oneshot ack + queue push (~3 context
 switches) just to deliver a message the actor will only forward
 unchanged.
 
@@ -107,8 +110,11 @@ before the driver is spawned. `Socket::send` matches on socket type:
 - everything else -- inline-validate frame count and push straight into
   the submitter.
 
-`SendSubmitter` is lock-free MPMC over flume, so concurrent cloned
-`Socket` handles are safe.
+`SendSubmitter` is cloneable and safe for concurrent cloned `Socket`
+handles. The exact data structure depends on the routing strategy:
+round-robin uses a shared active-pipe table plus per-peer MPSC pipes,
+fan-out and identity route directly to peer targets, and the fallback
+queue uses a bounded concurrent queue.
 
 ## Recv bypass (`ConnectionDriver`)
 
@@ -134,25 +140,49 @@ via `TypeState::post_recv_req_direct`. This variant skips the
 `req_awaiting_reply` flag check to avoid a race with
 `on_peer_disconnected` in the actor.
 
-## Direct shared-queue arm; pump-task elimination
+## Round-robin active pipes
 
-An earlier shape kept the shared `DropQueue` receiver in the
-`RoundRobin` routing strategy and spawned a pump task per peer: pump
-raced `shared_rx`, forwarded one message at a time to the driver's
-inbox. Three task hops end-to-end.
+Round-robin sockets (`PUSH`, `DEALER`, `REQ`, `CLIENT`, `SCATTER`) have
+two hot paths:
 
-Now each `ConnectionDriver` holds
-`shared_msg_rx: Option<flume::Receiver<Message>>` for byte-stream
-(TCP/IPC) connections and polls it in a dedicated `select!` arm. The
-arm greedily drains up to 256 messages / 512 KiB per wakeup, encodes
-them all, then flushes with a tight `write_all` + `write_vectored`
-loop. Result: **one task hop** for byte-stream sockets.
+- **Single byte-stream peer**: `Socket::send` encodes directly into
+  that peer's `PeerWireSlot`. The driver owns the writer and flushes the
+  already-encoded chunks from its `data_ready` select arm.
+- **Multiple byte-stream peers**: each peer registers an active
+  per-peer `blume` pipe. The socket-side submitter scans active pipes
+  from a moving cursor and `try_send`s into the first pipe with capacity.
+  Full pipes are skipped for that attempt; if every active pipe is full,
+  async `send` waits on one rotating pipe and `try_send` reports HWM
+  backpressure.
 
-Pump tasks are still spawned for inproc peers on round-robin sockets,
-which use a per-peer inbox channel rather than a shared receiver.
-Fan-out and identity sockets no longer use pump tasks at all: they
-send via `PeerSend` which routes directly to the per-peer
-`PeerWireSlot` (wire) or driver inbox (inproc).
+The active pipe is `blume::Sender<Message>` on the socket side and a
+single `blume::Receiver<Message>` owned by the `ConnectionDriver`.
+`blume` is MPSC, not MPMC: senders are cloneable, but there is exactly
+one receiver. That matches the tokio socket API, where cloned socket
+handles may send concurrently while each peer has one driver task.
+
+The driver polls its pipe in a dedicated `select!` arm after the ZMTP
+handshake. `recv_batch_mut()` drains all currently queued messages in
+one swap, then the driver batch-encodes and flushes locally. Encoding
+happens on the connection driver's runtime worker instead of on the
+application task, so multi-peer PUSH can use the driver workers instead
+of serializing all per-peer encode work at the caller.
+
+The old shared `DropQueue` is still present, but it is now the fallback
+path:
+
+- no connected peer yet, so sends need to survive connect-before-bind
+  and drain after handshake;
+- inproc peers, which have no byte-stream driver pipe;
+- mixed byte-stream + inproc round-robin sets, where using only active
+  byte-stream pipes would starve inproc.
+
+Inproc fallback still uses a pump task from the shared queue to the
+peer inbox. Byte-stream drivers still poll `shared_msg_rx` so messages
+queued before a peer becomes active drain in order before new pipe
+traffic. Fan-out and identity sockets do not use pump tasks: they send
+via `PeerSend`, which routes directly to the per-peer `PeerWireSlot`
+(wire) or driver inbox (inproc).
 
 ## Arena encoding (`ARENA_THRESHOLD` = 96 KiB)
 
@@ -193,7 +223,7 @@ offloading, but the routing strategies do not wire this up yet.
 
 The connection driver reads into a `BytesMut` (128 KiB initial
 capacity) via `read_buf`. After each read, `buf.split().freeze()`
-hands the codec a zero-copy `Bytes` — no allocation or memcpy per
+hands the codec a zero-copy `Bytes`; no allocation or memcpy per
 syscall. `BytesMut` reuses its backing allocation across reads.
 
 ## Routing strategies
@@ -203,12 +233,12 @@ the actor:
 
 | Strategy | Used by | Shape |
 |---|---|---|
-| `round_robin` | PUSH / DEALER / REQ / CLIENT / SCATTER | One shared send queue + work-stealing send pumps; per-socket HWM |
+| `round_robin` | PUSH / DEALER / REQ / CLIENT / SCATTER | Single-peer `PeerWireSlot`; multi-peer active per-peer MPSC pipes; shared fallback queue for no-peer/inproc |
 | `exclusive` | PAIR / CHANNEL | Single-peer slot; awaits peer-ready on send-before-connect |
 | `fan_out` | PUB / XPUB / RADIO | Per-peer `PeerWireSlot`; subscription/group filter; conflate applies here |
 | `identity` | ROUTER / REP / SERVER / PEER | First frame is destination identity; lookup in identity table; per-peer `PeerWireSlot` |
 | `fair_queue` | PULL / SUB / XSUB / GATHER / DISH | Recv-only; round-robin across peer drivers |
-| `drop_queue` | (HWM behaviour) | Bounded queue with drop-on-full when `send_hwm` reached |
+| `drop_queue` | (HWM behavior) | Bounded queue with drop-on-full when `send_hwm` reached |
 | `pump` | inproc peers | Per-peer pump task between shared queue and inbox |
 | `peer_send` | (shared type) | `PeerSend` enum (`Wire`/`Inbox`): unified per-peer send dispatch used by fan-out, identity, and exclusive strategies |
 
@@ -245,9 +275,11 @@ The driver drain arm loops until the slot is empty (or
 `max_batch_bytes` reached), so messages that arrive during
 `write_vectored` are flushed without re-entering `select!`.
 
-`PeerWireSlot` is used by all send strategies for wire peers:
+`PeerWireSlot` is used by most send strategies for wire peers:
 
-- **RoundRobin**: single-peer fast path via `try_encode`.
+- **RoundRobin**: single-peer fast path via `try_encode`. Multi-peer
+  round-robin uses active raw-message pipes instead, so the peer driver
+  does encoding locally.
 - **Exclusive**: PAIR/CHANNEL direct to slot.
 - **FanOut**: message encoded once via `pre_encode()`, shared chunks
   pushed into each matching peer's slot via `try_push_encoded`.
@@ -265,9 +297,10 @@ driver drains enough bytes.
 
 Both follow the same shape as compio (see [`compio.md`](compio.md) for
 detail): a dial supervisor task owns a handle that is `None` while
-reconnect is in flight; sends fall back to the shared queue (bounded by
-`send_hwm`) and drain through the new driver after handshake.
-Subscriptions and group joins are replayed.
+reconnect is in flight. Round-robin sends fall back to the shared queue
+(bounded by `send_hwm`) while no active peer pipe exists and drain
+through the new driver after handshake. Subscriptions and group joins
+are replayed.
 
 `Socket::monitor()` returns the same `Stream<Item = MonitorEvent>`
 shape on both backends; events carry an owned `PeerInfo` snapshot.
@@ -275,9 +308,20 @@ shape on both backends; events carry an owned `PeerInfo` snapshot.
 ## Concurrency model
 
 Within a tokio runtime, multiple `Socket` clones can call `send` /
-`recv` concurrently from different worker threads. The hot-path
-`SendSubmitter` is a lock-free MPMC channel; the recv-side
-`async_channel::Sender` is also multi-producer. The actor remains the
-serialization point for any state that must be observed atomically
-(REQ alternation, ROUTER identity table, XPUB subscription trie),
-which is why those paths still go through `cmd_tx`.
+`recv` concurrently from different worker threads. The round-robin
+active-pipe table is protected by a short `std::sync::Mutex` around the
+peer vector and cursor; message payloads are moved into per-peer MPSC
+pipes outside actor control. The recv-side `async_channel::Sender` is
+multi-producer. The actor remains the serialization point for any state
+that must be observed atomically (REQ alternation, ROUTER identity
+table, XPUB subscription trie), which is why those paths still go
+through `cmd_tx`.
+
+## Benchmark note
+
+The fan-out comparison benchmark keeps `omq-tokio-mt` fan-out puller
+processes on current-thread runtimes while the pusher uses the
+multi-thread runtime. The benchmark is measuring the PUSH socket's
+multi-peer send path; giving every PULL process a full multi-thread
+worker pool oversubscribes the machine and can make peer fairness look
+broken even when the pusher distributes evenly.

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -34,6 +34,8 @@ soak = []
 [dependencies]
 omq-proto = { path = "../omq-proto", version = "0.18.1", default-features = false }
 yring = { path = "../yring", version = "0.3.2" }
+blume = { path = "../blume", version = "0.4.2" }
+arc-swap = "1.7.1"
 async-channel = "2.5.0"
 bytes = "1.12.0"
 concurrent-queue = "2.5.0"

--- a/omq-tokio/src/engine/compression_pool.rs
+++ b/omq-tokio/src/engine/compression_pool.rs
@@ -61,4 +61,8 @@ impl CompressionPool {
         self.encoders.lock().unwrap().push(enc);
         self.in_flight.fetch_sub(1, Ordering::Relaxed);
     }
+
+    pub(crate) fn clear(&self) {
+        self.encoders.lock().unwrap().clear();
+    }
 }

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -298,6 +298,7 @@ pub struct DriverHandle {
     pub inbox: mpsc::Sender<DriverCommand>,
     pub cancel: CancellationToken,
     pub(crate) wire_slot: Option<Arc<PeerWireSlot>>,
+    pub(crate) send_pipe: Option<blume::Sender<Message>>,
 }
 
 /// What a [`ConnectionDriver`] writes to its shared peer-event
@@ -352,6 +353,7 @@ where
     /// wire. Replaces the `DirectIo` pattern where the handle locked the
     /// writer directly.
     wire_slot: Option<Arc<PeerWireSlot>>,
+    send_pipe_rx: Option<blume::Receiver<Message>>,
     arena_threshold: usize,
 }
 
@@ -402,6 +404,7 @@ where
             compression_pool: None,
             offload_threshold: 0,
             wire_slot: None,
+            send_pipe_rx: None,
             arena_threshold: omq_proto::encoded_queue::ARENA_THRESHOLD,
         }
     }
@@ -468,6 +471,14 @@ where
         self
     }
 
+    /// Install a per-peer send pipe. The public socket handle pushes raw
+    /// messages into the sender; this driver drains and encodes locally.
+    #[must_use]
+    pub(crate) fn with_send_pipe(mut self, rx: blume::Receiver<Message>) -> Self {
+        self.send_pipe_rx = Some(rx);
+        self
+    }
+
     #[must_use]
     pub(crate) fn with_arena_threshold(mut self, threshold: usize) -> Self {
         self.arena_threshold = threshold;
@@ -481,14 +492,14 @@ where
     ///
     /// In every exit path (success or error) the driver sends one final
     /// `PeerOut::Closed` on the shared peer-event channel so the
-    /// `SocketDriver` can clean up its peer entry. The previous shim task
-    /// that did this wrapping is gone - we save one task spawn and one
-    /// per-message channel hop on every connection.
+    /// `SocketDriver` can clean up its peer entry. The notification is
+    /// best-effort because actor teardown joins peer tasks while it no
+    /// longer drains this channel.
     pub async fn run(self) -> Result<()> {
         let peer_out = self.peer_out.clone();
         let peer_id = self.peer_id;
         let result = self.run_inner_body().await;
-        let _ = peer_out.send((peer_id, PeerOut::Closed)).await;
+        let _ = peer_out.try_send((peer_id, PeerOut::Closed));
         result
     }
 
@@ -509,6 +520,7 @@ where
             compression_pool,
             offload_threshold,
             wire_slot,
+            mut send_pipe_rx,
             arena_threshold,
         } = self;
         let passthrough = encoder.as_ref().and_then(MessageEncoder::passthrough_info);
@@ -517,6 +529,7 @@ where
         let mut read_buf = BytesMut::with_capacity(READ_BUF_SIZE);
         let mut eq = EncodedQueue::with_arena_threshold(arena_threshold);
         let mut drain_buf: Vec<Bytes> = Vec::with_capacity(64);
+        let mut pipe_batch: Vec<Message> = Vec::with_capacity(SHARED_MAX_BATCH_MSGS);
         let mut last_input = Instant::now();
         let mut handshake_deadline: Option<Instant> =
             config.handshake_timeout.map(|d| last_input + d);
@@ -575,12 +588,6 @@ where
                     if let Some(ref slot) = wire_slot {
                         slot.mark_dead();
                     }
-                    drain_on_cancel(
-                        &mut inbox, shared_msg_rx.as_ref(),
-                        wire_slot.as_ref(),
-                        &mut encoder, &mut codec, &mut eq,
-                        &mut drain_buf, &mut writer, passthrough.as_ref(),
-                    ).await;
                     return Ok(());
                 }
 
@@ -758,6 +765,24 @@ where
                     ).await?;
                 },
 
+                // Per-peer send pipe: active round-robin pushes raw
+                // messages to this driver, which encodes and writes locally.
+                n = async {
+                    send_pipe_rx.as_mut().unwrap().recv_batch_mut(&mut pipe_batch).await
+                }, if send_pipe_rx.is_some() && codec.is_ready() => {
+                    if n.is_err() {
+                        drain_writes(&mut writer, &mut codec).await.ok();
+                        return Ok(());
+                    }
+                    drain_send_pipe_batch(
+                        &mut pipe_batch,
+                        &mut encoder, &mut codec, &mut eq,
+                        passthrough.as_ref(), compression_pool.as_ref(),
+                        offload_threshold, &mut offload_pipeline,
+                        &mut drain_buf, &mut writer,
+                    ).await?;
+                },
+
                 // Heartbeat tick: enabled only post-handshake when
                 // `heartbeat_interval` is set. Uses a persistent pinned
                 // sleep so the safety-net timeout doesn't reset it.
@@ -795,50 +820,6 @@ async fn sleep_until_opt(deadline: Option<Instant>) {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
-async fn drain_on_cancel<W: AsyncWrite + Unpin>(
-    inbox: &mut mpsc::Receiver<DriverCommand>,
-    shared_msg_rx: Option<&QueueReceiver>,
-    wire_slot: Option<&Arc<PeerWireSlot>>,
-    encoder: &mut Option<MessageEncoder>,
-    codec: &mut Connection,
-    eq: &mut EncodedQueue,
-    drain_buf: &mut Vec<Bytes>,
-    writer: &mut W,
-    passthrough: Option<&(Bytes, usize)>,
-) {
-    if let Some(slot) = wire_slot {
-        drain_buf.clear();
-        slot.drain_into_vec(drain_buf, 1024);
-        eq.push_shared_chunks(drain_buf);
-        drain_buf.clear();
-    }
-    while let Ok(cmd) = inbox.try_recv() {
-        match cmd {
-            DriverCommand::SendMessage(msg) => {
-                encode_msg(&msg, encoder, codec, eq, passthrough).ok();
-            }
-            DriverCommand::SendEncoded(chunks) => {
-                eq.push_shared_chunks(&chunks);
-            }
-            DriverCommand::SendCommand(c) => {
-                let _ = codec.send_command(&c);
-            }
-            DriverCommand::Close => break,
-        }
-    }
-    if let Some(rx) = shared_msg_rx {
-        let mut drained = 0usize;
-        while let Some(msg) = rx.try_pop() {
-            encode_msg(&msg, encoder, codec, eq, passthrough).ok();
-            drained += 1;
-        }
-        rx.release_permits(drained);
-    }
-    let _ = flush_encoded_queue(writer, eq, drain_buf).await;
-    drain_writes(writer, codec).await.ok();
-}
-
 /// Flush `EncodedQueue` to the writer, then drain any pending codec
 /// transmits (command frames queued during encoding).
 async fn flush_all<W: AsyncWrite + Unpin>(
@@ -874,6 +855,39 @@ async fn drain_wire_slot<W: AsyncWrite + Unpin>(
             slot.data_ready.notify_one();
             break;
         }
+    }
+    Ok(())
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn drain_send_pipe_batch<W: AsyncWrite + Unpin>(
+    batch: &mut Vec<Message>,
+    encoder: &mut Option<MessageEncoder>,
+    codec: &mut Connection,
+    eq: &mut EncodedQueue,
+    passthrough: Option<&(Bytes, usize)>,
+    compression_pool: Option<&Arc<CompressionPool>>,
+    offload_threshold: usize,
+    offload_pipeline: &mut OffloadPipeline,
+    drain_buf: &mut Vec<Bytes>,
+    writer: &mut W,
+) -> Result<()> {
+    batch.reverse();
+    while let Some(first) = batch.pop() {
+        batch_encode(
+            &first,
+            || batch.pop(),
+            SHARED_MAX_BATCH_MSGS,
+            encoder,
+            codec,
+            eq,
+            passthrough,
+            compression_pool,
+            offload_threshold,
+            offload_pipeline,
+        )
+        .await?;
+        flush_all(writer, eq, drain_buf, codec).await?;
     }
     Ok(())
 }
@@ -1248,12 +1262,14 @@ mod tests {
                 inbox: c_inbox_tx,
                 cancel: c_cancel,
                 wire_slot: None,
+                send_pipe: None,
             },
             EventAdapter { rx: c_evt_rx },
             DriverHandle {
                 inbox: s_inbox_tx,
                 cancel: s_cancel,
                 wire_slot: None,
+                send_pipe: None,
             },
             EventAdapter { rx: s_evt_rx },
         )

--- a/omq-tokio/src/engine/wire_slot.rs
+++ b/omq-tokio/src/engine/wire_slot.rs
@@ -5,7 +5,7 @@
 // in-flight message may still be in the inbox while the next message
 // takes the wire slot fast path and reaches the wire first.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -46,7 +46,6 @@ pub(crate) struct PeerWireSlot {
     ws_masked: bool,
     pub(crate) dead: AtomicBool,
     pub(crate) peer_id: u64,
-    pub(crate) consecutive_full: AtomicU32,
     queued_msgs: AtomicUsize,
 }
 
@@ -88,7 +87,6 @@ impl PeerWireSlot {
             ws_masked,
             dead: AtomicBool::new(false),
             peer_id,
-            consecutive_full: AtomicU32::new(0),
             queued_msgs: AtomicUsize::new(0),
         })
     }
@@ -209,6 +207,13 @@ impl PeerWireSlot {
 
     pub(crate) fn mark_dead(&self) {
         self.dead.store(true, Ordering::Release);
+        {
+            let mut eq = self.eq.lock().expect("wire_slot eq poisoned");
+            *eq = EncodedQueue::one_shot();
+        }
+        self.pending.store(false, Ordering::Relaxed);
+        self.queued_msgs.store(0, Ordering::Relaxed);
+        self.data_ready.notify_waiters();
         self.space_available.notify_waiters();
     }
 

--- a/omq-tokio/src/routing/drop_queue.rs
+++ b/omq-tokio/src/routing/drop_queue.rs
@@ -158,6 +158,20 @@ impl DropQueue {
         self.inner.queue.close();
         self.inner.recv_notify.notify_waiters();
     }
+
+    pub(crate) fn shutdown(&self) {
+        self.inner.queue.close();
+        let mut drained = 0usize;
+        while self.inner.queue.pop().is_ok() {
+            drained += 1;
+        }
+        if drained > 0
+            && let Some(ref slots) = self.inner.slots
+        {
+            slots.add_permits(drained);
+        }
+        self.inner.recv_notify.notify_waiters();
+    }
 }
 
 impl QueueReceiver {

--- a/omq-tokio/src/routing/exclusive.rs
+++ b/omq-tokio/src/routing/exclusive.rs
@@ -13,6 +13,11 @@ pub(crate) struct Submitter {
 }
 
 impl Submitter {
+    pub(crate) fn shutdown(&self) {
+        *self.peer.lock().expect("exclusive peer") = None;
+        self.peer_ready.notify_waiters();
+    }
+
     pub(crate) async fn send(&self, msg: Message) -> Result<()> {
         loop {
             let handle = self.peer.lock().expect("exclusive peer").clone();
@@ -85,8 +90,10 @@ impl ExclusiveSend {
         *self.peer.lock().expect("exclusive peer") = None;
     }
 
-    #[expect(clippy::unused_self)]
-    pub(crate) fn shutdown(&self) {}
+    pub(crate) fn shutdown(&self) {
+        *self.peer.lock().expect("exclusive peer") = None;
+        self.peer_ready.notify_waiters();
+    }
 
     #[expect(clippy::unused_self)]
     pub(crate) fn is_drained(&self) -> bool {

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -94,6 +94,15 @@ impl Clone for Submitter {
 }
 
 impl Submitter {
+    pub(crate) fn shutdown(&self) {
+        let mut cached = self.cached.lock().unwrap();
+        cached.sole_wire = None;
+        cached.all_targets = None;
+        cached.encoder = None;
+        cached.all_wire = false;
+        cached.generation = u64::MAX;
+    }
+
     fn validate_group(msg: Message) -> core::result::Result<(Message, Option<String>), Error> {
         if msg.len() != 2 {
             return Err(Error::Protocol(
@@ -459,10 +468,15 @@ impl FanOutSend {
         }
     }
 
-    // Kept for the SendStrategy enum dispatch; fan-out has no pump task
-    // to cancel since dispatch is inline on the sending task.
-    #[expect(clippy::unused_self)]
-    pub(crate) fn shutdown(&self) {}
+    pub(crate) fn shutdown(&self) {
+        let mut g = self.inner.lock().expect("fanout inner poisoned");
+        g.peers.clear();
+        g.all_subscribe_all = false;
+        g.all_targets.clear();
+        g.fan_out_encoder = None;
+        drop(g);
+        self.bump_generation();
+    }
 
     pub(crate) fn is_drained(&self) -> bool {
         let g = self.inner.lock().expect("fanout inner poisoned");

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -32,6 +32,12 @@ pub(crate) struct Submitter {
 }
 
 impl Submitter {
+    pub(crate) fn shutdown(&self) {
+        let mut g = self.inner.lock().expect("identity inner poisoned");
+        g.peers.clear();
+        g.identity_to_peer.clear();
+    }
+
     fn resolve_target(&self, msg: &mut Message) -> Result<Option<PeerSend>> {
         if msg.is_empty() {
             return Err(Error::Unroutable);
@@ -138,8 +144,11 @@ impl IdentitySend {
         g.identity_to_peer.get(identity).copied()
     }
 
-    #[expect(clippy::unused_self)]
-    pub(crate) fn shutdown(&self) {}
+    pub(crate) fn shutdown(&self) {
+        let mut g = self.inner.lock().expect("identity inner poisoned");
+        g.peers.clear();
+        g.identity_to_peer.clear();
+    }
 
     pub(crate) fn is_drained(&self) -> bool {
         let g = self.inner.lock().expect("identity inner poisoned");

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -66,6 +66,16 @@ pub(crate) enum SendSubmitter {
 }
 
 impl SendSubmitter {
+    pub(crate) fn shutdown(&self) {
+        match self {
+            Self::None => {}
+            Self::RoundRobin(s) => s.shutdown(),
+            Self::Exclusive(s) => s.shutdown(),
+            Self::FanOut(s) => s.shutdown(),
+            Self::Identity(s) => s.shutdown(),
+        }
+    }
+
     pub(crate) async fn send(&self, msg: Message) -> Result<()> {
         match self {
             Self::None => Err(Error::Protocol("socket type does not support send".into())),

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -1,13 +1,15 @@
 //! Round-robin send.
 //!
-//! A single shared send queue feeds N per-peer pumps. Each pump is a
-//! tokio task that races its peers for the next message. Fast peers
-//! naturally pull more; slow peers pull what they can. Load-balancing
-//! semantics for PUSH / DEALER / REQ / PAIR / CLIENT / CHANNEL / SCATTER.
+//! Byte-stream peers register active per-peer pipes. The socket submitter
+//! scans those pipes from a moving cursor, sends to the first pipe with
+//! capacity, and skips full peers. If every pipe is full, async `send`
+//! waits for one selected pipe while `try_send` reports backpressure.
 //!
-//! Per-batch fairness: each pump wakes, pulls one message, then opportun-
-//! istically drains up to 256 more or 512 KiB (whichever first), then
-//! `tokio::task::yield_now()`s so the tokio worker can schedule peers.
+//! Inproc and mixed peer sets use the shared fallback queue so peers without
+//! byte-stream driver pipes stay visible to the existing pump path.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 use tokio_util::sync::CancellationToken;
 
@@ -18,37 +20,164 @@ use omq_proto::options::Options;
 
 use super::drop_queue::{DropQueue, QueueReceiver};
 
+#[derive(Clone, Debug)]
+struct ActivePipe {
+    peer_id: u64,
+    tx: blume::Sender<Message>,
+}
+
+#[derive(Debug, Default)]
+struct ActivePipes {
+    pipes: Vec<ActivePipe>,
+    pipe_peers: HashSet<u64>,
+    fallback_peers: HashSet<u64>,
+    cursor: usize,
+}
+
+impl ActivePipes {
+    fn remove_peer(&mut self, peer_id: u64) {
+        self.pipe_peers.remove(&peer_id);
+        self.fallback_peers.remove(&peer_id);
+        if let Some(pos) = self.pipes.iter().position(|pipe| pipe.peer_id == peer_id) {
+            self.pipes.swap_remove(pos);
+            if self.pipes.is_empty() {
+                self.cursor = 0;
+            } else {
+                self.cursor %= self.pipes.len();
+            }
+        }
+    }
+
+    fn should_use_fallback(&self) -> bool {
+        self.pipes.is_empty() || !self.fallback_peers.is_empty()
+    }
+}
+
 /// Cloneable handle for submitting messages into a [`RoundRobinSend`].
 #[derive(Debug, Clone)]
 pub(crate) struct Submitter {
     queue: DropQueue,
+    active: Arc<Mutex<ActivePipes>>,
 }
 
 impl Submitter {
-    pub(crate) async fn send(&self, msg: Message) -> Result<()> {
-        self.queue.send(msg).await
+    pub(crate) fn shutdown(&self) {
+        self.queue.shutdown();
+        let mut active = self.active.lock().expect("round_robin active");
+        active.pipes.clear();
+        active.pipe_peers.clear();
+        active.fallback_peers.clear();
+        active.cursor = 0;
+    }
+
+    pub(crate) async fn send(&self, mut msg: Message) -> Result<()> {
+        loop {
+            match self.try_send(msg) {
+                Ok(()) => return Ok(()),
+                Err(omq_proto::error::TrySendError::Full(returned)) => {
+                    msg = returned;
+                }
+                Err(omq_proto::error::TrySendError::Error(e)) => return Err(e),
+                Err(omq_proto::error::TrySendError::Closed) => {
+                    return Err(omq_proto::error::Error::Closed);
+                }
+            }
+
+            let tx = {
+                let mut active = self.active.lock().expect("round_robin active");
+                if active.should_use_fallback() {
+                    None
+                } else {
+                    active.next_pipe_any()
+                }
+            };
+
+            let Some(tx) = tx else {
+                return self.queue.send(msg).await;
+            };
+
+            match tx.send_async(msg).await {
+                Ok(()) => return Ok(()),
+                Err(blume::SendError(returned)) => {
+                    msg = returned;
+                }
+            }
+        }
     }
 
     pub(crate) fn try_send(
         &self,
-        msg: Message,
+        mut msg: Message,
     ) -> core::result::Result<(), omq_proto::error::TrySendError> {
-        self.queue
-            .try_send(msg)
-            .map_err(omq_proto::error::TrySendError::Full)
+        let mut active = self.active.lock().expect("round_robin active");
+        if active.should_use_fallback() {
+            return self
+                .queue
+                .try_send(msg)
+                .map_err(omq_proto::error::TrySendError::Full);
+        }
+
+        let mut scanned = 0usize;
+        while scanned < active.pipes.len() {
+            let i = active.cursor % active.pipes.len();
+            active.cursor = (i + 1) % active.pipes.len();
+            scanned += 1;
+            match active.pipes[i].tx.try_send(msg) {
+                Ok(()) => return Ok(()),
+                Err(blume::TrySendError::Full(returned)) => {
+                    msg = returned;
+                }
+                Err(blume::TrySendError::Disconnected(returned)) => {
+                    let peer_id = active.pipes[i].peer_id;
+                    active.pipe_peers.remove(&peer_id);
+                    active.pipes.swap_remove(i);
+                    if active.pipes.is_empty() {
+                        active.cursor = 0;
+                    } else {
+                        active.cursor %= active.pipes.len();
+                    }
+                    msg = returned;
+                }
+            }
+        }
+
+        Err(omq_proto::error::TrySendError::Full(msg))
+    }
+}
+
+impl ActivePipes {
+    fn next_pipe_any(&mut self) -> Option<blume::Sender<Message>> {
+        if self.pipes.is_empty() {
+            return None;
+        }
+
+        let mut scanned = 0usize;
+        while scanned < self.pipes.len() {
+            let i = self.cursor % self.pipes.len();
+            self.cursor = (i + 1) % self.pipes.len();
+            scanned += 1;
+            if !self.pipes[i].tx.is_disconnected() {
+                return Some(self.pipes[i].tx.clone());
+            }
+            let peer_id = self.pipes[i].peer_id;
+            self.pipe_peers.remove(&peer_id);
+            self.pipes.swap_remove(i);
+            if self.pipes.is_empty() {
+                self.cursor = 0;
+                return None;
+            }
+            self.cursor %= self.pipes.len();
+        }
+        None
     }
 }
 
 /// Round-robin send strategy.
-///
-/// A single shared queue feeds all connection drivers directly.
-/// Each driver polls `shared_rx` inside its own select! loop after the
-/// ZMTP handshake completes, eliminating the pump-task intermediary and
-/// the per-message inbox hop that it implied.
 #[derive(Debug)]
 pub(crate) struct RoundRobinSend {
     queue: DropQueue,
     shared_rx: QueueReceiver,
+    active: Arc<Mutex<ActivePipes>>,
     root_cancel: CancellationToken,
     peer_count: usize,
 }
@@ -60,6 +189,7 @@ impl RoundRobinSend {
         Self {
             queue,
             shared_rx,
+            active: Arc::new(Mutex::new(ActivePipes::default())),
             root_cancel: CancellationToken::new(),
             peer_count: 0,
         }
@@ -71,28 +201,38 @@ impl RoundRobinSend {
         self.shared_rx.clone()
     }
 
-    pub(crate) fn connection_added(
-        &mut self,
-        _peer_id: u64,
-        handle: DriverHandle,
-        is_inproc: bool,
-    ) {
+    pub(crate) fn connection_added(&mut self, peer_id: u64, handle: DriverHandle, is_inproc: bool) {
         self.peer_count += 1;
         self.shared_rx.set_peer_count(self.peer_count);
+
+        let mut active = self.active.lock().expect("round_robin active");
+        if !is_inproc && let Some(tx) = handle.send_pipe.clone() {
+            active.remove_peer(peer_id);
+            active.pipe_peers.insert(peer_id);
+            active.pipes.push(ActivePipe { peer_id, tx });
+            return;
+        }
+        active.fallback_peers.insert(peer_id);
+        drop(active);
+
+        // inproc_peer_driver reads from inbox (mpsc), not from shared_rx.
+        // Spawn a forwarding pump. The pump self-cancels when the peer's
+        // inbox closes (driver exits) or root_cancel fires (shutdown).
         if is_inproc {
-            // inproc_peer_driver reads from inbox (mpsc), not from shared_rx.
-            // Spawn a forwarding pump. The pump self-cancels when the peer's
-            // inbox closes (driver exits) or root_cancel fires (shutdown).
             let rx = self.shared_rx.clone();
             let cancel = self.root_cancel.child_token();
             tokio::spawn(super::pump::drain_one(rx, handle, cancel));
         }
-        // Byte-stream: driver reads from shared_rx directly; no pump needed.
+        // Byte-stream without a pipe also falls back to shared_rx directly.
     }
 
-    pub(crate) fn connection_removed(&mut self, _peer_id: u64) {
+    pub(crate) fn connection_removed(&mut self, peer_id: u64) {
         self.peer_count = self.peer_count.saturating_sub(1);
         self.shared_rx.set_peer_count(self.peer_count);
+        self.active
+            .lock()
+            .expect("round_robin active")
+            .remove_peer(peer_id);
         // Byte-stream drivers self-cancel via their CancellationToken.
         // Inproc pumps self-cancel when peer inbox closes (driver exits).
     }
@@ -103,14 +243,28 @@ impl RoundRobinSend {
     pub(crate) fn submitter(&self) -> Submitter {
         Submitter {
             queue: self.queue.clone(),
+            active: self.active.clone(),
         }
     }
 
     pub(crate) fn shutdown(&self) {
         self.root_cancel.cancel();
+        self.queue.shutdown();
+        let mut active = self.active.lock().expect("round_robin active");
+        active.pipes.clear();
+        active.pipe_peers.clear();
+        active.fallback_peers.clear();
+        active.cursor = 0;
     }
 
     pub(crate) fn is_drained(&self) -> bool {
-        self.queue.len() == 0
+        let active_empty = self
+            .active
+            .lock()
+            .expect("round_robin active")
+            .pipes
+            .iter()
+            .all(|pipe| pipe.tx.is_empty());
+        self.queue.len() == 0 && active_empty
     }
 }

--- a/omq-tokio/src/socket/actor/lifecycle.rs
+++ b/omq-tokio/src/socket/actor/lifecycle.rs
@@ -1,7 +1,6 @@
+use super::{DisconnectReason, Message, MonitorEvent, PeerEntry, SocketDriver, SocketType};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-
-use super::{DisconnectReason, Message, MonitorEvent, PeerEntry, SocketDriver, SocketType};
 
 pub(super) struct PeerLifecycle<'a> {
     driver: &'a mut SocketDriver,
@@ -51,17 +50,9 @@ impl<'a> PeerLifecycle<'a> {
         }
         if count == 1 && self.driver.peers.len() == 1 {
             let s = sole_spsc.unwrap();
-            *self.driver.spsc.send_ring.write().unwrap() = Some(s.clone());
-            self.driver
-                .spsc
-                .send_ring_active
-                .store(true, Ordering::Release);
+            self.driver.spsc.send_ring.store(Some(s.clone()));
         } else {
-            *self.driver.spsc.send_ring.write().unwrap() = None;
-            self.driver
-                .spsc
-                .send_ring_active
-                .store(false, Ordering::Release);
+            self.driver.spsc.send_ring.store(None);
         }
     }
 

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -144,6 +144,7 @@ struct PeerEntry {
     is_client: bool,
     /// SPSC ring for this inproc peer (None for wire/stream peers).
     spsc: Option<Arc<crate::transport::inproc::InprocSpsc>>,
+    task: Option<JoinHandle<()>>,
 }
 
 struct ListenerEntry {
@@ -262,7 +263,7 @@ impl SocketDriver {
     async fn run(mut self) {
         loop {
             if self.should_exit() {
-                self.teardown();
+                self.teardown().await;
                 return;
             }
 
@@ -273,11 +274,11 @@ impl SocketDriver {
             tokio::select! {
                 biased;
                 () = self.cancel.cancelled() => {
-                    self.teardown();
+                    self.teardown().await;
                     return;
                 }
                 () = async { linger_sleep.unwrap().await }, if self.close_deadline.is_some() => {
-                    self.teardown();
+                    self.teardown().await;
                     return;
                 }
                 cmd = self.cmd_rx.recv(), if !self.closing => match cmd {
@@ -401,12 +402,26 @@ impl SocketDriver {
         }
     }
 
-    fn teardown(&mut self) {
+    async fn teardown(&mut self) {
+        self.cmd_rx.close();
+        self.internal_rx.close();
+        self.peer_out_rx.close();
         self.send_strategy.shutdown();
+        let mut peer_tasks = Vec::new();
         for p in self.peers.values() {
+            if let Some(ref slot) = p.handle.wire_slot {
+                slot.mark_dead();
+            }
+            if let Some(ref pipe) = p.handle.send_pipe {
+                pipe.close();
+            }
             p.handle.cancel.cancel();
         }
-        self.peers.clear();
+        for (_, mut peer) in self.peers.drain() {
+            if let Some(task) = peer.task.take() {
+                peer_tasks.push(task);
+            }
+        }
         for l in &self.listeners {
             l.cancel.cancel();
         }
@@ -415,6 +430,17 @@ impl SocketDriver {
             d.cancel.cancel();
         }
         self.dialers.clear();
+        if let Some(pool) = self.compression_pool.take() {
+            pool.clear();
+        }
+        for task in &peer_tasks {
+            if !task.is_finished() {
+                task.abort();
+            }
+        }
+        for task in peer_tasks {
+            let _ = task.await;
+        }
         self.monitor.publish(MonitorEvent::Closed);
         if let Some(ack) = self.close_ack.take() {
             let _ = ack.send(Ok(()));

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -38,14 +38,18 @@ impl SocketDriver {
                 self.handle_peer_event(peer_id, event).await;
             }
             InternalEvent::PeerClosed { peer_id, reason } => {
-                if let Some(peer) = PeerLifecycle::new(self).remove_peer(peer_id, reason)
-                    && peer.is_client
-                    && !self.closing
-                    && !matches!(self.options.reconnect, ReconnectPolicy::Disabled)
-                {
-                    let ep = peer.endpoint.clone();
-                    self.dialers.retain(|d| d.endpoint != ep);
-                    self.start_dial(ep);
+                if let Some(mut peer) = PeerLifecycle::new(self).remove_peer(peer_id, reason) {
+                    if let Some(task) = peer.task.take() {
+                        let _ = task.await;
+                    }
+                    if peer.is_client
+                        && !self.closing
+                        && !matches!(self.options.reconnect, ReconnectPolicy::Disabled)
+                    {
+                        let ep = peer.endpoint.clone();
+                        self.dialers.retain(|d| d.endpoint != ep);
+                        self.start_dial(ep);
+                    }
                 }
             }
         }
@@ -249,6 +253,9 @@ impl SocketDriver {
             Some(ref s) => driver.with_wire_slot(s.clone()),
             None => driver,
         };
+        let pipe_cap = self.options.send_hwm.unwrap_or(1024).max(16) as usize;
+        let (send_pipe, send_pipe_rx) = blume::bounded(pipe_cap);
+        let driver = driver.with_send_pipe(send_pipe_rx);
 
         // Recv bypass: for socket types whose recv path is a plain fair-queue
         // delivery with no per-type post-processing, route messages directly
@@ -292,20 +299,25 @@ impl SocketDriver {
                     inbox: inbox_tx,
                     cancel: child_cancel,
                     wire_slot: slot.clone(),
+                    send_pipe: Some(send_pipe),
                 },
                 identity: bytes::Bytes::new(),
                 info: None,
                 endpoint,
                 is_client: !is_server,
                 spsc: None,
+                task: None,
             },
         );
 
         PeerLifecycle::new(self).after_peer_inserted();
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let _ = driver.run().await;
         });
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
+            peer.task = Some(task);
+        }
     }
 
     fn spawn_stream_connection(
@@ -336,6 +348,7 @@ impl SocketDriver {
                 endpoint,
                 is_client: !is_server,
                 spsc: None,
+                task: None,
             },
         );
 
@@ -423,12 +436,14 @@ impl SocketDriver {
                     inbox: inbox_tx,
                     cancel: child_cancel.clone(),
                     wire_slot: None,
+                    send_pipe: None,
                 },
                 identity: bytes::Bytes::new(),
                 info: None,
                 endpoint,
                 is_client: !is_server,
                 spsc: spsc.clone(),
+                task: None,
             },
         );
 
@@ -445,7 +460,7 @@ impl SocketDriver {
         }
         PeerLifecycle::new(self).update_send_ring();
 
-        tokio::spawn(inproc_peer_driver(
+        let task = tokio::spawn(inproc_peer_driver(
             inbox_rx,
             in_rx,
             out,
@@ -460,6 +475,9 @@ impl SocketDriver {
                 recv_sink,
             },
         ));
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
+            peer.task = Some(task);
+        }
     }
 
     async fn handle_peer_event(&mut self, peer_id: u64, event: ZmtpEvent) {
@@ -830,7 +848,7 @@ async fn inproc_peer_driver(
     if let Some(ref ring) = spsc {
         ring.recv_notify.notify_one();
     }
-    let _ = peer_out.send((peer_id, PeerOut::Closed)).await;
+    let _ = peer_out.try_send((peer_id, PeerOut::Closed));
 }
 
 /// Try to push a message into the SPSC ring. Returns `None` if pushed
@@ -879,6 +897,6 @@ fn xpub_notification(tag: u8, prefix: &bytes::Bytes) -> Message {
 }
 
 /// Spawn a socket driver on the current tokio runtime.
-pub(crate) fn spawn_driver(driver: SocketDriver) {
-    tokio::spawn(async move { driver.run().await });
+pub(crate) fn spawn_driver(driver: SocketDriver) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move { driver.run().await })
 }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -62,13 +62,12 @@ struct Inner {
     /// on the same worker thread can drain and flush.
     send_ops: AtomicU32,
     last_bound_endpoint: RwLock<Option<Endpoint>>,
+    actor_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 const SEND_YIELD_INTERVAL: u32 = 4096;
 
 impl Socket {
-    const STARVATION_THRESHOLD: u32 = 2;
-
     /// Create a new socket of the given type with the given options. Spawns
     /// the driver task on the current tokio runtime.
     ///
@@ -131,7 +130,7 @@ impl Socket {
             wire_slots.clone(),
             recv_sink_config,
         );
-        spawn_driver(driver);
+        let actor_task = spawn_driver(driver);
         Self {
             inner: Arc::new(Inner {
                 socket_type,
@@ -145,6 +144,7 @@ impl Socket {
                 wire_slots,
                 send_ops: AtomicU32::new(0),
                 last_bound_endpoint: RwLock::new(None),
+                actor_task: Mutex::new(Some(actor_task)),
             }),
         }
     }
@@ -268,7 +268,7 @@ impl Socket {
                 if self.inner.wire_slots.single_exists() {
                     self.send_wire_slow(msg).await
                 } else {
-                    self.send_round_robin_wire(msg).await
+                    self.inner.send_submitter.send(msg).await
                 }
             }
         }
@@ -501,10 +501,18 @@ impl Socket {
             .await;
         // Even if the driver is already gone, the channel may be closed; we
         // treat that as "already closed" (success).
-        match rx.await {
+        let res = match rx.await {
             Ok(res) => res,
             Err(_) => Ok(()),
+        };
+        self.inner.send_submitter.shutdown();
+        self.inner.wire_slots.clear_single();
+        self.inner.recv_rx.shutdown();
+        let actor_task = self.inner.actor_task.lock().unwrap().take();
+        if let Some(task) = actor_task {
+            let _ = task.await;
         }
+        res
     }
 }
 
@@ -593,21 +601,6 @@ impl Socket {
         self.inner.wire_slots.try_send(msg)
     }
 
-    /// Multi-peer round-robin with anti-starvation.
-    ///
-    /// Normal path: try all slots, skip Full, encode into the first Ok.
-    /// Anti-starvation: when any slot has been skipped more than
-    /// `STARVATION_THRESHOLD` consecutive times, wait briefly for
-    /// that slot's driver to drain (bounded by timeout). This
-    /// breaks the TCP flow-control feedback loop that otherwise
-    /// causes permanent starvation under MT scheduling.
-    async fn send_round_robin_wire(&self, msg: Message) -> Result<()> {
-        self.inner
-            .wire_slots
-            .send_round_robin(msg, &self.inner.send_submitter, Self::STARVATION_THRESHOLD)
-            .await
-    }
-
     async fn send_wire_slow(&self, msg: Message) -> Result<()> {
         self.inner
             .wire_slots
@@ -629,5 +622,8 @@ impl Drop for Inner {
         // Last handle dropped: signal cancellation. The driver tears down
         // without waiting for linger since there's no one to await it.
         self.root_cancel.cancel();
+        self.send_submitter.shutdown();
+        self.wire_slots.clear_single();
+        self.recv_rx.shutdown();
     }
 }

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -1,9 +1,10 @@
 //! Socket recv mux for async-channel plus per-peer yring fast paths.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
+use arc_swap::ArcSwapOption;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 
@@ -13,11 +14,7 @@ use crate::transport::inproc::InprocSpsc;
 pub(crate) type SpscConsumers = Arc<RwLock<Vec<Arc<InprocSpsc>>>>;
 
 /// Single-peer send fast path ring. Actor sets/clears.
-pub(crate) type SpscSendRing = Arc<RwLock<Option<Arc<InprocSpsc>>>>;
-
-/// Fast-path guard: true when `send_ring` contains `Some`. Lets TCP-only
-/// sockets skip the `RwLock` read entirely.
-pub(crate) type SpscSendRingActive = Arc<AtomicBool>;
+pub(crate) type SpscSendRing = Arc<ArcSwapOption<InprocSpsc>>;
 
 /// Shared recv notification. All inproc producers notify this.
 pub(crate) type SpscRecvNotify = Arc<tokio::sync::Notify>;
@@ -53,7 +50,6 @@ pub(crate) struct SpscHandles {
     pub consumers: SpscConsumers,
     pub consumer_generation: SpscConsumerGeneration,
     pub send_ring: SpscSendRing,
-    pub send_ring_active: SpscSendRingActive,
     pub recv_notify: SpscRecvNotify,
     pub activated: SpscActivated,
     pub tcp_consumers: TcpConsumers,
@@ -64,8 +60,7 @@ impl Default for SpscHandles {
         Self {
             consumers: Arc::new(RwLock::new(Vec::new())),
             consumer_generation: Arc::new(AtomicU64::new(0)),
-            send_ring: Arc::new(RwLock::new(None)),
-            send_ring_active: Arc::new(AtomicBool::new(false)),
+            send_ring: Arc::new(ArcSwapOption::empty()),
             recv_notify: Arc::new(tokio::sync::Notify::new()),
             activated: Arc::new(tokio::sync::Notify::new()),
             tcp_consumers: Arc::new(RwLock::new(Vec::new())),
@@ -92,8 +87,6 @@ pub(crate) struct SpscAwareRecv {
     activated: SpscActivated,
     /// Single-peer send fast path ring (None when sender has >1 peer).
     send_ring: SpscSendRing,
-    /// True when `send_ring` is `Some`. Lets the hot path skip the `RwLock`.
-    send_ring_active: SpscSendRingActive,
     /// Batched messages drained from consumers (inproc + TCP).
     inproc_cache: Mutex<VecDeque<Message>>,
     /// Cached clone of consumers Vecs, refreshed when generation changes.
@@ -117,7 +110,6 @@ impl SpscAwareRecv {
             recv_notify: handles.recv_notify,
             activated: handles.activated,
             send_ring: handles.send_ring,
-            send_ring_active: handles.send_ring_active,
             inproc_cache: Mutex::new(VecDeque::new()),
             cached_consumers: Mutex::new(CachedConsumers {
                 generation: u64::MAX,
@@ -241,15 +233,25 @@ impl SpscAwareRecv {
         })
     }
 
+    pub(crate) fn shutdown(&self) {
+        self.inproc_cache.lock().unwrap().clear();
+        {
+            let mut cached = self.cached_consumers.lock().unwrap();
+            cached.inproc.clear();
+            cached.tcp.clear();
+            cached.generation = u64::MAX;
+        }
+        self.consumers.write().unwrap().clear();
+        self.tcp_consumers.write().unwrap().clear();
+        self.send_ring.store(None);
+        while self.rx.try_recv().is_ok() {}
+    }
+
     /// SPSC send fast path: push directly into the peer's yring.
     /// Returns `Ok(())` if sent, `Err(msg)` if the fast path is
     /// unavailable or the ring is full.
     pub(crate) fn try_push_spsc(&self, msg: Message) -> core::result::Result<(), Message> {
-        if !self.send_ring_active.load(Ordering::Acquire) {
-            return Err(msg);
-        }
-        let spsc = self.send_ring.read().unwrap().clone();
-        let Some(ref pair) = spsc else {
+        let Some(pair) = self.send_ring.load_full() else {
             return Err(msg);
         };
         if !pair.recv_ready.load(Ordering::Acquire)

--- a/omq-tokio/src/socket/udp.rs
+++ b/omq-tokio/src/socket/udp.rs
@@ -138,5 +138,6 @@ pub(crate) fn fake_handle(
         inbox,
         cancel,
         wire_slot: None,
+        send_pipe: None,
     }
 }

--- a/omq-tokio/src/socket/wire_slot_cache.rs
+++ b/omq-tokio/src/socket/wire_slot_cache.rs
@@ -1,8 +1,9 @@
 //! Shared wire-slot cache between the socket handle and actor.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
+use arc_swap::ArcSwapOption;
 use omq_proto::error::Result;
 use omq_proto::message::Message;
 use omq_proto::proto::SocketType;
@@ -12,36 +13,20 @@ use super::handle::TrySendError;
 use crate::engine::wire_slot::{PeerWireSlot, TryEncodeResult};
 use crate::routing::SendSubmitter;
 
-type WireSlotHolder = Arc<Mutex<Option<Arc<PeerWireSlot>>>>;
-type RrSlots = Arc<RrSlotsInner>;
-
-/// Multi-peer round-robin wire slots, shared between the handle (reads)
-/// and the actor (writes on peer add/remove). When more than one wire
-/// peer is active on a round-robin socket and none are inproc, the actor
-/// fills `slots` with every peer's [`PeerWireSlot`]; the handle picks the
-/// next one per send via `cursor`, giving strict round-robin distribution
-/// over the per-peer direct-encode fast path. Empty for single-peer /
-/// inproc-mixed / identity-routed sockets (those fall back to the shared
-/// work-stealing queue).
-#[derive(Debug, Default)]
-struct RrSlotsInner {
-    slots: Mutex<Vec<Arc<PeerWireSlot>>>,
-    cursor: AtomicUsize,
-}
-
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct WireSlotCache {
-    single: WireSlotHolder,
-    rr: RrSlots,
+    single: Arc<ArcSwapOption<PeerWireSlot>>,
 }
 
 impl WireSlotCache {
     pub(crate) fn new() -> Self {
-        Self::default()
+        Self {
+            single: Arc::new(ArcSwapOption::empty()),
+        }
     }
 
     pub(crate) fn clear_single(&self) {
-        *self.single.lock().expect("wire_slot") = None;
+        self.single.store(None);
     }
 
     pub(crate) fn rebuild<I>(&self, socket_type: SocketType, peer_count: usize, peer_slots: I)
@@ -54,33 +39,15 @@ impl WireSlotCache {
         }
 
         let slots: Vec<_> = peer_slots.into_iter().collect();
-        let mut guard = self.single.lock().expect("wire_slot");
-        let mut rr = self.rr.slots.lock().expect("rr_slots");
-        rr.clear();
-
         if peer_count == 1
             && let Some(Some(slot)) = slots.first()
             && slot.handshake_done.load(Ordering::Acquire)
         {
-            *guard = Some(slot.clone());
+            self.single.store(Some(slot.clone()));
             return;
         }
 
-        *guard = None;
-        // Multi-peer round-robin: populate per-peer wire slots so the handle
-        // dispatches directly to one peer at a time. Only when every peer is
-        // a wire peer (no inproc) - inproc peers have no wire slot and would
-        // be starved if the round-robin only cycled wire slots. Mixed or
-        // inproc-only sets fall back to the shared queue (rr left empty).
-        if matches!(cat, SendCategory::RoundRobin)
-            && peer_count > 1
-            && slots.iter().all(|slot| {
-                slot.as_ref()
-                    .is_some_and(|s| s.handshake_done.load(Ordering::Acquire))
-            })
-        {
-            rr.extend(slots.into_iter().flatten());
-        }
+        self.single.store(None);
     }
 
     /// Synchronous single-peer wire encode fast path. Returns true if
@@ -94,61 +61,14 @@ impl WireSlotCache {
     }
 
     pub(crate) fn single_exists(&self) -> bool {
-        self.single.lock().expect("wire_slot").is_some()
+        self.single.load().is_some()
     }
 
     pub(crate) fn single_dead(&self) -> bool {
         self.single
-            .lock()
-            .expect("wire_slot")
+            .load()
             .as_ref()
             .is_some_and(|s| s.dead.load(Ordering::Acquire))
-    }
-
-    pub(crate) async fn send_round_robin(
-        &self,
-        msg: Message,
-        submitter: &SendSubmitter,
-        starvation_threshold: u32,
-    ) -> Result<()> {
-        let starved = {
-            let slots = self.rr.slots.lock().expect("rr_slots");
-            let n = slots.len();
-            let mut starved_slot = None;
-            for _ in 0..n {
-                let i = self.rr.cursor.fetch_add(1, Ordering::Relaxed) % n;
-                match slots[i].try_encode(&msg) {
-                    TryEncodeResult::Ok => {
-                        slots[i].consecutive_full.store(0, Ordering::Relaxed);
-                        return Ok(());
-                    }
-                    TryEncodeResult::Full => {
-                        let prev = slots[i].consecutive_full.fetch_add(1, Ordering::Relaxed);
-                        if prev >= starvation_threshold {
-                            starved_slot = Some(slots[i].clone());
-                            break;
-                        }
-                    }
-                    TryEncodeResult::Dead | TryEncodeResult::Ineligible => {}
-                }
-            }
-            starved_slot
-        };
-
-        if let Some(slot) = starved {
-            let notified = slot.space_available.notified();
-            if slot.try_encode(&msg) == TryEncodeResult::Ok {
-                slot.consecutive_full.store(0, Ordering::Relaxed);
-                return Ok(());
-            }
-            let _ = tokio::time::timeout(std::time::Duration::from_millis(1), notified).await;
-            if slot.try_encode(&msg) == TryEncodeResult::Ok {
-                slot.consecutive_full.store(0, Ordering::Relaxed);
-                return Ok(());
-            }
-        }
-
-        submitter.send(msg).await
     }
 
     /// Single-peer async slow path: handles backpressure (Full -> wait
@@ -192,6 +112,6 @@ impl WireSlotCache {
     }
 
     fn single_slot(&self) -> Option<Arc<PeerWireSlot>> {
-        self.single.lock().expect("wire_slot").clone()
+        self.single.load_full()
     }
 }

--- a/omq-tokio/src/transport/stream_raw.rs
+++ b/omq-tokio/src/transport/stream_raw.rs
@@ -77,12 +77,13 @@ pub(crate) fn spawn(
         // Disconnect notification.
         let notif = ZmtpEvent::Message(Message::single(Bytes::new()));
         let _ = peer_out_tx.send((peer_id, PeerOut::Event(notif))).await;
-        let _ = peer_out_tx.send((peer_id, PeerOut::Closed)).await;
+        let _ = peer_out_tx.try_send((peer_id, PeerOut::Closed));
     });
 
     DriverHandle {
         inbox: inbox_tx,
         cancel: handle_cancel,
         wire_slot: None,
+        send_pipe: None,
     }
 }

--- a/omq-tokio/tests/random_sizes.rs
+++ b/omq-tokio/tests/random_sizes.rs
@@ -30,9 +30,10 @@ async fn random_message_sizes() {
         .collect();
     let hashes: Vec<u128> = payloads.iter().map(|p| xxh3_128(p)).collect();
 
+    let push_sender = push.clone();
     let send_handle = tokio::spawn(async move {
         for payload in payloads {
-            push.send(Message::single(payload)).await.unwrap();
+            push_sender.send(Message::single(payload)).await.unwrap();
         }
     });
 

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -188,10 +188,11 @@ async fn req_rep_1000_cycles_tcp() {
     req.connect(ep).await.unwrap();
     test_support::wait_for_handshake(&req).await;
 
+    let rep_worker = rep.clone();
     let rep_task = tokio::spawn(async move {
         for _ in 0..CYCLES {
-            let m = rep.recv().await.unwrap();
-            rep.send(m).await.unwrap(); // echo
+            let m = rep_worker.recv().await.unwrap();
+            rep_worker.send(m).await.unwrap(); // echo
         }
     });
 

--- a/omq-tokio/tests/soak_blake3zmq.rs
+++ b/omq-tokio/tests/soak_blake3zmq.rs
@@ -29,7 +29,7 @@ fn soak_blake3zmq_sustained() {
     let client_kp = Blake3ZmqKeypair::generate();
     let server_pub = server_kp.public;
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pull = Socket::new(
             SocketType::Pull,

--- a/omq-tokio/tests/soak_cancel_safety.rs
+++ b/omq-tokio/tests/soak_cancel_safety.rs
@@ -45,7 +45,7 @@ fn soak_cancel_safety() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let mut rng = rand::make_rng::<StdRng>();
         let start = Instant::now();

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -65,6 +65,17 @@ pub fn soak_duration() -> Duration {
     Duration::from_secs(secs.max(5))
 }
 
+pub fn tokio_runtime() -> tokio::runtime::Runtime {
+    match std::env::var("OMQ_SOAK_TOKIO_RUNTIME").as_deref() {
+        Ok("current_thread") => tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime"),
+        Ok("multi_thread") | Err(_) => tokio::runtime::Runtime::new().expect("runtime"),
+        Ok(other) => panic!("unsupported OMQ_SOAK_TOKIO_RUNTIME={other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Endpoint helpers
 // ---------------------------------------------------------------------------

--- a/omq-tokio/tests/soak_compression_lz4.rs
+++ b/omq-tokio/tests/soak_compression_lz4.rs
@@ -64,7 +64,7 @@ fn soak_compression_lz4_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let (pull, ep) = pull_on_loopback().await;
         let push = Socket::new(

--- a/omq-tokio/tests/soak_curve.rs
+++ b/omq-tokio/tests/soak_curve.rs
@@ -24,7 +24,7 @@ fn soak_curve_sustained() {
     let client_kp = CurveKeypair::generate();
     let server_pub = server_kp.public;
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pull = Socket::new(
             SocketType::Pull,

--- a/omq-tokio/tests/soak_hwm_reconnect.rs
+++ b/omq-tokio/tests/soak_hwm_reconnect.rs
@@ -44,7 +44,7 @@ fn run_hwm_storm(name: &str, mute: OnMute) {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         // Probe for a port, then close so we can rebind.
         let probe = Socket::new(SocketType::Pull, soak_common::soak_options());

--- a/omq-tokio/tests/soak_inproc_cross_thread.rs
+++ b/omq-tokio/tests/soak_inproc_cross_thread.rs
@@ -21,7 +21,7 @@ fn soak_inproc_cross_thread() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pull = Socket::new(SocketType::Pull, Options::default());
         pull.bind(ep.clone()).await.unwrap();

--- a/omq-tokio/tests/soak_large_throughput.rs
+++ b/omq-tokio/tests/soak_large_throughput.rs
@@ -93,7 +93,7 @@ fn soak_large_message_throughput() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     let stats = Arc::new(std::sync::Mutex::new(PayloadStats::new()));
 
     rt.block_on(async {

--- a/omq-tokio/tests/soak_mechanism_reconnect.rs
+++ b/omq-tokio/tests/soak_mechanism_reconnect.rs
@@ -46,7 +46,7 @@ fn run_mechanism_storm(
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let probe = make_server();
         let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_multi_socket.rs
+++ b/omq-tokio/tests/soak_multi_socket.rs
@@ -68,7 +68,7 @@ fn soak_multi_socket() {
     let monitor = soak_common::ResourceMonitor::start();
     let mut tracker = soak_common::ThroughputTracker::new(Duration::from_secs(10));
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pairs = create_pairs().await;
         eprintln!("[multi_socket] created {} socket pairs", pairs.len());

--- a/omq-tokio/tests/soak_peer_churn.rs
+++ b/omq-tokio/tests/soak_peer_churn.rs
@@ -16,7 +16,7 @@ use omq_tokio::{Message, Socket, SocketType};
 fn soak_peer_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let push = Socket::new(SocketType::Push, soak_common::soak_options().send_hwm(1024));
         let ep = push.bind(soak_common::tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_plain.rs
+++ b/omq-tokio/tests/soak_plain.rs
@@ -20,7 +20,7 @@ fn soak_plain_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pull = Socket::new(
             SocketType::Pull,

--- a/omq-tokio/tests/soak_pub_sub_churn.rs
+++ b/omq-tokio/tests/soak_pub_sub_churn.rs
@@ -20,7 +20,7 @@ fn soak_pub_sub_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let ep = soak_common::inproc_ep("soak-pub-sub-churn");
         let publisher = Socket::new(SocketType::Pub, Options::default());

--- a/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
+++ b/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
@@ -34,7 +34,7 @@ fn soak_pub_sub_churn_tcp() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let publisher = Socket::new(SocketType::Pub, soak_common::soak_options());
         let ep = publisher.bind(soak_common::tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/soak_reconnect_all_types.rs
@@ -147,7 +147,7 @@ fn soak_reconnect_all_types() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let mut pairs = create_all_pairs().await;
 

--- a/omq-tokio/tests/soak_reconnect_storm.rs
+++ b/omq-tokio/tests/soak_reconnect_storm.rs
@@ -15,7 +15,7 @@ fn soak_reconnect_storm() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         // Bind port 0 to discover a free port, then use that endpoint for
         // repeated bind/close cycles so the dialer reconnects to the same address.

--- a/omq-tokio/tests/soak_router_dealer_churn.rs
+++ b/omq-tokio/tests/soak_router_dealer_churn.rs
@@ -128,7 +128,7 @@ fn soak_router_dealer_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let router = Socket::new(
             SocketType::Router,

--- a/omq-tokio/tests/soak_ws.rs
+++ b/omq-tokio/tests/soak_ws.rs
@@ -52,7 +52,7 @@ fn soak_ws_throughput() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let pull = Socket::new(SocketType::Pull, soak_common::soak_options());
         let ep = pull.bind(ws_ep(0)).await.unwrap();
@@ -112,7 +112,7 @@ fn soak_ws_reconnect_storm() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         // Probe for a port.
         let probe = Socket::new(SocketType::Pull, soak_common::soak_options());

--- a/omq-tokio/tests/soak_xpub_xsub_churn.rs
+++ b/omq-tokio/tests/soak_xpub_xsub_churn.rs
@@ -34,7 +34,7 @@ fn soak_xpub_xsub_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let rt = soak_common::tokio_runtime();
     rt.block_on(async {
         let xpub = Socket::new(SocketType::XPub, soak_common::soak_options());
         let ep = xpub.bind(soak_common::tcp_ep(0)).await.unwrap();


### PR DESCRIPTION
- Add `blume` batch receive and shutdown primitives used by `omq-tokio` teardown.
- Route `omq-tokio` byte-stream round-robin sends through per-peer pipes and keep inproc/mixed peers on the fallback queue.
- Clear send/recv caches, close submitters, and abort stuck peer tasks during `omq-tokio` socket teardown.
- Document the tokio send/teardown architecture and add `OMQ_SOAK_TOKIO_RUNTIME` for current-thread soak coverage.
- Verified: `cargo clippy -p omq-tokio --all-targets --features "soak lz4 plain curve blake3zmq ws"`.
- Verified: all `omq-tokio` soaks at 600s, batches of 3, for both `multi_thread` and `current_thread` runtimes.