### PR TITLE
omq-libzmq: reduce variance and improve small-message throughput

### DIFF
--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -2,18 +2,18 @@
   <rect width="850" height="684" fill="white"/>
   <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
-  <line x1="90" y1="384.0" x2="760" y2="384.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="384.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">0</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90" y1="328.2" x2="760" y2="328.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="328.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
+  <line x1="90" y1="272.3" x2="760" y2="272.3" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="272.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
+  <line x1="90" y1="160.7" x2="760" y2="160.7" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="160.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <line x1="90" y1="104.8" x2="760" y2="104.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="104.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
   <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
   <line x1="90" y1="384.0" x2="760" y2="384.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="384.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.0 MB/s</text>
   <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
@@ -43,38 +43,38 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,146.6 145.8,164.7 201.7,153.8 257.5,151.4 313.3,150.8 369.2,152.3 425.0,148.7 480.8,139.6 536.7,265.0 592.5,314.7 648.3,341.5 704.2,356.4 760.0,370.7" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,254.8 145.8,254.1 201.7,251.5 257.5,255.6 313.3,257.3 369.2,259.0 425.0,263.2 480.8,280.0 536.7,286.5 592.5,314.0 648.3,342.3 704.2,359.7 760.0,371.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,231.1 145.8,227.8 201.7,226.4 257.5,246.0 313.3,271.8 369.2,285.1 425.0,281.4 480.8,304.5 536.7,328.8 592.5,351.2 648.3,366.4 704.2,374.6 760.0,376.6" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,377.2 145.8,377.1 201.7,377.2 257.5,377.2 313.3,377.6 369.2,377.4 425.0,377.3 480.8,377.4 536.7,377.5 592.5,377.7 648.3,377.9 704.2,378.0 760.0,378.6" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,383.2 145.8,382.5 201.7,380.9 257.5,377.8 313.3,371.6 369.2,359.3 425.0,333.8 480.8,279.7 536.7,282.5 592.5,265.8 648.3,239.1 704.2,195.6 760.0,203.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="380.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="377.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="371.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="359.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="333.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="279.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="282.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="265.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="239.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="195.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="203.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.6 145.8,383.1 201.7,382.2 257.5,380.6 313.3,377.2 369.2,370.7 425.0,358.2 480.8,339.6 536.7,300.8 592.5,264.5 648.3,241.7 704.2,217.9 760.0,206.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,116.3 145.8,108.2 201.7,115.5 257.5,111.0 313.3,153.3 369.2,154.6 425.0,153.9 480.8,225.2 536.7,286.9 592.5,325.4 648.3,345.8 704.2,361.2 760.0,371.2" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,278.6 145.8,277.4 201.7,276.9 257.5,274.6 313.3,279.9 369.2,283.4 425.0,287.0 480.8,294.8 536.7,303.9 592.5,324.7 648.3,346.5 704.2,362.2 760.0,371.7" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,256.6 145.8,253.8 201.7,252.7 257.5,269.0 313.3,290.5 369.2,301.6 425.0,298.5 480.8,317.7 536.7,338.0 592.5,356.7 648.3,369.3 704.2,376.2 760.0,377.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,378.4 145.8,378.3 201.7,378.3 257.5,378.3 313.3,378.7 369.2,378.5 425.0,378.4 480.8,378.5 536.7,378.6 592.5,378.8 648.3,378.9 704.2,379.0 760.0,379.5" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,382.9 145.8,381.8 201.7,379.7 257.5,375.3 313.3,369.2 369.2,354.6 425.0,325.1 480.8,302.7 536.7,284.6 592.5,263.9 648.3,227.7 704.2,197.6 760.0,174.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="381.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="379.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="375.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="369.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="354.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="325.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="302.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="284.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="263.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="227.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="197.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="174.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.6 145.8,383.1 201.7,382.3 257.5,380.5 313.3,377.3 369.2,371.1 425.0,359.2 480.8,338.3 536.7,302.0 592.5,262.6 648.3,230.3 704.2,205.2 760.0,182.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="382.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="380.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="377.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="370.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="358.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="339.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="300.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="264.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="241.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="217.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="206.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="382.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="380.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="377.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="371.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="359.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="338.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="302.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="262.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="230.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="205.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="182.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,380.3 313.3,378.0 369.2,373.4 425.0,362.1 480.8,350.1 536.7,336.9 592.5,328.0 648.3,323.9 704.2,319.7 760.0,282.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -153,34 +153,34 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,534.9 145.8,535.3 201.7,535.2 257.5,535.0 313.3,535.0 369.2,534.6 425.0,534.4 480.8,534.3 536.7,532.8 592.5,531.5 648.3,530.5 704.2,528.0 760.0,521.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="534.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="535.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,535.3 145.8,535.5 201.7,535.0 257.5,534.7 313.3,535.0 369.2,534.6 425.0,534.6 480.8,534.6 536.7,533.4 592.5,532.2 648.3,530.4 704.2,527.4 760.0,521.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="535.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="534.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="534.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="534.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="534.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="532.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="531.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="530.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="528.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="521.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,514.7 145.8,513.1 201.7,513.6 257.5,513.7 313.3,512.9 369.2,513.3 425.0,512.0 480.8,512.6 536.7,511.4 592.5,510.3 648.3,507.9 704.2,505.4 760.0,500.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="514.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="513.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="513.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="513.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="512.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="513.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="512.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="512.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="511.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="510.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="507.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="505.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="500.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="534.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="534.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="533.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="532.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="530.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="521.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,514.2 145.8,513.5 201.7,513.5 257.5,513.4 313.3,513.5 369.2,513.5 425.0,512.7 480.8,513.0 536.7,511.2 592.5,510.8 648.3,508.6 704.2,505.5 760.0,499.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="514.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="513.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="512.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="513.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="511.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="510.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="508.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="505.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="499.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,527.6 145.8,526.5 201.7,527.1 257.5,526.0 313.3,527.5 369.2,525.6 425.0,525.4 480.8,524.9 536.7,522.6 592.5,522.7 648.3,509.5 704.2,509.3 760.0,500.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="526.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -884,7 +884,7 @@ def gen_combined_chart(data, path):
     async_omq_tp = data["async_omq_tp"]
     async_pz_tp = data["async_pz_tp"]
 
-    msg_max = 2_500_000
+    msg_max = 3_000_000
     mbps_max = 6_000
 
     def y_msg(v):
@@ -921,9 +921,8 @@ def gen_combined_chart(data, path):
             f' fill="#9ca3af" font-size="10">{hw_label}</text>'
         )
 
-    n_l_ticks = 5
-    for i in range(n_l_ticks + 1):
-        val = i * msg_max / n_l_ticks
+    msg_tick = 500_000
+    for val in range(msg_tick, msg_max + 1, msg_tick):
         yy = y_msg(val)
         L.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -3,14 +3,14 @@
   <text x="475.0" y="16.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput, TCP loopback, 2-process</text>
   <text x="475.0" y="30.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="224.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">small messages (higher is better)</text>
-  <line x1="70.0" y1="256.6" x2="378.0" y2="256.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="256.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
-  <line x1="70.0" y1="193.3" x2="378.0" y2="193.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="193.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
-  <line x1="70.0" y1="129.9" x2="378.0" y2="129.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="129.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
-  <line x1="70.0" y1="66.5" x2="378.0" y2="66.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="66.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
+  <line x1="70.0" y1="255.6" x2="378.0" y2="255.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="255.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
+  <line x1="70.0" y1="191.1" x2="378.0" y2="191.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="191.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
+  <line x1="70.0" y1="126.7" x2="378.0" y2="126.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="126.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
+  <line x1="70.0" y1="62.3" x2="378.0" y2="62.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="62.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="131.6" y1="60.0" x2="131.6" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -20,55 +20,62 @@
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="320.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="70.0,221.5 131.6,223.4 193.2,223.2 254.8,230.3 316.4,240.8 378.0,247.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="221.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="223.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="223.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="230.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="240.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="247.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,283.0 131.6,268.1 193.2,254.6 254.8,242.8 316.4,245.2 378.0,258.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="283.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="268.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="254.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="242.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="245.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="258.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,309.3 131.6,310.6 193.2,311.5 254.8,312.0 316.4,312.2 378.0,312.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="309.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="310.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,211.0 131.6,221.7 193.2,218.9 254.8,228.8 316.4,223.9 378.0,242.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="211.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="221.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="218.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="228.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="223.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="242.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,278.6 131.6,267.2 193.2,248.3 254.8,241.5 316.4,241.0 378.0,255.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="278.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="267.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="248.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="241.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="241.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="255.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,309.1 131.6,310.5 193.2,311.5 254.8,311.9 316.4,312.0 378.0,312.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="309.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="310.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="193.2" cy="311.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="312.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="312.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,93.9 131.6,109.7 193.2,176.0 254.8,249.2 316.4,255.7 378.0,291.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="93.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="109.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="176.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="249.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="255.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="291.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,100.9 131.6,107.0 193.2,180.5 254.8,248.3 316.4,253.9 378.0,292.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="100.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="107.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="180.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="248.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="253.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="292.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,114.6 131.6,116.1 193.2,118.8 254.8,138.3 316.4,166.8 378.0,212.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="114.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="116.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="118.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="138.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="166.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="212.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,107.1 131.6,110.0 193.2,122.3 254.8,143.3 316.4,186.6 378.0,234.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="107.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="110.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="122.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="143.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="186.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="234.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="311.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="312.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,101.8 131.6,106.2 193.2,181.9 254.8,248.0 316.4,254.0 378.0,291.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="101.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="106.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="181.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="248.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="254.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="291.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,93.9 131.6,103.4 193.2,171.2 254.8,247.1 316.4,253.8 378.0,291.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="93.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="103.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="171.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="247.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="253.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="291.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,157.3 131.6,141.2 193.2,119.0 254.8,129.9 316.4,143.7 378.0,203.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="157.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="141.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="119.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="129.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="143.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="203.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,108.1 131.6,112.7 193.2,112.1 254.8,135.2 316.4,155.5 378.0,209.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="108.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="112.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="112.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="135.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="155.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="209.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,98.6 131.6,106.5 193.2,118.5 254.8,140.3 316.4,185.9 378.0,230.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="98.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="106.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="118.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="140.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="185.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="230.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="70.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="131.6" y="333.0" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
   <text x="193.2" y="333.0" text-anchor="middle" fill="#374151" font-size="8">64 B</text>
@@ -101,80 +108,91 @@
   <line x1="880.0" y1="60.0" x2="880.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="418.0" y1="60.0" x2="418.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="418.0" y1="320.0" x2="880.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="418.0,295.1 469.3,272.7 520.7,228.4 572.0,194.1 623.3,173.8 674.7,184.4 726.0,128.7 777.3,128.4 828.7,154.3 880.0,164.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="295.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,290.2 469.3,272.7 520.7,224.1 572.0,194.1 623.3,157.0 674.7,184.4 726.0,115.9 777.3,128.4 828.7,154.3 880.0,164.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="290.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="272.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="228.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="224.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="194.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="173.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="157.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="184.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="128.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="115.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="128.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="154.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="164.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,296.5 469.3,277.5 520.7,242.1 572.0,214.7 623.3,210.0 674.7,183.9 726.0,194.4 777.3,185.9 828.7,216.2 880.0,209.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="296.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,295.5 469.3,277.5 520.7,240.5 572.0,214.7 623.3,190.1 674.7,183.9 726.0,198.7 777.3,185.9 828.7,216.2 880.0,209.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="295.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="277.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="242.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="240.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="214.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="210.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="190.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="183.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="194.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="198.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="185.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="216.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="209.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,317.5 469.3,315.4 520.7,311.1 572.0,302.9 623.3,289.1 674.7,266.7 726.0,215.3 777.3,194.5 828.7,199.6 880.0,236.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="418.0,317.5 469.3,315.4 520.7,310.8 572.0,302.9 623.3,289.6 674.7,266.7 726.0,230.4 777.3,194.5 828.7,199.6 880.0,236.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="418.0" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="315.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="311.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="310.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="302.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="289.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="289.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="266.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="215.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="230.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="194.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="199.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="236.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,299.7 469.3,291.2 520.7,284.5 572.0,280.3 623.3,276.4 674.7,278.7 726.0,274.9 777.3,246.3 828.7,171.3 880.0,169.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="299.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,299.6 469.3,291.2 520.7,284.6 572.0,280.3 623.3,275.7 674.7,278.7 726.0,274.0 777.3,246.3 828.7,171.3 880.0,169.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="299.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="291.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="284.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="284.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="280.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="276.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="275.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="278.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="274.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="274.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="246.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="171.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="169.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,299.2 469.3,290.7 520.7,284.9 572.0,279.6 623.3,277.2 674.7,275.1 726.0,276.0 777.3,247.0 828.7,166.2 880.0,151.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="299.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,299.5 469.3,290.7 520.7,284.8 572.0,279.6 623.3,276.8 674.7,275.1 726.0,274.1 777.3,247.0 828.7,166.2 880.0,151.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="299.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="290.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="284.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="279.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="277.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="276.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="275.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="276.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="274.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="247.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="166.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="151.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,271.7 469.3,250.6 520.7,184.3 572.0,160.0 623.3,128.4 674.7,94.7 726.0,114.7 777.3,110.3 828.7,141.4 880.0,151.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="271.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,265.4 469.3,228.4 520.7,176.0 572.0,115.7 623.3,150.1 674.7,127.3 726.0,133.3 777.3,123.6 828.7,175.6 880.0,157.2" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="265.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="228.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="176.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="115.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="150.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="127.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="133.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="123.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="175.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="157.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,269.1 469.3,250.6 520.7,183.2 572.0,160.0 623.3,104.7 674.7,94.7 726.0,103.6 777.3,110.3 828.7,141.4 880.0,151.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="269.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="250.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="184.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="183.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="160.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="128.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="104.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="94.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="114.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="103.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="110.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="141.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="151.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,278.0 469.3,247.1 520.7,211.9 572.0,184.3 623.3,147.7 674.7,160.3 726.0,113.5 777.3,93.9 828.7,110.6 880.0,136.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="278.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,278.5 469.3,247.1 520.7,209.7 572.0,184.3 623.3,148.1 674.7,160.3 726.0,99.8 777.3,93.9 828.7,110.6 880.0,136.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="278.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="247.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="211.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="209.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="572.0" cy="184.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="148.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="674.7" cy="160.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="113.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="99.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="777.3" cy="93.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="110.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="136.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
@@ -200,14 +218,17 @@
   <line x1="665" y1="350" x2="679" y2="350" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="672" cy="350" r="2.5" fill="#dc2626"/>
   <text x="685" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (4T)</text>
-  <line x1="190" y1="370" x2="204" y2="370" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="197" cy="370" r="2.5" fill="#2563eb"/>
-  <text x="210" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="380" y1="370" x2="394" y2="370" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="387" cy="370" r="2.5" fill="#16a34a"/>
-  <text x="400" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="570" y1="370" x2="584" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="577" cy="370" r="2.5" fill="#15803d"/>
-  <text x="590" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="95" y1="370" x2="109" y2="370" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="102" cy="370" r="2.5" fill="#06b6d4"/>
+  <text x="115" y="374" fill="#374151" font-size="10" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="285" y1="370" x2="299" y2="370" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="292" cy="370" r="2.5" fill="#2563eb"/>
+  <text x="305" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="475" y1="370" x2="489" y2="370" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="482" cy="370" r="2.5" fill="#16a34a"/>
+  <text x="495" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="665" y1="370" x2="679" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="672" cy="370" r="2.5" fill="#15803d"/>
+  <text x="685" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="475.0" y="388.0" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
 </svg>

--- a/doc/charts/pubsub/tcp.svg
+++ b/doc/charts/pubsub/tcp.svg
@@ -36,6 +36,7 @@
   <polyline points="78.0,191.8 180.1,193.5 282.3,194.7 384.4,202.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,189.6 180.1,184.7 282.3,209.6 384.4,229.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,185.3 180.1,184.7 282.3,207.8 384.4,228.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,197.6 180.1,184.1 282.3,184.9 384.4,190.4" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,191.6 180.1,192.3 282.3,192.7 384.4,195.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,252.7 180.1,252.7 282.3,252.7 384.4,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,260.5 180.1,224.3 282.3,219.2 384.4,237.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -55,6 +56,11 @@
   <circle cx="180.1" cy="191.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="263.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="294.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,195.1 180.1,163.5 282.3,184.5 384.4,208.6" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="195.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="163.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="184.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="208.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,203.6 180.1,206.6 282.3,219.0 384.4,231.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="203.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="206.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -119,6 +125,7 @@
   <polyline points="482.4,194.7 635.6,202.3 788.8,228.8 942.0,242.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,209.6 635.6,229.0 788.8,246.4 942.0,244.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,207.8 635.6,228.4 788.8,246.0 942.0,245.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,184.9 635.6,190.4 788.8,188.0 942.0,184.9" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,192.7 635.6,195.1 788.8,198.0 942.0,208.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,252.7 635.6,252.7 788.8,252.9 942.0,252.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,219.2 635.6,237.2 788.8,239.6 942.0,252.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -138,6 +145,11 @@
   <circle cx="635.6" cy="288.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="277.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="277.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,278.4 635.6,180.8 788.8,151.9 942.0,126.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="278.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="180.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="151.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="126.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,289.2 635.6,209.0 788.8,117.2 942.0,151.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="289.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="209.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -189,6 +201,7 @@
   <polyline points="78.0,551.5 180.1,553.6 282.3,554.1 384.4,559.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,555.2 180.1,562.3 282.3,574.9 384.4,581.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,516.6 180.1,516.9 282.3,521.6 384.4,522.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,615.1 180.1,616.7 282.3,606.8 384.4,617.0" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,463.5 180.1,464.9 282.3,460.6 384.4,457.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,583.3 180.1,583.2 282.3,583.0 384.4,583.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,550.3 180.1,549.7 282.3,555.5 384.4,556.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -208,6 +221,11 @@
   <circle cx="180.1" cy="499.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="549.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="599.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,619.9 180.1,621.3 282.3,608.9 384.4,632.8" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="619.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="621.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="608.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="632.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,482.5 180.1,501.4 282.3,551.0 384.4,563.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="482.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="501.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -262,6 +280,7 @@
   <polyline points="482.4,554.1 635.6,559.6 788.8,572.7 942.0,579.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,574.9 635.6,581.9 788.8,584.0 942.0,583.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,521.6 635.6,522.6 788.8,530.7 942.0,524.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,606.8 635.6,617.0 788.8,575.8 942.0,566.3" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,460.6 635.6,457.7 788.8,473.8 942.0,459.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,583.0 635.6,583.0 788.8,583.3 942.0,583.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,555.5 635.6,556.3 788.8,549.0 942.0,544.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -281,6 +300,11 @@
   <circle cx="635.6" cy="591.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="587.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="583.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,629.1 635.6,631.7 788.8,565.8 942.0,520.3" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="629.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="631.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="565.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="520.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,611.4 635.6,547.0 788.8,463.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="611.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="547.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -338,6 +362,7 @@
   <polyline points="78.0,884.2 180.1,886.3 282.3,885.6 384.4,888.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,881.2 180.1,885.9 282.3,899.9 384.4,906.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,862.1 180.1,866.1 282.3,867.8 384.4,874.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,931.5 180.1,933.1 282.3,934.7 384.4,900.7" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,796.9 180.1,797.6 282.3,764.1 384.4,776.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,900.8 180.1,899.7 282.3,899.9 384.4,899.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,861.7 180.1,848.8 282.3,858.9 384.4,851.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -357,6 +382,11 @@
   <circle cx="180.1" cy="856.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="903.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="938.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,928.6 180.1,933.0 282.3,947.2 384.4,928.5" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="928.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="933.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="947.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="928.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,750.7 180.1,785.6 282.3,861.1 384.4,885.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="785.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -413,6 +443,7 @@
   <polyline points="482.4,885.6 635.6,888.6 788.8,897.3 942.0,899.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,899.9 635.6,906.1 788.8,906.0 942.0,903.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,867.8 635.6,874.4 788.8,875.3 942.0,867.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,934.7 635.6,900.7 788.8,928.7 942.0,892.5" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,764.1 635.6,776.3 788.8,793.3 942.0,792.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,899.9 635.6,899.9 788.8,899.7 942.0,899.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,858.9 635.6,851.5 788.8,848.5 942.0,866.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -432,6 +463,11 @@
   <circle cx="635.6" cy="927.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="924.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="918.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,951.8 635.6,911.9 788.8,926.3 942.0,840.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="951.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="911.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="926.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="840.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,916.9 635.6,842.8 788.8,753.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="916.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="842.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -468,15 +504,18 @@
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
   <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
-  <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
-  <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
-  <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="130" y1="1009" x2="144" y2="1009" stroke="#06b6d4" stroke-width="2.5"/>
+  <circle cx="137" cy="1009" r="2.5" fill="#06b6d4"/>
+  <text x="150" y="1013" fill="#374151" font-size="11" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="320" y1="1009" x2="334" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="327" cy="1009" r="2.5" fill="#2563eb"/>
+  <text x="340" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="510" y1="1009" x2="524" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
+  <circle cx="517" cy="1009" r="2.5" fill="#16a34a"/>
+  <text x="530" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
+  <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
+  <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>

--- a/doc/charts/pubsub/tcp.svg
+++ b/doc/charts/pubsub/tcp.svg
@@ -3,69 +3,111 @@
   <text x="510.0" y="32.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="510.0" y="51.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 1 subscriber: TCP loopback</text>
   <text x="231.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="274.0" x2="384.4" y2="274.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="274.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="227.0" x2="384.4" y2="227.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="227.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="180.0" x2="384.4" y2="180.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="180.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="133.0" x2="384.4" y2="133.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="133.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="78.0" y1="291.6" x2="384.4" y2="291.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="78.0" y1="262.2" x2="384.4" y2="262.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="232.9" x2="384.4" y2="232.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="78.0" y1="203.5" x2="384.4" y2="203.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="174.1" x2="384.4" y2="174.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="78.0" y1="144.8" x2="384.4" y2="144.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="115.4" x2="384.4" y2="115.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="384.4" y1="259.0" x2="388.4" y2="259.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="259.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="197.0" x2="388.4" y2="197.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="197.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="135.0" x2="388.4" y2="135.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="135.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="384.4" y1="261.0" x2="388.4" y2="261.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="261.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="201.0" x2="388.4" y2="201.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="201.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="141.1" x2="388.4" y2="141.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="141.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="86.0" x2="231.2" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="321.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,203.5)">CPU %</text>
-  <polyline points="78.0,142.3 231.2,146.3 384.4,146.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,123.5 231.2,131.1 384.4,169.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,121.9 231.2,133.9 384.4,164.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,177.8 231.2,178.6 384.4,179.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,246.6 231.2,243.0 384.4,241.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,248.2 231.2,228.0 384.4,209.8" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,224.0 231.2,225.5 384.4,226.8" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,268.9 231.2,268.7 384.4,266.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,120.3 231.2,188.0 384.4,262.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,116.7 231.2,188.6 384.4,263.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,156.5 231.2,180.9 384.4,186.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,146.5 231.2,178.2 384.4,204.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,306.4 231.2,287.9 384.4,271.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,312.1 231.2,313.0 384.4,313.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,191.8 180.1,193.5 282.3,194.7 384.4,202.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,189.6 180.1,184.7 282.3,209.6 384.4,229.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,185.3 180.1,184.7 282.3,207.8 384.4,228.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,191.6 180.1,192.3 282.3,192.7 384.4,195.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,252.7 180.1,252.7 282.3,252.7 384.4,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,260.5 180.1,224.3 282.3,219.2 384.4,237.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,257.4 180.1,260.1 282.3,261.9 384.4,262.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,236.3 180.1,237.8 282.3,238.9 384.4,251.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="236.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="237.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="238.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="251.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,121.9 180.1,194.3 282.3,263.7 384.4,294.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="121.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="194.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="263.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="294.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,116.7 180.1,191.8 282.3,263.5 384.4,294.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="116.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="191.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="263.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="294.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,203.6 180.1,206.6 282.3,219.0 384.4,231.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="203.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="206.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="219.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="231.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,199.2 180.1,206.2 282.3,228.6 384.4,257.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="199.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="206.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="228.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="257.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,283.7 180.1,256.7 282.3,252.0 384.4,266.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="283.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="256.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="252.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="266.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,312.4 180.1,313.7 282.3,314.3 384.4,315.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="312.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="313.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="314.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="315.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="482.4" y1="274.0" x2="942.0" y2="274.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="274.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="482.4" y1="227.0" x2="942.0" y2="227.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="227.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="482.4" y1="180.0" x2="942.0" y2="180.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="180.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="482.4" y1="133.0" x2="942.0" y2="133.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="133.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="482.4" y1="291.6" x2="942.0" y2="291.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="482.4" y1="262.2" x2="942.0" y2="262.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="482.4" y1="232.9" x2="942.0" y2="232.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="482.4" y1="203.5" x2="942.0" y2="203.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="482.4" y1="174.1" x2="942.0" y2="174.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="482.4" y1="144.8" x2="942.0" y2="144.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="482.4" y1="115.4" x2="942.0" y2="115.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="942.0" y1="284.9" x2="946.0" y2="284.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="284.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
-  <line x1="942.0" y1="248.8" x2="946.0" y2="248.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="248.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="212.6" x2="946.0" y2="212.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="212.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3 GB/s</text>
-  <line x1="942.0" y1="176.5" x2="946.0" y2="176.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="176.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="140.4" x2="946.0" y2="140.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="140.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5 GB/s</text>
-  <line x1="942.0" y1="104.3" x2="946.0" y2="104.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="104.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="284.5" x2="946.0" y2="284.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="284.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
+  <line x1="942.0" y1="247.9" x2="946.0" y2="247.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="247.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="211.4" x2="946.0" y2="211.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="211.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3 GB/s</text>
+  <line x1="942.0" y1="174.8" x2="946.0" y2="174.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="174.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="138.3" x2="946.0" y2="138.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="138.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5 GB/s</text>
+  <line x1="942.0" y1="101.7" x2="946.0" y2="101.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="101.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -74,121 +116,141 @@
   <line x1="942.0" y1="86.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="321.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,203.5)">CPU %</text>
-  <polyline points="482.4,146.2 635.6,146.3 788.8,171.1 942.0,189.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,169.4 635.6,177.1 788.8,181.6 942.0,191.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,164.9 635.6,172.1 788.8,175.9 942.0,188.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,179.3 635.6,181.8 788.8,197.4 942.0,202.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,241.3 635.6,230.4 788.8,239.4 942.0,238.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,209.8 635.6,211.9 788.8,208.2 942.0,206.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,226.8 635.6,227.8 788.8,228.6 942.0,228.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,304.8 635.6,260.0 788.8,186.3 942.0,126.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="304.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="260.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="186.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="126.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,303.5 635.6,289.0 788.8,280.2 942.0,278.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="303.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="289.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="280.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="278.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,304.0 635.6,289.4 788.8,275.6 942.0,277.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="304.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="289.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="275.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="277.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,280.7 635.6,194.9 788.8,143.3 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="280.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="194.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="143.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,286.2 635.6,230.4 788.8,177.8 942.0,147.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="286.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="230.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="177.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="147.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,306.3 635.6,268.3 788.8,205.0 942.0,176.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="306.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="268.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="205.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="176.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,318.9 635.6,313.2 788.8,294.7 942.0,241.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,194.7 635.6,202.3 788.8,228.8 942.0,242.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,209.6 635.6,229.0 788.8,246.4 942.0,244.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,207.8 635.6,228.4 788.8,246.0 942.0,245.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,192.7 635.6,195.1 788.8,198.0 942.0,208.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,252.7 635.6,252.7 788.8,252.9 942.0,252.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,219.2 635.6,237.2 788.8,239.6 942.0,252.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,261.9 635.6,262.3 788.8,262.5 942.0,263.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,295.4 635.6,233.8 788.8,169.9 942.0,116.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="295.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="233.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="169.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="116.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.1 635.6,288.3 788.8,277.1 942.0,277.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="288.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="277.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="277.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.1 635.6,288.4 788.8,277.7 942.0,277.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="288.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="277.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="277.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,289.2 635.6,209.0 788.8,117.2 942.0,151.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="289.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="209.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="117.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="151.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,292.2 635.6,242.2 788.8,183.2 942.0,161.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="292.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="242.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="183.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="161.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,299.5 635.6,252.8 788.8,192.0 942.0,177.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="299.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="252.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="192.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="177.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,318.9 635.6,313.5 788.8,295.0 942.0,236.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="318.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="313.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="294.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="241.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="313.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="295.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="236.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="510.0" y="368.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 8 subscribers: TCP loopback</text>
   <text x="231.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="608.6" x2="384.4" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="579.2" x2="384.4" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="549.9" x2="384.4" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="520.5" x2="384.4" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="78.0" y1="491.1" x2="384.4" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="78.0" y1="461.8" x2="384.4" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
-  <line x1="78.0" y1="432.4" x2="384.4" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <line x1="78.0" y1="591.0" x2="384.4" y2="591.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="591.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="544.0" x2="384.4" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="497.0" x2="384.4" y2="497.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="497.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="450.0" x2="384.4" y2="450.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="450.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="384.4" y1="558.0" x2="388.4" y2="558.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="558.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="477.9" x2="388.4" y2="477.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="477.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <line x1="384.4" y1="558.6" x2="388.4" y2="558.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="558.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="479.2" x2="388.4" y2="479.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="479.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="403.0" x2="231.2" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="638.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,520.5)">CPU %</text>
-  <polyline points="78.0,465.0 231.2,465.7 384.4,468.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,493.6 231.2,500.5 384.4,495.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,478.9 231.2,499.0 384.4,484.3" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,474.1 231.2,478.0 384.4,477.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,554.0 231.2,549.6 384.4,557.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,485.2 231.2,503.7 384.4,513.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,520.8 231.2,524.2 384.4,528.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,572.5 231.2,571.6 384.4,574.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,436.8 231.2,517.4 384.4,583.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,484.7 231.2,508.0 384.4,550.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,525.2 231.2,533.9 384.4,557.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,433.7 231.2,464.8 384.4,514.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,589.8 231.2,588.8 384.4,593.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,632.7 231.2,633.6 384.4,634.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,551.5 180.1,553.6 282.3,554.1 384.4,559.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,555.2 180.1,562.3 282.3,574.9 384.4,581.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,516.6 180.1,516.9 282.3,521.6 384.4,522.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,463.5 180.1,464.9 282.3,460.6 384.4,457.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,583.3 180.1,583.2 282.3,583.0 384.4,583.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,550.3 180.1,549.7 282.3,555.5 384.4,556.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,584.1 180.1,586.9 282.3,589.8 384.4,590.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,522.3 180.1,527.0 282.3,544.0 384.4,575.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="522.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="527.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="544.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="575.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,448.7 180.1,518.4 282.3,583.6 384.4,621.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="448.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="518.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="583.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="621.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,477.8 180.1,499.7 282.3,549.9 384.4,599.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="477.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="499.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="549.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="599.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,482.5 180.1,501.4 282.3,551.0 384.4,563.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="482.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="501.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="551.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="563.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,463.9 282.3,511.7 384.4,586.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="463.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="511.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="586.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,576.0 180.1,574.1 282.3,579.2 384.4,593.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="576.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="574.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="579.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="593.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,632.8 180.1,633.5 282.3,634.6 384.4,634.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="632.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="633.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="634.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="482.4" y1="608.6" x2="942.0" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="482.4" y1="579.2" x2="942.0" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="482.4" y1="549.9" x2="942.0" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="482.4" y1="520.5" x2="942.0" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="482.4" y1="491.1" x2="942.0" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="482.4" y1="461.8" x2="942.0" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
-  <line x1="482.4" y1="432.4" x2="942.0" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <line x1="482.4" y1="591.0" x2="942.0" y2="591.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="591.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="482.4" y1="544.0" x2="942.0" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="482.4" y1="497.0" x2="942.0" y2="497.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="497.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="482.4" y1="450.0" x2="942.0" y2="450.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="450.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="942.0" y1="579.2" x2="946.0" y2="579.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="579.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="520.3" x2="946.0" y2="520.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="520.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="461.5" x2="946.0" y2="461.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="461.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <line x1="942.0" y1="590.7" x2="946.0" y2="590.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="590.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="543.3" x2="946.0" y2="543.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="543.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="496.0" x2="946.0" y2="496.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="496.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="448.6" x2="946.0" y2="448.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="448.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -197,129 +259,149 @@
   <line x1="942.0" y1="403.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="638.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,520.5)">CPU %</text>
-  <polyline points="482.4,468.4 635.6,476.8 788.8,501.1 942.0,531.8" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,495.3 635.6,492.5 788.8,488.6 942.0,513.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,484.3 635.6,481.7 788.8,479.9 942.0,471.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,477.7 635.6,477.1 788.8,501.0 942.0,491.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,557.0 635.6,575.2 788.8,573.6 942.0,574.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,513.5 635.6,520.0 788.8,510.5 942.0,496.8" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,528.3 635.6,529.3 788.8,531.7 942.0,539.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,614.1 635.6,561.0 788.8,486.0 942.0,453.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="614.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="561.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="486.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="453.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,617.5 635.6,612.8 788.8,610.9 942.0,607.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="617.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="612.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="610.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="607.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,604.9 635.6,582.0 788.8,576.3 942.0,565.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="604.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="582.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="576.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="565.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,607.8 635.6,549.9 788.8,445.4 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="607.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="549.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="445.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,554.1 635.6,559.6 788.8,572.7 942.0,579.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,574.9 635.6,581.9 788.8,584.0 942.0,583.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,521.6 635.6,522.6 788.8,530.7 942.0,524.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,460.6 635.6,457.7 788.8,473.8 942.0,459.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,583.0 635.6,583.0 788.8,583.3 942.0,583.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,555.5 635.6,556.3 788.8,549.0 942.0,544.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,589.8 635.6,590.5 788.8,590.9 942.0,591.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,609.3 635.6,561.6 788.8,509.0 942.0,490.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="609.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="561.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="509.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="490.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,621.4 635.6,617.4 788.8,616.1 942.0,613.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="621.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="617.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="616.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="613.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,611.1 635.6,591.0 788.8,587.3 942.0,583.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="611.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="591.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="587.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="583.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,611.4 635.6,547.0 788.8,463.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="611.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="547.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="463.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,591.4 635.6,556.2 788.8,479.9 942.0,449.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="591.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="556.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="479.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="449.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,621.1 635.6,582.1 788.8,513.0 942.0,464.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="621.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="582.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="513.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="464.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,636.6 635.6,632.8 788.8,620.0 942.0,585.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="636.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="632.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="620.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="585.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,599.4 635.6,575.1 788.8,526.5 942.0,511.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="599.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="575.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="526.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="511.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,620.1 635.6,583.3 788.8,531.0 942.0,500.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="620.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="583.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="531.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="500.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,637.0 635.6,634.1 788.8,624.0 942.0,595.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="637.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="624.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="595.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="510.0" y="685.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 32 subscribers: TCP loopback</text>
   <text x="231.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="925.6" x2="384.4" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="896.2" x2="384.4" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="866.9" x2="384.4" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="837.5" x2="384.4" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="78.0" y1="808.1" x2="384.4" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="78.0" y1="778.8" x2="384.4" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
-  <line x1="78.0" y1="749.4" x2="384.4" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <line x1="78.0" y1="908.0" x2="384.4" y2="908.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="908.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="861.0" x2="384.4" y2="861.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="861.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="814.0" x2="384.4" y2="814.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="814.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="767.0" x2="384.4" y2="767.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="384.4" y1="904.7" x2="388.4" y2="904.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="904.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">100k/s</text>
-  <line x1="384.4" y1="854.3" x2="388.4" y2="854.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="854.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
-  <line x1="384.4" y1="804.0" x2="388.4" y2="804.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="804.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">300k/s</text>
-  <line x1="384.4" y1="753.6" x2="388.4" y2="753.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="753.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
+  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <line x1="384.4" y1="908.1" x2="388.4" y2="908.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="908.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">100k/s</text>
+  <line x1="384.4" y1="861.3" x2="388.4" y2="861.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="861.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
+  <line x1="384.4" y1="814.4" x2="388.4" y2="814.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="814.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">300k/s</text>
+  <line x1="384.4" y1="767.5" x2="388.4" y2="767.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="767.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
+  <line x1="384.4" y1="720.6" x2="388.4" y2="720.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="720.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="720.0" x2="231.2" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="955.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,837.5)">CPU %</text>
-  <polyline points="78.0,773.9 231.2,775.1 384.4,776.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,811.1 231.2,811.5 384.4,811.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,788.4 231.2,783.9 384.4,792.1" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,778.5 231.2,783.7 384.4,785.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,828.2 231.2,828.0 384.4,862.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,770.2 231.2,779.5 384.4,792.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,821.2 231.2,816.2 384.4,818.9" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,913.1 231.2,907.7 384.4,910.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,804.2 231.2,859.9 384.4,916.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,824.1 231.2,846.8 384.4,900.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,750.7 231.2,792.5 384.4,831.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,810.8 231.2,841.3 384.4,896.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,920.4 231.2,922.8 384.4,927.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,951.1 231.2,950.9 384.4,951.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,884.2 180.1,886.3 282.3,885.6 384.4,888.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,881.2 180.1,885.9 282.3,899.9 384.4,906.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,862.1 180.1,866.1 282.3,867.8 384.4,874.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,796.9 180.1,797.6 282.3,764.1 384.4,776.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,900.8 180.1,899.7 282.3,899.9 384.4,899.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,861.7 180.1,848.8 282.3,858.9 384.4,851.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,902.7 180.1,902.9 282.3,904.0 384.4,908.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,880.2 180.1,888.3 282.3,896.0 384.4,916.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="880.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="888.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="896.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="916.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,810.3 180.1,868.4 282.3,919.7 384.4,944.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="810.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="868.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="919.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="944.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,832.1 180.1,856.9 282.3,903.2 384.4,938.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="832.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="856.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="903.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="938.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,750.7 180.1,785.6 282.3,861.1 384.4,885.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="785.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="861.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="885.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,822.6 180.1,839.5 282.3,900.8 384.4,914.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="822.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="839.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="900.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="914.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,920.4 180.1,911.9 282.3,917.7 384.4,926.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="920.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="911.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="917.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="926.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,951.4 180.1,951.3 282.3,951.5 384.4,952.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="951.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="951.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="951.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="952.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="482.4" y1="925.6" x2="942.0" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="482.4" y1="896.2" x2="942.0" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="482.4" y1="866.9" x2="942.0" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="482.4" y1="837.5" x2="942.0" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="482.4" y1="808.1" x2="942.0" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="482.4" y1="778.8" x2="942.0" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
-  <line x1="482.4" y1="749.4" x2="942.0" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <line x1="482.4" y1="908.0" x2="942.0" y2="908.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="908.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="482.4" y1="861.0" x2="942.0" y2="861.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="861.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="482.4" y1="814.0" x2="942.0" y2="814.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="814.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="482.4" y1="767.0" x2="942.0" y2="767.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="942.0" y1="913.6" x2="946.0" y2="913.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="913.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="872.2" x2="946.0" y2="872.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="872.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="830.8" x2="946.0" y2="830.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="830.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="789.5" x2="946.0" y2="789.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="789.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="748.1" x2="946.0" y2="748.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="748.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <line x1="942.0" y1="908.5" x2="946.0" y2="908.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="908.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="862.1" x2="946.0" y2="862.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="862.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="815.6" x2="946.0" y2="815.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="815.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="769.2" x2="946.0" y2="769.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="769.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="722.7" x2="946.0" y2="722.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="722.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -328,79 +410,78 @@
   <line x1="942.0" y1="720.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="955.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,837.5)">CPU %</text>
-  <polyline points="482.4,776.7 635.6,786.8 788.8,803.3 942.0,836.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,811.7 635.6,807.0 788.8,811.4 942.0,824.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,792.1 635.6,790.8 788.8,786.0 942.0,782.1" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,785.5 635.6,784.1 788.8,789.1 942.0,777.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,862.9 635.6,874.0 788.8,876.8 942.0,887.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,792.2 635.6,796.4 788.8,792.5 942.0,789.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,818.9 635.6,822.3 788.8,821.4 942.0,833.9" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,939.9 635.6,905.3 788.8,851.2 942.0,828.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="939.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="905.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="851.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="828.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,942.1 635.6,939.4 788.8,939.1 942.0,935.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="942.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="939.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="939.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="935.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,936.7 635.6,929.9 788.8,927.9 942.0,922.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="936.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="929.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="927.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="922.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,913.2 635.6,851.3 788.8,778.8 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="913.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="851.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="778.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,885.6 635.6,888.6 788.8,897.3 942.0,899.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,899.9 635.6,906.1 788.8,906.0 942.0,903.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,867.8 635.6,874.4 788.8,875.3 942.0,867.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,764.1 635.6,776.3 788.8,793.3 942.0,792.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,899.9 635.6,899.9 788.8,899.7 942.0,899.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,858.9 635.6,851.5 788.8,848.5 942.0,866.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,904.0 635.6,908.5 788.8,908.4 942.0,908.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,931.0 635.6,892.0 788.8,834.5 942.0,813.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="931.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="892.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="834.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="813.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,940.7 635.6,938.2 788.8,937.2 942.0,932.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="940.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="938.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="937.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="932.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,934.0 635.6,927.3 788.8,924.7 942.0,918.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="927.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="924.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="918.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,916.9 635.6,842.8 788.8,753.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="916.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="842.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="753.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,935.4 635.6,897.1 788.8,846.4 942.0,816.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="935.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="897.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="846.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="816.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,945.8 635.6,921.5 788.8,879.7 942.0,838.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="945.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="921.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="879.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="838.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,953.7 635.6,951.3 788.8,942.4 942.0,917.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="953.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="951.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="942.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="917.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,933.0 635.6,889.3 788.8,840.8 942.0,825.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="933.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="889.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="840.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="825.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,939.8 635.6,909.4 788.8,865.6 942.0,827.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="939.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="909.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="865.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="827.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,953.6 635.6,951.0 788.8,941.3 942.0,913.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="953.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="951.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="941.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="913.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
-  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4 IO threads)</text>
+  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
   <line x1="510" y1="989" x2="524" y2="989" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="517" cy="989" r="2.5" fill="#f97316"/>
-  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="567" cy="1049" r="3.0" fill="#6b7280"/>
   <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/fanin/tcp.svg
+++ b/doc/charts/pushpull/fanin/tcp.svg
@@ -40,6 +40,7 @@
   <polyline points="78.0,231.6 180.1,237.6 282.3,233.4 384.4,224.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,205.2 180.1,204.5 282.3,206.1 384.4,208.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,195.9 180.1,194.4 282.3,200.8 384.4,166.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,208.6 180.1,208.4 282.3,228.6 384.4,237.5" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,222.6 180.1,234.9 282.3,218.3 384.4,207.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,202.3 180.1,207.3 282.3,217.9 384.4,216.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -59,6 +60,11 @@
   <circle cx="180.1" cy="179.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="242.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,202.5 180.1,194.1 282.3,235.3 384.4,261.5" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="202.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="194.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="235.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="261.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,135.4 180.1,159.6 282.3,193.0 384.4,231.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="135.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="159.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -119,6 +125,7 @@
   <polyline points="482.4,233.4 635.6,224.5 788.8,232.6 942.0,235.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,206.1 635.6,208.2 788.8,207.3 942.0,223.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,200.8 635.6,166.4 788.8,164.4 942.0,178.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,228.6 635.6,237.5 788.8,242.2 942.0,251.5" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,218.3 635.6,207.0 788.8,208.4 942.0,238.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,217.9 635.6,216.7 788.8,215.3 942.0,208.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -138,6 +145,11 @@
   <circle cx="635.6" cy="271.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="260.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="257.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,291.4 635.6,238.9 788.8,165.8 942.0,163.9" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="291.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="238.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="165.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="163.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,276.8 635.6,197.2 788.8,116.7 942.0,158.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="276.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="197.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -201,6 +213,7 @@
   <polyline points="78.0,553.5 180.1,554.0 282.3,545.9 384.4,544.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,522.0 180.1,521.3 282.3,526.4 384.4,525.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,514.5 180.1,516.2 282.3,510.2 384.4,490.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,526.8 180.1,524.9 282.3,544.7 384.4,556.0" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,558.6 180.1,547.1 282.3,522.5 384.4,490.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.5 180.1,579.4 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,472.9 180.1,517.0 282.3,527.5 384.4,507.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -220,6 +233,11 @@
   <circle cx="180.1" cy="478.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="533.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="589.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,520.9 180.1,509.1 282.3,552.6 384.4,588.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="520.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="509.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="552.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="588.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,447.1 180.1,444.5 282.3,487.5 384.4,535.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="447.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="444.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -280,6 +298,7 @@
   <polyline points="482.4,545.9 635.6,544.9 788.8,555.1 942.0,555.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,526.4 635.6,525.4 788.8,526.1 942.0,541.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,510.2 635.6,490.5 788.8,484.4 942.0,490.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,544.7 635.6,556.0 788.8,569.5 942.0,573.1" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,522.5 635.6,490.4 788.8,490.4 942.0,529.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,527.5 635.6,507.1 788.8,509.5 942.0,511.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -299,6 +318,11 @@
   <circle cx="635.6" cy="576.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="567.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="556.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,610.9 635.6,574.4 788.8,537.5 942.0,506.1" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="610.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="574.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="537.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="506.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,590.2 635.6,507.5 788.8,441.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="590.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="507.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -356,6 +380,7 @@
   <polyline points="78.0,901.5 180.1,900.7 282.3,880.7 384.4,877.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,863.1 180.1,861.6 282.3,863.2 384.4,864.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,855.0 180.1,855.5 282.3,854.3 384.4,842.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,868.3 180.1,865.7 282.3,874.6 384.4,887.1" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,891.5 180.1,885.1 282.3,860.2 384.4,835.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,908.7 180.1,908.0 282.3,908.1 384.4,908.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,758.6 180.1,847.1 282.3,860.5 384.4,830.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -375,6 +400,11 @@
   <circle cx="180.1" cy="790.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="839.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="903.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,843.0 180.1,837.0 282.3,854.6 384.4,900.3" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="843.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="837.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="854.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="900.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,750.7 180.1,751.1 282.3,798.1 384.4,850.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="751.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -437,6 +467,7 @@
   <polyline points="482.4,862.1 635.6,858.3 788.8,869.3 942.0,875.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,840.2 635.6,842.4 788.8,844.0 942.0,866.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,829.1 635.6,814.4 788.8,798.9 942.0,791.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,854.5 635.6,870.1 788.8,885.8 942.0,890.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,836.4 635.6,805.8 788.8,829.9 942.0,837.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.4 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,836.8 635.6,799.8 788.8,789.1 942.0,803.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -456,6 +487,11 @@
   <circle cx="635.6" cy="897.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="884.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="869.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,926.5 635.6,892.9 788.8,865.9 942.0,837.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="926.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="892.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="865.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="837.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,910.4 635.6,836.0 788.8,773.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="910.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="836.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -492,15 +528,18 @@
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
   <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
-  <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
-  <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
-  <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="130" y1="1009" x2="144" y2="1009" stroke="#06b6d4" stroke-width="2.5"/>
+  <circle cx="137" cy="1009" r="2.5" fill="#06b6d4"/>
+  <text x="150" y="1013" fill="#374151" font-size="11" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="320" y1="1009" x2="334" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="327" cy="1009" r="2.5" fill="#2563eb"/>
+  <text x="340" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="510" y1="1009" x2="524" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
+  <circle cx="517" cy="1009" r="2.5" fill="#16a34a"/>
+  <text x="530" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
+  <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
+  <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>

--- a/doc/charts/pushpull/fanin/tcp.svg
+++ b/doc/charts/pushpull/fanin/tcp.svg
@@ -4,86 +4,110 @@
   <text x="510.0" y="51.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH fan-in (2 PUSH → 1 PULL): TCP loopback</text>
   <text x="231.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
   <line x1="78.0" y1="291.6" x2="384.4" y2="291.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <text x="70.0" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
   <line x1="78.0" y1="262.2" x2="384.4" y2="262.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <text x="70.0" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
   <line x1="78.0" y1="232.9" x2="384.4" y2="232.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <text x="70.0" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
   <line x1="78.0" y1="203.5" x2="384.4" y2="203.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <text x="70.0" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
   <line x1="78.0" y1="174.1" x2="384.4" y2="174.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="70.0" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
   <line x1="78.0" y1="144.8" x2="384.4" y2="144.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
+  <text x="70.0" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
   <line x1="78.0" y1="115.4" x2="384.4" y2="115.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="384.4" y1="286.3" x2="388.4" y2="286.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="286.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="251.7" x2="388.4" y2="251.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="251.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="217.0" x2="388.4" y2="217.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="217.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="182.4" x2="388.4" y2="182.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="182.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="147.7" x2="388.4" y2="147.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="147.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="384.4" y1="113.0" x2="388.4" y2="113.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="113.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
+  <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="384.4" y1="280.2" x2="388.4" y2="280.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="280.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="239.3" x2="388.4" y2="239.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="239.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="198.5" x2="388.4" y2="198.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="198.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="157.6" x2="388.4" y2="157.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="157.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="384.4" y1="116.8" x2="388.4" y2="116.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="116.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="86.0" x2="231.2" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="321.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,203.5)">CPU %</text>
-  <polyline points="78.0,187.7 231.2,193.1 384.4,192.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,187.5 231.2,153.0 384.4,138.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,195.2 231.2,163.4 384.4,144.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,173.9 231.2,177.2 384.4,184.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,238.9 231.2,238.9 384.4,248.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,244.4 231.2,247.9 384.4,252.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,223.2 231.2,230.6 384.4,232.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,283.5 231.2,284.2 384.4,284.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,177.5 231.2,202.9 384.4,250.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,179.1 231.2,204.2 384.4,249.7" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,140.6 231.2,199.1 384.4,219.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,116.7 231.2,186.6 384.4,228.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,280.1 231.2,281.2 384.4,282.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,306.1 231.2,310.9 384.4,312.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,231.6 180.1,237.6 282.3,233.4 384.4,224.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,205.2 180.1,204.5 282.3,206.1 384.4,208.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,195.9 180.1,194.4 282.3,200.8 384.4,166.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,222.6 180.1,234.9 282.3,218.3 384.4,207.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.3 180.1,262.3 282.3,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,202.3 180.1,207.3 282.3,217.9 384.4,216.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.0 180.1,261.8 282.3,262.4 384.4,261.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,256.1 180.1,267.9 282.3,263.0 384.4,271.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="256.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="267.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="263.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="271.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,154.1 180.1,183.8 282.3,239.1 384.4,289.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="154.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="183.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="239.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="289.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,156.9 180.1,179.9 282.3,242.6 384.4,284.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="156.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="179.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="242.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,135.4 180.1,159.6 282.3,193.0 384.4,231.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="135.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="159.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="193.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="231.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,116.7 180.1,134.8 282.3,220.1 384.4,266.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="116.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="134.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="220.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="266.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,282.6 180.1,254.5 282.3,251.1 384.4,263.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="282.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="254.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="251.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="263.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,303.3 180.1,309.6 282.3,310.8 384.4,311.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="303.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="309.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="310.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="311.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="291.6" x2="942.0" y2="291.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <text x="474.4" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
   <line x1="482.4" y1="262.2" x2="942.0" y2="262.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <text x="474.4" y="262.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
   <line x1="482.4" y1="232.9" x2="942.0" y2="232.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <text x="474.4" y="232.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
   <line x1="482.4" y1="203.5" x2="942.0" y2="203.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <text x="474.4" y="203.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
   <line x1="482.4" y1="174.1" x2="942.0" y2="174.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="474.4" y="174.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
   <line x1="482.4" y1="144.8" x2="942.0" y2="144.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
+  <text x="474.4" y="144.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
   <line x1="482.4" y1="115.4" x2="942.0" y2="115.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="942.0" y1="285.7" x2="946.0" y2="285.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="285.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
-  <line x1="942.0" y1="250.3" x2="946.0" y2="250.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="250.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="215.0" x2="946.0" y2="215.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="215.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3 GB/s</text>
-  <line x1="942.0" y1="179.6" x2="946.0" y2="179.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="179.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="144.3" x2="946.0" y2="144.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="144.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5 GB/s</text>
-  <line x1="942.0" y1="108.9" x2="946.0" y2="108.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="108.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="265.9" x2="946.0" y2="265.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="265.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="210.9" x2="946.0" y2="210.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="210.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="155.8" x2="946.0" y2="155.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="155.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="100.8" x2="946.0" y2="100.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="100.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -92,48 +116,48 @@
   <line x1="942.0" y1="86.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="321.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,203.5)">CPU %</text>
-  <polyline points="482.4,192.4 635.6,190.9 788.8,202.6 942.0,208.8" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,138.0 635.6,185.8 788.8,219.3 942.0,214.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,144.9 635.6,156.2 788.8,165.0 942.0,175.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,184.2 635.6,195.5 788.8,205.6 942.0,204.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,248.9 635.6,247.9 788.8,251.3 942.0,238.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,252.6 635.6,253.8 788.8,222.0 942.0,212.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,232.1 635.6,233.0 788.8,221.9 942.0,266.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,302.0 635.6,258.9 788.8,178.8 942.0,129.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="302.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="258.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="178.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="129.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,284.4 635.6,265.7 788.8,261.4 942.0,246.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="284.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="265.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="261.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="246.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,283.8 635.6,257.3 788.8,243.3 942.0,237.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="283.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="257.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="243.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="237.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,268.1 635.6,181.4 788.8,148.3 942.0,135.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="268.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="181.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="148.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="135.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,272.9 635.6,201.2 788.8,176.5 942.0,116.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="272.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="201.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="176.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="116.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,300.7 635.6,261.5 788.8,161.2 942.0,124.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="300.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="261.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="161.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="124.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,316.4 635.6,294.4 788.8,233.7 942.0,219.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="316.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="294.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="233.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="219.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,233.4 635.6,224.5 788.8,232.6 942.0,235.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,206.1 635.6,208.2 788.8,207.3 942.0,223.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,200.8 635.6,166.4 788.8,164.4 942.0,178.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,218.3 635.6,207.0 788.8,208.4 942.0,238.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,217.9 635.6,216.7 788.8,215.3 942.0,208.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.4 635.6,261.6 788.8,254.4 942.0,258.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,301.0 635.6,252.4 788.8,205.9 942.0,168.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="301.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="252.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="205.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="168.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,292.8 635.6,277.9 788.8,272.1 942.0,263.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="292.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="277.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="272.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="263.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,294.0 635.6,271.1 788.8,260.6 942.0,257.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="294.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="271.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="260.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="257.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,276.8 635.6,197.2 788.8,116.7 942.0,158.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="276.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="197.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="158.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,286.2 635.6,245.3 788.8,209.5 942.0,189.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="286.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="245.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="209.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="189.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,296.9 635.6,241.0 788.8,180.5 942.0,153.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="296.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="241.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="180.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="153.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,317.5 635.6,308.2 788.8,257.6 942.0,238.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="308.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="257.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="238.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -141,86 +165,110 @@
   <text x="510.0" y="368.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH fan-in (4 PUSH → 1 PULL): TCP loopback</text>
   <text x="231.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
   <line x1="78.0" y1="608.6" x2="384.4" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <text x="70.0" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
   <line x1="78.0" y1="579.2" x2="384.4" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <text x="70.0" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
   <line x1="78.0" y1="549.9" x2="384.4" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <text x="70.0" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
   <line x1="78.0" y1="520.5" x2="384.4" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <text x="70.0" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
   <line x1="78.0" y1="491.1" x2="384.4" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="70.0" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
   <line x1="78.0" y1="461.8" x2="384.4" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
+  <text x="70.0" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
   <line x1="78.0" y1="432.4" x2="384.4" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="384.4" y1="603.5" x2="388.4" y2="603.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="603.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="569.0" x2="388.4" y2="569.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="569.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="534.5" x2="388.4" y2="534.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="534.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="500.0" x2="388.4" y2="500.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="500.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="465.5" x2="388.4" y2="465.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="465.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="384.4" y1="431.0" x2="388.4" y2="431.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="431.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
+  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="384.4" y1="597.2" x2="388.4" y2="597.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="597.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="556.3" x2="388.4" y2="556.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="556.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="515.5" x2="388.4" y2="515.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="515.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="474.7" x2="388.4" y2="474.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="474.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="384.4" y1="433.8" x2="388.4" y2="433.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="433.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="403.0" x2="231.2" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="638.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,520.5)">CPU %</text>
-  <polyline points="78.0,453.5 231.2,450.9 384.4,456.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,518.7 231.2,463.2 384.4,475.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,514.1 231.2,477.9 384.4,464.1" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,497.3 231.2,493.5 384.4,496.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,554.3 231.2,553.1 384.4,565.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,530.2 231.2,536.6 384.4,542.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,473.1 231.2,485.2 384.4,503.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,596.6 231.2,598.4 384.4,601.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,475.7 231.2,504.8 384.4,562.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,485.9 231.2,510.0 384.4,547.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,475.9 231.2,516.4 384.4,530.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,433.7 231.2,506.0 384.4,548.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,604.1 231.2,602.5 384.4,601.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,589.0 231.2,591.1 384.4,598.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,553.5 180.1,554.0 282.3,545.9 384.4,544.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,522.0 180.1,521.3 282.3,526.4 384.4,525.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,514.5 180.1,516.2 282.3,510.2 384.4,490.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,558.6 180.1,547.1 282.3,522.5 384.4,490.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.5 180.1,579.4 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,472.9 180.1,517.0 282.3,527.5 384.4,507.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.2 180.1,577.3 282.3,576.7 384.4,574.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,574.9 180.1,575.4 282.3,573.6 384.4,588.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="574.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="575.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="573.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="588.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,446.3 180.1,481.1 282.3,547.7 384.4,605.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="446.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="481.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="547.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="605.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,457.4 180.1,478.1 282.3,533.3 384.4,589.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="457.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="478.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="533.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="589.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,447.1 180.1,444.5 282.3,487.5 384.4,535.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="447.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="444.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="487.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,452.8 282.3,540.3 384.4,584.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="452.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="540.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="584.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,591.2 180.1,566.6 282.3,563.9 384.4,575.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="591.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="566.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="563.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="575.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,583.1 180.1,587.3 282.3,592.7 384.4,610.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="583.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="587.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="592.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="610.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="608.6" x2="942.0" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <text x="474.4" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
   <line x1="482.4" y1="579.2" x2="942.0" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <text x="474.4" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
   <line x1="482.4" y1="549.9" x2="942.0" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <text x="474.4" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
   <line x1="482.4" y1="520.5" x2="942.0" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <text x="474.4" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
   <line x1="482.4" y1="491.1" x2="942.0" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="474.4" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
   <line x1="482.4" y1="461.8" x2="942.0" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
+  <text x="474.4" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
   <line x1="482.4" y1="432.4" x2="942.0" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="942.0" y1="601.3" x2="946.0" y2="601.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="601.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
-  <line x1="942.0" y1="564.5" x2="946.0" y2="564.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="564.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="527.8" x2="946.0" y2="527.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="527.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3 GB/s</text>
-  <line x1="942.0" y1="491.0" x2="946.0" y2="491.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="491.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="454.3" x2="946.0" y2="454.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="454.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5 GB/s</text>
-  <line x1="942.0" y1="417.6" x2="946.0" y2="417.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="417.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="587.3" x2="946.0" y2="587.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="587.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="536.7" x2="946.0" y2="536.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="536.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="486.0" x2="946.0" y2="486.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="486.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="435.4" x2="946.0" y2="435.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="435.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -229,135 +277,155 @@
   <line x1="942.0" y1="403.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="638.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,520.5)">CPU %</text>
-  <polyline points="482.4,456.0 635.6,451.9 788.8,454.8 942.0,460.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,475.1 635.6,509.6 788.8,535.6 942.0,538.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,464.1 635.6,464.4 788.8,467.9 942.0,462.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,496.4 635.6,496.5 788.8,493.1 942.0,493.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,565.5 635.6,571.1 788.8,561.9 942.0,549.6" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,542.1 635.6,544.4 788.8,519.8 942.0,505.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,503.2 635.6,534.6 788.8,569.8 942.0,585.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,618.1 635.6,570.6 788.8,495.1 942.0,448.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="618.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="570.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="495.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="448.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,596.6 635.6,580.1 788.8,571.7 942.0,556.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="596.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="580.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="571.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="556.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,588.8 635.6,549.8 788.8,535.0 942.0,516.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="588.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="549.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="535.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="516.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,579.6 635.6,479.6 788.8,447.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="579.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="479.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="447.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,545.9 635.6,544.9 788.8,555.1 942.0,555.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,526.4 635.6,525.4 788.8,526.1 942.0,541.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,510.2 635.6,490.5 788.8,484.4 942.0,490.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,522.5 635.6,490.4 788.8,490.4 942.0,529.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,527.5 635.6,507.1 788.8,509.5 942.0,511.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,576.7 635.6,574.6 788.8,575.1 942.0,574.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,617.5 635.6,575.2 788.8,532.4 942.0,508.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="617.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="575.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="532.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="508.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,609.3 635.6,597.0 788.8,592.1 942.0,579.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="609.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="597.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="592.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="579.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,604.7 635.6,576.9 788.8,567.2 942.0,556.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="604.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="576.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="567.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="556.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,590.2 635.6,507.5 788.8,441.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="590.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="507.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="441.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,589.1 635.6,536.4 788.8,492.2 942.0,465.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="589.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="536.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="492.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="465.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,618.3 635.6,567.0 788.8,479.6 942.0,439.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="618.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="567.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="479.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="439.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,616.4 635.6,584.4 788.8,550.0 942.0,536.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="616.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="584.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="550.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="536.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,607.0 635.6,570.6 788.8,534.6 942.0,499.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="607.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="570.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="534.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="499.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,614.5 635.6,558.9 788.8,506.9 942.0,502.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="614.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="558.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="506.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="502.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,623.6 635.6,602.9 788.8,577.6 942.0,569.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="623.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="602.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="577.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="569.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="510.0" y="685.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH fan-in (8 PUSH → 1 PULL): TCP loopback</text>
   <text x="231.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="925.6" x2="384.4" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="896.2" x2="384.4" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="866.9" x2="384.4" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="837.5" x2="384.4" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="78.0" y1="808.1" x2="384.4" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="78.0" y1="778.8" x2="384.4" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
-  <line x1="78.0" y1="749.4" x2="384.4" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <line x1="78.0" y1="908.0" x2="384.4" y2="908.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="908.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="861.0" x2="384.4" y2="861.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="861.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="814.0" x2="384.4" y2="814.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="814.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="767.0" x2="384.4" y2="767.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="384.4" y1="919.4" x2="388.4" y2="919.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="919.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="883.8" x2="388.4" y2="883.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="883.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="848.3" x2="388.4" y2="848.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="848.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="812.7" x2="388.4" y2="812.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="812.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="777.1" x2="388.4" y2="777.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="777.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="384.4" y1="741.5" x2="388.4" y2="741.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="741.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
+  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <line x1="384.4" y1="914.6" x2="388.4" y2="914.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="914.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="874.1" x2="388.4" y2="874.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="874.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="833.7" x2="388.4" y2="833.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="833.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="793.2" x2="388.4" y2="793.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="793.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="384.4" y1="752.8" x2="388.4" y2="752.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="752.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="720.0" x2="231.2" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="955.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,837.5)">CPU %</text>
-  <polyline points="78.0,750.8 231.2,751.7 384.4,750.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,816.1 231.2,797.2 384.4,800.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,822.5 231.2,799.6 384.4,787.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,802.2 231.2,797.2 384.4,801.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,868.2 231.2,869.9 384.4,880.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,807.9 231.2,831.3 384.4,839.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,765.9 231.2,794.7 384.4,818.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,915.4 231.2,916.1 384.4,913.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,779.4 231.2,808.9 384.4,874.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,785.8 231.2,808.8 384.4,856.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,782.1 231.2,816.2 384.4,833.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,750.7 231.2,820.6 384.4,862.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,919.6 231.2,919.2 384.4,917.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,907.5 231.2,908.3 384.4,915.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,901.5 180.1,900.7 282.3,880.7 384.4,877.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,863.1 180.1,861.6 282.3,863.2 384.4,864.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,855.0 180.1,855.5 282.3,854.3 384.4,842.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,891.5 180.1,885.1 282.3,860.2 384.4,835.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,908.7 180.1,908.0 282.3,908.1 384.4,908.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,758.6 180.1,847.1 282.3,860.5 384.4,830.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,909.1 180.1,908.3 282.3,907.9 384.4,906.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,899.7 180.1,898.6 282.3,884.5 384.4,904.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="899.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="898.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="884.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="904.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,757.8 180.1,789.4 282.3,861.7 384.4,922.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="757.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="789.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="861.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="922.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,762.7 180.1,790.8 282.3,839.3 384.4,903.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="762.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="790.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="839.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="903.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,750.7 180.1,751.1 282.3,798.1 384.4,850.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="751.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="798.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="850.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,764.5 180.1,778.8 282.3,863.3 384.4,903.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="764.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="778.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="863.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="903.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,917.8 180.1,879.2 282.3,877.7 384.4,892.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="917.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="879.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="877.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="892.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,901.0 180.1,902.4 282.3,910.3 384.4,926.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="901.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="902.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="910.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="926.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="925.6" x2="942.0" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <text x="474.4" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
   <line x1="482.4" y1="896.2" x2="942.0" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <text x="474.4" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
   <line x1="482.4" y1="866.9" x2="942.0" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <text x="474.4" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
   <line x1="482.4" y1="837.5" x2="942.0" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <text x="474.4" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
   <line x1="482.4" y1="808.1" x2="942.0" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="474.4" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
   <line x1="482.4" y1="778.8" x2="942.0" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">600%</text>
+  <text x="474.4" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
   <line x1="482.4" y1="749.4" x2="942.0" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">700%</text>
+  <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">800%</text>
-  <line x1="942.0" y1="916.7" x2="946.0" y2="916.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="916.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
-  <line x1="942.0" y1="878.4" x2="946.0" y2="878.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="878.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="840.0" x2="946.0" y2="840.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="840.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3 GB/s</text>
-  <line x1="942.0" y1="801.7" x2="946.0" y2="801.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="801.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="763.4" x2="946.0" y2="763.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="763.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5 GB/s</text>
-  <line x1="942.0" y1="725.1" x2="946.0" y2="725.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="725.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="910.1" x2="946.0" y2="910.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="910.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="865.2" x2="946.0" y2="865.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="865.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="820.3" x2="946.0" y2="820.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="820.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="775.4" x2="946.0" y2="775.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="775.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="730.5" x2="946.0" y2="730.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="730.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -366,79 +434,78 @@
   <line x1="942.0" y1="720.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="955.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,837.5)">CPU %</text>
-  <polyline points="482.4,750.2 635.6,750.7 788.8,750.2 942.0,750.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,800.8 635.6,827.1 788.8,845.5 942.0,853.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,787.0 635.6,781.3 788.8,779.1 942.0,775.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,801.3 635.6,792.9 788.8,794.4 942.0,789.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,880.4 635.6,887.1 788.8,879.3 942.0,865.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,839.5 635.6,834.0 788.8,810.1 942.0,799.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,818.4 635.6,854.6 788.8,888.8 942.0,901.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,932.1 635.6,891.1 788.8,817.9 942.0,757.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="932.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="891.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="817.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="757.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,910.8 635.6,892.9 788.8,885.0 942.0,869.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="910.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="892.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="885.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="869.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,900.9 635.6,857.2 788.8,834.7 942.0,807.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="900.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="857.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="834.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="807.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,888.1 635.6,782.3 788.8,770.9 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="888.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="782.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="770.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,862.1 635.6,858.3 788.8,869.3 942.0,875.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,840.2 635.6,842.4 788.8,844.0 942.0,866.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,829.1 635.6,814.4 788.8,798.9 942.0,791.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,836.4 635.6,805.8 788.8,829.9 942.0,837.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.4 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,836.8 635.6,799.8 788.8,789.1 942.0,803.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.2 635.6,893.8 788.8,892.3 942.0,891.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,935.0 635.6,897.3 788.8,858.3 942.0,836.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="935.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="897.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="858.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="836.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,928.5 635.6,918.5 788.8,914.3 942.0,902.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="928.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="918.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="914.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="902.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,922.1 635.6,897.0 788.8,884.9 942.0,869.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="922.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="897.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="884.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="869.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,910.4 635.6,836.0 788.8,773.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="910.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="836.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="773.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,904.1 635.6,848.0 788.8,803.5 942.0,779.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="904.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="848.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="803.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="779.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,934.1 635.6,871.7 788.8,787.4 942.0,765.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="871.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="787.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="765.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,932.9 635.6,899.0 788.8,865.9 942.0,855.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="932.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="899.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="865.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="855.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,929.0 635.6,896.7 788.8,860.4 942.0,841.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="929.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="896.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="860.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="841.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,933.0 635.6,884.4 788.8,846.2 942.0,839.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="933.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="884.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="846.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="839.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,942.3 635.6,922.6 788.8,903.8 942.0,897.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="942.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="922.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="903.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="897.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
-  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4 IO threads)</text>
+  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
   <line x1="510" y1="989" x2="524" y2="989" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="517" cy="989" r="2.5" fill="#f97316"/>
-  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="567" cy="1049" r="3.0" fill="#6b7280"/>
   <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -19,105 +19,156 @@
   <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="283.4" x2="388.4" y2="283.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="283.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="245.8" x2="388.4" y2="245.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="245.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="208.3" x2="388.4" y2="208.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="208.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
-  <line x1="384.4" y1="170.7" x2="388.4" y2="170.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="170.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="133.1" x2="388.4" y2="133.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="133.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="95.5" x2="388.4" y2="95.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="95.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="283.1" x2="388.4" y2="283.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="283.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="245.2" x2="388.4" y2="245.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="245.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="207.3" x2="388.4" y2="207.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="207.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
+  <line x1="384.4" y1="169.4" x2="388.4" y2="169.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="169.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="131.5" x2="388.4" y2="131.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="131.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="93.6" x2="388.4" y2="93.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="93.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="86.0" x2="231.2" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="86.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="321.0" x2="384.4" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,203.5)">CPU %</text>
-  <polyline points="78.0,205.1 231.2,205.5 384.4,204.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,210.9 231.2,212.7 384.4,234.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,162.4 231.2,155.1 384.4,162.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,138.5 231.2,140.8 384.4,141.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,262.3 231.2,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,232.3 231.2,175.9 384.4,167.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,262.7 231.2,262.3 384.4,262.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="225.2" x2="78.0" y2="223.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="225.2" x2="81.0" y2="225.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="223.4" x2="81.0" y2="223.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="230.2" x2="231.2" y2="229.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="230.2" x2="234.2" y2="230.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="229.7" x2="234.2" y2="229.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="234.1" x2="384.4" y2="232.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="234.1" x2="387.4" y2="234.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="232.9" x2="387.4" y2="232.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,224.3 231.2,230.0 384.4,233.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="116.7" x2="78.0" y2="116.6" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="116.7" x2="81.0" y2="116.7" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="116.6" x2="81.0" y2="116.6" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="235.4" x2="231.2" y2="235.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="235.4" x2="234.2" y2="235.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="235.4" x2="234.2" y2="235.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="284.3" x2="384.4" y2="284.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="284.3" x2="387.4" y2="284.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="284.3" x2="387.4" y2="284.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,116.7 231.2,235.4 384.4,284.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="162.8" x2="78.0" y2="136.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="162.8" x2="81.0" y2="162.8" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="136.6" x2="81.0" y2="136.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="234.7" x2="231.2" y2="233.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="234.7" x2="234.2" y2="234.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="233.3" x2="234.2" y2="233.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="282.8" x2="384.4" y2="282.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="282.8" x2="387.4" y2="282.8" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="282.7" x2="387.4" y2="282.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,149.7 231.2,234.0 384.4,282.7" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="127.7" x2="78.0" y2="127.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="127.7" x2="81.0" y2="127.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="127.5" x2="81.0" y2="127.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="226.0" x2="231.2" y2="225.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="226.0" x2="234.2" y2="226.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="225.6" x2="234.2" y2="225.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="226.0" x2="384.4" y2="225.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="226.0" x2="387.4" y2="226.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="225.4" x2="387.4" y2="225.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,127.6 231.2,225.8 384.4,225.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="197.5" x2="78.0" y2="197.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="197.5" x2="81.0" y2="197.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="197.5" x2="81.0" y2="197.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="244.8" x2="231.2" y2="244.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="244.8" x2="234.2" y2="244.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="244.8" x2="234.2" y2="244.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="256.0" x2="384.4" y2="256.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="256.0" x2="387.4" y2="256.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="256.0" x2="387.4" y2="256.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,197.5 231.2,244.8 384.4,256.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="279.6" x2="78.0" y2="279.4" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="279.6" x2="81.0" y2="279.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="279.4" x2="81.0" y2="279.4" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="250.5" x2="231.2" y2="249.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="250.5" x2="234.2" y2="250.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="249.8" x2="234.2" y2="249.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="242.9" x2="384.4" y2="242.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="242.9" x2="387.4" y2="242.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="242.5" x2="387.4" y2="242.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,279.5 231.2,250.1 384.4,242.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,206.3 180.1,203.7 282.3,204.3 384.4,222.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,211.9 180.1,214.9 282.3,233.1 384.4,244.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,159.8 180.1,157.3 282.3,165.9 384.4,172.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,142.2 180.1,141.2 282.3,140.8 384.4,146.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.4 180.1,262.4 282.3,262.3 384.4,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,227.1 180.1,194.2 282.3,178.3 384.4,185.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.3 180.1,262.3 282.3,262.9 384.4,262.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <line x1="78.0" y1="229.7" x2="78.0" y2="227.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="229.7" x2="81.0" y2="229.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="227.7" x2="81.0" y2="227.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="230.9" x2="180.1" y2="230.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="230.9" x2="183.1" y2="230.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="230.9" x2="183.1" y2="230.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="230.2" x2="282.3" y2="230.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="230.2" x2="285.3" y2="230.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="230.1" x2="285.3" y2="230.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="264.4" x2="384.4" y2="264.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="264.4" x2="387.4" y2="264.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="264.2" x2="387.4" y2="264.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,228.7 180.1,230.9 282.3,230.1 384.4,264.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="228.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="230.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="230.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="264.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="118.3" x2="78.0" y2="115.0" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="118.3" x2="81.0" y2="118.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="115.0" x2="81.0" y2="115.0" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="235.3" x2="180.1" y2="235.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="235.3" x2="183.1" y2="235.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="235.3" x2="183.1" y2="235.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="284.1" x2="282.3" y2="284.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="284.1" x2="285.3" y2="284.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="284.1" x2="285.3" y2="284.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="305.8" x2="384.4" y2="305.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="305.8" x2="387.4" y2="305.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="305.8" x2="387.4" y2="305.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,116.7 180.1,235.3 282.3,284.1 384.4,305.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="116.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="235.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="284.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="305.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="156.8" x2="78.0" y2="146.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="156.8" x2="81.0" y2="156.8" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="146.1" x2="81.0" y2="146.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="236.6" x2="180.1" y2="235.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="236.6" x2="183.1" y2="236.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="235.9" x2="183.1" y2="235.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="283.5" x2="282.3" y2="283.2" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="283.5" x2="285.3" y2="283.5" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="283.2" x2="285.3" y2="283.2" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="296.4" x2="384.4" y2="295.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="296.4" x2="387.4" y2="296.4" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="295.7" x2="387.4" y2="295.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,151.5 180.1,236.2 282.3,283.4 384.4,296.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="151.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="236.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="283.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="296.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="159.2" x2="78.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="159.2" x2="81.0" y2="159.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="158.6" x2="81.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="155.9" x2="180.1" y2="154.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="155.9" x2="183.1" y2="155.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="154.6" x2="183.1" y2="154.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="198.8" x2="282.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="198.8" x2="285.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="198.8" x2="285.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="216.2" x2="384.4" y2="215.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="216.2" x2="387.4" y2="216.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="215.2" x2="387.4" y2="215.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,158.9 180.1,155.2 282.3,198.8 384.4,215.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="158.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="155.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="198.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="215.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="213.1" x2="78.0" y2="213.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="213.1" x2="81.0" y2="213.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="213.0" x2="81.0" y2="213.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="220.4" x2="180.1" y2="220.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="220.4" x2="183.1" y2="220.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="220.3" x2="183.1" y2="220.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="246.6" x2="282.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="246.6" x2="285.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="246.6" x2="285.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="272.2" x2="384.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="272.2" x2="387.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="272.2" x2="387.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,213.0 180.1,220.3 282.3,246.6 384.4,272.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="213.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="220.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="246.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="272.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="280.7" x2="78.0" y2="280.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="280.7" x2="81.0" y2="280.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="280.0" x2="81.0" y2="280.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="261.8" x2="180.1" y2="253.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="261.8" x2="183.1" y2="261.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="253.5" x2="183.1" y2="253.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="248.2" x2="282.3" y2="245.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="248.2" x2="285.3" y2="248.2" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="245.6" x2="285.3" y2="245.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="255.4" x2="384.4" y2="253.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="255.4" x2="387.4" y2="255.4" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="253.7" x2="387.4" y2="253.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,280.3 180.1,257.6 282.3,246.9 384.4,254.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="280.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="257.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="246.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="254.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="316.2" x2="78.0" y2="316.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="316.2" x2="81.0" y2="316.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="316.2" x2="81.0" y2="316.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="316.4" x2="231.2" y2="316.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="316.4" x2="234.2" y2="316.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="316.4" x2="234.2" y2="316.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="316.7" x2="384.4" y2="316.7" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="316.7" x2="387.4" y2="316.7" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="316.7" x2="387.4" y2="316.7" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,316.2 231.2,316.4 384.4,316.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="180.1" y1="316.5" x2="180.1" y2="316.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="316.5" x2="183.1" y2="316.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="316.5" x2="183.1" y2="316.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="316.8" x2="282.3" y2="316.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="316.8" x2="285.3" y2="316.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="316.8" x2="285.3" y2="316.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="317.1" x2="384.4" y2="317.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="317.1" x2="387.4" y2="317.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="317.1" x2="387.4" y2="317.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,316.2 180.1,316.5 282.3,316.8 384.4,317.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="316.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="316.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="316.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="317.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="291.6" x2="942.0" y2="291.6" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="291.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
@@ -135,14 +186,18 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="270.8" x2="946.0" y2="270.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="270.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="220.5" x2="946.0" y2="220.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="220.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="170.3" x2="946.0" y2="170.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="170.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="120.0" x2="946.0" y2="120.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="120.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="285.3" x2="946.0" y2="285.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="285.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="249.5" x2="946.0" y2="249.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="249.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="213.8" x2="946.0" y2="213.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="213.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="178.1" x2="946.0" y2="178.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="178.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="142.3" x2="946.0" y2="142.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="142.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="106.6" x2="946.0" y2="106.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="106.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -151,48 +206,48 @@
   <line x1="942.0" y1="86.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="321.0" x2="942.0" y2="321.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="203.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,203.5)">CPU %</text>
-  <polyline points="482.4,204.2 635.6,222.5 788.8,245.4 942.0,257.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,234.4 635.6,245.6 788.8,252.9 942.0,256.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,162.0 635.6,170.8 788.8,190.2 942.0,192.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,141.0 635.6,142.0 788.8,177.9 942.0,195.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,167.9 635.6,177.3 788.8,193.2 942.0,209.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,262.3 635.6,262.5 788.8,262.1 942.0,262.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,291.0 635.6,245.8 788.8,192.4 942.0,164.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="291.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="245.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="192.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="164.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,308.4 635.6,298.6 788.8,294.8 942.0,293.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="308.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="298.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="294.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="293.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,307.9 635.6,287.2 788.8,270.3 942.0,264.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="307.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="287.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="270.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="264.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,288.4 635.6,194.2 788.8,136.2 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="288.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="194.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="136.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,204.3 635.6,222.1 788.8,245.6 942.0,257.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,233.1 635.6,244.4 788.8,255.4 942.0,257.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,165.9 635.6,172.8 788.8,188.6 942.0,193.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,140.8 635.6,146.5 788.8,180.8 942.0,194.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.3 635.6,262.5 788.8,262.5 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,178.3 635.6,185.7 788.8,205.1 942.0,206.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.9 635.6,262.5 788.8,262.3 942.0,262.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,299.1 635.6,266.3 788.8,229.4 942.0,210.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="299.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="266.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="229.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="210.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,312.1 635.6,306.3 788.8,302.6 942.0,302.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="312.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="306.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="302.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="302.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,311.9 635.6,296.9 788.8,284.8 942.0,280.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="311.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="296.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="280.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,291.5 635.6,219.3 788.8,159.0 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="291.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="219.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="159.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,298.7 635.6,265.2 788.8,233.8 942.0,215.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="298.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="265.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="233.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="215.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,294.2 635.6,225.0 788.8,164.0 942.0,178.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="294.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="225.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="164.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="178.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,319.5 635.6,315.7 788.8,302.2 942.0,267.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="319.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="315.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="302.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="267.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.0 635.6,273.9 788.8,237.1 942.0,213.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="273.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="237.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="213.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.1 635.6,256.8 788.8,220.3 942.0,210.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="256.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="220.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="210.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,320.0 635.6,317.2 788.8,307.9 942.0,284.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="320.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="317.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="307.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="284.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -215,103 +270,154 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="598.4" x2="388.4" y2="598.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="598.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="558.7" x2="388.4" y2="558.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="558.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="519.1" x2="388.4" y2="519.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="519.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
-  <line x1="384.4" y1="479.4" x2="388.4" y2="479.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="479.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="439.8" x2="388.4" y2="439.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="439.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
+  <line x1="384.4" y1="596.2" x2="388.4" y2="596.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="596.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="554.4" x2="388.4" y2="554.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="554.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="512.6" x2="388.4" y2="512.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="512.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="470.8" x2="388.4" y2="470.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="470.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="429.0" x2="388.4" y2="429.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="429.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="403.0" x2="231.2" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="638.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,520.5)">CPU %</text>
-  <polyline points="78.0,530.7 231.2,536.7 384.4,531.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,529.3 231.2,529.9 384.4,551.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,473.5 231.2,463.0 384.4,459.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,433.6 231.2,427.9 384.4,432.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.1 231.2,579.1 384.4,579.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,506.5 231.2,475.5 384.4,475.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.5 231.2,579.5 384.4,579.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="540.2" x2="78.0" y2="536.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="540.2" x2="81.0" y2="540.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="536.3" x2="81.0" y2="536.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="545.5" x2="231.2" y2="540.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="545.5" x2="234.2" y2="545.5" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="540.9" x2="234.2" y2="540.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="546.2" x2="384.4" y2="544.5" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="546.2" x2="387.4" y2="546.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="544.5" x2="387.4" y2="544.5" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,538.2 231.2,543.1 384.4,545.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="433.7" x2="78.0" y2="433.6" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="433.7" x2="81.0" y2="433.7" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,532.5 180.1,535.2 282.3,531.9 384.4,544.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,531.5 180.1,528.7 282.3,552.4 384.4,565.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,471.0 180.1,444.3 282.3,442.2 384.4,456.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,437.1 180.1,437.5 282.3,430.3 384.4,469.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.5 180.1,579.1 282.3,579.5 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,513.4 180.1,477.5 282.3,477.0 384.4,488.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.1 180.1,579.3 282.3,579.5 384.4,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <line x1="78.0" y1="536.8" x2="78.0" y2="532.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="536.8" x2="81.0" y2="536.8" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="532.1" x2="81.0" y2="532.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="547.1" x2="180.1" y2="535.6" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="547.1" x2="183.1" y2="547.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="535.6" x2="183.1" y2="535.6" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="539.3" x2="282.3" y2="537.0" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="539.3" x2="285.3" y2="539.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="537.0" x2="285.3" y2="537.0" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="567.9" x2="384.4" y2="566.8" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="567.9" x2="387.4" y2="567.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="566.8" x2="387.4" y2="566.8" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,534.0 180.1,539.7 282.3,538.2 384.4,567.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="534.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="539.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="538.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="567.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="433.8" x2="78.0" y2="433.6" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="433.8" x2="81.0" y2="433.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="433.6" x2="81.0" y2="433.6" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="547.0" x2="231.2" y2="546.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="547.0" x2="234.2" y2="547.0" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="546.4" x2="234.2" y2="546.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="601.1" x2="384.4" y2="601.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="601.1" x2="387.4" y2="601.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="601.1" x2="387.4" y2="601.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,433.7 231.2,546.7 384.4,601.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="467.4" x2="78.0" y2="444.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="467.4" x2="81.0" y2="467.4" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="444.6" x2="81.0" y2="444.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="564.7" x2="231.2" y2="555.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="564.7" x2="234.2" y2="564.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="555.3" x2="234.2" y2="555.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="610.4" x2="384.4" y2="593.2" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="610.4" x2="387.4" y2="610.4" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="593.2" x2="387.4" y2="593.2" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,456.8 231.2,560.9 384.4,602.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="471.6" x2="78.0" y2="447.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="471.6" x2="81.0" y2="471.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="447.4" x2="81.0" y2="447.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="544.1" x2="231.2" y2="537.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="544.1" x2="234.2" y2="544.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="537.0" x2="234.2" y2="537.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="548.3" x2="384.4" y2="542.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="548.3" x2="387.4" y2="548.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="542.1" x2="387.4" y2="542.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,461.2 231.2,540.9 384.4,545.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="503.6" x2="78.0" y2="503.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="503.6" x2="81.0" y2="503.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="503.5" x2="81.0" y2="503.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="556.2" x2="231.2" y2="556.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="556.2" x2="234.2" y2="556.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="556.0" x2="234.2" y2="556.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="569.4" x2="384.4" y2="569.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="569.4" x2="387.4" y2="569.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="569.3" x2="387.4" y2="569.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,503.5 231.2,556.2 384.4,569.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="574.8" x2="78.0" y2="567.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="574.8" x2="81.0" y2="574.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="567.5" x2="81.0" y2="567.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="569.5" x2="231.2" y2="559.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="569.5" x2="234.2" y2="569.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="559.1" x2="234.2" y2="559.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="574.7" x2="384.4" y2="567.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="574.7" x2="387.4" y2="574.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="567.7" x2="387.4" y2="567.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,572.2 231.2,566.1 384.4,569.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="633.9" x2="78.0" y2="633.9" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="633.9" x2="81.0" y2="633.9" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="633.9" x2="81.0" y2="633.9" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="634.2" x2="231.2" y2="634.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="634.2" x2="234.2" y2="634.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="634.2" x2="234.2" y2="634.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="634.6" x2="384.4" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="634.6" x2="387.4" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="634.6" x2="387.4" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,633.9 231.2,634.2 384.4,634.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="180.1" y1="542.4" x2="180.1" y2="541.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="542.4" x2="183.1" y2="542.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="541.9" x2="183.1" y2="541.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="600.1" x2="282.3" y2="600.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="600.1" x2="285.3" y2="600.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="600.1" x2="285.3" y2="600.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="622.3" x2="384.4" y2="622.0" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="622.3" x2="387.4" y2="622.3" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="622.0" x2="387.4" y2="622.0" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,433.7 180.1,542.0 282.3,600.1 384.4,622.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="542.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="600.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="622.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="496.3" x2="78.0" y2="459.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="496.3" x2="81.0" y2="496.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="459.1" x2="81.0" y2="459.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="568.4" x2="180.1" y2="562.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="568.4" x2="183.1" y2="568.4" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="562.1" x2="183.1" y2="562.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="604.4" x2="282.3" y2="603.0" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="604.4" x2="285.3" y2="604.4" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="603.0" x2="285.3" y2="603.0" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="613.9" x2="384.4" y2="611.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="613.9" x2="387.4" y2="613.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="611.6" x2="387.4" y2="611.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,473.7 180.1,564.4 282.3,603.8 384.4,612.7" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="473.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="564.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="603.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="612.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="479.8" x2="78.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="479.8" x2="81.0" y2="479.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="462.4" x2="81.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="488.7" x2="180.1" y2="472.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="488.7" x2="183.1" y2="488.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="472.0" x2="183.1" y2="472.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="524.2" x2="282.3" y2="514.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="524.2" x2="285.3" y2="524.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="514.2" x2="285.3" y2="514.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="544.4" x2="384.4" y2="535.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="544.4" x2="387.4" y2="544.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="535.9" x2="387.4" y2="535.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,470.3 180.1,479.7 282.3,519.1 384.4,540.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="470.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="479.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="519.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="540.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="516.6" x2="78.0" y2="516.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="516.6" x2="81.0" y2="516.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="516.3" x2="81.0" y2="516.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="525.3" x2="180.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="525.3" x2="183.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="525.3" x2="183.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="555.2" x2="282.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="555.2" x2="285.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="555.2" x2="285.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="585.7" x2="384.4" y2="585.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="585.7" x2="387.4" y2="585.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="585.6" x2="387.4" y2="585.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,516.5 180.1,525.3 282.3,555.2 384.4,585.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="525.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="555.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="585.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="573.3" x2="78.0" y2="568.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="573.3" x2="81.0" y2="573.3" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="568.6" x2="81.0" y2="568.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="567.1" x2="180.1" y2="560.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="567.1" x2="183.1" y2="567.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="560.6" x2="183.1" y2="560.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="566.9" x2="282.3" y2="564.3" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="566.9" x2="285.3" y2="566.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="564.3" x2="285.3" y2="564.3" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="575.5" x2="384.4" y2="572.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="575.5" x2="387.4" y2="575.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="572.9" x2="387.4" y2="572.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,570.5 180.1,563.6 282.3,566.2 384.4,573.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="570.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="563.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="566.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="573.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="633.6" x2="78.0" y2="633.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="633.6" x2="81.0" y2="633.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="633.6" x2="81.0" y2="633.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="634.1" x2="180.1" y2="634.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="634.1" x2="183.1" y2="634.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="634.1" x2="183.1" y2="634.1" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="634.6" x2="282.3" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="634.6" x2="285.3" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="634.6" x2="285.3" y2="634.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="634.8" x2="384.4" y2="634.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="634.8" x2="387.4" y2="634.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="634.8" x2="387.4" y2="634.8" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,633.6 180.1,634.1 282.3,634.6 384.4,634.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="633.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="634.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="634.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="608.6" x2="942.0" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
@@ -329,14 +435,16 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="585.8" x2="946.0" y2="585.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="585.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="533.7" x2="946.0" y2="533.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="533.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="481.5" x2="946.0" y2="481.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="481.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="429.4" x2="946.0" y2="429.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="429.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="596.5" x2="946.0" y2="596.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="596.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="555.0" x2="946.0" y2="555.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="555.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="513.5" x2="946.0" y2="513.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="513.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="472.0" x2="946.0" y2="472.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="472.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="430.5" x2="946.0" y2="430.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="430.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -345,48 +453,48 @@
   <line x1="942.0" y1="403.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="638.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,520.5)">CPU %</text>
-  <polyline points="482.4,531.6 635.6,541.1 788.8,562.3 942.0,573.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,551.8 635.6,565.7 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,459.6 635.6,453.8 788.8,481.4 942.0,483.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,432.0 635.6,435.1 788.8,457.2 942.0,466.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.5 635.6,579.3 788.8,579.3 942.0,579.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,475.6 635.6,485.7 788.8,523.4 942.0,518.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.5 635.6,579.3 788.8,579.3 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,606.8 635.6,552.9 788.8,498.8 942.0,476.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="606.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="552.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="498.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="476.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,625.6 635.6,616.9 788.8,614.2 942.0,612.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="625.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="616.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="614.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="612.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,625.9 635.6,605.3 788.8,579.8 942.0,562.7" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="625.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="605.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="579.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="562.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,606.8 635.6,517.3 788.8,496.5 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="606.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="517.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="496.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,531.9 635.6,544.2 788.8,562.4 942.0,573.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,552.4 635.6,565.5 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,442.2 635.6,456.7 788.8,478.8 942.0,484.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,430.3 635.6,469.6 788.8,505.0 942.0,510.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,477.0 635.6,488.3 788.8,524.4 942.0,516.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,612.6 635.6,565.9 788.8,526.7 942.0,505.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="565.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="526.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="505.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,628.4 635.6,621.8 788.8,619.2 942.0,617.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="628.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="621.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="619.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="617.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,629.3 635.6,612.3 788.8,590.4 942.0,579.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="629.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="612.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="590.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="579.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,607.8 635.6,539.0 788.8,474.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="607.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="539.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="474.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,614.9 635.6,581.1 788.8,554.5 942.0,531.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="614.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="581.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="554.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="531.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,615.0 635.6,553.4 788.8,500.9 942.0,480.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="615.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="553.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="500.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="480.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,636.9 635.6,633.8 788.8,622.5 942.0,590.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="636.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="633.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="622.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="590.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,617.0 635.6,584.8 788.8,540.6 942.0,511.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="617.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="584.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="540.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="511.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,619.7 635.6,572.8 788.8,529.0 942.0,510.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="619.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="572.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="529.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="510.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,637.1 635.6,634.7 788.8,625.9 942.0,601.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="637.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="625.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="601.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -409,97 +517,148 @@
   <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="873.9" x2="388.4" y2="873.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="873.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="792.8" x2="388.4" y2="792.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="792.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="871.2" x2="388.4" y2="871.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="871.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="787.3" x2="388.4" y2="787.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="787.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="231.2" y1="720.0" x2="231.2" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="955.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,837.5)">CPU %</text>
-  <polyline points="78.0,859.6 231.2,861.6 384.4,855.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,851.2 231.2,847.5 384.4,868.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,806.0 231.2,788.0 384.4,782.3" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,756.5 231.2,749.4 384.4,751.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,896.5 231.2,896.5 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,821.5 231.2,802.8 384.4,790.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,896.9 231.2,896.9 384.4,896.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="855.7" x2="78.0" y2="855.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="855.7" x2="81.0" y2="855.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="855.4" x2="81.0" y2="855.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="857.2" x2="231.2" y2="857.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="857.2" x2="234.2" y2="857.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="857.1" x2="234.2" y2="857.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="868.2" x2="384.4" y2="858.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="868.2" x2="387.4" y2="868.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="858.3" x2="387.4" y2="858.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,855.6 231.2,857.2 384.4,860.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="752.4" x2="78.0" y2="749.7" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="752.4" x2="81.0" y2="752.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="749.7" x2="81.0" y2="749.7" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="862.1" x2="231.2" y2="861.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="862.1" x2="234.2" y2="862.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="861.8" x2="234.2" y2="861.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="918.1" x2="384.4" y2="918.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="918.1" x2="387.4" y2="918.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="918.1" x2="387.4" y2="918.1" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,750.7 231.2,861.9 384.4,918.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="807.3" x2="78.0" y2="781.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="807.3" x2="81.0" y2="807.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="781.1" x2="81.0" y2="781.1" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="893.8" x2="231.2" y2="881.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="893.8" x2="234.2" y2="893.8" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="881.7" x2="234.2" y2="881.7" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="929.5" x2="384.4" y2="908.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="929.5" x2="387.4" y2="929.5" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="908.6" x2="387.4" y2="908.6" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,798.0 231.2,890.0 384.4,923.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="787.0" x2="78.0" y2="755.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="787.0" x2="81.0" y2="787.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="755.5" x2="81.0" y2="755.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="863.6" x2="231.2" y2="858.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="863.6" x2="234.2" y2="863.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="858.2" x2="234.2" y2="858.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="865.3" x2="384.4" y2="862.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="865.3" x2="387.4" y2="865.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="862.3" x2="387.4" y2="862.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,769.7 231.2,860.6 384.4,863.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="809.6" x2="78.0" y2="807.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="809.6" x2="81.0" y2="809.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="807.9" x2="81.0" y2="807.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="870.4" x2="231.2" y2="870.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="870.4" x2="234.2" y2="870.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="870.2" x2="234.2" y2="870.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="885.8" x2="384.4" y2="885.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="885.8" x2="387.4" y2="885.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="885.7" x2="387.4" y2="885.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,809.3 231.2,870.3 384.4,885.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="890.5" x2="78.0" y2="887.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="890.5" x2="81.0" y2="890.5" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="887.1" x2="81.0" y2="887.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="886.4" x2="231.2" y2="884.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="886.4" x2="234.2" y2="886.4" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="884.7" x2="234.2" y2="884.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="888.2" x2="384.4" y2="884.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="888.2" x2="387.4" y2="888.2" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="884.8" x2="387.4" y2="884.8" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,888.3 231.2,885.3 384.4,886.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <line x1="78.0" y1="949.6" x2="78.0" y2="949.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="949.6" x2="81.0" y2="949.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,860.0 180.1,860.1 282.3,858.2 384.4,860.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,848.5 180.1,850.4 282.3,872.0 384.4,884.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,810.5 180.1,789.6 282.3,780.8 384.4,800.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,757.2 180.1,754.9 282.3,755.7 384.4,766.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,822.3 180.1,806.7 282.3,796.9 384.4,804.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <line x1="78.0" y1="866.6" x2="78.0" y2="861.0" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="866.6" x2="81.0" y2="866.6" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="861.0" x2="81.0" y2="861.0" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="858.2" x2="180.1" y2="856.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="858.2" x2="183.1" y2="858.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="856.3" x2="183.1" y2="856.3" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="861.2" x2="282.3" y2="859.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="861.2" x2="285.3" y2="861.2" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="859.1" x2="285.3" y2="859.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="892.4" x2="384.4" y2="889.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="892.4" x2="387.4" y2="892.4" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="889.9" x2="387.4" y2="889.9" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,861.8 180.1,856.6 282.3,859.7 384.4,890.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="861.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="856.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="859.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="890.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="750.9" x2="78.0" y2="750.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="750.9" x2="81.0" y2="750.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="750.4" x2="81.0" y2="750.4" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="857.2" x2="180.1" y2="857.2" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="857.2" x2="183.1" y2="857.2" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="857.2" x2="183.1" y2="857.2" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="917.9" x2="282.3" y2="917.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="917.9" x2="285.3" y2="917.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="917.9" x2="285.3" y2="917.9" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="939.8" x2="384.4" y2="939.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="939.8" x2="387.4" y2="939.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="939.8" x2="387.4" y2="939.8" stroke="#eab308" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,750.7 180.1,857.2 282.3,917.9 384.4,939.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="750.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="857.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="917.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="939.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="815.3" x2="78.0" y2="793.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="815.3" x2="81.0" y2="815.3" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="793.9" x2="81.0" y2="793.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="892.5" x2="180.1" y2="880.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="892.5" x2="183.1" y2="892.5" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="880.9" x2="183.1" y2="880.9" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="922.8" x2="282.3" y2="922.0" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="922.8" x2="285.3" y2="922.8" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="922.0" x2="285.3" y2="922.0" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="934.2" x2="384.4" y2="931.5" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="934.2" x2="387.4" y2="934.2" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="931.5" x2="387.4" y2="931.5" stroke="#a16207" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,806.5 180.1,887.1 282.3,922.4 384.4,932.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="806.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="887.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="922.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="932.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="797.8" x2="78.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="797.8" x2="81.0" y2="797.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="784.8" x2="81.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="819.4" x2="180.1" y2="799.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="819.4" x2="183.1" y2="819.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="799.8" x2="183.1" y2="799.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="840.4" x2="282.3" y2="825.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="840.4" x2="285.3" y2="840.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="825.9" x2="285.3" y2="825.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="869.4" x2="384.4" y2="854.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="869.4" x2="387.4" y2="869.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="854.7" x2="387.4" y2="854.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,789.8 180.1,805.4 282.3,832.8 384.4,861.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="789.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="805.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="832.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="861.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="837.9" x2="78.0" y2="837.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="837.9" x2="81.0" y2="837.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="837.3" x2="81.0" y2="837.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="841.5" x2="180.1" y2="841.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="841.5" x2="183.1" y2="841.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="841.2" x2="183.1" y2="841.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="875.8" x2="282.3" y2="875.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="875.8" x2="285.3" y2="875.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="875.5" x2="285.3" y2="875.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="907.1" x2="384.4" y2="906.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="907.1" x2="387.4" y2="907.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="906.9" x2="387.4" y2="906.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,837.7 180.1,841.3 282.3,875.7 384.4,907.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="837.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="841.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="875.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="907.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="891.2" x2="78.0" y2="886.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="891.2" x2="81.0" y2="891.2" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="886.7" x2="81.0" y2="886.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="889.9" x2="180.1" y2="883.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="889.9" x2="183.1" y2="889.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="883.0" x2="183.1" y2="883.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="891.0" x2="282.3" y2="885.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="891.0" x2="285.3" y2="891.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="885.7" x2="285.3" y2="885.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="899.1" x2="384.4" y2="894.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="899.1" x2="387.4" y2="899.1" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="894.9" x2="387.4" y2="894.9" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,888.3 180.1,884.8 282.3,888.1 384.4,897.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="888.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="884.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="888.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="897.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="949.5" x2="78.0" y2="949.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="949.5" x2="81.0" y2="949.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="231.2" y1="950.4" x2="231.2" y2="950.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="950.4" x2="234.2" y2="950.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="228.2" y1="950.4" x2="234.2" y2="950.4" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="951.3" x2="384.4" y2="951.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="951.3" x2="387.4" y2="951.3" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="951.2" x2="387.4" y2="951.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,949.6 231.2,950.4 384.4,951.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="75.0" y1="949.5" x2="81.0" y2="949.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="950.5" x2="180.1" y2="950.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="950.5" x2="183.1" y2="950.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="950.5" x2="183.1" y2="950.5" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="951.2" x2="282.3" y2="951.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="951.2" x2="285.3" y2="951.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="951.2" x2="285.3" y2="951.2" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="951.7" x2="384.4" y2="951.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="951.7" x2="387.4" y2="951.7" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="951.6" x2="387.4" y2="951.6" stroke="#2563eb" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,949.5 180.1,950.5 282.3,951.2 384.4,951.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="949.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="950.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="951.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="951.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="231.2" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="482.4" y1="925.6" x2="942.0" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
@@ -517,12 +676,16 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="892.9" x2="946.0" y2="892.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="892.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="830.8" x2="946.0" y2="830.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="830.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="768.7" x2="946.0" y2="768.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="768.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="912.6" x2="946.0" y2="912.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="912.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="870.3" x2="946.0" y2="870.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="870.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="827.9" x2="946.0" y2="827.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="827.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="785.5" x2="946.0" y2="785.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="785.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="743.2" x2="946.0" y2="743.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="743.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -531,79 +694,78 @@
   <line x1="942.0" y1="720.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="955.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,837.5)">CPU %</text>
-  <polyline points="482.4,855.4 635.6,862.9 788.8,878.9 942.0,891.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,868.1 635.6,885.5 788.8,892.9 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,782.3 635.6,800.9 788.8,811.3 942.0,812.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,751.2 635.6,756.8 788.8,749.1 942.0,760.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.3 635.6,896.5 788.8,896.1 942.0,896.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,790.3 635.6,803.1 788.8,827.5 942.0,828.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.7 635.6,896.1 788.8,896.3 942.0,896.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,918.0 635.6,854.2 788.8,783.3 942.0,762.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="918.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="854.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="783.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="762.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,940.5 635.6,931.8 788.8,929.1 942.0,923.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="940.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="931.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="929.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="923.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,942.5 635.6,919.4 788.8,898.7 942.0,881.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="942.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="919.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="898.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="881.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,919.1 635.6,827.4 788.8,788.8 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="919.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="827.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="788.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,858.2 635.6,860.9 788.8,879.4 942.0,891.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,872.0 635.6,884.7 788.8,891.8 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,780.8 635.6,800.5 788.8,809.7 942.0,815.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,755.7 635.6,766.3 788.8,811.1 942.0,819.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.5 635.6,896.3 788.8,896.3 942.0,896.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,796.9 635.6,804.4 788.8,825.5 942.0,825.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.5 635.6,896.1 788.8,896.4 942.0,896.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,930.3 635.6,888.6 788.8,843.7 942.0,822.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="930.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="888.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="843.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="822.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,945.4 635.6,939.2 788.8,937.5 942.0,934.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="945.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="939.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="937.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="934.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,946.6 635.6,932.1 788.8,914.9 942.0,905.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="946.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="932.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="914.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="905.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,923.4 635.6,858.0 788.8,787.1 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="923.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="858.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="787.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,927.9 635.6,888.6 788.8,859.0 942.0,826.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="927.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="888.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="859.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="826.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,928.2 635.6,866.7 788.8,796.0 942.0,769.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="928.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="866.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="796.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="769.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,953.5 635.6,949.9 788.8,936.5 942.0,898.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="953.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="949.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="936.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="898.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,934.5 635.6,905.3 788.8,855.6 942.0,826.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="905.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="855.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="826.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,937.7 635.6,895.3 788.8,843.8 942.0,826.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="937.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="895.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="843.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="826.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,954.0 635.6,951.5 788.8,942.4 942.0,917.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="954.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="951.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="942.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="917.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
-  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4 IO threads)</text>
+  <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
   <line x1="510" y1="989" x2="524" y2="989" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="517" cy="989" r="2.5" fill="#f97316"/>
-  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (MT)</text>
+  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring, MT)</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="567" cy="1049" r="3.0" fill="#6b7280"/>
   <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -42,6 +42,7 @@
   <polyline points="78.0,206.3 180.1,203.7 282.3,204.3 384.4,222.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,211.9 180.1,214.9 282.3,233.1 384.4,244.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,159.8 180.1,157.3 282.3,165.9 384.4,172.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,270.9 180.1,204.3 282.3,217.6 384.4,220.0" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,142.2 180.1,141.2 282.3,140.8 384.4,146.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.4 180.1,262.4 282.3,262.3 384.4,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,227.1 180.1,194.2 282.3,178.3 384.4,185.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -97,6 +98,23 @@
   <circle cx="180.1" cy="236.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="283.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="296.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="263.9" x2="78.0" y2="243.2" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="263.9" x2="81.0" y2="263.9" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="243.2" x2="81.0" y2="243.2" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="165.9" x2="180.1" y2="148.8" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="165.9" x2="183.1" y2="165.9" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="148.8" x2="183.1" y2="148.8" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="282.4" x2="282.3" y2="280.5" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="282.4" x2="285.3" y2="282.4" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="280.5" x2="285.3" y2="280.5" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="293.3" x2="384.4" y2="292.8" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="293.3" x2="387.4" y2="293.3" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="292.8" x2="387.4" y2="292.8" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,253.6 180.1,157.3 282.3,281.5 384.4,293.1" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="253.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="157.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="281.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="293.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="159.2" x2="78.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="159.2" x2="81.0" y2="159.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="158.6" x2="81.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
@@ -209,6 +227,7 @@
   <polyline points="482.4,204.3 635.6,222.1 788.8,245.6 942.0,257.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,233.1 635.6,244.4 788.8,255.4 942.0,257.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,165.9 635.6,172.8 788.8,188.6 942.0,193.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,217.6 635.6,220.0 788.8,234.9 942.0,234.7" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,140.8 635.6,146.5 788.8,180.8 942.0,194.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.3 635.6,262.5 788.8,262.5 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,178.3 635.6,185.7 788.8,205.1 942.0,206.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -228,6 +247,11 @@
   <circle cx="635.6" cy="296.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="280.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,311.5 635.6,294.0 788.8,272.2 942.0,249.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="311.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="294.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="272.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="249.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,291.5 635.6,219.3 788.8,159.0 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="291.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="219.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -291,6 +315,7 @@
   <polyline points="78.0,532.5 180.1,535.2 282.3,531.9 384.4,544.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,531.5 180.1,528.7 282.3,552.4 384.4,565.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,471.0 180.1,444.3 282.3,442.2 384.4,456.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,549.2 180.1,598.7 282.3,585.7 384.4,541.7" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,437.1 180.1,437.5 282.3,430.3 384.4,469.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.5 180.1,579.1 282.3,579.5 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,513.4 180.1,477.5 282.3,477.0 384.4,488.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -346,6 +371,23 @@
   <circle cx="180.1" cy="564.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="603.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="612.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="637.3" x2="78.0" y2="391.9" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="637.3" x2="81.0" y2="637.3" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="391.9" x2="81.0" y2="391.9" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="589.7" x2="180.1" y2="568.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="589.7" x2="183.1" y2="589.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="568.6" x2="183.1" y2="568.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="622.8" x2="282.3" y2="615.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="622.8" x2="285.3" y2="622.8" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="615.6" x2="285.3" y2="615.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="609.5" x2="384.4" y2="607.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="609.5" x2="387.4" y2="609.5" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="607.6" x2="387.4" y2="607.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,506.2 180.1,583.5 282.3,619.1 384.4,608.6" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="506.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="583.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="619.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="608.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="479.8" x2="78.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="479.8" x2="81.0" y2="479.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="462.4" x2="81.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
@@ -456,6 +498,7 @@
   <polyline points="482.4,531.9 635.6,544.2 788.8,562.4 942.0,573.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,552.4 635.6,565.5 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,442.2 635.6,456.7 788.8,478.8 942.0,484.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,585.7 635.6,541.7 788.8,552.8 942.0,559.1" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,430.3 635.6,469.6 788.8,505.0 942.0,510.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,477.0 635.6,488.3 788.8,524.4 942.0,516.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -475,6 +518,11 @@
   <circle cx="635.6" cy="612.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="590.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="579.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,633.2 635.6,608.1 788.8,581.6 942.0,560.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="633.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="608.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="581.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="560.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,607.8 635.6,539.0 788.8,474.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="607.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="539.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -532,6 +580,7 @@
   <polyline points="78.0,860.0 180.1,860.1 282.3,858.2 384.4,860.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,848.5 180.1,850.4 282.3,872.0 384.4,884.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,810.5 180.1,789.6 282.3,780.8 384.4,800.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,838.2 180.1,900.6 282.3,849.9 384.4,860.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,757.2 180.1,754.9 282.3,755.7 384.4,766.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,822.3 180.1,806.7 282.3,796.9 384.4,804.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -587,6 +636,23 @@
   <circle cx="180.1" cy="887.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="922.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="932.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="942.7" x2="78.0" y2="552.0" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="942.7" x2="81.0" y2="942.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="552.0" x2="81.0" y2="552.0" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="949.6" x2="180.1" y2="834.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="949.6" x2="183.1" y2="949.6" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="834.7" x2="183.1" y2="834.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="923.4" x2="282.3" y2="899.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="923.4" x2="285.3" y2="923.4" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="899.7" x2="285.3" y2="899.7" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="936.5" x2="384.4" y2="921.1" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="936.5" x2="387.4" y2="936.5" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="921.1" x2="387.4" y2="921.1" stroke="#06b6d4" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,796.9 180.1,879.3 282.3,911.9 384.4,928.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="796.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="879.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="911.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="928.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="797.8" x2="78.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="797.8" x2="81.0" y2="797.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="784.8" x2="81.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
@@ -697,6 +763,7 @@
   <polyline points="482.4,858.2 635.6,860.9 788.8,879.4 942.0,891.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,872.0 635.6,884.7 788.8,891.8 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,780.8 635.6,800.5 788.8,809.7 942.0,815.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,849.9 635.6,860.8 788.8,869.8 942.0,874.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,755.7 635.6,766.3 788.8,811.1 942.0,819.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.5 635.6,896.3 788.8,896.3 942.0,896.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,796.9 635.6,804.4 788.8,825.5 942.0,825.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -716,6 +783,11 @@
   <circle cx="635.6" cy="932.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="914.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="905.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,943.9 635.6,927.0 788.8,905.2 942.0,878.5" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="943.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="927.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="905.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="878.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="482.4,923.4 635.6,858.0 788.8,787.1 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="923.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="858.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -752,15 +824,18 @@
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
   <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
-  <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
-  <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="415" y1="1009" x2="429" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
-  <circle cx="422" cy="1009" r="2.5" fill="#16a34a"/>
-  <text x="435" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="605" y1="1009" x2="619" y2="1009" stroke="#15803d" stroke-width="2.5"/>
-  <circle cx="612" cy="1009" r="2.5" fill="#15803d"/>
-  <text x="625" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="130" y1="1009" x2="144" y2="1009" stroke="#06b6d4" stroke-width="2.5"/>
+  <circle cx="137" cy="1009" r="2.5" fill="#06b6d4"/>
+  <text x="150" y="1013" fill="#374151" font-size="11" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="320" y1="1009" x2="334" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="327" cy="1009" r="2.5" fill="#2563eb"/>
+  <text x="340" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="510" y1="1009" x2="524" y2="1009" stroke="#16a34a" stroke-width="2.5"/>
+  <circle cx="517" cy="1009" r="2.5" fill="#16a34a"/>
+  <text x="530" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
+  <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
+  <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>

--- a/doc/charts/pushpull/inproc.svg
+++ b/doc/charts/pushpull/inproc.svg
@@ -19,34 +19,56 @@
   <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="368.4" y1="296.3" x2="372.4" y2="296.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="296.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="239.6" x2="372.4" y2="239.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="239.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="182.9" x2="372.4" y2="182.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="182.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="126.2" x2="372.4" y2="126.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="126.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="294.1" x2="372.4" y2="294.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="294.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="235.1" x2="372.4" y2="235.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="235.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="176.2" x2="372.4" y2="176.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="176.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="117.2" x2="372.4" y2="117.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="117.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="223.2" y1="73.0" x2="223.2" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="353.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,213.0)">CPU %</text>
-  <polyline points="78.0,109.3 223.2,110.6 368.4,113.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,180.1 223.2,179.4 368.4,187.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,212.3 223.2,212.3 368.4,212.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,283.0 223.2,283.0 368.4,283.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,210.7 223.2,200.9 368.4,193.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,303.9 223.2,302.3 368.4,301.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,109.5 223.2,212.0 368.4,290.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,265.8 223.2,252.0 368.4,253.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,160.9 223.2,150.9 368.4,150.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,282.7 223.2,280.7 368.4,284.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,125.8 174.8,121.8 271.6,143.5 368.4,137.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,191.5 174.8,191.3 271.6,198.8 368.4,193.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,212.3 174.8,212.3 271.6,212.3 368.4,212.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,283.0 174.8,283.5 271.6,283.0 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,131.9 174.8,126.1 271.6,132.4 368.4,130.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,251.0 174.8,249.0 271.6,253.3 368.4,251.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="251.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="249.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="253.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="251.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,216.2 271.6,289.0 368.4,303.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="109.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="216.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="289.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="303.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,284.1 174.8,276.9 271.6,275.9 368.4,277.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="284.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="276.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="275.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="277.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,197.7 174.8,197.1 271.6,185.6 368.4,185.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="197.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="197.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="185.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="185.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,248.1 174.8,248.4 271.6,253.3 368.4,248.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="248.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="248.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="253.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="248.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="223.2" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="684.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="466.4" y1="318.0" x2="902.0" y2="318.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="458.4" y="318.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
@@ -82,61 +104,60 @@
   <line x1="902.0" y1="73.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="466.4" y1="353.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="418.4" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,418.4,213.0)">CPU %</text>
-  <polyline points="466.4,113.2 611.6,129.5 756.8,118.3 902.0,115.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,187.1 611.6,184.0 756.8,180.5 902.0,192.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,212.0 611.6,212.0 756.8,212.0 902.0,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,283.4 611.6,283.4 756.8,283.4 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,193.1 611.6,168.2 756.8,215.2 902.0,236.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,306.2 611.6,264.4 756.8,222.2 902.0,181.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="306.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="264.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="222.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="181.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,300.1 611.6,265.1 756.8,228.3 902.0,198.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="300.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="265.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="228.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="198.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,286.1 611.6,245.3 756.8,199.9 902.0,159.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="286.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="245.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="199.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="159.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,264.6 611.6,222.6 756.8,181.0 902.0,138.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="264.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="222.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="181.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="138.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,297.6 611.6,265.2 756.8,252.7 902.0,265.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="297.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="265.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="252.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="265.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,143.5 611.6,137.2 756.8,127.9 902.0,134.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,198.8 611.6,193.4 756.8,191.3 902.0,199.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,212.3 611.6,212.5 756.8,211.8 902.0,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,283.0 611.6,283.0 756.8,283.0 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,132.4 611.6,130.7 756.8,126.3 902.0,132.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,287.4 611.6,244.6 756.8,202.5 902.0,159.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="287.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="244.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="202.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="159.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,300.9 611.6,266.4 756.8,229.4 902.0,198.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="300.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="266.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="229.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="198.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,295.2 611.6,253.8 756.8,210.4 902.0,170.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="295.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="253.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="210.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="170.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,271.6 611.6,229.4 756.8,187.9 902.0,145.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="271.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="229.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="187.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="145.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,287.4 611.6,243.8 756.8,203.1 902.0,160.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="287.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="243.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="203.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="160.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <text x="466.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="611.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="756.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="205" y1="391" x2="219" y2="391" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="212" cy="391" r="2.5" fill="#eab308"/>
-  <text x="225" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="225" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="395" y1="391" x2="409" y2="391" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="402" cy="391" r="2.5" fill="#f97316"/>
-  <text x="415" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="415" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="585" y1="391" x2="599" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="592" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="605" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="605" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="300" y1="411" x2="314" y2="411" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="307" cy="411" r="2.5" fill="#16a34a"/>
-  <text x="320" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="320" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="490" y1="411" x2="504" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="497" cy="411" r="2.5" fill="#15803d"/>
-  <text x="510" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="510" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="547" cy="451" r="3.0" fill="#6b7280"/>
   <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel, log)</text>
 </svg>

--- a/doc/charts/pushpull/ipc.svg
+++ b/doc/charts/pushpull/ipc.svg
@@ -3,57 +3,101 @@
   <text x="490.0" y="17.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput: IPC, 2-process</text>
   <text x="490.0" y="31.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="223.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="297.0" x2="368.4" y2="297.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="297.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="241.0" x2="368.4" y2="241.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="241.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="185.0" x2="368.4" y2="185.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="185.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="129.0" x2="368.4" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="78.0" y1="318.0" x2="368.4" y2="318.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="318.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="78.0" y1="283.0" x2="368.4" y2="283.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="283.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="248.0" x2="368.4" y2="248.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="248.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="78.0" y1="213.0" x2="368.4" y2="213.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="213.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="178.0" x2="368.4" y2="178.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="178.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="78.0" y1="143.0" x2="368.4" y2="143.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="143.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="108.0" x2="368.4" y2="108.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="368.4" y1="283.3" x2="372.4" y2="283.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="283.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="213.5" x2="372.4" y2="213.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="213.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="143.8" x2="372.4" y2="143.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="143.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="74.1" x2="372.4" y2="74.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="74.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="368.4" y1="284.4" x2="372.4" y2="284.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="284.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="215.9" x2="372.4" y2="215.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="215.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="147.3" x2="372.4" y2="147.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="147.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="78.8" x2="372.4" y2="78.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="78.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="223.2" y1="73.0" x2="223.2" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="353.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,213.0)">CPU %</text>
-  <polyline points="78.0,164.4 223.2,167.0 368.4,162.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,151.3 223.2,124.6 368.4,150.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,137.6 223.2,141.9 368.4,144.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,250.1 223.2,254.7 368.4,252.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,295.3 223.2,300.1 368.4,301.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,266.2 223.2,265.4 368.4,265.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,288.9 223.2,290.2 368.4,282.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,109.5 223.2,195.9 368.4,278.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,137.9 223.2,213.9 368.4,212.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,123.4 223.2,205.3 368.4,226.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,271.3 223.2,275.0 368.4,279.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,333.6 223.2,333.8 368.4,334.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,224.2 174.8,221.0 271.6,220.3 368.4,233.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,213.2 174.8,197.1 271.6,214.4 368.4,243.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,245.7 174.8,194.6 271.6,215.3 368.4,245.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,194.6 174.8,193.2 271.6,229.6 368.4,250.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,283.0 174.8,283.0 271.6,283.0 368.4,286.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,279.0 174.8,266.2 271.6,271.8 368.4,273.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,251.0 174.8,252.4 271.6,250.6 368.4,249.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,251.9 174.8,248.9 271.6,242.9 368.4,278.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="251.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="248.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="242.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="278.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,196.5 271.6,275.6 368.4,317.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="109.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="196.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="275.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="317.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,117.4 174.8,195.9 271.6,276.0 368.4,316.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="117.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="195.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="276.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="316.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,163.7 174.8,162.5 271.6,201.8 368.4,238.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="163.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="162.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="201.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="238.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,114.5 174.8,127.2 271.6,188.5 368.4,256.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="114.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="127.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="188.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="256.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,274.9 174.8,260.2 271.6,262.4 368.4,290.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="274.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="260.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="262.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="290.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,333.8 174.8,334.1 271.6,335.0 368.4,335.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="333.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="334.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="335.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="335.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="223.2" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="684.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="466.4" y1="297.0" x2="902.0" y2="297.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="458.4" y="297.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="466.4" y1="241.0" x2="902.0" y2="241.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="458.4" y="241.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="466.4" y1="185.0" x2="902.0" y2="185.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="458.4" y="185.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="466.4" y1="129.0" x2="902.0" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="458.4" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="466.4" y1="318.0" x2="902.0" y2="318.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="318.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="466.4" y1="283.0" x2="902.0" y2="283.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="283.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="466.4" y1="248.0" x2="902.0" y2="248.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="248.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="466.4" y1="213.0" x2="902.0" y2="213.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="213.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="466.4" y1="178.0" x2="902.0" y2="178.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="178.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="466.4" y1="143.0" x2="902.0" y2="143.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="143.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="466.4" y1="108.0" x2="902.0" y2="108.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="458.4" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="466.4" y1="73.0" x2="902.0" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="458.4" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
+  <text x="458.4" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="902.0" y1="306.3" x2="906.0" y2="306.3" stroke="#9ca3af" stroke-width="1"/>
   <text x="910.0" y="306.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1 GB/s</text>
   <line x1="902.0" y1="259.7" x2="906.0" y2="259.7" stroke="#9ca3af" stroke-width="1"/>
@@ -74,70 +118,78 @@
   <line x1="902.0" y1="73.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="466.4" y1="353.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="418.4" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,418.4,213.0)">CPU %</text>
-  <polyline points="466.4,162.6 611.6,166.2 756.8,188.9 902.0,204.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,150.4 611.6,166.4 756.8,181.3 902.0,178.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,144.2 611.6,159.1 756.8,174.9 902.0,193.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,252.9 611.6,257.2 756.8,263.2 902.0,269.6" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,301.5 611.6,241.1 756.8,242.2 902.0,297.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,265.4 611.6,206.7 756.8,217.9 902.0,299.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,329.0 611.6,270.9 756.8,185.0 902.0,127.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="329.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="270.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="185.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="127.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,327.4 611.6,301.8 756.8,288.8 902.0,272.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="327.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="301.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="288.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="272.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,304.8 611.6,196.8 756.8,94.2 902.0,68.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="304.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="196.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="94.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="68.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,309.6 611.6,241.2 756.8,164.5 902.0,162.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="309.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="241.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="164.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="162.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,327.7 611.6,280.4 756.8,237.9 902.0,239.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="327.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="280.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="237.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="239.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,346.6 611.6,329.1 756.8,285.1 902.0,217.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="346.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="329.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="285.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="217.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,220.3 611.6,233.1 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,214.4 611.6,243.8 756.8,273.4 902.0,260.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,215.3 611.6,245.4 756.8,273.2 902.0,266.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,229.6 611.6,250.8 756.8,263.4 902.0,268.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,283.0 611.6,286.0 756.8,282.8 902.0,283.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,271.8 611.6,273.5 756.8,278.3 902.0,279.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,250.6 611.6,249.0 756.8,267.6 902.0,293.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,314.6 611.6,249.7 756.8,171.5 902.0,130.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="314.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="249.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="171.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="130.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,326.0 611.6,303.1 756.8,289.1 902.0,272.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="326.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="303.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="289.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="272.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,326.2 611.6,302.5 756.8,289.3 902.0,270.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="326.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="302.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="289.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="270.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,300.3 611.6,193.8 756.8,97.7 902.0,38.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="300.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="193.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="97.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="38.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,295.7 611.6,218.6 756.8,111.7 902.0,25.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="295.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="218.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="111.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="25.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,321.4 611.6,265.8 756.8,236.1 902.0,224.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="321.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="265.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="236.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="224.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,346.7 611.6,329.2 756.8,282.7 902.0,219.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="346.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="329.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="282.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="219.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="466.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="611.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="756.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <line x1="205" y1="391" x2="219" y2="391" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="212" cy="391" r="2.5" fill="#eab308"/>
-  <text x="225" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="395" y1="391" x2="409" y2="391" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="402" cy="391" r="2.5" fill="#f97316"/>
-  <text x="415" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
-  <line x1="585" y1="391" x2="599" y2="391" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="592" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="605" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <line x1="110" y1="391" x2="124" y2="391" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="117" cy="391" r="2.5" fill="#eab308"/>
+  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <line x1="300" y1="391" x2="314" y2="391" stroke="#a16207" stroke-width="2.5"/>
+  <circle cx="307" cy="391" r="2.5" fill="#a16207"/>
+  <text x="320" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
+  <line x1="490" y1="391" x2="504" y2="391" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="497" cy="391" r="2.5" fill="#f97316"/>
+  <text x="510" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
+  <line x1="680" y1="391" x2="694" y2="391" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="687" cy="391" r="2.5" fill="#dc2626"/>
+  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="205" y1="411" x2="219" y2="411" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="212" cy="411" r="2.5" fill="#2563eb"/>
-  <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="395" y1="411" x2="409" y2="411" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="402" cy="411" r="2.5" fill="#16a34a"/>
-  <text x="415" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="415" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="585" y1="411" x2="599" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="592" cy="411" r="2.5" fill="#15803d"/>
-  <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="547" cy="451" r="3.0" fill="#6b7280"/>
   <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/tcp.svg
+++ b/doc/charts/pushpull/tcp.svg
@@ -38,6 +38,7 @@
   <polyline points="78.0,212.8 174.8,215.2 271.6,223.8 368.4,232.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,215.6 174.8,200.2 271.6,227.2 368.4,246.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,196.4 174.8,192.2 271.6,227.5 368.4,244.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,201.8 174.8,192.0 271.6,191.3 368.4,225.1" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,208.8 174.8,210.7 271.6,211.1 368.4,242.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,282.5 174.8,283.0 271.6,284.6 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,305.4 174.8,280.9 271.6,270.7 368.4,272.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -57,6 +58,11 @@
   <circle cx="174.8" cy="192.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="271.6" cy="281.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="368.4" cy="322.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,177.8 174.8,136.5 271.6,163.1 368.4,227.8" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="177.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="136.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="163.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="227.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="78.0,124.8 174.8,129.1 271.6,175.9 368.4,234.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="124.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="174.8" cy="129.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -121,6 +127,7 @@
   <polyline points="466.4,223.8 611.6,232.4 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.2 611.6,246.9 756.8,265.5 902.0,262.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.5 611.6,244.7 756.8,266.9 902.0,265.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,191.3 611.6,225.1 756.8,218.4 902.0,231.9" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,211.1 611.6,242.4 756.8,252.7 902.0,271.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,284.6 611.6,283.0 756.8,283.2 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,270.7 611.6,272.7 756.8,267.6 902.0,284.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -140,6 +147,11 @@
   <circle cx="611.6" cy="310.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="301.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="298.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,287.6 611.6,180.5 756.8,149.6 902.0,129.5" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="287.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="180.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="149.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="129.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="466.4,292.0 611.6,189.2 756.8,95.2 902.0,93.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="292.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="189.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -176,15 +188,18 @@
   <line x1="680" y1="391" x2="694" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="687" cy="391" r="2.5" fill="#dc2626"/>
   <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
-  <line x1="205" y1="411" x2="219" y2="411" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="212" cy="411" r="2.5" fill="#2563eb"/>
-  <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="395" y1="411" x2="409" y2="411" stroke="#16a34a" stroke-width="2.5"/>
-  <circle cx="402" cy="411" r="2.5" fill="#16a34a"/>
-  <text x="415" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="585" y1="411" x2="599" y2="411" stroke="#15803d" stroke-width="2.5"/>
-  <circle cx="592" cy="411" r="2.5" fill="#15803d"/>
-  <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="110" y1="411" x2="124" y2="411" stroke="#06b6d4" stroke-width="2.5"/>
+  <circle cx="117" cy="411" r="2.5" fill="#06b6d4"/>
+  <text x="130" y="415" fill="#374151" font-size="11" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="300" y1="411" x2="314" y2="411" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="307" cy="411" r="2.5" fill="#2563eb"/>
+  <text x="320" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="490" y1="411" x2="504" y2="411" stroke="#16a34a" stroke-width="2.5"/>
+  <circle cx="497" cy="411" r="2.5" fill="#16a34a"/>
+  <text x="510" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="680" y1="411" x2="694" y2="411" stroke="#15803d" stroke-width="2.5"/>
+  <circle cx="687" cy="411" r="2.5" fill="#15803d"/>
+  <text x="700" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>

--- a/doc/charts/pushpull/tcp.svg
+++ b/doc/charts/pushpull/tcp.svg
@@ -3,48 +3,84 @@
   <text x="490.0" y="17.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput: TCP loopback, 2-process</text>
   <text x="490.0" y="31.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="223.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="297.0" x2="368.4" y2="297.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="297.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="241.0" x2="368.4" y2="241.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="241.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="185.0" x2="368.4" y2="185.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="185.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="129.0" x2="368.4" y2="129.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="129.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="78.0" y1="318.0" x2="368.4" y2="318.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="318.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="78.0" y1="283.0" x2="368.4" y2="283.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="283.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="248.0" x2="368.4" y2="248.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="248.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="78.0" y1="213.0" x2="368.4" y2="213.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="213.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="178.0" x2="368.4" y2="178.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="178.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="78.0" y1="143.0" x2="368.4" y2="143.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="143.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="108.0" x2="368.4" y2="108.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="368.4" y1="285.6" x2="372.4" y2="285.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="285.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="218.2" x2="372.4" y2="218.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="218.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="150.8" x2="372.4" y2="150.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="150.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="83.4" x2="372.4" y2="83.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="83.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="368.4" y1="283.6" x2="372.4" y2="283.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="283.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="214.2" x2="372.4" y2="214.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="214.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="144.8" x2="372.4" y2="144.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="144.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="75.4" x2="372.4" y2="75.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="75.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="223.2" y1="73.0" x2="223.2" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="368.4" y1="73.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="353.0" x2="368.4" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,213.0)">CPU %</text>
-  <polyline points="78.0,168.2 223.2,169.0 368.4,175.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,129.9 223.2,125.3 368.4,167.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,119.8 223.2,125.4 368.4,169.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,149.4 223.2,147.6 368.4,153.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,247.9 223.2,253.8 368.4,255.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,238.0 223.2,238.2 368.4,246.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,234.8 223.2,239.4 368.4,240.9" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,292.3 223.2,293.4 368.4,296.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,109.5 223.2,198.4 368.4,282.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,114.8 223.2,196.5 368.4,284.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,116.0 223.2,194.6 368.4,203.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,147.0 223.2,217.1 368.4,238.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,274.5 223.2,275.1 368.4,281.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <polyline points="78.0,341.5 223.2,343.8 368.4,344.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,212.8 174.8,215.2 271.6,223.8 368.4,232.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,215.6 174.8,200.2 271.6,227.2 368.4,246.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,196.4 174.8,192.2 271.6,227.5 368.4,244.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,208.8 174.8,210.7 271.6,211.1 368.4,242.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,282.5 174.8,283.0 271.6,284.6 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,305.4 174.8,280.9 271.6,270.7 368.4,272.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,275.3 174.8,280.9 271.6,282.8 368.4,283.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,235.6 174.8,244.1 271.6,249.5 368.4,269.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="235.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="244.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="249.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="269.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,118.0 174.8,204.3 271.6,281.9 368.4,322.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="118.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="204.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="281.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="322.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,192.8 271.6,281.7 368.4,322.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="109.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="192.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="281.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="322.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,124.8 174.8,129.1 271.6,175.9 368.4,234.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="124.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="129.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="175.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="234.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,114.6 174.8,136.0 271.6,208.5 368.4,257.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="114.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="136.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="208.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="257.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,308.4 174.8,275.8 271.6,267.9 368.4,283.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="308.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="275.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="267.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="283.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,341.3 174.8,343.8 271.6,344.4 368.4,345.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="341.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="343.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="344.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="345.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="223.2" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="368.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="684.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
   <line x1="466.4" y1="318.0" x2="902.0" y2="318.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="458.4" y="318.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
@@ -82,79 +118,78 @@
   <line x1="902.0" y1="73.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="466.4" y1="353.0" x2="902.0" y2="353.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="418.4" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,418.4,213.0)">CPU %</text>
-  <polyline points="466.4,130.5 611.6,129.4 756.8,152.1 902.0,166.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,120.5 611.6,141.6 756.8,148.4 902.0,156.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,123.9 611.6,133.4 756.8,146.3 902.0,160.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,103.5 611.6,115.2 756.8,184.4 902.0,152.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,230.7 611.6,234.4 756.8,241.9 902.0,242.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,219.8 611.6,219.1 756.8,203.1 902.0,194.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,212.9 611.6,213.1 756.8,213.5 902.0,214.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,332.8 611.6,275.2 756.8,171.6 902.0,102.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="332.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="275.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="171.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="102.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,328.0 611.6,310.7 756.8,298.0 902.0,297.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="328.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="310.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="298.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="297.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,328.6 611.6,310.8 756.8,298.9 902.0,298.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="328.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,223.8 611.6,232.4 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,227.2 611.6,246.9 756.8,265.5 902.0,262.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,227.5 611.6,244.7 756.8,266.9 902.0,265.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,211.1 611.6,242.4 756.8,252.7 902.0,271.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,284.6 611.6,283.0 756.8,283.2 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,270.7 611.6,272.7 756.8,267.6 902.0,284.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,282.8 611.6,283.0 756.8,283.2 902.0,283.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,317.4 611.6,238.2 756.8,157.9 902.0,108.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="317.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="238.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="157.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="108.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,328.5 611.6,310.6 756.8,299.9 902.0,297.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="328.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="310.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="299.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="297.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,328.5 611.6,310.8 756.8,301.2 902.0,298.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="328.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="310.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="298.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="298.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,300.0 611.6,189.3 756.8,216.1 902.0,94.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="300.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="189.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="216.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="94.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,312.3 611.6,250.0 756.8,191.8 902.0,170.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="312.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="250.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="191.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="170.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,327.7 611.6,276.7 756.8,202.0 902.0,172.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="327.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="276.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="202.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="172.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,350.0 611.6,341.8 756.8,315.8 902.0,243.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="350.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="341.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="315.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="243.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="301.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="298.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,292.0 611.6,189.2 756.8,95.2 902.0,93.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="292.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="189.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="95.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="93.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,303.3 611.6,220.9 756.8,147.1 902.0,89.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="303.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="220.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="147.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="89.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,323.7 611.6,257.8 756.8,197.5 902.0,207.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="323.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="257.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="197.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="207.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,350.1 611.6,342.0 756.8,316.6 902.0,245.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="350.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="342.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="316.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="245.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="466.4" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="611.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="756.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="110" y1="391" x2="124" y2="391" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="117" cy="391" r="2.5" fill="#eab308"/>
-  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="300" y1="391" x2="314" y2="391" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="307" cy="391" r="2.5" fill="#a16207"/>
-  <text x="320" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4 IO threads)</text>
+  <text x="320" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
   <line x1="490" y1="391" x2="504" y2="391" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="497" cy="391" r="2.5" fill="#f97316"/>
-  <text x="510" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="510" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="680" y1="391" x2="694" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="687" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="205" y1="411" x2="219" y2="411" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="212" cy="411" r="2.5" fill="#2563eb"/>
-  <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="395" y1="411" x2="409" y2="411" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="402" cy="411" r="2.5" fill="#16a34a"/>
-  <text x="415" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="415" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="585" y1="411" x2="599" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="592" cy="411" r="2.5" fill="#15803d"/>
-  <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
   <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
   <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
   <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="547" cy="451" r="3.0" fill="#6b7280"/>
   <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/reqrep/inproc.svg
+++ b/doc/charts/reqrep/inproc.svg
@@ -36,46 +36,46 @@
   <line x1="760.0" y1="49.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
-  <polyline points="90.0,115.1 224.0,115.4 358.0,112.7 492.0,110.2 626.0,125.7 760.0,119.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,128.5 224.0,133.2 358.0,132.1 492.0,125.1 626.0,129.6 760.0,128.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,76.9 224.0,66.3 358.0,70.5 492.0,69.4 626.0,83.4 760.0,74.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,142.0 224.0,143.2 358.0,142.1 492.0,142.5 626.0,143.4 760.0,141.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,106.8 224.0,98.9 358.0,101.9 492.0,111.0 626.0,100.8 760.0,106.0" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,130.6 224.0,113.9 358.0,122.5 492.0,120.1 626.0,115.4 760.0,126.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="130.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="113.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="122.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="120.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="115.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="126.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,110.2 224.0,102.8 358.0,101.1 492.0,97.2 626.0,106.9 760.0,89.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="110.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="102.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="101.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="97.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="106.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="89.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,138.3 224.0,139.5 358.0,131.6 492.0,135.2 626.0,117.3 760.0,133.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="138.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="139.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="135.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="117.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="133.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,201.4 224.0,201.0 358.0,201.4 492.0,201.3 626.0,201.0 760.0,201.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="201.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="201.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="201.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="201.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="201.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,65.9 224.0,80.8 358.0,90.6 492.0,78.5 626.0,84.5 760.0,56.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="65.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="80.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="90.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="78.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="84.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="56.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,111.1 224.0,117.8 358.0,117.9 492.0,109.5 626.0,115.2 760.0,115.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,129.7 224.0,130.9 358.0,128.7 492.0,127.4 626.0,124.3 760.0,130.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,103.7 224.0,111.2 358.0,109.3 492.0,105.3 626.0,100.6 760.0,101.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,150.9 224.0,151.1 358.0,150.9 492.0,124.3 626.0,150.3 760.0,150.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,122.5 224.0,115.6 358.0,109.3 492.0,113.2 626.0,115.8 760.0,110.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,109.4 224.0,119.4 358.0,101.3 492.0,119.3 626.0,111.5 760.0,126.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="109.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="119.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="101.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="119.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="111.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="126.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,98.9 224.0,104.4 358.0,105.2 492.0,102.0 626.0,97.1 760.0,88.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="98.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="104.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="105.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="102.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="97.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="88.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,109.1 224.0,97.4 358.0,98.0 492.0,96.4 626.0,96.1 760.0,94.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="109.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="97.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="98.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="96.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="96.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="94.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,198.3 224.0,198.3 358.0,198.3 492.0,198.4 626.0,198.5 760.0,198.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="198.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="198.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="198.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,114.6 224.0,119.0 358.0,110.8 492.0,121.7 626.0,110.5 760.0,111.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="114.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="119.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="110.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="121.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="110.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="111.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <text x="90.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="224.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="358.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -84,20 +84,20 @@
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="140" y1="269" x2="154" y2="269" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="147" cy="269" r="2.5" fill="#eab308"/>
-  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
+  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
   <line x1="330" y1="269" x2="344" y2="269" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="337" cy="269" r="2.5" fill="#f97316"/>
-  <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
+  <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="520" y1="269" x2="534" y2="269" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="527" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="235" y1="289" x2="249" y2="289" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="242" cy="289" r="2.5" fill="#16a34a"/>
-  <text x="255" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="255" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="425" y1="289" x2="439" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="432" cy="289" r="2.5" fill="#15803d"/>
-  <text x="445" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="445" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
   <circle cx="272" cy="329" r="2" fill="#6b7280"/>
   <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>

--- a/doc/charts/reqrep/ipc.svg
+++ b/doc/charts/reqrep/ipc.svg
@@ -16,22 +16,14 @@
   <text x="82.0" y="85.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120</text>
   <line x1="90.0" y1="61.0" x2="760.0" y2="61.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="61.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140</text>
-  <line x1="90.0" y1="206.5" x2="760.0" y2="206.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="206.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">50%</text>
   <line x1="90.0" y1="184.0" x2="760.0" y2="184.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="184.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100%</text>
-  <line x1="90.0" y1="161.5" x2="760.0" y2="161.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="161.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">150%</text>
+  <text x="768.0" y="184.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">50%</text>
   <line x1="90.0" y1="139.0" x2="760.0" y2="139.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="139.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">200%</text>
-  <line x1="90.0" y1="116.5" x2="760.0" y2="116.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="116.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">250%</text>
+  <text x="768.0" y="139.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100%</text>
   <line x1="90.0" y1="94.0" x2="760.0" y2="94.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="94.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">300%</text>
-  <line x1="90.0" y1="71.5" x2="760.0" y2="71.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="71.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">350%</text>
+  <text x="768.0" y="94.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">150%</text>
   <line x1="90.0" y1="49.0" x2="760.0" y2="49.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">400%</text>
+  <text x="768.0" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">200%</text>
   <line x1="90.0" y1="49.0" x2="90.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="224.0" y1="49.0" x2="224.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="358.0" y1="49.0" x2="358.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,79 +34,90 @@
   <line x1="760.0" y1="49.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
-  <polyline points="90.0,136.0 224.0,138.3 358.0,136.8 492.0,136.1 626.0,138.1 760.0,146.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,176.6 224.0,178.4 358.0,178.6 492.0,177.8 626.0,178.3 760.0,174.6" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,163.9 224.0,161.8 358.0,163.8 492.0,165.2 626.0,164.4 760.0,166.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,168.3 224.0,166.4 358.0,166.8 492.0,170.5 626.0,168.2 760.0,167.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,166.9 224.0,169.0 358.0,167.5 492.0,167.8 626.0,168.0 760.0,171.0" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,172.5 224.0,173.2 358.0,173.7 492.0,176.5 626.0,170.4 760.0,175.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,167.8 224.0,170.8 358.0,170.6 492.0,166.3 626.0,160.4 760.0,156.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="167.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="170.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="170.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="166.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="160.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="156.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,131.0 224.0,117.3 358.0,121.7 492.0,128.0 626.0,109.7 760.0,107.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="131.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="117.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="121.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="128.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="109.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="107.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,125.8 224.0,131.0 358.0,124.2 492.0,102.5 626.0,120.3 760.0,98.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="125.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="131.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="124.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="102.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="120.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="98.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,185.1 224.0,187.6 358.0,186.5 492.0,182.1 626.0,175.2 760.0,168.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="185.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="187.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="186.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="182.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="175.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="168.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,88.5 224.0,87.8 358.0,87.8 492.0,85.1 626.0,78.8 760.0,67.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="88.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="87.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="87.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="85.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="78.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="67.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,180.9 224.0,187.6 358.0,179.1 492.0,178.5 626.0,181.8 760.0,154.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="180.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="187.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="179.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="178.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="181.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="154.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,136.6 224.0,136.5 358.0,141.0 492.0,141.4 626.0,141.6 760.0,146.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,179.5 224.0,177.3 358.0,178.9 492.0,180.7 626.0,180.5 760.0,177.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,178.6 224.0,176.7 358.0,180.6 492.0,180.7 626.0,180.2 760.0,176.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,173.5 224.0,169.9 358.0,166.0 492.0,163.1 626.0,173.0 760.0,166.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,169.5 224.0,170.8 358.0,172.1 492.0,171.6 626.0,174.3 760.0,171.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,164.7 224.0,174.5 358.0,165.5 492.0,166.7 626.0,169.0 760.0,172.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,169.3 224.0,172.1 358.0,181.6 492.0,173.2 626.0,178.1 760.0,174.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,173.8 224.0,173.5 358.0,165.8 492.0,164.0 626.0,159.1 760.0,156.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="173.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="173.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="165.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="164.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="159.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="156.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,116.9 224.0,126.7 358.0,126.3 492.0,125.3 626.0,115.9 760.0,110.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="116.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="126.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="126.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="125.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="115.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="110.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,122.8 224.0,128.2 358.0,123.9 492.0,122.5 626.0,110.9 760.0,97.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="122.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="128.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="123.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="122.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="110.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="97.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,107.3 224.0,117.2 358.0,117.6 492.0,117.0 626.0,99.5 760.0,108.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="107.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="117.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="117.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="117.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="99.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="108.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,185.5 224.0,183.1 358.0,183.2 492.0,181.9 626.0,172.9 760.0,170.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="185.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="183.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="183.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="181.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="172.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,128.0 224.0,113.4 358.0,123.4 492.0,117.8 626.0,115.8 760.0,92.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="128.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="113.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="123.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="117.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="115.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="92.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,190.3 224.0,183.5 358.0,171.4 492.0,182.9 626.0,163.0 760.0,157.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="190.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="183.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="171.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="182.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="163.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="157.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="224.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="358.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="492.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="626.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <line x1="140" y1="269" x2="154" y2="269" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="147" cy="269" r="2.5" fill="#eab308"/>
-  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="330" y1="269" x2="344" y2="269" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="337" cy="269" r="2.5" fill="#f97316"/>
-  <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
-  <line x1="520" y1="269" x2="534" y2="269" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="527" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <line x1="45" y1="269" x2="59" y2="269" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="52" cy="269" r="2.5" fill="#eab308"/>
+  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <line x1="235" y1="269" x2="249" y2="269" stroke="#a16207" stroke-width="2.5"/>
+  <circle cx="242" cy="269" r="2.5" fill="#a16207"/>
+  <text x="255" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
+  <line x1="425" y1="269" x2="439" y2="269" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="432" cy="269" r="2.5" fill="#f97316"/>
+  <text x="445" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
+  <line x1="615" y1="269" x2="629" y2="269" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="622" cy="269" r="2.5" fill="#dc2626"/>
+  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="140" y1="289" x2="154" y2="289" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="147" cy="289" r="2.5" fill="#2563eb"/>
-  <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="330" y1="289" x2="344" y2="289" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="337" cy="289" r="2.5" fill="#16a34a"/>
-  <text x="350" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="350" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="520" y1="289" x2="534" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="527" cy="289" r="2.5" fill="#15803d"/>
-  <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
   <circle cx="272" cy="329" r="2" fill="#6b7280"/>
   <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>

--- a/doc/charts/reqrep/tcp.svg
+++ b/doc/charts/reqrep/tcp.svg
@@ -16,22 +16,14 @@
   <text x="82.0" y="85.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120</text>
   <line x1="90.0" y1="61.0" x2="760.0" y2="61.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82.0" y="61.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140</text>
-  <line x1="90.0" y1="206.5" x2="760.0" y2="206.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="206.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">50%</text>
   <line x1="90.0" y1="184.0" x2="760.0" y2="184.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="184.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100%</text>
-  <line x1="90.0" y1="161.5" x2="760.0" y2="161.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="161.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">150%</text>
+  <text x="768.0" y="184.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">50%</text>
   <line x1="90.0" y1="139.0" x2="760.0" y2="139.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="139.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">200%</text>
-  <line x1="90.0" y1="116.5" x2="760.0" y2="116.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="116.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">250%</text>
+  <text x="768.0" y="139.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">100%</text>
   <line x1="90.0" y1="94.0" x2="760.0" y2="94.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="94.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">300%</text>
-  <line x1="90.0" y1="71.5" x2="760.0" y2="71.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="71.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">350%</text>
+  <text x="768.0" y="94.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">150%</text>
   <line x1="90.0" y1="49.0" x2="760.0" y2="49.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768.0" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">400%</text>
+  <text x="768.0" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">200%</text>
   <line x1="90.0" y1="49.0" x2="90.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="224.0" y1="49.0" x2="224.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="358.0" y1="49.0" x2="358.0" y2="229.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,79 +34,90 @@
   <line x1="760.0" y1="49.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90.0" y1="229.0" x2="760.0" y2="229.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
-  <polyline points="90.0,140.1 224.0,139.8 358.0,140.1 492.0,141.3 626.0,141.5 760.0,146.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,176.4 224.0,176.1 358.0,175.9 492.0,176.2 626.0,176.6 760.0,172.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,169.4 224.0,165.6 358.0,167.6 492.0,163.3 626.0,169.8 760.0,166.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,179.0 224.0,179.8 358.0,178.7 492.0,178.1 626.0,181.3 760.0,179.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,171.9 224.0,171.5 358.0,173.3 492.0,171.2 626.0,172.1 760.0,173.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,178.6 224.0,178.8 358.0,180.8 492.0,177.9 626.0,179.2 760.0,181.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,159.1 224.0,160.7 358.0,155.5 492.0,154.6 626.0,152.5 760.0,144.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="159.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="160.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="155.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="154.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="152.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="144.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,119.5 224.0,122.8 358.0,122.4 492.0,121.8 626.0,108.3 760.0,94.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="119.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="122.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="122.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="121.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="108.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="94.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,114.3 224.0,106.8 358.0,111.0 492.0,113.8 626.0,109.4 760.0,98.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="114.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="106.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="111.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="113.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="109.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="98.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,167.8 224.0,166.1 358.0,166.6 492.0,166.2 626.0,165.5 760.0,157.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="167.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="166.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="166.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="166.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="165.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="157.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,80.7 224.0,80.2 358.0,77.1 492.0,78.0 626.0,73.1 760.0,62.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="80.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="80.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="77.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="78.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="73.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="62.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,162.7 224.0,168.9 358.0,161.0 492.0,164.0 626.0,161.2 760.0,139.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="162.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="168.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="161.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="164.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="161.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="139.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,142.6 224.0,143.8 358.0,141.2 492.0,146.4 626.0,142.7 760.0,147.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,179.0 224.0,179.3 358.0,179.2 492.0,180.0 626.0,179.5 760.0,175.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,177.4 224.0,180.5 358.0,178.8 492.0,179.0 626.0,178.2 760.0,175.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,165.4 224.0,167.4 358.0,167.2 492.0,166.9 626.0,165.4 760.0,166.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,184.2 224.0,182.4 358.0,181.8 492.0,182.0 626.0,182.5 760.0,180.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,173.2 224.0,171.7 358.0,172.7 492.0,173.6 626.0,172.9 760.0,173.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,180.8 224.0,181.7 358.0,182.9 492.0,180.0 626.0,183.2 760.0,182.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,161.8 224.0,154.9 358.0,155.8 492.0,156.2 626.0,153.2 760.0,146.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="161.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="154.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="155.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="156.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="153.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="146.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,115.5 224.0,123.4 358.0,116.4 492.0,119.8 626.0,112.8 760.0,95.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="115.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="123.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="116.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="119.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="112.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="95.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,119.4 224.0,117.3 358.0,115.1 492.0,119.0 626.0,112.4 760.0,90.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="119.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="117.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="115.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="119.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="112.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="90.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,106.7 224.0,100.7 358.0,114.0 492.0,111.9 626.0,112.5 760.0,110.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="106.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="100.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="114.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="111.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="112.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="110.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,165.6 224.0,166.4 358.0,166.9 492.0,168.7 626.0,162.6 760.0,160.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="165.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="166.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="166.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="168.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="162.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="160.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,102.9 224.0,113.9 358.0,101.1 492.0,106.4 626.0,108.0 760.0,90.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="102.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="113.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="101.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="106.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="108.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="90.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,162.9 224.0,163.5 358.0,163.7 492.0,164.7 626.0,153.4 760.0,140.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="162.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="163.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="163.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="164.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="153.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="140.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="224.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="358.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="492.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="626.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <line x1="140" y1="269" x2="154" y2="269" stroke="#eab308" stroke-width="2.5"/>
-  <circle cx="147" cy="269" r="2.5" fill="#eab308"/>
-  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5</text>
-  <line x1="330" y1="269" x2="344" y2="269" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="337" cy="269" r="2.5" fill="#f97316"/>
-  <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (ST)</text>
-  <line x1="520" y1="269" x2="534" y2="269" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="527" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (MT)</text>
+  <line x1="45" y1="269" x2="59" y2="269" stroke="#eab308" stroke-width="2.5"/>
+  <circle cx="52" cy="269" r="2.5" fill="#eab308"/>
+  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <line x1="235" y1="269" x2="249" y2="269" stroke="#a16207" stroke-width="2.5"/>
+  <circle cx="242" cy="269" r="2.5" fill="#a16207"/>
+  <text x="255" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
+  <line x1="425" y1="269" x2="439" y2="269" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="432" cy="269" r="2.5" fill="#f97316"/>
+  <text x="445" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
+  <line x1="615" y1="269" x2="629" y2="269" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="622" cy="269" r="2.5" fill="#dc2626"/>
+  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
   <line x1="140" y1="289" x2="154" y2="289" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="147" cy="289" r="2.5" fill="#2563eb"/>
-  <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 (MT)</text>
+  <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
   <line x1="330" y1="289" x2="344" y2="289" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="337" cy="289" r="2.5" fill="#16a34a"/>
-  <text x="350" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (MT)</text>
+  <text x="350" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
   <line x1="520" y1="289" x2="534" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="527" cy="289" r="2.5" fill="#15803d"/>
-  <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.22 (io_uring, MT)</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">ST = single-threaded   MT = multi-threaded</text>
+  <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
   <circle cx="272" cy="329" r="2" fill="#6b7280"/>
   <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>

--- a/doc/charts/reqrep/tcp.svg
+++ b/doc/charts/reqrep/tcp.svg
@@ -37,6 +37,7 @@
   <polyline points="90.0,142.6 224.0,143.8 358.0,141.2 492.0,146.4 626.0,142.7 760.0,147.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,179.0 224.0,179.3 358.0,179.2 492.0,180.0 626.0,179.5 760.0,175.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,177.4 224.0,180.5 358.0,178.8 492.0,179.0 626.0,178.2 760.0,175.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,95.0 224.0,95.8 358.0,95.9 492.0,94.9 626.0,95.8 760.0,100.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,165.4 224.0,167.4 358.0,167.2 492.0,166.9 626.0,165.4 760.0,166.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,184.2 224.0,182.4 358.0,181.8 492.0,182.0 626.0,182.5 760.0,180.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,173.2 224.0,171.7 358.0,172.7 492.0,173.6 626.0,172.9 760.0,173.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -62,6 +63,13 @@
   <circle cx="492.0" cy="119.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="112.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="90.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,166.5 224.0,164.2 358.0,165.0 492.0,161.0 626.0,150.5 760.0,128.2" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="166.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="164.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="165.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="161.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="150.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="128.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="90.0,106.7 224.0,100.7 358.0,114.0 492.0,111.9 626.0,112.5 760.0,110.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="106.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="100.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -108,15 +116,18 @@
   <line x1="615" y1="269" x2="629" y2="269" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="622" cy="269" r="2.5" fill="#dc2626"/>
   <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
-  <line x1="140" y1="289" x2="154" y2="289" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="147" cy="289" r="2.5" fill="#2563eb"/>
-  <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="330" y1="289" x2="344" y2="289" stroke="#16a34a" stroke-width="2.5"/>
-  <circle cx="337" cy="289" r="2.5" fill="#16a34a"/>
-  <text x="350" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="520" y1="289" x2="534" y2="289" stroke="#15803d" stroke-width="2.5"/>
-  <circle cx="527" cy="289" r="2.5" fill="#15803d"/>
-  <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="45" y1="289" x2="59" y2="289" stroke="#06b6d4" stroke-width="2.5"/>
+  <circle cx="52" cy="289" r="2.5" fill="#06b6d4"/>
+  <text x="65" y="293" fill="#374151" font-size="11" font-weight="500">omq-libzmq [1T]</text>
+  <line x1="235" y1="289" x2="249" y2="289" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="242" cy="289" r="2.5" fill="#2563eb"/>
+  <text x="255" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="425" y1="289" x2="439" y2="289" stroke="#16a34a" stroke-width="2.5"/>
+  <circle cx="432" cy="289" r="2.5" fill="#16a34a"/>
+  <text x="445" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="615" y1="289" x2="629" y2="289" stroke="#15803d" stroke-width="2.5"/>
+  <circle cx="622" cy="289" r="2.5" fill="#15803d"/>
+  <text x="635" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
   <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
   <circle cx="272" cy="329" r="2" fill="#6b7280"/>

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -520,19 +520,44 @@ pub extern "C" fn zmq_msg_recv(
         Ok((frame, more)) => {
             zmq_msg_close(msg);
             let sz = frame.len();
-            let boxed = Box::new(frame);
-            let data_ptr = boxed.as_ptr().cast_mut();
             // SAFETY: msg was just closed above and is ready for reinitialization.
             let r = unsafe { repr(msg) };
-            r.kind = KIND_BYTES;
-            r.more = u8::from(more);
-            r.pad = [0; 6];
-            r.size = sz as u64;
-            r.ptr = data_ptr;
-            r.free_fn = std::ptr::null_mut();
-            r.hint = std::ptr::null_mut();
-            r.boxed = Box::into_raw(boxed).cast::<libc::c_void>();
-            r.reserved = [0; 16];
+            if sz <= 128 {
+                // Small frame: malloc + memcpy (1 alloc) instead of
+                // Box<Bytes> (2 allocs: Bytes::copy_from_slice + Box::new).
+                // SAFETY: libc::malloc is always safe to call.
+                let ptr = unsafe { libc::malloc(sz).cast::<u8>() };
+                if ptr.is_null() && sz > 0 {
+                    return crate::error::fail(libc::ENOMEM);
+                }
+                if sz > 0 {
+                    // SAFETY: frame is valid for sz bytes; ptr was just allocated.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(frame.as_ptr(), ptr, sz);
+                    }
+                }
+                r.kind = KIND_HEAP;
+                r.more = u8::from(more);
+                r.pad = [0; 6];
+                r.size = sz as u64;
+                r.ptr = ptr;
+                r.free_fn = std::ptr::null_mut();
+                r.hint = std::ptr::null_mut();
+                r.boxed = std::ptr::null_mut();
+                r.reserved = [0; 16];
+            } else {
+                let boxed = Box::new(frame);
+                let data_ptr = boxed.as_ptr().cast_mut();
+                r.kind = KIND_BYTES;
+                r.more = u8::from(more);
+                r.pad = [0; 6];
+                r.size = sz as u64;
+                r.ptr = data_ptr;
+                r.free_fn = std::ptr::null_mut();
+                r.hint = std::ptr::null_mut();
+                r.boxed = Box::into_raw(boxed).cast::<libc::c_void>();
+                r.reserved = [0; 16];
+            }
             match c_int::try_from(sz) {
                 Ok(n) => n,
                 Err(_) => crate::error::fail(libc::EMSGSIZE),

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -200,25 +200,16 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
     let dontwait = (flags & ZMQ_DONTWAIT) != 0 || sndtimeo == 0;
 
     match inner.try_send(msg) {
-        Ok(()) => {
-            // SAFETY: zmq contract guarantees single-threaded access per socket.
-            let (count, bytes) = sock.send_yield.get();
-            *count += 1;
-            *bytes += len;
-            if *count >= 64 || *bytes >= 1_024 * 1_024 {
-                *count = 0;
-                *bytes = 0;
-                std::thread::yield_now();
-            }
-            ret_len
-        }
+        Ok(()) => ret_len,
         Err(omq_tokio::TrySendError::Closed | omq_tokio::TrySendError::Error(_)) => fail(ETERM),
         Err(omq_tokio::TrySendError::Full(_)) if dontwait => fail(libc::EAGAIN),
         Err(omq_tokio::TrySendError::Full(mut msg)) => {
-            // Queue full: spin-yield to let the tokio driver drain,
-            // then fall back to block_on if still full.
-            for _ in 0..64 {
-                std::thread::yield_now();
+            for i in 0..8 {
+                if i < 4 {
+                    std::hint::spin_loop();
+                } else {
+                    std::thread::yield_now();
+                }
                 match inner.try_send(msg) {
                     Ok(()) => return ret_len,
                     Err(omq_tokio::TrySendError::Closed | omq_tokio::TrySendError::Error(_)) => {
@@ -316,6 +307,8 @@ pub extern "C" fn zmq_recv(
 }
 
 fn zmq_recv_impl(sock: &OmqSocket, buf: *mut libc::c_void, buf_len: usize, flags: c_int) -> c_int {
+    use std::sync::atomic::Ordering;
+
     // Inproc bypass fast path: copy from byte ring directly into user
     // buffer. Zero intermediate Bytes allocation.
     // SAFETY: zmq contract guarantees single-threaded access per socket.
@@ -326,6 +319,67 @@ fn zmq_recv_impl(sock: &OmqSocket, buf: *mut libc::c_void, buf_len: usize, flags
             Err(e) => return fail(e),
         }
     }
+
+    // Multipart drain: leftover frames use the Bytes-returning path.
+    if sock.drain_nonempty.load(Ordering::Relaxed) {
+        return zmq_recv_via_frame(sock, buf, buf_len, flags);
+    }
+
+    // Fast path: pop Message from yring, borrow first frame directly.
+    // Avoids the Bytes::copy_from_slice that pop_recv_frame/decompose_message
+    // would do for inline messages.
+    // SAFETY: zmq contract guarantees single-threaded access per socket.
+    let Some(cons) = sock.recv_cons.get() else {
+        return fail(ETERM);
+    };
+
+    if let Some(m) = try_pop_dual(cons, sock) {
+        signal_recv_space(sock);
+        return recv_msg_to_buf(sock, &m, buf, buf_len);
+    }
+
+    let rcvtimeo = sock.rcvtimeo_ms.load(Ordering::Relaxed);
+    let dontwait = (flags & ZMQ_DONTWAIT) != 0 || rcvtimeo == 0;
+    if dontwait {
+        return fail(libc::EAGAIN);
+    }
+
+    match block_recv(sock, rcvtimeo, || {
+        let m = try_pop_dual(cons, sock)?;
+        signal_recv_space(sock);
+        Some(m)
+    }) {
+        Ok(m) => recv_msg_to_buf(sock, &m, buf, buf_len),
+        Err(e) => fail(e),
+    }
+}
+
+/// Borrow the first frame of a Message and copy into the user buffer.
+/// Zero heap allocation for inline messages.
+#[inline]
+fn recv_msg_to_buf(
+    sock: &OmqSocket,
+    m: &omq_tokio::Message,
+    buf: *mut libc::c_void,
+    buf_len: usize,
+) -> c_int {
+    let start = msg_start_index(sock, m);
+    let data = m.get(start).unwrap_or(&[]);
+    copy_to_buf(buf, buf_len, data);
+    stash_remaining_parts(sock, m, start);
+    match checked_c_int_len(data.len()) {
+        Ok(n) => n,
+        Err(e) => fail(e),
+    }
+}
+
+/// Fallback for `zmq_recv` when multipart drain is non-empty.
+fn zmq_recv_via_frame(
+    sock: &OmqSocket,
+    buf: *mut libc::c_void,
+    buf_len: usize,
+    flags: c_int,
+) -> c_int {
     match pop_recv_frame(sock, flags) {
         Ok((frame, _more)) => {
             let frame_len = frame.len();
@@ -455,11 +509,10 @@ fn recv_bypass_direct(
         && let Some(m) = try_pop_dual(cons, sock)
     {
         signal_recv_space(sock);
-        let (frame, _more) = decompose_message(sock, &m).map_err(|_| ETERM)?;
-        let frame_len = frame.len();
-        copy_to_buf(buf, buf_len, &frame);
-        #[expect(clippy::cast_possible_wrap)]
-        return Ok(frame_len as c_int);
+        let data = m.get(0).unwrap_or(&[]);
+        copy_to_buf(buf, buf_len, data);
+        stash_remaining_parts(sock, &m, 0);
+        return checked_c_int_len(data.len());
     }
 
     let rcvtimeo = sock.rcvtimeo_ms.load(Ordering::Relaxed);
@@ -503,13 +556,10 @@ fn try_recv_bypass_or_yring(
         && let Some(m) = try_pop_dual(cons, sock)
     {
         signal_recv_space(sock);
-        let frame = m.part_bytes(0).unwrap_or_default();
-        let frame_len = frame.len();
-        // Handle multipart: stash remaining parts.
-        if m.len() > 1 {
-            let _ = decompose_message(sock, &m);
-        }
-        copy_to_buf(buf, buf_len, &frame);
+        let data = m.get(0).unwrap_or(&[]);
+        let frame_len = data.len();
+        copy_to_buf(buf, buf_len, data);
+        stash_remaining_parts(sock, &m, 0);
         return checked_c_int_len(frame_len).map(Some);
     }
     Ok(None)
@@ -529,6 +579,27 @@ fn try_pop_dual(
     cons.fast
         .prefetch_and_pop()
         .or_else(|| cons.pump.prefetch_and_pop())
+}
+
+#[inline]
+fn msg_start_index(sock: &OmqSocket, msg: &omq_tokio::Message) -> usize {
+    usize::from(sock.socket_type == omq_tokio::SocketType::Dish && msg.len() >= 2)
+}
+
+fn stash_remaining_parts(sock: &OmqSocket, msg: &omq_tokio::Message, start: usize) {
+    let nparts = msg.len();
+    let next = start + 1;
+    if next < nparts {
+        sock.drain_nonempty
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut drain) = sock.recv_drain.lock() {
+            for i in next..nparts {
+                if let Some(b) = msg.part_bytes(i) {
+                    drain.push_back(b);
+                }
+            }
+        }
+    }
 }
 
 fn decompose_message(sock: &OmqSocket, msg: &omq_tokio::Message) -> Result<(Bytes, bool), c_int> {

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -85,9 +85,6 @@ pub(crate) struct OmqSocket {
     pub notify: Arc<PlatformNotifyHandle>,
     pub bound_or_connected: AtomicBool,
     pub recv_pump: std::sync::OnceLock<tokio::task::JoinHandle<()>>,
-    /// Send yield state: (message count, bytes queued). Accessed only
-    /// from the `zmq_send` caller thread (ZMQ single-thread contract).
-    pub send_yield: crate::local_cell::LocalCell<(u32, usize)>,
 }
 
 /// Map ZMQ socket-type integer to `SocketType`.
@@ -277,7 +274,6 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
         notify,
         bound_or_connected: AtomicBool::new(false),
         recv_pump: std::sync::OnceLock::new(),
-        send_yield: crate::local_cell::LocalCell::new((0, 0)),
     });
 
     Box::into_raw(Box::new(sock)).cast()

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -392,12 +392,8 @@ fn kind_bytes_arc_stolen_on_zmq_msg_send() {
         let rc = zmq_msg_recv(msg.0.as_mut_ptr().cast(), pull, 0);
         assert_eq!(rc as usize, payload.len());
 
-        // boxed field lives at offset 40 in OmqMsgRepr (see repr layout in msg.rs).
-        let boxed_before = usize::from_ne_bytes(msg.0[40..48].try_into().unwrap());
-        assert_ne!(boxed_before, 0, "boxed must be non-null after zmq_msg_recv");
-
-        // Forward. Arc should be stolen (r.boxed set to null) before zmq_msg_close runs.
-        // A double-free of the arc would crash here or at drop of the forwarded Bytes.
+        // Forward via zmq_msg_send. Must not double-free regardless of
+        // internal kind (KIND_HEAP for small, KIND_BYTES for large).
         let rc = zmq_msg_send(msg.0.as_mut_ptr().cast(), fwd_push, 0);
         assert_eq!(rc as usize, payload.len());
 

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -1724,7 +1724,7 @@ def main():
         "inproc": "inproc",
     }
 
-    tcp_impls = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs", "rzmq", "rzmq-iouring"]
+    tcp_impls = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "omq-libzmq", "zmq.rs", "rzmq", "rzmq-iouring"]
     ipc_impls = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs", "rzmq", "rzmq-iouring"]
     inproc_impls = ["libzmq", "omq-tokio", "omq-tokio-mt", "rzmq", "rzmq-iouring"]
 

--- a/scripts/gen_main_chart.py
+++ b/scripts/gen_main_chart.py
@@ -24,14 +24,15 @@ sys.path.insert(0, str(REPO / "scripts"))
 from chart_hw import detect_hardware
 
 # Union of all impls plotted in the main chart; used only as a load filter.
-IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs",
-         "rzmq", "rzmq-iouring"]
+IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "omq-libzmq",
+         "zmq.rs", "rzmq", "rzmq-iouring"]
 
 COLORS = {
     "libzmq": "#eab308",
     "libzmq-mt": "#a16207",
     "omq-tokio": "#f97316",
     "omq-tokio-mt": "#dc2626",
+    "omq-libzmq": "#06b6d4",
     "zmq.rs": "#2563eb",
     "rzmq": "#16a34a",
     "rzmq-iouring": "#15803d",
@@ -42,15 +43,16 @@ LABELS = {
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
     "omq-tokio-mt": "omq-tokio (4T)",
+    "omq-libzmq": "omq-libzmq [1T]",
     "zmq.rs": "zmq.rs v0.6.0 [6T]",
     "rzmq": "rzmq v0.5.24 [6T]",
     "rzmq-iouring": "rzmq v0.5.24 (io_uring) [6T]",
 }
 
 MAIN_IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt",
-              "zmq.rs", "rzmq", "rzmq-iouring"]
+              "omq-libzmq", "zmq.rs", "rzmq", "rzmq-iouring"]
 MAIN_DRAW_ORDER = ["rzmq-iouring", "rzmq", "zmq.rs", "libzmq",
-                   "libzmq-mt", "omq-tokio-mt", "omq-tokio"]
+                   "libzmq-mt", "omq-libzmq", "omq-tokio-mt", "omq-tokio"]
 MAIN_TITLE = "PUSH/PULL throughput, TCP loopback, 2-process"
 
 


### PR DESCRIPTION
- Remove unconditional `thread::yield_now()` on send success (was ~78K `sched_yield` syscalls/sec at small-message throughput, primary variance source)
- Reduce spin-yield on queue-full from 64 to 8 iterations, first 4 use `std::hint::spin_loop()`
- Zero-alloc `zmq_recv` fast path: pop `Message` from yring, borrow via `msg.get()` instead of `Bytes::copy_from_slice` through `decompose_message`
- `zmq_msg_recv` uses `KIND_HEAP` (single `malloc`) for frames <=128B instead of `KIND_BYTES` (`Bytes::copy_from_slice` + `Box::new`)
- Add `omq-libzmq` to TCP comparison and main charts
- Remove `send_yield` field from `OmqSocket`