### PR TITLE
New features, tests, and docs

### DIFF
--- a/bindings/pyomq/src/conversions.rs
+++ b/bindings/pyomq/src/conversions.rs
@@ -63,7 +63,11 @@ pub fn message_from_pylist(parts: &Bound<'_, PyAny>) -> PyResult<Message> {
     let collected: Vec<Bytes> = it
         .map(|part| bytes_from_pyany(&part?))
         .collect::<PyResult<_>>()?;
-    Ok(Message::multipart(collected))
+    Ok(match collected.len() {
+        0 => Message::new(),
+        1 => Message::single(collected.into_iter().next().unwrap()),
+        _ => Message::multipart(collected),
+    })
 }
 
 /// Return a Python list of bytes - one per message frame.

--- a/bindings/pyomq/src/dispatch.rs
+++ b/bindings/pyomq/src/dispatch.rs
@@ -21,8 +21,7 @@ where
 {
     let sock = inner.ensure_socket()?;
     let ctx = inner.ctx.clone();
-    py.detach(|| ctx.with_socket(&sock, op))
-        .map_err(map_err)
+    py.detach(|| ctx.with_socket(&sock, op)).map_err(map_err)
 }
 
 /// Like `sync_unit` but returns a `String`.
@@ -37,8 +36,7 @@ where
 {
     let sock = inner.ensure_socket()?;
     let ctx = inner.ctx.clone();
-    py.detach(|| ctx.with_socket(&sock, op))
-        .map_err(map_err)
+    py.detach(|| ctx.with_socket(&sock, op)).map_err(map_err)
 }
 
 /// Async version: spawn a `Result<()>`-returning op via an asyncio.Future.

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -829,9 +829,10 @@ pub fn getsockopt<'py>(
         | constants::TCP_MAXRT
         | constants::MULTICAST_HOPS
         | constants::RECOVERY_IVL => Ok(int_to_bound(py, 0_i64)),
-        constants::RECONNECT_STOP => {
-            Ok(int_to_bound(py, i64::from(sock.overlay.lock().unwrap().reconnect_stop)))
-        }
+        constants::RECONNECT_STOP => Ok(int_to_bound(
+            py,
+            i64::from(sock.overlay.lock().unwrap().reconnect_stop),
+        )),
         constants::FD => {
             sock.materialize()?;
             let mat = sock.materialized.read().unwrap();

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -76,6 +76,7 @@ pub struct Overlay {
     pub on_mute: OnMute,
     pub compression_dict: Option<Bytes>,
     pub compression_auto_train: bool,
+    pub reconnect_stop: i32,
 }
 
 impl Default for Overlay {
@@ -120,6 +121,7 @@ impl Default for Overlay {
             on_mute: OnMute::Block,
             compression_dict: None,
             compression_auto_train: true,
+            reconnect_stop: 0,
         }
     }
 }
@@ -154,6 +156,7 @@ impl Overlay {
             compression_auto_train: self.compression_auto_train,
             arena_threshold: Some(64 * 1024),
             transmit_slot_cap: None,
+            reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             ..Default::default()
         };
         #[cfg(feature = "plain")]
@@ -301,6 +304,7 @@ impl Overlay {
             on_mute: o.on_mute,
             compression_dict: o.compression_dict.clone(),
             compression_auto_train: o.compression_auto_train,
+            reconnect_stop: i32::from(o.reconnect_stop_conn_refused),
         }
     }
 }
@@ -529,8 +533,11 @@ pub fn setsockopt(
         | constants::TCP_MAXRT
         | constants::MULTICAST_HOPS
         | constants::RECOVERY_IVL
-        | constants::RECONNECT_STOP
         | constants::ZAP_DOMAIN => {}
+        constants::RECONNECT_STOP => {
+            let v: i32 = value.extract()?;
+            sock.overlay.lock().unwrap().reconnect_stop = v;
+        }
         constants::AFFINITY => return Err(not_implemented("AFFINITY")),
         constants::BACKLOG => return Err(not_implemented("BACKLOG")),
         constants::TYPE | constants::RCVMORE => return Err(not_implemented("read-only option")),
@@ -821,8 +828,10 @@ pub fn getsockopt<'py>(
         | constants::ROUTER_HANDOVER
         | constants::TCP_MAXRT
         | constants::MULTICAST_HOPS
-        | constants::RECOVERY_IVL
-        | constants::RECONNECT_STOP => Ok(int_to_bound(py, 0_i64)),
+        | constants::RECOVERY_IVL => Ok(int_to_bound(py, 0_i64)),
+        constants::RECONNECT_STOP => {
+            Ok(int_to_bound(py, i64::from(sock.overlay.lock().unwrap().reconnect_stop)))
+        }
         constants::FD => {
             sock.materialize()?;
             let mat = sock.materialized.read().unwrap();

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -244,6 +244,7 @@ impl ContextInner {
         };
         let (otx, orx) = flume::bounded(1);
         handle.spawn(async move {
+            let _ = tokio::time::timeout(Duration::from_secs(1), recv_pump).await;
             let _ = tokio::time::timeout(Duration::from_secs(1), send_pump).await;
             let s = Arc::try_unwrap(sock).unwrap_or_else(|arc| (*arc).clone());
             let _ = tokio::time::timeout(Duration::from_secs(1), s.close()).await;

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -271,8 +271,12 @@ impl SocketInner {
             return None;
         }
         let mut buf = self.sndbuf.lock().unwrap();
-        let parts: Vec<Bytes> = buf.parts.drain(..).chain(std::iter::once(bytes)).collect();
-        Some(omq_tokio::Message::multipart(parts))
+        if buf.parts.is_empty() {
+            Some(omq_tokio::Message::single(bytes))
+        } else {
+            let parts: Vec<Bytes> = buf.parts.drain(..).chain(std::iter::once(bytes)).collect();
+            Some(omq_tokio::Message::multipart(parts))
+        }
     }
 
     /// Pop the head of any leftover RCVMORE frames; `Some` when one
@@ -561,17 +565,14 @@ impl Socket {
     fn recv_multipart<'py>(&self, py: Python<'py>, flags: i32) -> PyResult<Bound<'py, PyList>> {
         let leftover = self.inner.take_rxbuf();
         if !leftover.is_empty() {
-            return Ok(PyList::new(
-                py,
-                leftover.into_iter().map(|b| PyBytes::new(py, &b)),
-            )?);
+            return PyList::new(py, leftover.into_iter().map(|b| PyBytes::new(py, &b)));
         }
         let msg = if flags & crate::constants::NOBLOCK != 0 {
             self.try_recv_message()?
         } else {
             self.recv_message(py)?
         };
-        Ok(conversions::parts_to_pylist(py, msg)?)
+        conversions::parts_to_pylist(py, msg)
     }
 
     fn subscribe(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<()> {
@@ -612,7 +613,7 @@ impl Socket {
             .iter()
             .map(|cs| crate::socket::connection_status_to_dict(py, cs))
             .collect::<PyResult<Vec<Bound<'py, PyDict>>>>()?;
-        Ok(PyList::new(py, temp)?)
+        PyList::new(py, temp)
     }
 
     /// Return a dict for the peer with the given `connection_id`, or

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -226,7 +226,7 @@ impl AsyncSocket {
             .iter()
             .map(|cs| crate::socket::connection_status_to_dict(py, cs))
             .collect::<PyResult<Vec<Bound<'py, PyDict>>>>()?;
-        Ok(PyList::new(py, temp)?)
+        PyList::new(py, temp)
     }
 
     fn connection_info<'py>(

--- a/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
+++ b/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
@@ -114,10 +114,10 @@ def test_pub_sub_throughput():
     for i, count in enumerate(recv_counts):
         assert count > 0, f"sub[{i}] received nothing"
 
-    report = monitor.stop()
-    report.assert_no_leak("pub_sub_throughput")
-
     for s in subs:
         s.close()
     pub.close()
     ctx.term()
+
+    report = monitor.stop()
+    report.assert_no_leak("pub_sub_throughput")

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -76,9 +76,11 @@ traffic. Larger single-part messages use `Bytes`; multipart messages use
 
 `FrameBuffer` is the outbound framing buffer: a 256 KiB arena plus an entry list.
 Frame headers always go into the arena. Small messages below `ARENA_THRESHOLD`
-encode header and payload contiguously into the arena. Large messages write
-the header into the arena and keep payload `Bytes` as external entries for
-gather write.
+(8 KiB) encode header and payload contiguously into the arena. Large messages
+write the header into the arena and keep payload `Bytes` as external entries
+for gather write. The arena tracks its peak capacity so that after
+`split().freeze()` reclaims the buffer, the next reserve pre-allocates at full
+size instead of cascading through doubling copies.
 
 `PeerTransmitSlot` wraps `FrameBuffer` in a short-held `std::sync::Mutex`, capped
 at 512 KiB (close to the kernel TCP send buffer). Socket handles encode into
@@ -105,11 +107,15 @@ it before newer pipe-fed sends, so messages queued before handshake are not
 overtaken.
 
 Fan-out sockets (`PUB`, `XPUB`, `RADIO`) encode once and distribute matching
-wire bytes. Wide multi-thread fan-out may use shard workers. Each shard owns
-its peer filter state, pushes encoded items into peer rings, then signals
-touched peers once per batch. Fan-out sockets drop on mute; `OnMute::Block`
-does not make `PUB` or `XPUB` wait. `xpub_nodrop` stays on the direct
-backpressure path.
+wire bytes. Wide multi-thread fan-out uses shard workers. Each shard has
+split channels: a `yring` control channel for subscribe, cancel, add-peer,
+remove-peer, and shutdown commands, and a `yring` data channel for encoded
+dispatches. The worker drains all control commands unconditionally every
+iteration, then drains data dispatches up to `DrainBudget::WORKER` (256
+messages / 2 MiB). This separation guarantees control commands are reachable
+within bounded time regardless of data throughput. Fan-out sockets drop on
+mute; `OnMute::Block` does not make `PUB` or `XPUB` wait. `xpub_nodrop`
+stays on the direct backpressure path.
 
 Identity-routed sockets (`ROUTER`, `REP`, `SERVER`, `PEER`) route by peer
 identity. Exclusive sockets (`PAIR`, `CHANNEL`) target one peer. Fair-queue
@@ -122,6 +128,27 @@ send pipes and deliver `InboundFrame::Message` through `inproc_peer_driver`.
 Same-thread paths use `blume` batching where applicable. Public semantics
 remain the same: HWM backpressure, round-robin fairness, and
 connect-before-bind.
+
+## Drain Budgets And Signaling
+
+Every loop that drains a channel or queue is capped by `DrainBudget`: both a
+message count and a byte count. Unbounded drains would starve the tokio runtime
+and other tasks. Standard presets: `DrainBudget::WORKER` (256 messages / 2 MiB)
+for shard workers and deferred fan-out, `DrainBudget::WIRE_DRAIN` (1024 / 1
+MiB) for wire-slot drain.
+
+All producer-to-consumer signaling uses `DataSignal`, an atomic flag plus
+`Notify`. `mark()` fires `notify_one` only on the `false`-to-`true` transition.
+The consumer `clear()`s before draining, then `rearm_if_nonempty()` to self-wake
+if data remains. `reschedule()` fires unconditionally for budget-interrupted
+drains where the consumer already knows data remains. Wire slot, send pipe,
+drop queue, and shard workers all use `DataSignal`.
+
+Control commands (subscribe, cancel, add-peer, remove-peer, shutdown) travel on
+dedicated channels separate from data. Shard workers, for example, drain all
+control commands unconditionally before draining data up to budget. This
+guarantees control latency is bounded by one data budget drain, not by queue
+depth.
 
 ## Transports
 

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -59,6 +59,7 @@ pub(crate) struct SocketOverlay {
     pub req_correlate: bool,
     pub req_relaxed: bool,
     pub xpub_nodrop: bool,
+    pub reconnect_stop: i32,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -153,6 +154,7 @@ impl SocketOverlay {
             recv_buffer_size: self.rcvbuf,
             mechanism,
             xpub_nodrop: self.xpub_nodrop,
+            reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             ..Default::default()
         }
     }
@@ -641,6 +643,12 @@ pub extern "C" fn zmq_setsockopt(
             };
             lock_overlay!(sock_arc).xpub_nodrop = v != 0;
         }
+        ZMQ_RECONNECT_STOP => {
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).reconnect_stop = v;
+        }
         #[expect(clippy::match_same_arms)]
         ZMQ_AFFINITY
         | ZMQ_RATE
@@ -698,7 +706,6 @@ pub extern "C" fn zmq_setsockopt(
         | ZMQ_WSS_HOSTNAME
         | ZMQ_WSS_TRUST_SYSTEM
         | ZMQ_ONLY_FIRST_SUBSCRIBE
-        | ZMQ_RECONNECT_STOP
         | ZMQ_HELLO_MSG
         | ZMQ_DISCONNECT_MSG
         | ZMQ_PRIORITY
@@ -1061,6 +1068,7 @@ pub extern "C" fn zmq_getsockopt(
             optvallen,
             i32::from(lock_overlay!(sock_arc).xpub_nodrop),
         ),
+        ZMQ_RECONNECT_STOP => write_i32(optval, optvallen, lock_overlay!(sock_arc).reconnect_stop),
         ZMQ_IPV4ONLY => write_i32(optval, optvallen, i32::from(!lock_overlay!(sock_arc).ipv6)),
         ZMQ_MULTICAST_MAXTPDU => write_i32(optval, optvallen, 1500),
         ZMQ_USE_FD => write_i32(optval, optvallen, -1),
@@ -1095,7 +1103,6 @@ pub extern "C" fn zmq_getsockopt(
         | ZMQ_OUT_BATCH_SIZE
         | ZMQ_WSS_TRUST_SYSTEM
         | ZMQ_ONLY_FIRST_SUBSCRIBE
-        | ZMQ_RECONNECT_STOP
         | ZMQ_PRIORITY
         | ZMQ_BUSY_POLL
         | ZMQ_XSUB_VERBOSE_UNSUBSCRIBE

--- a/omq-proto/src/error.rs
+++ b/omq-proto/src/error.rs
@@ -50,6 +50,12 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
+impl Error {
+    pub fn is_connection_refused(&self) -> bool {
+        matches!(self, Self::Io(e) if e.kind() == std::io::ErrorKind::ConnectionRefused)
+    }
+}
+
 /// Error returned by `Socket::try_send`.
 #[derive(Debug)]
 pub enum TrySendError {

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -341,7 +341,14 @@ impl Message {
     {
         let payloads: Vec<Payload> = parts
             .into_iter()
-            .map(|p| Payload::from_bytes(p.into()))
+            .map(|p| {
+                let b = p.into();
+                if b.len() <= MAX_INLINE_PAYLOAD {
+                    Payload::from_slice(&b)
+                } else {
+                    Payload::from_bytes(b)
+                }
+            })
             .collect();
         match payloads.len() {
             0 => Self::new(),
@@ -966,6 +973,21 @@ mod tests {
         assert_eq!(m.len(), 3);
         assert_eq!(m.byte_len(), 6);
         assert_eq!(m.part_bytes(1).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn message_multipart_inlines_small_parts() {
+        let m = Message::multipart([
+            Bytes::from_static(b"a"),
+            Bytes::copy_from_slice(&[b'b'; MAX_INLINE_PAYLOAD]),
+            Bytes::copy_from_slice(&[b'c'; MAX_INLINE_PAYLOAD + 1]),
+        ]);
+        let MessageInner::Multi(parts) = &m.inner else {
+            panic!("expected multipart");
+        };
+        assert!(matches!(parts[0].inner, PayloadInner::Inline { .. }));
+        assert!(matches!(parts[1].inner, PayloadInner::Inline { .. }));
+        assert!(matches!(parts[2].inner, PayloadInner::Single(_)));
     }
 
     #[test]

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -166,6 +166,9 @@ pub struct Options {
     /// transmit slot is at capacity.
     pub xpub_nodrop: bool,
 
+    /// Stop reconnecting on `ECONNREFUSED` (`ZMQ_RECONNECT_STOP`).
+    pub reconnect_stop_conn_refused: bool,
+
     /// TLS configuration for `wss://` endpoints. Ignored for non-WSS
     /// transports. Requires the `ws` feature.
     #[cfg(feature = "ws")]
@@ -217,6 +220,7 @@ impl Default for Options {
             arena_threshold: None,
             transmit_slot_cap: None,
             xpub_nodrop: false,
+            reconnect_stop_conn_refused: false,
             #[cfg(feature = "ws")]
             wss_tls: WssTls::default(),
         }
@@ -323,6 +327,12 @@ impl Options {
     #[must_use]
     pub fn reconnect(mut self, policy: ReconnectPolicy) -> Self {
         self.reconnect = policy;
+        self
+    }
+
+    #[must_use]
+    pub fn reconnect_stop_conn_refused(mut self, stop: bool) -> Self {
+        self.reconnect_stop_conn_refused = stop;
         self
     }
 

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -1,12 +1,13 @@
 #[cfg(feature = "ws")]
 use super::AnyListener;
 use super::{
-    Canceled, ConnectionStatus, DialerEntry, Duration, Endpoint, Error, InternalEvent,
-    ListenerEntry, MonitorEvent, PeerIdent, Result, SocketDriver, SocketType, UdpDialerEntry,
-    UdpListenerEntry, bind_any, connect_any, dial_with_backoff, fake_handle, mpsc,
+    Canceled, ConnectionStatus, DialerEntry, DisconnectReason, Duration, Endpoint, Error,
+    InternalEvent, ListenerEntry, MonitorEvent, PeerIdent, Result, SocketDriver, SocketType,
+    UdpDialerEntry, UdpListenerEntry, bind_any, connect_any, dial_with_backoff, fake_handle, mpsc,
     reject_encrypted_inproc, spawn_dish_listener, spawn_radio_sender, supports_groups,
     supports_subscribe,
 };
+use crate::socket::actor::lifecycle::PeerLifecycle;
 
 impl SocketDriver {
     pub(super) fn unbind(&mut self, endpoint: &Endpoint) -> Result<()> {
@@ -34,12 +35,12 @@ impl SocketDriver {
         }
     }
 
-    /// Tear down dialer(s) targeting `endpoint`. The dial loop, including
-    /// any in-flight reconnect backoff, is canceled. Already-handshaked
-    /// peers from this dialer are not closed (they belong to `peers` and
-    /// outlive the dialer). Returns `Error::Unroutable` if no dialer
-    /// matches.
-    pub(super) fn disconnect(&mut self, endpoint: &Endpoint) -> Result<()> {
+    /// Tear down dialer(s) and live outbound peers targeting `endpoint`.
+    ///
+    /// The dial loop, any in-flight reconnect backoff, and already-
+    /// handshaked client-side peer tasks are stopped. Returns
+    /// `Error::Unroutable` if no dialer or live client peer matches.
+    pub(super) async fn disconnect(&mut self, endpoint: &Endpoint) -> Result<()> {
         let before = self.dialers.len() + self.udp_dialers.len();
         self.dialers.retain(|d| {
             if &d.endpoint == endpoint {
@@ -61,10 +62,47 @@ impl SocketDriver {
                 true
             }
         });
+        let removed_udp_peers = removed_peers.len();
         for pid in removed_peers {
             self.send_strategy.connection_removed(pid);
         }
-        if self.dialers.len() + self.udp_dialers.len() < before {
+
+        let peer_ids: Vec<u64> = self
+            .peers
+            .iter()
+            .filter_map(|(id, peer)| {
+                if peer.is_client && &peer.endpoint == endpoint {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let removed_live_peers = peer_ids.len();
+        let mut peer_tasks = Vec::with_capacity(peer_ids.len());
+        for peer_id in peer_ids {
+            if let Some(mut peer) =
+                PeerLifecycle::new(self).remove_peer(peer_id, DisconnectReason::LocalClose)
+            {
+                peer.handle.cancel.cancel();
+                if let Some(task) = peer.task.take() {
+                    peer_tasks.push(task);
+                }
+            }
+        }
+        for task in &peer_tasks {
+            if !task.is_finished() {
+                task.abort();
+            }
+        }
+        for task in peer_tasks {
+            let _ = task.await;
+        }
+
+        if self.dialers.len() + self.udp_dialers.len() < before
+            || removed_udp_peers > 0
+            || removed_live_peers > 0
+        {
             Ok(())
         } else {
             Err(Error::Unroutable)

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -338,6 +338,7 @@ impl SocketDriver {
         let tx = self.internal_tx.clone();
         let child_cancel = cancel.clone();
         let policy = self.options.reconnect;
+        let stop_conn_refused = self.options.reconnect_stop_conn_refused;
         let dialer_ep = endpoint.clone();
         let monitor_ep = endpoint.clone();
         let tx_for_delay = tx.clone();
@@ -364,6 +365,7 @@ impl SocketDriver {
                     )
                 },
                 policy,
+                stop_conn_refused,
                 &child_cancel,
                 |delay, attempt| {
                     let ep = monitor_ep.clone();
@@ -389,7 +391,7 @@ impl SocketDriver {
                         })
                         .await;
                 }
-                Err(Canceled::Token | Canceled::PolicyDisabled) => {
+                Err(Canceled::Token | Canceled::PolicyDisabled | Canceled::StoppedConnRefused) => {
                     let _ = tx.send(InternalEvent::ConnectGaveUp).await;
                 }
             }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -356,7 +356,7 @@ impl SocketDriver {
                 let _ = ack.send(self.unbind(&endpoint));
             }
             SocketCommand::Disconnect { endpoint, ack } => {
-                let _ = ack.send(self.disconnect(&endpoint));
+                let _ = ack.send(self.disconnect(&endpoint).await);
             }
             SocketCommand::QueryConnection { connection_id, ack } => {
                 let _ = ack.send(self.peer_status(connection_id));

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -474,6 +474,34 @@ impl Socket {
         rx.await.map_err(|_| Error::Closed)
     }
 
+    /// Wait until at least `min_peers` peers are connected, or `timeout`
+    /// expires. Returns the peer count at the time the threshold was met,
+    /// or `Error::Timeout` if the deadline is reached first.
+    ///
+    /// This is a data-plane readiness check. It polls `connections()`
+    /// rather than relying on `MonitorStream` events, which are
+    /// diagnostic and may lag under load.
+    pub async fn wait_connected(
+        &self,
+        min_peers: usize,
+        timeout: std::time::Duration,
+    ) -> Result<usize> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let conns = self.connections().await?;
+            if conns.len() >= min_peers {
+                return Ok(conns.len());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(Error::Timeout);
+            }
+            tokio::time::sleep_until(
+                deadline.min(tokio::time::Instant::now() + std::time::Duration::from_millis(5)),
+            )
+            .await;
+        }
+    }
+
     /// Snapshot every currently-connected peer. Empty vec when no peers
     /// are live. Useful for introspection / health checks.
     pub async fn connections(&self) -> Result<Vec<ConnectionStatus>> {

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -446,10 +446,10 @@ impl Socket {
         rx.await.map_err(|_| Error::Closed)?
     }
 
-    /// Tear down a previously-started connect. Cancels the dial loop
-    /// and any in-flight reconnect backoff; existing handshaked peers
-    /// from this dialer remain connected. Returns `Error::Unroutable`
-    /// if no dialer at `endpoint` is registered.
+    /// Tear down a previously-started connect. Cancels the dial loop,
+    /// any in-flight reconnect backoff, and live peers connected through
+    /// `endpoint`. Returns `Error::Unroutable` if no dialer or live peer
+    /// at `endpoint` is registered.
     pub async fn disconnect(&self, endpoint: Endpoint) -> Result<()> {
         let (ack, rx) = oneshot::channel();
         self.inner

--- a/omq-tokio/src/socket/monitor.rs
+++ b/omq-tokio/src/socket/monitor.rs
@@ -21,6 +21,12 @@ pub use omq_proto::monitor::{
 pub(crate) const MONITOR_CAPACITY: usize = 64;
 
 /// Pull-style monitor stream. Drop to stop receiving events.
+///
+/// Monitor events are diagnostic. Under sustained data-plane load they
+/// may lag (the broadcast channel has a 64-slot buffer). Do not use
+/// monitor events for readiness gating in production. Use
+/// [`Socket::wait_connected`] or [`Socket::connections`] for routing
+/// readiness.
 #[derive(Debug)]
 pub struct MonitorStream {
     rx: broadcast::Receiver<MonitorEvent>,

--- a/omq-tokio/src/transport/backoff.rs
+++ b/omq-tokio/src/transport/backoff.rs
@@ -22,6 +22,9 @@ pub enum Canceled {
     /// The policy is [`ReconnectPolicy::Disabled`] and we exhausted the
     /// single attempt.
     PolicyDisabled,
+    /// The dial failed with `ECONNREFUSED` and
+    /// `reconnect_stop_conn_refused` was set.
+    StoppedConnRefused,
 }
 
 /// Keep trying to connect. Returns the established stream on success, or
@@ -37,6 +40,7 @@ pub enum Canceled {
 pub async fn dial_with_backoff<F, Fut, S>(
     mut dial: F,
     policy: ReconnectPolicy,
+    stop_conn_refused: bool,
     cancel: &CancellationToken,
     mut on_delay: impl FnMut(Duration, u32),
 ) -> std::result::Result<S, Canceled>
@@ -51,7 +55,10 @@ where
         }
         match dial().await {
             Ok(stream) => return Ok(stream),
-            Err(_err) => {
+            Err(err) => {
+                if stop_conn_refused && err.is_connection_refused() {
+                    return Err(Canceled::StoppedConnRefused);
+                }
                 attempt = attempt.saturating_add(1);
                 let Some(delay) = next_delay(&policy, attempt) else {
                     return Err(Canceled::PolicyDisabled);

--- a/omq-tokio/tests/reconnect_stop.rs
+++ b/omq-tokio/tests/reconnect_stop.rs
@@ -1,0 +1,113 @@
+mod test_support;
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use omq_tokio::endpoint::Host;
+use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+#[tokio::test]
+async fn reconnect_stop_conn_refused_stops_dial() {
+    // Grab a port, then close the listener so the port is unbound.
+    let probe = Socket::new(SocketType::Pull, Options::default());
+    let ep = probe.bind(tcp_ep(0)).await.unwrap();
+    drop(probe);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let opts = Options::default()
+        .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(50)))
+        .reconnect_stop_conn_refused(true);
+    let push = Socket::new(SocketType::Push, opts);
+    let mut mon = push.monitor();
+    push.connect(ep).await.unwrap();
+
+    // With reconnect_stop_conn_refused, the first ECONNREFUSED should
+    // stop the dialer. No ConnectDelayed events should fire.
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let evt = mon.recv().await.unwrap();
+            if matches!(evt, MonitorEvent::ConnectDelayed { .. }) {
+                return true;
+            }
+        }
+    })
+    .await;
+
+    // Timeout means no ConnectDelayed arrived. That's the expected path.
+    assert!(result.is_err(), "expected no ConnectDelayed events");
+}
+
+#[tokio::test]
+async fn reconnect_stop_default_retries() {
+    let probe = Socket::new(SocketType::Pull, Options::default());
+    let ep = probe.bind(tcp_ep(0)).await.unwrap();
+    drop(probe);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Default: reconnect_stop_conn_refused is false. Should retry.
+    let opts = Options::default().reconnect(ReconnectPolicy::Fixed(Duration::from_millis(30)));
+    let push = Socket::new(SocketType::Push, opts);
+    let mut mon = push.monitor();
+    push.connect(ep).await.unwrap();
+
+    let mut count = 0u32;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let evt = mon.recv().await.unwrap();
+            if matches!(evt, MonitorEvent::ConnectDelayed { .. }) {
+                count += 1;
+                if count >= 3 {
+                    return;
+                }
+            }
+        }
+    })
+    .await
+    .expect("should see at least 3 ConnectDelayed events");
+}
+
+#[tokio::test]
+async fn reconnect_stop_after_established_session() {
+    let opts = Options::default()
+        .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(50)))
+        .reconnect_stop_conn_refused(true);
+    let push = Socket::new(SocketType::Push, opts);
+
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull.bind(tcp_ep(0)).await.unwrap();
+    push.connect(ep).await.unwrap();
+
+    // Wait for the connection to establish.
+    push.send(Message::from("hello")).await.unwrap();
+    let msg = pull.recv().await.unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), &b"hello"[..]);
+
+    // Drop the listener. The port becomes unbound.
+    drop(pull);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // The reconnect attempt should hit ECONNREFUSED and stop.
+    let mut mon = push.monitor();
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let evt = mon.recv().await.unwrap();
+            if matches!(evt, MonitorEvent::ConnectDelayed { .. }) {
+                return true;
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "expected no ConnectDelayed after ECONNREFUSED stop"
+    );
+}

--- a/omq-tokio/tests/reconnect_stop.rs
+++ b/omq-tokio/tests/reconnect_stop.rs
@@ -53,13 +53,13 @@ async fn reconnect_stop_default_retries() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Default: reconnect_stop_conn_refused is false. Should retry.
-    let opts = Options::default().reconnect(ReconnectPolicy::Fixed(Duration::from_millis(30)));
+    let opts = Options::default().reconnect(ReconnectPolicy::Fixed(Duration::from_millis(50)));
     let push = Socket::new(SocketType::Push, opts);
     let mut mon = push.monitor();
     push.connect(ep).await.unwrap();
 
     let mut count = 0u32;
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let evt = mon.recv().await.unwrap();
             if matches!(evt, MonitorEvent::ConnectDelayed { .. }) {

--- a/omq-tokio/tests/stream.rs
+++ b/omq-tokio/tests/stream.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
+#[cfg(unix)]
 use omq_tokio::endpoint::IpcPath;
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -114,12 +115,15 @@ async fn stream_peer_disconnect() {
 async fn stream_non_tcp_rejected() {
     let stream = Socket::new(SocketType::Stream, Options::default());
 
-    let ipc_result = stream
-        .bind(Endpoint::Ipc(IpcPath::Filesystem(
-            "/tmp/omq-stream-test.sock".into(),
-        )))
-        .await;
-    assert!(ipc_result.is_err(), "IPC should be rejected for STREAM");
+    #[cfg(unix)]
+    {
+        let ipc_result = stream
+            .bind(Endpoint::Ipc(IpcPath::Filesystem(
+                "/tmp/omq-stream-test.sock".into(),
+            )))
+            .await;
+        assert!(ipc_result.is_err(), "IPC should be rejected for STREAM");
+    }
 
     let inproc_result = stream
         .bind(Endpoint::Inproc {
@@ -131,15 +135,18 @@ async fn stream_non_tcp_rejected() {
         "inproc should be rejected for STREAM"
     );
 
-    let connect_ipc = stream
-        .connect(Endpoint::Ipc(IpcPath::Filesystem(
-            "/tmp/omq-stream-test2.sock".into(),
-        )))
-        .await;
-    assert!(
-        connect_ipc.is_err(),
-        "IPC connect should be rejected for STREAM"
-    );
+    #[cfg(unix)]
+    {
+        let connect_ipc = stream
+            .connect(Endpoint::Ipc(IpcPath::Filesystem(
+                "/tmp/omq-stream-test2.sock".into(),
+            )))
+            .await;
+        assert!(
+            connect_ipc.is_err(),
+            "IPC connect should be rejected for STREAM"
+        );
+    }
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/stream.rs
+++ b/omq-tokio/tests/stream.rs
@@ -1,0 +1,285 @@
+//! STREAM socket integration tests.
+//!
+//! STREAM bypasses ZMTP framing: raw TCP bytes in, identity-prefixed
+//! messages out. Send `[identity, data]` to route to a peer. Empty
+//! data frame closes the peer connection.
+
+mod test_support;
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::endpoint::IpcPath;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+fn tcp_ep(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+fn resolved_addr(ep: &Endpoint) -> std::net::SocketAddr {
+    match ep {
+        Endpoint::Tcp { host, port } => {
+            let ip = match host {
+                Host::Ip(ip) => *ip,
+                _ => panic!("expected IP host"),
+            };
+            std::net::SocketAddr::new(ip, *port)
+        }
+        _ => panic!("expected TCP endpoint"),
+    }
+}
+
+#[tokio::test]
+async fn stream_basic_roundtrip() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let ep = stream.bind(tcp_ep(0)).await.unwrap();
+    let addr = resolved_addr(&ep);
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+
+    // Connect notification: empty data with the peer identity.
+    let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .expect("timed out waiting for connect notification")
+        .unwrap();
+    let identity = connect_msg.part_bytes(0).unwrap();
+    assert!(!identity.is_empty(), "identity should be non-empty");
+    let data = connect_msg.part_bytes(1).unwrap();
+    assert!(data.is_empty(), "connect notification data should be empty");
+
+    // Client sends raw bytes.
+    client.write_all(b"hello stream").await.unwrap();
+
+    let recv_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .expect("timed out waiting for data")
+        .unwrap();
+    let recv_ident = recv_msg.part_bytes(0).unwrap();
+    assert_eq!(recv_ident, identity, "identity should match");
+    let recv_data = recv_msg.part_bytes(1).unwrap();
+    assert_eq!(&recv_data[..], b"hello stream");
+
+    // STREAM sends reply using identity routing.
+    let reply = Message::multipart([identity.clone(), Bytes::from_static(b"reply back")]);
+    stream.send(reply).await.unwrap();
+
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+        .await
+        .expect("timed out waiting for reply")
+        .unwrap();
+    assert_eq!(&buf[..n], b"reply back");
+}
+
+#[tokio::test]
+async fn stream_peer_disconnect() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let ep = stream.bind(tcp_ep(0)).await.unwrap();
+    let addr = resolved_addr(&ep);
+
+    let client = TcpStream::connect(addr).await.unwrap();
+
+    // Consume connect notification.
+    let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let identity = connect_msg.part_bytes(0).unwrap();
+
+    // Drop the client.
+    drop(client);
+
+    // Should get a disconnect notification (empty data).
+    let disconnect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .expect("timed out waiting for disconnect notification")
+        .unwrap();
+    let disc_ident = disconnect_msg.part_bytes(0).unwrap();
+    assert_eq!(disc_ident, identity);
+    let disc_data = disconnect_msg.part_bytes(1).unwrap();
+    assert!(
+        disc_data.is_empty(),
+        "disconnect notification data should be empty"
+    );
+}
+
+#[tokio::test]
+async fn stream_non_tcp_rejected() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+
+    let ipc_result = stream
+        .bind(Endpoint::Ipc(IpcPath::Filesystem(
+            "/tmp/omq-stream-test.sock".into(),
+        )))
+        .await;
+    assert!(ipc_result.is_err(), "IPC should be rejected for STREAM");
+
+    let inproc_result = stream
+        .bind(Endpoint::Inproc {
+            name: "stream-test".into(),
+        })
+        .await;
+    assert!(
+        inproc_result.is_err(),
+        "inproc should be rejected for STREAM"
+    );
+
+    let connect_ipc = stream
+        .connect(Endpoint::Ipc(IpcPath::Filesystem(
+            "/tmp/omq-stream-test2.sock".into(),
+        )))
+        .await;
+    assert!(
+        connect_ipc.is_err(),
+        "IPC connect should be rejected for STREAM"
+    );
+}
+
+#[tokio::test]
+async fn stream_multiple_peers() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let ep = stream.bind(tcp_ep(0)).await.unwrap();
+    let addr = resolved_addr(&ep);
+
+    let mut clients = Vec::new();
+    let mut identities = Vec::new();
+
+    // Connect all clients first and collect identities.
+    for _ in 0..3u8 {
+        let client = TcpStream::connect(addr).await.unwrap();
+        clients.push(client);
+
+        let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let ident = connect_msg.part_bytes(0).unwrap();
+        assert!(!ident.is_empty());
+        identities.push(ident);
+    }
+
+    // Now send data from each client.
+    for (i, client) in clients.iter_mut().enumerate() {
+        client
+            .write_all(format!("msg-{i}").as_bytes())
+            .await
+            .unwrap();
+    }
+
+    // Receive data from each client.
+    let mut received = std::collections::HashMap::new();
+    for _ in 0..3 {
+        let msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let ident = msg.part_bytes(0).unwrap();
+        let data = msg.part_bytes(1).unwrap();
+        received.insert(ident, data);
+    }
+
+    // Verify all identities received data.
+    for (i, ident) in identities.iter().enumerate() {
+        let data = received.get(ident).unwrap_or_else(|| {
+            panic!("missing data for peer {i}");
+        });
+        assert_eq!(&data[..], format!("msg-{i}").as_bytes());
+    }
+
+    // Send replies to each peer using their identity.
+    for (i, ident) in identities.iter().enumerate() {
+        let reply = Message::multipart([ident.clone(), Bytes::from(format!("reply-{i}"))]);
+        stream.send(reply).await.unwrap();
+    }
+
+    // Verify each client receives its reply.
+    for (i, client) in clients.iter_mut().enumerate() {
+        let mut buf = [0u8; 64];
+        let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+            .await
+            .expect("timed out waiting for reply")
+            .unwrap();
+        assert_eq!(&buf[..n], format!("reply-{i}").as_bytes());
+    }
+}
+
+#[tokio::test]
+async fn stream_empty_send_closes_peer() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let ep = stream.bind(tcp_ep(0)).await.unwrap();
+    let addr = resolved_addr(&ep);
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+
+    let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let identity = connect_msg.part_bytes(0).unwrap();
+
+    // Send empty data frame to close the peer.
+    let close_msg = Message::multipart([identity, Bytes::new()]);
+    stream.send(close_msg).await.unwrap();
+
+    // Client should see EOF.
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+        .await
+        .expect("timed out waiting for EOF")
+        .unwrap();
+    assert_eq!(n, 0, "expected EOF after empty send");
+}
+
+#[tokio::test]
+async fn stream_connect_to_raw_listener() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let ep = Endpoint::Tcp {
+        host: Host::Ip(addr.ip()),
+        port: addr.port(),
+    };
+
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    stream.connect(ep).await.unwrap();
+
+    let (mut peer, _peer_addr) = tokio::time::timeout(Duration::from_secs(2), listener.accept())
+        .await
+        .expect("timed out waiting for accept")
+        .unwrap();
+
+    // Consume the connect notification from the STREAM socket.
+    let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let identity = connect_msg.part_bytes(0).unwrap();
+    assert!(!identity.is_empty());
+
+    // Raw server sends data.
+    peer.write_all(b"from server").await.unwrap();
+
+    let data_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(data_msg.part_bytes(0).unwrap(), identity);
+    assert_eq!(&data_msg.part_bytes(1).unwrap()[..], b"from server");
+
+    // STREAM sends to raw server.
+    let reply = Message::multipart([identity, Bytes::from_static(b"from stream")]);
+    stream.send(reply).await.unwrap();
+
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(2), peer.read(&mut buf))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&buf[..n], b"from stream");
+}

--- a/omq-tokio/tests/unbind_disconnect.rs
+++ b/omq-tokio/tests/unbind_disconnect.rs
@@ -12,6 +12,20 @@ fn tcp_loopback(port: u16) -> Endpoint {
     }
 }
 
+async fn wait_no_connections(sock: &Socket) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if sock.connections().await.unwrap().is_empty() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "socket still has live connections"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 #[tokio::test]
 async fn unbind_unregistered_endpoint_errors() {
     let s = Socket::new(SocketType::Pull, Options::default());
@@ -64,6 +78,17 @@ async fn disconnect_after_connect_succeeds() {
     assert_eq!(m.part_bytes(0).unwrap(), &b"hi"[..]);
 
     push.disconnect(tcp_loopback(port)).await.unwrap();
+    wait_no_connections(&push).await;
+    wait_no_connections(&pull).await;
+
     let r = push.disconnect(tcp_loopback(port)).await;
     assert!(matches!(r, Err(Error::Unroutable)), "got {r:?}");
+
+    push.connect(tcp_loopback(port)).await.unwrap();
+    push.send(Message::single("again")).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"again"[..]);
 }


### PR DESCRIPTION
- Add `Socket::wait_connected` with configurable timeout; document monitor event lag
- Add `reconnect_stop_conn_refused` option to stop reconnecting after connection refused
- Add STREAM socket integration tests (bind/connect, raw TCP interop, identity routing, multi-peer)
- Implement `Socket::disconnect` for live peers (previously only worked for pending endpoints)
- pyomq: release Python buffer references immediately after copying into `Bytes`
- Update `doc/architecture.md` for DataSignal, DrainBudget, send pipe, fallback queue, shard workers