### PR TITLE
Reject 32-bit targets at compile time

### DIFF
--- a/omq-proto/src/lib.rs
+++ b/omq-proto/src/lib.rs
@@ -6,6 +6,9 @@
 //! subscription matcher. None of this depends on a runtime.
 #![forbid(unsafe_code)]
 
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("omq requires a 64-bit target");
+
 pub mod backoff;
 pub mod endpoint;
 pub mod error;

--- a/omq-tokio/tests/soak_pub_sub_realworld_churn_tcp.rs
+++ b/omq-tokio/tests/soak_pub_sub_realworld_churn_tcp.rs
@@ -166,6 +166,10 @@ impl SubscriberProbe {
             self.received += 1;
         }
     }
+
+    fn reset_gap_window(&mut self) {
+        self.last_seq_by_topic = [None; 4];
+    }
 }
 
 async fn set_target_subscribers(
@@ -253,6 +257,10 @@ fn soak_pub_sub_realworld_churn_tcp() {
                     sent_at_measure_start = seq;
                     recv_at_measure_start = subs.iter().map(|s| s.received).sum();
                     gaps_at_measure_start = subs.iter().map(|s| s.gaps).sum();
+                    // First post-warmup message starts the in-phase gap window.
+                    for sub in &mut subs {
+                        sub.reset_gap_window();
+                    }
                 }
 
                 if last_log.elapsed() >= Duration::from_secs(30) {


### PR DESCRIPTION
- `compile_error!` in `omq-proto/src/lib.rs` for non-64-bit targets
- Fires before crate-specific guards (e.g. `yring`) since `omq-proto` is the root dependency
- 32-bit is not feasible: `yring` monotonic `AtomicUsize` counters wrap in ~14 min at 5M msg/s, `Message`/`OmqMsgRepr` size assertions fail, `AtomicU64` unavailable on some 32-bit targets