### PR TITLE
Improve multi-peer PUSH throughput

### DIFF
--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -43,8 +43,8 @@
   <polyline points="78.0,211.9 180.1,214.9 282.3,233.1 384.4,244.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,159.8 180.1,157.3 282.3,165.9 384.4,172.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,270.9 180.1,204.3 282.3,217.6 384.4,220.0" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,142.2 180.1,141.2 282.3,140.8 384.4,146.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,262.4 180.1,262.4 282.3,262.3 384.4,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,142.6 180.1,141.8 282.3,142.4 384.4,150.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.3 180.1,262.3 282.3,262.5 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,227.1 180.1,194.2 282.3,178.3 384.4,185.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.9 384.4,262.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <line x1="78.0" y1="229.7" x2="78.0" y2="227.7" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
@@ -115,40 +115,40 @@
   <circle cx="180.1" cy="157.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="281.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="293.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="159.2" x2="78.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="159.2" x2="81.0" y2="159.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="158.6" x2="81.0" y2="158.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="155.9" x2="180.1" y2="154.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="155.9" x2="183.1" y2="155.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="154.6" x2="183.1" y2="154.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="198.8" x2="282.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="198.8" x2="285.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="198.8" x2="285.3" y2="198.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="216.2" x2="384.4" y2="215.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="216.2" x2="387.4" y2="216.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="215.2" x2="387.4" y2="215.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,158.9 180.1,155.2 282.3,198.8 384.4,215.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="158.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="155.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="198.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="215.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="213.1" x2="78.0" y2="213.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="213.1" x2="81.0" y2="213.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="213.0" x2="81.0" y2="213.0" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="220.4" x2="180.1" y2="220.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="220.4" x2="183.1" y2="220.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="220.3" x2="183.1" y2="220.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="246.6" x2="282.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="246.6" x2="285.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="246.6" x2="285.3" y2="246.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="272.2" x2="384.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="272.2" x2="387.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="272.2" x2="387.4" y2="272.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,213.0 180.1,220.3 282.3,246.6 384.4,272.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="213.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="220.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="246.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="272.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="154.1" x2="78.0" y2="153.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="154.1" x2="81.0" y2="154.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="153.5" x2="81.0" y2="153.5" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="153.6" x2="180.1" y2="153.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="153.6" x2="183.1" y2="153.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="153.6" x2="183.1" y2="153.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="197.4" x2="282.3" y2="197.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="197.4" x2="285.3" y2="197.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="197.3" x2="285.3" y2="197.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="212.6" x2="384.4" y2="209.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="212.6" x2="387.4" y2="212.6" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="209.3" x2="387.4" y2="209.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,153.8 180.1,153.6 282.3,197.4 384.4,210.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="153.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="153.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="197.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="210.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="209.5" x2="78.0" y2="209.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="209.5" x2="81.0" y2="209.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="209.5" x2="81.0" y2="209.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="223.3" x2="180.1" y2="223.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="223.3" x2="183.1" y2="223.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="223.3" x2="183.1" y2="223.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="242.9" x2="282.3" y2="242.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="242.9" x2="285.3" y2="242.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="242.8" x2="285.3" y2="242.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="271.5" x2="384.4" y2="271.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="271.5" x2="387.4" y2="271.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="271.5" x2="387.4" y2="271.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,209.5 180.1,223.3 282.3,242.8 384.4,271.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="209.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="223.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="242.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="271.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="280.7" x2="78.0" y2="280.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="280.7" x2="81.0" y2="280.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="280.0" x2="81.0" y2="280.0" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
@@ -204,18 +204,18 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="285.3" x2="946.0" y2="285.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="285.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="249.5" x2="946.0" y2="249.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="249.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="213.8" x2="946.0" y2="213.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="213.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="178.1" x2="946.0" y2="178.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="178.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="142.3" x2="946.0" y2="142.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="142.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
-  <line x1="942.0" y1="106.6" x2="946.0" y2="106.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="106.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
+  <line x1="942.0" y1="285.0" x2="946.0" y2="285.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="285.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="249.0" x2="946.0" y2="249.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="249.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="212.9" x2="946.0" y2="212.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="212.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="176.9" x2="946.0" y2="176.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="176.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="140.9" x2="946.0" y2="140.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="140.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="104.9" x2="946.0" y2="104.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="104.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -228,50 +228,50 @@
   <polyline points="482.4,233.1 635.6,244.4 788.8,255.4 942.0,257.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,165.9 635.6,172.8 788.8,188.6 942.0,193.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,217.6 635.6,220.0 788.8,234.9 942.0,234.7" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,140.8 635.6,146.5 788.8,180.8 942.0,194.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,262.3 635.6,262.5 788.8,262.5 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,142.4 635.6,150.0 788.8,185.1 942.0,195.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.5 635.6,262.3 788.8,262.3 942.0,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,178.3 635.6,185.7 788.8,205.1 942.0,206.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.9 635.6,262.5 788.8,262.3 942.0,262.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,299.1 635.6,266.3 788.8,229.4 942.0,210.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="299.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="266.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="229.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="210.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,312.1 635.6,306.3 788.8,302.6 942.0,302.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="312.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="306.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="302.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="302.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,311.9 635.6,296.9 788.8,284.8 942.0,280.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="311.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="296.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="280.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,311.5 635.6,294.0 788.8,272.2 942.0,249.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="311.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="294.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="272.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="249.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,291.5 635.6,219.3 788.8,159.0 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="291.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="219.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="159.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,298.9 635.6,265.8 788.8,228.7 942.0,209.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="298.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="265.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="228.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="209.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,312.0 635.6,306.2 788.8,302.4 942.0,302.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="312.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="306.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="302.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="302.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,311.8 635.6,296.7 788.8,284.5 942.0,280.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="311.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="296.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="284.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="280.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,311.4 635.6,293.8 788.8,271.8 942.0,249.1" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="311.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="293.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="271.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="249.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,290.9 635.6,213.9 788.8,165.7 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="290.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="213.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="165.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,303.0 635.6,273.9 788.8,237.1 942.0,213.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="303.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="273.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="237.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="213.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,303.1 635.6,256.8 788.8,220.3 942.0,210.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="303.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="256.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="220.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="210.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,320.0 635.6,317.2 788.8,307.9 942.0,284.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,302.0 635.6,272.8 788.8,237.2 942.0,210.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="302.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="272.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="237.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="210.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.0 635.6,256.3 788.8,219.5 942.0,209.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="256.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="219.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="209.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,320.0 635.6,317.2 788.8,307.8 942.0,283.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="320.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="317.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="307.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="284.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="307.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="283.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -316,8 +316,8 @@
   <polyline points="78.0,531.5 180.1,528.7 282.3,552.4 384.4,565.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,471.0 180.1,444.3 282.3,442.2 384.4,456.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,549.2 180.1,598.7 282.3,585.7 384.4,541.7" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,437.1 180.1,437.5 282.3,430.3 384.4,469.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.5 180.1,579.1 282.3,579.5 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,430.3 180.1,436.9 282.3,430.2 384.4,460.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.3 180.1,579.1 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,513.4 180.1,477.5 282.3,477.0 384.4,488.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.1 180.1,579.3 282.3,579.5 384.4,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <line x1="78.0" y1="536.8" x2="78.0" y2="532.1" stroke="#15803d" stroke-width="1.0" opacity="0.45"/>
@@ -388,40 +388,40 @@
   <circle cx="180.1" cy="583.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="619.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="608.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="479.8" x2="78.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="479.8" x2="81.0" y2="479.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="462.4" x2="81.0" y2="462.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="488.7" x2="180.1" y2="472.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="488.7" x2="183.1" y2="488.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="472.0" x2="183.1" y2="472.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="524.2" x2="282.3" y2="514.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="524.2" x2="285.3" y2="524.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="514.2" x2="285.3" y2="514.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="544.4" x2="384.4" y2="535.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="544.4" x2="387.4" y2="544.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="535.9" x2="387.4" y2="535.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,470.3 180.1,479.7 282.3,519.1 384.4,540.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="470.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="479.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="519.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="540.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="516.6" x2="78.0" y2="516.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="516.6" x2="81.0" y2="516.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="516.3" x2="81.0" y2="516.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="525.3" x2="180.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="525.3" x2="183.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="525.3" x2="183.1" y2="525.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="555.2" x2="282.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="555.2" x2="285.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="555.2" x2="285.3" y2="555.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="585.7" x2="384.4" y2="585.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="585.7" x2="387.4" y2="585.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="585.6" x2="387.4" y2="585.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,516.5 180.1,525.3 282.3,555.2 384.4,585.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="525.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="555.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="585.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="477.0" x2="78.0" y2="458.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="477.0" x2="81.0" y2="477.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="458.9" x2="81.0" y2="458.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="480.9" x2="180.1" y2="472.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="480.9" x2="183.1" y2="480.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="472.2" x2="183.1" y2="472.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="521.9" x2="282.3" y2="511.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="521.9" x2="285.3" y2="521.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="511.2" x2="285.3" y2="511.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="534.9" x2="384.4" y2="528.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="534.9" x2="387.4" y2="534.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="528.0" x2="387.4" y2="528.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,466.6 180.1,476.9 282.3,516.4 384.4,531.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="466.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="476.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="516.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="531.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="508.8" x2="78.0" y2="508.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="508.8" x2="81.0" y2="508.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="508.7" x2="81.0" y2="508.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="518.1" x2="180.1" y2="517.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="518.1" x2="183.1" y2="518.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="517.9" x2="183.1" y2="517.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="551.6" x2="282.3" y2="551.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="551.6" x2="285.3" y2="551.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="551.5" x2="285.3" y2="551.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="583.5" x2="384.4" y2="583.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="583.5" x2="387.4" y2="583.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="583.5" x2="387.4" y2="583.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,508.7 180.1,517.9 282.3,551.6 384.4,583.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="508.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="551.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="583.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="573.3" x2="78.0" y2="568.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="573.3" x2="81.0" y2="573.3" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="568.6" x2="81.0" y2="568.6" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
@@ -477,16 +477,16 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="596.5" x2="946.0" y2="596.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="596.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="555.0" x2="946.0" y2="555.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="555.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="513.5" x2="946.0" y2="513.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="513.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="472.0" x2="946.0" y2="472.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="472.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="430.5" x2="946.0" y2="430.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="430.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="594.8" x2="946.0" y2="594.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="594.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="551.6" x2="946.0" y2="551.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="551.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="508.4" x2="946.0" y2="508.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="508.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="465.2" x2="946.0" y2="465.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="465.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="422.0" x2="946.0" y2="422.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="422.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -499,50 +499,50 @@
   <polyline points="482.4,552.4 635.6,565.5 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,442.2 635.6,456.7 788.8,478.8 942.0,484.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,585.7 635.6,541.7 788.8,552.8 942.0,559.1" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,430.3 635.6,469.6 788.8,505.0 942.0,510.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,430.2 635.6,460.2 788.8,507.2 942.0,514.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,477.0 635.6,488.3 788.8,524.4 942.0,516.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,612.6 635.6,565.9 788.8,526.7 942.0,505.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="612.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="565.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="526.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="505.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,628.4 635.6,621.8 788.8,619.2 942.0,617.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="628.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="621.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="619.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="617.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,629.3 635.6,612.3 788.8,590.4 942.0,579.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="629.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="612.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="590.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="579.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,633.2 635.6,608.1 788.8,581.6 942.0,560.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="633.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="608.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="581.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="560.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,607.8 635.6,539.0 788.8,474.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="607.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="539.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="474.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,611.6 635.6,563.0 788.8,522.1 942.0,500.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="611.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="563.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="522.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="500.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,628.0 635.6,621.1 788.8,618.4 942.0,616.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="628.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="621.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="618.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="616.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,629.0 635.6,611.2 788.8,588.4 942.0,577.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="629.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="611.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="588.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="577.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,633.0 635.6,606.9 788.8,579.3 942.0,556.8" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="633.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="606.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="579.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="556.8" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,605.8 635.6,525.6 788.8,475.0 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="605.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="525.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="475.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,617.0 635.6,584.8 788.8,540.6 942.0,511.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="617.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="584.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="540.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="511.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,619.7 635.6,572.8 788.8,529.0 942.0,510.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="619.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="572.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="529.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="510.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,637.1 635.6,634.7 788.8,625.9 942.0,601.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,615.1 635.6,580.3 788.8,537.1 942.0,506.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="615.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="580.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="537.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="506.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,619.0 635.6,570.2 788.8,524.5 942.0,505.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="619.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="570.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="524.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="505.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,637.1 635.6,634.6 788.8,625.4 942.0,599.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="637.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="634.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="625.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="601.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="625.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="599.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -581,7 +581,7 @@
   <polyline points="78.0,848.5 180.1,850.4 282.3,872.0 384.4,884.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,810.5 180.1,789.6 282.3,780.8 384.4,800.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,838.2 180.1,900.6 282.3,849.9 384.4,860.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,757.2 180.1,754.9 282.3,755.7 384.4,766.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,761.5 180.1,757.3 282.3,749.2 384.4,778.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,822.3 180.1,806.7 282.3,796.9 384.4,804.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -653,40 +653,40 @@
   <circle cx="180.1" cy="879.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="911.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="928.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="797.8" x2="78.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="797.8" x2="81.0" y2="797.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="784.8" x2="81.0" y2="784.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="819.4" x2="180.1" y2="799.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="819.4" x2="183.1" y2="819.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="799.8" x2="183.1" y2="799.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="840.4" x2="282.3" y2="825.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="840.4" x2="285.3" y2="840.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="825.9" x2="285.3" y2="825.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="869.4" x2="384.4" y2="854.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="869.4" x2="387.4" y2="869.4" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="854.7" x2="387.4" y2="854.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,789.8 180.1,805.4 282.3,832.8 384.4,861.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="789.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="805.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="832.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="861.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="837.9" x2="78.0" y2="837.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="837.9" x2="81.0" y2="837.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="75.0" y1="837.3" x2="81.0" y2="837.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="180.1" y1="841.5" x2="180.1" y2="841.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="841.5" x2="183.1" y2="841.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="177.1" y1="841.2" x2="183.1" y2="841.2" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="282.3" y1="875.8" x2="282.3" y2="875.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="875.8" x2="285.3" y2="875.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="279.3" y1="875.5" x2="285.3" y2="875.5" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="384.4" y1="907.1" x2="384.4" y2="906.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="907.1" x2="387.4" y2="907.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <line x1="381.4" y1="906.9" x2="387.4" y2="906.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
-  <polyline points="78.0,837.7 180.1,841.3 282.3,875.7 384.4,907.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="837.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="841.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="875.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="907.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="793.1" x2="78.0" y2="781.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="793.1" x2="81.0" y2="793.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="781.1" x2="81.0" y2="781.1" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="808.9" x2="180.1" y2="790.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="808.9" x2="183.1" y2="808.9" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="790.0" x2="183.1" y2="790.0" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="844.3" x2="282.3" y2="830.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="844.3" x2="285.3" y2="844.3" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="830.8" x2="285.3" y2="830.8" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="865.7" x2="384.4" y2="853.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="865.7" x2="387.4" y2="865.7" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="853.2" x2="387.4" y2="853.2" stroke="#dc2626" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,786.6 180.1,796.1 282.3,835.4 384.4,858.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="786.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="796.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="835.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="858.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="824.6" x2="78.0" y2="824.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="824.6" x2="81.0" y2="824.6" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="75.0" y1="824.4" x2="81.0" y2="824.4" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="180.1" y1="840.9" x2="180.1" y2="840.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="840.9" x2="183.1" y2="840.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="177.1" y1="840.7" x2="183.1" y2="840.7" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="282.3" y1="870.8" x2="282.3" y2="870.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="870.8" x2="285.3" y2="870.8" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="279.3" y1="870.3" x2="285.3" y2="870.3" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="384.4" y1="903.1" x2="384.4" y2="902.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="903.1" x2="387.4" y2="903.1" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <line x1="381.4" y1="902.9" x2="387.4" y2="902.9" stroke="#f97316" stroke-width="1.0" opacity="0.45"/>
+  <polyline points="78.0,824.5 180.1,840.9 282.3,870.7 384.4,903.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="824.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="840.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="870.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="903.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="891.2" x2="78.0" y2="886.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="891.2" x2="81.0" y2="891.2" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
   <line x1="75.0" y1="886.7" x2="81.0" y2="886.7" stroke="#16a34a" stroke-width="1.0" opacity="0.45"/>
@@ -742,16 +742,16 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="912.6" x2="946.0" y2="912.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="912.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="870.3" x2="946.0" y2="870.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="870.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="827.9" x2="946.0" y2="827.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="827.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="785.5" x2="946.0" y2="785.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="785.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="743.2" x2="946.0" y2="743.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="743.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="911.3" x2="946.0" y2="911.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="911.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="867.5" x2="946.0" y2="867.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="867.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="823.8" x2="946.0" y2="823.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="823.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="780.0" x2="946.0" y2="780.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="780.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="736.3" x2="946.0" y2="736.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="736.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -764,50 +764,50 @@
   <polyline points="482.4,872.0 635.6,884.7 788.8,891.8 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,780.8 635.6,800.5 788.8,809.7 942.0,815.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,849.9 635.6,860.8 788.8,869.8 942.0,874.8" fill="none" stroke="#06b6d4" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,755.7 635.6,766.3 788.8,811.1 942.0,819.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.5 635.6,896.3 788.8,896.3 942.0,896.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,749.2 635.6,778.3 788.8,814.0 942.0,821.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.5 635.6,896.3 788.8,896.1 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,796.9 635.6,804.4 788.8,825.5 942.0,825.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.5 635.6,896.1 788.8,896.4 942.0,896.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,930.3 635.6,888.6 788.8,843.7 942.0,822.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="930.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="888.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="843.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="822.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,945.4 635.6,939.2 788.8,937.5 942.0,934.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="945.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="939.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="937.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="934.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,946.6 635.6,932.1 788.8,914.9 942.0,905.2" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="946.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="932.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="914.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="905.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,943.9 635.6,927.0 788.8,905.2 942.0,878.5" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="943.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="927.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="905.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="878.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,923.4 635.6,858.0 788.8,787.1 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="923.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="858.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="787.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,929.5 635.6,886.4 788.8,840.0 942.0,817.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="929.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="886.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="840.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="817.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,945.1 635.6,938.7 788.8,936.9 942.0,933.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="945.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="938.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="936.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="933.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,946.3 635.6,931.3 788.8,913.6 942.0,903.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="946.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="931.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="913.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="903.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,943.5 635.6,926.1 788.8,903.6 942.0,876.0" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="943.5" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="926.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="903.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="876.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,923.0 635.6,852.0 788.8,783.4 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="923.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="852.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="783.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,934.5 635.6,905.3 788.8,855.6 942.0,826.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="905.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="855.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="826.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,937.7 635.6,895.3 788.8,843.8 942.0,826.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="937.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="895.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="843.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="826.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,954.0 635.6,951.5 788.8,942.4 942.0,917.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,932.5 635.6,899.4 788.8,853.4 942.0,821.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="932.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="899.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="853.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="821.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,937.1 635.6,893.3 788.8,840.2 942.0,822.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="937.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="893.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="840.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="822.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,954.0 635.6,951.4 788.8,942.0 942.0,916.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="954.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="951.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="942.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="917.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="951.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="942.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="916.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>

--- a/omq-proto/src/frame_buffer.rs
+++ b/omq-proto/src/frame_buffer.rs
@@ -103,6 +103,20 @@ impl FrameBuffer {
         self.entries.is_empty() && !self.arena.is_empty()
     }
 
+    /// Advance past `n` bytes of arena content that have been written
+    /// to the wire. Only valid when `has_arena_only()`.
+    pub fn advance_arena(&mut self, n: usize) {
+        use bytes::Buf;
+        debug_assert!(self.entries.is_empty());
+        debug_assert!(n <= self.arena.len());
+        if n >= self.arena.len() {
+            self.clear_arena();
+        } else {
+            self.arena.advance(n);
+            self.total_bytes -= n;
+        }
+    }
+
     pub fn uncommitted_arena(&self) -> &[u8] {
         &self.arena[self.arena_mark as usize..]
     }

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1136,6 +1136,23 @@ pub(crate) async fn flush_frame_buffer<W>(
 where
     W: AsyncWrite + Unpin,
 {
+    if eq.has_arena_only() {
+        loop {
+            let len = eq.arena_bytes().len();
+            if len == 0 {
+                return Ok(());
+            }
+            let n = {
+                let data = eq.arena_bytes();
+                writer.write_vectored(&[io::IoSlice::new(data)]).await?
+            };
+            if n == 0 {
+                return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
+            }
+            eq.advance_arena(n);
+        }
+    }
+
     loop {
         drain_buf.clear();
         eq.drain(drain_buf, 1024);

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -37,7 +37,7 @@ use omq_proto::routing::{FanOutKind, RecvCategory, SendCategory, recv_category, 
 /// Max messages one shared-queue consumer batch-encodes before flushing.
 /// Scaled down per peer by [`RoundRobinSend`] to improve distribution
 /// fairness when multiple drivers compete on the same queue.
-pub(crate) const SHARED_MAX_BATCH_MSGS: usize = 256;
+pub(crate) const SHARED_MAX_BATCH_MSGS: usize = 512;
 
 pub(crate) use exclusive::{ExclusiveSend, Submitter as ExclusiveSubmitter};
 pub(crate) use fair_queue::FairQueueRecv;

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -51,14 +51,15 @@ impl ActivePipes {
     fn deactivate(&mut self, pos: usize) {
         let pipe = self.active.swap_remove(pos);
         self.inactive.push(pipe);
-        if self.active.is_empty() {
+        if self.active.is_empty() || self.cursor >= self.active.len() {
             self.cursor = 0;
-        } else {
-            self.cursor %= self.active.len();
         }
     }
 
     fn try_reactivate_any(&mut self) {
+        if self.inactive.is_empty() {
+            return;
+        }
         let mut i = 0;
         while i < self.inactive.len() {
             if self.inactive[i].tx.above_lwm.load(Ordering::Acquire) {
@@ -75,10 +76,8 @@ impl ActivePipes {
         self.fallback_peers.remove(&peer_id);
         if let Some(pos) = self.active.iter().position(|p| p.peer_id == peer_id) {
             self.active.swap_remove(pos);
-            if self.active.is_empty() {
+            if self.active.is_empty() || self.cursor >= self.active.len() {
                 self.cursor = 0;
-            } else {
-                self.cursor %= self.active.len();
             }
         } else if let Some(pos) = self.inactive.iter().position(|p| p.peer_id == peer_id) {
             self.inactive.swap_remove(pos);
@@ -163,8 +162,11 @@ impl Submitter {
 
         let mut scanned = 0usize;
         while scanned < active.active.len() {
-            let i = active.cursor % active.active.len();
-            active.cursor = (i + 1) % active.active.len();
+            let i = active.cursor;
+            active.cursor += 1;
+            if active.cursor >= active.active.len() {
+                active.cursor = 0;
+            }
             scanned += 1;
             match active.active[i].tx.try_send(msg) {
                 Ok(()) => return Ok(()),


### PR DESCRIPTION
- `flush_frame_buffer` arena direct-write: write from `BytesMut`
  arena directly for arena-only batches, skip `split()`/`freeze()`/
  `Bytes::slice()`/`drop()` cycle and per-batch arena reallocation
- `Submitter::try_send`: replace `cursor % active.len()` with
  wrapping comparison, guard `try_reactivate_any()` on non-empty
  inactive list
- `SHARED_MAX_BATCH_MSGS` 256 to 512: halves select iterations
  for small messages where the byte cap (1 MiB) is not binding