### PR TITLE
Bench and chart infrastructure improvements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -151,6 +151,8 @@ Produces `doc/charts/{pushpull,pubsub,reqrep}/*.svg`,
 
 ```sh
 python3 scripts/run_comparisons.py --omq
+python3 scripts/run_comparisons.py --omq --transport tcp --no-latency \
+  --no-pubsub --sizes 32,128,512,2048,8192,32768
 python3 scripts/gen_comparison_chart.py
 ```
 
@@ -166,6 +168,21 @@ python3 scripts/gen_comparison_chart.py
 
 Stop if `run_comparisons.py` prints any warning or timeout. Fix the
 bench peer or script first, then rerun before charting.
+
+**CPU% charting rule.** Charts show only the "interesting" process's
+CPU, not the sum of all processes:
+
+| benchmark | charted process | JSONL field |
+|-----------|----------------|-------------|
+| PUSH/PULL throughput | sender (PUSH) | `push_cpu_time` |
+| PUB/SUB | sender (PUB) | `pub_cpu_time` |
+| fan-out (1 PUSH to N PULL) | sender (PUSH) | `push_cpu_time` |
+| fan-in (N PUSH to 1 PULL) | receiver (PULL) | `pull_cpu_time` |
+| REQ/REP latency | sender (REQ) | `req_cpu_time` |
+
+The combined `cpu_time` field (sum of all processes) is still recorded
+for backwards compatibility. Chart loaders prefer the per-process
+field and fall back to `cpu_time` when it is absent.
 
 ### Mechanism Chart
 

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -3,109 +3,211 @@
   <text x="475.0" y="16.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput, TCP loopback, 2-process</text>
   <text x="475.0" y="30.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="224.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">small messages (higher is better)</text>
-  <line x1="70.0" y1="257.4" x2="378.0" y2="257.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="257.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
-  <line x1="70.0" y1="194.8" x2="378.0" y2="194.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="194.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
-  <line x1="70.0" y1="132.3" x2="378.0" y2="132.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="132.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
-  <line x1="70.0" y1="69.7" x2="378.0" y2="69.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="69.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
+  <line x1="70.0" y1="256.6" x2="378.0" y2="256.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="256.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
+  <line x1="70.0" y1="193.3" x2="378.0" y2="193.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="193.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
+  <line x1="70.0" y1="129.9" x2="378.0" y2="129.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="129.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
+  <line x1="70.0" y1="66.5" x2="378.0" y2="66.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="66.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="224.0" y1="60.0" x2="224.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="131.6" y1="60.0" x2="131.6" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="193.2" y1="60.0" x2="193.2" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="254.8" y1="60.0" x2="254.8" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="316.4" y1="60.0" x2="316.4" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="320.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="70.0,263.6 224.0,264.7 378.0,267.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,247.1 224.0,247.6 378.0,253.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,309.3 224.0,311.5 378.0,312.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,93.9 224.0,176.4 378.0,254.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,98.8 224.0,174.6 378.0,256.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,99.9 224.0,172.9 378.0,181.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="70.0,128.7 224.0,193.8 378.0,213.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="70.0,221.5 131.6,223.4 193.2,223.2 254.8,230.3 316.4,240.8 378.0,247.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="221.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="223.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="223.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="230.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="240.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="247.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,283.0 131.6,268.1 193.2,254.6 254.8,242.8 316.4,245.2 378.0,258.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="283.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="268.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="254.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="242.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="245.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="258.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,309.3 131.6,310.6 193.2,311.5 254.8,312.0 316.4,312.2 378.0,312.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="309.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="310.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="311.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="312.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="312.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,93.9 131.6,109.7 193.2,176.0 254.8,249.2 316.4,255.7 378.0,291.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="93.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="109.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="176.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="249.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="255.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="291.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,100.9 131.6,107.0 193.2,180.5 254.8,248.3 316.4,253.9 378.0,292.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="100.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="107.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="180.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="248.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="253.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="292.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,114.6 131.6,116.1 193.2,118.8 254.8,138.3 316.4,166.8 378.0,212.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="114.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="116.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="118.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="138.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="166.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="212.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,107.1 131.6,110.0 193.2,122.3 254.8,143.3 316.4,186.6 378.0,234.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="107.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="110.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="122.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="143.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="186.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="234.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="70.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
-  <text x="224.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">64 B</text>
-  <text x="378.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
+  <text x="131.6" y="333.0" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
+  <text x="193.2" y="333.0" text-anchor="middle" fill="#374151" font-size="8">64 B</text>
+  <text x="254.8" y="333.0" text-anchor="middle" fill="#374151" font-size="8">128 B</text>
+  <text x="316.4" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
+  <text x="378.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
   <text x="649.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">medium/large messages (higher is better)</text>
-  <line x1="418.0" y1="279.3" x2="880.0" y2="279.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="279.3" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">1 GB/s</text>
-  <line x1="418.0" y1="238.5" x2="880.0" y2="238.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="238.5" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">2 GB/s</text>
-  <line x1="418.0" y1="197.8" x2="880.0" y2="197.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="197.8" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">3 GB/s</text>
-  <line x1="418.0" y1="157.0" x2="880.0" y2="157.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="157.0" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">4 GB/s</text>
-  <line x1="418.0" y1="116.3" x2="880.0" y2="116.3" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="116.3" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">5 GB/s</text>
-  <line x1="418.0" y1="75.5" x2="880.0" y2="75.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="75.5" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">6 GB/s</text>
+  <line x1="418.0" y1="281.0" x2="880.0" y2="281.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="281.0" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">1 GB/s</text>
+  <line x1="418.0" y1="242.1" x2="880.0" y2="242.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="242.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">2 GB/s</text>
+  <line x1="418.0" y1="203.1" x2="880.0" y2="203.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="203.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">3 GB/s</text>
+  <line x1="418.0" y1="164.1" x2="880.0" y2="164.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="164.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">4 GB/s</text>
+  <line x1="418.0" y1="125.2" x2="880.0" y2="125.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="125.2" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">5 GB/s</text>
+  <line x1="418.0" y1="86.2" x2="880.0" y2="86.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="86.2" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">6 GB/s</text>
   <line x1="880.0" y1="60.0" x2="880.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="418.0" y1="60.0" x2="418.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="469.3" y1="60.0" x2="469.3" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="520.7" y1="60.0" x2="520.7" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="572.0" y1="60.0" x2="572.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="623.3" y1="60.0" x2="623.3" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="674.7" y1="60.0" x2="674.7" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="726.0" y1="60.0" x2="726.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="777.3" y1="60.0" x2="777.3" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="828.7" y1="60.0" x2="828.7" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="880.0" y1="60.0" x2="880.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="418.0" y1="60.0" x2="418.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="418.0" y1="320.0" x2="880.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="418.0,302.4 572.0,252.1 726.0,161.6 880.0,101.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="302.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="252.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="161.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="101.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,297.9 572.0,253.4 726.0,188.2 880.0,162.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="297.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="253.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="188.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="162.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,317.4 572.0,310.3 726.0,287.5 880.0,224.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="317.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="310.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="287.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="224.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,298.2 572.0,283.1 726.0,272.0 880.0,271.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="298.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="283.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="272.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="271.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,298.7 572.0,283.1 726.0,272.8 880.0,272.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="298.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="283.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="272.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="272.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,273.8 572.0,177.1 726.0,200.4 880.0,93.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="273.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="177.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="200.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="93.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,284.5 572.0,230.0 726.0,179.3 880.0,160.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="284.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="230.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="179.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="160.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,295.1 469.3,272.7 520.7,228.4 572.0,194.1 623.3,173.8 674.7,184.4 726.0,128.7 777.3,128.4 828.7,154.3 880.0,164.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="295.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="272.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="228.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="194.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="173.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="184.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="128.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="128.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="154.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="164.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,296.5 469.3,277.5 520.7,242.1 572.0,214.7 623.3,210.0 674.7,183.9 726.0,194.4 777.3,185.9 828.7,216.2 880.0,209.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="296.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="277.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="242.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="214.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="210.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="183.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="194.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="185.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="216.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="209.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,317.5 469.3,315.4 520.7,311.1 572.0,302.9 623.3,289.1 674.7,266.7 726.0,215.3 777.3,194.5 828.7,199.6 880.0,236.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="315.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="311.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="302.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="289.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="266.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="215.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="194.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="199.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="236.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,299.7 469.3,291.2 520.7,284.5 572.0,280.3 623.3,276.4 674.7,278.7 726.0,274.9 777.3,246.3 828.7,171.3 880.0,169.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="299.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="291.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="284.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="280.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="276.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="278.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="274.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="246.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="171.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="169.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,299.2 469.3,290.7 520.7,284.9 572.0,279.6 623.3,277.2 674.7,275.1 726.0,276.0 777.3,247.0 828.7,166.2 880.0,151.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="299.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="290.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="284.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="279.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="277.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="275.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="276.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="247.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="166.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="151.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,271.7 469.3,250.6 520.7,184.3 572.0,160.0 623.3,128.4 674.7,94.7 726.0,114.7 777.3,110.3 828.7,141.4 880.0,151.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="271.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="250.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="184.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="160.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="128.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="94.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="114.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="110.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="141.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="151.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,278.0 469.3,247.1 520.7,211.9 572.0,184.3 623.3,147.7 674.7,160.3 726.0,113.5 777.3,93.9 828.7,110.6 880.0,136.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="278.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="247.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="211.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="184.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="160.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="113.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="93.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="110.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="136.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="418.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
-  <text x="572.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
-  <text x="726.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">4 KiB</text>
-  <text x="880.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 KiB</text>
+  <text x="469.3" y="333.0" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
+  <text x="520.7" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
+  <text x="572.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">2 KiB</text>
+  <text x="623.3" y="333.0" text-anchor="middle" fill="#374151" font-size="8">4 KiB</text>
+  <text x="674.7" y="333.0" text-anchor="middle" fill="#374151" font-size="8">8 KiB</text>
+  <text x="726.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 KiB</text>
+  <text x="777.3" y="333.0" text-anchor="middle" fill="#374151" font-size="8">32 KiB</text>
+  <text x="828.7" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
+  <text x="880.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">4 MiB</text>
   <line x1="95" y1="350" x2="109" y2="350" stroke="#eab308" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="102" cy="350" r="2.5" fill="#eab308"/>
-  <text x="115" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5</text>
+  <text x="115" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="285" y1="350" x2="299" y2="350" stroke="#a16207" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="292" cy="350" r="2.5" fill="#a16207"/>
-  <text x="305" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 (4 IO threads)</text>
+  <text x="305" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 (4T)</text>
   <line x1="475" y1="350" x2="489" y2="350" stroke="#f97316" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="482" cy="350" r="2.5" fill="#f97316"/>
-  <text x="495" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (ST)</text>
+  <text x="495" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (1T)</text>
   <line x1="665" y1="350" x2="679" y2="350" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="672" cy="350" r="2.5" fill="#dc2626"/>
-  <text x="685" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (MT)</text>
+  <text x="685" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (4T)</text>
   <line x1="190" y1="370" x2="204" y2="370" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="197" cy="370" r="2.5" fill="#2563eb"/>
-  <text x="210" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="210" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="380" y1="370" x2="394" y2="370" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="387" cy="370" r="2.5" fill="#16a34a"/>
-  <text x="400" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="400" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="570" y1="370" x2="584" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="577" cy="370" r="2.5" fill="#15803d"/>
-  <text x="590" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="475.0" y="388.0" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="590" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="475.0" y="388.0" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
 </svg>

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -443,21 +443,25 @@ fn rustc_version_runtime() -> String {
         .to_string()
 }
 
-/// Build the benchmark runtime. Defaults to multi-thread with one
-/// worker per available CPU. Set `OMQ_BENCH_RUNTIME=current_thread`
-/// to use the single-threaded current-thread runtime instead.
+/// Build the benchmark runtime. Set `OMQ_BENCH_TOKIO_THREADS=N` to
+/// control the thread count: 1 = current_thread, 2+ = multi_thread.
+/// Defaults to multi-thread with one worker per available CPU.
 pub(crate) fn build_runtime() -> tokio::runtime::Runtime {
-    if std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "current_thread") {
+    let threads: usize = std::env::var("OMQ_BENCH_TOKIO_THREADS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or_else(|| std::thread::available_parallelism().map_or(2, std::num::NonZero::get));
+    if threads <= 1 {
         println!("runtime: current_thread\n");
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("bench: tokio runtime")
     } else {
-        let workers = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
-        println!("runtime: multi_thread ({workers} workers)\n");
+        println!("runtime: multi_thread ({threads} workers)\n");
         tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(workers)
+            .worker_threads(threads)
             .enable_all()
             .build()
             .expect("bench: tokio runtime")

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -444,7 +444,7 @@ fn rustc_version_runtime() -> String {
 }
 
 /// Build the benchmark runtime. Set `OMQ_BENCH_TOKIO_THREADS=N` to
-/// control the thread count: 1 = current_thread, 2+ = multi_thread.
+/// control the thread count: 1 = `current_thread`, 2+ = `multi_thread`.
 /// Defaults to multi-thread with one worker per available CPU.
 pub(crate) fn build_runtime() -> tokio::runtime::Runtime {
     let threads: usize = std::env::var("OMQ_BENCH_TOKIO_THREADS")

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -60,23 +60,17 @@ extern "C" fn exit_on_signal(_sig: libc::c_int) {
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let force_current_thread = matches!(args.get(1).map(String::as_str), Some("pull"))
-        && std::env::var("OMQ_BENCH_PULL_CURRENT_THREAD").is_ok_and(|v| v == "1")
-        || matches!(args.get(1).map(String::as_str), Some("sub"))
-            && std::env::var("OMQ_BENCH_SUB_CURRENT_THREAD").is_ok_and(|v| v == "1");
-    let rt = if !force_current_thread
-        && std::env::var("OMQ_BENCH_RUNTIME").is_ok_and(|v| v == "multi_thread")
-    {
+    let threads: usize = std::env::var("OMQ_BENCH_TOKIO_THREADS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(1);
+    let rt = if threads > 1 {
         #[cfg(feature = "rt-multi-thread")]
         {
-            let workers = std::env::var("OMQ_BENCH_WORKERS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .filter(|&v| v > 0)
-                .unwrap_or(4);
-            eprintln!("runtime: multi_thread ({workers} workers)");
+            eprintln!("runtime: multi_thread ({threads} workers)");
             tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(workers)
+                .worker_threads(threads)
                 .enable_all()
                 .build()
                 .expect("tokio runtime")

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -98,6 +98,11 @@ async fn async_main(args: Vec<String>) {
             libc::SIGINT,
             exit_on_signal as *const () as libc::sighandler_t,
         );
+        libc::signal(
+            libc::SIGALRM,
+            exit_on_signal as *const () as libc::sighandler_t,
+        );
+        libc::alarm(60);
     }
     match args.get(1).map(String::as_str) {
         Some("push") => {

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -54,6 +54,7 @@ fn print_bound_port(ep: &Endpoint) {
     }
 }
 
+#[cfg(unix)]
 extern "C" fn exit_on_signal(_sig: libc::c_int) {
     unsafe { libc::_exit(0) };
 }
@@ -89,6 +90,7 @@ fn main() {
 
 #[expect(clippy::too_many_lines)]
 async fn async_main(args: Vec<String>) {
+    #[cfg(unix)]
     unsafe {
         libc::signal(
             libc::SIGTERM,

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -440,6 +440,9 @@ fn bench_options(msg_size: usize) -> Options {
         let dict = Bytes::from(std::fs::read(&path).expect("read dict file"));
         o = o.compression_dict(dict);
     }
+    if let Ok(val) = std::env::var("OMQ_BENCH_ARENA_THRESHOLD") {
+        o = o.arena_threshold(val.parse().expect("OMQ_BENCH_ARENA_THRESHOLD"));
+    }
     o
 }
 

--- a/scripts/bench_compression_tokio.py
+++ b/scripts/bench_compression_tokio.py
@@ -226,6 +226,8 @@ def main():
     with open(JSONL, "a") as f:
         for row in all_rows:
             f.write(json.dumps(row) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
     print(f"Appended {len(all_rows)} rows to {JSONL}", file=sys.stderr)
 
     if args.chart:

--- a/scripts/bench_mechanism.py
+++ b/scripts/bench_mechanism.py
@@ -178,6 +178,8 @@ def append_jsonl(jsonl_path: Path, rid: str, mechanism: str, size: int, result: 
     })
     with open(jsonl_path, "a") as f:
         f.write(row + "\n")
+        f.flush()
+        os.fsync(f.fileno())
 
 
 def main():

--- a/scripts/bench_pubsub_lz4.py
+++ b/scripts/bench_pubsub_lz4.py
@@ -262,6 +262,8 @@ def main():
     with open(JSONL, "a") as f:
         for row in all_rows:
             f.write(json.dumps(row, separators=(",", ":")) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
     print(f"Appended {len(all_rows)} rows to {JSONL}", file=sys.stderr)
 
     if args.chart:

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -14,7 +14,7 @@ REPO = Path(__file__).resolve().parent.parent
 CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
 JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
 COMPARISON_CHART_SIZES = {16, 64, 256, 1024, 4096, 16384}
-SMALL_MESSAGE_SIZES = [16, 64, 256]
+SMALL_MESSAGE_SIZES = [16, 64, 256, 1024]
 LARGE_MESSAGE_SIZES = [256, 1024, 4096, 16384]
 METRIC_LINE_WIDTH = 2.5
 CPU_LINE_WIDTH = 1.6
@@ -102,7 +102,7 @@ def load_data(transport: str, impls: list[str]) -> dict:
                 mbps = r.get("mbps", 0)
                 gbs = mbps / 1000.0
                 tput.setdefault(size, {})[impl_name] = (msgs_s, gbs)
-                cpu_time = r.get("cpu_time", 0)
+                cpu_time = r.get("push_cpu_time", r.get("cpu_time", 0))
                 elapsed = r.get("elapsed", 0)
                 if elapsed > 0 and cpu_time > 0:
                     tput_cpu.setdefault(size, {})[impl_name] = cpu_time / elapsed * 100
@@ -112,7 +112,7 @@ def load_data(transport: str, impls: list[str]) -> dict:
             if key not in seen_lat or seq >= seen_lat[key]:
                 seen_lat[key] = seq
                 lat.setdefault(size, {})[impl_name] = r.get("p50_us", 0)
-                cpu_time = r.get("cpu_time", 0)
+                cpu_time = r.get("req_cpu_time", r.get("cpu_time", 0))
                 elapsed = r.get("elapsed", 0)
                 if elapsed > 0 and cpu_time > 0:
                     lat_cpu.setdefault(size, {})[impl_name] = cpu_time / elapsed * 100
@@ -347,7 +347,7 @@ def draw_throughput_panel(
         if pts:
             L.append(svg_polyline(pts, COLORS[name], width=2, dash="6,4"))
 
-    # solid throughput lines with dots
+    # solid throughput lines
     for name in draw_order:
         pts = [
             (xs[i], y_tput(tput[sizes[i]][name][1]))
@@ -662,12 +662,18 @@ def draw_split_throughput_cpu_panel(
             L.append(svg_polyline(pts, COLORS[name],
                                   width=METRIC_LINE_WIDTH,
                                   dash=MSG_LINE_DASH))
-            zero_pts = [
-                (xs[i], y_metric(tput[sizes[i]][name][metric_idx]))
-                for i in range(len(sizes))
-                if name in tput.get(sizes[i], {})
-                and tput[sizes[i]][name][0] == 0
-            ]
+            zero_pts = []
+            nonzero_pts = []
+            for i in range(len(sizes)):
+                if name not in tput.get(sizes[i], {}):
+                    continue
+                pt = (xs[i], y_metric(tput[sizes[i]][name][metric_idx]))
+                if tput[sizes[i]][name][0] == 0:
+                    zero_pts.append(pt)
+                else:
+                    nonzero_pts.append(pt)
+            L.extend(svg_dots(nonzero_pts, COLORS[name],
+                              radius=MARKER_RADIUS))
             L.extend(svg_x_marks(zero_pts, COLORS[name],
                                  radius=MARKER_RADIUS))
         else:
@@ -860,7 +866,7 @@ def draw_throughput_cpu_panel(
                     )
             L.append(svg_polyline(pts, COLORS[name], width=2.0, dash="5,3"))
 
-    # solid GB/s lines with dots (inner right axis)
+    # solid GB/s lines (inner right axis)
     for name in draw_order:
         pts = [
             (xs[i], y_gbs(tput[sizes[i]][name][1]))
@@ -1043,8 +1049,7 @@ def _draw_impl_legend(L: list[str], impls: list[str], mid_x: float, leg_y: float
         L.append(
             f'  <text x="{mid_x}" y="{st_y}" text-anchor="middle"'
             f' fill="#9ca3af" font-size="9">'
-            f'(nT) = user-chosen'
-            f'   [nT] = fixed by implementation</text>'
+            f'(nT) = user-chosen   ·   [nT] = fixed by implementation</text>'
         )
         extra += 18
     return extra
@@ -1120,7 +1125,6 @@ def generate_chart(data: dict, impls: list[str], transport_label: str,
         f'  <line x1="{lt_right:.0f}" y1="{lt_y}" x2="{lt_right + 20:.0f}" y2="{lt_y}"'
         f' stroke="#6b7280" stroke-width="2"/>'
     )
-    L.append(f'  <circle cx="{lt_right + 10:.0f}" cy="{lt_y}" r="2" fill="#6b7280"/>')
     gbs_label = "throughput / GB/s (right axis, log)" if log_gbs \
         else "throughput / GB/s (right axis)"
     L.append(
@@ -1297,10 +1301,6 @@ def generate_chart_cpu(data: dict, impls: list[str], transport_label: str,
         f' stroke="#6b7280" stroke-width="{METRIC_LINE_WIDTH}"/>'
     )
     L.append(
-        f'  <circle cx="{lt_right + 7:.0f}" cy="{lt_y}"'
-        f' r="{MARKER_RADIUS}" fill="#6b7280"/>'
-    )
-    L.append(
         f'  <text x="{lt_right + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
         f' font-size="10">GB/s (large panel{", log" if log_gbs else ""})</text>'
     )
@@ -1409,7 +1409,7 @@ def load_pubsub_data(transport: str, impls: list[str], peers: int) -> dict:
         impl_name = r.get("impl")
         if impl_name not in impls:
             continue
-        cpu_time = r.get("cpu_time", 0)
+        cpu_time = r.get("pub_cpu_time", r.get("cpu_time", 0))
         elapsed = r.get("elapsed", 0)
         if elapsed <= 0 or (cpu_time <= 0 and not r.get("zero_transport")):
             continue
@@ -1523,7 +1523,6 @@ def generate_pubsub_chart(
         f'  <line x1="{lt_right:.0f}" y1="{lt_y}" x2="{lt_right + 20:.0f}" y2="{lt_y}"'
         f' stroke="#6b7280" stroke-width="2"/>'
     )
-    L.append(f'  <circle cx="{lt_right + 10:.0f}" cy="{lt_y}" r="2" fill="#6b7280"/>')
     gbs_label = "throughput / GB/s (right axis, log)" if log_gbs \
         else "throughput / GB/s (right axis)"
     L.append(
@@ -1566,11 +1565,9 @@ def load_fanio_data(transport: str, impls: list[str], peers: int,
                 r.get("peer_max", 0),
             )
             if kind == "fan_out":
-                # Fan-out CPU is producer-side only. Older rows stored
-                # producer+puller CPU in cpu_time, so ignore them here.
                 cpu_time = r.get("push_cpu_time", 0)
             else:
-                cpu_time = r.get("cpu_time", 0)
+                cpu_time = r.get("pull_cpu_time", r.get("cpu_time", 0))
             elapsed = r.get("elapsed", 0)
             if elapsed > 0 and cpu_time > 0:
                 tput_cpu.setdefault(size, {})[impl_name] = cpu_time / elapsed * 100
@@ -1700,10 +1697,6 @@ def generate_multi_panel_cpu_chart(
         f' stroke="#6b7280" stroke-width="{METRIC_LINE_WIDTH}"/>'
     )
     L.append(
-        f'  <circle cx="{lt_right + 7:.0f}" cy="{lt_y}"'
-        f' r="{MARKER_RADIUS}" fill="#6b7280"/>'
-    )
-    L.append(
         f'  <text x="{lt_right + 20:.0f}" y="{lt_y + 4}" fill="#6b7280"'
         f' font-size="10">GB/s (large panel)</text>'
     )
@@ -1826,7 +1819,7 @@ def main():
             print(f"Written: {out}", file=sys.stderr)
 
 
-    # ── Main hero charts ────────────────────────────────────────
+    # ── Main chart ─────────────────────────────────────────────
     from gen_main_chart import (MAIN_DRAW_ORDER, MAIN_IMPLS, MAIN_TITLE,
                                 generate_main_chart,
                                 load_data as load_main_data)

--- a/scripts/gen_main_chart.py
+++ b/scripts/gen_main_chart.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate the main hero chart:
+"""Generate the main chart:
 doc/charts/main_tcp.svg.
 
 Panel 1: PUSH/PULL throughput (MB/s + msg/s dashed), small messages.
@@ -17,13 +17,13 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
 JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
-SMALL_SIZES = [16, 64, 256]
-LARGE_SIZES = [256, 1024, 4096, 16384]
+SMALL_SIZES = [16, 32, 64, 128, 256, 1024]
+LARGE_SIZES = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 262144, 4194304]
 
 sys.path.insert(0, str(REPO / "scripts"))
 from chart_hw import detect_hardware
 
-# Union of all impls plotted in either hero; used only as a load filter.
+# Union of all impls plotted in the main chart; used only as a load filter.
 IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs",
          "rzmq", "rzmq-iouring"]
 
@@ -55,6 +55,8 @@ MAIN_TITLE = "PUSH/PULL throughput, TCP loopback, 2-process"
 
 
 def fmt_size(b: int) -> str:
+    if b >= 1024 * 1024:
+        return f"{b // (1024 * 1024)} MiB"
     if b >= 1024:
         return f"{b // 1024} KiB"
     return f"{b} B"
@@ -267,11 +269,17 @@ def draw_throughput_panel(
             ]
             if pts:
                 L.append(svg_polyline(pts, COLORS[name], width=2.5, dash="6,3"))
-                zero_pts = [
-                    (xs[i], y_msgs(msgs[sizes[i]][name]))
-                    for i in range(len(sizes))
-                    if name in msgs.get(sizes[i], {}) and msgs[sizes[i]][name] == 0
-                ]
+                zero_pts = []
+                nonzero_pts = []
+                for i in range(len(sizes)):
+                    if name not in msgs.get(sizes[i], {}):
+                        continue
+                    pt = (xs[i], y_msgs(msgs[sizes[i]][name]))
+                    if msgs[sizes[i]][name] == 0:
+                        zero_pts.append(pt)
+                    else:
+                        nonzero_pts.append(pt)
+                L.extend(svg_dots(nonzero_pts, COLORS[name]))
                 L.extend(svg_x_marks(zero_pts, COLORS[name]))
     else:
         for name in draw_order:
@@ -446,7 +454,7 @@ def generate_main_chart(tput: dict, msgs: dict, impls: list[str],
     leg_extra = (len(rows) - 1) * row_gap
     abbr_y = leg_y + leg_extra + 18
     L.append(svg_text(mid_x, abbr_y,
-                       "(nT) = user-chosen   [nT] = fixed by implementation",
+                       "(nT) = user-chosen   ·   [nT] = fixed by implementation",
                        size=9, fill="#9ca3af"))
 
     L.append("</svg>")

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -115,6 +115,7 @@ def _cleanup_ipc_sockets():
 CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq"
 JSONL_PATH = CACHE_DIR / "comparisons.jsonl"
 COMPARISON_CHART_SIZES = [16, 64, 256, 1024, 4096, 16384]
+MAIN_EXTRA_CHART_SIZES = [32, 128, 512, 2048, 8192, 32768, 262144, 4194304]
 QUICK_SIZES = [64, 1024, 4096]
 
 # Physical sanity ceiling for a single TCP loopback stream (MB/s). Measured
@@ -488,6 +489,8 @@ def _run_throughput_once(
                         transport, size, 1, "pull CPU (peer stdout)")
         if push_ok and pull_ok:
             result["cpu_time"] = push_cpu + result["pull_cpu"]
+        if push_ok:
+            result["push_cpu_time"] = push_cpu
         result["_issues"] = issues
     return result
 
@@ -599,6 +602,8 @@ def _run_pubsub_once(
                            f"{len(parsed)} subscribers (peer stdout)")
             if pub_ok and sub_ok:
                 result["cpu_time"] = pub_cpu + pull_cpu
+            if pub_ok:
+                result["pub_cpu_time"] = pub_cpu
     if result:
         result["_issues"] = issues
         if peers > 1 and "peers_measured" not in result:
@@ -812,6 +817,8 @@ def _run_fanin_once(
                               size, peers, "collector CPU (peer stdout)")
         if push_ok and pull_ok:
             result["cpu_time"] = sum(pusher_cpus) + result["pull_cpu"]
+        if pull_ok:
+            result["pull_cpu_time"] = result["pull_cpu"]
         result["_issues"] = issues
     return result
 
@@ -872,6 +879,8 @@ def run_latency_cell(
                        size, 1, "req CPU (peer stdout)")
         if rep_ok and req_ok:
             result["cpu_time"] = rep_cpu + result["req_cpu"]
+        if req_ok:
+            result["req_cpu_time"] = result["req_cpu"]
         result["_issues"] = issues
         _flush_issues(result)
     return result
@@ -1157,6 +1166,8 @@ def run_benchmarks(
                             row["elapsed"] = round(result["elapsed"], 6)
                         if "cpu_time" in result:
                             row["cpu_time"] = round(result["cpu_time"], 6)
+                        if "push_cpu_time" in result:
+                            row["push_cpu_time"] = round(result["push_cpu_time"], 6)
                         if result.get("zero_transport"):
                             row["zero_transport"] = True
                         append_jsonl(row)
@@ -1210,6 +1221,8 @@ def run_benchmarks(
                         }
                         if "cpu_time" in result:
                             row["cpu_time"] = round(result["cpu_time"], 6)
+                        if "req_cpu_time" in result:
+                            row["req_cpu_time"] = round(result["req_cpu_time"], 6)
                         if "elapsed" in result:
                             row["elapsed"] = round(result["elapsed"], 6)
                         append_jsonl(row)
@@ -1269,6 +1282,8 @@ def run_benchmarks(
                                 row["elapsed"] = round(result["elapsed"], 6)
                             if "cpu_time" in result:
                                 row["cpu_time"] = round(result["cpu_time"], 6)
+                            if "pub_cpu_time" in result:
+                                row["pub_cpu_time"] = round(result["pub_cpu_time"], 6)
                             if result.get("zero_transport"):
                                 row["zero_transport"] = True
                             append_jsonl(row)
@@ -1391,6 +1406,8 @@ def run_benchmarks(
                                 row["elapsed"] = round(result["elapsed"], 6)
                             if "cpu_time" in result:
                                 row["cpu_time"] = round(result["cpu_time"], 6)
+                            if "pull_cpu_time" in result:
+                                row["pull_cpu_time"] = round(result["pull_cpu_time"], 6)
                             if result.get("zero_transport"):
                                 row["zero_transport"] = True
                             append_jsonl(row)
@@ -1427,8 +1444,8 @@ def main():
     )
     parser.add_argument(
         "--sizes", type=str, default=None,
-        help="comma-separated message sizes; must be comparison chart sizes "
-             "unless --allow-non-chart-sizes is set",
+        help="comma-separated message sizes; must be comparison or main chart "
+             "sizes unless --allow-non-chart-sizes is set",
     )
     parser.add_argument(
         "--allow-non-chart-sizes", action="store_true",
@@ -1509,7 +1526,8 @@ def main():
     sizes = QUICK_SIZES if args.quick_run else COMPARISON_CHART_SIZES
     if args.sizes:
         sizes = [int(x) for x in args.sizes.split(",")]
-        non_chart = sorted(set(sizes) - set(COMPARISON_CHART_SIZES))
+        chart_sizes = set(COMPARISON_CHART_SIZES) | set(MAIN_EXTRA_CHART_SIZES)
+        non_chart = sorted(set(sizes) - chart_sizes)
         if non_chart and not args.allow_non_chart_sizes:
             parser.error(
                 "--sizes includes non-chart sizes "

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -446,6 +446,7 @@ def _run_throughput_once(
     dur = str(duration)
     issues: list = []
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
+    recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
     if transport == "inproc":
         fresh_name = f"{addr}-{next_addr_id()}"
         timeout_s = max(int(duration) + 5, 8)
@@ -474,7 +475,7 @@ def _run_throughput_once(
         connect_addr = str(port)
     try:
         output = capture_process(binary, "pull", connect_addr, str(size), dur,
-                                 env=cell_env)
+                                 env=recv_env)
         push_cpu = read_proc_cpu(push.pid)
     finally:
         _hard_kill(push)
@@ -533,8 +534,7 @@ def _run_pubsub_once(
     else:
         addr = _fresh_addr(addr)
         cleanup_ipc_socket(addr)
-        if impl == "omq-tokio-mt":
-            cell_env["OMQ_BENCH_SUB_CURRENT_THREAD"] = "1"
+        recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
         pub_args = [binary, "pub", addr, str(size)]
         if pub_needs_peers:
             pub_args.append(str(peers))
@@ -553,7 +553,7 @@ def _run_pubsub_once(
         try:
             for _ in range(peers):
                 subs.append(spawn_process(binary, "sub", connect_addr,
-                                          str(size), dur, env=cell_env))
+                                          str(size), dur, env=recv_env))
             time.sleep(0.05)
             timeout_s = max(int(duration) + 5, 8)
             for s in subs:
@@ -638,9 +638,7 @@ def _run_fanout_once(
     issues: list = []
     start_at = time.time() + 2.0
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{start_at:.6f}"}
-    if push_subcmd == "push-fanout":
-        if impl == "omq-tokio-mt":
-            cell_env["OMQ_BENCH_PULL_CURRENT_THREAD"] = "1"
+    recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
     # Some peers need the worker count up front to
     # accept exactly N connections; pass it as a trailing arg when required.
     push_args = [binary, push_subcmd, addr, str(size)]
@@ -666,7 +664,7 @@ def _run_fanout_once(
     try:
         for _ in range(peers):
             pulls.append(spawn_process(binary, "pull", connect_addr,
-                                       str(size), str(duration), env=cell_env))
+                                       str(size), str(duration), env=recv_env))
         time.sleep(0.05)
         time.sleep(max(0.0, start_at + PEER_WARMUP_SECS - time.time()))
         push_cpu_before = read_proc_cpu(push.pid)
@@ -911,6 +909,8 @@ def append_jsonl(row: dict):
     JSONL_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(JSONL_PATH, "a") as f:
         f.write(json.dumps(row, separators=(",", ":")) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
 
 
 def append_zero_tput_row(
@@ -963,7 +963,7 @@ IMPLS = {
         "fanout_push_subcmd": "push-fanout",
         "fanio_needs_peer_count": True,
         "supports_pubsub": True,
-        "env": {"OMQ_BENCH_RUNTIME": "multi_thread"},
+        "env": {"OMQ_BENCH_TOKIO_THREADS": "4"},
     },
     "libzmq": {
         "prefix": "z",


### PR DESCRIPTION
- Fix omq-tokio-mt throughput cell to use `current_thread` for the pull side
- Replace four bench runtime env vars with `OMQ_BENCH_TOKIO_THREADS`
- Flush and fsync JSONL after bench writes
- Add 60-second SIGALRM guard to `bench_peer_tokio`
- Add 1 KiB overlap and 4 MiB to main chart size ranges
- Record per-process CPU% in JSONL (`push_cpu_time`, `pub_cpu_time`, `pull_cpu_time`, `req_cpu_time`)
- Remove circle markers from line-type legend entries; improve `(nT)`/`[nT]` separator
- Add `OMQ_BENCH_ARENA_THRESHOLD` env var to `bench_peer_tokio`
- Document CPU% charting rule in `DEVELOPMENT.md`