### PR TITLE
Fix doc inaccuracies and reorganize comparison sections

### DIFF
--- a/BENCHMARKS_COMPRESSION.md
+++ b/BENCHMARKS_COMPRESSION.md
@@ -5,8 +5,8 @@ LZ4 default compression. Dictionary auto-training is off by default
 (2 KiB capacity when enabled).
 
 Virtual throughput = msg/s x uncompressed size (effective app data rate
-on a constrained link). Charts show projected throughput at 10 Gbps,
-1 Gbps, 100 Mbps, and 10 Mbps.
+on a constrained link). Charts show projected throughput at 1 Gbps,
+100 Mbps, and 10 Mbps.
 
 - **Auto-dict off by default:** when enabled, the encoder trains a
   2 KiB dict from the first 100 messages, ships it once, then uses it
@@ -26,7 +26,7 @@ across link speeds and dict sizes:
 
 | Transport | No dict | With dict |
 |-----------|---------|-----------|
-| lz4+tcp   | 512 B   | 128 B     |
+| lz4+tcp   | 512 B   | 64 B      |
 
 Operators on high-bandwidth links who send many small messages can
 raise the threshold further via `Options::compression_threshold()` to
@@ -42,33 +42,3 @@ produce marginally better wire ratios at 2 KiB+ message sizes but hurt
 throughput at smaller sizes due to L1/L2 cache pressure during
 compression. The default max accepted dict size from a peer is 8 KiB.
 
-<details><summary>Test environment</summary>
-
-Linux 6.12 (Debian 13) VM, Intel i7-8700B 3.2 GHz (turbo off,
-governor=performance, 6 vCPU), Rust 1.95.0. Min wall time across
-multiple runs with warmup. Link-speed projections computed from
-measured compression ratio and CPU-limited throughput.
-
-</details>
-
-## Running the benchmarks
-
-One bench run at full loopback speed measures CPU-limited msg/s and
-wire bytes per message. The chart scripts project throughput at each
-link speed: `effective_msgs_s = min(cpu_msgs_s, link_bytes_s / wire_bytes)`.
-No kernel-level rate limiting is used; slow-link simulation via `tc`/`netem`
-is unreliable on loopback due to kernel buffering.
-
-```sh
-cargo bench -p omq-tokio  --features lz4 --bench compression
-
-# Generate charts
-python3 scripts/gen_compression_chart.py --backend tokio
-```
-
-Environment variables:
-
-- `OMQ_BENCH_SIZES` -- override payload sizes (default: chart sizes, 8 B to 256 KiB)
-- `OMQ_BENCH_ROUNDS` / `OMQ_BENCH_ROUND_MS` -- tune measurement duration
-- `OMQ_BENCH_COMPRESSION_THRESHOLD` -- override minimum payload size for compression
-- `OMQ_BENCH_DICT_SIZES` -- override dict sizes to bench (default: 2048; e.g. `256,512,1024,2048,4096,8192`)

--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -43,6 +43,23 @@ pattern in this benchmark suite.
   <img src="doc/charts/pushpull/inproc.svg" alt="PUSH/PULL throughput: inproc" width="850">
 </p>
 
+### Fan-Out
+
+1-to-N PUSH/PULL over TCP. Whiskers show the slowest and fastest
+puller in a measured round.
+
+<p align="center">
+  <img src="doc/charts/pushpull/fanout/tcp.svg" alt="PUSH fan-out: TCP" width="850">
+</p>
+
+### Fan-In
+
+N-to-1 PUSH/PULL over TCP.
+
+<p align="center">
+  <img src="doc/charts/pushpull/fanin/tcp.svg" alt="PUSH fan-in: TCP" width="850">
+</p>
+
 ## REQ/REP Latency
 
 <p align="center">
@@ -61,23 +78,6 @@ pattern in this benchmark suite.
 
 <p align="center">
   <img src="doc/charts/pubsub/tcp.svg" alt="PUB/SUB throughput: TCP" width="850">
-</p>
-
-## Fan-Out
-
-1-to-N PUSH/PULL over TCP. Whiskers show the slowest and fastest
-puller in a measured round.
-
-<p align="center">
-  <img src="doc/charts/pushpull/fanout/tcp.svg" alt="PUSH fan-out: TCP" width="850">
-</p>
-
-## Fan-In
-
-N-to-1 PUSH/PULL over TCP.
-
-<p align="center">
-  <img src="doc/charts/pushpull/fanin/tcp.svg" alt="PUSH fan-in: TCP" width="850">
 </p>
 
 ## Mechanisms


### PR DESCRIPTION
- `BENCHMARKS_COMPRESSION.md`: fix dict threshold (`64 B`, not `128 B`), remove stale `10 Gbps` from link speed list, remove "Running the benchmarks" and "Test environment" sections.
- `COMPARISONS.md`: move fan-out and fan-in into the PUSH/PULL section, demoted to `###` subsections.