### PR TITLE
Clean up main comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 - No C compiler, no libzmq, no libsodium
 - Python binding ([pyomq](bindings/pyomq/)), C API ([omq-libzmq](omq-libzmq/))
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
+</p>
+
+[Full comparison charts](COMPARISONS.md)
+
 ## The hard parts
 
 OMQ is designed for real ZMQ behavior, not just happy-path PUSH/PULL throughput. You get:
@@ -24,12 +30,6 @@ OMQ is designed for real ZMQ behavior, not just happy-path PUSH/PULL throughput.
 - Benchmarks cover the real shapes: CPU accounting, fan-in/fan-out, fairness, transport differences (see charts below).
 
 ### Benchmarks
-
-[Full comparison charts](COMPARISONS.md)
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
-</p>
 
 <details>
 <summary>PUSH/PULL by transport</summary>

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -55,13 +55,6 @@
   <circle cx="254.8" cy="247.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="316.4" cy="253.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="378.0" cy="291.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,157.3 131.6,141.2 193.2,119.0 254.8,129.9 316.4,143.7 378.0,203.7" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="157.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="141.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="119.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="129.9" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="143.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="203.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="70.0,108.1 131.6,112.7 193.2,112.1 254.8,135.2 316.4,155.5 378.0,209.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="70.0" cy="108.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="131.6" cy="112.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -163,17 +156,6 @@
   <circle cx="777.3" cy="247.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="166.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="151.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,265.4 469.3,228.4 520.7,176.0 572.0,115.7 623.3,150.1 674.7,127.3 726.0,133.3 777.3,123.6 828.7,175.6 880.0,157.2" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="265.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="228.4" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="176.0" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="115.7" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="150.1" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="127.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="133.3" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="123.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="175.6" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="157.2" r="3" fill="#06b6d4" stroke="white" stroke-width="1"/>
   <polyline points="418.0,269.1 469.3,250.6 520.7,183.2 572.0,160.0 623.3,104.7 674.7,94.7 726.0,103.6 777.3,110.3 828.7,141.4 880.0,151.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="418.0" cy="269.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="469.3" cy="250.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
@@ -218,18 +200,15 @@
   <line x1="665" y1="350" x2="679" y2="350" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="672" cy="350" r="2.5" fill="#dc2626"/>
   <text x="685" y="354" fill="#374151" font-size="10" font-weight="500">omq-tokio (4T)</text>
-  <line x1="95" y1="370" x2="109" y2="370" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="102" cy="370" r="2.5" fill="#06b6d4"/>
-  <text x="115" y="374" fill="#374151" font-size="10" font-weight="500">omq-libzmq [1T]</text>
-  <line x1="285" y1="370" x2="299" y2="370" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="292" cy="370" r="2.5" fill="#2563eb"/>
-  <text x="305" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>
-  <line x1="475" y1="370" x2="489" y2="370" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="482" cy="370" r="2.5" fill="#16a34a"/>
-  <text x="495" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 [6T]</text>
-  <line x1="665" y1="370" x2="679" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
-  <circle cx="672" cy="370" r="2.5" fill="#15803d"/>
-  <text x="685" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
+  <line x1="190" y1="370" x2="204" y2="370" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="197" cy="370" r="2.5" fill="#2563eb"/>
+  <text x="210" y="374" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>
+  <line x1="380" y1="370" x2="394" y2="370" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="387" cy="370" r="2.5" fill="#16a34a"/>
+  <text x="400" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 [6T]</text>
+  <line x1="570" y1="370" x2="584" y2="370" stroke="#15803d" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="577" cy="370" r="2.5" fill="#15803d"/>
+  <text x="590" y="374" fill="#374151" font-size="10" font-weight="500">rzmq v0.5.24 (io_uring) [6T]</text>
   <text x="70.0" y="388.0" text-anchor="start" fill="#9ca3af" font-size="9">(nT) = configurable IO threads</text>
   <text x="70.0" y="401.0" text-anchor="start" fill="#9ca3af" font-size="9">[nT] = fixed IO threads</text>
 </svg>

--- a/scripts/gen_main_chart.py
+++ b/scripts/gen_main_chart.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(REPO / "scripts"))
 from chart_hw import detect_hardware
 
 # Union of all impls plotted in the main chart; used only as a load filter.
-IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "omq-libzmq",
+IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt",
          "zmq.rs", "rzmq", "rzmq-iouring"]
 
 COLORS = {
@@ -32,7 +32,6 @@ COLORS = {
     "libzmq-mt": "#a16207",
     "omq-tokio": "#f97316",
     "omq-tokio-mt": "#dc2626",
-    "omq-libzmq": "#06b6d4",
     "zmq.rs": "#2563eb",
     "rzmq": "#16a34a",
     "rzmq-iouring": "#15803d",
@@ -43,16 +42,15 @@ LABELS = {
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
     "omq-tokio-mt": "omq-tokio (4T)",
-    "omq-libzmq": "omq-libzmq [1T]",
     "zmq.rs": "zmq.rs v0.6.0 [6T]",
     "rzmq": "rzmq v0.5.24 [6T]",
     "rzmq-iouring": "rzmq v0.5.24 (io_uring) [6T]",
 }
 
 MAIN_IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt",
-              "omq-libzmq", "zmq.rs", "rzmq", "rzmq-iouring"]
+              "zmq.rs", "rzmq", "rzmq-iouring"]
 MAIN_DRAW_ORDER = ["rzmq-iouring", "rzmq", "zmq.rs", "libzmq",
-                   "libzmq-mt", "omq-libzmq", "omq-tokio-mt", "omq-tokio"]
+                   "libzmq-mt", "omq-tokio-mt", "omq-tokio"]
 MAIN_TITLE = "PUSH/PULL throughput, TCP loopback, 2-process"
 
 


### PR DESCRIPTION
- Remove `omq-libzmq` from `main_tcp.svg` (too many lines). Detail charts still include it.
- Move the chart to the top of `README.md`, right after the feature list.