### PR TITLE
Harden point-release edge cases

### DIFF
--- a/blume/src/receiver.rs
+++ b/blume/src/receiver.rs
@@ -139,16 +139,11 @@ impl<T> Receiver<T> {
     /// Signal senders that the receiver is closed. Subsequent and
     /// in-flight `send_async` calls will return `SendError`.
     pub fn close(&self) {
-        self.cache.borrow_mut().clear();
-        let mut inner = self.shared.lock_inner();
-        inner.closed_recv = true;
-        let drained = inner.queue.len();
-        inner.queue.clear();
-        self.shared
-            .queued
-            .fetch_sub(drained, std::sync::atomic::Ordering::Release);
-        drop(inner);
+        let cache = std::mem::take(&mut *self.cache.borrow_mut());
+        let queue = self.shared.close_recv();
         self.shared.send_event.notify(usize::MAX);
+        drop(queue);
+        drop(cache);
     }
 
     fn drain_cache_into(cache: &mut VecDeque<T>, out: &mut Vec<T>) -> usize {

--- a/blume/src/receiver.rs
+++ b/blume/src/receiver.rs
@@ -140,11 +140,7 @@ impl<T> Receiver<T> {
     /// in-flight `send_async` calls will return `SendError`.
     pub fn close(&self) {
         self.cache.borrow_mut().clear();
-        let mut inner = self
-            .shared
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut inner = self.shared.lock_inner();
         inner.closed_recv = true;
         let drained = inner.queue.len();
         inner.queue.clear();

--- a/blume/src/sender.rs
+++ b/blume/src/sender.rs
@@ -59,7 +59,12 @@ impl<T> Sender<T> {
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
-        self.shared.sender_count.fetch_add(1, Ordering::Relaxed);
+        self.shared
+            .sender_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                count.checked_add(1)
+            })
+            .expect("blume: sender count overflow");
         Self {
             shared: Arc::clone(&self.shared),
         }
@@ -81,5 +86,35 @@ impl<T> Drop for Sender<T> {
 impl<T> fmt::Debug for Sender<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sender").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::{Arc, Mutex};
+
+    use event_listener::Event;
+
+    use super::*;
+    use crate::shared::{Inner, Shared};
+
+    #[test]
+    #[should_panic(expected = "blume: sender count overflow")]
+    fn clone_panics_on_sender_count_overflow() {
+        let sender = Sender::<()>::new(Arc::new(Shared {
+            inner: Mutex::new(Inner {
+                queue: VecDeque::new(),
+                closed_recv: false,
+            }),
+            capacity: 1,
+            queued: AtomicUsize::new(0),
+            sender_count: AtomicUsize::new(usize::MAX),
+            recv_event: Event::new(),
+            send_event: Event::new(),
+        }));
+
+        let _ = sender.clone();
     }
 }

--- a/blume/src/sender.rs
+++ b/blume/src/sender.rs
@@ -50,11 +50,7 @@ impl<T> Sender<T> {
     /// Used by socket teardown when the receiver task may still be alive but
     /// its queued payloads are no longer deliverable.
     pub fn close(&self) {
-        let mut inner = self
-            .shared
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut inner = self.shared.lock_inner();
         inner.closed_recv = true;
         let drained = inner.queue.len();
         inner.queue.clear();
@@ -80,12 +76,7 @@ impl<T> Drop for Sender<T> {
             // Lock+drop synchronizes with try_drain: guarantees that any
             // in-flight send() has completed and its items are visible
             // before we notify the receiver of channel closure.
-            drop(
-                self.shared
-                    .inner
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner),
-            );
+            drop(self.shared.lock_inner());
             self.shared.recv_event.notify(usize::MAX);
         }
     }

--- a/blume/src/sender.rs
+++ b/blume/src/sender.rs
@@ -50,14 +50,10 @@ impl<T> Sender<T> {
     /// Used by socket teardown when the receiver task may still be alive but
     /// its queued payloads are no longer deliverable.
     pub fn close(&self) {
-        let mut inner = self.shared.lock_inner();
-        inner.closed_recv = true;
-        let drained = inner.queue.len();
-        inner.queue.clear();
-        self.shared.queued.fetch_sub(drained, Ordering::Release);
-        drop(inner);
+        let queue = self.shared.close_recv();
         self.shared.send_event.notify(usize::MAX);
         self.shared.recv_event.notify(usize::MAX);
+        drop(queue);
     }
 }
 

--- a/blume/src/shared.rs
+++ b/blume/src/shared.rs
@@ -59,6 +59,15 @@ impl<T> Shared<T> {
         Ok(())
     }
 
+    pub(crate) fn close_recv(&self) -> VecDeque<T> {
+        let mut inner = self.lock_inner();
+        inner.closed_recv = true;
+        let drained = inner.queue.len();
+        let queue = std::mem::take(&mut inner.queue);
+        self.queued.fetch_sub(drained, Ordering::Release);
+        queue
+    }
+
     pub(crate) async fn send_async(&self, val: T) -> Result<(), SendError<T>> {
         let mut val = val;
         loop {

--- a/blume/src/shared.rs
+++ b/blume/src/shared.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use event_listener::{Event, Listener};
 
@@ -37,8 +37,12 @@ impl<T> Shared<T> {
         })
     }
 
+    pub(crate) fn lock_inner(&self) -> MutexGuard<'_, Inner<T>> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
     pub(crate) fn try_send(&self, val: T) -> Result<(), TrySendError<T>> {
-        let mut inner = self.inner.lock().expect("blume: poisoned");
+        let mut inner = self.lock_inner();
         if inner.closed_recv {
             return Err(TrySendError::Disconnected(val));
         }
@@ -93,9 +97,9 @@ impl<T> Shared<T> {
     }
 
     pub(crate) fn try_drain(&self, cache: &mut VecDeque<T>) -> Result<bool, RecvError> {
-        let mut inner = self.inner.lock().expect("blume: poisoned");
+        let mut inner = self.lock_inner();
         if inner.queue.is_empty() {
-            return if self.all_senders_dropped() {
+            return if inner.closed_recv || self.all_senders_dropped() {
                 Err(RecvError)
             } else {
                 Ok(false)
@@ -136,7 +140,7 @@ impl<T> Shared<T> {
     }
 
     pub(crate) fn is_recv_disconnected(&self) -> bool {
-        let inner = self.inner.lock().expect("blume: poisoned");
+        let inner = self.lock_inner();
         inner.closed_recv
     }
 }

--- a/blume/tests/disconnect.rs
+++ b/blume/tests/disconnect.rs
@@ -1,12 +1,23 @@
 use blume::{RecvError, SendError, TryRecvError, TrySendError};
 
+struct PanicOnDrop(bool);
+
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        if self.0 {
+            self.0 = false;
+            panic!("intentional panic in drop");
+        }
+    }
+}
+
 #[test]
 fn recv_after_all_senders_drop() {
     let (tx, rx) = blume::bounded::<i32>(4);
     tx.try_send(1).unwrap();
     drop(tx);
     assert_eq!(rx.try_recv(), Ok(1));
-    assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
 }
 
 #[test]
@@ -31,7 +42,7 @@ fn sender_close_disconnects_receiver() {
     tx.try_send(1).unwrap();
     tx.close();
 
-    assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
 }
 
 #[test]
@@ -45,6 +56,43 @@ fn async_recv_wakes_on_sender_close() {
         assert_eq!(rx.recv_async().await, Err(RecvError));
         handle.join().unwrap();
     });
+}
+
+#[test]
+fn sender_close_marks_disconnected_before_dropping_payloads() {
+    let (tx, rx) = blume::bounded::<PanicOnDrop>(4);
+    tx.try_send(PanicOnDrop(true)).unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tx.close();
+    }));
+
+    assert!(result.is_err());
+    assert!(tx.is_disconnected());
+    assert!(matches!(
+        tx.try_send(PanicOnDrop(false)),
+        Err(TrySendError::Disconnected(_))
+    ));
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
+}
+
+#[test]
+fn receiver_close_marks_disconnected_before_dropping_cached_payloads() {
+    let (tx, rx) = blume::bounded::<PanicOnDrop>(4);
+    tx.try_send(PanicOnDrop(false)).unwrap();
+    tx.try_send(PanicOnDrop(true)).unwrap();
+    drop(rx.try_recv().unwrap());
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        rx.close();
+    }));
+
+    assert!(result.is_err());
+    assert!(tx.is_disconnected());
+    assert!(matches!(
+        tx.try_send(PanicOnDrop(false)),
+        Err(TrySendError::Disconnected(_))
+    ));
 }
 
 #[test]

--- a/blume/tests/disconnect.rs
+++ b/blume/tests/disconnect.rs
@@ -26,6 +26,28 @@ fn async_send_after_receiver_drop() {
 }
 
 #[test]
+fn sender_close_disconnects_receiver() {
+    let (tx, rx) = blume::bounded::<i32>(4);
+    tx.try_send(1).unwrap();
+    tx.close();
+
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
+}
+
+#[test]
+fn async_recv_wakes_on_sender_close() {
+    futures_lite::future::block_on(async {
+        let (tx, rx) = blume::bounded::<i32>(4);
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            tx.close();
+        });
+        assert_eq!(rx.recv_async().await, Err(RecvError));
+        handle.join().unwrap();
+    });
+}
+
+#[test]
 fn is_disconnected_sender() {
     let (tx, rx) = blume::bounded::<i32>(4);
     assert!(!tx.is_disconnected());

--- a/omq-compio/src/socket/direct_io.rs
+++ b/omq-compio/src/socket/direct_io.rs
@@ -27,7 +27,7 @@ pub(crate) struct DirectIoState {
     pub(crate) recv_state_changed: Event,
     pub(crate) recv_codec_ready: Event,
     pub(crate) eof_signal: Event,
-    pub(crate) last_input_nanos: AtomicU64,
+    pub(crate) last_input_millis: AtomicU64,
     pub(crate) hb_epoch: Instant,
     pub(crate) handshake_done: Cell<bool>,
     pub(crate) has_transform: bool,
@@ -150,10 +150,7 @@ async fn one_shot_with_prefix(
         }
         restore.buf.take().unwrap().freeze()
     };
-    state.last_input_nanos.store(
-        state.hb_epoch.elapsed().as_nanos() as u64,
-        Ordering::Relaxed,
-    );
+    state.mark_input();
     state.large_recv_pending.store(0, Ordering::Release);
     {
         let Ok(mut io) = state.peer_io.lock() else {
@@ -182,10 +179,7 @@ pub(crate) async fn one_shot_recv_and_feed(
         Ok(b) => b,
         Err(e) => return OneShotLargeRecvOutcome::IoErr(e),
     };
-    state.last_input_nanos.store(
-        state.hb_epoch.elapsed().as_nanos() as u64,
-        Ordering::Relaxed,
-    );
+    state.mark_input();
     {
         let Ok(mut io) = state.peer_io.lock() else {
             return OneShotLargeRecvOutcome::IoErr(std::io::Error::other("peer_io"));
@@ -205,10 +199,7 @@ pub(crate) async fn one_shot_recv_and_feed(
                 if bytes.is_empty() {
                     break OneShotLargeRecvOutcome::IoErr(std::io::Error::other("eof"));
                 }
-                state.last_input_nanos.store(
-                    state.hb_epoch.elapsed().as_nanos() as u64,
-                    Ordering::Relaxed,
-                );
+                state.mark_input();
                 let Ok(mut io) = state.peer_io.lock() else {
                     break OneShotLargeRecvOutcome::IoErr(std::io::Error::other("peer_io"));
                 };
@@ -237,6 +228,16 @@ pub(crate) async fn one_shot_recv_and_feed(
 }
 
 impl DirectIoState {
+    pub(crate) fn hb_elapsed_millis(&self) -> u64 {
+        let ms = self.hb_epoch.elapsed().as_millis();
+        ms.min(u128::from(u64::MAX)) as u64
+    }
+
+    pub(crate) fn mark_input(&self) {
+        self.last_input_millis
+            .store(self.hb_elapsed_millis(), Ordering::Relaxed);
+    }
+
     /// Bump the direct-encode message counter and wake the driver if it
     /// is parked in `select_biased!`. Called after every successful
     /// direct-encode (flat, gather, prefixed, transform, or WebSocket).
@@ -292,7 +293,7 @@ impl DirectIoState {
             recv_state_changed: Event::new(),
             recv_codec_ready: Event::new(),
             eof_signal: Event::new(),
-            last_input_nanos: AtomicU64::new(0),
+            last_input_millis: AtomicU64::new(0),
             hb_epoch: Instant::now(),
             handshake_done: Cell::new(false),
             has_transform,

--- a/omq-compio/src/socket/recv.rs
+++ b/omq-compio/src/socket/recv.rs
@@ -100,10 +100,7 @@ async fn accumulate_large_recv(state: &Arc<DirectIoState>) -> Result<RecvAction>
                 state.signal_eof();
                 return Err(Error::Closed);
             }
-            state.last_input_nanos.store(
-                state.hb_epoch.elapsed().as_nanos() as u64,
-                Ordering::Relaxed,
-            );
+            state.mark_input();
             let payload = restore.buf.take().unwrap().freeze();
             state.large_recv_pending.store(0, Ordering::Release);
             let mut io = state.lock_io();
@@ -141,10 +138,7 @@ async fn accumulate_large_recv(state: &Arc<DirectIoState>) -> Result<RecvAction>
                     drop(buf);
                     Some(e)
                 };
-                state.last_input_nanos.store(
-                    state.hb_epoch.elapsed().as_nanos() as u64,
-                    Ordering::Relaxed,
-                );
+                state.mark_input();
                 if acc.len() >= payload_len {
                     let payload = acc_guard.take().unwrap().freeze();
                     drop(acc_guard);
@@ -238,10 +232,7 @@ async fn pull_and_feed(state: &Arc<DirectIoState>) -> PullOutcome {
                     if handle_result.is_err() {
                         PullOutcome::ProtoErr
                     } else {
-                        state.last_input_nanos.store(
-                            state.hb_epoch.elapsed().as_nanos() as u64,
-                            Ordering::Relaxed,
-                        );
+                        state.mark_input();
                         crate::socket::try_one_shot_large_recv(state, &mut sguard)
                             .await
                             .into()

--- a/omq-compio/src/transport/driver.rs
+++ b/omq-compio/src/transport/driver.rs
@@ -386,10 +386,7 @@ pub(crate) async fn run_connection(
         .and_then(|d| u16::try_from(d.as_millis() / 100).ok())
         .unwrap_or(0);
     let mut ls = DriverLoopState::new(options.handshake_timeout);
-    state.last_input_nanos.store(
-        state.hb_epoch.elapsed().as_nanos() as u64,
-        Ordering::Relaxed,
-    );
+    state.mark_input();
 
     // Persistent futures: kept alive across loop iterations so their
     // internal heap state (flume hook, event_listener node) is reused
@@ -731,9 +728,9 @@ impl DriverLoopState {
         hb_timeout: Duration,
     ) -> Result<()> {
         if self.hb_ping_sent {
-            let now_nanos = state.hb_epoch.elapsed().as_nanos() as u64;
-            let last_nanos = state.last_input_nanos.load(Ordering::Relaxed);
-            let elapsed = Duration::from_nanos(now_nanos.saturating_sub(last_nanos));
+            let now_millis = state.hb_elapsed_millis();
+            let last_millis = state.last_input_millis.load(Ordering::Relaxed);
+            let elapsed = Duration::from_millis(now_millis.saturating_sub(last_millis));
             if elapsed > hb_timeout {
                 return Err(Error::Timeout);
             }

--- a/omq-compio/src/transport/recv_stream.rs
+++ b/omq-compio/src/transport/recv_stream.rs
@@ -56,10 +56,7 @@ async fn pull_stream_accumulating(
             if let Err(e) = fd.read_until(acc, payload_len).await {
                 return StreamArmOutcome::Err(e);
             }
-            state.last_input_nanos.store(
-                state.hb_epoch.elapsed().as_nanos() as u64,
-                Ordering::Relaxed,
-            );
+            state.mark_input();
             let payload = restore.buf.take().unwrap().freeze();
             state.large_recv_pending.store(0, Ordering::Release);
             let mut io = peer_io.lock().expect("peer_io");
@@ -82,10 +79,7 @@ async fn pull_stream_accumulating(
                 Some(Err(e)) => StreamArmOutcome::Err(e),
                 Some(Ok(buf)) if buf.is_empty() => StreamArmOutcome::Eof,
                 Some(Ok(buf)) => {
-                    state.last_input_nanos.store(
-                        state.hb_epoch.elapsed().as_nanos() as u64,
-                        Ordering::Relaxed,
-                    );
+                    state.mark_input();
                     let bytes = bytes::Bytes::copy_from_slice(&buf[..]);
                     drop(buf);
                     StreamArmOutcome::AccData(bytes)
@@ -138,10 +132,7 @@ pub(super) async fn pull_stream(
                     if buf.is_empty() {
                         return StreamArmOutcome::Eof;
                     }
-                    state.last_input_nanos.store(
-                        state.hb_epoch.elapsed().as_nanos() as u64,
-                        Ordering::Relaxed,
-                    );
+                    state.mark_input();
                     let handle_result = {
                         let mut io = peer_io.lock().expect("peer_io");
                         let bytes = bytes::Bytes::copy_from_slice(&buf[..]);

--- a/omq-compio/src/transport/tcp.rs
+++ b/omq-compio/src/transport/tcp.rs
@@ -10,13 +10,22 @@ use omq_proto::error::{Error, Result};
 pub use crate::transport::driver::DriverCommand as TcpDriverCommand;
 
 pub(crate) fn resolve_name(name: &str, port: u16) -> Result<SocketAddr> {
-    use std::net::ToSocketAddrs;
-    let mut addrs = (name, port)
-        .to_socket_addrs()
-        .map_err(|e| Error::InvalidEndpoint(format!("{name}: {e}")))?;
-    addrs
+    resolve_name_all(name, port)?
+        .into_iter()
         .next()
         .ok_or_else(|| Error::InvalidEndpoint(format!("no addresses for {name}")))
+}
+
+pub(crate) fn resolve_name_all(name: &str, port: u16) -> Result<Vec<SocketAddr>> {
+    use std::net::ToSocketAddrs;
+    let addrs: Vec<_> = (name, port)
+        .to_socket_addrs()
+        .map_err(|e| Error::InvalidEndpoint(format!("{name}: {e}")))?
+        .collect();
+    if addrs.is_empty() {
+        return Err(Error::InvalidEndpoint(format!("no addresses for {name}")));
+    }
+    Ok(addrs)
 }
 
 fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
@@ -29,13 +38,13 @@ fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
     }
 }
 
-fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
+fn resolve_connect(host: &Host, port: u16) -> Result<Vec<SocketAddr>> {
     match host {
         Host::Wildcard => Err(Error::InvalidEndpoint(
             "cannot connect to wildcard host".into(),
         )),
-        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
-        Host::Name(name) => resolve_name(name, port),
+        Host::Ip(ip) => Ok(vec![SocketAddr::new(*ip, port)]),
+        Host::Name(name) => resolve_name_all(name, port),
         _ => unreachable!(),
     }
 }
@@ -74,8 +83,21 @@ pub async fn connect(endpoint: &Endpoint) -> Result<TcpStream> {
             "tcp transport got non-tcp endpoint: {endpoint}"
         )));
     };
-    let addr = resolve_connect(host, *port)?;
-    let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
-    stream.set_nodelay(true).map_err(Error::Io)?;
-    Ok(stream)
+    connect_any_resolved(resolve_connect(host, *port)?).await
+}
+
+pub(crate) async fn connect_any_resolved(addrs: Vec<SocketAddr>) -> Result<TcpStream> {
+    let mut last_err = None;
+    for addr in addrs {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => {
+                stream.set_nodelay(true).map_err(Error::Io)?;
+                return Ok(stream);
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(Error::Io(last_err.unwrap_or_else(|| {
+        std::io::Error::other("no addresses to connect")
+    })))
 }

--- a/omq-compio/src/transport/ws.rs
+++ b/omq-compio/src/transport/ws.rs
@@ -41,13 +41,13 @@ fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
     }
 }
 
-fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
+fn resolve_connect(host: &Host, port: u16) -> Result<Vec<SocketAddr>> {
     match host {
         Host::Wildcard => Err(Error::InvalidEndpoint(
             "cannot connect to wildcard host".into(),
         )),
-        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
-        Host::Name(name) => super::tcp::resolve_name(name, port),
+        Host::Ip(ip) => Ok(vec![SocketAddr::new(*ip, port)]),
+        Host::Name(name) => super::tcp::resolve_name_all(name, port),
         _ => unreachable!(),
     }
 }
@@ -292,9 +292,7 @@ pub(crate) async fn connect(
             )));
         }
     };
-    let addr = resolve_connect(host, port)?;
-    let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
-    let _ = stream.set_nodelay(true);
+    let stream = super::tcp::connect_any_resolved(resolve_connect(host, port)?).await?;
 
     let subprotocol = mechanism_subprotocol(mechanism);
 

--- a/omq-compio/src/transport/ws.rs
+++ b/omq-compio/src/transport/ws.rs
@@ -57,7 +57,6 @@ fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
 pub(crate) type TlsStream = compio_tls::TlsStream<TcpStream>;
 pub(crate) type SharedTls = std::sync::Arc<async_lock::Mutex<TlsStream>>;
 
-#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn build_tls_connector(accept_invalid_certs: bool) -> Result<compio_tls::TlsConnector> {
     use std::sync::Arc;
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -69,7 +68,14 @@ pub(crate) fn build_tls_connector(accept_invalid_certs: bool) -> Result<compio_t
         cfg
     } else {
         let mut roots = rustls::RootCertStore::empty();
-        for cert in rustls_native_certs::load_native_certs().expect("load system certs") {
+        let cert_result = rustls_native_certs::load_native_certs();
+        if cert_result.certs.is_empty() && !cert_result.errors.is_empty() {
+            return Err(Error::Io(std::io::Error::other(format!(
+                "failed to load system certificates: {:?}",
+                cert_result.errors
+            ))));
+        }
+        for cert in cert_result.certs {
             let _ = roots.add(cert);
         }
         rustls::ClientConfig::builder()

--- a/omq-libzmq/README.md
+++ b/omq-libzmq/README.md
@@ -1,6 +1,6 @@
 # omq-libzmq
 
-libzmq-compatible C interface backed by [omq-compio](https://crates.io/crates/omq-compio).
+libzmq-compatible C interface backed by [omq-tokio](https://crates.io/crates/omq-tokio).
 
 Exposes `zmq_socket`, `zmq_bind`, `zmq_connect`, `zmq_send`, `zmq_recv`, and
 friends with the same ABI as libzmq, allowing C/C++ programs (and FFI bindings

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -207,6 +207,9 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
             // io threads already running; setting this is a no-op
         }
         ZMQ_MAX_SOCKETS => {
+            if value < 0 {
+                return crate::error::fail(libc::EINVAL);
+            }
             ctx.max_sockets.store(value, Ordering::Relaxed);
         }
         ZMQ_MAX_MSGSZ => {

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -317,8 +317,23 @@ pub extern "C" fn zmq_msg_get(msg: *const OmqMsgRepr, property: c_int) -> c_int 
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn zmq_msg_set(_msg: *mut OmqMsgRepr, _property: c_int, _val: c_int) -> c_int {
-    0
+pub extern "C" fn zmq_msg_set(msg: *mut OmqMsgRepr, property: c_int, val: c_int) -> c_int {
+    if msg.is_null() {
+        return crate::error::fail(libc::EFAULT);
+    }
+    // SAFETY: msg is non-null (checked above).
+    let r = unsafe { repr(msg) };
+    match property {
+        1 => {
+            r.more = u8::from(val != 0);
+            0
+        }
+        5 => {
+            r.reserved[0..4].copy_from_slice(&(val as u32).to_le_bytes());
+            0
+        }
+        _ => crate::error::fail(libc::EINVAL),
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -108,6 +108,9 @@ pub extern "C" fn zmq_msg_init_data(
     if msg.is_null() {
         return crate::error::fail(libc::EFAULT);
     }
+    if data.is_null() && size > 0 {
+        return crate::error::fail(libc::EFAULT);
+    }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
     r.kind = KIND_EXTERNAL;
@@ -130,6 +133,9 @@ pub extern "C" fn zmq_msg_init_buffer(
     buf: *const libc::c_void,
     size: usize,
 ) -> c_int {
+    if buf.is_null() && size > 0 {
+        return crate::error::fail(libc::EFAULT);
+    }
     if zmq_msg_init_size(msg, size) != 0 {
         return -1;
     }
@@ -261,6 +267,9 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
         KIND_HEAP | KIND_EXTERNAL => {
             // Deep copy into a new heap allocation.
             let size = s.size as usize;
+            if size > 0 && s.ptr.is_null() {
+                return crate::error::fail(libc::EFAULT);
+            }
             // SAFETY: libc::malloc is always safe to call.
             let new_ptr = unsafe { libc::malloc(size).cast::<u8>() };
             if size > 0 && new_ptr.is_null() {
@@ -415,6 +424,8 @@ pub extern "C" fn zmq_msg_send(
     let bytes = if r.kind == KIND_BYTES && !r.boxed.is_null() {
         // SAFETY: boxed was created by Box::into_raw in zmq_msg_recv; non-null.
         unsafe { &*(r.boxed.cast::<Bytes>()) }.clone()
+    } else if r.ptr.is_null() && r.size > 0 {
+        return crate::error::fail(libc::EFAULT);
     } else {
         extract_bytes(msg)
     };

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -282,6 +282,8 @@ const ZMQ_NULL: c_int = 0;
 const ZMQ_PLAIN: c_int = 1;
 const ZMQ_CURVE: c_int = 2;
 
+const DEFAULT_HANDSHAKE_IVL_MS: i32 = 30_000;
+
 #[expect(clippy::too_many_lines)]
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_setsockopt(
@@ -400,7 +402,7 @@ pub extern "C" fn zmq_setsockopt(
             lock_overlay!(sock_arc).handshake_ivl = if v <= 0 {
                 None
             } else {
-                Some(Duration::from_secs(v as u64))
+                Some(Duration::from_millis(v as u64))
             };
         }
         ZMQ_MAXMSGSIZE => {
@@ -902,7 +904,7 @@ pub extern "C" fn zmq_getsockopt(
         ZMQ_HANDSHAKE_IVL => {
             let v = lock_overlay!(sock_arc)
                 .handshake_ivl
-                .map_or(30, |d| d.as_secs() as i32);
+                .map_or(DEFAULT_HANDSHAKE_IVL_MS, |d| d.as_millis() as i32);
             write_i32(optval, optvallen, v)
         }
         ZMQ_MAXMSGSIZE => {
@@ -1278,4 +1280,36 @@ fn write_key(optval: *mut libc::c_void, optvallen: *mut usize, key: &[u8; 32]) -
         return 0;
     }
     crate::error::fail(libc::EINVAL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handshake_ivl_is_milliseconds_in_options() {
+        let overlay = SocketOverlay {
+            handshake_ivl: Some(Duration::from_millis(10)),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            overlay.to_options().handshake_timeout,
+            Some(Duration::from_millis(10))
+        );
+    }
+
+    #[test]
+    fn connect_timeout_caps_handshake_ivl_in_milliseconds() {
+        let overlay = SocketOverlay {
+            handshake_ivl: Some(Duration::from_secs(30)),
+            connect_timeout: 10,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            overlay.to_options().handshake_timeout,
+            Some(Duration::from_millis(10))
+        );
+    }
 }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -1184,7 +1184,7 @@ fn read_key(optval: *const libc::c_void, optvallen: usize) -> Option<[u8; 32]> {
 
 fn write_i32(optval: *mut libc::c_void, optvallen: *mut usize, val: i32) -> c_int {
     if optval.is_null() || optvallen.is_null() {
-        return 0;
+        return crate::error::fail(libc::EFAULT);
     }
     // SAFETY: optvallen is non-null (checked above); reading the available size.
     let avail = unsafe { *optvallen };
@@ -1201,7 +1201,7 @@ fn write_i32(optval: *mut libc::c_void, optvallen: *mut usize, val: i32) -> c_in
 
 fn write_i64(optval: *mut libc::c_void, optvallen: *mut usize, val: i64) -> c_int {
     if optval.is_null() || optvallen.is_null() {
-        return 0;
+        return crate::error::fail(libc::EFAULT);
     }
     // SAFETY: optvallen is non-null (checked above).
     let avail = unsafe { *optvallen };
@@ -1218,14 +1218,16 @@ fn write_i64(optval: *mut libc::c_void, optvallen: *mut usize, val: i64) -> c_in
 
 fn write_bytes(optval: *mut libc::c_void, optvallen: *mut usize, data: &[u8]) -> c_int {
     if optval.is_null() || optvallen.is_null() {
-        return 0;
+        return crate::error::fail(libc::EFAULT);
     }
     // SAFETY: optvallen is non-null (checked above).
     let avail = unsafe { *optvallen };
-    let copy_len = data.len().min(avail);
-    // SAFETY: optval is non-null with at least copy_len bytes available.
+    if avail < data.len() {
+        return crate::error::fail(libc::EINVAL);
+    }
+    // SAFETY: optval is non-null with at least data.len() bytes available.
     unsafe {
-        std::ptr::copy_nonoverlapping(data.as_ptr(), optval.cast::<u8>(), copy_len);
+        std::ptr::copy_nonoverlapping(data.as_ptr(), optval.cast::<u8>(), data.len());
         *optvallen = data.len();
     }
     0
@@ -1233,7 +1235,7 @@ fn write_bytes(optval: *mut libc::c_void, optvallen: *mut usize, data: &[u8]) ->
 
 fn write_string(optval: *mut libc::c_void, optvallen: *mut usize, data: &[u8]) -> c_int {
     if optval.is_null() || optvallen.is_null() {
-        return 0;
+        return crate::error::fail(libc::EFAULT);
     }
     // SAFETY: optvallen is non-null (checked above).
     let avail = unsafe { *optvallen };
@@ -1252,7 +1254,7 @@ fn write_string(optval: *mut libc::c_void, optvallen: *mut usize, data: &[u8]) -
 
 fn write_key(optval: *mut libc::c_void, optvallen: *mut usize, key: &[u8; 32]) -> c_int {
     if optval.is_null() || optvallen.is_null() {
-        return 0;
+        return crate::error::fail(libc::EFAULT);
     }
     // SAFETY: optvallen is non-null (checked above).
     let avail = unsafe { *optvallen };

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -1164,19 +1164,22 @@ fn read_key(optval: *const libc::c_void, optvallen: usize) -> Option<[u8; 32]> {
         // SAFETY: optval is non-null (checked above) and optvallen == 32.
         let slice = unsafe { std::slice::from_raw_parts(optval.cast::<u8>(), 32) };
         key.copy_from_slice(slice);
-    } else if optvallen >= 40 {
+        return Some(key);
+    }
+    if optvallen >= 40 {
         // SAFETY: optval is non-null (checked above) and optvallen >= 40.
         let slice = unsafe { std::slice::from_raw_parts(optval.cast::<u8>(), 40) };
         let Ok(s) = std::str::from_utf8(slice) else {
-            return Some(key);
+            return None;
         };
         if let Ok(decoded) = omq_tokio::proto::z85::decode(s)
             && decoded.len() == 32
         {
             key.copy_from_slice(&decoded);
+            return Some(key);
         }
     }
-    Some(key)
+    None
 }
 
 fn write_i32(optval: *mut libc::c_void, optvallen: *mut usize, val: i32) -> c_int {

--- a/omq-libzmq/src/poll.rs
+++ b/omq-libzmq/src/poll.rs
@@ -113,8 +113,12 @@ pub extern "C" fn zmq_poll(
         return crate::error::fail(libc::EFAULT);
     }
     let n = nitems as usize;
-    // SAFETY: items is non-null (checked above) with nitems elements.
-    let items_slice = unsafe { std::slice::from_raw_parts_mut(items, n) };
+    let items_slice = if n == 0 {
+        &mut []
+    } else {
+        // SAFETY: items is non-null (checked above) with nitems elements.
+        unsafe { std::slice::from_raw_parts_mut(items, n) }
+    };
 
     let ready = check_immediate(items_slice);
     if ready > 0 || timeout_ms == 0 {

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -265,6 +265,9 @@ pub extern "C" fn zmq_send(
     {
         return fail(ETERM);
     }
+    if buf.is_null() && len > 0 {
+        return fail(libc::EFAULT);
+    }
 
     let data = if buf.is_null() || len == 0 {
         &[]
@@ -304,6 +307,9 @@ pub extern "C" fn zmq_recv(
         .load(std::sync::atomic::Ordering::Acquire)
     {
         return fail(ETERM);
+    }
+    if buf.is_null() && buf_len > 0 {
+        return fail(libc::EFAULT);
     }
 
     zmq_recv_impl(sock, buf, buf_len, flags)

--- a/omq-libzmq/tests/basic.rs
+++ b/omq-libzmq/tests/basic.rs
@@ -54,6 +54,26 @@ fn caddr(s: &str) -> CString {
 }
 
 #[test]
+fn send_recv_null_nonzero_buffer_returns_efault() {
+    let ctx = zmq_ctx_new();
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+    let pull = zmq_socket(ctx, ZMQ_PULL);
+    assert!(!push.is_null() && !pull.is_null());
+
+    let rc = zmq_send(push, std::ptr::null(), 1, 0);
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    let rc = zmq_recv(pull, std::ptr::null_mut(), 1, ZMQ_DONTWAIT);
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    zmq_close(push);
+    zmq_close(pull);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn push_pull_inproc() {
     let ctx = zmq_ctx_new();
     let push = zmq_socket(ctx, ZMQ_PUSH);

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -64,6 +64,15 @@ fn ctx_set_max_sockets() {
 }
 
 #[test]
+fn ctx_set_negative_max_sockets_returns_einval() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_MAX_SOCKETS, -1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_MAX_SOCKETS), 1023);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn ctx_set_max_msgsz() {
     let ctx = zmq_ctx_new();
     assert_eq!(zmq_ctx_set(ctx, ZMQ_MAX_MSGSZ, 65536), 0);

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_getsockopt, zmq_msg_close,
     zmq_msg_copy, zmq_msg_data, zmq_msg_init, zmq_msg_init_buffer, zmq_msg_init_data,
-    zmq_msg_init_size, zmq_msg_more, zmq_msg_move, zmq_msg_recv, zmq_msg_send, zmq_msg_size,
-    zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
+    zmq_msg_init_size, zmq_msg_more, zmq_msg_move, zmq_msg_recv, zmq_msg_send, zmq_msg_set,
+    zmq_msg_size, zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
 };
 
 const ZMQ_PUSH: i32 = 8;
@@ -20,6 +20,8 @@ const ZMQ_PULL: i32 = 7;
 const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_RCVMORE: i32 = 13;
 const ZMQ_RCVTIMEO: i32 = 27;
+const ZMQ_MORE: i32 = 1;
+const ZMQ_ROUTING_ID: i32 = 5;
 
 // 64-byte opaque zmq_msg_t, aligned to pointer size (OmqMsgRepr has *mut u8 fields).
 #[repr(C, align(8))]
@@ -120,6 +122,28 @@ fn msg_move_and_copy_self_alias_are_noops() {
     let data = zmq_msg_data(m.0.as_mut_ptr().cast());
     let slice = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), payload.len()) };
     assert_eq!(slice, payload);
+
+    zmq_msg_close(m.0.as_mut_ptr().cast());
+}
+
+#[test]
+fn msg_set_handles_supported_and_invalid_properties() {
+    let mut m = ZmqMsg::new();
+
+    assert_eq!(zmq_msg_set(m.0.as_mut_ptr().cast(), ZMQ_MORE, 1), 0);
+    assert_eq!(zmq_msg_more(m.0.as_ptr().cast()), 1);
+
+    assert_eq!(
+        zmq_msg_set(m.0.as_mut_ptr().cast(), ZMQ_ROUTING_ID, 1234),
+        0
+    );
+    assert_eq!(omq_zmq::zmq_msg_routing_id(m.0.as_ptr().cast()), 1234);
+
+    assert_eq!(zmq_msg_set(m.0.as_mut_ptr().cast(), 9999, 1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    assert_eq!(zmq_msg_set(std::ptr::null_mut(), ZMQ_MORE, 1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
 
     zmq_msg_close(m.0.as_mut_ptr().cast());
 }

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -69,6 +69,28 @@ fn msg_init_size() {
 }
 
 #[test]
+fn msg_init_data_and_buffer_reject_null_nonzero_payload() {
+    let mut m = ZmqMsg([0u8; 64]);
+    assert_eq!(
+        zmq_msg_init_data(
+            m.0.as_mut_ptr().cast(),
+            std::ptr::null_mut(),
+            1,
+            None,
+            std::ptr::null_mut()
+        ),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    assert_eq!(
+        zmq_msg_init_buffer(m.0.as_mut_ptr().cast(), std::ptr::null(), 1),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+}
+
+#[test]
 fn msg_move_and_copy_self_alias_are_noops() {
     let payload = b"alias";
     let mut m = ZmqMsg([0u8; 64]);

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -157,6 +157,47 @@ fn identity_roundtrip() {
 }
 
 #[test]
+fn getsockopt_identity_small_buffer_returns_einval() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_DEALER);
+
+    assert_eq!(set_bytes(s, ZMQ_IDENTITY, b"my-dealer"), 0);
+
+    let mut buf = [0u8; 4];
+    let mut len = buf.len();
+    let rc = zmq_getsockopt(s, ZMQ_IDENTITY, buf.as_mut_ptr().cast(), &mut len);
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn getsockopt_null_output_returns_efault() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_PUSH);
+
+    let mut len = size_of::<i32>();
+    let rc = zmq_getsockopt(s, ZMQ_TYPE, std::ptr::null_mut(), &mut len);
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    let mut ty = 0i32;
+    let rc = zmq_getsockopt(
+        s,
+        ZMQ_TYPE,
+        (&mut ty as *mut i32).cast(),
+        std::ptr::null_mut(),
+    );
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn type_query() {
     let ctx = zmq_ctx_new();
 

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -263,7 +263,7 @@ fn handshake_ivl_roundtrip() {
     let ctx = zmq_ctx_new();
     let s = zmq_socket(ctx, ZMQ_PUSH);
 
-    assert_eq!(get_i32(s, ZMQ_HANDSHAKE_IVL), 30);
+    assert_eq!(get_i32(s, ZMQ_HANDSHAKE_IVL), 30_000);
 
     set_i32(s, ZMQ_HANDSHAKE_IVL, 10);
     assert_eq!(get_i32(s, ZMQ_HANDSHAKE_IVL), 10);

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -649,26 +649,41 @@ fn ipv6_req_rep() {
     zmq_ctx_term(ctx);
 }
 
-/// Non-UTF-8 bytes in a Z85 key slot must not cause UB.
-///
-/// Before the fix, `read_key` called `from_utf8_unchecked` on the raw
-/// C input, which is undefined behavior if the bytes are not valid UTF-8.
-/// The fix uses `from_utf8`, returning a zeroed key on invalid input.
+/// Non-UTF-8 bytes in a Z85 key slot must not cause UB or install a zero key.
 #[test]
-fn curve_key_non_utf8_does_not_crash() {
+fn curve_key_non_utf8_returns_einval() {
     let ctx = zmq_ctx_new();
     let s = zmq_socket(ctx, ZMQ_REQ);
 
     // 40 bytes with invalid UTF-8 (0xFF is never valid).
     let bad_z85 = [0xFFu8; 40];
-    set_bytes(s, ZMQ_CURVE_SERVERKEY, &bad_z85);
+    let rc = zmq_setsockopt(
+        s,
+        ZMQ_CURVE_SERVERKEY,
+        bad_z85.as_ptr().cast(),
+        bad_z85.len(),
+    );
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
 
-    // The key should remain zeroed (Z85 decode fails on non-UTF-8).
-    let mut out = [0xAA_u8; 32];
-    let mut sz = 32usize;
-    zmq_getsockopt(s, ZMQ_CURVE_SERVERKEY, out.as_mut_ptr().cast(), &mut sz);
-    assert_eq!(sz, 32);
-    assert_eq!(out, [0u8; 32]);
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn curve_key_short_z85_returns_einval() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_REQ);
+
+    let short_z85 = [b'0'; 39];
+    let rc = zmq_setsockopt(
+        s,
+        ZMQ_CURVE_SERVERKEY,
+        short_z85.as_ptr().cast(),
+        short_z85.len(),
+    );
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
 
     zmq_close(s);
     zmq_ctx_term(ctx);

--- a/omq-libzmq/tests/poll.rs
+++ b/omq-libzmq/tests/poll.rs
@@ -47,6 +47,12 @@ fn set_timeo(sock: *mut c_void, ms: i32) {
 }
 
 #[test]
+fn poll_null_items_zero_count_is_valid() {
+    let rc = zmq_poll(std::ptr::null_mut(), 0, 0);
+    assert_eq!(rc, 0);
+}
+
+#[test]
 fn poll_timeout_no_events() {
     let ctx = zmq_ctx_new();
     let pull = zmq_socket(ctx, ZMQ_PULL);

--- a/omq-proto/src/backoff.rs
+++ b/omq-proto/src/backoff.rs
@@ -29,16 +29,27 @@ pub fn next_delay(policy: &ReconnectPolicy, attempt: u32) -> Option<Duration> {
     }
 }
 
-/// Apply ±10% jitter to a duration. Zero stays zero.
+/// Apply ±10% jitter to a duration, rounded to whole milliseconds. Zero stays
+/// zero; any non-zero sub-millisecond delay is treated as 1 ms.
 pub fn jitter(d: Duration) -> Duration {
     if d.is_zero() {
         return d;
     }
     let mut rng = rand::rng();
-    let ns = d.as_nanos() as u64;
-    let delta = ns / 10;
+    let ms = d.as_millis().max(1);
+    let delta = ms / 10;
     let offset = rng.random_range(0..=2 * delta).saturating_sub(delta);
-    Duration::from_nanos(ns.saturating_add(offset))
+    duration_from_millis(ms.saturating_add(offset))
+}
+
+fn duration_from_millis(ms: u128) -> Duration {
+    const MILLIS_PER_SEC: u128 = 1_000;
+    let secs = ms / MILLIS_PER_SEC;
+    let millis = (ms % MILLIS_PER_SEC) as u32;
+    if secs > u128::from(u64::MAX) {
+        return Duration::new(u64::MAX, 999_000_000);
+    }
+    Duration::new(secs as u64, millis * 1_000_000)
 }
 
 #[cfg(test)]
@@ -88,5 +99,19 @@ mod tests {
     #[test]
     fn zero_duration_has_no_jitter() {
         assert_eq!(jitter(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn huge_duration_jitter_does_not_truncate_to_u64_nanos() {
+        let base = Duration::from_secs(u64::MAX / 1_000_000_000 + 1);
+        for _ in 0..10 {
+            let d = jitter(base);
+            assert!(d >= base * 9 / 10, "jittered duration truncated: {d:?}");
+        }
+    }
+
+    #[test]
+    fn sub_millisecond_jitter_rounds_up_to_one_millisecond() {
+        assert_eq!(jitter(Duration::from_micros(500)), Duration::from_millis(1));
     }
 }

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -434,6 +434,9 @@ fn parse_ws(rest: &str, tls: bool) -> Result<Endpoint> {
         None => (rest, "/"),
     };
     let (host, port) = parse_host_port(hp)?;
+    if path.bytes().any(|b| matches!(b, b'\r' | b'\n')) {
+        return Err(Error::InvalidEndpoint("invalid ws path".into()));
+    }
     let path = path.to_string();
     if tls {
         Ok(Endpoint::Wss { host, port, path })

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -194,7 +194,7 @@ impl Connection {
             && self.in_buf.len() >= hdr.header_len + hdr.payload_len
         {
             if let Some(max) = self.config.max_message_size
-                && hdr.payload_len > max
+                && hdr.payload_len.saturating_add(size_of::<Payload>()) > max
             {
                 return Err(Error::MessageTooLarge {
                     size: hdr.payload_len,
@@ -670,9 +670,18 @@ impl Connection {
             [0; 4]
         };
 
-        self.in_buf.advance(header_len);
-
         let zmtp_payload_len = ws_payload_len - 1;
+
+        if let Some(max) = self.config.max_message_size
+            && zmtp_payload_len.saturating_add(size_of::<Payload>()) > max
+        {
+            return Err(Error::MessageTooLarge {
+                size: zmtp_payload_len,
+                max,
+            });
+        }
+
+        self.in_buf.advance(header_len);
 
         let mut data = [0u8; crate::message::MAX_INLINE_MESSAGE];
 

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -433,6 +433,11 @@ impl Connection {
             return None;
         }
         let hdr = frame::peek_frame_header(&self.in_buf).ok().flatten()?;
+        if let Some(max) = self.config.max_message_size
+            && hdr.payload_len.saturating_add(size_of::<Payload>()) > max
+        {
+            return None;
+        }
         if self.in_buf.len() != hdr.header_len {
             return None;
         }
@@ -462,6 +467,11 @@ impl Connection {
             return None;
         }
         let hdr = frame::peek_frame_header(&self.in_buf).ok().flatten()?;
+        if let Some(max) = self.config.max_message_size
+            && hdr.payload_len.saturating_add(size_of::<Payload>()) > max
+        {
+            return None;
+        }
         if self.in_buf.len() < hdr.header_len {
             return None;
         }

--- a/omq-proto/src/proto/connection/mod.rs
+++ b/omq-proto/src/proto/connection/mod.rs
@@ -533,6 +533,34 @@ mod tests {
     }
 
     #[test]
+    fn begin_supplied_payload_refuses_oversized_header() {
+        let mut c = ready_connection(Some(500));
+        // Stage only the frame header directly; public handle_input rejects
+        // this earlier, before begin_supplied_payload is reachable.
+        let mut wire = BytesMut::new();
+        wire.put_u8(frame::FLAG_LONG);
+        wire.put_u64(1_000_000);
+        c.in_buf.push(wire.freeze());
+
+        assert!(c.begin_supplied_payload().is_none());
+        assert!(matches!(c.state, State::Ready));
+    }
+
+    #[test]
+    fn begin_supplied_payload_with_prefix_refuses_oversized_header() {
+        let mut c = ready_connection(Some(500));
+        // Include one buffered payload byte to exercise the prefix variant.
+        let mut wire = BytesMut::new();
+        wire.put_u8(frame::FLAG_LONG);
+        wire.put_u64(1_000_000);
+        wire.put_u8(0);
+        c.in_buf.push(wire.freeze());
+
+        assert!(c.begin_supplied_payload_with_prefix().is_none());
+        assert!(matches!(c.state, State::Ready));
+    }
+
+    #[test]
     fn peer_minor_downgrades_to_zero() {
         // Peer announces 3.0; we speak 3.1; effective minor should be 0.
         let mut c = Connection::new(ConnectionConfig::new(Role::Server, SocketType::Pull));

--- a/omq-proto/src/proto/ws_handshake.rs
+++ b/omq-proto/src/proto/ws_handshake.rs
@@ -29,6 +29,15 @@ pub fn validate_ws_accept(key: &str, accept: &str) -> bool {
     compute_ws_accept(key) == accept
 }
 
+fn valid_ws_key(key: &str) -> bool {
+    key.len() == 24
+        && key.bytes().enumerate().all(|(i, b)| {
+            matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/')
+                || (i >= 22 && b == b'=')
+        })
+        && key.ends_with("==")
+}
+
 /// Format a client HTTP upgrade request.
 pub fn format_client_upgrade(host: &str, path: &str, key: &str, subprotocol: &str) -> Vec<u8> {
     let mut req = Vec::with_capacity(256);
@@ -137,6 +146,9 @@ pub fn parse_client_upgrade(request: &[u8]) -> Result<UpgradeRequest> {
         ));
     }
     let key = key.ok_or_else(|| Error::HandshakeFailed("missing Sec-WebSocket-Key".into()))?;
+    if !valid_ws_key(&key) {
+        return Err(Error::HandshakeFailed("invalid Sec-WebSocket-Key".into()));
+    }
 
     Ok(UpgradeRequest {
         key,
@@ -369,6 +381,18 @@ mod tests {
         assert_eq!(parsed.key, "dGhlIHNhbXBsZSBub25jZQ==");
         assert_eq!(parsed.path, "/zmtp");
         assert_eq!(parsed.subprotocols, vec!["ZWS2.0/NULL", "ZWS2.0"]);
+    }
+
+    #[test]
+    fn parse_client_upgrade_rejects_invalid_key() {
+        let req = b"GET /zmtp HTTP/1.1\r\n\
+            Host: localhost:9000\r\n\
+            Upgrade: websocket\r\n\
+            Connection: Upgrade\r\n\
+            Sec-WebSocket-Key: not-a-valid-key\r\n\
+            Sec-WebSocket-Version: 13\r\n\
+            \r\n";
+        assert!(parse_client_upgrade(req).is_err());
     }
 
     #[test]

--- a/omq-proto/tests/connection.rs
+++ b/omq-proto/tests/connection.rs
@@ -7,7 +7,7 @@
 use bytes::Bytes;
 
 use omq_proto::error::Error;
-use omq_proto::message::Message;
+use omq_proto::message::{Message, Payload};
 use omq_proto::proto::SocketType;
 use omq_proto::proto::command::Command;
 use omq_proto::proto::connection::{Connection, ConnectionConfig, Event, Role};
@@ -172,6 +172,24 @@ fn oversized_message_rejected() {
     while b.poll_event().is_some() {}
 
     b.send_message(&Message::single("too-big-payload")).unwrap();
+    let bytes = b.poll_transmit();
+    b.advance_transmit(bytes.len());
+    let err = a.handle_input(bytes).unwrap_err();
+    assert!(matches!(err, Error::MessageTooLarge { .. }));
+}
+
+#[test]
+fn single_frame_fast_path_enforces_message_overhead_limit() {
+    let max = std::mem::size_of::<Payload>();
+    let mut a = Connection::new(
+        ConnectionConfig::new(Role::Client, SocketType::Pair).max_message_size(max),
+    );
+    let mut b = Connection::new(ConnectionConfig::new(Role::Server, SocketType::Pair));
+    pump(&mut a, &mut b);
+    while a.poll_event().is_some() {}
+    while b.poll_event().is_some() {}
+
+    b.send_message(&Message::single("x")).unwrap();
     let bytes = b.poll_transmit();
     b.advance_transmit(bytes.len());
     let err = a.handle_input(bytes).unwrap_err();
@@ -742,6 +760,29 @@ mod ws {
         pump_ws(&mut push, &mut pull);
         let msg = pull.poll_message().unwrap();
         assert_eq!(msg.part_bytes(0).unwrap(), &b"hello"[..]);
+    }
+
+    #[test]
+    fn ws_fast_path_enforces_message_overhead_limit() {
+        let max = std::mem::size_of::<Payload>();
+        let mut push = Connection::new(
+            ConnectionConfig::new(Role::Client, SocketType::Push)
+                .identity(Bytes::from_static(b"p"))
+                .ws_role(WsRole::Client),
+        );
+        let mut pull = Connection::new(
+            ConnectionConfig::new(Role::Server, SocketType::Pull)
+                .max_message_size(max)
+                .ws_role(WsRole::Server),
+        );
+        pump_ws(&mut push, &mut pull);
+        assert!(push.is_ready());
+        assert!(pull.is_ready());
+
+        push.send_message(&Message::single("x")).unwrap();
+        let bytes = push.poll_transmit();
+        let err = pull.handle_input(bytes).unwrap_err();
+        assert!(matches!(err, Error::MessageTooLarge { .. }));
     }
 
     #[test]

--- a/omq-proto/tests/endpoint.rs
+++ b/omq-proto/tests/endpoint.rs
@@ -253,6 +253,13 @@ fn ws_default_path() {
 
 #[test]
 #[cfg(feature = "ws")]
+fn ws_rejects_header_injection_path() {
+    assert!("ws://host:8080/ok\r\nX-Bad: 1".parse::<Endpoint>().is_err());
+    assert!("wss://host:443/ok\nX-Bad: 1".parse::<Endpoint>().is_err());
+}
+
+#[test]
+#[cfg(feature = "ws")]
 fn ws_wildcard_port() {
     let ep = parse("ws://*:*");
     assert!(matches!(

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -19,6 +19,7 @@ use rustc_hash::FxHashMap;
 use bytes::Bytes;
 
 use crate::engine::DriverHandle;
+use crate::engine::wire_slot::TryEncodeResult;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 use omq_proto::options::Options;
@@ -62,12 +63,21 @@ impl Submitter {
         &self,
         mut msg: Message,
     ) -> core::result::Result<(), omq_proto::error::TrySendError> {
+        let retry = msg.clone();
         let target = self
             .resolve_target(&mut msg)
             .map_err(omq_proto::error::TrySendError::Error)?;
 
         if let Some(t) = target {
-            let _ = t.try_encode(&msg);
+            match t.try_encode(&msg) {
+                TryEncodeResult::Ok => {}
+                TryEncodeResult::Full | TryEncodeResult::Ineligible => {
+                    return Err(omq_proto::error::TrySendError::Full(retry));
+                }
+                TryEncodeResult::Dead => {
+                    return Err(omq_proto::error::TrySendError::Closed);
+                }
+            }
         }
         Ok(())
     }
@@ -192,5 +202,57 @@ impl IdentityRecv {
             g.get(&peer_id).cloned().unwrap_or_default()
         };
         Message::with_prefix(identity, msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::engine::DriverCommand;
+
+    #[test]
+    fn try_send_reports_full_and_preserves_routing_frame() {
+        let mut send = IdentitySend::new(&Options::default());
+        let submitter = send.submitter();
+        let (tx, mut rx) = mpsc::channel(1);
+        send.connection_added(
+            1,
+            DriverHandle {
+                inbox: tx,
+                cancel: CancellationToken::new(),
+                wire_slot: None,
+                send_pipe: None,
+            },
+            Bytes::from_static(b"id"),
+        );
+
+        submitter
+            .try_send(Message::multipart([
+                Bytes::from_static(b"id"),
+                Bytes::from_static(b"one"),
+            ]))
+            .unwrap();
+
+        let returned = match submitter.try_send(Message::multipart([
+            Bytes::from_static(b"id"),
+            Bytes::from_static(b"two"),
+        ])) {
+            Err(omq_proto::error::TrySendError::Full(msg)) => msg,
+            other => panic!("expected Full, got {other:?}"),
+        };
+
+        assert_eq!(returned.part_bytes(0).unwrap(), &b"id"[..]);
+        assert_eq!(returned.part_bytes(1).unwrap(), &b"two"[..]);
+
+        match rx.try_recv().unwrap() {
+            DriverCommand::SendMessage(msg) => {
+                assert_eq!(msg.part_bytes(0).unwrap(), &b"one"[..]);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -343,6 +343,7 @@ impl SocketDriver {
         let tx_for_delay = tx.clone();
         let snapshot = self.inproc_snapshot();
         let recv_notify = self.spsc.recv_notify.clone();
+        let max_message_size = self.options.max_message_size;
         #[cfg(feature = "ws")]
         let accept_invalid_certs = self.options.wss_tls.accept_invalid_certs;
         #[cfg(feature = "ws")]
@@ -355,6 +356,7 @@ impl SocketDriver {
                         &ep_for_dial,
                         &snapshot,
                         &recv_notify,
+                        max_message_size,
                         #[cfg(feature = "ws")]
                         accept_invalid_certs,
                         #[cfg(feature = "ws")]

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -288,6 +288,7 @@ pub(super) async fn connect_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    max_message_size: Option<usize>,
     #[cfg(feature = "ws")] accept_invalid_certs: bool,
     #[cfg(feature = "ws")] mechanism: &omq_proto::MechanismSetup,
 ) -> Result<AnyConn> {
@@ -330,8 +331,13 @@ pub(super) async fn connect_any(
     }
     match endpoint {
         Endpoint::Inproc { name } => {
-            let conn =
-                inproc_transport::connect(name, snapshot.clone(), recv_notify.clone()).await?;
+            let conn = inproc_transport::connect(
+                name,
+                snapshot.clone(),
+                recv_notify.clone(),
+                max_message_size,
+            )
+            .await?;
             Ok(AnyConn::Inproc {
                 conn,
                 peer_ident: PeerIdent::Inproc(name.clone()),

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -93,6 +93,7 @@ struct InprocConnectRequest {
     connector_to_listener_rx: mpsc::Receiver<InboundFrame>,
     listener_to_connector_tx: mpsc::Sender<InboundFrame>,
     connector_recv_notify: Arc<tokio::sync::Notify>,
+    connector_max_message_size: Option<usize>,
     accept_ack: oneshot::Sender<(InprocPeerSnapshot, Option<Arc<InprocSpsc>>)>,
 }
 
@@ -141,6 +142,7 @@ pub async fn connect(
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_notify: Arc<tokio::sync::Notify>,
+    max_message_size: Option<usize>,
 ) -> Result<InprocConn> {
     let req_tx = {
         let reg = REGISTRY.lock().expect("inproc registry poisoned");
@@ -158,6 +160,7 @@ pub async fn connect(
         connector_to_listener_rx: c2l_rx,
         listener_to_connector_tx: l2c_tx,
         connector_recv_notify: recv_notify,
+        connector_max_message_size: max_message_size,
         accept_ack: ack_tx,
     };
 
@@ -208,6 +211,7 @@ impl InprocListener {
             connector_to_listener_rx,
             listener_to_connector_tx,
             connector_recv_notify,
+            connector_max_message_size,
             accept_ack,
         } = req;
         let spsc = if is_spsc_eligible(self.snapshot.socket_type, connector.socket_type) {
@@ -221,7 +225,7 @@ impl InprocListener {
             let mms = if listener_is_recv {
                 self.max_message_size
             } else {
-                None
+                connector_max_message_size
             };
             Some(Arc::new(InprocSpsc {
                 producer: Mutex::new(p),
@@ -273,7 +277,7 @@ mod tests {
         let mut l = bind("test-bca", snap(SocketType::Pull), notify(), None).unwrap();
         let n = notify();
         let connector =
-            tokio::spawn(async move { connect("test-bca", snap(SocketType::Push), n).await });
+            tokio::spawn(async move { connect("test-bca", snap(SocketType::Push), n, None).await });
         let server_side = l.accept().await.unwrap();
         let client_side = connector.await.unwrap().unwrap();
 
@@ -312,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn connect_without_bind_fails() {
         assert!(matches!(
-            connect("test-unbound", snap(SocketType::Push), notify()).await,
+            connect("test-unbound", snap(SocketType::Push), notify(), None).await,
             Err(Error::InvalidEndpoint(_))
         ));
     }

--- a/omq-tokio/src/transport/tcp.rs
+++ b/omq-tokio/src/transport/tcp.rs
@@ -51,10 +51,7 @@ impl Transport for TcpTransport {
                 "TCP transport got non-TCP endpoint: {endpoint}"
             )));
         };
-        let addr = resolve_connect(host, *port).await?;
-        let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        Ok(stream)
+        connect_any_resolved(resolve_connect(host, *port).await?).await
     }
 }
 
@@ -104,21 +101,47 @@ async fn resolve_bind(host: &Host, port: u16) -> Result<SocketAddr> {
     }
 }
 
-async fn resolve_connect(host: &Host, port: u16) -> Result<SocketAddr> {
+async fn resolve_connect(host: &Host, port: u16) -> Result<Vec<SocketAddr>> {
     match host {
         Host::Wildcard => Err(Error::InvalidEndpoint(
             "cannot connect to wildcard host".into(),
         )),
-        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
-        Host::Name(name) => resolve_first(&format!("{name}:{port}")).await,
+        Host::Ip(ip) => Ok(vec![SocketAddr::new(*ip, port)]),
+        Host::Name(name) => resolve_all(&format!("{name}:{port}")).await,
         _ => unreachable!(),
     }
 }
 
 async fn resolve_first(s: &str) -> Result<SocketAddr> {
-    let mut it = tokio::net::lookup_host(s).await?;
-    it.next()
+    resolve_all(s)
+        .await?
+        .into_iter()
+        .next()
         .ok_or_else(|| Error::Io(io::Error::other(format!("no addresses for {s}"))))
+}
+
+async fn resolve_all(s: &str) -> Result<Vec<SocketAddr>> {
+    let addrs: Vec<_> = tokio::net::lookup_host(s).await?.collect();
+    if addrs.is_empty() {
+        return Err(Error::Io(io::Error::other(format!("no addresses for {s}"))));
+    }
+    Ok(addrs)
+}
+
+async fn connect_any_resolved(addrs: Vec<SocketAddr>) -> Result<TcpStream> {
+    let mut last_err = None;
+    for addr in addrs {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => {
+                stream.set_nodelay(true)?;
+                return Ok(stream);
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(Error::Io(last_err.unwrap_or_else(|| {
+        io::Error::other("no addresses to connect")
+    })))
 }
 
 #[cfg(test)]
@@ -173,5 +196,22 @@ mod tests {
             TcpTransport::connect(&ep).await,
             Err(Error::InvalidEndpoint(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn connect_tries_later_resolved_address() {
+        let bad = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let bad_addr = bad.local_addr().unwrap();
+        let listener = TokioTcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let good_addr = listener.local_addr().unwrap();
+        drop(bad);
+
+        let connect = tokio::spawn(connect_any_resolved(vec![bad_addr, good_addr]));
+        let (_accepted, _) = listener.accept().await.unwrap();
+        let stream = connect.await.unwrap().unwrap();
+
+        assert_eq!(stream.peer_addr().unwrap(), good_addr);
     }
 }

--- a/omq-tokio/src/transport/udp.rs
+++ b/omq-tokio/src/transport/udp.rs
@@ -49,7 +49,7 @@ pub fn decode_datagram(data: &[u8]) -> Option<(Bytes, Bytes)> {
     if data.len() < 2 {
         return None;
     }
-    if data[0] & FLAG_DATA == 0 {
+    if data[0] != FLAG_DATA {
         return None;
     }
     let glen = data[1] as usize;
@@ -164,9 +164,9 @@ mod tests {
 
     #[test]
     fn decode_rejects_wrong_flag() {
-        // flags=0 isn't a data datagram.
-        let bytes = [0x00, 0x00];
-        assert!(decode_datagram(&bytes).is_none());
+        for bytes in [[0x00, 0x00], [0x03, 0x00], [0x81, 0x00]] {
+            assert!(decode_datagram(&bytes).is_none());
+        }
     }
 
     #[tokio::test]

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -240,21 +240,28 @@ pub(crate) async fn connect(
     accept_invalid_certs: bool,
     mechanism: &omq_proto::MechanismSetup,
 ) -> Result<WsConnected> {
-    let addr = match host {
+    let addrs = match host {
         omq_proto::endpoint::Host::Wildcard => {
             return Err(Error::InvalidEndpoint(
                 "cannot connect to wildcard host".into(),
             ));
         }
-        omq_proto::endpoint::Host::Ip(ip) => SocketAddr::new(*ip, port),
-        omq_proto::endpoint::Host::Name(name) => tokio::net::lookup_host(format!("{name}:{port}"))
-            .await
-            .map_err(Error::Io)?
-            .next()
-            .ok_or_else(|| Error::InvalidEndpoint(format!("DNS lookup failed for {name}")))?,
+        omq_proto::endpoint::Host::Ip(ip) => vec![SocketAddr::new(*ip, port)],
+        omq_proto::endpoint::Host::Name(name) => {
+            let addrs: Vec<_> = tokio::net::lookup_host(format!("{name}:{port}"))
+                .await
+                .map_err(Error::Io)?
+                .collect();
+            if addrs.is_empty() {
+                return Err(Error::InvalidEndpoint(format!(
+                    "DNS lookup failed for {name}"
+                )));
+            }
+            addrs
+        }
         _ => unreachable!(),
     };
-    let stream = TcpStream::connect(addr).await.map_err(Error::Io)?;
+    let stream = connect_any_resolved(addrs).await?;
     let _ = stream.set_nodelay(true);
 
     let mut transport = if tls {
@@ -314,6 +321,19 @@ pub(crate) async fn connect(
         transport,
         leftover,
     })
+}
+
+async fn connect_any_resolved(addrs: Vec<SocketAddr>) -> Result<TcpStream> {
+    let mut last_err = None;
+    for addr in addrs {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(Error::Io(last_err.unwrap_or_else(|| {
+        std::io::Error::other("no addresses to connect")
+    })))
 }
 
 fn build_tls_connector(accept_invalid_certs: bool) -> Result<tokio_rustls::TlsConnector> {

--- a/omq-tokio/tests/options_polish.rs
+++ b/omq-tokio/tests/options_polish.rs
@@ -91,6 +91,28 @@ async fn max_message_size_rejects_oversize() {
 }
 
 #[tokio::test]
+async fn max_message_size_rejects_oversize_when_receiver_connects_inproc() {
+    let ep = inproc_ep("opt-mms-connect-recv");
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.bind(ep.clone()).await.unwrap();
+
+    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(8));
+    pull.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push.send(Message::single("12345678")).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_millis(500), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().len(), 8);
+
+    push.send(Message::single("123456789")).await.unwrap();
+    let r = tokio::time::timeout(Duration::from_millis(200), pull.recv()).await;
+    assert!(r.is_err(), "oversize must not be delivered");
+}
+
+#[tokio::test]
 async fn drop_newest_silently_discards_overflow() {
     // HWM=1, DropNewest. Sender pushes 3 messages; only the first survives.
     let ep = inproc_ep("opt-drop-new");

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -79,15 +79,20 @@ impl<T> Ring<T> {
     }
 
     #[inline]
+    fn distance(from: usize, to: usize) -> usize {
+        from.wrapping_sub(to)
+    }
+
+    #[inline]
     pub(crate) fn push(
         &self,
         cursor: &mut usize,
         cached_head: &mut usize,
         val: T,
     ) -> Result<(), T> {
-        if *cursor - *cached_head >= self.capacity() {
+        if Self::distance(*cursor, *cached_head) >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            if *cursor - *cached_head >= self.capacity() {
+            if Self::distance(*cursor, *cached_head) >= self.capacity() {
                 return Err(val);
             }
         }
@@ -96,7 +101,7 @@ impl<T> Ring<T> {
         self.buf[*cursor & self.mask].with_mut(|ptr| unsafe {
             (*ptr).write(val);
         });
-        *cursor += 1;
+        *cursor = cursor.wrapping_add(1);
         Ok(())
     }
 
@@ -106,7 +111,7 @@ impl<T> Ring<T> {
         if cursor == prev_tail {
             return FlushResult::NothingToFlush;
         }
-        let count = cursor - prev_tail;
+        let count = Self::distance(cursor, prev_tail);
         *cached_head = self.head.0.load(Ordering::Acquire);
         let was_empty = prev_tail == *cached_head;
         self.tail.0.store(cursor, Ordering::Release);
@@ -115,9 +120,9 @@ impl<T> Ring<T> {
 
     #[inline]
     pub(crate) fn is_full(&self, cursor: usize, cached_head: &mut usize) -> bool {
-        if cursor - *cached_head >= self.capacity() {
+        if Self::distance(cursor, *cached_head) >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            cursor - *cached_head >= self.capacity()
+            Self::distance(cursor, *cached_head) >= self.capacity()
         } else {
             false
         }
@@ -141,7 +146,7 @@ impl<T> Ring<T> {
         // SAFETY: head < cached_tail, so this slot was written by the
         // producer and made visible via flush (Release store).
         let val = self.buf[*head & self.mask].with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
-        *head += 1;
+        *head = head.wrapping_add(1);
         Some(val)
     }
 
@@ -183,12 +188,14 @@ impl<T> Ring<T> {
         // Advance head before the loop so a panicking T::drop cannot
         // cause a second call to re-drop the same items.
         self.head.0.store(tail, Ordering::Relaxed);
-        for i in head..tail {
+        let mut i = head;
+        while i != tail {
             // SAFETY: &mut self guarantees exclusive access. Slots
             // [head..tail] were written by the producer and flushed.
             self.buf[i & self.mask].with_mut(|ptr| unsafe {
                 (*ptr).assume_init_drop();
             });
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -529,6 +536,36 @@ mod tests {
     }
 
     #[test]
+    fn counters_wrap_without_panicking() {
+        let (mut p, mut c) = spsc::<u32>(4);
+        p.cursor = usize::MAX - 1;
+        p.cached_head = usize::MAX - 1;
+        c.head = usize::MAX - 1;
+        c.cached_tail = usize::MAX - 1;
+        p.ring.head.0.store(usize::MAX - 1, Ordering::Relaxed);
+        p.ring.tail.0.store(usize::MAX - 1, Ordering::Relaxed);
+
+        p.push(1).unwrap();
+        p.push(2).unwrap();
+        p.push(3).unwrap();
+        assert_eq!(
+            p.flush_and_check(),
+            FlushResult::Flushed {
+                count: 3,
+                was_empty: true
+            }
+        );
+
+        assert_eq!(c.prefetch(), 3);
+        assert_eq!(c.pop(), Some(1));
+        assert_eq!(c.pop(), Some(2));
+        assert_eq!(c.pop(), Some(3));
+        assert_eq!(c.pop(), None);
+        c.release();
+        assert!(p.is_empty());
+    }
+
+    #[test]
     fn drop_remaining() {
         use std::sync::atomic::AtomicUsize;
         static DROPS: AtomicUsize = AtomicUsize::new(0);
@@ -541,6 +578,36 @@ mod tests {
         }
         DROPS.store(0, Ordering::Relaxed);
         let (mut p, c) = spsc::<Counted>(4);
+        p.push(Counted).unwrap();
+        p.push(Counted).unwrap();
+        p.push(Counted).unwrap();
+        p.flush();
+        drop(p);
+        drop(c);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn drop_remaining_handles_wrapped_counters() {
+        use std::sync::atomic::AtomicUsize;
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+        #[derive(Debug)]
+        struct Counted;
+        impl Drop for Counted {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        DROPS.store(0, Ordering::Relaxed);
+        let (mut p, mut c) = spsc::<Counted>(4);
+        p.cursor = usize::MAX - 1;
+        p.cached_head = usize::MAX - 1;
+        c.head = usize::MAX - 1;
+        c.cached_tail = usize::MAX - 1;
+        p.ring.head.0.store(usize::MAX - 1, Ordering::Relaxed);
+        p.ring.tail.0.store(usize::MAX - 1, Ordering::Relaxed);
+
         p.push(Counted).unwrap();
         p.push(Counted).unwrap();
         p.push(Counted).unwrap();

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -57,7 +57,9 @@ unsafe impl<T: Send> Sync for Ring<T> {}
 impl<T> Ring<T> {
     pub(crate) fn new(capacity: usize) -> Self {
         assert!(capacity > 0, "capacity must be > 0");
-        let cap = capacity.next_power_of_two();
+        let cap = capacity
+            .checked_next_power_of_two()
+            .expect("capacity must fit in the next power of two");
         let buf: Vec<UnsafeCell<MaybeUninit<T>>> = (0..cap)
             .map(|_| UnsafeCell::new(MaybeUninit::uninit()))
             .collect();
@@ -518,6 +520,12 @@ mod tests {
         assert_eq!(p.capacity(), 8);
         let (p, _c) = spsc::<u8>(1);
         assert_eq!(p.capacity(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must fit in the next power of two")]
+    fn capacity_overflow_panics_with_message() {
+        let _ = spsc::<u8>(usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
- harden `omq-proto` size guards, UDP reserved flags, WebSocket handshakes, and reconnect jitter duration handling
- harden `omq-tokio`, `omq-compio`, `omq-libzmq`, `blume`, and `yring` panic/edge cases found during audit
- fix `omq-libzmq` `ZMQ_HANDSHAKE_IVL` unit handling to use libzmq-compatible milliseconds
- make named TCP/WS connects try all resolved addresses before failing
- keep public API shapes unchanged; behavior changes reject invalid input or propagate existing backpressure/error states more accurately
- fix stale `omq-libzmq` README backend wording