### PR TITLE
Add Socket::wait_subscribed

### DIFF
--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -6,7 +6,7 @@ mod peer;
 
 pub(crate) use peer::spawn_driver;
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 
 use rustc_hash::FxHashMap;
@@ -206,6 +206,7 @@ pub(crate) struct SocketDriver {
     transmit_slots: super::transmit_slot_cache::TransmitSlotCache,
     compression_pool: Option<Arc<crate::engine::compression_pool::CompressionPool>>,
     recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
+    subscribe_count: Arc<AtomicU64>,
 }
 
 impl SocketDriver {
@@ -223,6 +224,7 @@ impl SocketDriver {
         req_awaiting_reply: Arc<AtomicBool>,
         transmit_slots: super::transmit_slot_cache::TransmitSlotCache,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
+        subscribe_count: Arc<AtomicU64>,
     ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(128);
         let (peer_out_tx, peer_out_rx) = mpsc::channel(256);
@@ -257,6 +259,7 @@ impl SocketDriver {
             transmit_slots,
             compression_pool: None,
             recv_sink_config,
+            subscribe_count,
         }
     }
 

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -582,6 +582,8 @@ impl SocketDriver {
         match cmd {
             Command::Subscribe(prefix) => {
                 self.send_strategy.peer_subscribe(peer_id, prefix.clone());
+                self.subscribe_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Release);
                 self.monitor.publish(MonitorEvent::SubscribeReceived {
                     prefix: prefix.clone(),
                 });

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -1,6 +1,6 @@
 //! Public `Socket` handle.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::channel::oneshot;
@@ -60,6 +60,9 @@ struct Inner {
     /// synchronous sends, `send()` yields to the runtime so driver tasks
     /// on the same worker thread can drain and flush.
     send_ops: AtomicU32,
+    /// Subscription commands received from peers. Incremented by the
+    /// actor on each `Command::Subscribe`; read by `wait_subscribed`.
+    subscribe_count: Arc<AtomicU64>,
     last_bound_endpoint: RwLock<Option<Endpoint>>,
     actor_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -115,6 +118,7 @@ impl Socket {
         let type_state = Arc::new(Mutex::new(TypeState::new()));
         let req_awaiting_reply = Arc::new(AtomicBool::new(false));
         let transmit_slots = TransmitSlotCache::new();
+        let subscribe_count = Arc::new(AtomicU64::new(0));
         let driver = SocketDriver::new(
             socket_type,
             options,
@@ -128,6 +132,7 @@ impl Socket {
             req_awaiting_reply.clone(),
             transmit_slots.clone(),
             recv_sink_config,
+            subscribe_count.clone(),
         );
         let actor_task = spawn_driver(driver);
         Self {
@@ -142,6 +147,7 @@ impl Socket {
                 req_awaiting_reply,
                 transmit_slots,
                 send_ops: AtomicU32::new(0),
+                subscribe_count,
                 last_bound_endpoint: RwLock::new(None),
                 actor_task: Mutex::new(Some(actor_task)),
             }),
@@ -491,6 +497,35 @@ impl Socket {
             let conns = self.connections().await?;
             if conns.len() >= min_peers {
                 return Ok(conns.len());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(Error::Timeout);
+            }
+            tokio::time::sleep_until(
+                deadline.min(tokio::time::Instant::now() + std::time::Duration::from_millis(5)),
+            )
+            .await;
+        }
+    }
+
+    /// Wait until the socket has received at least `min_subscriptions`
+    /// subscription commands from peers, or until `timeout` expires.
+    /// Returns the total subscription count at the time the threshold
+    /// was met, or `Error::Timeout`.
+    ///
+    /// Reads an atomic counter incremented by the actor on each
+    /// `Subscribe` command, so it reflects fully-processed subscriptions
+    /// (after routing registration), not just wire arrival.
+    pub async fn wait_subscribed(
+        &self,
+        min_subscriptions: u64,
+        timeout: std::time::Duration,
+    ) -> Result<u64> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let count = self.inner.subscribe_count.load(Ordering::Acquire);
+            if count >= min_subscriptions {
+                return Ok(count);
             }
             if tokio::time::Instant::now() >= deadline {
                 return Err(Error::Timeout);

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -186,7 +186,9 @@ async fn pub_sub_connect_before_bind(ep: Endpoint) {
 
     let pub_ = Socket::new(SocketType::Pub, Options::default());
     pub_.bind(ep).await.unwrap();
-    test_support::wait_for_subscribe(&pub_).await;
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     let deadline = std::time::Instant::now() + TIMEOUT;
     loop {

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -26,7 +26,7 @@ fn tcp_from_lz4(ep: &Endpoint) -> Endpoint {
     }
 }
 
-async fn bind_lz4_loopback(sock: &Socket) -> (Endpoint, omq_tokio::MonitorStream) {
+async fn bind_lz4_loopback(sock: &Socket) -> Endpoint {
     let mut mon = sock.monitor();
     sock.bind(lz4_loopback()).await.unwrap();
     let port = loop {
@@ -37,29 +37,10 @@ async fn bind_lz4_loopback(sock: &Socket) -> (Endpoint, omq_tokio::MonitorStream
             break port;
         }
     };
-    let ep = Endpoint::Lz4Tcp {
+    Endpoint::Lz4Tcp {
         host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
         port,
-    };
-    (ep, mon)
-}
-
-async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
-    let fut = async {
-        let mut count = 0;
-        while count < n {
-            match mon.recv().await {
-                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
-                Ok(_) => {}
-                Err(e) => {
-                    panic!("monitor closed after {count}/{n} subscribes: {e:?}")
-                }
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), fut)
-        .await
-        .expect("subscribes did not propagate within 5s");
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -77,7 +58,7 @@ async fn pub_sub_lz4_sharded_fan_out_ships_dict_to_late_subscriber() {
     let opts = Options::default().compression_dict(dict);
 
     let publisher = Socket::new(SocketType::Pub, opts.clone());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let mut decoded_subs = Vec::with_capacity(N_DECODED_SUBS);
     for _ in 0..N_DECODED_SUBS {
@@ -86,12 +67,18 @@ async fn pub_sub_lz4_sharded_fan_out_ships_dict_to_late_subscriber() {
         sub.subscribe(bytes::Bytes::new()).await.unwrap();
         decoded_subs.push(sub);
     }
-    wait_for_subscribes(&mut mon, N_DECODED_SUBS).await;
+    publisher
+        .wait_subscribed(N_DECODED_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     let raw_sub = Socket::new(SocketType::Sub, Options::default());
     raw_sub.connect(tcp_from_lz4(&ep)).await.unwrap();
     raw_sub.subscribe(bytes::Bytes::new()).await.unwrap();
-    wait_for_subscribes(&mut mon, 1).await;
+    publisher
+        .wait_subscribed((N_DECODED_SUBS + 1) as u64, Duration::from_secs(1))
+        .await
+        .expect("raw subscriber subscription did not arrive");
 
     let payload1 = bytes::Bytes::from(format!("{sample}{}", " ".repeat(256)));
     let payload2 = bytes::Bytes::from(format!("{sample}{}", " ".repeat(300)));
@@ -159,7 +146,7 @@ async fn pub_sub_lz4_sharded_fan_out_auto_trains_dict_for_late_subscriber() {
 
     let opts = Options::default().compression_auto_train(true);
     let publisher = Socket::new(SocketType::Pub, opts.clone());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let mut decoded_subs = Vec::with_capacity(N_DECODED_SUBS);
     for _ in 0..N_DECODED_SUBS {
@@ -168,7 +155,10 @@ async fn pub_sub_lz4_sharded_fan_out_auto_trains_dict_for_late_subscriber() {
         sub.subscribe(bytes::Bytes::new()).await.unwrap();
         decoded_subs.push(sub);
     }
-    wait_for_subscribes(&mut mon, N_DECODED_SUBS).await;
+    publisher
+        .wait_subscribed(N_DECODED_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0..N_TRAINING_MSGS {
         let payload = bytes::Bytes::from(format!(
@@ -190,7 +180,10 @@ async fn pub_sub_lz4_sharded_fan_out_auto_trains_dict_for_late_subscriber() {
     let raw_sub = Socket::new(SocketType::Sub, Options::default());
     raw_sub.connect(tcp_from_lz4(&ep)).await.unwrap();
     raw_sub.subscribe(bytes::Bytes::new()).await.unwrap();
-    wait_for_subscribes(&mut mon, 1).await;
+    publisher
+        .wait_subscribed((N_DECODED_SUBS + 1) as u64, Duration::from_secs(1))
+        .await
+        .expect("raw subscriber subscription did not arrive");
 
     let late_payload = bytes::Bytes::from(format!(
         "{{\"kind\":\"quote\",\"venue\":\"XNAS\",\"symbol\":\"OMQ\",\"seq\":1000,\"bid\":101.25,\"ask\":101.27,\"depth\":[10125,10126,10127],\"pad\":\"{}\"}}",
@@ -249,7 +242,7 @@ async fn pub_sub_lz4_sharded_fan_out_deferred_large_message_preserves_order() {
         .compression_offload_threshold(Some(1));
 
     let publisher = Socket::new(SocketType::Pub, opts.clone());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let mut subs = Vec::with_capacity(N_SUBS);
     for _ in 0..N_SUBS {
@@ -258,7 +251,10 @@ async fn pub_sub_lz4_sharded_fan_out_deferred_large_message_preserves_order() {
         sub.subscribe(bytes::Bytes::new()).await.unwrap();
         subs.push(sub);
     }
-    wait_for_subscribes(&mut mon, N_SUBS).await;
+    publisher
+        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     let mut expected = Vec::with_capacity(N_MSGS);
     let first = bytes::Bytes::from(vec![b'A'; 2 * 1024 * 1024]);
@@ -289,13 +285,16 @@ async fn pub_sub_lz4_sharded_fan_out_deferred_large_message_preserves_order() {
 #[tokio::test]
 async fn pub_sub_prefix_filter() {
     let publisher = Socket::new(SocketType::Pub, Options::default());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let subscriber = Socket::new(SocketType::Sub, Options::default());
     subscriber.connect(ep).await.unwrap();
     subscriber.subscribe("news.").await.unwrap();
 
-    wait_for_subscribes(&mut mon, 1).await;
+    publisher
+        .wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     publisher
         .send(Message::multipart(["news.sports", "ball scores"]))
@@ -340,7 +339,7 @@ async fn pub_sub_lz4_fan_out() {
     const N_MSGS: usize = 200;
 
     let publisher = Socket::new(SocketType::Pub, Options::default());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let mut subs = Vec::with_capacity(N_SUBS);
     for _ in 0..N_SUBS {
@@ -349,7 +348,10 @@ async fn pub_sub_lz4_fan_out() {
         s.subscribe(bytes::Bytes::new()).await.unwrap();
         subs.push(s);
     }
-    wait_for_subscribes(&mut mon, N_SUBS).await;
+    publisher
+        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0..N_MSGS {
         let body = format!("msg-{i:04}");
@@ -394,7 +396,7 @@ async fn pub_sub_lz4_fan_out_with_dict() {
     let opts = Options::default().compression_dict(dict);
 
     let publisher = Socket::new(SocketType::Pub, opts.clone());
-    let (ep, mut mon) = bind_lz4_loopback(&publisher).await;
+    let ep = bind_lz4_loopback(&publisher).await;
 
     let mut subs = Vec::with_capacity(N_SUBS);
     for _ in 0..N_SUBS {
@@ -403,7 +405,10 @@ async fn pub_sub_lz4_fan_out_with_dict() {
         s.subscribe(bytes::Bytes::new()).await.unwrap();
         subs.push(s);
     }
-    wait_for_subscribes(&mut mon, N_SUBS).await;
+    publisher
+        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0..N_MSGS {
         let body = format!(r#"{{"seq":{i},"msg":"hello world","tag":"bench"}}"#);

--- a/omq-tokio/tests/lz4_ws.rs
+++ b/omq-tokio/tests/lz4_ws.rs
@@ -14,19 +14,18 @@ fn lz4_ws_loopback(port: u16) -> Endpoint {
     }
 }
 
-async fn bind_lz4_ws(sock: &Socket) -> (u16, omq_tokio::MonitorStream) {
+async fn bind_lz4_ws(sock: &Socket) -> u16 {
     let mut mon = sock.monitor();
     sock.bind(lz4_ws_loopback(0)).await.unwrap();
-    let port = loop {
+    loop {
         match mon.recv().await {
             Ok(MonitorEvent::Listening {
                 endpoint: Endpoint::Lz4Ws { port, .. },
-            }) => break port,
+            }) => return port,
             Ok(_) => {}
             other => panic!("expected Lz4Ws Listening, got {other:?}"),
         }
-    };
-    (port, mon)
+    }
 }
 
 async fn wait_handshake(sock: &Socket) {
@@ -44,28 +43,12 @@ async fn wait_handshake(sock: &Socket) {
     .expect("handshake did not complete within 5s");
 }
 
-async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
-    let fut = async {
-        let mut count = 0;
-        while count < n {
-            match mon.recv().await {
-                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
-                Ok(_) => {}
-                Err(e) => panic!("monitor closed after {count}/{n} subscribes: {e:?}"),
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), fut)
-        .await
-        .expect("subscribes did not propagate within 5s");
-}
-
 // ---- PUSH / PULL ----
 
 #[tokio::test]
 async fn lz4_ws_small_message_roundtrip() {
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -83,7 +66,7 @@ async fn lz4_ws_small_message_roundtrip() {
 #[tokio::test]
 async fn lz4_ws_large_compressible_message_roundtrip() {
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -100,7 +83,7 @@ async fn lz4_ws_large_compressible_message_roundtrip() {
 #[tokio::test]
 async fn lz4_ws_multipart_message_roundtrip() {
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -121,7 +104,7 @@ async fn lz4_ws_multipart_message_roundtrip() {
 #[tokio::test]
 async fn lz4_ws_empty_message_roundtrip() {
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -137,7 +120,7 @@ async fn lz4_ws_empty_message_roundtrip() {
 #[tokio::test]
 async fn lz4_ws_incompressible_data_roundtrip() {
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -157,7 +140,7 @@ async fn lz4_ws_incompressible_data_roundtrip() {
 async fn lz4_ws_many_messages_in_a_row() {
     const N: usize = 200;
     let pull = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -180,7 +163,7 @@ async fn lz4_ws_many_messages_in_a_row() {
 #[tokio::test]
 async fn lz4_ws_req_rep() {
     let rep = Socket::new(SocketType::Rep, Options::default());
-    let (port, _mon) = bind_lz4_ws(&rep).await;
+    let port = bind_lz4_ws(&rep).await;
 
     let req = Socket::new(SocketType::Req, Options::default());
     req.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -205,7 +188,7 @@ async fn lz4_ws_req_rep() {
 #[tokio::test]
 async fn lz4_ws_router_dealer_identity_routing() {
     let router = Socket::new(SocketType::Router, Options::default());
-    let (port, _mon) = bind_lz4_ws(&router).await;
+    let port = bind_lz4_ws(&router).await;
 
     let dealer = Socket::new(
         SocketType::Dealer,
@@ -240,13 +223,16 @@ async fn lz4_ws_router_dealer_identity_routing() {
 #[tokio::test]
 async fn lz4_ws_pub_sub_prefix_filter() {
     let publisher = Socket::new(SocketType::Pub, Options::default());
-    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+    let port = bind_lz4_ws(&publisher).await;
 
     let subscriber = Socket::new(SocketType::Sub, Options::default());
     subscriber.connect(lz4_ws_loopback(port)).await.unwrap();
     subscriber.subscribe("news.").await.unwrap();
 
-    wait_for_subscribes(&mut mon, 1).await;
+    publisher
+        .wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     publisher
         .send(Message::multipart(["news.sports", "ball scores"]))
@@ -288,7 +274,7 @@ async fn lz4_ws_pub_sub_fan_out() {
     const N_MSGS: usize = 50;
 
     let publisher = Socket::new(SocketType::Pub, Options::default());
-    let (port, mut mon) = bind_lz4_ws(&publisher).await;
+    let port = bind_lz4_ws(&publisher).await;
 
     let mut subs = Vec::with_capacity(N_SUBS);
     for _ in 0..N_SUBS {
@@ -297,7 +283,10 @@ async fn lz4_ws_pub_sub_fan_out() {
         s.subscribe(Bytes::new()).await.unwrap();
         subs.push(s);
     }
-    wait_for_subscribes(&mut mon, N_SUBS).await;
+    publisher
+        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0..N_MSGS {
         let body = format!("msg-{i:04}");
@@ -331,7 +320,7 @@ async fn lz4_ws_dict_roundtrip() {
     let opts = || Options::default().compression_dict(dict.clone());
 
     let pull = Socket::new(SocketType::Pull, opts());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, opts());
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -362,7 +351,7 @@ async fn lz4_ws_auto_train_dict() {
     let opts = Options::default().compression_dict(dict);
 
     let pull = Socket::new(SocketType::Pull, opts.clone());
-    let (port, _mon) = bind_lz4_ws(&pull).await;
+    let port = bind_lz4_ws(&pull).await;
 
     let push = Socket::new(SocketType::Push, opts);
     push.connect(lz4_ws_loopback(port)).await.unwrap();
@@ -385,7 +374,7 @@ async fn lz4_ws_auto_train_dict() {
 #[tokio::test]
 async fn lz4_ws_reconnect_after_server_restart() {
     let pull1 = Socket::new(SocketType::Pull, Options::default());
-    let (port, _mon) = bind_lz4_ws(&pull1).await;
+    let port = bind_lz4_ws(&pull1).await;
 
     let push = Socket::new(SocketType::Push, Options::default());
     push.connect(lz4_ws_loopback(port)).await.unwrap();

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -4,26 +4,10 @@ mod test_support;
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, MonitorEvent, OnMute, Options, Socket, SocketType};
+use omq_tokio::{Endpoint, Message, OnMute, Options, Socket, SocketType};
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
-}
-
-async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
-    let fut = async {
-        let mut count = 0;
-        while count < n {
-            match mon.recv().await {
-                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
-                Ok(_) => {}
-                Err(e) => panic!("monitor closed before subscriptions: {e:?}"),
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), fut)
-        .await
-        .expect("subscriptions did not propagate within 5s");
 }
 
 #[tokio::test]
@@ -208,7 +192,9 @@ async fn pub_tcp_multi_sub_all_receive() {
         s.connect(test_support::tcp_loopback(port)).await.unwrap();
         subs.push(s);
     }
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    pub_.wait_subscribed(4, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0u32..20 {
         pub_.send(Message::single(i.to_le_bytes().to_vec()))
@@ -242,7 +228,10 @@ async fn pub_tcp_subscriber_churn() {
         s2.subscribe(bytes::Bytes::new()).await.unwrap();
         s2.connect(test_support::tcp_loopback(port)).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        let expected = (u64::from(round) + 1) * 2;
+        pub_.wait_subscribed(expected, Duration::from_secs(5))
+            .await
+            .expect("subscriptions did not arrive");
 
         let tag = format!("round-{round}");
         pub_.send(Message::single(tag.clone())).await.unwrap();
@@ -275,7 +264,9 @@ async fn xpub_nodrop_delivers_all_under_backpressure() {
     let sub = Socket::new(SocketType::Sub, Options::default().recv_hwm(2));
     sub.subscribe(bytes::Bytes::new()).await.unwrap();
     sub.connect(test_support::tcp_loopback(port)).await.unwrap();
-    test_support::wait_for_subscribe(&pub_).await;
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     let count = 10u32;
     let sender = tokio::spawn({
@@ -313,7 +304,9 @@ async fn pub_sharded_fanout_all_receive() {
         s.connect(test_support::tcp_loopback(port)).await.unwrap();
         subs.push(s);
     }
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    pub_.wait_subscribed(8, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     let msg_count = 100u32;
     for i in 0..msg_count {
@@ -350,7 +343,9 @@ async fn pub_sharded_fanout_subscription_filter() {
         s.connect(test_support::tcp_loopback(port)).await.unwrap();
         subs.push(s);
     }
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    pub_.wait_subscribed(prefixes.len() as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for &pfx in &prefixes {
         pub_.send(Message::single(format!("{pfx}hello")))
@@ -386,7 +381,6 @@ async fn pub_sharded_fanout_block_on_mute_does_not_block_slow_sub() {
         Options::default().send_hwm(1).on_mute(OnMute::Block),
     );
     let port = test_support::bind_loopback(&pub_).await;
-    let mut mon = pub_.monitor();
 
     let mut subs = Vec::with_capacity(SUBS);
     for _ in 0..SUBS {
@@ -395,7 +389,9 @@ async fn pub_sharded_fanout_block_on_mute_does_not_block_slow_sub() {
         sub.connect(test_support::tcp_loopback(port)).await.unwrap();
         subs.push(sub);
     }
-    wait_for_subscribes(&mut mon, SUBS).await;
+    pub_.wait_subscribed(SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     let _keep_subs = subs;
     tokio::time::timeout(Duration::from_secs(2), async {
@@ -424,7 +420,9 @@ async fn pub_sharded_fanout_two_worker_runtime_all_receive() {
         sub.connect(test_support::tcp_loopback(port)).await.unwrap();
         subs.push(sub);
     }
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    pub_.wait_subscribed(SUBS as u64, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
 
     for i in 0..MSGS {
         pub_.send(Message::single(i.to_le_bytes().to_vec()))
@@ -443,4 +441,57 @@ async fn pub_sharded_fanout_two_worker_runtime_all_receive() {
             assert_eq!(got, expected, "subscriber {sub_idx}");
         }
     }
+}
+
+#[tokio::test]
+async fn wait_subscribed_returns_after_subscribe() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let port = test_support::bind_loopback(&pub_).await;
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.subscribe("a.").await.unwrap();
+    sub.connect(test_support::tcp_loopback(port)).await.unwrap();
+
+    let count = pub_
+        .wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("wait_subscribed timed out");
+    assert!(count >= 1);
+
+    sub.subscribe("b.").await.unwrap();
+    let count = pub_
+        .wait_subscribed(2, Duration::from_secs(1))
+        .await
+        .expect("wait_subscribed timed out for second subscribe");
+    assert!(count >= 2);
+}
+
+#[tokio::test]
+async fn wait_subscribed_times_out_with_no_subscribers() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let _port = test_support::bind_loopback(&pub_).await;
+
+    let result = pub_.wait_subscribed(1, Duration::from_millis(50)).await;
+    assert!(result.is_err(), "should time out with no subscribers");
+}
+
+#[tokio::test]
+async fn wait_subscribed_cumulative_across_peers() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let port = test_support::bind_loopback(&pub_).await;
+
+    for i in 0u64..4 {
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.subscribe(bytes::Bytes::new()).await.unwrap();
+        sub.connect(test_support::tcp_loopback(port)).await.unwrap();
+        pub_.wait_subscribed(i + 1, Duration::from_secs(1))
+            .await
+            .expect("wait_subscribed timed out");
+    }
+
+    let count = pub_
+        .wait_subscribed(4, Duration::from_millis(50))
+        .await
+        .expect("should already be at 4");
+    assert_eq!(count, 4);
 }

--- a/omq-tokio/tests/test_support/mod.rs
+++ b/omq-tokio/tests/test_support/mod.rs
@@ -46,22 +46,6 @@ pub async fn wait_for_handshake_on(mon: &mut MonitorStream) {
         .expect("handshake did not complete within 5s");
 }
 
-pub async fn wait_for_subscribe(pub_sock: &Socket) {
-    let mut mon = pub_sock.monitor();
-    let fut = async {
-        loop {
-            match mon.recv().await {
-                Ok(MonitorEvent::SubscribeReceived { .. }) => return,
-                Ok(_) => {}
-                Err(e) => panic!("monitor closed before subscribe: {e:?}"),
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), fut)
-        .await
-        .expect("subscribe did not propagate within 5s");
-}
-
 pub async fn wait_for_join(sock: &Socket) {
     let mut mon = sock.monitor();
     let fut = async {

--- a/omq-tokio/tests/ws_pub_sub.rs
+++ b/omq-tokio/tests/ws_pub_sub.rs
@@ -29,8 +29,9 @@ async fn ws_pub_sub_basic() {
     let sub = Socket::new(SocketType::Sub, Options::default());
     sub.subscribe("news.").await.unwrap();
     sub.connect(ws_endpoint(port)).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     pub_.send(Message::multipart([
         Bytes::from_static(b"news.sports"),
@@ -57,8 +58,9 @@ async fn ws_pub_sub_unsubscribe() {
     let sub = Socket::new(SocketType::Sub, Options::default());
     sub.subscribe("news.").await.unwrap();
     sub.connect(ws_endpoint(port)).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
 
     pub_.send(Message::multipart([
         Bytes::from_static(b"news.sports"),
@@ -99,7 +101,6 @@ async fn ws_pub_sub_fan_out() {
     let bound = pub_.bind(ws_endpoint(0)).await.unwrap();
     let port = get_port(&bound);
 
-    let mut mon = pub_.monitor();
     let mut subs = Vec::with_capacity(N_SUBS);
     for _ in 0..N_SUBS {
         let s = Socket::new(SocketType::Sub, Options::default());
@@ -107,20 +108,9 @@ async fn ws_pub_sub_fan_out() {
         s.subscribe(Bytes::new()).await.unwrap();
         subs.push(s);
     }
-
-    let fut = async {
-        let mut count = 0;
-        while count < N_SUBS {
-            match mon.recv().await {
-                Ok(omq_tokio::MonitorEvent::SubscribeReceived { .. }) => count += 1,
-                Ok(_) => {}
-                Err(e) => panic!("monitor closed after {count}/{N_SUBS} subscribes: {e:?}"),
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), fut)
+    pub_.wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
         .await
-        .expect("subscribes did not propagate");
+        .expect("subscriptions did not arrive");
 
     for i in 0..N_MSGS {
         pub_.send(Message::single(format!("msg-{i:04}")))


### PR DESCRIPTION
- Atomic `subscribe_count` shared between actor and handle, incremented after `send_strategy.peer_subscribe()`
- `Socket::wait_subscribed(min, timeout)` polls it (Acquire/Release), no actor round-trip
- Replaces all `sleep()`-based and monitor-based subscribe waits in integration tests: `pub_sub`, `connect_before_bind`, `ws_pub_sub`, `lz4_pub_sub`, `lz4_ws`
- Removes `test_support::wait_for_subscribe` and per-file `wait_for_subscribes` helpers
- Adds 3 dedicated tests for `wait_subscribed` (basic, timeout, cumulative)