### PR TITLE
Hardening: livelock fix, closed flag, malloc(0), doc + clarity

### DIFF
--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -8,7 +8,7 @@ fairness where the pattern has multiple peers.
 
 - `libzmq v4.3.5`
 - `zeromq v0.6.0`
-- `rzmq v0.5.22` in its normal and io_uring modes
+- `rzmq v0.5.24` in its normal and io_uring modes
 - OMQ from this repository
 
 ## Methodology

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -208,7 +208,7 @@
   <text x="880.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">4 MiB</text>
   <line x1="95" y1="350" x2="109" y2="350" stroke="#eab308" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="102" cy="350" r="2.5" fill="#eab308"/>
-  <text x="115" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="115" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="285" y1="350" x2="299" y2="350" stroke="#a16207" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="292" cy="350" r="2.5" fill="#a16207"/>
   <text x="305" y="354" fill="#374151" font-size="10" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -230,5 +230,6 @@
   <line x1="665" y1="370" x2="679" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="672" cy="370" r="2.5" fill="#15803d"/>
   <text x="685" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="475.0" y="388.0" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
+  <text x="70.0" y="388.0" text-anchor="start" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="70.0" y="401.0" text-anchor="start" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
 </svg>

--- a/doc/charts/pubsub/tcp.svg
+++ b/doc/charts/pubsub/tcp.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1105" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="1020" height="1105" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1118" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="1020" height="1118" fill="white"/>
   <text x="510.0" y="32.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="510.0" y="51.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 1 subscriber: TCP loopback</text>
   <text x="231.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -494,7 +494,7 @@
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
   <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -516,11 +516,12 @@
   <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
   <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
+  <text x="130" y="1027" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="130" y="1040" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="225" y1="1062" x2="239" y2="1062" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="245" y="1066" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="370" y1="1062" x2="384" y2="1062" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="390" y="1066" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="560" y1="1062" x2="574" y2="1062" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="580" y="1066" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/fanin/tcp.svg
+++ b/doc/charts/pushpull/fanin/tcp.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1105" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="1020" height="1105" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1118" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="1020" height="1118" fill="white"/>
   <text x="510.0" y="32.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="510.0" y="51.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH fan-in (2 PUSH → 1 PULL): TCP loopback</text>
   <text x="231.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -518,7 +518,7 @@
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
   <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -540,11 +540,12 @@
   <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
   <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
+  <text x="130" y="1027" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="130" y="1040" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="225" y1="1062" x2="239" y2="1062" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="245" y="1066" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="370" y1="1062" x2="384" y2="1062" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="390" y="1066" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="560" y1="1062" x2="574" y2="1062" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="580" y="1066" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1105" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="1020" height="1105" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 1118" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="1020" height="1118" fill="white"/>
   <text x="510.0" y="32.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="510.0" y="51.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH fan-out (1 PUSH → 2 PULL): TCP loopback</text>
   <text x="231.2" y="73.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -814,7 +814,7 @@
   <text x="942.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="130" y1="989" x2="144" y2="989" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="137" cy="989" r="2.5" fill="#eab308"/>
-  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="150" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="320" y1="989" x2="334" y2="989" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="327" cy="989" r="2.5" fill="#a16207"/>
   <text x="340" y="993" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -836,11 +836,12 @@
   <line x1="700" y1="1009" x2="714" y2="1009" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="707" cy="1009" r="2.5" fill="#15803d"/>
   <text x="720" y="1013" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="510.0" y="1027" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="225" y1="1049" x2="239" y2="1049" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="245" y="1053" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="370" y1="1049" x2="384" y2="1049" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="390" y="1053" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="560" y1="1049" x2="574" y2="1049" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="580" y="1053" fill="#6b7280" font-size="10">GB/s (large panel)</text>
+  <text x="130" y="1027" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="130" y="1040" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="225" y1="1062" x2="239" y2="1062" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="245" y="1066" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="370" y1="1062" x2="384" y2="1062" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="390" y="1066" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="560" y1="1062" x2="574" y2="1062" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="580" y="1066" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/inproc.svg
+++ b/doc/charts/pushpull/inproc.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 477" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="980" height="477" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 490" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="980" height="490" fill="white"/>
   <text x="490.0" y="17.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput: inproc</text>
   <text x="490.0" y="31.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="223.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -140,7 +140,7 @@
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="205" y1="391" x2="219" y2="391" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="212" cy="391" r="2.5" fill="#eab308"/>
-  <text x="225" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="225" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="395" y1="391" x2="409" y2="391" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="402" cy="391" r="2.5" fill="#f97316"/>
   <text x="415" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
@@ -153,11 +153,12 @@
   <line x1="490" y1="411" x2="504" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="497" cy="411" r="2.5" fill="#15803d"/>
   <text x="510" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel, log)</text>
+  <text x="205" y="429" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="205" y="442" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="205" y1="464" x2="219" y2="464" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="225" y="468" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="350" y1="464" x2="364" y2="464" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="370" y="468" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="540" y1="464" x2="554" y2="464" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="560" y="468" fill="#6b7280" font-size="10">GB/s (large panel, log)</text>
 </svg>

--- a/doc/charts/pushpull/ipc.svg
+++ b/doc/charts/pushpull/ipc.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 477" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="980" height="477" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 490" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="980" height="490" fill="white"/>
   <text x="490.0" y="17.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput: IPC, 2-process</text>
   <text x="490.0" y="31.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="223.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -166,7 +166,7 @@
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="110" y1="391" x2="124" y2="391" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="117" cy="391" r="2.5" fill="#eab308"/>
-  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="300" y1="391" x2="314" y2="391" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="307" cy="391" r="2.5" fill="#a16207"/>
   <text x="320" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -185,11 +185,12 @@
   <line x1="585" y1="411" x2="599" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="592" cy="411" r="2.5" fill="#15803d"/>
   <text x="605" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel)</text>
+  <text x="110" y="429" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="110" y="442" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="205" y1="464" x2="219" y2="464" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="225" y="468" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="350" y1="464" x2="364" y2="464" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="370" y="468" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="540" y1="464" x2="554" y2="464" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="560" y="468" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/pushpull/tcp.svg
+++ b/doc/charts/pushpull/tcp.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 477" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="980" height="477" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 490" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="980" height="490" fill="white"/>
   <text x="490.0" y="17.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput: TCP loopback, 2-process</text>
   <text x="490.0" y="31.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="223.2" y="60.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
@@ -178,7 +178,7 @@
   <text x="902.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="110" y1="391" x2="124" y2="391" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="117" cy="391" r="2.5" fill="#eab308"/>
-  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="130" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="300" y1="391" x2="314" y2="391" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="307" cy="391" r="2.5" fill="#a16207"/>
   <text x="320" y="395" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -200,11 +200,12 @@
   <line x1="680" y1="411" x2="694" y2="411" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="687" cy="411" r="2.5" fill="#15803d"/>
   <text x="700" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="490.0" y="429" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="205" y1="451" x2="219" y2="451" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="225" y="455" fill="#6b7280" font-size="10">CPU % (left)</text>
-  <line x1="350" y1="451" x2="364" y2="451" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <text x="370" y="455" fill="#6b7280" font-size="10">msg/s (small panel)</text>
-  <line x1="540" y1="451" x2="554" y2="451" stroke="#6b7280" stroke-width="2.5"/>
-  <text x="560" y="455" fill="#6b7280" font-size="10">GB/s (large panel)</text>
+  <text x="110" y="429" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="110" y="442" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="205" y1="464" x2="219" y2="464" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="225" y="468" fill="#6b7280" font-size="10">CPU % (left)</text>
+  <line x1="350" y1="464" x2="364" y2="464" stroke="#6b7280" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <text x="370" y="468" fill="#6b7280" font-size="10">msg/s (small panel)</text>
+  <line x1="540" y1="464" x2="554" y2="464" stroke="#6b7280" stroke-width="2.5"/>
+  <text x="560" y="468" fill="#6b7280" font-size="10">GB/s (large panel)</text>
 </svg>

--- a/doc/charts/reqrep/inproc.svg
+++ b/doc/charts/reqrep/inproc.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 372" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="372" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 385" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="385" fill="white"/>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="425.0" y="32.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: inproc (p50 µs)</text>
   <line x1="90.0" y1="206.5" x2="760.0" y2="206.5" stroke="#e5e7eb" stroke-width="1"/>
@@ -84,7 +84,7 @@
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="140" y1="269" x2="154" y2="269" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="147" cy="269" r="2.5" fill="#eab308"/>
-  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="160" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="330" y1="269" x2="344" y2="269" stroke="#f97316" stroke-width="2.5"/>
   <circle cx="337" cy="269" r="2.5" fill="#f97316"/>
   <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
@@ -97,10 +97,11 @@
   <line x1="425" y1="289" x2="439" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="432" cy="289" r="2.5" fill="#15803d"/>
   <text x="445" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="272" cy="329" r="2" fill="#6b7280"/>
-  <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>
-  <line x1="435" y1="329" x2="449" y2="329" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="455" y="333" fill="#6b7280" font-size="10">CPU % (right)</text>
+  <text x="140" y="307" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="140" y="320" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="265" y1="342" x2="279" y2="342" stroke="#6b7280" stroke-width="2.5"/>
+  <circle cx="272" cy="342" r="2" fill="#6b7280"/>
+  <text x="285" y="346" fill="#6b7280" font-size="10">p50 latency (left)</text>
+  <line x1="435" y1="342" x2="449" y2="342" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="455" y="346" fill="#6b7280" font-size="10">CPU % (right)</text>
 </svg>

--- a/doc/charts/reqrep/ipc.svg
+++ b/doc/charts/reqrep/ipc.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 372" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="372" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 385" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="385" fill="white"/>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="425.0" y="32.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: IPC, 2-process (p50 µs)</text>
   <line x1="90.0" y1="205.0" x2="760.0" y2="205.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -98,7 +98,7 @@
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="45" y1="269" x2="59" y2="269" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="52" cy="269" r="2.5" fill="#eab308"/>
-  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="235" y1="269" x2="249" y2="269" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="242" cy="269" r="2.5" fill="#a16207"/>
   <text x="255" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -117,10 +117,11 @@
   <line x1="520" y1="289" x2="534" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="527" cy="289" r="2.5" fill="#15803d"/>
   <text x="540" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="272" cy="329" r="2" fill="#6b7280"/>
-  <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>
-  <line x1="435" y1="329" x2="449" y2="329" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="455" y="333" fill="#6b7280" font-size="10">CPU % (right)</text>
+  <text x="45" y="307" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="45" y="320" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="265" y1="342" x2="279" y2="342" stroke="#6b7280" stroke-width="2.5"/>
+  <circle cx="272" cy="342" r="2" fill="#6b7280"/>
+  <text x="285" y="346" fill="#6b7280" font-size="10">p50 latency (left)</text>
+  <line x1="435" y1="342" x2="449" y2="342" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="455" y="346" fill="#6b7280" font-size="10">CPU % (right)</text>
 </svg>

--- a/doc/charts/reqrep/tcp.svg
+++ b/doc/charts/reqrep/tcp.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 372" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="372" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 385" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="385" fill="white"/>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="425.0" y="32.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: TCP loopback, 2-process (p50 µs)</text>
   <line x1="90.0" y1="205.0" x2="760.0" y2="205.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -106,7 +106,7 @@
   <text x="760.0" y="243.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <line x1="45" y1="269" x2="59" y2="269" stroke="#eab308" stroke-width="2.5"/>
   <circle cx="52" cy="269" r="2.5" fill="#eab308"/>
-  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 [1T]</text>
+  <text x="65" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (1T)</text>
   <line x1="235" y1="269" x2="249" y2="269" stroke="#a16207" stroke-width="2.5"/>
   <circle cx="242" cy="269" r="2.5" fill="#a16207"/>
   <text x="255" y="273" fill="#374151" font-size="11" font-weight="500">libzmq v4.3.5 (4T)</text>
@@ -128,10 +128,11 @@
   <line x1="615" y1="289" x2="629" y2="289" stroke="#15803d" stroke-width="2.5"/>
   <circle cx="622" cy="289" r="2.5" fill="#15803d"/>
   <text x="635" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
-  <text x="425.0" y="307" text-anchor="middle" fill="#9ca3af" font-size="9">(nT) = user-chosen   ·   [nT] = fixed by implementation</text>
-  <line x1="265" y1="329" x2="279" y2="329" stroke="#6b7280" stroke-width="2.5"/>
-  <circle cx="272" cy="329" r="2" fill="#6b7280"/>
-  <text x="285" y="333" fill="#6b7280" font-size="10">p50 latency (left)</text>
-  <line x1="435" y1="329" x2="449" y2="329" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <text x="455" y="333" fill="#6b7280" font-size="10">CPU % (right)</text>
+  <text x="45" y="307" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
+  <text x="45" y="320" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
+  <line x1="265" y1="342" x2="279" y2="342" stroke="#6b7280" stroke-width="2.5"/>
+  <circle cx="272" cy="342" r="2" fill="#6b7280"/>
+  <text x="285" y="346" fill="#6b7280" font-size="10">p50 latency (left)</text>
+  <line x1="435" y1="342" x2="449" y2="342" stroke="#6b7280" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <text x="455" y="346" fill="#6b7280" font-size="10">CPU % (right)</text>
 </svg>

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -270,15 +270,18 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
             if size > 0 && s.ptr.is_null() {
                 return crate::error::fail(libc::EFAULT);
             }
-            // SAFETY: libc::malloc is always safe to call.
-            let new_ptr = unsafe { libc::malloc(size).cast::<u8>() };
-            if size > 0 && new_ptr.is_null() {
-                return crate::error::fail(libc::ENOMEM);
-            }
-            if size > 0 {
-                // SAFETY: s.ptr is valid for size bytes; new_ptr was just allocated.
-                unsafe { std::ptr::copy_nonoverlapping(s.ptr, new_ptr, size) };
-            }
+            let new_ptr = if size > 0 {
+                // SAFETY: libc::malloc is always safe to call.
+                let p = unsafe { libc::malloc(size).cast::<u8>() };
+                if p.is_null() {
+                    return crate::error::fail(libc::ENOMEM);
+                }
+                // SAFETY: s.ptr is valid for size bytes; p was just allocated.
+                unsafe { std::ptr::copy_nonoverlapping(s.ptr, p, size) };
+                p
+            } else {
+                std::ptr::null_mut()
+            };
             // SAFETY: dst was closed above and is ready for reinitialization.
             let d = unsafe { repr(dst) };
             d.kind = KIND_HEAP;
@@ -525,17 +528,20 @@ pub extern "C" fn zmq_msg_recv(
             if sz <= 128 {
                 // Small frame: malloc + memcpy (1 alloc) instead of
                 // Box<Bytes> (2 allocs: Bytes::copy_from_slice + Box::new).
-                // SAFETY: libc::malloc is always safe to call.
-                let ptr = unsafe { libc::malloc(sz).cast::<u8>() };
-                if ptr.is_null() && sz > 0 {
-                    return crate::error::fail(libc::ENOMEM);
-                }
-                if sz > 0 {
-                    // SAFETY: frame is valid for sz bytes; ptr was just allocated.
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(frame.as_ptr(), ptr, sz);
+                let ptr = if sz > 0 {
+                    // SAFETY: libc::malloc is always safe to call.
+                    let p = unsafe { libc::malloc(sz).cast::<u8>() };
+                    if p.is_null() {
+                        return crate::error::fail(libc::ENOMEM);
                     }
-                }
+                    // SAFETY: frame is valid for sz bytes; p was just allocated.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(frame.as_ptr(), p, sz);
+                    }
+                    p
+                } else {
+                    std::ptr::null_mut()
+                };
                 r.kind = KIND_HEAP;
                 r.more = u8::from(more);
                 r.pad = [0; 6];

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -592,11 +592,10 @@ fn stash_remaining_parts(sock: &OmqSocket, msg: &omq_tokio::Message, start: usiz
     if next < nparts {
         sock.drain_nonempty
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Ok(mut drain) = sock.recv_drain.lock() {
-            for i in next..nparts {
-                if let Some(b) = msg.part_bytes(i) {
-                    drain.push_back(b);
-                }
+        let mut drain = sock.recv_drain.lock().expect("recv_drain");
+        for i in next..nparts {
+            if let Some(b) = msg.part_bytes(i) {
+                drain.push_back(b);
             }
         }
     }

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -149,7 +149,7 @@ pub struct Options {
     /// larger messages produce per-frame iovecs referencing the original
     /// `Bytes` payload.
     ///
-    /// `None` uses the default (`ARENA_THRESHOLD`, 8 KiB). Raise this
+    /// `None` uses the default (`ARENA_THRESHOLD`, 4 KiB). Raise this
     /// when payloads are owned by an external runtime (e.g. Python
     /// refcounted objects) where the gather path's per-chunk refcount
     /// traffic is more expensive than a flat memcpy.
@@ -424,7 +424,7 @@ impl Options {
 
     /// Set the per-`FrameBuffer` arena threshold. Messages smaller than
     /// this are copied into a contiguous arena buffer; larger ones use
-    /// zero-copy gather-write. Default: 8 KiB.
+    /// zero-copy gather-write. Default: 4 KiB.
     #[must_use]
     pub fn arena_threshold(mut self, bytes: usize) -> Self {
         self.arena_threshold = Some(bytes);

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -157,6 +157,9 @@ impl RecvSink {
                         }
                         Err(returned) => {
                             msg = returned;
+                            if sink.producer.is_consumer_dropped() {
+                                return false;
+                            }
                             let notified = sink.space.notified();
                             tokio::pin!(notified);
                             notified.as_mut().enable();

--- a/omq-tokio/src/routing/exclusive.rs
+++ b/omq-tokio/src/routing/exclusive.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::Notify;
@@ -10,16 +11,21 @@ use omq_proto::message::Message;
 pub(crate) struct Submitter {
     peer: Arc<Mutex<Option<PeerDriverHandle>>>,
     peer_ready: Arc<Notify>,
+    closed: Arc<AtomicBool>,
 }
 
 impl Submitter {
     pub(crate) fn shutdown(&self) {
+        self.closed.store(true, Ordering::Release);
         *self.peer.lock().expect("exclusive peer") = None;
         self.peer_ready.notify_waiters();
     }
 
     pub(crate) async fn send(&self, msg: Message) -> Result<()> {
         loop {
+            if self.closed.load(Ordering::Acquire) {
+                return Err(Error::Closed);
+            }
             let handle = self.peer.lock().expect("exclusive peer").clone();
             match handle {
                 Some(h) => {
@@ -44,6 +50,9 @@ impl Submitter {
         &self,
         msg: Message,
     ) -> core::result::Result<(), omq_proto::error::TrySendError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(omq_proto::error::TrySendError::Closed);
+        }
         let handle = self.peer.lock().expect("exclusive peer").clone();
         match handle {
             Some(h) => h
@@ -64,6 +73,7 @@ impl Submitter {
 pub(crate) struct ExclusiveSend {
     peer: Arc<Mutex<Option<PeerDriverHandle>>>,
     peer_ready: Arc<Notify>,
+    closed: Arc<AtomicBool>,
 }
 
 impl ExclusiveSend {
@@ -71,6 +81,7 @@ impl ExclusiveSend {
         Self {
             peer: Arc::new(Mutex::new(None)),
             peer_ready: Arc::new(Notify::new()),
+            closed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -78,6 +89,7 @@ impl ExclusiveSend {
         Submitter {
             peer: self.peer.clone(),
             peer_ready: self.peer_ready.clone(),
+            closed: self.closed.clone(),
         }
     }
 
@@ -91,6 +103,7 @@ impl ExclusiveSend {
     }
 
     pub(crate) fn shutdown(&self) {
+        self.closed.store(true, Ordering::Release);
         *self.peer.lock().expect("exclusive peer") = None;
         self.peer_ready.notify_waiters();
     }

--- a/omq-tokio/src/routing/fallback_queue.rs
+++ b/omq-tokio/src/routing/fallback_queue.rs
@@ -108,7 +108,7 @@ impl FallbackQueue {
                     }
                 }
             }
-            _ => unreachable!(),
+            OnMute::Block | _ => unreachable!("callers dispatch Block separately"),
         }
     }
 

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -422,6 +422,15 @@ impl FanOutShards {
         Self::push_control_spinning(endpoint, cmd);
     }
 
+    /// Spin-loop until the shard worker's control ring has space.
+    ///
+    /// libzmq uses an unbounded yqueue for control commands (never fails,
+    /// never blocks). We use a bounded yring (cap 64) to cap memory. If
+    /// the ring is full, we spin with `yield_now()` until the worker
+    /// drains. The ring size is generous relative to typical control
+    /// command rate (subscribe, add/remove peer). On the multi-thread
+    /// runtime, `push_control` wraps this in `block_in_place` so the
+    /// spin does not starve cooperative tasks.
     fn push_control_spinning(endpoint: &mut ShardEndpoint, mut cmd: ShardControl) {
         loop {
             match endpoint.ctrl_tx.push(cmd) {
@@ -483,6 +492,11 @@ impl FanOutShards {
         }
     }
 
+    /// Push an encoded frame to every active shard's data ring. If a
+    /// shard's ring is full, the message is silently dropped for that
+    /// shard's peer set. This acts as a shard-level backpressure
+    /// boundary separate from per-peer HWM. Acceptable because fan-out
+    /// sockets (PUB/XPUB/RADIO) are lossy by design.
     fn dispatch(&self, dispatch: &ShardDispatch) {
         let mut state = self.state.lock().expect("fanout shards poisoned");
         let mut touched = SmallVec::<[usize; 8]>::new();
@@ -1093,6 +1107,13 @@ impl Submitter {
         CachedResult::Miss
     }
 
+    /// Encode a message through the shared transform encoder, then frame
+    /// the result for fan-out distribution. The Mutex serializes
+    /// concurrent callers because fan-out must encode once and distribute
+    /// the encoded bytes to all peers. lz4 block compression is fast, so
+    /// the hold is brief. For large messages above the offload threshold,
+    /// `DeferredFanOutWorker` takes the encoder out of the Mutex and
+    /// uses `spawn_blocking` instead.
     fn encode_fanout_batch(
         &self,
         msg: &Message,

--- a/omq-tokio/src/routing/peer_outbound.rs
+++ b/omq-tokio/src/routing/peer_outbound.rs
@@ -53,6 +53,10 @@ impl PeerOutbound {
         match self {
             Self::Wire { slot, inbox } => match slot.try_encode(&msg) {
                 TryFrameResult::Ok => Ok(()),
+                // HWM backpressure: retry until space is available or
+                // the slot dies. Termination: `mark_dead()` fires on
+                // peer disconnect, connection error, heartbeat timeout,
+                // or socket close, causing `try_encode` to return `Dead`.
                 TryFrameResult::Full => loop {
                     let notified = slot.space_available.notified();
                     match slot.try_encode(&msg) {

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -86,7 +86,7 @@ impl ActivePipes {
     }
 
     fn should_use_fallback(&self) -> bool {
-        self.active.is_empty() && self.inactive.is_empty() || !self.fallback_peers.is_empty()
+        (self.active.is_empty() && self.inactive.is_empty()) || !self.fallback_peers.is_empty()
     }
 }
 

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -34,7 +34,7 @@ COLORS = {
 }
 
 LABELS = {
-    "libzmq": "libzmq v4.3.5 [1T]",
+    "libzmq": "libzmq v4.3.5 (1T)",
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
     "omq-tokio-mt": "omq-tokio (4T)",
@@ -1007,7 +1007,7 @@ def _legend_extra(n_items: int, show_st_mt: bool = False) -> float:
     n_rows = 2 if n_items > 4 else 1
     extra = (n_rows - 1) * row_gap
     if show_st_mt:
-        extra += 18
+        extra += 31
     return extra
 
 
@@ -1026,10 +1026,13 @@ def _draw_impl_legend(L: list[str], impls: list[str], mid_x: float, leg_y: float
         rows = [legend_items]
 
     extra = 0
+    left_x = mid_x
     for row_idx, row in enumerate(rows):
         ry = leg_y + row_idx * row_gap
         total_w = len(row) * item_w
         start_x = mid_x - total_w / 2
+        if row_idx == 0:
+            left_x = start_x
         for i, (key, label) in enumerate(row):
             lx = start_x + i * item_w
             c = COLORS[key]
@@ -1047,11 +1050,16 @@ def _draw_impl_legend(L: list[str], impls: list[str], mid_x: float, leg_y: float
     if show_st_mt:
         st_y = leg_y + extra + 18
         L.append(
-            f'  <text x="{mid_x}" y="{st_y}" text-anchor="middle"'
+            f'  <text x="{left_x:.0f}" y="{st_y}"'
             f' fill="#9ca3af" font-size="9">'
-            f'(nT) = user-chosen   ·   [nT] = fixed by implementation</text>'
+            f'(nT) = configurable IO threads</text>'
         )
-        extra += 18
+        L.append(
+            f'  <text x="{left_x:.0f}" y="{st_y + 13}"'
+            f' fill="#9ca3af" font-size="9">'
+            f'[nT] = fixed IO threads</text>'
+        )
+        extra += 31
     return extra
 
 

--- a/scripts/gen_main_chart.py
+++ b/scripts/gen_main_chart.py
@@ -39,7 +39,7 @@ COLORS = {
 }
 
 LABELS = {
-    "libzmq": "libzmq v4.3.5 [1T]",
+    "libzmq": "libzmq v4.3.5 (1T)",
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
     "omq-tokio-mt": "omq-tokio (4T)",
@@ -454,10 +454,14 @@ def generate_main_chart(tput: dict, msgs: dict, impls: list[str],
             )
 
     leg_extra = (len(rows) - 1) * row_gap
+    abbr_x = x_pad_left
     abbr_y = leg_y + leg_extra + 18
-    L.append(svg_text(mid_x, abbr_y,
-                       "(nT) = user-chosen   ·   [nT] = fixed by implementation",
-                       size=9, fill="#9ca3af"))
+    L.append(svg_text(abbr_x, abbr_y,
+                       "(nT) = configurable IO threads",
+                       size=9, fill="#9ca3af", anchor="start"))
+    L.append(svg_text(abbr_x, abbr_y + 13,
+                       "[nT] = fixed IO threads",
+                       size=9, fill="#9ca3af", anchor="start"))
 
     L.append("</svg>")
     return "\n".join(L) + "\n"


### PR DESCRIPTION
- Fix `RecvSink::Yring` livelock when consumer is dropped (ring permanently full, inner loop unreachable by cancel)
- Add `closed` flag to `Exclusive::Submitter` so `send()` returns `Err(Closed)` after `shutdown()` instead of looping forever
- Crash on `recv_drain` mutex poison instead of silent hang in `omq-libzmq`
- Skip `malloc(0)` for zero-length frames in `zmq_msg_recv` and `zmq_msg_copy` (implementation-defined return)
- Add explicit parens in `should_use_fallback` to clarify `&&`/`||` precedence
- Name `Block` arm in `push_drop_policy` `unreachable!()` with explanation
- Fix stale `arena_threshold` doc comments (8 KiB -> 4 KiB)
- Document `PeerOutbound` Wire backpressure loop termination
- Document fan-out shard control spin, dispatch drop, and `encode_fanout_batch` Mutex
- Chart legends: clarify IO thread notation (`(nT)` configurable vs `[nT]` fixed)