### PR TITLE
Add windows support to pyomq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,30 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install --group test
+          .venv/bin/pip install --group test --group dev
       - name: build pyomq
         working-directory: bindings/pyomq
         run: .venv/bin/pip install .
+      - name: formatting
+        working-directory: bindings/pyomq
+        if: always()
+        run: .venv/bin/ruff format .
+      - name: linting
+        working-directory: bindings/pyomq
+        if: always()
+        run: .venv/bin/ruff check .
+      - name: type check
+        working-directory: bindings/pyomq
+        if: always()
+        run: .venv/bin/ty check .
+      - name: cargo test
+        working-directory: bindings/pyomq
+        if: always()
+        run: cargo test
       - name: pytest
         working-directory: bindings/pyomq
-        run: .venv/bin/pytest -v -k "not test_perf"
+        if: always()
+        run: .venv/bin/pytest -v -k "not test_perf" -W error
 
   ci-success:
     name: CI success

--- a/.github/workflows/release-pyomq.yml
+++ b/.github/workflows/release-pyomq.yml
@@ -17,7 +17,7 @@ jobs:
         target: [x86_64, aarch64]
         manylinux: [auto, musllinux_1_2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Disable local CPU rustflags
         run: rm -f .cargo/config.toml
       - uses: PyO3/maturin-action@v1
@@ -27,16 +27,73 @@ jobs:
           args: --release --out dist
           working-directory: bindings/pyomq
           manylinux: ${{ matrix.manylinux }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
+          path: bindings/pyomq/dist
+
+  windows:
+    name: Windows wheels (${{ matrix.platform.target }}, ${{ matrix.platform.python_arch }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+            python_arch: x64
+          - runner: windows-11-arm
+            target: aarch64
+            python_arch: arm64
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+          architecture: ${{ matrix.platform.python_arch }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          working-directory: bindings/pyomq
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: bindings/pyomq/dist
+
+  macos:
+    name: macOS wheels (${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-15-intel
+            target: x86_64
+          - runner: macos-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          working-directory: bindings/pyomq
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
           path: bindings/pyomq/dist
 
   sdist:
     name: Source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Disable local CPU rustflags
         run: rm -f .cargo/config.toml
       - uses: PyO3/maturin-action@v1
@@ -44,7 +101,7 @@ jobs:
           command: sdist
           args: --out dist
           working-directory: bindings/pyomq
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: bindings/pyomq/dist
@@ -54,11 +111,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: wheels-linux-x86_64-auto
           path: dist
@@ -68,14 +125,14 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux, sdist, smoke-test]
+    needs: [linux, windows, macos, sdist, smoke-test]
     environment:
       name: pypi
       url: https://pypi.org/p/pyomq
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: wheels-*
           merge-multiple: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ### Added
 
+- **Windows support for pyomq**
+  Compared to pyzmq pyomq can be used with the ProactorEventLoop
 - CI coverage for `i686-unknown-linux-gnu` and
   `armv7-unknown-linux-gnueabihf`.
+- ruff linting and ty type checking added to pyomq CI pipeline.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 - pyomq Windows async readiness drains consume latched wakeups instead of
   reusing stale wakeups after a waiter remains blocked.
+- pyomq Windows readiness signals skip unarmed wakeups to reduce stale async
+  callbacks during sustained receive drains.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to omq.rs will be documented here. Format loosely follows
   and per-message payloads remain bounded by platform allocation limits
   (below 4 GiB on 32-bit Linux).
 
+### Fixed
+
+- pyomq Windows async readiness drains consume latched wakeups instead of
+  reusing stale wakeups after a waiter remains blocked.
+
 ### Removed
 
 - `blume` workspace crate and unused `omq-tokio` dependency.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -274,6 +274,12 @@ python scripts/update_perf.py --impl pyomq
 python scripts/update_perf.py --chart-only
 ```
 
+For a local smoke run that does not append JSONL or update docs:
+
+```sh
+python scripts/update_perf.py --quick --impl pyomq
+```
+
 ## Releasing
 
 ### Automation

--- a/README.md
+++ b/README.md
@@ -189,9 +189,7 @@ notification fd for `zmq_poll`/`ZMQ_FD` readiness.
 pipes, inproc, UDP, and WebSocket transports. `omq-libzmq` builds and
 tests on Windows for the supported C API surface.
 
-`pyomq` currently publishes Linux wheels and an sdist. Windows pyomq
-support is separate from the Rust backend and is not complete on
-`main` yet.
+`pyomq` publishes Linux, macOS and Windows wheels and an sdist
 
 Requirements:
 

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows async readiness drains now consume the latched wakeup bit, avoiding
+  repeated stale drain callbacks after a waiter remains blocked.
+
+### Changed
+
+- `scripts/update_perf.py` has a `--quick` local-only mode and benchmark
+  knobs for shorter diagnostic runs.
+
 ## [0.16.4] - 2026-07-23
 
 ### Fixed

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Windows async readiness drains now consume the latched wakeup bit, avoiding
   repeated stale drain callbacks after a waiter remains blocked.
+- Windows readiness signals no longer latch wakeups when no waiter is armed,
+  reducing stale async callbacks during sustained receive drains.
 
 ### Changed
 
 - `scripts/update_perf.py` has a `--quick` local-only mode and benchmark
   knobs for shorter diagnostic runs.
+- `scripts/update_perf.py --quick` caps total throughput bytes per cell so
+  large-message checks do not spend the whole timeout on one sample.
+- `scripts/update_perf.py` now reports two-process throughput timeouts instead
+  of silently rendering them as `0`.
 
 ## [0.16.4] - 2026-07-23
 

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
 ]
 
 [[package]]
@@ -970,32 +970,54 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.2.0",
+ "windows-link",
+ "windows-result",
  "windows-strings",
- "windows-targets",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1020,12 +1042,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1039,12 +1062,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1057,68 +1079,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "x25519-dalek"

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -631,6 +631,7 @@ dependencies = [
  "omq-tokio",
  "pyo3",
  "tokio",
+ "windows",
  "yring",
 ]
 
@@ -968,10 +969,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-result"
@@ -983,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1055,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "x25519-dalek"

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -35,4 +35,4 @@ yring = { path = "../../yring", features = ["async"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py39", "extension-module"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security"] }

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -33,3 +33,6 @@ yring = { path = "../../yring", features = ["async"] }
 
 # PyO3 stable ABI: one wheel covers Python 3.9+.
 pyo3 = { version = "0.29.0", features = ["abi3-py39", "extension-module"] }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security"] }

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -78,8 +78,8 @@ See [COMPARISONS.md](https://github.com/paddor/omq.rs/blob/main/COMPARISONS.md) 
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.75 M/s |  1.53 M/s | **1.79×** |
-| REQ/REP rt/s       |   8,441/s |   4,511/s | **1.87×** |
+| PUSH/PULL msg/s    |  2.77 M/s |  1.53 M/s | **1.81×** |
+| REQ/REP rt/s       |   8,360/s |   4,511/s | **1.85×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/architecture.md
+++ b/bindings/pyomq/doc/architecture.md
@@ -16,10 +16,14 @@ src/
                     curve_keypair, has_feature
   runtime.rs        tokio runtime on dedicated thread; materialize,
                     wait_any, proxy
-  socket.rs         sync Socket + SocketInner + EventFdSignal (eventfd) +
-                    Monitor (connection event stream)
+  socket.rs         sync Socket + SocketInner + ReadinessSignal (platform
+                    abstraction) + Monitor (connection event stream)
   socket_async.rs   AsyncSocket: send (sync yring push), _try_recv,
-                    _recv_fd / _send_fd for eventfd polling
+                    platform-specific recv wakeup integration
+  notify/
+    mod.rs          ReadinessSignal: platform-agnostic public API
+    unix.rs         Unix EventFdSignal: eventfd(2) + parking flag
+    windows.rs      Windows WindowsSignal: Win32 event handles + async callback
   context.rs        Context / AsyncContext (stateless factories)
   options.rs        setsockopt/getsockopt: Overlay cache, option dispatch
   dispatch.rs       shared bind/connect/subscribe dispatch helpers
@@ -100,13 +104,29 @@ high-volume socket from starving others on the runtime.
 **Recv pump.** Drains `socket.recv()` into a `Producer<Message>` (read
 by Python). On ring-full, waits on `recv_space` (`StateSignal`, signaled
 by the Python consumer after draining). After pushing, signals the
-per-socket `EventFdSignal` and the process-global recv signal used by
+per-socket `ReadinessSignal` and the process-global recv signal used by
 `wait_any`.
 
-## EventFdSignal (eventfd)
+## ReadinessSignal abstraction
+
+The `ReadinessSignal` is a platform-agnostic interface for waking the
+Python asyncio loop when socket readiness changes. It wraps a backend
+chosen at compile time and abstracts away transport differences.
+
+### Common interface
+
+All backends implement:
+
+- `signal()`: notify waiter(s) that readiness state changed.
+- `force_wake()`: unconditional immediate wake (used on socket close).
+- `wait_timeout(duration)`: blocking wait with timeout (used by sync code).
+- `park_begin()` / `park_end()`: arm/disarm the parking flag (closes
+  races in polling loops).
+
+### Unix backend: EventFdSignal (eventfd)
 
 `EventFdSignal` wraps a Linux `eventfd(EFD_NONBLOCK)` plus an
-`AtomicBool parking` flag.
+`AtomicBool parking` flag (`notify/unix.rs`).
 
 - `signal()`: writes to the eventfd only if `parking` is true. On the
   hot path (consumer not parked), this is a single atomic load with no
@@ -120,6 +140,49 @@ per-socket `EventFdSignal` and the process-global recv signal used by
 The parking flag is set before re-checking the consumer. This closes
 the race where a notification arrives between the consumer check and
 the park.
+
+**Async integration:** Python's `asyncio.py` calls `_recv_fd()` to get
+a dup'd eventfd, then registers it with `loop.add_reader(callback)`.
+The recv pump writes the eventfd whenever it pushes a message; the
+kernel wakes the event loop, `callback` fires, and `_try_recv()` is
+invoked.
+
+### Windows backend: WindowsSignal (Win32 event handles + async callbacks)
+
+`WindowsSignal` wraps Win32 event handles with a callback-based
+wakeup model (`notify/windows.rs`).
+
+**State machine:**
+- `mode`: atomic u32 field stores wakeup configuration (ASYNC, SYNC, or NONE).
+  - `WAKEUP_MODE_ASYNC` (1): invoke Python callback when signal() is called.
+  - `WAKEUP_MODE_SYNC` (2): used by sync code for `wait_timeout()`.
+- `pending`: atomic bool latches the wakeup signal (set by `signal()`,
+  cleared by `wait_timeout()`).
+- `draining`: atomic bool tracks if Python callback is currently executing.
+  Additional wakeups during this window are coalesced to prevent callback
+  re-entrancy.
+- `callback_state`: atomic u8 state machine (IDLE, SCHEDULED, PENDING)
+  to prevent duplicate callbacks while draining is in progress.
+
+**Callback lifecycle:**
+1. Python calls `set_wakeup_hooks(async_callback, ...)` to register
+   the Python drain callback.
+2. Python calls `set_wakeup_mode(WAKEUP_MODE_ASYNC)` when adding a waiter.
+3. Rust calls `signal()` when data arrives.
+4. If `mode & WAKEUP_MODE_ASYNC`, `signal()` invokes the Python callback
+   directly (via PyO3).
+5. Python callback drains the waiter queue.
+6. Python calls `_mark_send_drain_complete()` / `_mark_recv_drain_complete()`
+   to clear the draining flag and re-trigger if more work arrived.
+
+**Wakeup modes:**
+- `WAKEUP_MODE_ASYNC`: callback-based. Used by async code.
+- `WAKEUP_MODE_SYNC`: event handle-based. Used by sync code's `wait_timeout()`.
+- `WAKEUP_MODE_NONE`: inactive. No wakeups until mode is re-enabled.
+
+The recv and send signals have independent modes: async code sets
+send to ASYNC, while sync code can set recv to SYNC simultaneously.
+
 
 ## Sync send path
 
@@ -138,7 +201,8 @@ Socket.send(bytes, flags)
 
 SNDMORE frames accumulate in a `SendBuffer` (`Vec<Bytes>`). The final
 `send` (no SNDMORE flag) flushes all buffered frames plus the final
-frame into one multipart `Message`.
+frame into one multipart `Message`. (Platform-independent; yring is
+populated by both Unix and Windows backends.)
 
 ## Sync recv path
 
@@ -148,44 +212,164 @@ Socket.recv(flags)
   -> recv_message()
       lock consumer, try pop (fast path)
       if Some(msg): return first frame, store rest in rxbuf
-      else: release GIL, slow path:
-          park_begin()
-          re-check consumer (closes race)
-          loop:
-              wait_timeout(100 ms or remaining RCVTIMEO)
-              re-check consumer
-              if msg: park_end(), return
-              check RCVTIMEO deadline -> raise EAGAIN
+      else:
+          # Platform: Unix uses eventfd + poll(2)
+          # Platform: Windows uses ReadinessSignal.wait_timeout() with Win32 handles
+          release GIL, slow path:
+              park_begin()
+              re-check consumer (closes race)
+              loop:
+                  wait_timeout(100 ms or remaining RCVTIMEO)
+                  re-check consumer
+                  if msg: park_end(), return
+                  check RCVTIMEO deadline -> raise EAGAIN
 ```
 
 Each `recv()` returns one frame. If the message is multipart, remaining
 frames go into `rxbuf` and are returned by subsequent `recv()` calls.
-`recv_multipart()` returns all frames at once.
+`recv_multipart()` returns all frames at once. Both platforms use
+`ReadinessSignal.wait_timeout()`, which internally handles eventfd
+on Unix or Win32 event handles on Windows.
 
 ## Async send/recv
 
-Both send and recv are completion-based. No Rust futures are bridged
-to Python asyncio. No `tokio_future_into_py`, no `call_soon_threadsafe`.
+Async operations are completion-based with platform-specific wakeup
+mechanisms. No Rust futures are bridged to Python asyncio.
 
-**Send.** `AsyncSocket.send()` pushes directly into the send yring
-(synchronous, returns `()` or raises EAGAIN). The Python wrapper
-returns `_SEND_DONE` (a zero-allocation awaitable). On EAGAIN (ring
-full), it falls back to an eventfd-based wait: `_send_fd()` returns a
-dup'd eventfd for the send-side notification, and a `_RecvFuture`
-retries the push when the fd becomes readable.
+### Async send with backpressure
 
-**Recv.** `_try_recv()` pops from the recv yring (returns the message
-or `None`). If `None`, `_recv_fd()` returns a dup'd eventfd. The
-Python wrapper registers it with `loop.add_reader()`. When the recv
-pump pushes a message and writes the eventfd, the callback fires,
-calls `_try_recv()`, and resolves the pending `asyncio.Future`. The
-fd is registered once per socket (persistent) and shared across recv
-calls via a waiter queue.
+**Happy path (ring not full):**
 
-The recv pump always writes the eventfd when pushing (the parking
-flag is permanently armed via `arm_persistent`). This is correct
-under concurrency: multiple coroutines can await recv on the same
-socket without starving each other.
+```
+AsyncSocket.send(data, flags)
+  -> prod.push_and_flush(msg)
+      if Ok: return
+```
+
+The send yring is an `AsyncProducer`, allowing non-blocking push from
+Python.
+
+**Backpressure (ring full):**
+
+```
+AsyncSocket.send(data, flags)
+  -> prod.push_and_flush(msg)
+      if Err(ring full):
+        raise EAGAIN to Python wrapper
+```
+
+Python wrapper (`asyncio.py`) catches EAGAIN and enters the waiter queue
+pattern:
+
+1. Calls `_add_waitable(try_fn=socket.send, waiters=_send_waiters, set_mode)`.
+2. `set_mode` lambda calls `_set_wakeup_modes(send_mode=WAKEUP_MODE_ASYNC)`.
+3. Appends a waiter closure to `_send_waiters` deque.
+4. Returns future for caller to await.
+
+**Wakeup path (Unix):**
+- Waiter future is pending.
+- recv pump on tokio thread finishes forwarding a message, freeing ring space.
+- recv pump calls `send_ready.signal()`.
+- `EventFdSignal.signal()` writes to the eventfd (because `parking=true`).
+- Kernel wakes asyncio event loop via epoll/select.
+- Loop fires the registered callback, which calls `_drain_send_waiters()`.
+- `_drain_send_waiters()` pops waiters from queue and invokes each:
+  - Waiter calls `try_fn()` (socket.send) -> succeeds, future resolved.
+- After draining, calls `_mark_send_drain_complete()` to clear Rust callback state.
+
+**Wakeup path (Windows):**
+- Waiter future is pending.
+- recv pump on tokio thread finishes forwarding a message, freeing ring space.
+- recv pump calls `send_ready.signal()`.
+- `WindowsSignal.signal()` sees `mode & WAKEUP_MODE_ASYNC` and directly
+  invokes the Python callback (stored during `set_wakeup_hooks()`).
+- Callback is `_schedule_send_drain`, which calls
+  `loop.call_soon_threadsafe(self._drain_send_waiters)`.
+- Asyncio loop invokes `_drain_send_waiters()` in main thread context:
+  - Pops waiters and invokes each, same as Unix.
+- After draining, calls `_mark_send_drain_complete()` which clears the
+  Rust draining flag and re-triggers if follow-up work arrived.
+
+### Async recv with waiter queue
+
+**Setup (registration once per socket):**
+
+```python
+_register_wakeup_hooks()
+  -> sock._set_wakeup_hooks(
+       recv_async=_schedule_recv_drain,
+       send_async=_schedule_send_drain,
+       recv_event=_recv_wakeup_event,
+       send_event=_send_wakeup_event
+     )
+```
+
+This is called once; Rust stores callbacks and event handles.
+
+**Recv with message ready:**
+
+```
+AsyncSocket._try_recv()
+  -> socket.recv_nowait() from yring
+      if Some(msg): return msg
+      else: return None
+```
+
+**Recv with waiter (no message):**
+
+```
+AsyncSocket._add_recv_event(try_fn=_try_recv)
+  -> _add_waitable(try_fn, waiters=_recv_waiters, set_mode)
+```
+
+Similar to send: appends waiter, sets mode, returns future.
+
+**Wakeup path (Unix):**
+- Waiter future is pending, registered with `loop.add_reader(fd, callback)`.
+- send pump on tokio thread drains yring, calls `recv_ready.signal()`.
+- `EventFdSignal.signal()` writes to eventfd.
+- Kernel wakes asyncio event loop.
+- Registered fd callback fires:
+  - Calls `_drain_recv_waiters()` directly (no intermediate deferral).
+  - `_drain_recv_waiters()` pops waiters, invokes each:
+    - Waiter calls `_try_recv()` -> succeeds, future resolved.
+- After draining, clears the parking flag and may re-enable recv in the
+  ReadinessSignal.
+
+**Wakeup path (Windows):**
+- Waiter future is pending.
+- send pump on tokio thread drains yring, calls `recv_ready.signal()`.
+- `WindowsSignal.signal()` sees `mode & WAKEUP_MODE_ASYNC` and directly
+  invokes the Python callback (`_schedule_recv_drain`).
+- Callback queues `_drain_recv_waiters()` to the asyncio event loop.
+- Event loop invokes `_drain_recv_waiters()` in main thread context:
+  - Pops waiters and invokes each.
+- After draining, calls `_mark_recv_drain_complete()` to clear Rust state.
+
+### Waiter queue drain logic (platform-independent)
+
+Both Unix and Windows converge on the same Python code for draining:
+
+```python
+def _drain_send_waiters(self):
+    try:
+        waiters = self._send_waiters
+        while waiters and waiters[0]():
+            waiters.popleft()
+    finally:
+        self._sock._mark_send_drain_complete()
+        # Race window: re-check for notifications that arrived
+        # between the loop end and mark_drain_complete().
+        while waiters and waiters[0]():
+            waiters.popleft()
+        # If waiters remain, re-enable async mode.
+        if waiters:
+            self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
+```
+
+Each waiter is a closure that attempts the operation (send/recv) and
+returns `True` if done or `False` if blocked. The drain stops when a
+waiter returns False, preserving queue order (fairness).
 
 ## Zero-copy conversions
 

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -49,38 +49,38 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,231.9 145.8,240.3 201.7,236.5 257.5,263.3 313.3,259.3 369.2,255.4 425.0,253.0 480.8,265.3 536.7,283.5 592.5,326.2 648.3,352.2 704.2,366.6 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,319.4 145.8,319.1 201.7,318.8 257.5,319.8 313.3,320.4 369.2,321.6 425.0,324.3 480.8,328.7 536.7,338.8 592.5,344.5 648.3,356.2 704.2,366.2 760.0,376.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,244.8 145.8,249.8 201.7,247.2 257.5,253.9 313.3,275.9 369.2,255.9 425.0,257.2 480.8,273.6 536.7,284.3 592.5,325.6 648.3,351.0 704.2,366.7 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,319.7 145.8,319.0 201.7,318.8 257.5,320.0 313.3,320.6 369.2,322.7 425.0,324.3 480.8,329.2 536.7,339.8 592.5,349.2 648.3,358.2 704.2,365.7 760.0,376.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,305.5 145.8,306.4 201.7,303.5 257.5,314.7 313.3,326.6 369.2,336.9 425.0,333.7 480.8,343.9 536.7,356.1 592.5,367.6 648.3,375.3 704.2,379.4 760.0,380.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,380.6 145.8,380.5 201.7,380.6 257.5,380.6 313.3,380.6 369.2,380.5 425.0,380.6 480.8,380.6 536.7,380.7 592.5,380.9 648.3,380.9 704.2,381.0 760.0,381.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.8 145.8,381.7 201.7,379.3 257.5,376.3 313.3,368.0 369.2,351.1 425.0,316.9 480.8,262.4 536.7,178.3 592.5,147.3 648.3,123.8 704.2,98.8 760.0,103.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="381.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="379.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="376.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="368.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="351.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="316.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="262.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="178.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="147.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="123.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="98.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="103.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.0 425.0,353.4 480.8,327.4 536.7,291.5 592.5,222.0 648.3,156.1 704.2,92.0 760.0,122.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,382.9 145.8,381.9 201.7,379.6 257.5,375.7 313.3,370.2 369.2,351.2 425.0,319.1 480.8,270.9 536.7,179.9 592.5,144.8 648.3,113.6 704.2,101.2 760.0,101.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="381.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="379.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="375.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="370.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="351.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="319.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="270.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="179.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="144.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="113.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="101.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="101.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.3 425.0,353.4 480.8,327.9 536.7,293.5 592.5,241.5 648.3,172.8 704.2,85.0 760.0,137.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="381.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="379.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="375.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="368.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="368.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="425.0" cy="353.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="327.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="291.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="222.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="156.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="92.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="122.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="327.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="293.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="241.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="172.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="85.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="137.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,383.4 145.8,382.8 201.7,381.4 257.5,379.6 313.3,376.7 369.2,371.9 425.0,358.3 480.8,342.9 536.7,326.9 592.5,316.6 648.3,313.1 704.2,309.2 760.0,261.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -159,34 +159,34 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,551.3 145.8,551.2 201.7,550.3 257.5,551.0 313.3,550.5 369.2,550.5 425.0,550.9 480.8,549.9 536.7,548.9 592.5,544.6 648.3,545.3 704.2,529.4 760.0,522.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="551.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="550.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="551.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="550.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="549.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="548.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="544.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="545.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="529.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,516.9 145.8,517.8 201.7,517.9 257.5,520.0 313.3,517.3 369.2,518.1 425.0,517.3 480.8,518.7 536.7,515.1 592.5,512.6 648.3,510.0 704.2,505.3 760.0,497.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="516.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="520.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="517.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="518.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="517.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="518.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="515.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="512.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="510.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="505.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="497.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,550.7 145.8,550.5 201.7,550.7 257.5,551.3 313.3,550.6 369.2,552.5 425.0,551.3 480.8,550.7 536.7,548.3 592.5,546.2 648.3,543.7 704.2,532.2 760.0,521.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="550.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="552.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="548.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="546.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="543.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="532.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="521.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,517.2 145.8,516.5 201.7,515.5 257.5,517.8 313.3,518.9 369.2,516.4 425.0,516.8 480.8,516.8 536.7,514.3 592.5,511.1 648.3,508.6 704.2,501.1 760.0,495.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="517.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="515.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="518.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="516.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="514.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="511.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="508.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="501.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="495.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,527.6 145.8,527.1 201.7,527.8 257.5,527.3 313.3,525.3 369.2,527.4 425.0,526.1 480.8,526.4 536.7,524.4 592.5,524.0 648.3,509.9 704.2,508.3 760.0,499.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="527.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -31,11 +31,14 @@ test = [
     "pytest>=7",
     "pytest-asyncio>=0.21",
     "pyzmq>=25",
+    "tornado>=6",
 ]
 lint = ["ruff"]
+type-check = ["ty"]
 dev = [
   { include-group = "test" },
   { include-group = "lint" },
+  { include-group = "type-check" },
 ]
 
 [project.urls]

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -29,12 +29,13 @@ classifiers = [
 [dependency-groups]
 test = [
     "pytest>=7",
-    "pytest-asyncio>=0.21",
+    "pytest-asyncio>=0.21,<1.4; python_version < '3.10'",
+    "pytest-asyncio>=1.4.0; python_version >= '3.10'",
     "pyzmq>=25",
     "tornado>=6",
 ]
-lint = ["ruff"]
-type-check = ["ty"]
+lint = ["ruff==0.15.22"]
+type-check = ["ty==0.0.63"]
 dev = [
   { include-group = "test" },
   { include-group = "lint" },
@@ -49,6 +50,12 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 addopts = "--ignore=tests/soak"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["E402", "E702", "F401", "F841"]
+
+[tool.ty.src]
+exclude = ["tests/soak/**"]
 
 [tool.maturin]
 # Stable ABI - one wheel covers all supported Python versions.

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -181,6 +181,7 @@ zmq_version_info = (4, 3, 4)
 
 # ── Top-level functions ──────────────────────────────────────────────
 
+
 def strerror(errnum):
     return os.strerror(errnum)
 
@@ -228,11 +229,26 @@ if hasattr(_native, "PeerInfo"):
 # ── Socket option attribute map ──────────────────────────────────────
 
 _TYPE_NAMES = {
-    PAIR: "PAIR", PUB: "PUB", SUB: "SUB", REQ: "REQ", REP: "REP",
-    DEALER: "DEALER", ROUTER: "ROUTER", PULL: "PULL", PUSH: "PUSH",
-    XPUB: "XPUB", XSUB: "XSUB", SERVER: "SERVER", CLIENT: "CLIENT",
-    RADIO: "RADIO", DISH: "DISH", GATHER: "GATHER", SCATTER: "SCATTER",
-    PEER: "PEER", CHANNEL: "CHANNEL", STREAM: "STREAM",
+    PAIR: "PAIR",
+    PUB: "PUB",
+    SUB: "SUB",
+    REQ: "REQ",
+    REP: "REP",
+    DEALER: "DEALER",
+    ROUTER: "ROUTER",
+    PULL: "PULL",
+    PUSH: "PUSH",
+    XPUB: "XPUB",
+    XSUB: "XSUB",
+    SERVER: "SERVER",
+    CLIENT: "CLIENT",
+    RADIO: "RADIO",
+    DISH: "DISH",
+    GATHER: "GATHER",
+    SCATTER: "SCATTER",
+    PEER: "PEER",
+    CHANNEL: "CHANNEL",
+    STREAM: "STREAM",
 }
 
 _SOCKOPT_NAMES = {
@@ -280,6 +296,7 @@ _SOCKOPT_NAMES = {
 
 
 # ── MessageTracker / Message / Frame (pyzmq compat) ─────────────────
+
 
 class NotDone(ZMQBaseError):
     pass
@@ -348,6 +365,7 @@ class Socket(metaclass=_SocketMeta):
     @classmethod
     def shadow(cls, socket):
         from . import asyncio as _zmq_async
+
         if isinstance(socket, _zmq_async.Socket):
             return _ShadowSocket(socket)
         return socket
@@ -611,8 +629,7 @@ class Socket(metaclass=_SocketMeta):
     def __del__(self):
         self.close()
 
-    def bind_to_random_port(self, addr, min_port=49152, max_port=65536,
-                            max_tries=100):
+    def bind_to_random_port(self, addr, min_port=49152, max_port=65536, max_tries=100):
         ep = self.bind(f"{addr}:0")
         if isinstance(ep, bytes):
             ep = ep.decode()
@@ -637,12 +654,14 @@ class Socket(metaclass=_SocketMeta):
 
 # ── Shadow socket (sync recv bridge over async handle) ──────────────
 
+
 class _ShadowSocket:
     """Blocking recv bridge over an async socket's native handle.
 
     Returned by Socket.shadow() when given a pyomq.asyncio.Socket.
     Provides sync recv via select() + eventfd without entering the
     asyncio event loop, matching pyzmq's shadow(underlying) behavior.
+
     """
 
     def __init__(self, async_socket):
@@ -798,16 +817,12 @@ class _ShadowSocket:
         return parts
 
     def send(self, data, flags=0, copy=True, track=False):
-        self._blocking_send(
-            lambda: self._native.send(data, flags)
-        )
+        self._blocking_send(lambda: self._native.send(data, flags))
         if track:
             return MessageTracker(_pending=True)
 
     def send_multipart(self, parts, flags=0, copy=True, track=False):
-        self._blocking_send(
-            lambda: self._native.send_multipart(parts, flags)
-        )
+        self._blocking_send(lambda: self._native.send_multipart(parts, flags))
         if track:
             return MessageTracker(_pending=True)
 
@@ -916,11 +931,15 @@ class Context:
         ns_bytes = ns_str.encode()
         if isinstance(endpoint, bytes):
             pfx = b"inproc://"
-            if endpoint.startswith(pfx) and not endpoint[len(pfx):].startswith(ns_bytes):
-                return pfx + ns_bytes + endpoint[len(pfx):]
+            if endpoint.startswith(pfx) and not endpoint[len(pfx) :].startswith(
+                ns_bytes
+            ):
+                return pfx + ns_bytes + endpoint[len(pfx) :]
         elif isinstance(endpoint, str):
-            if endpoint.startswith(_INPROC_PREFIX) and not endpoint[len(_INPROC_PREFIX):].startswith(ns_str):
-                return f"inproc://{ns_str}{endpoint[len(_INPROC_PREFIX):]}"
+            if endpoint.startswith(_INPROC_PREFIX) and not endpoint[
+                len(_INPROC_PREFIX) :
+            ].startswith(ns_str):
+                return f"inproc://{ns_str}{endpoint[len(_INPROC_PREFIX) :]}"
         return endpoint
 
     def __class_getitem__(cls, item):
@@ -994,6 +1013,7 @@ Context._socket_class = Socket
 
 # ── Poller ───────────────────────────────────────────────────────────
 
+
 class Poller:
     def __init__(self):
         self._sockets = {}  # native_socket_id -> (Socket, flags)
@@ -1016,23 +1036,18 @@ class Poller:
     def poll(self, timeout=None):
         if not self._sockets:
             return []
-        pollin_socks = [
-            s._sock
-            for k, (s, f) in self._sockets.items()
-            if f & POLLIN
-        ]
+        pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
         if not pollin_socks:
             return []
         t = None if (timeout is None or timeout < 0) else int(timeout)
         ready_ids = _native.wait_any(pollin_socks, t)
         return [
-            (self._sockets[rid][0], POLLIN)
-            for rid in ready_ids
-            if rid in self._sockets
+            (self._sockets[rid][0], POLLIN) for rid in ready_ids if rid in self._sockets
         ]
 
 
 # ── select ──────────────────────────────────────────────────────────
+
 
 def select(rlist, wlist, xlist, timeout=None):
     if timeout is not None:
@@ -1056,16 +1071,19 @@ def select(rlist, wlist, xlist, timeout=None):
 
 # ── proxy ────────────────────────────────────────────────────────────
 
+
 def proxy(frontend, backend, capture=None):
     _native.native_proxy(
-        frontend._sock, backend._sock,
+        frontend._sock,
+        backend._sock,
         capture._sock if capture is not None else None,
     )
 
 
 def proxy_steerable(frontend, backend, capture=None, control=None):
     _native.native_proxy(
-        frontend._sock, backend._sock,
+        frontend._sock,
+        backend._sock,
         capture._sock if capture is not None else None,
         control._sock if control is not None else None,
     )
@@ -1101,52 +1119,144 @@ __all__ = [
     "select",
     "error",
     # socket types
-    "PAIR", "PUB", "SUB", "REQ", "REP", "DEALER", "ROUTER",
-    "PULL", "PUSH", "XPUB", "XSUB", "STREAM",
+    "PAIR",
+    "PUB",
+    "SUB",
+    "REQ",
+    "REP",
+    "DEALER",
+    "ROUTER",
+    "PULL",
+    "PUSH",
+    "XPUB",
+    "XSUB",
+    "STREAM",
     # draft socket types
-    "SERVER", "CLIENT", "RADIO", "DISH", "GATHER", "SCATTER",
-    "PEER", "CHANNEL",
+    "SERVER",
+    "CLIENT",
+    "RADIO",
+    "DISH",
+    "GATHER",
+    "SCATTER",
+    "PEER",
+    "CHANNEL",
     # options
-    "AFFINITY", "IDENTITY", "ROUTING_ID", "SUBSCRIBE", "UNSUBSCRIBE",
-    "RCVMORE", "TYPE", "LINGER", "RECONNECT_IVL", "RECONNECT_IVL_MAX",
-    "BACKLOG", "MAXMSGSIZE", "SNDHWM", "RCVHWM", "RCVTIMEO", "SNDTIMEO",
-    "ROUTER_MANDATORY", "IMMEDIATE", "IPV6",
-    "HEARTBEAT_IVL", "HEARTBEAT_TTL", "HEARTBEAT_TIMEOUT",
-    "HANDSHAKE_IVL", "CONFLATE",
-    "TCP_KEEPALIVE", "TCP_KEEPALIVE_IDLE", "TCP_KEEPALIVE_CNT",
+    "AFFINITY",
+    "IDENTITY",
+    "ROUTING_ID",
+    "SUBSCRIBE",
+    "UNSUBSCRIBE",
+    "RCVMORE",
+    "TYPE",
+    "LINGER",
+    "RECONNECT_IVL",
+    "RECONNECT_IVL_MAX",
+    "BACKLOG",
+    "MAXMSGSIZE",
+    "SNDHWM",
+    "RCVHWM",
+    "RCVTIMEO",
+    "SNDTIMEO",
+    "ROUTER_MANDATORY",
+    "IMMEDIATE",
+    "IPV6",
+    "HEARTBEAT_IVL",
+    "HEARTBEAT_TTL",
+    "HEARTBEAT_TIMEOUT",
+    "HANDSHAKE_IVL",
+    "CONFLATE",
+    "TCP_KEEPALIVE",
+    "TCP_KEEPALIVE_IDLE",
+    "TCP_KEEPALIVE_CNT",
     "TCP_KEEPALIVE_INTVL",
-    "SNDMORE", "NOBLOCK", "DONTWAIT",
-    "CURVE_SERVER", "CURVE_PUBLICKEY", "CURVE_SECRETKEY", "CURVE_SERVERKEY",
-    "OMQ_ON_MUTE", "OMQ_COMPRESSION_DICT",
+    "SNDMORE",
+    "NOBLOCK",
+    "DONTWAIT",
+    "CURVE_SERVER",
+    "CURVE_PUBLICKEY",
+    "CURVE_SECRETKEY",
+    "CURVE_SERVERKEY",
+    "OMQ_ON_MUTE",
+    "OMQ_COMPRESSION_DICT",
     "OMQ_COMPRESSION_AUTO_TRAIN",
-    "OMQ_ON_MUTE_BLOCK", "OMQ_ON_MUTE_DROP_NEWEST", "OMQ_ON_MUTE_DROP_OLDEST",
+    "OMQ_ON_MUTE_BLOCK",
+    "OMQ_ON_MUTE_DROP_NEWEST",
+    "OMQ_ON_MUTE_DROP_OLDEST",
     # poll / compat constants
-    "POLLIN", "POLLOUT", "POLLERR", "POLLPRI", "HWM",
+    "POLLIN",
+    "POLLOUT",
+    "POLLERR",
+    "POLLPRI",
+    "HWM",
     # additional compat constants
-    "LAST_ENDPOINT", "FD", "EVENTS", "MECHANISM", "SNDBUF", "RCVBUF",
-    "RATE", "CONNECT_TIMEOUT", "XPUB_VERBOSE", "PROBE_ROUTER",
-    "REQ_CORRELATE", "REQ_RELAXED", "ROUTER_HANDOVER", "IPV4ONLY",
-    "TCP_ACCEPT_FILTER", "TCP_MAXRT", "MULTICAST_HOPS", "RECOVERY_IVL",
-    "RECONNECT_STOP", "PLAIN_SERVER", "PLAIN_USERNAME", "PLAIN_PASSWORD",
+    "LAST_ENDPOINT",
+    "FD",
+    "EVENTS",
+    "MECHANISM",
+    "SNDBUF",
+    "RCVBUF",
+    "RATE",
+    "CONNECT_TIMEOUT",
+    "XPUB_VERBOSE",
+    "PROBE_ROUTER",
+    "REQ_CORRELATE",
+    "REQ_RELAXED",
+    "ROUTER_HANDOVER",
+    "IPV4ONLY",
+    "TCP_ACCEPT_FILTER",
+    "TCP_MAXRT",
+    "MULTICAST_HOPS",
+    "RECOVERY_IVL",
+    "RECONNECT_STOP",
+    "PLAIN_SERVER",
+    "PLAIN_USERNAME",
+    "PLAIN_PASSWORD",
     "ZAP_DOMAIN",
     # device types
-    "FORWARDER", "QUEUE", "STREAMER",
+    "FORWARDER",
+    "QUEUE",
+    "STREAMER",
     # security mechanism constants
-    "NULL", "PLAIN", "CURVE",
+    "NULL",
+    "PLAIN",
+    "CURVE",
     # version
-    "__version__", "zmq_version_info", "zmq_version",
-    "pyomq_version", "pyomq_version_info",
+    "__version__",
+    "zmq_version_info",
+    "zmq_version",
+    "pyomq_version",
+    "pyomq_version_info",
     # errno constants
-    "EAGAIN", "ENOTSUP", "EINVAL", "EFAULT", "ENOMEM", "ENODEV",
-    "EMSGSIZE", "EAFNOSUPPORT", "ENETUNREACH", "ECONNABORTED",
-    "ECONNRESET", "ENOTCONN", "ETIMEDOUT", "EHOSTUNREACH", "ENETRESET",
-    "EADDRINUSE", "EADDRNOTAVAIL",
+    "EAGAIN",
+    "ENOTSUP",
+    "EINVAL",
+    "EFAULT",
+    "ENOMEM",
+    "ENODEV",
+    "EMSGSIZE",
+    "EAFNOSUPPORT",
+    "ENETUNREACH",
+    "ECONNABORTED",
+    "ECONNRESET",
+    "ENOTCONN",
+    "ETIMEDOUT",
+    "EHOSTUNREACH",
+    "ENETRESET",
+    "EADDRINUSE",
+    "EADDRNOTAVAIL",
     # pyzmq compat types
-    "NotDone", "MessageTracker", "Message", "Frame",
+    "NotDone",
+    "MessageTracker",
+    "Message",
+    "Frame",
     # extra constants
-    "ETERM", "ENOTSOCK", "COPY_THRESHOLD",
+    "ETERM",
+    "ENOTSOCK",
+    "COPY_THRESHOLD",
     # curve
-    "curve_keypair", "curve_public", "PeerInfo",
+    "curve_keypair",
+    "curve_public",
+    "PeerInfo",
 ]
 
 
@@ -1156,6 +1266,7 @@ __all__ = [
 # mock-based tests and heartbeat code can construct ZMQError(errno, msg).
 _orig_zmqerror_init = _native.ZMQError.__init__
 
+
 def _zmqerror_init(self, *args, **kwargs):
     if args and isinstance(args[0], int):
         _orig_zmqerror_init(self, args[1] if len(args) > 1 else "")
@@ -1163,5 +1274,6 @@ def _zmqerror_init(self, *args, **kwargs):
         self.strerror = args[1] if len(args) > 1 else ""
     else:
         _orig_zmqerror_init(self, *args, **kwargs)
+
 
 _native.ZMQError.__init__ = _zmqerror_init

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -770,6 +770,9 @@ class _ShadowSocket:
                         return result
             finally:
                 self._recv_waiter_pending = False
+                self._async_socket._clear_wakeup_modes(
+                    recv_mode=_WAKEUP_MODE_SYNC,
+                )
     else:
 
         def _blocking_recv(self, try_fn):
@@ -857,6 +860,9 @@ class _ShadowSocket:
                             raise error.from_native(e) from None
             finally:
                 self._send_waiter_pending = False
+                self._async_socket._clear_wakeup_modes(
+                    send_mode=_WAKEUP_MODE_SYNC,
+                )
     else:
 
         def _blocking_send(self, send_fn):

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -19,6 +19,7 @@ import json
 import os
 import pickle
 import select as _select
+import sys
 import threading
 import weakref
 
@@ -113,6 +114,10 @@ POLLOUT = 2
 POLLERR = 4
 POLLPRI = 32
 HWM = 1
+_WAKEUP_MODE_NONE = 0
+_WAKEUP_MODE_ASYNC = 1
+_WAKEUP_MODE_SYNC = 2
+_IS_WINDOWS = sys.platform == "win32"
 
 ROUTING_ID = 5
 LAST_ENDPOINT = 32
@@ -646,6 +651,11 @@ class _ShadowSocket:
         self._context = async_socket._context
         self._closed = False
         self._last_endpoint = async_socket._last_endpoint
+        if _IS_WINDOWS:
+            self._recv_waiter_pending = False
+            self._send_waiter_pending = False
+            self._recv_wakeup_event = async_socket._recv_wakeup_event
+            self._send_wakeup_event = async_socket._send_wakeup_event
 
     def __getattr__(self, name):
         opt = _SOCKOPT_NAMES.get(name)
@@ -701,16 +711,49 @@ class _ShadowSocket:
     def get(self, option):
         return self.getsockopt(option)
 
-    def _blocking_recv(self, try_fn):
-        try:
-            result = try_fn()
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-        if result is not None:
-            return result
+    if _IS_WINDOWS:
 
-        fd = self._native._recv_fd()
-        try:
+        def _register_wakeup_hooks(self):
+            self._async_socket._register_wakeup_hooks()
+    else:
+
+        def _register_wakeup_hooks(self):
+            return None
+
+    if _IS_WINDOWS:
+
+        def _blocking_recv(self, try_fn):
+            if self._recv_waiter_pending:
+                raise RuntimeError(
+                    "cannot have more than one pending recv waiter on a shadow socket"
+                )
+            self._recv_waiter_pending = True
+            self._register_wakeup_hooks()
+            self._async_socket._set_wakeup_modes(
+                recv_mode=_WAKEUP_MODE_SYNC,
+            )
+            try:
+                try:
+                    result = try_fn()
+                except _native.ZMQError as e:
+                    raise error.from_native(e) from None
+                if result is not None:
+                    return result
+
+                while True:
+                    self._recv_wakeup_event.clear()
+                    self._recv_wakeup_event.wait()
+                    try:
+                        result = try_fn()
+                    except _native.ZMQError as e:
+                        raise error.from_native(e) from None
+                    if result is not None:
+                        return result
+            finally:
+                self._recv_waiter_pending = False
+    else:
+
+        def _blocking_recv(self, try_fn):
             try:
                 result = try_fn()
             except _native.ZMQError as e:
@@ -718,20 +761,29 @@ class _ShadowSocket:
             if result is not None:
                 return result
 
-            while True:
-                _select.select([fd], [], [])
-                try:
-                    os.read(fd, 8)
-                except OSError:
-                    pass
+            fd = self._native._recv_fd()
+            try:
                 try:
                     result = try_fn()
                 except _native.ZMQError as e:
                     raise error.from_native(e) from None
                 if result is not None:
                     return result
-        finally:
-            os.close(fd)
+
+                while True:
+                    _select.select([fd], [], [])
+                    try:
+                        os.read(fd, 8)
+                    except OSError:
+                        pass
+                    try:
+                        result = try_fn()
+                    except _native.ZMQError as e:
+                        raise error.from_native(e) from None
+                    if result is not None:
+                        return result
+            finally:
+                os.close(fd)
 
     def recv(self, flags=0, copy=True, track=False):
         data = self._blocking_recv(self._native._try_recv)
@@ -759,16 +811,40 @@ class _ShadowSocket:
         if track:
             return MessageTracker(_pending=True)
 
-    def _blocking_send(self, send_fn):
-        try:
-            send_fn()
-            return
-        except _native.ZMQError as e:
-            if getattr(e, "errno", None) != _errno.EAGAIN:
-                raise error.from_native(e) from None
+    if _IS_WINDOWS:
 
-        fd = self._native._send_fd()
-        try:
+        def _blocking_send(self, send_fn):
+            if self._send_waiter_pending:
+                raise RuntimeError(
+                    "cannot have more than one pending send waiter on a shadow socket"
+                )
+            self._send_waiter_pending = True
+            self._register_wakeup_hooks()
+            self._async_socket._set_wakeup_modes(
+                send_mode=_WAKEUP_MODE_SYNC,
+            )
+            try:
+                try:
+                    send_fn()
+                    return
+                except _native.ZMQError as e:
+                    if getattr(e, "errno", None) != _errno.EAGAIN:
+                        raise error.from_native(e) from None
+
+                while True:
+                    self._send_wakeup_event.clear()
+                    self._send_wakeup_event.wait()
+                    try:
+                        send_fn()
+                        return
+                    except _native.ZMQError as e:
+                        if getattr(e, "errno", None) != _errno.EAGAIN:
+                            raise error.from_native(e) from None
+            finally:
+                self._send_waiter_pending = False
+    else:
+
+        def _blocking_send(self, send_fn):
             try:
                 send_fn()
                 return
@@ -776,20 +852,29 @@ class _ShadowSocket:
                 if getattr(e, "errno", None) != _errno.EAGAIN:
                     raise error.from_native(e) from None
 
-            while True:
-                _select.select([fd], [], [])
-                try:
-                    os.read(fd, 8)
-                except OSError:
-                    pass
+            fd = self._native._send_fd()
+            try:
                 try:
                     send_fn()
                     return
                 except _native.ZMQError as e:
                     if getattr(e, "errno", None) != _errno.EAGAIN:
                         raise error.from_native(e) from None
-        finally:
-            os.close(fd)
+
+                while True:
+                    _select.select([fd], [], [])
+                    try:
+                        os.read(fd, 8)
+                    except OSError:
+                        pass
+                    try:
+                        send_fn()
+                        return
+                    except _native.ZMQError as e:
+                        if getattr(e, "errno", None) != _errno.EAGAIN:
+                            raise error.from_native(e) from None
+            finally:
+                os.close(fd)
 
     def close(self, linger=None):
         pass

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -23,10 +23,10 @@ import sys
 import threading
 import weakref
 
-from . import _native  # type: ignore[attr-defined]
+from . import _native  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from . import error as error  # noqa: F401
 
-from ._native import (  # type: ignore[attr-defined]
+from ._native import (  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
     backend_name,
     version,
     # Socket types

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -331,15 +331,13 @@ Frame = Message
 
 # ── Socket wrapper ───────────────────────────────────────────────────
 
-import sys as _sys
-
 
 class _SocketMeta(type):
     def __instancecheck__(cls, instance):
         if type.__instancecheck__(cls, instance):
             return True
         if cls is Socket:
-            amod = _sys.modules.get("pyomq.asyncio")
+            amod = sys.modules.get("pyomq.asyncio")
             if amod is not None and type.__instancecheck__(amod.Socket, instance):
                 return True
         return False
@@ -761,6 +759,12 @@ class _ShadowSocket:
 
                 while True:
                     self._recv_wakeup_event.clear()
+                    try:
+                        result = try_fn()
+                    except _native.ZMQError as e:
+                        raise error.from_native(e) from None
+                    if result is not None:
+                        return result
                     self._recv_wakeup_event.wait()
                     try:
                         result = try_fn()
@@ -851,6 +855,12 @@ class _ShadowSocket:
 
                 while True:
                     self._send_wakeup_event.clear()
+                    try:
+                        send_fn()
+                        return
+                    except _native.ZMQError as e:
+                        if getattr(e, "errno", None) != _errno.EAGAIN:
+                            raise error.from_native(e) from None
                     self._send_wakeup_event.wait()
                     try:
                         send_fn()

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -25,8 +25,15 @@ from . import error
 from . import Context as _SyncContext
 from . import _next_ctx_id
 from . import (
-    FD, POLLIN, POLLOUT, SNDHWM, RCVHWM, LINGER, TYPE, LAST_ENDPOINT,
-    _TYPE_NAMES, _SOCKOPT_NAMES,
+    FD,
+    POLLIN,
+    SNDHWM,
+    RCVHWM,
+    LINGER,
+    LAST_ENDPOINT,
+    _TYPE_NAMES,
+    _SOCKOPT_NAMES,
+    _IS_WINDOWS,
 )
 
 
@@ -140,7 +147,7 @@ class _RecvFuture:
                 return
             if r is not None:
                 try:
-                    os.write(fd, b'\x01\x00\x00\x00\x00\x00\x00\x00')
+                    os.write(fd, b"\x01\x00\x00\x00\x00\x00\x00\x00")
                 except OSError:
                     pass
                 loop.remove_reader(fd)
@@ -266,9 +273,11 @@ class Socket:
     def recv(self, flags=0, copy=True, track=False):
         if not copy:
             from pyomq import Frame
+
             async def _wrap():
                 data = await self._add_recv_event(self._sock._try_recv)
                 return Frame(data)
+
             return asyncio.ensure_future(_wrap())
         return self._add_recv_event(self._sock._try_recv)
 
@@ -284,9 +293,11 @@ class Socket:
     def recv_multipart(self, flags=0, copy=True, track=False):
         if not copy:
             from pyomq import Frame
+
             async def _wrap():
                 parts = await self._add_recv_event(self._sock._try_recv_multipart)
                 return [Frame(p) for p in parts]
+
             return asyncio.ensure_future(_wrap())
         return self._add_recv_event(self._sock._try_recv_multipart)
 
@@ -314,6 +325,7 @@ class Socket:
 
     def _send_with_backpressure(self, data, flags):
         fd = self._sock._send_fd()
+
         def try_send():
             try:
                 self._sock.send(data, flags)
@@ -322,10 +334,12 @@ class Socket:
                 if e.errno == _EAGAIN:
                     return None
                 raise
+
         return _RecvFuture(try_send, fd)
 
     def _send_multipart_with_backpressure(self, parts, flags):
         fd = self._sock._send_fd()
+
         def try_send():
             try:
                 self._sock.send_multipart(parts, flags)
@@ -334,6 +348,7 @@ class Socket:
                 if e.errno == _EAGAIN:
                     return None
                 raise
+
         return _RecvFuture(try_send, fd)
 
     # ── Serialization helpers ────────────────────────────────────────
@@ -345,9 +360,7 @@ class Socket:
         return (await self.recv(flags)).decode(encoding)
 
     def send_json(self, obj, flags=0, **kwargs):
-        return self.send(
-            json.dumps(obj, **kwargs).encode("utf-8"), flags
-        )
+        return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
     async def recv_json(self, flags=0, **kwargs):
         return json.loads(await self.recv(flags), **kwargs)
@@ -358,11 +371,9 @@ class Socket:
     async def recv_pyobj(self, flags=0):
         return pickle.loads(await self.recv(flags))
 
-    def send_serialized(self, msg, serialize, flags=0, copy=True,
-                        **kwargs):
+    def send_serialized(self, msg, serialize, flags=0, copy=True, **kwargs):
         frames = serialize(msg)
-        return self.send_multipart(frames, flags=flags, copy=copy,
-                                   **kwargs)
+        return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
     async def recv_serialized(self, deserialize, flags=0, copy=True):
         frames = await self.recv_multipart(flags=flags, copy=copy)
@@ -378,6 +389,7 @@ class Socket:
 
     def getsockopt(self, option):
         from pyomq import LAST_ENDPOINT
+
         if option == LAST_ENDPOINT:
             return self._last_endpoint
         try:
@@ -410,6 +422,7 @@ class Socket:
             raise error.from_native(e) from None
         except AttributeError:
             from . import ZMQNotImplementedError
+
             raise ZMQNotImplementedError("curve feature not compiled")
 
     def set_hwm(self, value):
@@ -520,22 +533,14 @@ class Poller:
     async def poll(self, timeout=None):
         if not self._sockets:
             return []
-        pollin_socks = [
-            s._sock
-            for k, (s, f) in self._sockets.items()
-            if f & POLLIN
-        ]
+        pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
         if not pollin_socks:
             return []
         t = None if (timeout is None or timeout < 0) else int(timeout)
         loop = asyncio.get_running_loop()
-        ready_ids = await loop.run_in_executor(
-            None, _native.wait_any, pollin_socks, t
-        )
+        ready_ids = await loop.run_in_executor(None, _native.wait_any, pollin_socks, t)
         return [
-            (self._sockets[rid][0], POLLIN)
-            for rid in ready_ids
-            if rid in self._sockets
+            (self._sockets[rid][0], POLLIN) for rid in ready_ids if rid in self._sockets
         ]
 
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -324,9 +324,13 @@ class Socket:
         def _set_wakeup_modes(self, *, recv_mode=None, send_mode=None):
             self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
+        def _clear_wakeup_modes(self, *, recv_mode=None, send_mode=None):
+            self._sock._clear_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
+
         def _schedule_recv_drain(self):
             loop = self._loop
             if loop is None or loop.is_closed():
+                self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
                 self._sock._mark_recv_drain_complete()
                 return
             loop.call_soon_threadsafe(self._drain_recv_waiters)
@@ -334,6 +338,7 @@ class Socket:
         def _schedule_send_drain(self):
             loop = self._loop
             if loop is None or loop.is_closed():
+                self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
                 self._sock._mark_send_drain_complete()
                 return
             loop.call_soon_threadsafe(self._drain_send_waiters)
@@ -350,6 +355,10 @@ class Socket:
                 # the end of the try block and the call to _mark_recv_drain_complete.
                 while waiters and waiters[0]():
                     waiters.popleft()
+                if waiters:
+                    self._set_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
+                else:
+                    self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
 
         def _drain_send_waiters(self):
             """Invoke each waiter until one returns False (not ready)."""
@@ -360,11 +369,15 @@ class Socket:
             finally:
                 self._sock._mark_send_drain_complete()
                 # Ensure we drain any notification that arrived in between
-                # the end of the try block and the call to _mark_recv_drain_complete.
+                # the end of the try block and the call to _mark_send_drain_complete.
                 while waiters and waiters[0]():
                     waiters.popleft()
+                if waiters:
+                    self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
+                else:
+                    self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
 
-        def _add_waitable(self, try_fn, waiters, set_mode):
+        def _add_waitable(self, try_fn, waiters, set_mode, clear_mode):
             """Register a Windows waiter that resolves when try_fn returns
             non-None. try_fn must return None when not ready and raise on
             real errors."""
@@ -405,6 +418,8 @@ class Socket:
                 # Queue might have been modified by drain callback (race condition).
                 # This is OK - drain already processed the waiter and marked it done.
                 pass
+            if not waiters:
+                clear_mode()
 
             return fut
 
@@ -419,6 +434,7 @@ class Socket:
                 safe_try,
                 self._recv_waiters,
                 lambda: self._set_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC),
+                lambda: self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC),
             )
 
         def _send_with_backpressure(self, data, flags):
@@ -435,6 +451,7 @@ class Socket:
                 try_send,
                 self._send_waiters,
                 lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
+                lambda: self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
             )
 
         def _send_multipart_with_backpressure(self, parts, flags):
@@ -451,6 +468,7 @@ class Socket:
                 try_send,
                 self._send_waiters,
                 lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
+                lambda: self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
             )
     else:
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -346,6 +346,10 @@ class Socket:
                     waiters.popleft()
             finally:
                 self._sock._mark_recv_drain_complete()
+                # Ensure we drain any notification that arrived in between
+                # the end of the try block and the call to _mark_recv_drain_complete.
+                while waiters and waiters[0]():
+                    waiters.popleft()
 
         def _drain_send_waiters(self):
             """Invoke each waiter until one returns False (not ready)."""
@@ -355,6 +359,10 @@ class Socket:
                     waiters.popleft()
             finally:
                 self._sock._mark_send_drain_complete()
+                # Ensure we drain any notification that arrived in between
+                # the end of the try block and the call to _mark_recv_drain_complete.
+                while waiters and waiters[0]():
+                    waiters.popleft()
 
         def _add_waitable(self, try_fn, waiters, set_mode):
             """Register a Windows waiter that resolves when try_fn returns
@@ -386,8 +394,17 @@ class Socket:
 
             waiters.append(_waiter)
             set_mode()
-            if _waiter():
-                waiters.remove(_waiter)
+            # Try once more immediately; if ready, remove from queue before returning.
+            # This must happen before we return the future to the caller.
+            # Catch ValueError in case drain callback already processed this waiter (race).
+            try:
+                if _waiter():
+                    # Successfully resolved, remove from queue so drain doesn't process it.
+                    waiters.remove(_waiter)
+            except ValueError:
+                # Queue might have been modified by drain callback (race condition).
+                # This is OK - drain already processed the waiter and marked it done.
+                pass
 
             return fut
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -14,11 +14,15 @@ Use::
 """
 
 import asyncio
+import errno as _errno
 import json
 import os
 import pickle
+import select as _select
+import sys
 import threading
 import weakref
+from collections import deque
 
 from . import _native  # type: ignore[attr-defined]
 from . import error
@@ -33,8 +37,12 @@ from . import (
     LAST_ENDPOINT,
     _TYPE_NAMES,
     _SOCKOPT_NAMES,
-    _IS_WINDOWS,
 )
+
+_IS_WINDOWS = sys.platform == "win32"
+_WAKEUP_MODE_NONE = 0
+_WAKEUP_MODE_ASYNC = 1
+_WAKEUP_MODE_SYNC = 2
 
 
 def _resolved_future(result):
@@ -43,9 +51,6 @@ def _resolved_future(result):
     fut.set_result(result)
     return fut
 
-
-import errno as _errno
-import select as _select
 
 _EAGAIN = _errno.EAGAIN
 _MISSING = object()
@@ -170,18 +175,21 @@ class Socket:
     _context: "Context"
     _closed: bool
 
-    def __init__(self, _sock, _context):
+    def _init_socket_state(self, _sock, _context):
         self._sock = _sock
         self._context = _context
         self._closed = False
         self._last_endpoint = None
         if _IS_WINDOWS:
             self._loop = None
-            self._recv_waiters = None
-            self._send_waiters = None
+            self._recv_waiters = deque()
+            self._send_waiters = deque()
             self._recv_wakeup_event = threading.Event()
             self._send_wakeup_event = threading.Event()
             self._wakeup_registered = False
+
+    def __init__(self, _sock, _context):
+        self._init_socket_state(_sock, _context)
 
     def __getattr__(self, name):
         opt = _SOCKOPT_NAMES.get(name)
@@ -301,55 +309,183 @@ class Socket:
             return asyncio.ensure_future(_wrap())
         return self._add_recv_event(self._sock._try_recv_multipart)
 
-    def _add_recv_event(self, try_fn):
-        # Fast path: message already available, no event loop needed.
-        try:
-            result = try_fn()
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-        if result is not None:
-            return _resolved_future(result)
+    if _IS_WINDOWS:
 
-        fd = self._sock._recv_fd()
+        def _register_wakeup_hooks(self):
+            if not self._wakeup_registered:
+                self._sock._set_wakeup_hooks(
+                    recv_async=self._schedule_recv_drain,
+                    recv_event=self._recv_wakeup_event,
+                    send_async=self._schedule_send_drain,
+                    send_event=self._send_wakeup_event,
+                )
+                self._wakeup_registered = True
 
-        try:
-            result = try_fn()
-        except _native.ZMQError as e:
-            os.close(fd)
-            raise error.from_native(e) from None
-        if result is not None:
-            os.close(fd)
-            return _resolved_future(result)
+        def _set_wakeup_modes(self, *, recv_mode=None, send_mode=None):
+            self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
-        return _RecvFuture(try_fn, fd)
+        def _schedule_recv_drain(self):
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                self._sock._mark_recv_drain_complete()
+                return
+            loop.call_soon_threadsafe(self._drain_recv_waiters)
 
-    def _send_with_backpressure(self, data, flags):
-        fd = self._sock._send_fd()
+        def _schedule_send_drain(self):
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                self._sock._mark_send_drain_complete()
+                return
+            loop.call_soon_threadsafe(self._drain_send_waiters)
 
-        def try_send():
+        def _drain_recv_waiters(self):
+            """Invoke each waiter until one returns False (not ready)."""
             try:
-                self._sock.send(data, flags)
-                return True
-            except _native.ZMQError as e:
-                if e.errno == _EAGAIN:
-                    return None
-                raise
+                waiters = self._recv_waiters
+                while waiters and waiters[0]():
+                    waiters.popleft()
+            finally:
+                self._sock._mark_recv_drain_complete()
 
-        return _RecvFuture(try_send, fd)
-
-    def _send_multipart_with_backpressure(self, parts, flags):
-        fd = self._sock._send_fd()
-
-        def try_send():
+        def _drain_send_waiters(self):
+            """Invoke each waiter until one returns False (not ready)."""
             try:
-                self._sock.send_multipart(parts, flags)
-                return True
-            except _native.ZMQError as e:
-                if e.errno == _EAGAIN:
-                    return None
-                raise
+                waiters = self._send_waiters
+                while waiters and waiters[0]():
+                    waiters.popleft()
+            finally:
+                self._sock._mark_send_drain_complete()
 
-        return _RecvFuture(try_send, fd)
+        def _add_waitable(self, try_fn, waiters, set_mode):
+            """Register a Windows waiter that resolves when try_fn returns
+            non-None. try_fn must return None when not ready and raise on
+            real errors."""
+            loop = asyncio.get_running_loop()
+            self._loop = loop
+
+            result = try_fn()
+            if result is not None:
+                return _resolved_future(result)
+
+            self._register_wakeup_hooks()
+            fut = loop.create_future()
+
+            def _waiter() -> bool:
+                if fut.done():
+                    return True
+                try:
+                    result = try_fn()
+                except Exception as e:
+                    if not fut.done():
+                        fut.set_exception(e)
+                    return True
+                if result is not None and not fut.done():
+                    fut.set_result(result)
+                    return True
+                return False
+
+            waiters.append(_waiter)
+            set_mode()
+            if _waiter():
+                waiters.remove(_waiter)
+
+            return fut
+
+        def _add_recv_event(self, try_fn):
+            def safe_try():
+                try:
+                    return try_fn()
+                except _native.ZMQError as e:
+                    raise error.from_native(e) from None
+
+            return self._add_waitable(
+                safe_try,
+                self._recv_waiters,
+                lambda: self._set_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC),
+            )
+
+        def _send_with_backpressure(self, data, flags):
+            def try_send():
+                try:
+                    self._sock.send(data, flags)
+                    return True
+                except _native.ZMQError as e:
+                    if e.errno == _errno.EAGAIN:
+                        return None
+                    raise error.from_native(e) from None
+
+            return self._add_waitable(
+                try_send,
+                self._send_waiters,
+                lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
+            )
+
+        def _send_multipart_with_backpressure(self, parts, flags):
+            def try_send():
+                try:
+                    self._sock.send_multipart(parts, flags)
+                    return True
+                except _native.ZMQError as e:
+                    if e.errno == _errno.EAGAIN:
+                        return None
+                    raise error.from_native(e) from None
+
+            return self._add_waitable(
+                try_send,
+                self._send_waiters,
+                lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
+            )
+    else:
+
+        def _add_recv_event(self, try_fn):
+            # Fast path: message already available, no event loop needed.
+            try:
+                result = try_fn()
+            except _native.ZMQError as e:
+                raise error.from_native(e) from None
+            if result is not None:
+                return _resolved_future(result)
+
+            fd = self._sock._recv_fd()
+
+            try:
+                result = try_fn()
+            except _native.ZMQError as e:
+                os.close(fd)
+                raise error.from_native(e) from None
+            if result is not None:
+                os.close(fd)
+                return _resolved_future(result)
+
+            return _RecvFuture(try_fn, fd)
+
+        def _send_with_backpressure(self, data, flags):
+            fd = self._sock._send_fd()
+
+            def try_send():
+                try:
+                    self._sock.send(data, flags)
+                    return True
+                except _native.ZMQError as e:
+                    if e.errno == _errno.EAGAIN:
+                        return None
+                    raise
+
+            return _RecvFuture(try_send, fd)
+
+        def _send_multipart_with_backpressure(self, parts, flags):
+            fd = self._sock._send_fd()
+
+            def try_send():
+                try:
+                    self._sock.send_multipart(parts, flags)
+                    return True
+                except _native.ZMQError as e:
+                    if e.errno == _errno.EAGAIN:
+                        return None
+                    raise
+
+            return _RecvFuture(try_send, fd)
 
     # ── Serialization helpers ────────────────────────────────────────
 
@@ -460,23 +596,6 @@ class Socket:
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    # ── Windows wakeup integration ───────────────────────────────────
-
-    if _IS_WINDOWS:
-
-        def _register_wakeup_hooks(self):
-            if not self._wakeup_registered:
-                self._sock._set_wakeup_hooks(
-                    recv_async=None,
-                    recv_event=self._recv_wakeup_event,
-                    send_async=None,
-                    send_event=self._send_wakeup_event,
-                )
-                self._wakeup_registered = True
-
-        def _set_wakeup_modes(self, *, recv_mode=None, send_mode=None):
-            self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
-
     # ── Lifecycle ────────────────────────────────────────────────────
 
     def close(self, linger=None):
@@ -573,6 +692,7 @@ class Context(_SyncContext):
         s._pid = os.getpid()
         s._binds = []
         s._connects = []
+        s._init_socket_state(native, self)
         self._sockets.add(s)
         return s
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import os
 import pickle
+import threading
 import weakref
 
 from . import _native  # type: ignore[attr-defined]
@@ -167,6 +168,13 @@ class Socket:
         self._context = _context
         self._closed = False
         self._last_endpoint = None
+        if _IS_WINDOWS:
+            self._loop = None
+            self._recv_waiters = None
+            self._send_waiters = None
+            self._recv_wakeup_event = threading.Event()
+            self._send_wakeup_event = threading.Event()
+            self._wakeup_registered = False
 
     def __getattr__(self, name):
         opt = _SOCKOPT_NAMES.get(name)
@@ -438,6 +446,23 @@ class Socket:
             return self._sock.leave(group)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
+
+    # ── Windows wakeup integration ───────────────────────────────────
+
+    if _IS_WINDOWS:
+
+        def _register_wakeup_hooks(self):
+            if not self._wakeup_registered:
+                self._sock._set_wakeup_hooks(
+                    recv_async=None,
+                    recv_event=self._recv_wakeup_event,
+                    send_async=None,
+                    send_event=self._send_wakeup_event,
+                )
+                self._wakeup_registered = True
+
+        def _set_wakeup_modes(self, *, recv_mode=None, send_mode=None):
+            self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
     # ── Lifecycle ────────────────────────────────────────────────────
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -345,11 +345,13 @@ class Socket:
 
         def _drain_recv_waiters(self):
             """Invoke each waiter until one returns False (not ready)."""
+            waiters = self._recv_waiters
             try:
-                waiters = self._recv_waiters
                 while waiters and waiters[0]():
                     waiters.popleft()
             finally:
+                if not waiters:
+                    self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
                 self._sock._mark_recv_drain_complete()
                 # Ensure we drain any notification that arrived in between
                 # the end of the try block and the call to _mark_recv_drain_complete.
@@ -362,11 +364,13 @@ class Socket:
 
         def _drain_send_waiters(self):
             """Invoke each waiter until one returns False (not ready)."""
+            waiters = self._send_waiters
             try:
-                waiters = self._send_waiters
                 while waiters and waiters[0]():
                     waiters.popleft()
             finally:
+                if not waiters:
+                    self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
                 self._sock._mark_send_drain_complete()
                 # Ensure we drain any notification that arrived in between
                 # the end of the try block and the call to _mark_send_drain_complete.

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -61,7 +61,7 @@ class _DoneFuture:
 
     def __await__(self):
         return
-        yield  # noqa: unreachable -- makes this a generator
+        yield  # makes this a generator
 
     def result(self):
         return None

--- a/bindings/pyomq/python/pyomq/error.py
+++ b/bindings/pyomq/python/pyomq/error.py
@@ -8,8 +8,8 @@ pyzmq's hierarchy. ``ZMQBindError`` is a sibling of ``ZMQError`` under
 import builtins
 import errno as _errno
 
-from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]
-from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]
+from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
+from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 
 
 class Again(ZMQError):

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -421,8 +421,12 @@ import os; os._exit(0)
         stdin=subprocess.PIPE,
         text=True,
     )
+    push_stdout = push_proc.stdout
+    push_stdin = push_proc.stdin
+    assert push_stdout is not None
+    assert push_stdin is not None
     try:
-        port_line = push_proc.stdout.readline().strip()
+        port_line = push_stdout.readline().strip()
         if not port_line:
             push_proc.terminate()
             push_proc.wait(timeout=5)
@@ -442,8 +446,8 @@ import os; os._exit(0)
             result = 0.0
     finally:
         try:
-            push_proc.stdin.write("\n")
-            push_proc.stdin.flush()
+            push_stdin.write("\n")
+            push_stdin.flush()
         except OSError:
             pass
         push_proc.terminate()
@@ -544,8 +548,12 @@ asyncio.run(run())
         stdin=subprocess.PIPE,
         text=True,
     )
+    push_stdout = push_proc.stdout
+    push_stdin = push_proc.stdin
+    assert push_stdout is not None
+    assert push_stdin is not None
     try:
-        port_line = push_proc.stdout.readline().strip()
+        port_line = push_stdout.readline().strip()
         if not port_line:
             push_proc.terminate()
             push_proc.wait(timeout=5)
@@ -565,8 +573,8 @@ asyncio.run(run())
             result = 0.0
     finally:
         try:
-            push_proc.stdin.write("\n")
-            push_proc.stdin.flush()
+            push_stdin.write("\n")
+            push_stdin.flush()
         except OSError:
             pass
         push_proc.terminate()
@@ -822,8 +830,10 @@ except Exception:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
+    proxy_stdout = proxy_proc.stdout
+    assert proxy_stdout is not None
     try:
-        line = proxy_proc.stdout.readline()
+        line = proxy_stdout.readline()
         fe_port, be_port = json.loads(line)
     except (json.JSONDecodeError, ValueError):
         proxy_proc.terminate()
@@ -958,8 +968,10 @@ except Exception:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
+    proxy_stdout = proxy_proc.stdout
+    assert proxy_stdout is not None
     try:
-        line = proxy_proc.stdout.readline()
+        line = proxy_stdout.readline()
         fe_port, be_port = json.loads(line)
     except (json.JSONDecodeError, ValueError):
         proxy_proc.terminate()

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -27,6 +27,7 @@ SUBPROCESS_TIMEOUT_S = 30.0
 LATENCY_TIMEOUT_S = 60.0
 SUBPROCESS_RETRIES = 2
 PROXY_DURATION_S = 2.0
+THROUGHPUT_MAX_BYTES = None
 README = os.path.join(os.path.dirname(__file__), "..", "README.md")
 CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
 _CACHE_DIR = os.path.join(
@@ -269,6 +270,9 @@ def configure_benchmark(args):
     global LATENCY_TIMEOUT_S
     global SUBPROCESS_RETRIES
     global PROXY_DURATION_S
+    global THROUGHPUT_MAX_BYTES
+
+    THROUGHPUT_MAX_BYTES = None
 
     if args.quick:
         SIZES = QUICK_SIZES.copy()
@@ -281,6 +285,7 @@ def configure_benchmark(args):
         LATENCY_TIMEOUT_S = 20.0
         SUBPROCESS_RETRIES = 0
         PROXY_DURATION_S = 1.0
+        THROUGHPUT_MAX_BYTES = 128 * 1024 * 1024
 
     if args.sizes is not None:
         SIZES = args.sizes
@@ -336,6 +341,16 @@ def _run_subprocess(code, label, timeout=None, retries=None):
     return None
 
 
+def _throughput_iters(size, n_target_per_s, *, max_messages=None):
+    n = max(int(n_target_per_s * TARGET_RUNTIME_S), 100)
+    if max_messages is not None:
+        n = min(n, max_messages)
+    if THROUGHPUT_MAX_BYTES is not None:
+        byte_limited = max(100, THROUGHPUT_MAX_BYTES // max(size, 1))
+        n = min(n, byte_limited)
+    return n
+
+
 def _measure_throughput_subprocess(lib_name, transport, size, n_target_per_s=200_000):
     """Run a throughput measurement. TCP uses 2 separate processes (push +
     pull) so each gets its own runtime. Inproc must stay single-process."""
@@ -344,7 +359,7 @@ def _measure_throughput_subprocess(lib_name, transport, size, n_target_per_s=200
     else:
         lib_import = "import pyomq as lib"
 
-    n = max(int(n_target_per_s * TARGET_RUNTIME_S), 100)
+    n = _throughput_iters(size, n_target_per_s)
 
     if transport == "inproc":
         code = f"""
@@ -431,18 +446,25 @@ import os; os._exit(0)
             push_proc.terminate()
             push_proc.wait(timeout=5)
             return 0.0
+        label = f"{lib_name} {transport} {size}B"
         pull_proc = subprocess.Popen(
             [sys.executable, "-c", pull_code, port_line],
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
         )
         try:
-            stdout, _ = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
+            stdout, stderr = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
             result = json.loads(stdout.strip())
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError):
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(f"  [{label} timeout]\n")
             pull_proc.kill()
             pull_proc.wait()
+            result = 0.0
+        except (json.JSONDecodeError, ValueError):
+            sys.stderr.write(f"  [{label} invalid output]\n")
+            if stderr:
+                sys.stderr.write(stderr)
             result = 0.0
     finally:
         try:
@@ -498,7 +520,7 @@ def _measure_async_subprocess(lib_name, size, n_target_per_s=200_000):
         lib_import = "import pyomq as lib; import pyomq.asyncio as alib"
         push_import = "import pyomq as lib"
 
-    n = min(max(int(n_target_per_s * TARGET_RUNTIME_S), 100), 20_000)
+    n = _throughput_iters(size, n_target_per_s, max_messages=20_000)
 
     push_code = f"""
 import sys
@@ -558,18 +580,25 @@ asyncio.run(run())
             push_proc.terminate()
             push_proc.wait(timeout=5)
             return 0.0
+        label = f"{lib_name} async tcp {size}B"
         pull_proc = subprocess.Popen(
             [sys.executable, "-c", pull_code, port_line],
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
         )
         try:
-            stdout, _ = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
+            stdout, stderr = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
             result = json.loads(stdout.strip())
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError):
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(f"  [{label} timeout]\n")
             pull_proc.kill()
             pull_proc.wait()
+            result = 0.0
+        except (json.JSONDecodeError, ValueError):
+            sys.stderr.write(f"  [{label} invalid output]\n")
+            if stderr:
+                sys.stderr.write(stderr)
             result = 0.0
     finally:
         try:

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -2,29 +2,37 @@
 """Measure pyomq vs pyzmq throughput and latency (sync + async).
 
 Run from the pyomq root (bindings/pyomq/) after `maturin develop --release`.
-Results are appended to doc/charts/bindings.jsonl (latest run_id wins per impl).
-Generates doc/charts/bindings.svg and updates the proxy table in README.md.
+Full runs append to doc/charts/bindings.jsonl (latest run_id wins per impl).
+They also generate doc/charts/bindings.svg and update the README proxy table.
 """
 
 import argparse
-import asyncio
 import json
 import math
 import os
 import re
 import subprocess
 import sys
-import threading
 import time
 
-SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+QUICK_SIZES = [8, 128, 1024, 4096, 32768]
+SIZES = DEFAULT_SIZES.copy()
 TARGET_RUNTIME_S = 0.4
 N_ROUNDS = 3
+WARMUP_ROUNDS = 1
 LATENCY_WARMUP = 1000
 LATENCY_ITERS = 10000
+SUBPROCESS_TIMEOUT_S = 30.0
+LATENCY_TIMEOUT_S = 60.0
+SUBPROCESS_RETRIES = 2
+PROXY_DURATION_S = 2.0
 README = os.path.join(os.path.dirname(__file__), "..", "README.md")
 CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
-_CACHE_DIR = os.path.join(os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")), "omq")
+_CACHE_DIR = os.path.join(
+    os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")),
+    "omq",
+)
 JSONL_FILE = os.path.join(_CACHE_DIR, "bindings.jsonl")
 
 
@@ -48,38 +56,104 @@ def append_jsonl(rows):
             f.write(json.dumps(r) + "\n")
 
 
-def save_results(run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr):
+def save_results(
+    run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
+):
     rows = []
     for i, size in enumerate(SIZES):
-        rows.append({"run_id": run_id, "impl": impl, "kind": "throughput",
-                      "mode": "sync", "transport": "inproc",
-                      "msg_size": size, "msgs_s": tp_inproc[i]})
-        rows.append({"run_id": run_id, "impl": impl, "kind": "throughput",
-                      "mode": "sync", "transport": "tcp",
-                      "msg_size": size, "msgs_s": tp_tcp[i]})
-        rows.append({"run_id": run_id, "impl": impl, "kind": "throughput",
-                      "mode": "async", "transport": "tcp",
-                      "msg_size": size, "msgs_s": atp_tcp[i]})
-        rows.append({"run_id": run_id, "impl": impl, "kind": "latency",
-                      "mode": "sync", "msg_size": size,
-                      "p50_us": lat[i][0], "p99_us": lat[i][1]})
-        rows.append({"run_id": run_id, "impl": impl, "kind": "latency",
-                      "mode": "async", "msg_size": size,
-                      "p50_us": alat[i][0], "p99_us": alat[i][1]})
-    rows.append({"run_id": run_id, "impl": impl, "kind": "proxy",
-                  "pattern": "pushpull", "msgs_s": proxy_pp})
-    rows.append({"run_id": run_id, "impl": impl, "kind": "proxy",
-                  "pattern": "reqrep", "msgs_s": proxy_rr})
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "sync",
+                "transport": "inproc",
+                "msg_size": size,
+                "msgs_s": tp_inproc[i],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "sync",
+                "transport": "tcp",
+                "msg_size": size,
+                "msgs_s": tp_tcp[i],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "async",
+                "transport": "tcp",
+                "msg_size": size,
+                "msgs_s": atp_tcp[i],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "latency",
+                "mode": "sync",
+                "msg_size": size,
+                "p50_us": lat[i][0],
+                "p99_us": lat[i][1],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "latency",
+                "mode": "async",
+                "msg_size": size,
+                "p50_us": alat[i][0],
+                "p99_us": alat[i][1],
+            }
+        )
+    rows.append(
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "pushpull",
+            "msgs_s": proxy_pp,
+        }
+    )
+    rows.append(
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "reqrep",
+            "msgs_s": proxy_rr,
+        }
+    )
     append_jsonl(rows)
     print(f"  appended {len(rows)} rows to {JSONL_FILE}")
 
 
 def save_proxy_results(run_id, impl, proxy_pp, proxy_rr):
     rows = [
-        {"run_id": run_id, "impl": impl, "kind": "proxy",
-         "pattern": "pushpull", "msgs_s": proxy_pp},
-        {"run_id": run_id, "impl": impl, "kind": "proxy",
-         "pattern": "reqrep", "msgs_s": proxy_rr},
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "pushpull",
+            "msgs_s": proxy_pp,
+        },
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "reqrep",
+            "msgs_s": proxy_rr,
+        },
     ]
     append_jsonl(rows)
     print(f"  appended {len(rows)} rows to {JSONL_FILE}")
@@ -119,17 +193,23 @@ def chart_data_from_jsonl():
     async_pz_lat = [get_lat("async", "pyzmq", s) for s in SIZES]
 
     return {
-        "sync_omq_tp": sync_omq_tp, "sync_pz_tp": sync_pz_tp,
-        "async_omq_tp": async_omq_tp, "async_pz_tp": async_pz_tp,
-        "sync_omq_lat": sync_omq_lat, "sync_pz_lat": sync_pz_lat,
-        "async_omq_lat": async_omq_lat, "async_pz_lat": async_pz_lat,
+        "sync_omq_tp": sync_omq_tp,
+        "sync_pz_tp": sync_pz_tp,
+        "async_omq_tp": async_omq_tp,
+        "async_pz_tp": async_pz_tp,
+        "sync_omq_lat": sync_omq_lat,
+        "sync_pz_lat": sync_pz_lat,
+        "async_omq_lat": async_omq_lat,
+        "async_pz_lat": async_pz_lat,
     }
 
 
 # ── helpers ──────────────────────────────────────────────────────────
 
+
 def free_tcp():
     import socket
+
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("127.0.0.1", 0))
     port = s.getsockname()[1]
@@ -153,13 +233,99 @@ def fmt_int(n):
     return f"{n:,.0f}"
 
 
+def parse_sizes(value):
+    sizes = []
+    for raw in value.split(","):
+        raw = raw.strip().lower()
+        if not raw:
+            continue
+        multiplier = 1
+        if raw.endswith("kib"):
+            multiplier = 1024
+            raw = raw[:-3]
+        elif raw.endswith("kb"):
+            multiplier = 1000
+            raw = raw[:-2]
+        elif raw.endswith("k"):
+            multiplier = 1024
+            raw = raw[:-1]
+        size = int(raw.strip()) * multiplier
+        if size <= 0:
+            raise argparse.ArgumentTypeError("sizes must be positive")
+        sizes.append(size)
+    if not sizes:
+        raise argparse.ArgumentTypeError("at least one size is required")
+    return sizes
+
+
+def configure_benchmark(args):
+    global SIZES
+    global TARGET_RUNTIME_S
+    global N_ROUNDS
+    global WARMUP_ROUNDS
+    global LATENCY_WARMUP
+    global LATENCY_ITERS
+    global SUBPROCESS_TIMEOUT_S
+    global LATENCY_TIMEOUT_S
+    global SUBPROCESS_RETRIES
+    global PROXY_DURATION_S
+
+    if args.quick:
+        SIZES = QUICK_SIZES.copy()
+        TARGET_RUNTIME_S = 0.15
+        N_ROUNDS = 1
+        WARMUP_ROUNDS = 0
+        LATENCY_WARMUP = 100
+        LATENCY_ITERS = 1000
+        SUBPROCESS_TIMEOUT_S = 15.0
+        LATENCY_TIMEOUT_S = 20.0
+        SUBPROCESS_RETRIES = 0
+        PROXY_DURATION_S = 1.0
+
+    if args.sizes is not None:
+        SIZES = args.sizes
+    if args.rounds is not None:
+        N_ROUNDS = args.rounds
+    if args.target_runtime is not None:
+        TARGET_RUNTIME_S = args.target_runtime
+    if args.latency_warmup is not None:
+        LATENCY_WARMUP = args.latency_warmup
+    if args.latency_iters is not None:
+        LATENCY_ITERS = args.latency_iters
+    if args.timeout is not None:
+        SUBPROCESS_TIMEOUT_S = args.timeout
+        LATENCY_TIMEOUT_S = max(args.timeout, 1.0)
+    if args.proxy_duration is not None:
+        PROXY_DURATION_S = args.proxy_duration
+
+    if N_ROUNDS < 1:
+        raise argparse.ArgumentTypeError("--rounds must be at least 1")
+    if TARGET_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--target-runtime must be positive")
+    if LATENCY_WARMUP < 0:
+        raise argparse.ArgumentTypeError("--latency-warmup cannot be negative")
+    if LATENCY_ITERS < 1:
+        raise argparse.ArgumentTypeError("--latency-iters must be at least 1")
+    if SUBPROCESS_TIMEOUT_S <= 0 or LATENCY_TIMEOUT_S <= 0:
+        raise argparse.ArgumentTypeError("--timeout must be positive")
+    if PROXY_DURATION_S <= 0:
+        raise argparse.ArgumentTypeError("--proxy-duration must be positive")
+
+
 # ── subprocess runner ────────────────────────────────────────────────
 
-def _run_subprocess(code, label, timeout=30, retries=2):
+
+def _run_subprocess(code, label, timeout=None, retries=None):
+    timeout = SUBPROCESS_TIMEOUT_S if timeout is None else timeout
+    retries = SUBPROCESS_RETRIES if retries is None else retries
     for attempt in range(1 + retries):
         try:
-            r = subprocess.run([sys.executable, "-c", code],
-                               capture_output=True, text=True, timeout=timeout)
+            r = subprocess.run(
+                [sys.executable, "-c", code],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
         except subprocess.TimeoutExpired:
             sys.stderr.write(f"  [{label} timeout, attempt {attempt + 1}]\n")
             continue
@@ -250,8 +416,10 @@ import os; os._exit(0)
 """
     push_proc = subprocess.Popen(
         [sys.executable, "-c", push_code],
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-        stdin=subprocess.PIPE, text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.PIPE,
+        text=True,
     )
     try:
         port_line = push_proc.stdout.readline().strip()
@@ -261,10 +429,12 @@ import os; os._exit(0)
             return 0.0
         pull_proc = subprocess.Popen(
             [sys.executable, "-c", pull_code, port_line],
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
         )
         try:
-            stdout, _ = pull_proc.communicate(timeout=30)
+            stdout, _ = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
             result = json.loads(stdout.strip())
         except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError):
             pull_proc.kill()
@@ -293,8 +463,9 @@ def run_throughput(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        _measure_throughput_subprocess(lib_name, "inproc", size)
-        _measure_throughput_subprocess(lib_name, "tcp", size)
+        for _ in range(WARMUP_ROUNDS):
+            _measure_throughput_subprocess(lib_name, "inproc", size)
+            _measure_throughput_subprocess(lib_name, "tcp", size)
 
         inproc = max(
             _measure_throughput_subprocess(lib_name, "inproc", size)
@@ -312,6 +483,7 @@ def run_throughput(lib_name):
 
 
 # ── async PUSH/PULL throughput ───────────────────────────────────────
+
 
 def _measure_async_subprocess(lib_name, size, n_target_per_s=200_000):
     """Async throughput: push in one process, async pull in another."""
@@ -367,8 +539,10 @@ asyncio.run(run())
 """
     push_proc = subprocess.Popen(
         [sys.executable, "-c", push_code],
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-        stdin=subprocess.PIPE, text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.PIPE,
+        text=True,
     )
     try:
         port_line = push_proc.stdout.readline().strip()
@@ -378,10 +552,12 @@ asyncio.run(run())
             return 0.0
         pull_proc = subprocess.Popen(
             [sys.executable, "-c", pull_code, port_line],
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
         )
         try:
-            stdout, _ = pull_proc.communicate(timeout=30)
+            stdout, _ = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
             result = json.loads(stdout.strip())
         except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError):
             pull_proc.kill()
@@ -409,8 +585,10 @@ def run_async_throughput(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        tcp = max(_measure_async_subprocess(lib_name, size)
-                  for _ in range(N_ROUNDS + 1))
+        for _ in range(WARMUP_ROUNDS):
+            _measure_async_subprocess(lib_name, size)
+
+        tcp = max(_measure_async_subprocess(lib_name, size) for _ in range(N_ROUNDS))
         results.append(tcp)
         print(f" {fmt_rate(tcp):>10}")
 
@@ -418,6 +596,7 @@ def run_async_throughput(lib_name):
 
 
 # ── sync REQ/REP latency ────────────────────────────────────────────
+
 
 def _measure_latency_subprocess(lib_name, size, warmup, iters):
     code = f"""
@@ -467,7 +646,11 @@ p99 = rtts[len(rtts)*99//100]*1e6
 print(json.dumps([p50, p99]))
 import sys; sys.stdout.flush(); import os; os._exit(0)
 """
-    result = _run_subprocess(code, f"{lib_name} lat {size}B", timeout=60)
+    result = _run_subprocess(
+        code,
+        f"{lib_name} lat {size}B",
+        timeout=LATENCY_TIMEOUT_S,
+    )
     return tuple(result) if result is not None else (999999.0, 999999.0)
 
 
@@ -478,10 +661,18 @@ def run_latency(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        _measure_latency_subprocess(lib_name, size, 200, 200)
+        warmup = (0.0, 0.0)
+        for _ in range(WARMUP_ROUNDS):
+            warmup = _measure_latency_subprocess(lib_name, size, 200, 200)
+        if warmup == (999999.0, 999999.0):
+            results.append(warmup)
+            print(" timeout")
+            continue
 
-        runs = [_measure_latency_subprocess(lib_name, size, LATENCY_WARMUP, LATENCY_ITERS)
-                for _ in range(N_ROUNDS)]
+        runs = [
+            _measure_latency_subprocess(lib_name, size, LATENCY_WARMUP, LATENCY_ITERS)
+            for _ in range(N_ROUNDS)
+        ]
         p50 = min(r[0] for r in runs)
         p99 = min(r[1] for r in runs)
         results.append((p50, p99))
@@ -492,13 +683,12 @@ def run_latency(lib_name):
 
 # ── async REQ/REP latency ───────────────────────────────────────────
 
+
 def _measure_async_latency_subprocess(lib_name, size, warmup, iters):
     if lib_name == "pyzmq":
         lib_import = "import zmq; import zmq.asyncio; lib = zmq; actx = zmq.asyncio"
-        close_expr = "sock.close()"
     else:
         lib_import = "import pyomq; import pyomq.asyncio as actx; lib = pyomq"
-        close_expr = "sock.close()"
 
     send_await = "await " if lib_name == "pyzmq" else ""
     code = f"""
@@ -548,7 +738,11 @@ async def run():
     import sys; sys.stdout.flush(); import os; os._exit(0)
 asyncio.run(run())
 """
-    result = _run_subprocess(code, f"{lib_name} async lat {size}B", timeout=60)
+    result = _run_subprocess(
+        code,
+        f"{lib_name} async lat {size}B",
+        timeout=LATENCY_TIMEOUT_S,
+    )
     return tuple(result) if result is not None else (999999.0, 999999.0)
 
 
@@ -559,10 +753,20 @@ def run_async_latency(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        _measure_async_latency_subprocess(lib_name, size, 200, 200)
+        warmup = (0.0, 0.0)
+        for _ in range(WARMUP_ROUNDS):
+            warmup = _measure_async_latency_subprocess(lib_name, size, 200, 200)
+        if warmup == (999999.0, 999999.0):
+            results.append(warmup)
+            print(" timeout")
+            continue
 
-        runs = [_measure_async_latency_subprocess(lib_name, size, LATENCY_WARMUP, LATENCY_ITERS)
-                for _ in range(N_ROUNDS)]
+        runs = [
+            _measure_async_latency_subprocess(
+                lib_name, size, LATENCY_WARMUP, LATENCY_ITERS
+            )
+            for _ in range(N_ROUNDS)
+        ]
         p50 = min(r[0] for r in runs)
         p99 = min(r[1] for r in runs)
         results.append((p50, p99))
@@ -572,6 +776,7 @@ def run_async_latency(lib_name):
 
 
 # ── proxy forwarding (2-process) ─────────────────────────────────────
+
 
 def _measure_proxy_subprocess(lib_name, pattern, n):
     if lib_name == "pyzmq":
@@ -614,7 +819,8 @@ except Exception:
 
     proxy_proc = subprocess.Popen(
         [sys.executable, "-c", proxy_code],
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
     )
     try:
         line = proxy_proc.stdout.readline()
@@ -688,7 +894,9 @@ sys.stdout.flush(); os._exit(0)
     try:
         r = subprocess.run(
             [sys.executable, "-c", bench_code],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True,
+            text=True,
+            timeout=LATENCY_TIMEOUT_S,
         )
         if r.returncode != 0:
             return 0.0
@@ -715,7 +923,8 @@ def _bench_proxy_client():
     return None
 
 
-def _measure_proxy_native(lib_name, client, duration=2.0):
+def _measure_proxy_native(lib_name, client, duration=None):
+    duration = PROXY_DURATION_S if duration is None else duration
     if lib_name == "pyzmq":
         lib_import = "import zmq as lib"
     else:
@@ -746,7 +955,8 @@ except Exception:
 
     proxy_proc = subprocess.Popen(
         [sys.executable, "-c", proxy_code],
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
     )
     try:
         line = proxy_proc.stdout.readline()
@@ -758,9 +968,9 @@ except Exception:
 
     try:
         r = subprocess.run(
-            [client, str(fe_port), str(be_port), "128",
-             str(duration)],
-            capture_output=True, text=True,
+            [client, str(fe_port), str(be_port), "128", str(duration)],
+            capture_output=True,
+            text=True,
             timeout=duration + 10,
         )
         if r.returncode != 0:
@@ -781,12 +991,14 @@ def run_proxy(lib_name):
     sys.stdout.write("  PUSH/PULL ...")
     sys.stdout.flush()
     if client is not None:
-        _measure_proxy_native(lib_name, client, 1.0)
+        for _ in range(WARMUP_ROUNDS):
+            _measure_proxy_native(lib_name, client, min(PROXY_DURATION_S, 1.0))
         pushpull_rate = max(
             _measure_proxy_native(lib_name, client) for _ in range(N_ROUNDS)
         )
     else:
-        _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
+        for _ in range(WARMUP_ROUNDS):
+            _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
         pushpull_rate = max(
             _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
             for _ in range(N_ROUNDS)
@@ -795,10 +1007,10 @@ def run_proxy(lib_name):
 
     sys.stdout.write("  REQ/REP ...")
     sys.stdout.flush()
-    _measure_proxy_subprocess(lib_name, "reqrep", 10_000)
-    reqrep_rate = max(
+    for _ in range(WARMUP_ROUNDS):
         _measure_proxy_subprocess(lib_name, "reqrep", 10_000)
-        for _ in range(N_ROUNDS)
+    reqrep_rate = max(
+        _measure_proxy_subprocess(lib_name, "reqrep", 10_000) for _ in range(N_ROUNDS)
     )
     print(f" {fmt_rate(reqrep_rate)}")
 
@@ -813,11 +1025,12 @@ C_PYOMQ_ASYNC = "#f97316"
 C_PYZMQ = "#2563eb"
 C_PYZMQ_ASYNC = "#8b5cf6"
 
+
 def _nice_ceil(v):
     if v <= 0:
         return 1
     exp = math.floor(math.log10(v))
-    base = 10 ** exp
+    base = 10**exp
     for m in [1, 2, 5, 10]:
         candidate = m * base
         if candidate >= v:
@@ -946,7 +1159,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
-        f'PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>'
+        f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>"
     )
     if hw_label:
         L.append(
@@ -1040,7 +1253,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
-        f'REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>'
+        f"REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
     )
 
     sync_omq_lat = data["sync_omq_lat"]
@@ -1057,7 +1270,7 @@ def gen_combined_chart(data, path):
         L.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
             f' dominant-baseline="middle" fill="#374151" font-size="10">'
-            f'{_fmt_y_us(v)}</text>'
+            f"{_fmt_y_us(v)}</text>"
         )
 
     for x in xs:
@@ -1112,8 +1325,10 @@ def gen_combined_chart(data, path):
 
     leg_y = t2_bot + 40
     legend_items = [
-        ("pyomq", C_PYOMQ), ("pyomq async", C_PYOMQ_ASYNC),
-        ("pyzmq", C_PYZMQ), ("pyzmq async", C_PYZMQ_ASYNC),
+        ("pyomq", C_PYOMQ),
+        ("pyomq async", C_PYOMQ_ASYNC),
+        ("pyzmq", C_PYZMQ),
+        ("pyzmq async", C_PYZMQ_ASYNC),
     ]
     item_w = 140
     total_w = len(legend_items) * item_w
@@ -1125,9 +1340,7 @@ def gen_combined_chart(data, path):
             f'  <line x1="{lx:.0f}" y1="{leg_y}" x2="{lx + 14:.0f}" y2="{leg_y}"'
             f' stroke="{color}" stroke-width="2.5"/>'
         )
-        L.append(
-            f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>'
-        )
+        L.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
         L.append(
             f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
             f' font-size="11" font-weight="500">{label}</text>'
@@ -1137,7 +1350,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
         f' fill="#9ca3af" font-size="9">'
-        f'dashed = msg/s (left) · solid = throughput (right)</text>'
+        f"dashed = msg/s (left) · solid = throughput (right)</text>"
     )
 
     L.append("</svg>")
@@ -1150,6 +1363,7 @@ def gen_combined_chart(data, path):
 
 
 # ── README tables ────────────────────────────────────────────────────
+
 
 def build_proxy_table():
     rows = load_jsonl()
@@ -1169,25 +1383,30 @@ def build_proxy_table():
     pp_ratio = pp_omq / pp_pz if pp_pz > 0 else 0
     rr_ratio = rr_omq / rr_pz if rr_pz > 0 else 0
 
-    return "\n".join([
-        "|                    | pyomq     | pyzmq     | ratio     |",
-        "|--------------------|----------:|----------:|----------:|",
-        f"| PUSH/PULL msg/s    | {fmt_rate(pp_omq):>9} "
-        f"| {fmt_rate(pp_pz):>9} | **{pp_ratio:.2f}×** |",
-        f"| REQ/REP rt/s       | {fmt_int(rr_omq) + '/s':>9} "
-        f"| {fmt_int(rr_pz) + '/s':>9} | **{rr_ratio:.2f}×** |",
-    ])
+    return "\n".join(
+        [
+            "|                    | pyomq     | pyzmq     | ratio     |",
+            "|--------------------|----------:|----------:|----------:|",
+            f"| PUSH/PULL msg/s    | {fmt_rate(pp_omq):>9} "
+            f"| {fmt_rate(pp_pz):>9} | **{pp_ratio:.2f}×** |",
+            f"| REQ/REP rt/s       | {fmt_int(rr_omq) + '/s':>9} "
+            f"| {fmt_int(rr_pz) + '/s':>9} | **{rr_ratio:.2f}×** |",
+        ]
+    )
 
 
 # ── README update ────────────────────────────────────────────────────
+
 
 def update_marker(content, marker, table):
     pattern = rf"<!-- {marker}:START -->\n.*?\n<!-- {marker}:END -->"
     replacement = f"<!-- {marker}:START -->\n{table}\n<!-- {marker}:END -->"
     new_content, count = re.subn(pattern, replacement, content, flags=re.DOTALL)
     if count == 0:
-        print(f"ERROR: <!-- {marker}:START -->...<!-- {marker}:END --> "
-              f"markers not found in README.md")
+        print(
+            f"ERROR: <!-- {marker}:START -->...<!-- {marker}:END --> "
+            f"markers not found in README.md"
+        )
         sys.exit(1)
     return new_content
 
@@ -1204,17 +1423,72 @@ def update_readme_proxy_table():
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--impl", action="append", dest="impls",
-                        choices=["pyomq", "pyzmq"],
-                        help="implementation(s) to benchmark (default: both)")
-    parser.add_argument("--chart-only", action="store_true",
-                        help="regenerate SVG from existing JSONL, no benchmarking")
-    parser.add_argument("--proxy-only", action="store_true",
-                        help="benchmark proxy only and update README proxy table")
+    parser.add_argument(
+        "--impl",
+        action="append",
+        dest="impls",
+        choices=["pyomq", "pyzmq"],
+        help="implementation(s) to benchmark (default: both)",
+    )
+    parser.add_argument(
+        "--quick", action="store_true", help="run a short local-only benchmark"
+    )
+    parser.add_argument(
+        "--sizes",
+        type=parse_sizes,
+        help="comma-separated message sizes, e.g. 8,128,1k,32k",
+    )
+    parser.add_argument("--rounds", type=int, help="measured rounds per cell")
+    parser.add_argument(
+        "--target-runtime",
+        type=float,
+        help="target throughput runtime per round in seconds",
+    )
+    parser.add_argument("--latency-warmup", type=int, help="REQ/REP warmup iterations")
+    parser.add_argument("--latency-iters", type=int, help="REQ/REP measured iterations")
+    parser.add_argument(
+        "--timeout", type=float, help="subprocess timeout per attempt in seconds"
+    )
+    parser.add_argument(
+        "--proxy-duration",
+        type=float,
+        help="native proxy throughput duration in seconds",
+    )
+    parser.add_argument(
+        "--no-save", action="store_true", help="print results without appending JSONL"
+    )
+    parser.add_argument(
+        "--no-docs", action="store_true", help="skip README and chart updates"
+    )
+    parser.add_argument(
+        "--chart-only",
+        action="store_true",
+        help="regenerate SVG from existing JSONL, no benchmarking",
+    )
+    parser.add_argument(
+        "--proxy-only",
+        action="store_true",
+        help="benchmark proxy only and update README proxy table",
+    )
     args = parser.parse_args()
 
     if args.chart_only and args.proxy_only:
         parser.error("--chart-only and --proxy-only are mutually exclusive")
+    if args.chart_only and any(
+        value is not None
+        for value in (
+            args.sizes,
+            args.rounds,
+            args.target_runtime,
+            args.latency_warmup,
+            args.latency_iters,
+            args.timeout,
+            args.proxy_duration,
+        )
+    ):
+        parser.error("--chart-only cannot be combined with benchmark knobs")
+    if args.chart_only and args.quick:
+        parser.error("--chart-only cannot be combined with --quick")
 
     if args.chart_only:
         print("Generating chart from existing JSONL...")
@@ -1222,8 +1496,27 @@ def main():
         gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
         return
 
+    try:
+        configure_benchmark(args)
+    except argparse.ArgumentTypeError as e:
+        parser.error(str(e))
+
     run_id = time.strftime("%Y-%m-%dT%H:%M:%S")
     impls = args.impls or ["pyomq", "pyzmq"]
+    diagnostic_knobs = any(
+        value is not None
+        for value in (
+            args.sizes,
+            args.rounds,
+            args.target_runtime,
+            args.latency_warmup,
+            args.latency_iters,
+            args.timeout,
+            args.proxy_duration,
+        )
+    )
+    save_enabled = not args.no_save and not args.quick and not diagnostic_knobs
+    docs_enabled = save_enabled and not args.no_docs
 
     for impl in impls:
         print(f"\n{'=' * 40}")
@@ -1233,8 +1526,9 @@ def main():
         if args.proxy_only:
             print(f"\n{impl} zmq.proxy() forwarding...")
             proxy_pp, proxy_rr = run_proxy(impl)
-            print("\nSaving proxy results...")
-            save_proxy_results(run_id, impl, proxy_pp, proxy_rr)
+            if save_enabled:
+                print("\nSaving proxy results...")
+                save_proxy_results(run_id, impl, proxy_pp, proxy_rr)
             continue
 
         print(f"\n{impl} sync PUSH/PULL throughput...")
@@ -1252,18 +1546,26 @@ def main():
         print(f"\n{impl} zmq.proxy() forwarding...")
         proxy_pp, proxy_rr = run_proxy(impl)
 
-        print("\nSaving results...")
-        save_results(run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat,
-                     proxy_pp, proxy_rr)
+        if save_enabled:
+            print("\nSaving results...")
+            save_results(
+                run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
+            )
 
-    update_readme_proxy_table()
+    if not save_enabled:
+        print("\nSkipping JSONL, README, and chart updates.")
+        return
+
+    if docs_enabled:
+        update_readme_proxy_table()
 
     if args.proxy_only:
         return
 
-    print("\nGenerating chart...")
-    data = chart_data_from_jsonl()
-    gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
+    if docs_enabled:
+        print("\nGenerating chart...")
+        data = chart_data_from_jsonl()
+        gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
 
 
 if __name__ == "__main__":

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -8,6 +8,7 @@ mod context;
 mod conversions;
 mod dispatch;
 mod error;
+mod notify;
 mod options;
 #[cfg(feature = "curve")]
 mod peer_info;

--- a/bindings/pyomq/src/notify.rs
+++ b/bindings/pyomq/src/notify.rs
@@ -1,0 +1,128 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+#[cfg(windows)]
+use pyo3::prelude::*;
+#[cfg(windows)]
+use pyo3::types::PyAny;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+pub(crate) use unix::EventFdSignal as UnixSignal;
+#[cfg(windows)]
+pub(crate) use windows::WindowsSignal;
+
+/// Internal backend for the socket wakeup primitive.
+///
+/// The shared `ReadinessSignal` facade exposes the generic park/wake interface;
+/// the backend carries the platform-specific wake transport.
+#[cfg(unix)]
+type SignalBackend = UnixSignal;
+
+#[cfg(windows)]
+type SignalBackend = WindowsSignal;
+
+/// Platform-agnostic readiness signal for async socket wake-up paths.
+///
+/// The `parking` flag avoids syscalls on the hot path. The consumer
+/// sets it before sleeping; the producer only writes to the eventfd
+/// when it sees the flag.
+pub(crate) struct ReadinessSignal {
+    parking: AtomicBool,
+    backend: SignalBackend,
+}
+
+impl ReadinessSignal {
+    pub fn new() -> Self {
+        Self {
+            parking: AtomicBool::new(false),
+            backend: SignalBackend::new(),
+        }
+    }
+
+    pub fn signal(&self) {
+        #[cfg(unix)]
+        {
+            self.backend.signal(self.parking.load(Ordering::Acquire));
+        }
+        #[cfg(windows)]
+        {
+            self.backend.signal();
+        }
+    }
+
+    pub fn force_wake(&self) {
+        self.backend.force_wake();
+    }
+
+    #[cfg(windows)]
+    pub fn mark_drain_complete(&self) {
+        self.backend.mark_drain_complete();
+    }
+
+    pub fn park_begin(&self) {
+        self.parking.store(true, Ordering::Release);
+    }
+
+    pub fn park_end(&self) {
+        self.parking.store(false, Ordering::Relaxed);
+    }
+
+    pub fn wait_timeout(&self, timeout: Duration) -> bool {
+        self.backend.wait_timeout(timeout)
+    }
+
+    #[cfg(unix)]
+    pub fn fd(&self) -> i32 {
+        self.backend.fd()
+    }
+
+    #[cfg(not(unix))]
+    pub fn fd(&self) -> i32 {
+        -1
+    }
+
+    #[cfg(unix)]
+    pub fn dup_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
+        self.backend.dup_fd()
+    }
+
+    #[cfg(windows)]
+    pub fn set_wakeup_hooks(
+        &self,
+        async_callback: Option<Py<PyAny>>,
+        sync_event: Option<Py<PyAny>>,
+    ) {
+        self.backend.set_wakeup_hooks(async_callback, sync_event);
+    }
+
+    #[cfg(windows)]
+    pub fn set_wakeup_mode(&self, mode: u32) {
+        self.backend.set_wakeup_mode(mode);
+    }
+
+    /// Permanently arm the signal so wakeups are emitted even when no
+    /// thread is currently parked in the wait loop.
+    pub fn arm_persistent(&self) {
+        self.parking.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadinessSignal;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn parking_state_tracks_wait_loop() {
+        let signal = ReadinessSignal::new();
+        signal.park_begin();
+        assert!(signal.parking.load(Ordering::Acquire));
+        signal.park_end();
+        assert!(!signal.parking.load(Ordering::Acquire));
+    }
+}

--- a/bindings/pyomq/src/notify.rs
+++ b/bindings/pyomq/src/notify.rs
@@ -105,6 +105,11 @@ impl ReadinessSignal {
         self.backend.set_wakeup_mode(mode);
     }
 
+    #[cfg(windows)]
+    pub fn clear_wakeup_mode(&self, mode: u32) {
+        self.backend.clear_wakeup_mode(mode);
+    }
+
     /// Permanently arm the signal so wakeups are emitted even when no
     /// thread is currently parked in the wait loop.
     pub fn arm_persistent(&self) {

--- a/bindings/pyomq/src/notify.rs
+++ b/bindings/pyomq/src/notify.rs
@@ -51,7 +51,7 @@ impl ReadinessSignal {
         }
         #[cfg(windows)]
         {
-            self.backend.signal();
+            self.backend.signal(self.parking.load(Ordering::Acquire));
         }
     }
 

--- a/bindings/pyomq/src/notify/unix.rs
+++ b/bindings/pyomq/src/notify/unix.rs
@@ -1,0 +1,70 @@
+use std::time::Duration;
+
+pub(crate) struct EventFdSignal {
+    efd: i32,
+}
+
+impl EventFdSignal {
+    pub(crate) fn new() -> Self {
+        let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+        assert!(efd >= 0, "eventfd creation failed");
+        Self { efd }
+    }
+
+    pub(crate) fn signal(&self, parked: bool) {
+        if parked {
+            self.write_eventfd();
+        }
+    }
+
+    pub(crate) fn force_wake(&self) {
+        self.write_eventfd();
+    }
+
+    pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
+        let mut pfd = libc::pollfd {
+            fd: self.efd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let ret = unsafe { libc::poll(&mut pfd, 1, ms) };
+        if ret > 0 {
+            let mut val: u64 = 0;
+            unsafe {
+                libc::read(self.efd, &mut val as *mut u64 as *mut libc::c_void, 8);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn fd(&self) -> i32 {
+        self.efd
+    }
+
+    pub(crate) fn dup_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
+        use std::os::fd::{FromRawFd, OwnedFd};
+        let fd = unsafe { libc::dup(self.efd) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+
+    fn write_eventfd(&self) {
+        let val: u64 = 1;
+        while unsafe { libc::write(self.efd, &val as *const u64 as *const libc::c_void, 8) } < 0 {
+            if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+                break;
+            }
+        }
+    }
+}
+
+impl Drop for EventFdSignal {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.efd) };
+    }
+}

--- a/bindings/pyomq/src/notify/windows.rs
+++ b/bindings/pyomq/src/notify/windows.rs
@@ -69,6 +69,10 @@ impl WindowsWakeupState {
         self.hooks.set_mode(mode);
     }
 
+    fn clear_mode(&mut self, mode: u32) {
+        self.hooks.clear_mode(mode);
+    }
+
     fn begin_drain(&self) {
         self.draining.store(true, Ordering::Release);
     }
@@ -238,6 +242,11 @@ impl WindowsSignal {
             self.signal();
         }
     }
+
+    pub(crate) fn clear_wakeup_mode(&self, mode: u32) {
+        let mut state = self.state.lock().unwrap();
+        state.clear_mode(mode);
+    }
 }
 
 #[derive(Default)]
@@ -254,7 +263,19 @@ impl WakeupHooks {
     }
 
     fn set_mode(&mut self, mode: u32) {
-        self.mode.store(mode, Ordering::Relaxed);
+        if mode == 0 {
+            self.mode.store(0, Ordering::Relaxed);
+        } else {
+            self.mode.fetch_or(mode, Ordering::Relaxed);
+        }
+    }
+
+    fn clear_mode(&mut self, mode: u32) {
+        if mode == 0 {
+            self.mode.store(0, Ordering::Relaxed);
+        } else {
+            self.mode.fetch_and(!mode, Ordering::Relaxed);
+        }
     }
 }
 

--- a/bindings/pyomq/src/notify/windows.rs
+++ b/bindings/pyomq/src/notify/windows.rs
@@ -1,0 +1,274 @@
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::time::Duration;
+
+use pyo3::prelude::*;
+use pyo3::types::PyAny;
+
+use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{CreateEventW, ResetEvent, SetEvent, WaitForSingleObject};
+
+pub(crate) const WAKEUP_MODE_ASYNC: u32 = 1 << 0;
+pub(crate) const WAKEUP_MODE_SYNC: u32 = 1 << 1;
+const WAKEUP_CALLBACK_IDLE: u8 = 0;
+const WAKEUP_CALLBACK_SCHEDULED: u8 = 1 << 0;
+const WAKEUP_CALLBACK_PENDING: u8 = 1 << 1;
+
+pub(crate) struct WindowsSignal {
+    state: Mutex<WindowsWakeupState>,
+}
+
+struct WakeupDispatch {
+    async_callback: Option<Py<PyAny>>,
+    sync_event: Option<Py<PyAny>>,
+    mode: u32,
+}
+
+// The only non-native-thread-safe piece here is the Windows waitable event handle,
+// and it is fully protected by the mutex in this backend. The surrounding atomics
+// are only used for bookkeeping, so the backend is safe to send and share.
+unsafe impl Send for WindowsSignal {}
+unsafe impl Sync for WindowsSignal {}
+
+struct WindowsWakeupState {
+    // The waitable event used by the Windows side to wake the async loop.
+    event: HANDLE,
+    // Latched wakeup signal: once set, the waiter must consume it before it can
+    // go idle again. This is the OS-visible pending bit for the event path.
+    pending: AtomicBool,
+    // True while the Python-side drain callback is running. Additional wakeups
+    // during this window are coalesced into a follow-up callback instead of
+    // scheduling a new one immediately.
+    draining: AtomicBool,
+    // Small state machine for the callback path:
+    // - SCHEDULED: a drain callback has been queued
+    // - PENDING: another wakeup arrived while a drain was already in progress
+    // - IDLE: nothing pending for the callback path
+    callback_state: AtomicU8,
+    hooks: WakeupHooks,
+}
+
+impl WindowsWakeupState {
+    fn new() -> Self {
+        let event = unsafe { CreateEventW(None, true, false, None) }.expect("CreateEventW failed");
+        assert!(!event.is_invalid(), "CreateEventW failed");
+        Self {
+            event,
+            pending: AtomicBool::new(false),
+            draining: AtomicBool::new(false),
+            callback_state: AtomicU8::new(WAKEUP_CALLBACK_IDLE),
+            hooks: WakeupHooks::default(),
+        }
+    }
+
+    fn set_hooks(&mut self, async_callback: Option<Py<PyAny>>, sync_event: Option<Py<PyAny>>) {
+        self.hooks.set(async_callback, sync_event);
+    }
+
+    fn set_mode(&mut self, mode: u32) {
+        self.hooks.set_mode(mode);
+    }
+
+    fn begin_drain(&self) {
+        self.draining.store(true, Ordering::Release);
+    }
+
+    fn try_schedule_callback(&self) -> bool {
+        if self.draining.load(Ordering::Acquire) {
+            self.callback_state
+                .fetch_or(WAKEUP_CALLBACK_PENDING, Ordering::AcqRel);
+            false
+        } else {
+            self.begin_drain();
+            let prev = self
+                .callback_state
+                .fetch_or(WAKEUP_CALLBACK_SCHEDULED, Ordering::AcqRel);
+            if prev & WAKEUP_CALLBACK_SCHEDULED != 0 {
+                self.callback_state
+                    .fetch_or(WAKEUP_CALLBACK_PENDING, Ordering::AcqRel);
+                false
+            } else {
+                true
+            }
+        }
+    }
+
+    fn finish_callback(&self) -> bool {
+        let mut prev = self.callback_state.load(Ordering::Acquire);
+        loop {
+            let needs_followup = prev & WAKEUP_CALLBACK_PENDING != 0;
+            let next = WAKEUP_CALLBACK_IDLE;
+            match self.callback_state.compare_exchange_weak(
+                prev,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.draining.store(false, Ordering::Release);
+                    return needs_followup;
+                }
+                Err(current) => prev = current,
+            }
+        }
+    }
+}
+
+impl Drop for WindowsWakeupState {
+    fn drop(&mut self) {
+        if !self.event.is_invalid() {
+            unsafe {
+                let _ = windows::Win32::Foundation::CloseHandle(self.event);
+            }
+        }
+    }
+}
+
+impl WindowsSignal {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(WindowsWakeupState::new()),
+        }
+    }
+
+    pub(crate) fn signal(&self) {
+        let should_invoke = {
+            let state = self.state.lock().unwrap();
+            let already_pending = state.pending.swap(true, Ordering::AcqRel);
+            if !already_pending {
+                unsafe {
+                    let _ = SetEvent(state.event);
+                }
+            }
+            let mode = state.hooks.mode.load(Ordering::Relaxed);
+            let callback_enabled =
+                mode & WAKEUP_MODE_ASYNC != 0 && state.hooks.async_callback.is_some();
+            let sync_enabled = mode & WAKEUP_MODE_SYNC != 0 && state.hooks.sync_event.is_some();
+            if callback_enabled {
+                state.try_schedule_callback()
+            } else {
+                sync_enabled
+            }
+        };
+
+        if should_invoke {
+            Python::attach(|py| {
+                let dispatch = {
+                    let state = self.state.lock().unwrap();
+                    let async_callback = state
+                        .hooks
+                        .async_callback
+                        .as_ref()
+                        .map(|cb| cb.clone_ref(py));
+                    let sync_event = state.hooks.sync_event.as_ref().map(|ev| ev.clone_ref(py));
+                    let mode = state.hooks.mode.load(Ordering::Relaxed);
+                    WakeupDispatch {
+                        async_callback,
+                        sync_event,
+                        mode,
+                    }
+                };
+
+                if dispatch.mode & WAKEUP_MODE_ASYNC != 0
+                    && let Some(callback) = dispatch.async_callback.as_ref()
+                {
+                    let _ = callback.call(py, (), None);
+                }
+                if dispatch.mode & WAKEUP_MODE_SYNC != 0
+                    && let Some(event) = dispatch.sync_event.as_ref()
+                {
+                    let _ = event.call_method0(py, "set");
+                }
+            });
+        }
+    }
+
+    pub(crate) fn mark_drain_complete(&self) {
+        let rearm = {
+            let state = self.state.lock().unwrap();
+            state.finish_callback()
+        };
+        if rearm {
+            self.signal();
+        }
+    }
+
+    pub(crate) fn force_wake(&self) {
+        self.signal();
+    }
+
+    pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
+        let state = self.state.lock().unwrap();
+        if state.pending.swap(false, Ordering::AcqRel) {
+            return true;
+        }
+        unsafe {
+            let _ = ResetEvent(state.event);
+        }
+        if state.pending.swap(false, Ordering::AcqRel) {
+            return true;
+        }
+        let handle = state.event;
+        drop(state);
+
+        let timeout_ms = timeout.as_millis().min(u32::MAX as u128) as u32;
+        match unsafe { WaitForSingleObject(handle, timeout_ms) } {
+            WAIT_OBJECT_0 => true,
+            WAIT_TIMEOUT => false,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn set_wakeup_hooks(
+        &self,
+        async_callback: Option<Py<PyAny>>,
+        sync_event: Option<Py<PyAny>>,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        state.set_hooks(async_callback, sync_event);
+    }
+
+    pub(crate) fn set_wakeup_mode(&self, mode: u32) {
+        let pending = {
+            let mut state = self.state.lock().unwrap();
+            state.set_mode(mode);
+            state.pending.load(Ordering::Acquire)
+        };
+        if pending {
+            self.signal();
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct WakeupHooks {
+    pub async_callback: Option<Py<PyAny>>,
+    pub sync_event: Option<Py<PyAny>>,
+    pub mode: std::sync::atomic::AtomicU32,
+}
+
+impl WakeupHooks {
+    fn set(&mut self, async_callback: Option<Py<PyAny>>, sync_event: Option<Py<PyAny>>) {
+        self.async_callback = async_callback;
+        self.sync_event = sync_event;
+    }
+
+    fn set_mode(&mut self, mode: u32) {
+        self.mode.store(mode, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_wakeup_waits_for_drain_finish_before_rearming() {
+        let signal = WindowsSignal::new();
+        let state = signal.state.lock().unwrap();
+
+        assert!(state.try_schedule_callback());
+        assert!(!state.try_schedule_callback());
+        assert!(state.finish_callback());
+    }
+}

--- a/bindings/pyomq/src/notify/windows.rs
+++ b/bindings/pyomq/src/notify/windows.rs
@@ -142,19 +142,22 @@ impl WindowsSignal {
         }
     }
 
-    pub(crate) fn signal(&self) {
+    pub(crate) fn signal(&self, waiter_armed: bool) {
         let should_invoke = {
             let state = self.state.lock().unwrap();
+            let mode = state.hooks.mode.load(Ordering::Relaxed);
+            let callback_enabled =
+                mode & WAKEUP_MODE_ASYNC != 0 && state.hooks.async_callback.is_some();
+            let sync_enabled = mode & WAKEUP_MODE_SYNC != 0 && state.hooks.sync_event.is_some();
+            if !waiter_armed && !callback_enabled && !sync_enabled {
+                return;
+            }
             let already_pending = state.pending.swap(true, Ordering::AcqRel);
             if !already_pending {
                 unsafe {
                     let _ = SetEvent(state.event);
                 }
             }
-            let mode = state.hooks.mode.load(Ordering::Relaxed);
-            let callback_enabled =
-                mode & WAKEUP_MODE_ASYNC != 0 && state.hooks.async_callback.is_some();
-            let sync_enabled = mode & WAKEUP_MODE_SYNC != 0 && state.hooks.sync_event.is_some();
             if callback_enabled {
                 state.try_schedule_callback()
             } else {
@@ -201,12 +204,12 @@ impl WindowsSignal {
             state.finish_callback()
         };
         if rearm {
-            self.signal();
+            self.signal(true);
         }
     }
 
     pub(crate) fn force_wake(&self) {
-        self.signal();
+        self.signal(true);
     }
 
     pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
@@ -247,7 +250,7 @@ impl WindowsSignal {
             state.pending.load(Ordering::Acquire)
         };
         if pending {
-            self.signal();
+            self.signal(true);
         }
     }
 
@@ -320,5 +323,25 @@ mod tests {
             state.callback_state.load(Ordering::Acquire),
             WAKEUP_CALLBACK_IDLE
         );
+    }
+
+    #[test]
+    fn unarmed_signal_does_not_latch_pending_wakeup() {
+        let signal = WindowsSignal::new();
+
+        signal.signal(false);
+
+        let state = signal.state.lock().unwrap();
+        assert!(!state.pending.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn armed_signal_latches_pending_wakeup() {
+        let signal = WindowsSignal::new();
+
+        signal.signal(true);
+
+        let state = signal.state.lock().unwrap();
+        assert!(state.pending.load(Ordering::Acquire));
     }
 }

--- a/bindings/pyomq/src/notify/windows.rs
+++ b/bindings/pyomq/src/notify/windows.rs
@@ -116,6 +116,13 @@ impl WindowsWakeupState {
             }
         }
     }
+
+    fn consume_pending(&self) {
+        self.pending.store(false, Ordering::Release);
+        unsafe {
+            let _ = ResetEvent(self.event);
+        }
+    }
 }
 
 impl Drop for WindowsWakeupState {
@@ -190,6 +197,7 @@ impl WindowsSignal {
     pub(crate) fn mark_drain_complete(&self) {
         let rearm = {
             let state = self.state.lock().unwrap();
+            state.consume_pending();
             state.finish_callback()
         };
         if rearm {
@@ -291,5 +299,26 @@ mod tests {
         assert!(state.try_schedule_callback());
         assert!(!state.try_schedule_callback());
         assert!(state.finish_callback());
+    }
+
+    #[test]
+    fn completed_async_drain_consumes_pending_wakeup() {
+        let signal = WindowsSignal::new();
+
+        {
+            let state = signal.state.lock().unwrap();
+            state.pending.store(true, Ordering::Release);
+            assert!(state.try_schedule_callback());
+        }
+
+        signal.mark_drain_complete();
+
+        let state = signal.state.lock().unwrap();
+        assert!(!state.pending.load(Ordering::Acquire));
+        assert!(!state.draining.load(Ordering::Acquire));
+        assert_eq!(
+            state.callback_state.load(Ordering::Acquire),
+            WAKEUP_CALLBACK_IDLE
+        );
     }
 }

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -143,7 +143,10 @@ impl Overlay {
             compression_dict: self.compression_dict.clone(),
             compression_auto_train: self.compression_auto_train,
             arena_threshold: Some(64 * 1024),
-            transmit_slot_cap: None,
+            // Windows TCP PUSH/PULL throughput falls off when the fast-path
+            // transmit slot hits its byte cap before the default message HWM.
+            // 2 MiB keeps medium payloads batched without huge per-peer slack.
+            transmit_slot_cap: Some(2 * 1024 * 1024),
             reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             ..Default::default()
         };

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -143,10 +143,7 @@ impl Overlay {
             compression_dict: self.compression_dict.clone(),
             compression_auto_train: self.compression_auto_train,
             arena_threshold: Some(64 * 1024),
-            // Windows TCP PUSH/PULL throughput falls off when the fast-path
-            // transmit slot hits its byte cap before the default message HWM.
-            // 2 MiB keeps medium payloads batched without huge per-peer slack.
-            transmit_slot_cap: Some(2 * 1024 * 1024),
+            transmit_slot_cap: None,
             reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             ..Default::default()
         };

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -26,6 +26,8 @@ use pyo3::prelude::*;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
+use crate::notify::ReadinessSignal;
+
 struct RuntimeState {
     pid: u32,
     ctx: omq_tokio::Context,
@@ -33,13 +35,12 @@ struct RuntimeState {
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-static GLOBAL_RECV_SIGNAL: Mutex<Option<(u32, Arc<crate::socket::EventFdSignal>)>> =
-    Mutex::new(None);
+static GLOBAL_RECV_SIGNAL: Mutex<Option<(u32, Arc<ReadinessSignal>)>> = Mutex::new(None);
 
 /// Process-global recv signal for `wait_any`. Recv pumps from all
 /// contexts signal this after pushing a message; `wait_any` parks on it.
 /// Recreated after fork (PID guard).
-pub(crate) fn global_recv_signal() -> Arc<crate::socket::EventFdSignal> {
+pub(crate) fn global_recv_signal() -> Arc<ReadinessSignal> {
     let mut guard = GLOBAL_RECV_SIGNAL.lock().unwrap();
     let pid = std::process::id();
     if let Some((cached_pid, signal)) = guard.as_ref()
@@ -47,7 +48,7 @@ pub(crate) fn global_recv_signal() -> Arc<crate::socket::EventFdSignal> {
     {
         return signal.clone();
     }
-    let signal = Arc::new(crate::socket::EventFdSignal::new());
+    let signal = Arc::new(ReadinessSignal::new());
     *guard = Some((pid, signal.clone()));
     signal
 }
@@ -149,8 +150,8 @@ impl ContextInner {
         options: omq_tokio::Options,
         send_cons: yring::AsyncConsumer<omq_tokio::Message>,
         mut recv_prod: yring::Producer<omq_tokio::Message>,
-        recv_ready: Arc<crate::socket::EventFdSignal>,
-        send_ready: Arc<crate::socket::EventFdSignal>,
+        recv_ready: Arc<ReadinessSignal>,
+        send_ready: Arc<ReadinessSignal>,
         recv_space: Arc<omq_tokio::engine::StateSignal>,
     ) -> PyResult<(u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>)> {
         let handle = self.ensure_runtime()?;

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -168,6 +168,7 @@ impl ContextInner {
                 let mut batch = 0u32;
                 while let Some(msg) = futures::StreamExt::next(&mut send_cons).await {
                     let _ = send_socket.send(msg).await;
+                    send_cons.as_mut().get_mut().release();
                     send_ready.signal();
                     batch += 1;
                     if batch >= SEND_YIELD_INTERVAL {

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -35,6 +35,7 @@ use std::sync::atomic::AtomicU32;
 static FORK_GEN: AtomicU32 = AtomicU32::new(0);
 static PARENT_FORK_GEN: AtomicU32 = AtomicU32::new(0);
 static FORKED: AtomicBool = AtomicBool::new(false);
+#[cfg(unix)]
 static ATFORK_REGISTERED: std::sync::Once = std::sync::Once::new();
 
 #[cfg(unix)]
@@ -314,6 +315,7 @@ impl SocketInner {
         let materialized = self.materialized.write().unwrap().take();
         if let Some(ref state) = materialized {
             state.recv_ready.force_wake();
+            state.send_ready.force_wake();
         }
         materialized
     }
@@ -358,6 +360,19 @@ impl SocketInner {
             }
             if let Some(mode) = send_mode {
                 materialized.send_ready.set_wakeup_mode(mode);
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn clear_wakeup_modes(&self, recv_mode: Option<u32>, send_mode: Option<u32>) {
+        let materialized_guard = self.materialized.read().unwrap();
+        if let Some(materialized) = materialized_guard.as_ref() {
+            if let Some(mode) = recv_mode {
+                materialized.recv_ready.clear_wakeup_mode(mode);
+            }
+            if let Some(mode) = send_mode {
+                materialized.send_ready.clear_wakeup_mode(mode);
             }
         }
     }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -329,6 +329,54 @@ impl SocketInner {
             options::duration_from_millis,
         )
     }
+
+    #[cfg(windows)]
+    pub fn set_wakeup_hooks(
+        &self,
+        recv_async: Option<Py<PyAny>>,
+        recv_event: Option<Py<PyAny>>,
+        send_async: Option<Py<PyAny>>,
+        send_event: Option<Py<PyAny>>,
+    ) {
+        let materialized_guard = self.materialized.read().unwrap();
+        if let Some(materialized) = materialized_guard.as_ref() {
+            materialized
+                .recv_ready
+                .set_wakeup_hooks(recv_async, recv_event);
+            materialized
+                .send_ready
+                .set_wakeup_hooks(send_async, send_event);
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn set_wakeup_modes(&self, recv_mode: Option<u32>, send_mode: Option<u32>) {
+        let materialized_guard = self.materialized.read().unwrap();
+        if let Some(materialized) = materialized_guard.as_ref() {
+            if let Some(mode) = recv_mode {
+                materialized.recv_ready.set_wakeup_mode(mode);
+            }
+            if let Some(mode) = send_mode {
+                materialized.send_ready.set_wakeup_mode(mode);
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn mark_recv_wakeup_drain_complete(&self) {
+        let materialized_guard = self.materialized.read().unwrap();
+        if let Some(materialized) = materialized_guard.as_ref() {
+            materialized.recv_ready.mark_drain_complete();
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn mark_send_wakeup_drain_complete(&self) {
+        let materialized_guard = self.materialized.read().unwrap();
+        if let Some(materialized) = materialized_guard.as_ref() {
+            materialized.send_ready.mark_drain_complete();
+        }
+    }
 }
 
 /// Monitor event stream returned by `Socket.monitor()`. Delivers

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -20,6 +20,7 @@ use tokio::task::JoinHandle;
 use crate::conversions;
 use crate::dispatch;
 use crate::error::{map_err, timeout_err};
+use crate::notify::ReadinessSignal;
 use crate::options;
 use crate::runtime::ContextInner;
 
@@ -29,103 +30,6 @@ pub(crate) struct SendBuffer {
     pub parts: Vec<Bytes>,
 }
 
-/// Eventfd-backed readiness signal for Python-facing async paths.
-///
-/// The `parking` flag avoids syscalls on the hot path. The consumer
-/// sets it before sleeping; the producer only writes to the eventfd
-/// when it sees the flag.
-pub(crate) struct EventFdSignal {
-    efd: i32,
-    parking: AtomicBool,
-}
-
-unsafe impl Send for EventFdSignal {}
-unsafe impl Sync for EventFdSignal {}
-
-impl EventFdSignal {
-    pub fn new() -> Self {
-        let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
-        assert!(efd >= 0, "eventfd creation failed");
-        Self {
-            efd,
-            parking: AtomicBool::new(false),
-        }
-    }
-
-    pub fn signal(&self) {
-        if self.parking.load(Ordering::Acquire) {
-            self.write_eventfd();
-        }
-    }
-
-    pub fn force_wake(&self) {
-        self.write_eventfd();
-    }
-
-    fn write_eventfd(&self) {
-        let val: u64 = 1;
-        while unsafe { libc::write(self.efd, &val as *const u64 as *const libc::c_void, 8) } < 0 {
-            if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
-                break;
-            }
-        }
-    }
-
-    pub fn park_begin(&self) {
-        self.parking.store(true, Ordering::Release);
-    }
-
-    pub fn park_end(&self) {
-        self.parking.store(false, Ordering::Relaxed);
-    }
-
-    pub fn wait_timeout(&self, timeout: Duration) -> bool {
-        let mut pfd = libc::pollfd {
-            fd: self.efd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
-        let ret = unsafe { libc::poll(&mut pfd, 1, ms) };
-        if ret > 0 {
-            let mut val: u64 = 0;
-            unsafe {
-                libc::read(self.efd, &mut val as *mut u64 as *mut libc::c_void, 8);
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn fd(&self) -> i32 {
-        self.efd
-    }
-
-    /// Permanently arm the eventfd so the recv pump always writes on
-    /// message arrival. Required when the fd is exposed to an external
-    /// event loop (tornado/ZMQStream, asyncio) that polls it for
-    /// readiness.
-    pub fn arm_persistent(&self) {
-        self.parking.store(true, Ordering::Release);
-    }
-
-    pub fn dup_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
-        use std::os::fd::{FromRawFd, OwnedFd};
-        let fd = unsafe { libc::dup(self.efd) };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
-    }
-}
-
-impl Drop for EventFdSignal {
-    fn drop(&mut self) {
-        unsafe { libc::close(self.efd) };
-    }
-}
-
 use std::sync::atomic::AtomicU32;
 
 static FORK_GEN: AtomicU32 = AtomicU32::new(0);
@@ -133,21 +37,29 @@ static PARENT_FORK_GEN: AtomicU32 = AtomicU32::new(0);
 static FORKED: AtomicBool = AtomicBool::new(false);
 static ATFORK_REGISTERED: std::sync::Once = std::sync::Once::new();
 
+#[cfg(unix)]
 extern "C" fn atfork_child() {
     FORKED.store(true, Ordering::Relaxed);
     FORK_GEN.fetch_add(1, Ordering::Relaxed);
 }
 
+#[cfg(unix)]
 extern "C" fn atfork_parent() {
     // The parent's runtime remains valid, but sockets materialized before
     // fork need one safe receive to resynchronize with child-side peers.
     PARENT_FORK_GEN.fetch_add(1, Ordering::Relaxed);
 }
 
+#[cfg(unix)]
 pub(crate) fn register_atfork() {
     ATFORK_REGISTERED.call_once(|| unsafe {
         libc::pthread_atfork(Some(atfork_parent), None, Some(atfork_child));
     });
+}
+
+#[cfg(not(unix))]
+pub(crate) fn register_atfork() {
+    // No-op on non-Unix platforms
 }
 
 /// State that exists once the underlying omq Socket is materialized.
@@ -158,8 +70,8 @@ pub(crate) struct Materialized {
     pub socket: Arc<omq_tokio::Socket>,
     pub send_prod: Mutex<yring::AsyncProducer<omq_tokio::Message>>,
     pub recv_cons: Mutex<yring::Consumer<omq_tokio::Message>>,
-    pub recv_ready: Arc<EventFdSignal>,
-    pub send_ready: Arc<EventFdSignal>,
+    pub recv_ready: Arc<ReadinessSignal>,
+    pub send_ready: Arc<ReadinessSignal>,
     pub recv_space: Arc<omq_tokio::engine::StateSignal>,
     pub send_pump: JoinHandle<()>,
     pub recv_pump: JoinHandle<()>,
@@ -242,8 +154,8 @@ impl SocketInner {
         let recv_cap = opts.recv_hwm.max(1) as usize;
         let (send_prod, send_cons) = yring::async_spsc(send_cap);
         let (recv_prod, recv_cons) = yring::spsc(recv_cap);
-        let recv_ready = Arc::new(EventFdSignal::new());
-        let send_ready = Arc::new(EventFdSignal::new());
+        let recv_ready = Arc::new(ReadinessSignal::new());
+        let send_ready = Arc::new(ReadinessSignal::new());
         let recv_space = Arc::new(omq_tokio::engine::StateSignal::new());
         let socket_type = self.socket_type;
         let (id, socket, send_pump, recv_pump) = self.ctx.materialize(

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -157,6 +157,7 @@ impl AsyncSocket {
         }
     }
 
+    #[cfg(unix)]
     #[pyo3(name = "_recv_fd")]
     fn recv_fd(&self) -> PyResult<i32> {
         self.inner.materialize()?;
@@ -173,6 +174,15 @@ impl AsyncSocket {
         Ok(owned_fd.into_raw_fd())
     }
 
+    #[cfg(not(unix))]
+    #[pyo3(name = "_recv_fd")]
+    fn recv_fd(&self) -> PyResult<i32> {
+        Err(crate::error::map_err(omq_proto::error::Error::Protocol(
+            "_recv_fd() is only available on Unix platforms".to_string(),
+        )))
+    }
+
+    #[cfg(unix)]
     #[pyo3(name = "_send_fd")]
     fn send_fd(&self) -> PyResult<i32> {
         self.inner.materialize()?;
@@ -187,6 +197,14 @@ impl AsyncSocket {
         send_ready.park_begin();
         use std::os::fd::IntoRawFd;
         Ok(owned_fd.into_raw_fd())
+    }
+
+    #[cfg(not(unix))]
+    #[pyo3(name = "_send_fd")]
+    fn send_fd(&self) -> PyResult<i32> {
+        Err(crate::error::map_err(omq_proto::error::Error::Protocol(
+            "_send_fd() is only available on Unix platforms".to_string(),
+        )))
     }
 
     // ── Subscriptions / groups (sync) ───────────────────────────────

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -217,6 +217,7 @@ impl AsyncSocket {
         send_async: Option<&Bound<'_, PyAny>>,
         send_event: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
+        self.inner.materialize()?;
         self.inner.set_wakeup_hooks(
             recv_async.map(|cb| cb.clone().unbind()),
             recv_event.map(|event| event.clone().unbind()),
@@ -230,7 +231,20 @@ impl AsyncSocket {
     #[pyo3(name = "_set_wakeup_modes")]
     #[pyo3(signature = (recv_mode = None, send_mode = None))]
     fn set_wakeup_modes(&self, recv_mode: Option<u32>, send_mode: Option<u32>) -> PyResult<()> {
+        self.inner.materialize()?;
         self.inner.set_wakeup_modes(recv_mode, send_mode);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[pyo3(name = "_clear_wakeup_modes")]
+    #[pyo3(signature = (recv_mode = None, send_mode = None))]
+    fn clear_wakeup_modes(
+        &self,
+        recv_mode: Option<u32>,
+        send_mode: Option<u32>,
+    ) -> PyResult<()> {
+        self.inner.clear_wakeup_modes(recv_mode, send_mode);
         Ok(())
     }
 

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -207,6 +207,47 @@ impl AsyncSocket {
         )))
     }
 
+    #[cfg(windows)]
+    #[pyo3(name = "_set_wakeup_hooks")]
+    #[pyo3(signature = (recv_async = None, recv_event = None, send_async = None, send_event = None))]
+    fn set_wakeup_hooks(
+        &self,
+        recv_async: Option<&Bound<'_, PyAny>>,
+        recv_event: Option<&Bound<'_, PyAny>>,
+        send_async: Option<&Bound<'_, PyAny>>,
+        send_event: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<()> {
+        self.inner.set_wakeup_hooks(
+            recv_async.map(|cb| cb.clone().unbind()),
+            recv_event.map(|event| event.clone().unbind()),
+            send_async.map(|cb| cb.clone().unbind()),
+            send_event.map(|event| event.clone().unbind()),
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[pyo3(name = "_set_wakeup_modes")]
+    #[pyo3(signature = (recv_mode = None, send_mode = None))]
+    fn set_wakeup_modes(&self, recv_mode: Option<u32>, send_mode: Option<u32>) -> PyResult<()> {
+        self.inner.set_wakeup_modes(recv_mode, send_mode);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[pyo3(name = "_mark_recv_drain_complete")]
+    fn mark_recv_drain_complete(&self) -> PyResult<()> {
+        self.inner.mark_recv_wakeup_drain_complete();
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[pyo3(name = "_mark_send_drain_complete")]
+    fn mark_send_drain_complete(&self) -> PyResult<()> {
+        self.inner.mark_send_wakeup_drain_complete();
+        Ok(())
+    }
+
     // ── Subscriptions / groups (sync) ───────────────────────────────
 
     fn subscribe(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<()> {

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -239,11 +239,7 @@ impl AsyncSocket {
     #[cfg(windows)]
     #[pyo3(name = "_clear_wakeup_modes")]
     #[pyo3(signature = (recv_mode = None, send_mode = None))]
-    fn clear_wakeup_modes(
-        &self,
-        recv_mode: Option<u32>,
-        send_mode: Option<u32>,
-    ) -> PyResult<()> {
+    fn clear_wakeup_modes(&self, recv_mode: Option<u32>, send_mode: Option<u32>) -> PyResult<()> {
         self.inner.clear_wakeup_modes(recv_mode, send_mode);
         Ok(())
     }

--- a/bindings/pyomq/tests/conftest.py
+++ b/bindings/pyomq/tests/conftest.py
@@ -1,8 +1,38 @@
 """Shared fixtures."""
 
+import asyncio
+import sys
 import time
 
 import pytest
+
+
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line(
+        "markers", "event_loop: mark test requiring specific event loop type"
+    )
+
+
+def pytest_asyncio_loop_factories(config, item):
+    if sys.platform == "win32":
+        if m := item.get_closest_marker("event_loop"):
+            ev = {}
+            if "selector" in m.args:
+                ev["selector"] = asyncio.SelectorEventLoop
+            if "proactor" in m.args:
+                ev["proactor"] = asyncio.ProactorEventLoop
+            return ev
+        return {"proactor": asyncio.ProactorEventLoop}
+    else:
+        return {
+            "default": asyncio.new_event_loop,
+        }
+
+
+@pytest.fixture
+def require_selector_event_loop():
+    pass
 
 
 @pytest.fixture
@@ -18,9 +48,13 @@ def inproc_endpoint(request) -> str:
 
 @pytest.fixture
 def ipc_endpoint(request) -> str:
-    import os, hashlib
-    # Linux abstract namespace: no filesystem entry, auto-cleaned on close.
+    import hashlib
+    import os
+
     tag = hashlib.sha1(f"{os.getpid()}-{request.node.name}".encode()).hexdigest()[:16]
+    if sys.platform == "win32":
+        return f"ipc://pyomq-{tag}"
+    # Linux abstract namespace: no filesystem entry, auto-cleaned on close.
     return f"ipc://@pyomq-{tag}"
 
 

--- a/bindings/pyomq/tests/test_async.py
+++ b/bindings/pyomq/tests/test_async.py
@@ -9,6 +9,8 @@ import pytest
 import pyomq
 import pyomq.asyncio as zmq_async
 
+pytestmark = pytest.mark.event_loop("selector", "proactor")
+
 
 @pytest.mark.asyncio
 async def test_async_push_pull_inproc(inproc_endpoint):
@@ -248,6 +250,7 @@ async def test_async_dealer_router_identity(tcp_endpoint):
 async def test_async_push_pull_bulk_tcp(tcp_endpoint):
     """Async recv with sync sender in a thread."""
     import threading
+
     n = 20_000
     ctx = zmq_async.Context()
     pull = ctx.socket(pyomq.PULL)
@@ -257,7 +260,9 @@ async def test_async_push_pull_bulk_tcp(tcp_endpoint):
         push_sync.connect(ep)
 
         def sender():
-            import time; time.sleep(0.05)
+            import time
+
+            time.sleep(0.05)
             for _ in range(n):
                 push_sync.send(b"x" * 128)
 

--- a/bindings/pyomq/tests/test_fork.py
+++ b/bindings/pyomq/tests/test_fork.py
@@ -11,6 +11,10 @@ import pyomq as zmq
 pytestmark = pytest.mark.filterwarnings(
     "ignore:This process .* is multi-threaded, use of fork:DeprecationWarning"
 )
+pytestmark = [
+    pytestmark,
+    pytest.mark.skipif(os.name == "nt", reason="fork is Unix-only"),
+]
 
 FORK_TIMEOUT_MS = 5_000
 FORK_TIMEOUT_S = FORK_TIMEOUT_MS / 1_000

--- a/bindings/pyomq/tests/test_interop.py
+++ b/bindings/pyomq/tests/test_interop.py
@@ -6,11 +6,16 @@ intentionally absent: pyzmq's inproc and pyomq's inproc each maintain
 their own process-local registry, so they can never see each other.
 """
 
+import sys
 import time
 
 import pytest
 
 zmq_pyzmq = pytest.importorskip("zmq")  # pyzmq
+
+# PyZMQ requires to use the selector event loop on Windows,
+# so we skip the proactor event loop for these tests.
+pytestmark = pytest.mark.event_loop("selector")
 
 import pyomq
 
@@ -29,19 +34,25 @@ def endpoint(request):
 
 _TRANSPORTS = pytest.mark.parametrize(
     "endpoint",
-    ["tcp_endpoint", "ipc_endpoint"],
+    # pyzmq does not support IPC on Windows, so skip that transport there.
+    ["tcp_endpoint"] if sys.platform == "win32" else ["tcp_endpoint", "ipc_endpoint"],
     indirect=True,
 )
 
 
 # ---------- PUSH / PULL ----------
 
+
 @_TRANSPORTS
 def test_pyomq_push_pyzmq_pull(endpoint):
     py_ctx = zmq_pyzmq.Context.instance()
     pull = py_ctx.socket(zmq_pyzmq.PULL)
     pull.bind(endpoint)
-    ep = pull.last_endpoint.decode() if isinstance(pull.last_endpoint, bytes) else pull.last_endpoint
+    ep = (
+        pull.last_endpoint.decode()
+        if isinstance(pull.last_endpoint, bytes)
+        else pull.last_endpoint
+    )
     try:
         ctx = pyomq.Context()
         push = ctx.socket(pyomq.PUSH)
@@ -73,6 +84,7 @@ def test_pyzmq_push_pyomq_pull(endpoint):
 
 # ---------- PUB / SUB ----------
 
+
 @_TRANSPORTS
 def test_pyomq_pub_pyzmq_sub(endpoint):
     ctx = pyomq.Context()
@@ -99,7 +111,11 @@ def test_pyzmq_pub_pyomq_sub(endpoint):
     py_ctx = zmq_pyzmq.Context.instance()
     pub = py_ctx.socket(zmq_pyzmq.PUB)
     pub.bind(endpoint)
-    ep = pub.last_endpoint.decode() if isinstance(pub.last_endpoint, bytes) else pub.last_endpoint
+    ep = (
+        pub.last_endpoint.decode()
+        if isinstance(pub.last_endpoint, bytes)
+        else pub.last_endpoint
+    )
     try:
         ctx = pyomq.Context()
         sub = ctx.socket(pyomq.SUB)
@@ -118,12 +134,17 @@ def test_pyzmq_pub_pyomq_sub(endpoint):
 
 # ---------- REQ / REP ----------
 
+
 @_TRANSPORTS
 def test_pyomq_req_pyzmq_rep(endpoint):
     py_ctx = zmq_pyzmq.Context.instance()
     rep = py_ctx.socket(zmq_pyzmq.REP)
     rep.bind(endpoint)
-    ep = rep.last_endpoint.decode() if isinstance(rep.last_endpoint, bytes) else rep.last_endpoint
+    ep = (
+        rep.last_endpoint.decode()
+        if isinstance(rep.last_endpoint, bytes)
+        else rep.last_endpoint
+    )
     try:
         ctx = pyomq.Context()
         req = ctx.socket(pyomq.REQ)
@@ -159,12 +180,17 @@ def test_pyzmq_req_pyomq_rep(endpoint):
 
 # ---------- DEALER / ROUTER ----------
 
+
 @_TRANSPORTS
 def test_pyomq_dealer_pyzmq_router(endpoint):
     py_ctx = zmq_pyzmq.Context.instance()
     router = py_ctx.socket(zmq_pyzmq.ROUTER)
     router.bind(endpoint)
-    ep = router.last_endpoint.decode() if isinstance(router.last_endpoint, bytes) else router.last_endpoint
+    ep = (
+        router.last_endpoint.decode()
+        if isinstance(router.last_endpoint, bytes)
+        else router.last_endpoint
+    )
     try:
         ctx = pyomq.Context()
         dealer = ctx.socket(pyomq.DEALER)
@@ -206,12 +232,17 @@ def test_pyzmq_dealer_pyomq_router(endpoint):
 
 # ---------- PAIR ----------
 
+
 @_TRANSPORTS
 def test_pair_both_directions(endpoint):
     py_ctx = zmq_pyzmq.Context.instance()
     a = py_ctx.socket(zmq_pyzmq.PAIR)
     a.bind(endpoint)
-    ep = a.last_endpoint.decode() if isinstance(a.last_endpoint, bytes) else a.last_endpoint
+    ep = (
+        a.last_endpoint.decode()
+        if isinstance(a.last_endpoint, bytes)
+        else a.last_endpoint
+    )
     try:
         ctx = pyomq.Context()
         b = ctx.socket(pyomq.PAIR)
@@ -227,6 +258,7 @@ def test_pair_both_directions(endpoint):
 
 
 # ---------- XPUB / XSUB ----------
+
 
 @_TRANSPORTS
 def test_pyomq_xpub_pyzmq_xsub(endpoint):

--- a/bindings/pyomq/tests/test_interop_curve.py
+++ b/bindings/pyomq/tests/test_interop_curve.py
@@ -5,9 +5,17 @@ pyzmq's CURVE server requires a ZAP authenticator; we use CURVE_ALLOW_ANY
 to accept any client with a valid handshake.
 """
 
+import asyncio
+import sys
+
 import pytest
 
 zmq_pyzmq = pytest.importorskip("zmq")
+
+# PyZMQ requires to use the selector event loop on Windows,
+# so we skip the proactor event loop for these tests.
+pytestmark = pytest.mark.event_loop("selector")
+
 
 from zmq.auth.thread import ThreadAuthenticator
 
@@ -85,6 +93,9 @@ def test_pyomq_curve_server_pyzmq_curve_client_req_rep(tcp_endpoint):
 
 @_skip_no_curve
 def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
+    if sys.platform == "win32":
+        with pytest.warns(DeprecationWarning):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 
@@ -120,6 +131,9 @@ def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
 
 @_skip_no_curve
 def test_pyzmq_curve_server_pyomq_curve_client_req_rep(tcp_endpoint):
+    if sys.platform == "win32":
+        with pytest.warns(DeprecationWarning):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 


### PR DESCRIPTION
The bridge between tokio and the asyncio event loop is done by scheduling a callback on the Python event loop from tokio. The Python callback pull data from yring and complete the pending futures. A mechanism to avoid scheduling too many callback from tokio avoids congestion when sending/receiving many messages over short time intervals. 

This allows to use the default proactor event loop on windows which is more user friendly than what zmq does.

Polling rely on a windows event to avoid busy waiting.

I did not perform any serious performance tests but I am interested in an early review if possible.

All tests pass locally but I did not polish things yet.