### PR TITLE
Shrink Message from 80 B to 64 B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ Transport RFCs (wire format, dict shipping rules, security):
 
 **omq-proto key types.** `Connection`: ZMTP codec state machine
 (`handle_input`/`poll_event`/`send_message`/`poll_transmit`).
-`FrameBuffer`: arena (256 KiB) + entry-based framer used by both
-backends. Frame headers are always written into the arena. Small
-messages (<8 KiB `ARENA_THRESHOLD`) go contiguously into the arena
+`FrameBuffer`: arena (16 KiB TCP/WS, 64 KiB IPC) + entry-based framer
+used by both backends. Frame headers are always written into the arena.
+Small messages (<4 KiB `ARENA_THRESHOLD`) go contiguously into the arena
 (1 iovec per batch). Large payloads are tracked as external `Bytes`
-entries (zero-copy gather-write). `Message`: 80 B, inline up to 71 B.
+entries (zero-copy gather-write). `Message`: 64 B, inline up to 55 B.
 `Payload`: 64 B, inline up to 62 B.
 
 **omq-tokio hot path.** `SocketDriver` actor owns peer table and

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -74,8 +74,8 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.62 M/s |  1.52 M/s | **1.72×** |
-| REQ/REP rt/s       |   7,013/s |   4,437/s | **1.58×** |
+| PUSH/PULL msg/s    |  2.29 M/s |  1.52 M/s | **1.50×** |
+| REQ/REP rt/s       |   7,215/s |   4,437/s | **1.63×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="684" fill="white"/>
   <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor,  turbo off</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores</text>
   <line x1="90" y1="342.1" x2="760" y2="342.1" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82" y="342.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
   <text x="768" y="342.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
@@ -43,38 +43,38 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,181.3 145.8,175.3 201.7,174.3 257.5,173.2 313.3,208.7 369.2,212.6 425.0,210.1 480.8,271.2 536.7,313.8 592.5,339.1 648.3,355.0 704.2,367.2 760.0,374.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,303.6 145.8,302.6 201.7,302.5 257.5,301.4 313.3,305.6 369.2,308.3 425.0,310.3 480.8,315.0 536.7,321.3 592.5,339.4 648.3,355.5 704.2,367.6 760.0,374.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,182.0 145.8,171.9 201.7,168.9 257.5,195.5 313.3,210.6 369.2,204.7 425.0,252.3 480.8,276.1 536.7,314.9 592.5,338.5 648.3,354.0 704.2,365.5 760.0,373.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,302.8 145.8,301.8 201.7,300.1 257.5,301.7 313.3,303.9 369.2,306.3 425.0,308.6 480.8,316.2 536.7,326.1 592.5,340.7 648.3,355.6 704.2,367.1 760.0,374.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,288.4 145.8,286.4 201.7,285.5 257.5,297.8 313.3,313.9 369.2,322.2 425.0,319.9 480.8,334.3 536.7,349.5 592.5,363.5 648.3,373.0 704.2,378.1 760.0,379.4" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,379.8 145.8,379.7 201.7,379.7 257.5,379.7 313.3,380.0 369.2,379.9 425.0,379.8 480.8,379.9 536.7,380.0 592.5,380.1 648.3,380.2 704.2,380.3 760.0,380.6" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.4 145.8,380.7 201.7,377.3 257.5,370.5 313.3,361.6 369.2,340.1 425.0,295.0 480.8,268.5 536.7,240.3 592.5,200.2 648.3,146.4 704.2,109.4 760.0,65.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,382.4 145.8,380.6 201.7,377.1 257.5,371.9 313.3,361.8 369.2,338.1 425.0,316.6 480.8,273.5 536.7,242.5 592.5,197.5 648.3,138.2 704.2,80.2 760.0,33.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="380.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="370.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="361.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="340.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="295.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="268.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="240.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="200.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="146.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="109.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="65.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.4 145.8,382.7 201.7,381.4 257.5,378.7 313.3,374.0 369.2,364.6 425.0,346.3 480.8,313.3 536.7,255.6 592.5,201.4 648.3,150.3 704.2,114.9 760.0,72.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="145.8" cy="380.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="377.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="371.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="361.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="338.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="316.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="273.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="242.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="197.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="138.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="80.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="33.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.4 145.8,382.7 201.7,381.3 257.5,378.7 313.3,373.7 369.2,364.1 425.0,345.4 480.8,314.6 536.7,265.5 592.5,206.6 648.3,151.3 704.2,107.1 760.0,76.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="381.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="381.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="378.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="374.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="364.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="346.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="313.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="255.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="201.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="150.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="114.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="72.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="373.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="364.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="345.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="314.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="265.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="206.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="151.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="107.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="76.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,383.2 145.8,382.4 201.7,380.8 257.5,378.5 313.3,375.0 369.2,368.2 425.0,351.2 480.8,333.1 536.7,313.4 592.5,300.0 648.3,293.8 704.2,287.6 760.0,231.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -153,34 +153,34 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,535.3 145.8,535.1 201.7,535.6 257.5,534.9 313.3,535.0 369.2,534.4 425.0,534.8 480.8,534.4 536.7,532.8 592.5,531.1 648.3,529.8 704.2,527.6 760.0,522.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="535.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="535.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="534.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="534.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="534.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="534.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="532.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="531.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="529.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="527.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,513.3 145.8,513.4 201.7,513.3 257.5,513.2 313.3,513.2 369.2,512.5 425.0,513.3 480.8,511.5 536.7,509.9 592.5,510.7 648.3,508.7 704.2,505.4 760.0,498.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="513.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="513.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="513.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="513.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="513.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="512.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="513.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="511.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="509.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="510.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="508.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="505.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="498.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,537.6 145.8,537.5 201.7,536.8 257.5,535.8 313.3,536.0 369.2,536.7 425.0,536.2 480.8,536.2 536.7,535.0 592.5,533.8 648.3,531.2 704.2,528.0 760.0,521.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="537.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="537.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="536.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="535.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="536.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="536.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="536.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="536.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="533.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="531.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="528.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="521.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,516.1 145.8,516.2 201.7,516.5 257.5,515.7 313.3,516.1 369.2,515.3 425.0,515.3 480.8,514.1 536.7,513.5 592.5,512.6 648.3,511.2 704.2,507.6 760.0,499.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="516.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="516.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="515.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="516.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="514.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="512.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="511.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="507.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="499.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,527.6 145.8,526.5 201.7,527.1 257.5,526.0 313.3,527.5 369.2,525.6 425.0,525.4 480.8,524.9 536.7,522.6 592.5,522.7 648.3,509.5 704.2,509.3 760.0,500.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="526.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -67,16 +67,17 @@ enum MessageInner {
 }
 ```
 
-`Payload` is 64 B and stores up to 62 B inline. `Message` is 80 B and stores up
-to 71 B inline, so 64 B user messages avoid heap allocation and refcount
-traffic. Larger single-part messages use `Bytes`; multipart messages use
+`Payload` is 64 B and stores up to 62 B inline. `Message` is 64 B and stores up
+to 55 B inline, avoiding heap allocation and refcount traffic for small
+messages. Larger single-part messages use `Bytes`; multipart messages use
 `Vec<Payload>`.
 
 ## Encoding
 
-`FrameBuffer` is the outbound framing buffer: a 256 KiB arena plus an entry list.
-Frame headers always go into the arena. Small messages below `ARENA_THRESHOLD`
-(8 KiB) encode header and payload contiguously into the arena. Large messages
+`FrameBuffer` is the outbound framing buffer: an arena (16 KiB for TCP/WS,
+64 KiB for IPC) plus an entry list. Frame headers always go into the arena.
+Small messages below `ARENA_THRESHOLD` (4 KiB) encode header and payload
+contiguously into the arena. Large messages
 write the header into the arena and keep payload `Bytes` as external entries
 for gather write. The arena tracks its peak capacity so that after
 `split().freeze()` reclaims the buffer, the next reserve pre-allocates at full

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -3,14 +3,18 @@
   <text x="475.0" y="16.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput, TCP loopback, 2-process</text>
   <text x="475.0" y="30.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="224.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">small messages (higher is better)</text>
-  <line x1="70.0" y1="255.6" x2="378.0" y2="255.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="255.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
-  <line x1="70.0" y1="191.1" x2="378.0" y2="191.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="191.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
-  <line x1="70.0" y1="126.7" x2="378.0" y2="126.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="126.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
-  <line x1="70.0" y1="62.3" x2="378.0" y2="62.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="62.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
+  <line x1="70.0" y1="277.7" x2="378.0" y2="277.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="277.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
+  <line x1="70.0" y1="235.3" x2="378.0" y2="235.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="235.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
+  <line x1="70.0" y1="193.0" x2="378.0" y2="193.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="193.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
+  <line x1="70.0" y1="150.6" x2="378.0" y2="150.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="150.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
+  <line x1="70.0" y1="108.3" x2="378.0" y2="108.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="108.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">10 M msg/s</text>
+  <line x1="70.0" y1="65.9" x2="378.0" y2="65.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="65.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">12 M msg/s</text>
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="131.6" y1="60.0" x2="131.6" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -20,55 +24,55 @@
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="320.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="70.0,211.0 131.6,221.7 193.2,218.9 254.8,228.8 316.4,223.9 378.0,242.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="211.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="221.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="218.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="228.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="223.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="242.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,278.6 131.6,267.2 193.2,248.3 254.8,241.5 316.4,241.0 378.0,255.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="278.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="267.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="248.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="241.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="241.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="255.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,309.1 131.6,310.5 193.2,311.5 254.8,311.9 316.4,312.0 378.0,312.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="309.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="310.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="311.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="311.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="312.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,101.8 131.6,106.2 193.2,181.9 254.8,248.0 316.4,254.0 378.0,291.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="101.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="106.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="181.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="248.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="254.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="291.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,93.9 131.6,103.4 193.2,171.2 254.8,247.1 316.4,253.8 378.0,291.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="93.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="103.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="171.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="247.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="253.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="291.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,108.1 131.6,112.7 193.2,112.1 254.8,135.2 316.4,155.5 378.0,209.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="108.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="112.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="112.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="135.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="155.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="209.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,98.6 131.6,106.5 193.2,118.5 254.8,140.3 316.4,185.9 378.0,230.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="98.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="106.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="118.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="140.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="185.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="230.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,248.4 131.6,255.4 193.2,253.6 254.8,260.0 316.4,256.8 378.0,269.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="248.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="255.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="253.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="260.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="256.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="269.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,292.8 131.6,285.3 193.2,272.9 254.8,268.4 316.4,268.1 378.0,277.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="292.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="285.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="272.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="268.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="268.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="277.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,312.9 131.6,313.7 193.2,314.4 254.8,314.6 316.4,314.8 378.0,315.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="312.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="313.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="314.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="314.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="314.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="315.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,176.6 131.6,179.5 193.2,229.3 254.8,272.7 316.4,276.6 378.0,301.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="176.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="179.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="229.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="272.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="276.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="301.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,171.4 131.6,177.6 193.2,222.2 254.8,272.1 316.4,276.5 378.0,301.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="171.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="177.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="222.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="272.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="276.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="301.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,93.9 131.6,122.7 193.2,172.6 254.8,197.3 316.4,203.4 378.0,246.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="93.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="122.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="172.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="197.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="203.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="246.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,168.4 131.6,193.7 193.2,214.0 254.8,216.3 316.4,230.1 378.0,264.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="168.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="193.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="214.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="216.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="230.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="264.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="70.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="131.6" y="333.0" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
   <text x="193.2" y="333.0" text-anchor="middle" fill="#374151" font-size="8">64 B</text>
@@ -76,18 +80,18 @@
   <text x="316.4" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
   <text x="378.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
   <text x="649.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">medium/large messages (higher is better)</text>
-  <line x1="418.0" y1="281.0" x2="880.0" y2="281.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="281.0" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">1 GB/s</text>
-  <line x1="418.0" y1="242.1" x2="880.0" y2="242.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="242.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">2 GB/s</text>
-  <line x1="418.0" y1="203.1" x2="880.0" y2="203.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="203.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">3 GB/s</text>
-  <line x1="418.0" y1="164.1" x2="880.0" y2="164.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="164.1" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">4 GB/s</text>
-  <line x1="418.0" y1="125.2" x2="880.0" y2="125.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="125.2" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">5 GB/s</text>
-  <line x1="418.0" y1="86.2" x2="880.0" y2="86.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="888.0" y="86.2" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">6 GB/s</text>
+  <line x1="418.0" y1="276.8" x2="880.0" y2="276.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="276.8" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">1 GB/s</text>
+  <line x1="418.0" y1="233.7" x2="880.0" y2="233.7" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="233.7" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">2 GB/s</text>
+  <line x1="418.0" y1="190.5" x2="880.0" y2="190.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="190.5" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">3 GB/s</text>
+  <line x1="418.0" y1="147.3" x2="880.0" y2="147.3" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="147.3" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">4 GB/s</text>
+  <line x1="418.0" y1="104.2" x2="880.0" y2="104.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="104.2" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">5 GB/s</text>
+  <line x1="418.0" y1="61.0" x2="880.0" y2="61.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="888.0" y="61.0" text-anchor="start" dominant-baseline="middle" fill="#374151" font-size="8.5">6 GB/s</text>
   <line x1="880.0" y1="60.0" x2="880.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="418.0" y1="60.0" x2="418.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="469.3" y1="60.0" x2="469.3" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -101,83 +105,83 @@
   <line x1="880.0" y1="60.0" x2="880.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="418.0" y1="60.0" x2="418.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="418.0" y1="320.0" x2="880.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="418.0,290.2 469.3,272.7 520.7,224.1 572.0,194.1 623.3,157.0 674.7,184.4 726.0,115.9 777.3,128.4 828.7,154.3 880.0,164.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="290.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="272.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="224.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="194.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="157.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="184.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="115.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="128.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="154.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="164.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,295.5 469.3,277.5 520.7,240.5 572.0,214.7 623.3,190.1 674.7,183.9 726.0,198.7 777.3,185.9 828.7,216.2 880.0,209.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="295.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="277.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="240.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="214.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="190.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="183.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="198.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="185.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="216.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="209.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,317.5 469.3,315.4 520.7,310.8 572.0,302.9 623.3,289.6 674.7,266.7 726.0,230.4 777.3,194.5 828.7,199.6 880.0,236.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="315.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="310.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="302.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="289.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="266.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="230.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="194.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="199.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="236.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,299.6 469.3,291.2 520.7,284.6 572.0,280.3 623.3,275.7 674.7,278.7 726.0,274.0 777.3,246.3 828.7,171.3 880.0,169.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="299.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="291.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="284.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="280.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="275.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="278.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="274.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="246.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="171.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="169.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,299.5 469.3,290.7 520.7,284.8 572.0,279.6 623.3,276.8 674.7,275.1 726.0,274.1 777.3,247.0 828.7,166.2 880.0,151.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="299.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="290.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="279.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="276.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="275.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="274.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="247.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="166.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="151.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,269.1 469.3,250.6 520.7,183.2 572.0,160.0 623.3,104.7 674.7,94.7 726.0,103.6 777.3,110.3 828.7,141.4 880.0,151.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="269.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="250.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="183.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="160.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="104.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="94.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="103.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="110.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="141.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="151.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,278.5 469.3,247.1 520.7,209.7 572.0,184.3 623.3,148.1 674.7,160.3 726.0,99.8 777.3,93.9 828.7,110.6 880.0,136.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="278.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="247.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="209.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="184.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="148.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="160.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="99.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="93.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="110.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="136.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,287.0 469.3,267.6 520.7,213.8 572.0,180.5 623.3,139.5 674.7,169.8 726.0,93.9 777.3,107.8 828.7,136.4 880.0,147.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="287.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="267.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="213.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="180.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="139.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="169.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="93.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="107.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="136.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="147.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,292.9 469.3,272.9 520.7,232.0 572.0,203.4 623.3,176.1 674.7,169.3 726.0,185.6 777.3,171.5 828.7,205.0 880.0,197.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="292.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="272.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="232.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="203.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="176.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="169.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="185.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="171.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="205.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="197.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,317.3 469.3,314.9 520.7,309.8 572.0,301.0 623.3,286.4 674.7,260.9 726.0,220.8 777.3,180.9 828.7,186.6 880.0,227.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="317.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="314.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="309.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="301.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="286.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="260.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="220.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="180.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="186.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="227.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,297.3 469.3,288.1 520.7,280.8 572.0,276.0 623.3,270.9 674.7,274.2 726.0,269.0 777.3,238.4 828.7,155.2 880.0,152.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="297.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="288.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="280.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="276.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="270.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="274.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="269.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="238.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="155.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="152.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,297.3 469.3,287.5 520.7,281.0 572.0,275.2 623.3,272.1 674.7,270.2 726.0,269.2 777.3,239.2 828.7,149.6 880.0,133.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="297.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="287.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="281.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="275.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="272.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="270.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="269.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="239.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="149.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="133.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,259.1 469.3,234.3 520.7,165.8 572.0,158.2 623.3,112.4 674.7,131.6 726.0,122.2 777.3,127.0 828.7,125.4 880.0,127.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="259.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="234.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="165.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="158.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="112.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="122.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="127.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="125.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="127.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,273.1 469.3,239.5 520.7,203.2 572.0,166.8 623.3,116.6 674.7,137.1 726.0,115.9 777.3,124.0 828.7,122.0 880.0,124.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="273.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="239.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="203.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="166.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="116.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="137.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="115.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="124.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="122.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="124.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="418.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
   <text x="469.3" y="333.0" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
   <text x="520.7" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
@@ -220,20 +224,20 @@
   <circle cx="394.0" cy="433.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="718.0" cy="430.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="435.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,418.9 232.0,435.7 394.0,411.0 556.0,423.7 718.0,428.6 880.0,425.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="70.0" cy="418.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="232.0" cy="435.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.0" cy="411.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="556.0" cy="423.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="718.0" cy="428.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="425.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,497.4 232.0,501.6 394.0,498.5 556.0,500.4 718.0,499.2 880.0,501.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="70.0" cy="497.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="232.0" cy="501.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.0" cy="498.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="556.0" cy="500.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="718.0" cy="499.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="501.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,444.9 232.0,437.6 394.0,445.8 556.0,438.0 718.0,435.4 880.0,433.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="70.0" cy="444.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="232.0" cy="437.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.0" cy="445.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="556.0" cy="438.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="718.0" cy="435.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="433.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,501.6 232.0,505.5 394.0,500.0 556.0,504.1 718.0,503.0 880.0,499.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="70.0" cy="501.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="232.0" cy="505.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.0" cy="500.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="556.0" cy="504.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="718.0" cy="503.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="499.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="70.0,413.9 232.0,395.2 394.0,428.6 556.0,382.6 718.0,411.4 880.0,418.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="70.0" cy="413.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="232.0" cy="395.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -272,7 +276,7 @@
   <text x="495" y="584" fill="#374151" font-size="10" font-weight="500">omq-tokio (1T)</text>
   <line x1="665" y1="580" x2="679" y2="580" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="672" cy="580" r="2.5" fill="#dc2626"/>
-  <text x="685" y="584" fill="#374151" font-size="10" font-weight="500">omq-tokio (4T)</text>
+  <text x="685" y="584" fill="#374151" font-size="10" font-weight="500">omq-tokio (2T)</text>
   <line x1="190" y1="600" x2="204" y2="600" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round"/>
   <circle cx="197" cy="600" r="2.5" fill="#2563eb"/>
   <text x="210" y="604" fill="#374151" font-size="10" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/mechanism/tokio.svg
+++ b/doc/charts/mechanism/tokio.svg
@@ -3,67 +3,61 @@
   <text x="425.0" y="46.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: mechanism overhead, TCP loopback (omq-tokio, higher is better)</text>
   <text x="425.0" y="60.0" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <line x1="90" y1="384.0" x2="760" y2="384.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="384.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1k</text>
+  <text x="82" y="384.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100</text>
   <line x1="90" y1="364.7" x2="760" y2="364.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="364.7" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">2k</text>
+  <text x="82" y="364.7" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">200</text>
   <line x1="90" y1="339.1" x2="760" y2="339.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="339.1" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">5k</text>
+  <text x="82" y="339.1" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">500</text>
   <line x1="90" y1="319.8" x2="760" y2="319.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="319.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10k</text>
+  <text x="82" y="319.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1k</text>
   <line x1="90" y1="300.5" x2="760" y2="300.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="300.5" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">20k</text>
+  <text x="82" y="300.5" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">2k</text>
   <line x1="90" y1="274.9" x2="760" y2="274.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="274.9" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">50k</text>
+  <text x="82" y="274.9" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">5k</text>
   <line x1="90" y1="255.6" x2="760" y2="255.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="255.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100k</text>
+  <text x="82" y="255.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10k</text>
   <line x1="90" y1="236.3" x2="760" y2="236.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="236.3" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">200k</text>
+  <text x="82" y="236.3" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">20k</text>
   <line x1="90" y1="210.7" x2="760" y2="210.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="210.7" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">500k</text>
+  <text x="82" y="210.7" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">50k</text>
   <line x1="90" y1="191.4" x2="760" y2="191.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="191.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
+  <text x="82" y="191.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100k</text>
   <line x1="90" y1="172.1" x2="760" y2="172.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="172.1" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">2M</text>
+  <text x="82" y="172.1" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">200k</text>
   <line x1="90" y1="146.5" x2="760" y2="146.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="146.5" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">5M</text>
+  <text x="82" y="146.5" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">500k</text>
   <line x1="90" y1="127.2" x2="760" y2="127.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="127.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <text x="82" y="127.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
   <line x1="90" y1="107.9" x2="760" y2="107.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="107.9" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">20M</text>
+  <text x="82" y="107.9" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">2M</text>
   <line x1="90" y1="82.3" x2="760" y2="82.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="82" y="82.3" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">50M</text>
+  <text x="82" y="82.3" text-anchor="end" dominant-baseline="middle" fill="#9ca3af" font-size="9">5M</text>
   <line x1="90" y1="63.0" x2="760" y2="63.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="63.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100M</text>
+  <text x="82" y="63.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
   <line x1="90" y1="384.0" x2="760" y2="384.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="384.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.0001 GB/s</text>
-  <line x1="90" y1="364.7" x2="760" y2="364.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="364.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.0002 GB/s</text>
-  <line x1="90" y1="339.1" x2="760" y2="339.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="339.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.0005 GB/s</text>
-  <line x1="90" y1="319.8" x2="760" y2="319.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="319.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.001 GB/s</text>
-  <line x1="90" y1="300.5" x2="760" y2="300.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="300.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.002 GB/s</text>
-  <line x1="90" y1="274.9" x2="760" y2="274.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="274.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.005 GB/s</text>
-  <line x1="90" y1="255.6" x2="760" y2="255.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="255.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
-  <line x1="90" y1="236.3" x2="760" y2="236.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="236.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.02 GB/s</text>
-  <line x1="90" y1="210.7" x2="760" y2="210.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="210.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.05 GB/s</text>
-  <line x1="90" y1="191.4" x2="760" y2="191.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="191.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.1 GB/s</text>
-  <line x1="90" y1="172.1" x2="760" y2="172.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="172.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.2 GB/s</text>
-  <line x1="90" y1="146.5" x2="760" y2="146.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="146.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.5 GB/s</text>
-  <line x1="90" y1="127.2" x2="760" y2="127.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
-  <text x="768" y="127.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="107.9" x2="760" y2="107.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="107.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2 GB/s</text>
-  <line x1="90" y1="82.3" x2="760" y2="82.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
-  <text x="768" y="82.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">5 GB/s</text>
+  <text x="768" y="384.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.001 GB/s</text>
+  <line x1="90" y1="359.8" x2="760" y2="359.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="359.8" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.002 GB/s</text>
+  <line x1="90" y1="327.9" x2="760" y2="327.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="327.9" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.005 GB/s</text>
+  <line x1="90" y1="303.8" x2="760" y2="303.8" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="303.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.01 GB/s</text>
+  <line x1="90" y1="279.6" x2="760" y2="279.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="279.6" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.02 GB/s</text>
+  <line x1="90" y1="247.7" x2="760" y2="247.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="247.7" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.05 GB/s</text>
+  <line x1="90" y1="223.5" x2="760" y2="223.5" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="223.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">0.1 GB/s</text>
+  <line x1="90" y1="199.3" x2="760" y2="199.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="199.3" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.2 GB/s</text>
+  <line x1="90" y1="167.4" x2="760" y2="167.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="167.4" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">0.5 GB/s</text>
+  <line x1="90" y1="143.2" x2="760" y2="143.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
+  <text x="768" y="143.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90" y1="119.1" x2="760" y2="119.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="119.1" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">2 GB/s</text>
+  <line x1="90" y1="87.2" x2="760" y2="87.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="2,8"/>
+  <text x="768" y="87.2" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="9">5 GB/s</text>
   <line x1="90" y1="63.0" x2="760" y2="63.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,6"/>
   <text x="768" y="63.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">10 GB/s</text>
   <line x1="90.0" y1="63" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
@@ -102,60 +96,60 @@
   <text x="715.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 KiB</text>
   <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 KiB</text>
   <text x="40" y="223.5" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,223.5)">msg/s</text>
-  <polyline points="90.0,136.8 134.7,141.3 179.3,140.5 224.0,144.3 268.7,145.1 313.3,150.0 358.0,155.6 402.7,162.4 447.3,174.2 492.0,186.2 536.7,201.6 581.3,221.9 626.0,240.6 670.7,261.8 715.3,285.4 760.0,300.8" fill="none" stroke="#374151" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,246.3 134.7,247.7 179.3,248.7 224.0,252.9 268.7,252.4 313.3,254.9 358.0,258.5 402.7,262.6 447.3,268.7 492.0,278.5 536.7,288.8 581.3,303.4 626.0,317.6 670.7,335.7 715.3,353.3 760.0,372.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,244.8 134.7,246.1 179.3,244.9 224.0,248.4 268.7,248.7 313.3,251.2 358.0,254.5 402.7,257.0 447.3,262.1 492.0,267.0 536.7,274.7 581.3,283.6 626.0,295.4 670.7,308.8 715.3,327.1 760.0,343.8" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,207.3 134.7,192.4 179.3,172.3 224.0,156.7 268.7,138.2 313.3,123.8 358.0,110.1 402.7,97.5 447.3,90.0 492.0,82.7 536.7,78.7 581.3,79.8 626.0,79.1 670.7,81.0 715.3,85.3 760.0,81.4" fill="none" stroke="#374151" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="207.3" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="192.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="172.3" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="156.7" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="138.2" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="123.8" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="110.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="97.5" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="90.0" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="82.7" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="78.7" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="79.8" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="79.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="81.0" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="85.3" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="81.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,316.7 134.7,298.8 179.3,280.5 224.0,265.3 268.7,245.5 313.3,228.6 358.0,213.0 402.7,197.7 447.3,184.6 492.0,175.0 536.7,165.9 581.3,161.2 626.0,156.1 670.7,154.8 715.3,153.1 760.0,152.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="316.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="298.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="280.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="265.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="245.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="228.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="213.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="197.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="184.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="175.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="165.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="161.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="156.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="154.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="153.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="152.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,315.2 134.7,297.2 179.3,276.6 224.0,260.8 268.7,241.8 313.3,225.0 358.0,209.0 402.7,192.1 447.3,177.9 492.0,163.5 536.7,151.9 581.3,141.5 626.0,133.9 670.7,128.0 715.3,127.0 760.0,124.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="315.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="134.7" cy="297.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="179.3" cy="276.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="260.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="268.7" cy="241.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="225.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="209.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="402.7" cy="192.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="447.3" cy="177.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="163.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="151.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="581.3" cy="141.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="133.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="670.7" cy="128.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="715.3" cy="127.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="124.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,72.3 134.7,72.6 179.3,73.0 224.0,83.5 268.7,84.2 313.3,87.3 358.0,92.9 402.7,99.7 447.3,111.1 492.0,122.6 536.7,143.1 581.3,162.1 626.0,181.7 670.7,203.5 715.3,226.2 760.0,238.6" fill="none" stroke="#374151" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,125.5 134.7,126.2 179.3,129.7 224.0,132.2 268.7,136.5 313.3,142.1 358.0,151.1 402.7,164.9 447.3,180.9 492.0,197.3 536.7,215.9 581.3,234.7 626.0,253.9 670.7,279.7 715.3,296.9 760.0,316.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,116.7 134.7,117.0 179.3,117.1 224.0,122.2 268.7,126.0 313.3,129.7 358.0,138.1 402.7,152.2 447.3,167.1 492.0,180.9 536.7,196.4 581.3,209.9 626.0,228.1 670.7,246.4 715.3,277.5 760.0,296.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,242.9 134.7,219.1 179.3,195.4 224.0,184.4 268.7,161.2 313.3,140.9 358.0,123.7 402.7,108.1 447.3,98.1 492.0,88.4 536.7,89.9 581.3,89.4 626.0,89.7 670.7,92.8 715.3,97.1 760.0,88.4" fill="none" stroke="#374151" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="242.9" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="219.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="195.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="184.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="161.2" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="140.9" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="123.7" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="108.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="98.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="88.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="89.9" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="89.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="89.7" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="92.8" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="97.1" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="88.4" r="3" fill="#374151" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,309.4 134.7,286.1 179.3,266.3 224.0,245.3 268.7,226.6 313.3,209.3 358.0,196.4 402.7,189.5 447.3,185.4 492.0,181.8 536.7,180.9 581.3,180.2 626.0,180.0 670.7,188.1 715.3,185.5 760.0,185.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="309.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="286.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="266.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="245.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="226.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="209.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="196.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="189.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="185.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="181.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="180.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="180.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="180.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="188.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="185.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="185.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,298.4 134.7,274.6 179.3,250.6 224.0,232.8 268.7,213.4 313.3,193.8 358.0,180.3 402.7,173.7 447.3,168.1 492.0,161.2 536.7,156.5 581.3,149.1 626.0,147.8 670.7,146.5 715.3,161.2 760.0,160.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="298.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="134.7" cy="274.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="179.3" cy="250.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="232.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="268.7" cy="213.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="193.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="180.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="402.7" cy="173.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="447.3" cy="168.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="161.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="156.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="581.3" cy="149.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="147.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="670.7" cy="146.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="715.3" cy="161.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="160.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <line x1="215" y1="424" x2="229" y2="424" stroke="#374151" stroke-width="2.5"/>
   <circle cx="222" cy="424" r="2.5" fill="#374151"/>
   <text x="235" y="428" fill="#374151" font-size="11" font-weight="500">PLAIN</text>

--- a/doc/charts/pubsub/lz4_tcp.svg
+++ b/doc/charts/pubsub/lz4_tcp.svg
@@ -71,11 +71,11 @@
   <text x="659.3" y="303" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="700.0" y="303" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="179.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,179.0)">sender CPU %</text>
-  <polyline points="90.0,132.8 130.7,173.4 171.3,222.0 212.0,251.7 252.7,268.7 293.3,271.6 334.0,279.7 374.7,283.1 415.3,284.9 456.0,285.9 496.7,286.4 537.3,286.6 578.0,286.4 618.7,286.3 659.3,286.2 700.0,286.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,129.5 130.7,186.8 171.3,224.7 212.0,251.4 252.7,259.6 293.3,269.5 334.0,276.3 374.7,280.4 415.3,281.7 456.0,283.2 496.7,283.6 537.3,284.1 578.0,284.1 618.7,283.6 659.3,280.8 700.0,280.5" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,129.5 130.7,186.8 171.3,224.7 212.0,233.4 252.7,235.1 293.3,253.5 334.0,266.4 374.7,274.2 415.3,280.0 456.0,282.2 496.7,283.0 537.3,283.8 578.0,283.9 618.7,283.6 659.3,280.7 700.0,280.4" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,240.9 130.7,201.5 171.3,201.5 212.0,201.5 252.7,201.5 293.3,201.5 334.0,201.5 374.7,201.5 415.3,201.5 456.0,201.5 496.7,201.5 537.3,201.5 578.0,201.5 618.7,201.5 659.3,201.5 700.0,201.5" fill="none" stroke="#eab308" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="240.9" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,130.1 130.7,148.9 171.3,206.9 212.0,243.0 252.7,263.5 293.3,266.3 334.0,276.9 374.7,281.3 415.3,283.7 456.0,284.7 496.7,285.2 537.3,285.3 578.0,285.7 618.7,285.9 659.3,285.8 700.0,285.7" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,130.6 130.7,166.1 171.3,212.0 212.0,243.9 252.7,263.9 293.3,265.1 334.0,273.8 374.7,277.1 415.3,279.8 456.0,281.2 496.7,281.5 537.3,282.2 578.0,282.5 618.7,283.0 659.3,283.2 700.0,283.0" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,130.6 130.7,166.1 171.3,212.0 212.0,198.9 252.7,246.5 293.3,247.0 334.0,259.9 374.7,270.7 415.3,277.4 456.0,279.5 496.7,280.4 537.3,281.5 578.0,282.2 618.7,282.8 659.3,283.1 700.0,283.0" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,250.6 130.7,201.5 171.3,201.5 212.0,201.5 252.7,201.5 293.3,201.5 334.0,201.5 374.7,201.5 415.3,201.5 456.0,201.5 496.7,201.5 537.3,201.5 578.0,201.5 618.7,201.5 659.3,201.5 700.0,201.5" fill="none" stroke="#eab308" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="250.6" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="212.0" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -91,43 +91,43 @@
   <circle cx="618.7" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="659.3" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="201.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,247.0 130.7,222.8 171.3,212.7 212.0,207.2 252.7,204.4 293.3,202.9 334.0,185.2 374.7,167.9 415.3,142.8 456.0,124.1 496.7,107.2 537.3,94.4 578.0,87.2 618.7,82.4 659.3,82.5 700.0,81.5" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="247.0" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,255.1 130.7,222.8 171.3,212.7 212.0,207.2 252.7,204.4 293.3,202.9 334.0,187.8 374.7,154.7 415.3,136.2 456.0,122.4 496.7,109.6 537.3,97.9 578.0,86.7 618.7,83.8 659.3,81.9 700.0,81.1" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="255.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="222.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="212.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="212.0" cy="207.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="252.7" cy="204.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="293.3" cy="202.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="185.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="167.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="142.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="124.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="107.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="94.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="87.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="82.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="82.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="81.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,247.0 130.7,222.8 171.3,212.7 212.0,169.9 252.7,146.5 293.3,145.8 334.0,130.6 374.7,116.1 415.3,122.5 456.0,109.1 496.7,96.7 537.3,87.5 578.0,83.7 618.7,82.1 659.3,81.4 700.0,80.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="247.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="334.0" cy="187.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="154.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="136.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="122.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="109.6" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="97.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="86.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="83.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="81.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="81.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,255.1 130.7,222.8 171.3,212.7 212.0,141.0 252.7,154.1 293.3,149.1 334.0,125.4 374.7,113.8 415.3,114.5 456.0,104.1 496.7,96.7 537.3,89.3 578.0,83.6 618.7,82.0 659.3,81.2 700.0,80.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="255.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="222.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="212.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="212.0" cy="169.9" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="252.7" cy="146.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="145.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="130.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="116.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="122.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="109.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="212.0" cy="141.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="252.7" cy="154.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="149.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="334.0" cy="125.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="113.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="114.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="104.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="496.7" cy="96.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="87.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="83.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="82.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="81.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="89.3" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="83.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="82.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="81.2" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="80.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,77.9 130.7,83.6 171.3,97.7 212.0,111.8 252.7,125.9 293.3,140.0 334.0,154.0 374.7,168.1 415.3,182.2 456.0,196.3 496.7,210.4 537.3,224.5 578.0,238.6 618.7,252.7 659.3,266.8 700.0,280.9" fill="none" stroke="#eab308" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,79.2 130.7,88.1 171.3,100.1 212.0,113.0 252.7,126.5 293.3,140.3 334.0,150.6 374.7,161.0 415.3,169.7 456.0,179.9 496.7,190.4 537.3,201.7 578.0,214.3 618.7,227.4 659.3,241.5 700.0,255.4" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,79.2 130.7,88.1 171.3,100.1 212.0,105.0 252.7,114.2 293.3,128.1 334.0,139.0 374.7,150.0 415.3,165.4 456.0,176.7 496.7,188.1 537.3,200.3 578.0,213.6 618.7,227.3 659.3,241.2 700.0,255.2" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,79.9 130.7,83.6 171.3,97.7 212.0,111.8 252.7,125.9 293.3,140.0 334.0,154.0 374.7,168.1 415.3,182.2 456.0,196.3 496.7,210.4 537.3,224.5 578.0,238.6 618.7,252.7 659.3,266.8 700.0,280.9" fill="none" stroke="#eab308" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,80.9 130.7,88.1 171.3,100.1 212.0,113.0 252.7,126.5 293.3,140.3 334.0,151.1 374.7,158.2 415.3,168.4 456.0,179.5 496.7,190.9 537.3,202.5 578.0,214.2 618.7,227.7 659.3,241.3 700.0,255.3" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,80.9 130.7,88.1 171.3,100.1 212.0,98.9 252.7,115.8 293.3,128.8 334.0,137.9 374.7,149.5 415.3,163.7 456.0,175.6 496.7,188.1 537.3,200.6 578.0,213.5 618.7,227.3 659.3,241.2 700.0,255.1" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
   <text x="395.0" y="369" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">100 Mbps</text>
   <line x1="90" y1="489.0" x2="700" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50%</text>
@@ -193,9 +193,9 @@
   <text x="659.3" y="613" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="700.0" y="613" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="489.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,489.0)">sender CPU %</text>
-  <polyline points="90.0,551.8 130.7,575.9 171.3,585.6 212.0,591.5 252.7,594.9 293.3,595.5 334.0,597.1 374.7,597.8 415.3,598.2 456.0,598.4 496.7,598.5 537.3,598.5 578.0,598.5 618.7,598.5 659.3,598.4 700.0,598.5" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,564.8 130.7,578.6 171.3,586.1 212.0,591.5 252.7,593.1 293.3,595.1 334.0,596.5 374.7,597.3 415.3,597.5 456.0,597.8 496.7,597.9 537.3,598.0 578.0,598.0 618.7,597.9 659.3,597.4 700.0,597.3" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,564.8 130.7,578.6 171.3,586.1 212.0,587.9 252.7,588.2 293.3,591.9 334.0,594.5 374.7,596.0 415.3,597.2 456.0,597.6 496.7,597.8 537.3,598.0 578.0,598.0 618.7,597.9 659.3,597.3 700.0,597.3" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,545.8 130.7,571.0 171.3,582.6 212.0,589.8 252.7,593.9 293.3,594.5 334.0,596.6 374.7,597.5 415.3,597.9 456.0,598.1 496.7,598.2 537.3,598.3 578.0,598.3 618.7,598.4 659.3,598.4 700.0,598.3" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,562.0 130.7,574.4 171.3,583.6 212.0,590.0 252.7,594.0 293.3,594.2 334.0,596.0 374.7,596.6 415.3,597.2 456.0,597.4 496.7,597.5 537.3,597.6 578.0,597.7 618.7,597.8 659.3,597.8 700.0,597.8" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,562.0 130.7,574.4 171.3,583.6 212.0,581.0 252.7,590.5 293.3,590.6 334.0,593.2 374.7,595.3 415.3,596.7 456.0,597.1 496.7,597.3 537.3,597.5 578.0,597.6 618.7,597.8 659.3,597.8 700.0,597.8" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
   <polyline points="90.0,511.5 130.7,511.5 171.3,511.5 212.0,511.5 252.7,511.5 293.3,511.5 334.0,511.5 374.7,511.5 415.3,511.5 456.0,511.5 496.7,511.5 537.3,511.5 578.0,511.5 618.7,511.5 659.3,511.5 700.0,511.5" fill="none" stroke="#eab308" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="511.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="511.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -213,43 +213,43 @@
   <circle cx="618.7" cy="511.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="659.3" cy="511.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="511.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,550.2 130.7,532.8 171.3,522.7 212.0,517.2 252.7,514.4 293.3,512.9 334.0,495.2 374.7,477.9 415.3,452.8 456.0,434.1 496.7,417.2 537.3,404.4 578.0,397.2 618.7,392.4 659.3,392.5 700.0,391.5" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,550.2 130.7,532.8 171.3,522.7 212.0,517.2 252.7,514.4 293.3,512.9 334.0,497.8 374.7,464.7 415.3,446.2 456.0,432.4 496.7,419.6 537.3,407.9 578.0,396.7 618.7,393.8 659.3,391.9 700.0,391.1" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="550.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="532.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="522.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="212.0" cy="517.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="252.7" cy="514.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="293.3" cy="512.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="495.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="477.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="452.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="434.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="417.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="404.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="397.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="392.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="392.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="391.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,550.2 130.7,532.8 171.3,522.7 212.0,479.9 252.7,456.5 293.3,455.8 334.0,440.6 374.7,426.1 415.3,432.5 456.0,419.1 496.7,406.7 537.3,397.5 578.0,393.7 618.7,392.1 659.3,391.4 700.0,390.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="334.0" cy="497.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="464.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="446.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="432.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="419.6" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="407.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="396.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="393.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="391.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="391.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,550.2 130.7,532.8 171.3,522.7 212.0,451.0 252.7,464.1 293.3,459.1 334.0,435.4 374.7,423.8 415.3,424.5 456.0,414.1 496.7,406.7 537.3,399.3 578.0,393.6 618.7,392.0 659.3,391.2 700.0,390.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="550.2" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="532.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="522.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="212.0" cy="479.9" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="252.7" cy="456.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="455.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="440.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="426.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="432.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="419.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="212.0" cy="451.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="252.7" cy="464.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="459.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="334.0" cy="435.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="423.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="424.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="414.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="496.7" cy="406.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="397.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="393.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="392.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="391.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="399.3" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="393.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="392.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="391.2" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="390.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <polyline points="90.0,379.5 130.7,393.6 171.3,407.7 212.0,421.8 252.7,435.9 293.3,450.0 334.0,464.0 374.7,478.1 415.3,492.2 456.0,506.3 496.7,520.4 537.3,534.5 578.0,548.6 618.7,562.7 659.3,576.8 700.0,590.9" fill="none" stroke="#eab308" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,387.7 130.7,398.1 171.3,410.1 212.0,423.0 252.7,436.5 293.3,450.3 334.0,460.6 374.7,471.0 415.3,479.7 456.0,489.9 496.7,500.4 537.3,511.7 578.0,524.3 618.7,537.4 659.3,551.5 700.0,565.4" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,387.7 130.7,398.1 171.3,410.1 212.0,415.0 252.7,424.2 293.3,438.1 334.0,449.0 374.7,460.0 415.3,475.4 456.0,486.7 496.7,498.1 537.3,510.3 578.0,523.6 618.7,537.3 659.3,551.2 700.0,565.2" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,387.7 130.7,398.1 171.3,410.1 212.0,423.0 252.7,436.5 293.3,450.3 334.0,461.1 374.7,468.2 415.3,478.4 456.0,489.5 496.7,500.9 537.3,512.5 578.0,524.2 618.7,537.7 659.3,551.3 700.0,565.3" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,387.7 130.7,398.1 171.3,410.1 212.0,408.9 252.7,425.8 293.3,438.8 334.0,447.9 374.7,459.5 415.3,473.7 456.0,485.6 496.7,498.1 537.3,510.6 578.0,523.5 618.7,537.3 659.3,551.2 700.0,565.1" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
   <text x="395.0" y="679" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">10 Mbps</text>
   <line x1="90" y1="799.0" x2="700" y2="799.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82" y="799.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="9">50%</text>
@@ -312,9 +312,9 @@
   <text x="659.3" y="923" text-anchor="middle" fill="#374151" font-size="8">128 KiB</text>
   <text x="700.0" y="923" text-anchor="middle" fill="#374151" font-size="8">256 KiB</text>
   <text x="40" y="799.0" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,799.0)">sender CPU %</text>
-  <polyline points="90.0,904.3 130.7,906.7 171.3,907.7 212.0,908.3 252.7,908.6 293.3,908.7 334.0,908.8 374.7,908.9 415.3,908.9 456.0,908.9 496.7,908.9 537.3,909.0 578.0,908.9 618.7,908.9 659.3,908.9 700.0,908.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,905.6 130.7,907.0 171.3,907.7 212.0,908.2 252.7,908.4 293.3,908.6 334.0,908.7 374.7,908.8 415.3,908.9 456.0,908.9 496.7,908.9 537.3,908.9 578.0,908.9 618.7,908.9 659.3,908.8 700.0,908.8" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
-  <polyline points="90.0,905.6 130.7,907.0 171.3,907.7 212.0,907.9 252.7,907.9 293.3,908.3 334.0,908.5 374.7,908.7 415.3,908.8 456.0,908.9 496.7,908.9 537.3,908.9 578.0,908.9 618.7,908.9 659.3,908.8 700.0,908.8" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,903.7 130.7,906.2 171.3,907.4 212.0,908.1 252.7,908.5 293.3,908.5 334.0,908.8 374.7,908.8 415.3,908.9 456.0,908.9 496.7,908.9 537.3,908.9 578.0,908.9 618.7,908.9 659.3,908.9 700.0,908.9" fill="none" stroke="#eab308" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,905.3 130.7,906.5 171.3,907.5 212.0,908.1 252.7,908.5 293.3,908.5 334.0,908.7 374.7,908.8 415.3,908.8 456.0,908.8 496.7,908.9 537.3,908.9 578.0,908.9 618.7,908.9 659.3,908.9 700.0,908.9" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
+  <polyline points="90.0,905.3 130.7,906.5 171.3,907.5 212.0,907.2 252.7,908.2 293.3,908.2 334.0,908.4 374.7,908.6 415.3,908.8 456.0,908.8 496.7,908.8 537.3,908.9 578.0,908.9 618.7,908.9 659.3,908.9 700.0,908.9" fill="none" stroke="#1d4ed8" stroke-width="2" stroke-dasharray="2,3" opacity="0.7"/>
   <polyline points="90.0,821.5 130.7,821.5 171.3,821.5 212.0,821.5 252.7,821.5 293.3,821.5 334.0,821.5 374.7,821.5 415.3,821.5 456.0,821.5 496.7,821.5 537.3,821.5 578.0,821.5 618.7,821.5 659.3,821.5 700.0,821.5" fill="none" stroke="#eab308" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="821.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="821.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
@@ -332,43 +332,43 @@
   <circle cx="618.7" cy="821.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="659.3" cy="821.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="821.5" r="2.2" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,860.2 130.7,842.8 171.3,832.7 212.0,827.2 252.7,824.4 293.3,822.9 334.0,805.2 374.7,787.9 415.3,762.8 456.0,744.1 496.7,727.2 537.3,714.4 578.0,707.2 618.7,702.4 659.3,702.5 700.0,701.5" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,860.2 130.7,842.8 171.3,832.7 212.0,827.2 252.7,824.4 293.3,822.9 334.0,807.8 374.7,774.7 415.3,756.2 456.0,742.4 496.7,729.6 537.3,717.9 578.0,706.7 618.7,703.8 659.3,701.9 700.0,701.1" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="860.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="842.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="832.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="212.0" cy="827.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="252.7" cy="824.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
   <circle cx="293.3" cy="822.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="805.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="787.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="762.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="744.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="496.7" cy="727.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="714.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="707.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="702.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="702.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <circle cx="700.0" cy="701.5" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,860.2 130.7,842.8 171.3,832.7 212.0,789.9 252.7,766.5 293.3,765.8 334.0,750.6 374.7,736.1 415.3,742.5 456.0,729.1 496.7,716.7 537.3,707.5 578.0,703.7 618.7,702.1 659.3,701.4 700.0,700.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="334.0" cy="807.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="774.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="756.2" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="742.4" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="496.7" cy="729.6" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="717.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="706.7" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="703.8" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="701.9" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <circle cx="700.0" cy="701.1" r="2.2" fill="#60a5fa" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,860.2 130.7,842.8 171.3,832.7 212.0,761.0 252.7,774.1 293.3,769.1 334.0,745.4 374.7,733.8 415.3,734.5 456.0,724.1 496.7,716.7 537.3,709.3 578.0,703.6 618.7,702.0 659.3,701.2 700.0,700.5" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="860.2" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="130.7" cy="842.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="171.3" cy="832.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="212.0" cy="789.9" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="252.7" cy="766.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="293.3" cy="765.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="334.0" cy="750.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="374.7" cy="736.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="415.3" cy="742.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="456.0" cy="729.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="212.0" cy="761.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="252.7" cy="774.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="293.3" cy="769.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="334.0" cy="745.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="374.7" cy="733.8" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="415.3" cy="734.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="456.0" cy="724.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="496.7" cy="716.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="537.3" cy="707.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="578.0" cy="703.7" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="618.7" cy="702.1" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
-  <circle cx="659.3" cy="701.4" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="537.3" cy="709.3" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="578.0" cy="703.6" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="618.7" cy="702.0" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
+  <circle cx="659.3" cy="701.2" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <circle cx="700.0" cy="700.5" r="2.2" fill="#1d4ed8" stroke="white" stroke-width="1"/>
   <polyline points="90.0,689.6 130.7,707.5 171.3,725.4 212.0,743.3 252.7,761.2 293.3,779.1 334.0,797.0 374.7,814.9 415.3,832.8 456.0,850.7 496.7,868.7 537.3,886.6 578.0,904.5 618.7,909.0 659.3,909.0 700.0,909.0" fill="none" stroke="#eab308" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,700.1 130.7,713.3 171.3,728.5 212.0,744.9 252.7,762.0 293.3,779.5 334.0,792.6 374.7,805.9 415.3,817.0 456.0,829.8 496.7,843.2 537.3,857.6 578.0,873.6 618.7,890.2 659.3,908.1 700.0,909.0" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
-  <polyline points="90.0,700.1 130.7,713.3 171.3,728.5 212.0,734.8 252.7,746.4 293.3,764.1 334.0,777.9 374.7,791.9 415.3,811.5 456.0,825.8 496.7,840.3 537.3,855.8 578.0,872.6 618.7,890.1 659.3,907.8 700.0,909.0" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,700.1 130.7,713.3 171.3,728.5 212.0,744.9 252.7,762.0 293.3,779.5 334.0,793.4 374.7,802.3 415.3,815.2 456.0,829.4 496.7,843.8 537.3,858.5 578.0,873.5 618.7,890.6 659.3,907.9 700.0,909.0" fill="none" stroke="#60a5fa" stroke-width="2.0" stroke-dasharray="5,3"/>
+  <polyline points="90.0,700.1 130.7,713.3 171.3,728.5 212.0,727.0 252.7,748.4 293.3,765.0 334.0,776.5 374.7,791.2 415.3,809.3 456.0,824.4 496.7,840.3 537.3,856.2 578.0,872.6 618.7,890.1 659.3,907.7 700.0,909.0" fill="none" stroke="#1d4ed8" stroke-width="2.0" stroke-dasharray="5,3"/>
   <line x1="90" y1="941" x2="104" y2="941" stroke="#eab308" stroke-width="1.5" stroke-dasharray="2,3" opacity="0.7"/>
   <line x1="90" y1="953" x2="104" y2="953" stroke="#eab308" stroke-width="2.0"/>
   <line x1="90" y1="965" x2="104" y2="965" stroke="#eab308" stroke-width="2.0" stroke-dasharray="5,3"/>

--- a/doc/charts/pubsub/tcp.svg
+++ b/doc/charts/pubsub/tcp.svg
@@ -36,7 +36,7 @@
   <polyline points="78.0,191.8 180.1,193.5 282.3,194.7 384.4,202.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,189.6 180.1,184.7 282.3,209.6 384.4,229.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,185.3 180.1,184.7 282.3,207.8 384.4,228.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,191.6 180.1,192.3 282.3,192.7 384.4,195.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,184.7 180.1,183.9 282.3,183.1 384.4,191.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,252.7 180.1,252.7 282.3,252.7 384.4,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,260.5 180.1,224.3 282.3,219.2 384.4,237.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,257.4 180.1,260.1 282.3,261.9 384.4,262.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
@@ -55,16 +55,16 @@
   <circle cx="180.1" cy="191.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="263.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="294.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,203.6 180.1,206.6 282.3,219.0 384.4,231.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="203.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="206.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="219.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="231.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,199.2 180.1,206.2 282.3,228.6 384.4,257.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="199.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="206.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="228.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="257.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,250.0 180.1,254.4 282.3,253.5 384.4,265.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="250.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="254.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="253.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="265.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,276.7 180.1,284.1 282.3,285.5 384.4,282.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="276.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="284.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="285.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="282.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="78.0,283.7 180.1,256.7 282.3,252.0 384.4,266.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="283.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="256.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -119,8 +119,8 @@
   <polyline points="482.4,194.7 635.6,202.3 788.8,228.8 942.0,242.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,209.6 635.6,229.0 788.8,246.4 942.0,244.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,207.8 635.6,228.4 788.8,246.0 942.0,245.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,192.7 635.6,195.1 788.8,198.0 942.0,208.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,252.7 635.6,252.7 788.8,252.9 942.0,252.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,183.1 635.6,191.2 788.8,189.2 942.0,189.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,252.7 635.6,252.7 788.8,252.7 942.0,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,219.2 635.6,237.2 788.8,239.6 942.0,252.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,261.9 635.6,262.3 788.8,262.5 942.0,263.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,295.4 635.6,233.8 788.8,169.9 942.0,116.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -138,16 +138,16 @@
   <circle cx="635.6" cy="288.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="277.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="277.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,289.2 635.6,209.0 788.8,117.2 942.0,151.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="289.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="209.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="117.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="151.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,292.2 635.6,242.2 788.8,183.2 942.0,161.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="292.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="242.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="183.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="161.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,299.9 635.6,251.3 788.8,222.4 942.0,149.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="299.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="251.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="222.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="149.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,309.9 635.6,272.8 788.8,219.6 942.0,154.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="309.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="272.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="219.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="154.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="482.4,299.5 635.6,252.8 788.8,192.0 942.0,177.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="299.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="252.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -164,20 +164,30 @@
   <text x="942.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="510.0" y="368.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 8 subscribers: TCP loopback</text>
   <text x="231.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="591.0" x2="384.4" y2="591.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="591.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="544.0" x2="384.4" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="497.0" x2="384.4" y2="497.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="497.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="450.0" x2="384.4" y2="450.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="450.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="78.0" y1="608.6" x2="384.4" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="78.0" y1="579.2" x2="384.4" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="549.9" x2="384.4" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="78.0" y1="520.5" x2="384.4" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="491.1" x2="384.4" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="78.0" y1="461.8" x2="384.4" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="432.4" x2="384.4" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="384.4" y1="558.6" x2="388.4" y2="558.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="558.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="479.2" x2="388.4" y2="479.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="479.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="384.4" y1="585.2" x2="388.4" y2="585.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="585.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="532.5" x2="388.4" y2="532.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="532.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="479.7" x2="388.4" y2="479.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="479.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="427.0" x2="388.4" y2="427.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="427.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -186,71 +196,79 @@
   <line x1="384.4" y1="403.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="638.0" x2="384.4" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,520.5)">CPU %</text>
-  <polyline points="78.0,551.5 180.1,553.6 282.3,554.1 384.4,559.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,555.2 180.1,562.3 282.3,574.9 384.4,581.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,516.6 180.1,516.9 282.3,521.6 384.4,522.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,463.5 180.1,464.9 282.3,460.6 384.4,457.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,583.3 180.1,583.2 282.3,583.0 384.4,583.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,550.3 180.1,549.7 282.3,555.5 384.4,556.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,584.1 180.1,586.9 282.3,589.8 384.4,590.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,522.3 180.1,527.0 282.3,544.0 384.4,575.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="522.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="527.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="544.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="575.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,448.7 180.1,518.4 282.3,583.6 384.4,621.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="448.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="518.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="583.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="621.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,477.8 180.1,499.7 282.3,549.9 384.4,599.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="477.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="499.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="549.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="599.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,482.5 180.1,501.4 282.3,551.0 384.4,563.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="482.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="501.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="551.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="563.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,433.7 180.1,463.9 282.3,511.7 384.4,586.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="433.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="463.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="511.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="586.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,576.0 180.1,574.1 282.3,579.2 384.4,593.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="576.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="574.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="579.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="593.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,632.8 180.1,633.5 282.3,634.6 384.4,634.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="632.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="633.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="634.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,529.9 180.1,532.5 282.3,533.1 384.4,540.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,534.4 180.1,543.4 282.3,559.1 384.4,567.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,486.2 180.1,486.6 282.3,492.5 384.4,493.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,450.8 180.1,450.6 282.3,451.8 384.4,454.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,569.3 180.1,569.3 282.3,569.5 384.4,569.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,528.4 180.1,527.6 282.3,534.9 384.4,535.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,570.7 180.1,574.2 282.3,577.7 384.4,578.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,561.1 180.1,564.2 282.3,575.5 384.4,596.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="561.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="564.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="575.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="596.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,512.2 180.1,558.5 282.3,601.8 384.4,626.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="512.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="558.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="601.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="626.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,531.5 180.1,546.1 282.3,579.5 384.4,612.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="531.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="546.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="579.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="612.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,496.1 282.3,521.0 384.4,580.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="496.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="521.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="580.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,533.6 180.1,549.6 282.3,574.5 384.4,606.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="533.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="549.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="574.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="606.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,596.8 180.1,595.5 282.3,598.9 384.4,608.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="596.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="595.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="598.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="608.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,634.6 180.1,635.0 282.3,635.7 384.4,635.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="635.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="635.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="635.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="384.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="390.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="482.4" y1="591.0" x2="942.0" y2="591.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="591.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="482.4" y1="544.0" x2="942.0" y2="544.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="544.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="482.4" y1="497.0" x2="942.0" y2="497.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="497.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="482.4" y1="450.0" x2="942.0" y2="450.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="450.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="482.4" y1="608.6" x2="942.0" y2="608.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="608.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="482.4" y1="579.2" x2="942.0" y2="579.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="579.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="482.4" y1="549.9" x2="942.0" y2="549.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="549.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="482.4" y1="520.5" x2="942.0" y2="520.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="520.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="482.4" y1="491.1" x2="942.0" y2="491.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="491.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="482.4" y1="461.8" x2="942.0" y2="461.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="461.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="482.4" y1="432.4" x2="942.0" y2="432.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="942.0" y1="590.7" x2="946.0" y2="590.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="590.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="543.3" x2="946.0" y2="543.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="543.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="496.0" x2="946.0" y2="496.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="496.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="448.6" x2="946.0" y2="448.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="448.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="596.1" x2="946.0" y2="596.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="596.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="554.2" x2="946.0" y2="554.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="554.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="512.2" x2="946.0" y2="512.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="512.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="470.3" x2="946.0" y2="470.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="470.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="428.4" x2="946.0" y2="428.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="428.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -259,74 +277,78 @@
   <line x1="942.0" y1="403.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="638.0" x2="942.0" y2="638.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="520.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,520.5)">CPU %</text>
-  <polyline points="482.4,554.1 635.6,559.6 788.8,572.7 942.0,579.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,574.9 635.6,581.9 788.8,584.0 942.0,583.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,521.6 635.6,522.6 788.8,530.7 942.0,524.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,460.6 635.6,457.7 788.8,473.8 942.0,459.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,583.0 635.6,583.0 788.8,583.3 942.0,583.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,555.5 635.6,556.3 788.8,549.0 942.0,544.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,589.8 635.6,590.5 788.8,590.9 942.0,591.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,609.3 635.6,561.6 788.8,509.0 942.0,490.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="609.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="561.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="509.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="490.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,621.4 635.6,617.4 788.8,616.1 942.0,613.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="621.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="617.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="616.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="613.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,611.1 635.6,591.0 788.8,587.3 942.0,583.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="611.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="591.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="587.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="583.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,611.4 635.6,547.0 788.8,463.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="611.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="547.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="463.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,533.1 635.6,540.0 788.8,556.4 942.0,565.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,559.1 635.6,567.9 788.8,570.5 942.0,569.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,492.5 635.6,493.7 788.8,503.9 942.0,496.1" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,451.8 635.6,454.0 788.8,460.7 942.0,453.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,569.5 635.6,569.3 788.8,569.5 942.0,569.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,534.9 635.6,535.9 788.8,526.7 942.0,520.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,577.7 635.6,578.7 788.8,579.1 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,612.6 635.6,570.3 788.8,523.8 942.0,507.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="570.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="523.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="507.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,623.3 635.6,619.8 788.8,618.6 942.0,616.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="623.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="619.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="618.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="616.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,614.2 635.6,596.4 788.8,593.1 942.0,589.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="614.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="596.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="593.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="589.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,590.4 635.6,544.3 788.8,506.5 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="590.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="544.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="506.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,599.4 635.6,575.1 788.8,526.5 942.0,511.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="599.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="575.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="526.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="511.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,620.1 635.6,583.3 788.8,531.0 942.0,500.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="620.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="583.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="531.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="500.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,637.0 635.6,634.1 788.8,624.0 942.0,595.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="637.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="634.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="624.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="595.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,612.2 635.6,586.4 788.8,547.0 942.0,525.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="586.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="547.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="525.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,622.1 635.6,589.6 788.8,543.3 942.0,516.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="622.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="589.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="543.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="516.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,637.1 635.6,634.6 788.8,625.6 942.0,600.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="637.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="625.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="600.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
   <text x="942.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="510.0" y="685.0" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUB/SUB throughput, 32 subscribers: TCP loopback</text>
   <text x="231.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">small messages: msg/s</text>
-  <line x1="78.0" y1="908.0" x2="384.4" y2="908.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="908.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="78.0" y1="861.0" x2="384.4" y2="861.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="861.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="78.0" y1="814.0" x2="384.4" y2="814.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="814.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="78.0" y1="767.0" x2="384.4" y2="767.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="78.0" y1="925.6" x2="384.4" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="78.0" y1="896.2" x2="384.4" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="78.0" y1="866.9" x2="384.4" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="78.0" y1="837.5" x2="384.4" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="78.0" y1="808.1" x2="384.4" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="78.0" y1="778.8" x2="384.4" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="78.0" y1="749.4" x2="384.4" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="384.4" y1="908.1" x2="388.4" y2="908.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="908.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">100k/s</text>
-  <line x1="384.4" y1="861.3" x2="388.4" y2="861.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="861.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
-  <line x1="384.4" y1="814.4" x2="388.4" y2="814.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="814.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">300k/s</text>
-  <line x1="384.4" y1="767.5" x2="388.4" y2="767.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="767.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
-  <line x1="384.4" y1="720.6" x2="388.4" y2="720.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="720.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="384.4" y1="896.9" x2="388.4" y2="896.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="896.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
+  <line x1="384.4" y1="838.7" x2="388.4" y2="838.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="838.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
+  <line x1="384.4" y1="780.6" x2="388.4" y2="780.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="780.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">600k/s</text>
+  <line x1="384.4" y1="722.4" x2="388.4" y2="722.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="722.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">800k/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -335,73 +357,79 @@
   <line x1="384.4" y1="720.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="78.0" y1="955.0" x2="384.4" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="30.0" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,837.5)">CPU %</text>
-  <polyline points="78.0,884.2 180.1,886.3 282.3,885.6 384.4,888.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,881.2 180.1,885.9 282.3,899.9 384.4,906.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,862.1 180.1,866.1 282.3,867.8 384.4,874.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,796.9 180.1,797.6 282.3,764.1 384.4,776.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,900.8 180.1,899.7 282.3,899.9 384.4,899.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,861.7 180.1,848.8 282.3,858.9 384.4,851.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,902.7 180.1,902.9 282.3,904.0 384.4,908.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,880.2 180.1,888.3 282.3,896.0 384.4,916.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="880.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="888.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="896.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="916.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,810.3 180.1,868.4 282.3,919.7 384.4,944.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="810.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="868.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="919.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="944.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,832.1 180.1,856.9 282.3,903.2 384.4,938.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="832.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="856.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="903.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="938.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,750.7 180.1,785.6 282.3,861.1 384.4,885.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,866.5 180.1,869.1 282.3,868.2 384.4,872.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,862.8 180.1,868.7 282.3,886.1 384.4,893.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,838.9 180.1,843.8 282.3,846.0 384.4,854.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,762.1 180.1,770.4 282.3,772.5 384.4,768.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,885.7 180.1,885.9 282.3,886.0 384.4,885.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,838.4 180.1,822.2 282.3,834.8 384.4,825.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,889.6 180.1,889.8 282.3,891.2 384.4,896.9" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,908.6 180.1,913.6 282.3,918.4 384.4,930.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="908.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="913.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="918.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="930.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,865.2 180.1,901.3 282.3,933.1 384.4,948.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="865.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="901.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="933.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="948.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,878.8 180.1,894.1 282.3,922.9 384.4,944.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="878.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="894.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="922.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="944.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,750.7 180.1,801.1 282.3,865.3 384.4,925.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="785.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="861.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="885.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,822.6 180.1,839.5 282.3,900.8 384.4,914.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="822.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="839.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="900.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="914.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,920.4 180.1,911.9 282.3,917.7 384.4,926.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="920.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="911.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="917.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="926.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,951.4 180.1,951.3 282.3,951.5 384.4,952.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="951.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="951.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="951.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="952.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="801.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="865.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="925.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,878.8 180.1,891.5 282.3,923.9 384.4,932.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="878.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="891.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="923.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="932.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,933.6 180.1,928.3 282.3,931.9 384.4,937.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="933.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="928.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="931.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="937.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,952.7 180.1,952.7 282.3,952.8 384.4,953.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="952.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="952.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="952.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="953.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="384.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="712.2" y="707.0" text-anchor="middle" fill="#111827" font-size="11.5" font-weight="700">medium/large messages: GB/s</text>
-  <line x1="482.4" y1="908.0" x2="942.0" y2="908.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="908.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
-  <line x1="482.4" y1="861.0" x2="942.0" y2="861.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="861.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
-  <line x1="482.4" y1="814.0" x2="942.0" y2="814.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="814.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
-  <line x1="482.4" y1="767.0" x2="942.0" y2="767.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="482.4" y1="925.6" x2="942.0" y2="925.6" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="925.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">50%</text>
+  <line x1="482.4" y1="896.2" x2="942.0" y2="896.2" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="896.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">100%</text>
+  <line x1="482.4" y1="866.9" x2="942.0" y2="866.9" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="866.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">150%</text>
+  <line x1="482.4" y1="837.5" x2="942.0" y2="837.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="837.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">200%</text>
+  <line x1="482.4" y1="808.1" x2="942.0" y2="808.1" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="808.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">250%</text>
+  <line x1="482.4" y1="778.8" x2="942.0" y2="778.8" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="778.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">300%</text>
+  <line x1="482.4" y1="749.4" x2="942.0" y2="749.4" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="942.0" y1="908.5" x2="946.0" y2="908.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="908.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="862.1" x2="946.0" y2="862.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="862.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="815.6" x2="946.0" y2="815.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="815.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="769.2" x2="946.0" y2="769.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="769.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="722.7" x2="946.0" y2="722.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="722.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
+  <line x1="942.0" y1="909.0" x2="946.0" y2="909.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="863.1" x2="946.0" y2="863.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="863.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="817.1" x2="946.0" y2="817.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="817.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="771.1" x2="946.0" y2="771.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="771.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="725.2" x2="946.0" y2="725.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="725.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -410,48 +438,48 @@
   <line x1="942.0" y1="720.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="482.4" y1="955.0" x2="942.0" y2="955.0" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="434.4" y="837.5" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,434.4,837.5)">CPU %</text>
-  <polyline points="482.4,885.6 635.6,888.6 788.8,897.3 942.0,899.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,899.9 635.6,906.1 788.8,906.0 942.0,903.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,867.8 635.6,874.4 788.8,875.3 942.0,867.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,764.1 635.6,776.3 788.8,793.3 942.0,792.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,899.9 635.6,899.9 788.8,899.7 942.0,899.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,858.9 635.6,851.5 788.8,848.5 942.0,866.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,904.0 635.6,908.5 788.8,908.4 942.0,908.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,931.0 635.6,892.0 788.8,834.5 942.0,813.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="931.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="892.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="834.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="813.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,940.7 635.6,938.2 788.8,937.2 942.0,932.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="940.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="938.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="937.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="932.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,934.0 635.6,927.3 788.8,924.7 942.0,918.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="927.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="924.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="918.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,916.9 635.6,842.8 788.8,753.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="916.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="842.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="753.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,868.2 635.6,872.0 788.8,882.9 942.0,885.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,886.1 635.6,893.9 788.8,893.7 942.0,890.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,846.0 635.6,854.2 788.8,855.4 942.0,845.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,772.5 635.6,768.5 788.8,788.7 942.0,772.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,886.0 635.6,885.9 788.8,885.8 942.0,885.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,834.8 635.6,825.7 788.8,821.9 942.0,844.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,891.2 635.6,896.9 788.8,896.7 942.0,896.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,931.3 635.6,892.6 788.8,835.8 942.0,815.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="931.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="892.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="835.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="815.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,940.8 635.6,938.4 788.8,937.4 942.0,933.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="940.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="938.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="937.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="933.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,934.2 635.6,927.6 788.8,925.0 942.0,918.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="927.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="925.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="918.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,896.9 635.6,877.4 788.8,823.0 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="896.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="877.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="823.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,933.0 635.6,889.3 788.8,840.8 942.0,825.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="933.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="889.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="840.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="825.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,939.8 635.6,909.4 788.8,865.6 942.0,827.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="939.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="909.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="865.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="827.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,953.6 635.6,951.0 788.8,941.3 942.0,913.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,934.8 635.6,895.3 788.8,848.7 942.0,830.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="895.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="848.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="830.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,940.0 635.6,909.9 788.8,866.5 942.0,829.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="940.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="909.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="866.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="829.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,953.6 635.6,951.0 788.8,941.4 942.0,914.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="953.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="951.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="941.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="913.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="941.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="914.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -467,7 +495,7 @@
   <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
   <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/pushpull/fanin/tcp.svg
+++ b/doc/charts/pushpull/fanin/tcp.svg
@@ -19,16 +19,10 @@
   <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="280.2" x2="388.4" y2="280.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="280.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="239.3" x2="388.4" y2="239.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="239.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="198.5" x2="388.4" y2="198.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="198.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="157.6" x2="388.4" y2="157.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="157.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="116.8" x2="388.4" y2="116.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="116.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="240.7" x2="388.4" y2="240.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="240.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="160.4" x2="388.4" y2="160.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="160.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -40,45 +34,45 @@
   <polyline points="78.0,231.6 180.1,237.6 282.3,233.4 384.4,224.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,205.2 180.1,204.5 282.3,206.1 384.4,208.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,195.9 180.1,194.4 282.3,200.8 384.4,166.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,222.6 180.1,234.9 282.3,218.3 384.4,207.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,205.2 180.1,217.0 282.3,199.6 384.4,178.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,202.3 180.1,207.3 282.3,217.9 384.4,216.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.0 180.1,261.8 282.3,262.4 384.4,261.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,256.1 180.1,267.9 282.3,263.0 384.4,271.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="256.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="267.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="263.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="271.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,154.1 180.1,183.8 282.3,239.1 384.4,289.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="154.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="183.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="239.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="289.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,156.9 180.1,179.9 282.3,242.6 384.4,284.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="156.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="179.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="242.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="284.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,135.4 180.1,159.6 282.3,193.0 384.4,231.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="135.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="159.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="193.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="231.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,116.7 180.1,134.8 282.3,220.1 384.4,266.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="116.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="134.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="220.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="266.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,282.6 180.1,254.5 282.3,251.1 384.4,263.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="282.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="254.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="251.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="263.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,303.3 180.1,309.6 282.3,310.8 384.4,311.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="303.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="309.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="310.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="311.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,269.9 180.1,279.3 282.3,275.4 384.4,281.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="269.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="279.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="275.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="281.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,189.8 180.1,213.1 282.3,256.6 384.4,296.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="189.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="213.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="256.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,191.9 180.1,210.0 282.3,259.4 384.4,292.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="191.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="210.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="259.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="292.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,116.7 180.1,217.7 282.3,192.8 384.4,222.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="217.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="192.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="222.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,132.4 180.1,196.8 282.3,235.0 384.4,273.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="132.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="196.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="235.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="273.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,290.8 180.1,268.7 282.3,266.1 384.4,275.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="290.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="268.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="266.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="275.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,307.0 180.1,312.0 282.3,313.0 384.4,313.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="307.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="313.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="313.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -100,14 +94,16 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="265.9" x2="946.0" y2="265.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="265.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="210.9" x2="946.0" y2="210.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="210.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="155.8" x2="946.0" y2="155.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="155.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="100.8" x2="946.0" y2="100.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="100.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="279.5" x2="946.0" y2="279.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="279.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="238.1" x2="946.0" y2="238.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="238.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="196.6" x2="946.0" y2="196.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="196.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="155.1" x2="946.0" y2="155.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="155.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="113.6" x2="946.0" y2="113.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="113.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -119,45 +115,45 @@
   <polyline points="482.4,233.4 635.6,224.5 788.8,232.6 942.0,235.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,206.1 635.6,208.2 788.8,207.3 942.0,223.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,200.8 635.6,166.4 788.8,164.4 942.0,178.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,218.3 635.6,207.0 788.8,208.4 942.0,238.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,199.6 635.6,178.8 788.8,180.9 942.0,182.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,217.9 635.6,216.7 788.8,215.3 942.0,208.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.4 635.6,261.6 788.8,254.4 942.0,258.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,301.0 635.6,252.4 788.8,205.9 942.0,168.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="301.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="252.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="205.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="168.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,292.8 635.6,277.9 788.8,272.1 942.0,263.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="292.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="277.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="272.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="263.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,294.0 635.6,271.1 788.8,260.6 942.0,257.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="294.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="271.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="260.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="257.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,276.8 635.6,197.2 788.8,116.7 942.0,158.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="276.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="197.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,305.9 635.6,269.3 788.8,234.3 942.0,205.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="305.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="269.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="234.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="205.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,299.7 635.6,288.5 788.8,284.2 942.0,277.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="299.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="288.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="284.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="277.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,300.6 635.6,283.4 788.8,275.5 942.0,273.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="300.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="283.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="275.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="273.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,278.6 635.6,190.7 788.8,116.7 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="278.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="190.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="158.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,286.2 635.6,245.3 788.8,209.5 942.0,189.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="286.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="245.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="209.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="189.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,296.9 635.6,241.0 788.8,180.5 942.0,153.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="296.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="241.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="180.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="153.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,317.5 635.6,308.2 788.8,257.6 942.0,238.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="308.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="257.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="238.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,292.6 635.6,257.5 788.8,232.5 942.0,250.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="292.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="257.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="232.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="250.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,302.8 635.6,260.8 788.8,215.1 942.0,194.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="302.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="260.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="215.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="194.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,318.3 635.6,311.3 788.8,273.2 942.0,258.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="318.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="311.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="273.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="258.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -180,16 +176,12 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="597.2" x2="388.4" y2="597.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="597.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="556.3" x2="388.4" y2="556.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="556.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="515.5" x2="388.4" y2="515.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="515.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="474.7" x2="388.4" y2="474.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="474.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="433.8" x2="388.4" y2="433.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="433.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="574.5" x2="388.4" y2="574.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="574.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="510.9" x2="388.4" y2="510.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="510.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="447.4" x2="388.4" y2="447.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="447.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -201,45 +193,45 @@
   <polyline points="78.0,553.5 180.1,554.0 282.3,545.9 384.4,544.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,522.0 180.1,521.3 282.3,526.4 384.4,525.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,514.5 180.1,516.2 282.3,510.2 384.4,490.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,558.6 180.1,547.1 282.3,522.5 384.4,490.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.5 180.1,579.4 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,513.6 180.1,525.8 282.3,509.3 384.4,490.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.3 180.1,579.3 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,472.9 180.1,517.0 282.3,527.5 384.4,507.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.2 180.1,577.3 282.3,576.7 384.4,574.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,574.9 180.1,575.4 282.3,573.6 384.4,588.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="574.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="575.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="573.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="588.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,446.3 180.1,481.1 282.3,547.7 384.4,605.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="446.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="481.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="547.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="605.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,457.4 180.1,478.1 282.3,533.3 384.4,589.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="457.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="478.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="533.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="589.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,447.1 180.1,444.5 282.3,487.5 384.4,535.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="447.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="444.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="487.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="535.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,433.7 180.1,452.8 282.3,540.3 384.4,584.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="433.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="452.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="540.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="584.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,591.2 180.1,566.6 282.3,563.9 384.4,575.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="591.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="566.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="563.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="575.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,583.1 180.1,587.3 282.3,592.7 384.4,610.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="583.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="587.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="592.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="610.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,598.7 180.1,599.0 282.3,597.9 384.4,607.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="598.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="599.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="597.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="607.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,518.7 180.1,540.4 282.3,581.8 384.4,617.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="518.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="540.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="581.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="617.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,525.6 180.1,538.5 282.3,572.8 384.4,608.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="525.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="538.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="572.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="608.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,511.7 282.3,516.4 384.4,552.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="511.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="516.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="552.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,483.7 180.1,546.0 282.3,575.2 384.4,606.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="483.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="546.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="575.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="606.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,608.8 180.1,593.6 282.3,591.9 384.4,599.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="608.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="593.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="591.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="599.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,603.8 180.1,606.4 282.3,609.8 384.4,620.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="603.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="606.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="609.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="620.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -261,14 +253,18 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="587.3" x2="946.0" y2="587.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="587.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="536.7" x2="946.0" y2="536.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="536.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="486.0" x2="946.0" y2="486.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="486.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="435.4" x2="946.0" y2="435.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="435.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="602.7" x2="946.0" y2="602.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="602.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="567.5" x2="946.0" y2="567.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="567.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="532.2" x2="946.0" y2="532.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="532.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="497.0" x2="946.0" y2="497.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="497.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="461.7" x2="946.0" y2="461.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="461.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="426.4" x2="946.0" y2="426.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="426.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -280,45 +276,45 @@
   <polyline points="482.4,545.9 635.6,544.9 788.8,555.1 942.0,555.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,526.4 635.6,525.4 788.8,526.1 942.0,541.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,510.2 635.6,490.5 788.8,484.4 942.0,490.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,522.5 635.6,490.4 788.8,490.4 942.0,529.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,509.3 635.6,490.0 788.8,492.1 942.0,498.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,527.5 635.6,507.1 788.8,509.5 942.0,511.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,576.7 635.6,574.6 788.8,575.1 942.0,574.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,617.5 635.6,575.2 788.8,532.4 942.0,508.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="617.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="575.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="532.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="508.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,609.3 635.6,597.0 788.8,592.1 942.0,579.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="609.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="597.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="592.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="579.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,604.7 635.6,576.9 788.8,567.2 942.0,556.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="604.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="576.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="567.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="556.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,590.2 635.6,507.5 788.8,441.7 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="590.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="507.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="441.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,607.0 635.6,570.6 788.8,534.6 942.0,499.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="607.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="570.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="534.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="499.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,614.5 635.6,558.9 788.8,506.9 942.0,502.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="614.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="558.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="506.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="502.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,623.6 635.6,602.9 788.8,577.6 942.0,569.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="623.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="602.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="577.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="569.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,623.8 635.6,594.3 788.8,564.5 942.0,547.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="623.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="594.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="564.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="547.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,618.0 635.6,609.5 788.8,606.1 942.0,597.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="618.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="609.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="606.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="597.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,614.8 635.6,595.5 788.8,588.7 942.0,581.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="614.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="595.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="588.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="581.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,594.8 635.6,516.5 788.8,433.7 942.0,469.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="594.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="516.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="469.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,615.7 635.6,592.8 788.8,571.8 942.0,555.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="615.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="592.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="571.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="555.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,621.6 635.6,583.0 788.8,546.8 942.0,543.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="621.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="583.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="546.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="543.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,628.0 635.6,613.6 788.8,595.9 942.0,590.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="628.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="613.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="595.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="590.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -335,16 +331,12 @@
   <text x="70.0" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="384.4" y1="914.6" x2="388.4" y2="914.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="914.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="874.1" x2="388.4" y2="874.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="874.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="833.7" x2="388.4" y2="833.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="833.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="384.4" y1="793.2" x2="388.4" y2="793.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="793.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="384.4" y1="752.8" x2="388.4" y2="752.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="752.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="894.8" x2="388.4" y2="894.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="894.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="834.6" x2="388.4" y2="834.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="834.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="774.5" x2="388.4" y2="774.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="774.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -356,45 +348,45 @@
   <polyline points="78.0,901.5 180.1,900.7 282.3,880.7 384.4,877.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,863.1 180.1,861.6 282.3,863.2 384.4,864.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,855.0 180.1,855.5 282.3,854.3 384.4,842.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,891.5 180.1,885.1 282.3,860.2 384.4,835.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,908.7 180.1,908.0 282.3,908.1 384.4,908.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,850.7 180.1,860.1 282.3,850.8 384.4,847.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,908.0 180.1,908.1 282.3,908.0 384.4,908.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,758.6 180.1,847.1 282.3,860.5 384.4,830.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,909.1 180.1,908.3 282.3,907.9 384.4,906.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,899.7 180.1,898.6 282.3,884.5 384.4,904.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="899.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="898.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="884.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="904.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,757.8 180.1,789.4 282.3,861.7 384.4,922.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="757.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="789.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="861.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="922.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,762.7 180.1,790.8 282.3,839.3 384.4,903.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="762.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="790.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="839.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="903.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,750.7 180.1,751.1 282.3,798.1 384.4,850.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,922.1 180.1,921.4 282.3,913.0 384.4,924.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="922.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="921.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="913.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="924.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,837.7 180.1,856.4 282.3,899.5 384.4,935.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="837.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="856.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="899.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="935.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,840.5 180.1,857.3 282.3,886.2 384.4,924.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="840.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="857.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="886.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="924.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,750.7 180.1,833.5 282.3,834.9 384.4,880.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="751.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="798.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="850.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,764.5 180.1,778.8 282.3,863.3 384.4,903.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="764.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="778.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="863.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="903.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,917.8 180.1,879.2 282.3,877.7 384.4,892.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="917.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="879.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="877.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="892.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,901.0 180.1,902.4 282.3,910.3 384.4,926.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="901.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="902.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="910.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="926.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="833.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="834.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="880.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,813.6 180.1,868.3 282.3,896.2 384.4,925.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="813.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="868.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="896.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="925.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,932.9 180.1,909.9 282.3,909.0 384.4,918.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="932.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="909.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="909.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="918.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,922.9 180.1,923.7 282.3,928.4 384.4,938.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="922.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="923.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="928.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="938.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -416,16 +408,16 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="910.1" x2="946.0" y2="910.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="910.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="865.2" x2="946.0" y2="865.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="865.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="820.3" x2="946.0" y2="820.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="820.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="775.4" x2="946.0" y2="775.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="775.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="730.5" x2="946.0" y2="730.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="730.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="914.5" x2="946.0" y2="914.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="914.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="874.0" x2="946.0" y2="874.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="874.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="833.6" x2="946.0" y2="833.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="833.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="793.1" x2="946.0" y2="793.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="793.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="752.6" x2="946.0" y2="752.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="752.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -437,45 +429,45 @@
   <polyline points="482.4,862.1 635.6,858.3 788.8,869.3 942.0,875.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,840.2 635.6,842.4 788.8,844.0 942.0,866.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,829.1 635.6,814.4 788.8,798.9 942.0,791.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,836.4 635.6,805.8 788.8,829.9 942.0,837.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.4 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,824.8 635.6,820.3 788.8,810.4 942.0,817.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.3 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,836.8 635.6,799.8 788.8,789.1 942.0,803.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.2 635.6,893.8 788.8,892.3 942.0,891.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,935.0 635.6,897.3 788.8,858.3 942.0,836.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="935.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="897.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="858.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="836.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,928.5 635.6,918.5 788.8,914.3 942.0,902.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="928.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="918.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="914.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="902.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,922.1 635.6,897.0 788.8,884.9 942.0,869.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="922.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="897.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="884.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="869.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,910.4 635.6,836.0 788.8,773.5 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="910.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="836.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="773.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,929.0 635.6,896.7 788.8,860.4 942.0,841.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="929.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="896.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="860.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="841.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,933.0 635.6,884.4 788.8,846.2 942.0,839.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="933.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="884.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="846.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="839.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,942.3 635.6,922.6 788.8,903.8 942.0,897.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="942.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="922.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="903.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="897.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,936.9 635.6,902.9 788.8,867.8 942.0,848.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="936.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="902.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="867.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="848.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,931.1 635.6,922.1 788.8,918.3 942.0,907.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="931.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="922.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="918.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="907.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,925.4 635.6,902.7 788.8,891.8 942.0,877.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="925.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="902.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="891.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="877.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,903.3 635.6,827.1 788.8,750.7 942.0,764.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="903.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="827.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="764.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,929.7 635.6,903.8 788.8,879.0 942.0,883.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="929.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="903.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="879.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="883.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,935.2 635.6,891.3 788.8,856.9 942.0,851.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="935.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="891.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="856.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="851.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,943.6 635.6,925.8 788.8,908.9 942.0,902.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="943.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="925.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="908.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="902.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -491,7 +483,7 @@
   <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
   <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -19,18 +19,18 @@
   <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="283.1" x2="388.4" y2="283.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="283.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="245.2" x2="388.4" y2="245.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="245.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="207.3" x2="388.4" y2="207.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="207.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
-  <line x1="384.4" y1="169.4" x2="388.4" y2="169.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="169.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="131.5" x2="388.4" y2="131.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="131.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="93.6" x2="388.4" y2="93.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="93.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="287.3" x2="388.4" y2="287.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="287.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="253.6" x2="388.4" y2="253.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="253.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="219.9" x2="388.4" y2="219.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="219.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
+  <line x1="384.4" y1="186.2" x2="388.4" y2="186.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="186.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="152.5" x2="388.4" y2="152.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="152.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="118.8" x2="388.4" y2="118.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="118.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,129 +42,129 @@
   <polyline points="78.0,206.3 180.1,203.7 282.3,204.3 384.4,222.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,211.9 180.1,214.9 282.3,233.1 384.4,244.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,159.8 180.1,157.3 282.3,165.9 384.4,172.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,142.6 180.1,141.8 282.3,142.4 384.4,150.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,262.3 180.1,262.3 282.3,262.5 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,147.9 180.1,149.1 282.3,147.5 384.4,160.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.3 180.1,262.4 282.3,262.1 384.4,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,227.1 180.1,194.2 282.3,178.3 384.4,185.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.9 384.4,262.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="230.2" x2="78.0" y2="227.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="230.2" x2="82.0" y2="230.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="227.2" x2="82.0" y2="227.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="232.4" x2="180.1" y2="229.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="232.4" x2="184.1" y2="232.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="229.4" x2="184.1" y2="229.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="231.6" x2="282.3" y2="228.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="231.6" x2="286.3" y2="231.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="228.6" x2="286.3" y2="228.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="265.8" x2="384.4" y2="262.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="265.8" x2="388.4" y2="265.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="262.8" x2="388.4" y2="262.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,228.7 180.1,230.9 282.3,230.1 384.4,264.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="228.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="230.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="230.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="264.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="118.3" x2="78.0" y2="115.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="118.3" x2="82.0" y2="118.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="115.0" x2="82.0" y2="115.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="236.8" x2="180.1" y2="233.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="236.8" x2="184.1" y2="236.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="233.8" x2="184.1" y2="233.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="285.6" x2="282.3" y2="282.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="285.6" x2="286.3" y2="285.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="282.6" x2="286.3" y2="282.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="307.3" x2="384.4" y2="304.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="307.3" x2="388.4" y2="307.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="304.3" x2="388.4" y2="304.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,116.7 180.1,235.3 282.3,284.1 384.4,305.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="116.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="235.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="284.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="305.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="156.8" x2="78.0" y2="146.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="156.8" x2="82.0" y2="156.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="146.1" x2="82.0" y2="146.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="237.7" x2="180.1" y2="234.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="237.7" x2="184.1" y2="237.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="234.7" x2="184.1" y2="234.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="284.9" x2="282.3" y2="281.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="284.9" x2="286.3" y2="284.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="281.9" x2="286.3" y2="281.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="297.6" x2="384.4" y2="294.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="297.6" x2="388.4" y2="297.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="294.6" x2="388.4" y2="294.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,151.5 180.1,236.2 282.3,283.4 384.4,296.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="151.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="236.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="283.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="296.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="155.3" x2="78.0" y2="152.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="155.3" x2="82.0" y2="155.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="152.3" x2="82.0" y2="152.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="155.1" x2="180.1" y2="152.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="155.1" x2="184.1" y2="155.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="152.1" x2="184.1" y2="152.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="198.9" x2="282.3" y2="195.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="198.9" x2="286.3" y2="198.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="195.9" x2="286.3" y2="195.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="212.6" x2="384.4" y2="209.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="212.6" x2="388.4" y2="212.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="209.3" x2="388.4" y2="209.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,153.8 180.1,153.6 282.3,197.4 384.4,210.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="153.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="153.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="197.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="210.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="211.0" x2="78.0" y2="208.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="211.0" x2="82.0" y2="211.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="208.0" x2="82.0" y2="208.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="224.8" x2="180.1" y2="221.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="224.8" x2="184.1" y2="224.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="221.8" x2="184.1" y2="221.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="244.3" x2="282.3" y2="241.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="244.3" x2="286.3" y2="244.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="241.3" x2="286.3" y2="241.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="273.0" x2="384.4" y2="270.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="273.0" x2="388.4" y2="273.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="270.0" x2="388.4" y2="270.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,209.5 180.1,223.3 282.3,242.8 384.4,271.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="209.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="223.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="242.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="271.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="281.8" x2="78.0" y2="278.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="281.8" x2="82.0" y2="281.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="278.8" x2="82.0" y2="278.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="261.8" x2="180.1" y2="253.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="261.8" x2="184.1" y2="261.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="253.5" x2="184.1" y2="253.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="248.4" x2="282.3" y2="245.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="248.4" x2="286.3" y2="248.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="245.4" x2="286.3" y2="245.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="256.0" x2="384.4" y2="253.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="256.0" x2="388.4" y2="256.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="253.0" x2="388.4" y2="253.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,280.3 180.1,257.6 282.3,246.9 384.4,254.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="280.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="257.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="246.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="254.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="317.7" x2="78.0" y2="314.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="317.7" x2="82.0" y2="317.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="314.7" x2="82.0" y2="314.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="318.0" x2="180.1" y2="315.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="318.0" x2="184.1" y2="318.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="315.0" x2="184.1" y2="315.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="318.3" x2="282.3" y2="315.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="318.3" x2="286.3" y2="318.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="315.3" x2="286.3" y2="315.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="318.6" x2="384.4" y2="315.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="318.6" x2="388.4" y2="318.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="315.6" x2="388.4" y2="315.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,316.2 180.1,316.5 282.3,316.8 384.4,317.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="316.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="316.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="316.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="317.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="240.5" x2="78.0" y2="237.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="240.5" x2="82.0" y2="240.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="237.5" x2="82.0" y2="237.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="242.4" x2="180.1" y2="239.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="242.4" x2="184.1" y2="242.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="239.4" x2="184.1" y2="239.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="241.7" x2="282.3" y2="238.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="241.7" x2="286.3" y2="241.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="238.7" x2="286.3" y2="238.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="272.1" x2="384.4" y2="269.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="272.1" x2="388.4" y2="272.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="269.1" x2="388.4" y2="269.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,239.0 180.1,240.9 282.3,240.2 384.4,270.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="239.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="240.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="240.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="270.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="140.8" x2="78.0" y2="137.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="140.8" x2="82.0" y2="140.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="137.8" x2="82.0" y2="137.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="246.3" x2="180.1" y2="243.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="246.3" x2="184.1" y2="246.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="243.3" x2="184.1" y2="243.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="289.7" x2="282.3" y2="286.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="289.7" x2="286.3" y2="289.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="286.7" x2="286.3" y2="286.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="309.0" x2="384.4" y2="306.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="309.0" x2="388.4" y2="309.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="306.0" x2="388.4" y2="306.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,139.3 180.1,244.8 282.3,288.2 384.4,307.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="139.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="244.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="288.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="307.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="175.0" x2="78.0" y2="165.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="175.0" x2="82.0" y2="175.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="165.5" x2="82.0" y2="165.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="247.1" x2="180.1" y2="244.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="247.1" x2="184.1" y2="247.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="244.1" x2="184.1" y2="244.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="289.0" x2="282.3" y2="286.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="289.0" x2="286.3" y2="289.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="286.0" x2="286.3" y2="286.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="300.3" x2="384.4" y2="297.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="300.3" x2="388.4" y2="300.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="297.3" x2="388.4" y2="297.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,170.3 180.1,245.6 282.3,287.5 384.4,298.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="170.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="245.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="287.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="298.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="118.2" x2="78.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="118.2" x2="82.0" y2="118.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="115.2" x2="82.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="211.5" x2="180.1" y2="208.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="211.5" x2="184.1" y2="211.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="208.5" x2="184.1" y2="208.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="211.2" x2="282.3" y2="208.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="211.2" x2="286.3" y2="211.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="208.2" x2="286.3" y2="208.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="221.9" x2="384.4" y2="217.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="221.9" x2="388.4" y2="221.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="217.1" x2="388.4" y2="217.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,116.7 180.1,210.0 282.3,209.7 384.4,219.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="210.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="209.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="219.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="201.5" x2="78.0" y2="198.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="201.5" x2="82.0" y2="201.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="198.5" x2="82.0" y2="198.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="239.1" x2="180.1" y2="236.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="239.1" x2="184.1" y2="239.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="236.1" x2="184.1" y2="236.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="253.2" x2="282.3" y2="250.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="253.2" x2="286.3" y2="253.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="250.2" x2="286.3" y2="250.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="278.7" x2="384.4" y2="275.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="278.7" x2="388.4" y2="278.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="275.7" x2="388.4" y2="275.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,200.0 180.1,237.6 282.3,251.7 384.4,277.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="200.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="237.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="251.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="277.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="286.3" x2="78.0" y2="283.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="286.3" x2="82.0" y2="286.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="283.3" x2="82.0" y2="283.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="268.4" x2="180.1" y2="261.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="268.4" x2="184.1" y2="268.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="261.0" x2="184.1" y2="261.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="256.6" x2="282.3" y2="253.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="256.6" x2="286.3" y2="256.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="253.6" x2="286.3" y2="253.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="263.4" x2="384.4" y2="260.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="263.4" x2="388.4" y2="263.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="260.4" x2="388.4" y2="260.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,284.8 180.1,264.7 282.3,255.1 384.4,261.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="284.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="264.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="255.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="261.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="318.2" x2="78.0" y2="315.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="318.2" x2="82.0" y2="318.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="315.2" x2="82.0" y2="315.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="318.5" x2="180.1" y2="315.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="318.5" x2="184.1" y2="318.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="315.5" x2="184.1" y2="315.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="318.7" x2="282.3" y2="315.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="318.7" x2="286.3" y2="318.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="315.7" x2="286.3" y2="315.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="319.0" x2="384.4" y2="316.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="319.0" x2="388.4" y2="319.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="316.0" x2="388.4" y2="316.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,316.7 180.1,317.0 282.3,317.2 384.4,317.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="316.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="317.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="317.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="317.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -186,18 +186,14 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="285.0" x2="946.0" y2="285.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="285.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="249.0" x2="946.0" y2="249.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="249.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="212.9" x2="946.0" y2="212.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="212.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="176.9" x2="946.0" y2="176.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="176.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="140.9" x2="946.0" y2="140.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="140.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
-  <line x1="942.0" y1="104.9" x2="946.0" y2="104.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="104.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
+  <line x1="942.0" y1="272.8" x2="946.0" y2="272.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="272.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="224.5" x2="946.0" y2="224.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="224.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="176.3" x2="946.0" y2="176.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="176.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="128.1" x2="946.0" y2="128.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="128.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -209,129 +205,129 @@
   <polyline points="482.4,204.3 635.6,222.1 788.8,245.6 942.0,257.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,233.1 635.6,244.4 788.8,255.4 942.0,257.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,165.9 635.6,172.8 788.8,188.6 942.0,193.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,142.4 635.6,150.0 788.8,185.1 942.0,195.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,262.5 635.6,262.3 788.8,262.3 942.0,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,147.5 635.6,160.6 788.8,212.1 942.0,226.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.1 635.6,262.5 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,178.3 635.6,185.7 788.8,205.1 942.0,206.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.9 635.6,262.5 788.8,262.3 942.0,262.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="300.4" x2="482.4" y2="297.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="300.4" x2="486.4" y2="300.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="297.4" x2="486.4" y2="297.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="267.3" x2="635.6" y2="264.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="267.3" x2="639.6" y2="267.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="264.3" x2="639.6" y2="264.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="230.2" x2="788.8" y2="227.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="230.2" x2="792.8" y2="230.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="227.2" x2="792.8" y2="227.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="211.2" x2="942.0" y2="208.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="211.2" x2="946.0" y2="211.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="208.2" x2="946.0" y2="208.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,298.9 635.6,265.8 788.8,228.7 942.0,209.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="298.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="265.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="228.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="209.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="313.5" x2="482.4" y2="310.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="313.5" x2="486.4" y2="313.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="482.4" y1="292.9" x2="482.4" y2="289.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="292.9" x2="486.4" y2="292.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="289.9" x2="486.4" y2="289.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="248.6" x2="635.6" y2="245.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="248.6" x2="639.6" y2="248.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="245.6" x2="639.6" y2="245.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="198.9" x2="788.8" y2="195.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="198.9" x2="792.8" y2="198.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="195.9" x2="792.8" y2="195.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="173.5" x2="942.0" y2="170.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="173.5" x2="946.0" y2="173.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="170.5" x2="946.0" y2="170.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,291.4 635.6,247.1 788.8,197.4 942.0,172.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="291.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="247.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="197.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="172.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="310.5" x2="482.4" y2="307.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="478.4" y1="310.5" x2="486.4" y2="310.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="307.7" x2="635.6" y2="304.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="307.7" x2="639.6" y2="307.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="304.7" x2="639.6" y2="304.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="303.9" x2="788.8" y2="300.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="303.9" x2="792.8" y2="303.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="300.9" x2="792.8" y2="300.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="304.2" x2="942.0" y2="301.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="304.2" x2="946.0" y2="304.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="301.2" x2="946.0" y2="301.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,312.0 635.6,306.2 788.8,302.4 942.0,302.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="312.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="306.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="302.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="302.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="313.3" x2="482.4" y2="310.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="313.3" x2="486.4" y2="313.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="310.3" x2="486.4" y2="310.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="298.2" x2="635.6" y2="295.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="298.2" x2="639.6" y2="298.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="295.2" x2="639.6" y2="295.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="286.0" x2="788.8" y2="283.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="286.0" x2="792.8" y2="286.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="283.0" x2="792.8" y2="283.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="282.1" x2="942.0" y2="279.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="282.1" x2="946.0" y2="282.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="279.1" x2="946.0" y2="279.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,311.8 635.6,296.7 788.8,284.5 942.0,280.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="311.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="296.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="284.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="280.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="292.4" x2="482.4" y2="289.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="292.4" x2="486.4" y2="292.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="289.4" x2="486.4" y2="289.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="215.4" x2="635.6" y2="212.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="215.4" x2="639.6" y2="215.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="212.3" x2="639.6" y2="212.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="167.2" x2="788.8" y2="164.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="167.2" x2="792.8" y2="167.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="164.2" x2="792.8" y2="164.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="118.5" x2="942.0" y2="114.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="118.5" x2="946.0" y2="118.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="114.8" x2="946.0" y2="114.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,290.9 635.6,213.9 788.8,165.7 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="290.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="213.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="165.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="478.4" y1="307.5" x2="486.4" y2="307.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="302.7" x2="635.6" y2="299.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="302.7" x2="639.6" y2="302.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="299.7" x2="639.6" y2="299.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="297.6" x2="788.8" y2="294.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="297.6" x2="792.8" y2="297.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="294.6" x2="792.8" y2="294.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="298.0" x2="942.0" y2="295.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="298.0" x2="946.0" y2="298.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="295.0" x2="946.0" y2="295.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,309.0 635.6,301.2 788.8,296.1 942.0,296.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="309.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="301.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="296.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="310.2" x2="482.4" y2="307.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="310.2" x2="486.4" y2="310.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="307.2" x2="486.4" y2="307.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="290.0" x2="635.6" y2="287.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="290.0" x2="639.6" y2="290.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="287.0" x2="639.6" y2="287.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="273.6" x2="788.8" y2="270.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="273.6" x2="792.8" y2="273.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="270.6" x2="792.8" y2="270.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="268.4" x2="942.0" y2="265.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="268.4" x2="946.0" y2="268.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="265.4" x2="946.0" y2="265.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,308.7 635.6,288.5 788.8,272.1 942.0,266.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="308.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="288.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="272.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="266.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="281.7" x2="482.4" y2="278.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="281.7" x2="486.4" y2="281.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="278.7" x2="486.4" y2="278.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="175.7" x2="635.6" y2="168.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="175.7" x2="639.6" y2="175.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="168.7" x2="639.6" y2="168.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="151.1" x2="788.8" y2="148.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="151.1" x2="792.8" y2="151.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="148.1" x2="792.8" y2="148.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="121.1" x2="942.0" y2="112.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="121.1" x2="946.0" y2="121.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="112.2" x2="946.0" y2="112.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,280.2 635.6,172.2 788.8,149.6 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="280.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="172.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="149.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="303.5" x2="482.4" y2="300.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="303.5" x2="486.4" y2="303.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="300.5" x2="486.4" y2="300.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="274.3" x2="635.6" y2="271.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="274.3" x2="639.6" y2="274.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="271.3" x2="639.6" y2="271.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="238.7" x2="788.8" y2="235.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="238.7" x2="792.8" y2="238.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="235.7" x2="792.8" y2="235.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="211.7" x2="942.0" y2="208.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="211.7" x2="946.0" y2="211.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="208.7" x2="946.0" y2="208.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,302.0 635.6,272.8 788.8,237.2 942.0,210.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="302.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="272.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="237.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="210.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="304.5" x2="482.4" y2="301.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="304.5" x2="486.4" y2="304.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="301.5" x2="486.4" y2="301.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="257.8" x2="635.6" y2="254.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="257.8" x2="639.6" y2="257.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="254.8" x2="639.6" y2="254.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="221.0" x2="788.8" y2="218.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="221.0" x2="792.8" y2="221.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="218.0" x2="792.8" y2="218.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="211.2" x2="942.0" y2="208.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="211.2" x2="946.0" y2="211.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="208.2" x2="946.0" y2="208.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,303.0 635.6,256.3 788.8,219.5 942.0,209.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="303.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="256.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="219.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="209.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="321.5" x2="482.4" y2="318.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="321.5" x2="486.4" y2="321.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="318.5" x2="486.4" y2="318.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="318.7" x2="635.6" y2="315.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="318.7" x2="639.6" y2="318.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="315.7" x2="639.6" y2="315.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="309.3" x2="788.8" y2="306.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="309.3" x2="792.8" y2="309.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="306.3" x2="792.8" y2="306.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="285.2" x2="942.0" y2="282.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="285.2" x2="946.0" y2="285.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="282.2" x2="946.0" y2="282.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,320.0 635.6,317.2 788.8,307.8 942.0,283.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="320.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="317.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="307.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="283.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="297.1" x2="482.4" y2="294.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="297.1" x2="486.4" y2="297.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="294.1" x2="486.4" y2="294.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="258.3" x2="635.6" y2="255.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="258.3" x2="639.6" y2="258.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="255.3" x2="639.6" y2="255.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="211.5" x2="788.8" y2="208.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="211.5" x2="792.8" y2="211.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="208.5" x2="792.8" y2="208.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="178.0" x2="942.0" y2="175.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="178.0" x2="946.0" y2="178.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="175.0" x2="946.0" y2="175.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,295.6 635.6,256.8 788.8,210.0 942.0,176.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="295.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="256.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="210.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="176.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="298.4" x2="482.4" y2="295.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="298.4" x2="486.4" y2="298.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="295.4" x2="486.4" y2="295.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="235.9" x2="635.6" y2="232.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="235.9" x2="639.6" y2="235.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="232.9" x2="639.6" y2="232.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="186.8" x2="788.8" y2="183.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="186.8" x2="792.8" y2="186.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="183.4" x2="792.8" y2="183.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="173.4" x2="942.0" y2="170.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="173.4" x2="946.0" y2="173.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="170.4" x2="946.0" y2="170.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,296.9 635.6,234.4 788.8,185.1 942.0,171.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="296.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="234.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="185.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="171.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="321.1" x2="482.4" y2="318.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="321.1" x2="486.4" y2="321.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="318.1" x2="486.4" y2="318.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="317.4" x2="635.6" y2="314.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="317.4" x2="639.6" y2="317.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="314.4" x2="639.6" y2="314.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="304.8" x2="788.8" y2="301.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="304.8" x2="792.8" y2="304.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="301.8" x2="792.8" y2="301.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="272.6" x2="942.0" y2="269.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="272.6" x2="946.0" y2="272.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="269.6" x2="946.0" y2="269.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,319.6 635.6,315.9 788.8,303.3 942.0,271.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="319.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="315.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="303.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="271.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -354,16 +350,18 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="596.2" x2="388.4" y2="596.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="596.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="554.4" x2="388.4" y2="554.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="554.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="512.6" x2="388.4" y2="512.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="512.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
-  <line x1="384.4" y1="470.8" x2="388.4" y2="470.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="470.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="429.0" x2="388.4" y2="429.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="429.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
+  <line x1="384.4" y1="604.1" x2="388.4" y2="604.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="604.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="570.2" x2="388.4" y2="570.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="570.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="536.3" x2="388.4" y2="536.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="536.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="502.4" x2="388.4" y2="502.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="502.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="468.5" x2="388.4" y2="468.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="468.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
+  <line x1="384.4" y1="434.6" x2="388.4" y2="434.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="434.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -375,129 +373,129 @@
   <polyline points="78.0,532.5 180.1,535.2 282.3,531.9 384.4,544.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,531.5 180.1,528.7 282.3,552.4 384.4,565.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,471.0 180.1,444.3 282.3,442.2 384.4,456.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,430.3 180.1,436.9 282.3,430.2 384.4,460.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,464.8 180.1,465.4 282.3,464.7 384.4,464.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.3 180.1,579.1 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,513.4 180.1,477.5 282.3,477.0 384.4,488.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.1 180.1,579.3 282.3,579.5 384.4,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="536.8" x2="78.0" y2="532.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="536.8" x2="82.0" y2="536.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="532.1" x2="82.0" y2="532.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="547.1" x2="180.1" y2="535.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="547.1" x2="184.1" y2="547.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="535.6" x2="184.1" y2="535.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="539.6" x2="282.3" y2="536.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="539.6" x2="286.3" y2="539.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="536.6" x2="286.3" y2="536.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="568.9" x2="384.4" y2="565.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="568.9" x2="388.4" y2="568.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="565.9" x2="388.4" y2="565.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,534.0 180.1,539.7 282.3,538.2 384.4,567.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="534.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="539.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="538.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="567.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="435.2" x2="78.0" y2="432.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="435.2" x2="82.0" y2="435.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="432.2" x2="82.0" y2="432.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="543.7" x2="180.1" y2="540.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="543.7" x2="184.1" y2="543.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="540.7" x2="184.1" y2="540.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="601.6" x2="282.3" y2="598.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="601.6" x2="286.3" y2="601.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="598.6" x2="286.3" y2="598.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="623.6" x2="384.4" y2="620.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="78.0" y1="555.9" x2="78.0" y2="552.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="555.9" x2="82.0" y2="555.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="552.1" x2="82.0" y2="552.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="564.3" x2="180.1" y2="554.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="564.3" x2="184.1" y2="564.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="554.9" x2="184.1" y2="554.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="558.5" x2="282.3" y2="555.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="558.5" x2="286.3" y2="558.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="555.5" x2="286.3" y2="555.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="582.2" x2="384.4" y2="579.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="582.2" x2="388.4" y2="582.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="579.2" x2="388.4" y2="579.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,553.6 180.1,558.3 282.3,557.0 384.4,580.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="553.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="558.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="557.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="580.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="473.7" x2="78.0" y2="470.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="473.7" x2="82.0" y2="473.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="470.7" x2="82.0" y2="470.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="561.8" x2="180.1" y2="558.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="561.8" x2="184.1" y2="561.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="558.8" x2="184.1" y2="558.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="608.8" x2="282.3" y2="605.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="608.8" x2="286.3" y2="608.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="605.8" x2="286.3" y2="605.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="626.6" x2="384.4" y2="623.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="626.6" x2="388.4" y2="626.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="380.4" y1="623.6" x2="388.4" y2="623.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="620.6" x2="388.4" y2="620.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,433.7 180.1,542.0 282.3,600.1 384.4,622.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="433.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="542.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="600.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="622.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="496.3" x2="78.0" y2="459.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="496.3" x2="82.0" y2="496.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="459.1" x2="82.0" y2="459.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="568.4" x2="180.1" y2="562.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="568.4" x2="184.1" y2="568.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="562.1" x2="184.1" y2="562.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="605.2" x2="282.3" y2="602.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="605.2" x2="286.3" y2="605.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="602.2" x2="286.3" y2="602.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="614.3" x2="384.4" y2="611.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="614.3" x2="388.4" y2="614.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="611.3" x2="388.4" y2="611.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,473.7 180.1,564.4 282.3,603.8 384.4,612.7" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="473.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="564.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="603.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="612.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="477.0" x2="78.0" y2="458.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="477.0" x2="82.0" y2="477.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="458.9" x2="82.0" y2="458.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="480.9" x2="180.1" y2="472.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="480.9" x2="184.1" y2="480.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="472.2" x2="184.1" y2="472.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="521.9" x2="282.3" y2="511.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="521.9" x2="286.3" y2="521.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="511.2" x2="286.3" y2="511.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="534.9" x2="384.4" y2="528.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="534.9" x2="388.4" y2="534.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="528.0" x2="388.4" y2="528.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,466.6 180.1,476.9 282.3,516.4 384.4,531.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="466.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="476.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="516.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="531.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="510.2" x2="78.0" y2="507.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="510.2" x2="82.0" y2="510.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="507.2" x2="82.0" y2="507.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="519.5" x2="180.1" y2="516.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="519.5" x2="184.1" y2="519.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="516.5" x2="184.1" y2="516.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="553.0" x2="282.3" y2="550.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="553.0" x2="286.3" y2="553.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="550.0" x2="286.3" y2="550.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="585.0" x2="384.4" y2="582.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="585.0" x2="388.4" y2="585.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="582.0" x2="388.4" y2="582.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,508.7 180.1,517.9 282.3,551.6 384.4,583.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="508.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="551.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="583.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="573.3" x2="78.0" y2="568.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="573.3" x2="82.0" y2="573.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="568.6" x2="82.0" y2="568.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="567.1" x2="180.1" y2="560.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="567.1" x2="184.1" y2="567.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="560.6" x2="184.1" y2="560.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="567.1" x2="282.3" y2="564.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="567.1" x2="286.3" y2="567.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="564.1" x2="286.3" y2="564.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="575.7" x2="384.4" y2="572.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="575.7" x2="388.4" y2="575.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="572.7" x2="388.4" y2="572.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,570.5 180.1,563.6 282.3,566.2 384.4,573.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="570.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="563.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="566.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="573.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="635.1" x2="78.0" y2="632.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="635.1" x2="82.0" y2="635.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="632.1" x2="82.0" y2="632.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="635.6" x2="180.1" y2="632.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="635.6" x2="184.1" y2="635.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="632.6" x2="184.1" y2="632.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="636.1" x2="282.3" y2="633.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="636.1" x2="286.3" y2="636.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="633.1" x2="286.3" y2="633.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="636.3" x2="384.4" y2="633.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="636.3" x2="388.4" y2="636.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="633.3" x2="388.4" y2="633.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,633.6 180.1,634.1 282.3,634.6 384.4,634.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="633.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="634.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="634.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,472.2 180.1,560.1 282.3,607.3 384.4,625.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="472.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="560.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="607.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="625.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="523.0" x2="78.0" y2="492.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="523.0" x2="82.0" y2="523.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="492.8" x2="82.0" y2="492.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="581.6" x2="180.1" y2="576.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="581.6" x2="184.1" y2="581.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="576.5" x2="184.1" y2="576.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="611.7" x2="282.3" y2="608.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="611.7" x2="286.3" y2="611.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="608.7" x2="286.3" y2="608.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="619.0" x2="384.4" y2="616.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="619.0" x2="388.4" y2="619.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="616.0" x2="388.4" y2="616.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,504.7 180.1,578.2 282.3,610.3 384.4,617.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="504.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="578.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="610.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="617.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="440.8" x2="78.0" y2="425.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="440.8" x2="82.0" y2="440.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="425.8" x2="82.0" y2="425.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="527.7" x2="180.1" y2="520.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="527.7" x2="184.1" y2="527.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="520.3" x2="184.1" y2="520.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="535.8" x2="282.3" y2="523.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="535.8" x2="286.3" y2="535.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="523.1" x2="286.3" y2="523.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="539.5" x2="384.4" y2="524.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="539.5" x2="388.4" y2="539.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="524.7" x2="388.4" y2="524.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,433.7 180.1,523.4 282.3,526.4 384.4,530.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="523.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="526.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="530.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="513.5" x2="78.0" y2="510.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="513.5" x2="82.0" y2="513.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="510.5" x2="82.0" y2="510.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="554.4" x2="180.1" y2="551.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="554.4" x2="184.1" y2="554.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="551.4" x2="184.1" y2="551.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="568.8" x2="282.3" y2="565.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="568.8" x2="286.3" y2="568.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="565.8" x2="286.3" y2="565.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="596.7" x2="384.4" y2="593.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="596.7" x2="388.4" y2="596.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="593.7" x2="388.4" y2="593.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,512.0 180.1,553.0 282.3,567.3 384.4,595.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="512.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="553.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="567.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="595.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="585.5" x2="78.0" y2="581.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="585.5" x2="82.0" y2="585.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="581.7" x2="82.0" y2="581.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="580.5" x2="180.1" y2="575.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="580.5" x2="184.1" y2="580.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="575.2" x2="184.1" y2="575.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="580.8" x2="282.3" y2="577.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="580.8" x2="286.3" y2="580.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="577.8" x2="286.3" y2="577.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="587.8" x2="384.4" y2="584.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="587.8" x2="388.4" y2="587.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="584.8" x2="388.4" y2="584.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,583.2 180.1,577.6 282.3,579.7 384.4,586.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="583.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="577.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="579.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="586.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="636.0" x2="78.0" y2="633.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="636.0" x2="82.0" y2="636.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="633.0" x2="82.0" y2="633.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="636.3" x2="180.1" y2="633.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="636.3" x2="184.1" y2="636.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="633.3" x2="184.1" y2="633.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="636.7" x2="282.3" y2="633.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="636.7" x2="286.3" y2="636.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="633.7" x2="286.3" y2="633.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="636.9" x2="384.4" y2="633.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="636.9" x2="388.4" y2="636.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="633.9" x2="388.4" y2="633.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,634.5 180.1,634.8 282.3,635.2 384.4,635.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="634.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="634.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="635.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="635.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -519,16 +517,14 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="594.8" x2="946.0" y2="594.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="594.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="551.6" x2="946.0" y2="551.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="551.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="508.4" x2="946.0" y2="508.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="508.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="465.2" x2="946.0" y2="465.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="465.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="422.0" x2="946.0" y2="422.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="422.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="590.7" x2="946.0" y2="590.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="590.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="543.4" x2="946.0" y2="543.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="543.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="496.0" x2="946.0" y2="496.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="496.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="448.7" x2="946.0" y2="448.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="448.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -540,129 +536,129 @@
   <polyline points="482.4,531.9 635.6,544.2 788.8,562.4 942.0,573.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,552.4 635.6,565.5 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,442.2 635.6,456.7 788.8,478.8 942.0,484.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,430.2 635.6,460.2 788.8,507.2 942.0,514.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,464.7 635.6,464.4 788.8,523.9 942.0,526.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.3 635.6,579.3 788.8,580.9 942.0,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,477.0 635.6,488.3 788.8,524.4 942.0,516.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="613.1" x2="482.4" y2="610.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="613.1" x2="486.4" y2="613.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="610.1" x2="486.4" y2="610.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="564.7" x2="635.6" y2="561.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="564.7" x2="639.6" y2="564.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="561.7" x2="639.6" y2="561.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="523.6" x2="788.8" y2="520.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="523.6" x2="792.8" y2="523.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="520.6" x2="792.8" y2="520.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="501.5" x2="942.0" y2="498.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="501.5" x2="946.0" y2="501.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="498.5" x2="946.0" y2="498.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,611.6 635.6,563.0 788.8,522.1 942.0,500.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="611.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="563.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="522.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="500.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="629.5" x2="482.4" y2="626.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="629.5" x2="486.4" y2="629.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="626.5" x2="486.4" y2="626.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="622.7" x2="635.6" y2="619.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="622.7" x2="639.6" y2="622.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="619.7" x2="639.6" y2="619.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="619.9" x2="788.8" y2="616.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="619.9" x2="792.8" y2="619.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="616.9" x2="792.8" y2="616.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="618.2" x2="942.0" y2="615.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="618.2" x2="946.0" y2="618.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="615.2" x2="946.0" y2="615.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,628.0 635.6,621.1 788.8,618.4 942.0,616.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="628.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="621.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="618.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="616.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="630.4" x2="482.4" y2="627.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="630.4" x2="486.4" y2="630.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="627.4" x2="486.4" y2="627.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="612.8" x2="635.6" y2="609.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="612.8" x2="639.6" y2="612.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="609.8" x2="639.6" y2="609.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="592.4" x2="788.8" y2="584.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="592.4" x2="792.8" y2="592.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="584.8" x2="792.8" y2="584.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="586.4" x2="942.0" y2="573.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="586.4" x2="946.0" y2="586.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="573.1" x2="946.0" y2="573.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,629.0 635.6,611.2 788.8,588.4 942.0,577.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="629.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="611.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="588.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="577.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="607.4" x2="482.4" y2="604.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="607.4" x2="486.4" y2="607.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="604.4" x2="486.4" y2="604.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="528.8" x2="635.6" y2="521.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="528.8" x2="639.6" y2="528.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="521.5" x2="639.6" y2="521.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="478.5" x2="788.8" y2="472.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="478.5" x2="792.8" y2="478.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="472.9" x2="792.8" y2="472.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="439.0" x2="942.0" y2="429.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="439.0" x2="946.0" y2="439.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="429.8" x2="946.0" y2="429.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,605.8 635.6,525.6 788.8,475.0 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="605.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="525.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="475.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="610.5" x2="482.4" y2="607.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="610.5" x2="486.4" y2="610.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="607.5" x2="486.4" y2="607.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="557.6" x2="635.6" y2="554.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="557.6" x2="639.6" y2="557.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="554.6" x2="639.6" y2="554.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="512.6" x2="788.8" y2="509.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="512.6" x2="792.8" y2="512.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="509.6" x2="792.8" y2="509.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="488.3" x2="942.0" y2="485.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="488.3" x2="946.0" y2="488.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="485.3" x2="946.0" y2="485.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,609.1 635.6,555.8 788.8,511.0 942.0,486.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="609.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="555.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="511.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="486.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="628.5" x2="482.4" y2="625.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="628.5" x2="486.4" y2="628.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="625.5" x2="486.4" y2="625.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="621.1" x2="635.6" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="621.1" x2="639.6" y2="621.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="618.1" x2="639.6" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="618.1" x2="788.8" y2="615.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="618.1" x2="792.8" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="615.1" x2="792.8" y2="615.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="616.1" x2="942.0" y2="613.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="616.1" x2="946.0" y2="616.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="613.1" x2="946.0" y2="613.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,627.0 635.6,619.5 788.8,616.6 942.0,614.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="627.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="619.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="616.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="614.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="629.6" x2="482.4" y2="626.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="629.6" x2="486.4" y2="629.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="626.6" x2="486.4" y2="626.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="610.3" x2="635.6" y2="607.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="610.3" x2="639.6" y2="610.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="607.3" x2="639.6" y2="607.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="588.0" x2="788.8" y2="579.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="588.0" x2="792.8" y2="588.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="579.7" x2="792.8" y2="579.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="581.5" x2="942.0" y2="567.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="581.5" x2="946.0" y2="581.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="567.0" x2="946.0" y2="567.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,628.1 635.6,608.6 788.8,583.7 942.0,571.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="628.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="608.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="583.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="571.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="601.5" x2="482.4" y2="596.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="601.5" x2="486.4" y2="601.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="596.9" x2="486.4" y2="596.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="497.2" x2="635.6" y2="476.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="497.2" x2="639.6" y2="497.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="476.1" x2="639.6" y2="476.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="494.0" x2="788.8" y2="439.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="494.0" x2="792.8" y2="494.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="439.8" x2="792.8" y2="439.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="482.9" x2="942.0" y2="394.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="482.9" x2="946.0" y2="482.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="394.4" x2="946.0" y2="394.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,598.1 635.6,484.6 788.8,466.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="598.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="484.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="466.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="616.6" x2="482.4" y2="613.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="616.6" x2="486.4" y2="616.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="613.6" x2="486.4" y2="613.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="581.8" x2="635.6" y2="578.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="581.8" x2="639.6" y2="581.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="578.8" x2="639.6" y2="578.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="538.6" x2="788.8" y2="535.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="538.6" x2="792.8" y2="538.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="535.6" x2="792.8" y2="535.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="508.1" x2="942.0" y2="505.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="508.1" x2="946.0" y2="508.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="505.1" x2="946.0" y2="505.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,615.1 635.6,580.3 788.8,537.1 942.0,506.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="615.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="580.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="537.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="506.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="620.3" x2="482.4" y2="617.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="620.3" x2="486.4" y2="620.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="617.3" x2="486.4" y2="617.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="572.0" x2="635.6" y2="569.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="572.0" x2="639.6" y2="572.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="569.0" x2="639.6" y2="569.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="526.2" x2="788.8" y2="523.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="526.2" x2="792.8" y2="526.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="523.2" x2="792.8" y2="523.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="507.1" x2="942.0" y2="503.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="507.1" x2="946.0" y2="507.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="503.6" x2="946.0" y2="503.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,619.0 635.6,570.2 788.8,524.5 942.0,505.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="619.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="570.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="524.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="505.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="638.6" x2="482.4" y2="635.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="638.6" x2="486.4" y2="638.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="635.6" x2="486.4" y2="635.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="636.1" x2="635.6" y2="633.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="636.1" x2="639.6" y2="636.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="633.1" x2="639.6" y2="633.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="626.9" x2="788.8" y2="623.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="626.9" x2="792.8" y2="626.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="623.9" x2="792.8" y2="623.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="601.3" x2="942.0" y2="598.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="601.3" x2="946.0" y2="601.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="598.3" x2="946.0" y2="598.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,637.1 635.6,634.6 788.8,625.4 942.0,599.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="637.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="625.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="599.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="614.2" x2="482.4" y2="611.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="614.2" x2="486.4" y2="614.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="611.2" x2="486.4" y2="611.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="578.4" x2="635.6" y2="575.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="578.4" x2="639.6" y2="578.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="575.4" x2="639.6" y2="575.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="534.1" x2="788.8" y2="531.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="534.1" x2="792.8" y2="534.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="531.1" x2="792.8" y2="531.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="498.2" x2="942.0" y2="495.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="498.2" x2="946.0" y2="498.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="495.1" x2="946.0" y2="495.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,612.7 635.6,576.9 788.8,532.9 942.0,496.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="576.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="532.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="496.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="618.5" x2="482.4" y2="615.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="618.5" x2="486.4" y2="618.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="615.5" x2="486.4" y2="615.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="565.6" x2="635.6" y2="562.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="565.6" x2="639.6" y2="565.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="562.5" x2="639.6" y2="562.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="515.5" x2="788.8" y2="512.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="515.5" x2="792.8" y2="515.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="512.4" x2="792.8" y2="512.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="494.6" x2="942.0" y2="490.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="494.6" x2="946.0" y2="494.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="490.8" x2="946.0" y2="490.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,617.2 635.6,563.7 788.8,513.7 942.0,492.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="617.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="563.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="513.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="492.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="638.5" x2="482.4" y2="635.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="638.5" x2="486.4" y2="638.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="635.5" x2="486.4" y2="635.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="635.7" x2="635.6" y2="632.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="635.7" x2="639.6" y2="635.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="632.7" x2="639.6" y2="632.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="625.7" x2="788.8" y2="622.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="625.7" x2="792.8" y2="625.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="622.7" x2="792.8" y2="622.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="597.6" x2="942.0" y2="594.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="597.6" x2="946.0" y2="597.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="594.6" x2="946.0" y2="594.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,637.0 635.6,634.2 788.8,624.2 942.0,596.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="637.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="624.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="596.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -685,10 +681,12 @@
   <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="871.2" x2="388.4" y2="871.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="871.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="787.3" x2="388.4" y2="787.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="787.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="882.8" x2="388.4" y2="882.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="882.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="810.5" x2="388.4" y2="810.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="810.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="738.3" x2="388.4" y2="738.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="738.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -700,129 +698,129 @@
   <polyline points="78.0,860.0 180.1,860.1 282.3,858.2 384.4,860.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,848.5 180.1,850.4 282.3,872.0 384.4,884.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,810.5 180.1,789.6 282.3,780.8 384.4,800.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,761.5 180.1,757.3 282.3,749.2 384.4,778.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,781.6 180.1,781.2 282.3,780.8 384.4,780.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,896.3 180.1,896.1 282.3,896.3 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,822.3 180.1,806.7 282.3,796.9 384.4,804.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="866.6" x2="78.0" y2="861.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="866.6" x2="82.0" y2="866.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="861.0" x2="82.0" y2="861.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="858.8" x2="180.1" y2="855.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="858.8" x2="184.1" y2="858.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="855.8" x2="184.1" y2="855.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="861.6" x2="282.3" y2="858.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="861.6" x2="286.3" y2="861.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="858.6" x2="286.3" y2="858.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="892.7" x2="384.4" y2="889.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="892.7" x2="388.4" y2="892.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="889.7" x2="388.4" y2="889.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,861.8 180.1,856.6 282.3,859.7 384.4,890.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="861.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="856.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="859.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="890.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="752.1" x2="78.0" y2="749.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="752.1" x2="82.0" y2="752.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="749.1" x2="82.0" y2="749.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="858.7" x2="180.1" y2="855.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="858.7" x2="184.1" y2="858.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="855.7" x2="184.1" y2="855.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="919.4" x2="282.3" y2="916.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="919.4" x2="286.3" y2="919.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="916.4" x2="286.3" y2="916.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="941.3" x2="384.4" y2="938.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="941.3" x2="388.4" y2="941.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="938.3" x2="388.4" y2="938.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,750.7 180.1,857.2 282.3,917.9 384.4,939.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="750.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="857.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="917.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="939.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="815.3" x2="78.0" y2="793.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="815.3" x2="82.0" y2="815.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="793.9" x2="82.0" y2="793.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="892.5" x2="180.1" y2="880.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="892.5" x2="184.1" y2="892.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="880.9" x2="184.1" y2="880.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="923.9" x2="282.3" y2="920.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="923.9" x2="286.3" y2="923.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="920.9" x2="286.3" y2="920.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="934.3" x2="384.4" y2="931.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="934.3" x2="388.4" y2="934.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="931.3" x2="388.4" y2="931.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,806.5 180.1,887.1 282.3,922.4 384.4,932.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="806.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="887.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="922.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="932.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="793.1" x2="78.0" y2="781.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="793.1" x2="82.0" y2="793.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="781.1" x2="82.0" y2="781.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="808.9" x2="180.1" y2="790.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="808.9" x2="184.1" y2="808.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="790.0" x2="184.1" y2="790.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="844.3" x2="282.3" y2="830.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="844.3" x2="286.3" y2="844.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="830.8" x2="286.3" y2="830.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="865.7" x2="384.4" y2="853.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="865.7" x2="388.4" y2="865.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="853.2" x2="388.4" y2="853.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,786.6 180.1,796.1 282.3,835.4 384.4,858.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="786.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="796.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="835.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="858.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="826.0" x2="78.0" y2="823.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="826.0" x2="82.0" y2="826.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="823.0" x2="82.0" y2="823.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="842.3" x2="180.1" y2="839.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="842.3" x2="184.1" y2="842.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="839.3" x2="184.1" y2="839.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="872.0" x2="282.3" y2="869.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="872.0" x2="286.3" y2="872.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="869.0" x2="286.3" y2="869.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="904.5" x2="384.4" y2="901.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="904.5" x2="388.4" y2="904.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="901.5" x2="388.4" y2="901.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,824.5 180.1,840.9 282.3,870.7 384.4,903.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="824.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="840.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="870.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="903.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="891.2" x2="78.0" y2="886.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="891.2" x2="82.0" y2="891.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="886.7" x2="82.0" y2="886.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="889.9" x2="180.1" y2="883.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="889.9" x2="184.1" y2="889.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="883.0" x2="184.1" y2="883.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="891.0" x2="282.3" y2="885.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="891.0" x2="286.3" y2="891.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="885.7" x2="286.3" y2="885.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="899.1" x2="384.4" y2="894.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="899.1" x2="388.4" y2="899.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="894.9" x2="388.4" y2="894.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,888.3 180.1,884.8 282.3,888.1 384.4,897.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="888.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="884.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="888.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="897.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="951.0" x2="78.0" y2="948.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="951.0" x2="82.0" y2="951.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="948.0" x2="82.0" y2="948.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="952.0" x2="180.1" y2="949.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="952.0" x2="184.1" y2="952.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="949.0" x2="184.1" y2="949.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="952.7" x2="282.3" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="952.7" x2="286.3" y2="952.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="949.7" x2="286.3" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="953.1" x2="384.4" y2="950.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="953.1" x2="388.4" y2="953.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="950.1" x2="388.4" y2="950.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,949.5 180.1,950.5 282.3,951.2 384.4,951.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="949.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="950.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="951.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="951.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="878.8" x2="78.0" y2="874.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="878.8" x2="82.0" y2="878.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="874.0" x2="82.0" y2="874.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="872.3" x2="180.1" y2="869.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="872.3" x2="184.1" y2="872.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="869.3" x2="184.1" y2="869.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="874.7" x2="282.3" y2="871.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="874.7" x2="286.3" y2="874.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="871.7" x2="286.3" y2="871.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="901.5" x2="384.4" y2="898.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="901.5" x2="388.4" y2="901.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="898.5" x2="388.4" y2="898.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,874.6 180.1,870.2 282.3,872.8 384.4,899.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="874.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="870.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="872.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="899.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="780.4" x2="78.0" y2="777.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="780.4" x2="82.0" y2="780.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="777.4" x2="82.0" y2="777.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="872.2" x2="180.1" y2="869.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="872.2" x2="184.1" y2="872.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="869.2" x2="184.1" y2="869.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="924.5" x2="282.3" y2="921.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="924.5" x2="286.3" y2="924.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="921.5" x2="286.3" y2="921.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="943.4" x2="384.4" y2="940.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="943.4" x2="388.4" y2="943.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="940.4" x2="388.4" y2="940.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,778.9 180.1,870.7 282.3,923.0 384.4,941.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="778.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="870.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="923.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="941.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="834.6" x2="78.0" y2="816.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="834.6" x2="82.0" y2="834.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="816.1" x2="82.0" y2="816.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="901.1" x2="180.1" y2="891.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="901.1" x2="184.1" y2="901.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="891.1" x2="184.1" y2="891.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="928.4" x2="282.3" y2="925.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="928.4" x2="286.3" y2="928.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="925.4" x2="286.3" y2="925.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="937.4" x2="384.4" y2="934.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="937.4" x2="388.4" y2="937.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="934.4" x2="388.4" y2="934.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,827.0 180.1,896.5 282.3,926.9 384.4,935.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="827.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="896.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="926.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="935.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="760.0" x2="78.0" y2="728.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="760.0" x2="82.0" y2="760.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="728.6" x2="82.0" y2="728.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="838.2" x2="180.1" y2="815.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="838.2" x2="184.1" y2="838.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="815.7" x2="184.1" y2="815.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="844.5" x2="282.3" y2="827.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="844.5" x2="286.3" y2="844.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="827.6" x2="286.3" y2="827.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="846.5" x2="384.4" y2="836.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="846.5" x2="388.4" y2="846.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="836.1" x2="388.4" y2="836.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,750.7 180.1,831.3 282.3,837.1 384.4,840.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="831.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="837.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="840.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="818.1" x2="78.0" y2="815.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="818.1" x2="82.0" y2="818.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="815.1" x2="82.0" y2="815.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="862.3" x2="180.1" y2="859.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="862.3" x2="184.1" y2="862.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="859.3" x2="184.1" y2="859.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="880.3" x2="282.3" y2="877.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="880.3" x2="286.3" y2="880.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="877.3" x2="286.3" y2="877.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="911.8" x2="384.4" y2="908.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="911.8" x2="388.4" y2="911.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="908.8" x2="388.4" y2="908.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,817.0 180.1,861.2 282.3,879.1 384.4,910.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="817.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="861.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="879.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="910.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="900.0" x2="78.0" y2="896.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="900.0" x2="82.0" y2="900.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="896.1" x2="82.0" y2="896.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="898.9" x2="180.1" y2="892.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="898.9" x2="184.1" y2="898.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="892.9" x2="184.1" y2="892.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="899.8" x2="282.3" y2="895.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="899.8" x2="286.3" y2="899.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="895.2" x2="286.3" y2="895.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="906.8" x2="384.4" y2="903.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="906.8" x2="388.4" y2="906.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="903.2" x2="388.4" y2="903.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,897.5 180.1,894.5 282.3,897.4 384.4,905.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="897.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="894.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="897.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="905.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="951.8" x2="78.0" y2="948.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="951.8" x2="82.0" y2="951.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="948.8" x2="82.0" y2="948.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="952.6" x2="180.1" y2="949.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="952.6" x2="184.1" y2="952.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="949.6" x2="184.1" y2="949.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="953.2" x2="282.3" y2="950.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="953.2" x2="286.3" y2="953.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="950.2" x2="286.3" y2="950.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="953.6" x2="384.4" y2="950.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="953.6" x2="388.4" y2="953.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="950.6" x2="388.4" y2="950.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,950.3 180.1,951.1 282.3,951.7 384.4,952.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="950.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="951.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="951.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="952.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -844,16 +842,14 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="911.3" x2="946.0" y2="911.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="911.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="867.5" x2="946.0" y2="867.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="867.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="823.8" x2="946.0" y2="823.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="823.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="780.0" x2="946.0" y2="780.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="780.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="736.3" x2="946.0" y2="736.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="736.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="905.6" x2="946.0" y2="905.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="905.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="856.2" x2="946.0" y2="856.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="856.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="806.8" x2="946.0" y2="806.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="806.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="757.4" x2="946.0" y2="757.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="757.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -865,129 +861,129 @@
   <polyline points="482.4,858.2 635.6,860.9 788.8,879.4 942.0,891.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,872.0 635.6,884.7 788.8,891.8 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,780.8 635.6,800.5 788.8,809.7 942.0,815.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,749.2 635.6,778.3 788.8,814.0 942.0,821.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.5 635.6,896.3 788.8,896.1 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,780.8 635.6,780.3 788.8,833.5 942.0,845.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.3 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,796.9 635.6,804.4 788.8,825.5 942.0,825.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.5 635.6,896.1 788.8,896.4 942.0,896.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="931.2" x2="482.4" y2="928.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="931.2" x2="486.4" y2="931.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="928.2" x2="486.4" y2="928.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="888.3" x2="635.6" y2="885.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="888.3" x2="639.6" y2="888.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="885.3" x2="639.6" y2="885.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="841.9" x2="788.8" y2="838.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="841.9" x2="792.8" y2="841.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="838.9" x2="792.8" y2="838.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="819.2" x2="942.0" y2="816.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="819.2" x2="946.0" y2="819.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="816.2" x2="946.0" y2="816.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,929.5 635.6,886.4 788.8,840.0 942.0,817.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="929.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="886.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="840.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="817.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="946.6" x2="482.4" y2="943.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="946.6" x2="486.4" y2="946.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="943.6" x2="486.4" y2="943.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="940.2" x2="635.6" y2="937.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="940.2" x2="639.6" y2="940.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="937.2" x2="639.6" y2="937.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="938.4" x2="788.8" y2="935.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="938.4" x2="792.8" y2="938.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="935.4" x2="792.8" y2="935.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="934.8" x2="942.0" y2="931.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="934.8" x2="946.0" y2="934.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="931.8" x2="946.0" y2="931.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,945.1 635.6,938.7 788.8,936.9 942.0,933.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="945.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="938.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="936.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="933.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="947.8" x2="482.4" y2="944.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="947.8" x2="486.4" y2="947.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="944.8" x2="486.4" y2="944.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="932.8" x2="635.6" y2="929.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="932.8" x2="639.6" y2="932.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="482.4" y1="927.9" x2="482.4" y2="924.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="927.9" x2="486.4" y2="927.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="924.9" x2="486.4" y2="924.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="879.4" x2="635.6" y2="876.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="879.4" x2="639.6" y2="879.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="876.4" x2="639.6" y2="876.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="827.1" x2="788.8" y2="824.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="827.1" x2="792.8" y2="827.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="824.1" x2="792.8" y2="824.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="801.4" x2="942.0" y2="798.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="801.4" x2="946.0" y2="801.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="798.4" x2="946.0" y2="798.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,926.2 635.6,877.5 788.8,825.1 942.0,800.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="926.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="877.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="825.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="800.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="945.3" x2="482.4" y2="942.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="945.3" x2="486.4" y2="945.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="942.3" x2="486.4" y2="942.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="938.1" x2="635.6" y2="935.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="938.1" x2="639.6" y2="938.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="935.1" x2="639.6" y2="935.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="936.1" x2="788.8" y2="933.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="936.1" x2="792.8" y2="936.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="933.1" x2="792.8" y2="933.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="932.0" x2="942.0" y2="929.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="932.0" x2="946.0" y2="932.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="929.0" x2="946.0" y2="929.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,943.8 635.6,936.6 788.8,934.6 942.0,930.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="943.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="936.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="934.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="930.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="946.7" x2="482.4" y2="943.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="946.7" x2="486.4" y2="946.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="943.7" x2="486.4" y2="943.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="929.8" x2="635.6" y2="926.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
   <line x1="631.6" y1="929.8" x2="639.6" y2="929.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="914.8" x2="788.8" y2="911.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="914.8" x2="792.8" y2="914.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="911.8" x2="792.8" y2="911.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="931.1" x2="942.0" y2="838.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="931.1" x2="946.0" y2="931.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="838.9" x2="946.0" y2="838.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,946.3 635.6,931.3 788.8,913.6 942.0,903.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="946.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="931.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="913.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="903.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="925.4" x2="482.4" y2="921.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="925.4" x2="486.4" y2="925.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="921.8" x2="486.4" y2="921.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="859.6" x2="635.6" y2="846.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="859.6" x2="639.6" y2="859.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="846.2" x2="639.6" y2="846.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="788.9" x2="788.8" y2="779.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="788.9" x2="792.8" y2="788.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="779.1" x2="792.8" y2="779.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="766.4" x2="942.0" y2="741.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="766.4" x2="946.0" y2="766.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="741.8" x2="946.0" y2="741.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,923.0 635.6,852.0 788.8,783.4 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="923.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="852.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="783.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="631.6" y1="926.6" x2="639.6" y2="926.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="909.4" x2="788.8" y2="906.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="909.4" x2="792.8" y2="909.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="906.4" x2="792.8" y2="906.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="928.0" x2="942.0" y2="823.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="928.0" x2="946.0" y2="928.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="823.9" x2="946.0" y2="823.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,945.2 635.6,928.2 788.8,908.3 942.0,896.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="945.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="928.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="908.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="896.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="916.3" x2="482.4" y2="910.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="916.3" x2="486.4" y2="916.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="910.4" x2="486.4" y2="910.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="803.1" x2="635.6" y2="788.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="803.1" x2="639.6" y2="803.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="788.4" x2="639.6" y2="788.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="793.8" x2="788.8" y2="758.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="793.8" x2="792.8" y2="793.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="758.5" x2="792.8" y2="758.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="810.2" x2="942.0" y2="673.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="810.2" x2="946.0" y2="810.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="673.8" x2="946.0" y2="673.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,913.7 635.6,795.1 788.8,775.9 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="913.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="795.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="775.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="933.9" x2="482.4" y2="930.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="933.9" x2="486.4" y2="933.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="930.9" x2="486.4" y2="930.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="900.9" x2="635.6" y2="897.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="900.9" x2="639.6" y2="900.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="897.9" x2="639.6" y2="897.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="855.0" x2="788.8" y2="852.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="855.0" x2="792.8" y2="855.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="852.0" x2="792.8" y2="852.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="823.2" x2="942.0" y2="820.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="823.2" x2="946.0" y2="823.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="820.2" x2="946.0" y2="820.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,932.5 635.6,899.4 788.8,853.4 942.0,821.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="932.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="899.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="853.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="821.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="938.7" x2="482.4" y2="935.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="938.7" x2="486.4" y2="938.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="935.7" x2="486.4" y2="935.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="895.2" x2="635.6" y2="890.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="895.2" x2="639.6" y2="895.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="890.8" x2="639.6" y2="890.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="842.7" x2="788.8" y2="837.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="842.7" x2="792.8" y2="842.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="837.0" x2="792.8" y2="837.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="825.1" x2="942.0" y2="820.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="825.1" x2="946.0" y2="825.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="820.5" x2="946.0" y2="820.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,937.1 635.6,893.3 788.8,840.2 942.0,822.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="937.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="893.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="840.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="822.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="955.5" x2="482.4" y2="952.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="955.5" x2="486.4" y2="955.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="952.5" x2="486.4" y2="952.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="952.9" x2="635.6" y2="949.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="952.9" x2="639.6" y2="952.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="949.9" x2="639.6" y2="949.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="943.5" x2="788.8" y2="940.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="943.5" x2="792.8" y2="943.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="940.5" x2="792.8" y2="940.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="918.0" x2="942.0" y2="915.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="918.0" x2="946.0" y2="918.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="915.0" x2="946.0" y2="915.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,954.0 635.6,951.4 788.8,942.0 942.0,916.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="954.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="951.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="942.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="916.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="929.8" x2="482.4" y2="926.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="929.8" x2="486.4" y2="929.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="926.8" x2="486.4" y2="926.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="893.8" x2="635.6" y2="890.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="893.8" x2="639.6" y2="893.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="890.8" x2="639.6" y2="890.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="844.5" x2="788.8" y2="840.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="844.5" x2="792.8" y2="844.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="840.9" x2="792.8" y2="840.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="813.4" x2="942.0" y2="803.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="813.4" x2="946.0" y2="813.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="803.7" x2="946.0" y2="803.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,928.4 635.6,892.5 788.8,842.1 942.0,807.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="928.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="892.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="842.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="807.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="936.4" x2="482.4" y2="933.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="936.4" x2="486.4" y2="936.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="933.4" x2="486.4" y2="933.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="887.5" x2="635.6" y2="882.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="887.5" x2="639.6" y2="887.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="882.5" x2="639.6" y2="882.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="828.2" x2="788.8" y2="821.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="828.2" x2="792.8" y2="828.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="821.7" x2="792.8" y2="821.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="808.2" x2="942.0" y2="803.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="808.2" x2="946.0" y2="808.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="803.1" x2="946.0" y2="803.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,934.8 635.6,885.3 788.8,825.3 942.0,805.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="885.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="825.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="805.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="955.3" x2="482.4" y2="952.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="955.3" x2="486.4" y2="955.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="952.3" x2="486.4" y2="952.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="952.4" x2="635.6" y2="949.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="952.4" x2="639.6" y2="952.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="949.4" x2="639.6" y2="949.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="941.8" x2="788.8" y2="938.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="941.8" x2="792.8" y2="941.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="938.8" x2="792.8" y2="938.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="913.0" x2="942.0" y2="910.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="913.0" x2="946.0" y2="913.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="910.0" x2="946.0" y2="910.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,953.8 635.6,951.0 788.8,940.3 942.0,911.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="953.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="951.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="940.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="911.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -1003,7 +999,7 @@
   <text x="530" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="700" y1="989" x2="714" y2="989" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="707" cy="989" r="2.5" fill="#dc2626"/>
-  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="720" y="993" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="225" y1="1009" x2="239" y2="1009" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="232" cy="1009" r="2.5" fill="#2563eb"/>
   <text x="245" y="1013" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/pushpull/inproc.svg
+++ b/doc/charts/pushpull/inproc.svg
@@ -37,8 +37,8 @@
   <text x="30.0" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,213.0)">CPU %</text>
   <polyline points="78.0,125.8 174.8,121.8 271.6,143.5 368.4,137.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,191.5 174.8,191.3 271.6,198.8 368.4,193.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,212.3 174.8,212.3 271.6,212.3 368.4,212.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,283.0 174.8,283.5 271.6,283.0 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,212.1 174.8,211.6 271.6,212.1 368.4,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,283.0 174.8,283.0 271.6,283.0 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,131.9 174.8,126.1 271.6,132.4 368.4,130.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,251.0 174.8,249.0 271.6,253.3 368.4,251.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="251.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
@@ -50,16 +50,16 @@
   <circle cx="174.8" cy="216.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="271.6" cy="289.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="368.4" cy="303.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,284.1 174.8,276.9 271.6,275.9 368.4,277.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="284.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="276.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="275.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="277.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,197.7 174.8,197.1 271.6,185.6 368.4,185.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="197.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="197.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="185.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="185.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,271.6 174.8,268.0 271.6,270.0 368.4,260.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="271.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="268.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="270.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="260.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,199.8 174.8,195.0 271.6,191.4 368.4,191.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="199.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="195.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="191.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="191.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="78.0,248.1 174.8,248.4 271.6,253.3 368.4,248.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="248.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="174.8" cy="248.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -106,7 +106,7 @@
   <text x="418.4" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,418.4,213.0)">CPU %</text>
   <polyline points="466.4,143.5 611.6,137.2 756.8,127.9 902.0,134.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,198.8 611.6,193.4 756.8,191.3 902.0,199.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,212.3 611.6,212.5 756.8,211.8 902.0,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,212.1 611.6,212.3 756.8,212.1 902.0,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,283.0 611.6,283.0 756.8,283.0 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,132.4 611.6,130.7 756.8,126.3 902.0,132.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,287.4 611.6,244.6 756.8,202.5 902.0,159.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -119,16 +119,16 @@
   <circle cx="611.6" cy="266.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="229.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="198.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,295.2 611.6,253.8 756.8,210.4 902.0,170.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="295.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="253.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="210.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="170.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,271.6 611.6,229.4 756.8,187.9 902.0,145.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="271.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="229.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="187.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="145.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,293.0 611.6,247.4 756.8,206.0 902.0,164.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="293.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="247.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="206.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="164.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,272.7 611.6,230.6 756.8,188.4 902.0,146.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="272.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="230.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="188.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="146.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,287.4 611.6,243.8 756.8,203.1 902.0,160.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="287.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="243.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -146,7 +146,7 @@
   <text x="415" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="585" y1="391" x2="599" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="592" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="605" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="605" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="300" y1="411" x2="314" y2="411" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="307" cy="411" r="2.5" fill="#16a34a"/>
   <text x="320" y="415" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>

--- a/doc/charts/pushpull/ipc.svg
+++ b/doc/charts/pushpull/ipc.svg
@@ -19,14 +19,18 @@
   <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="368.4" y1="284.4" x2="372.4" y2="284.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="284.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="215.9" x2="372.4" y2="215.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="215.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="147.3" x2="372.4" y2="147.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="147.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="78.8" x2="372.4" y2="78.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="78.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="311.1" x2="372.4" y2="311.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="311.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="269.1" x2="372.4" y2="269.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="269.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="227.2" x2="372.4" y2="227.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="227.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="185.3" x2="372.4" y2="185.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="185.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="143.3" x2="372.4" y2="143.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="143.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="368.4" y1="101.4" x2="372.4" y2="101.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="101.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -38,45 +42,45 @@
   <polyline points="78.0,224.2 174.8,221.0 271.6,220.3 368.4,233.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,213.2 174.8,197.1 271.6,214.4 368.4,243.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,245.7 174.8,194.6 271.6,215.3 368.4,245.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,194.6 174.8,193.2 271.6,229.6 368.4,250.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,283.0 174.8,283.0 271.6,283.0 368.4,286.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,184.3 174.8,181.0 271.6,242.9 368.4,301.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,282.8 174.8,283.0 271.6,283.0 368.4,314.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,279.0 174.8,266.2 271.6,271.8 368.4,273.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,251.0 174.8,252.4 271.6,250.6 368.4,249.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,251.9 174.8,248.9 271.6,242.9 368.4,278.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="251.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="248.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="242.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="278.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,109.5 174.8,196.5 271.6,275.6 368.4,317.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="109.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="196.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="275.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="317.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,117.4 174.8,195.9 271.6,276.0 368.4,316.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="117.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="195.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="276.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="316.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,163.7 174.8,162.5 271.6,201.8 368.4,238.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="163.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="162.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="201.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="238.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,114.5 174.8,127.2 271.6,188.5 368.4,256.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="114.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="127.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="188.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="256.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,274.9 174.8,260.2 271.6,262.4 368.4,290.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="274.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="260.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="262.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="290.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,333.8 174.8,334.1 271.6,335.0 368.4,335.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="333.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="334.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="335.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="335.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,291.2 174.8,289.3 271.6,285.6 368.4,307.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="291.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="289.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="285.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="307.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,204.1 174.8,257.3 271.6,305.7 368.4,331.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="204.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="257.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="305.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="331.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,208.9 174.8,256.9 271.6,305.9 368.4,330.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="208.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="256.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="305.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="330.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,207.2 271.6,235.6 368.4,319.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="207.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="235.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="319.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,199.9 174.8,245.6 271.6,260.0 368.4,323.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="199.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="245.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="260.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="323.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,305.2 174.8,296.3 271.6,297.6 368.4,314.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="305.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="296.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="297.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="314.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,341.3 174.8,341.5 271.6,342.0 368.4,342.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="341.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="341.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="342.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="342.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -121,8 +125,8 @@
   <polyline points="466.4,220.3 611.6,233.1 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,214.4 611.6,243.8 756.8,273.4 902.0,260.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,215.3 611.6,245.4 756.8,273.2 902.0,266.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,229.6 611.6,250.8 756.8,263.4 902.0,268.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,283.0 611.6,286.0 756.8,282.8 902.0,283.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,242.9 611.6,301.2 756.8,310.1 902.0,284.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,283.0 611.6,314.0 756.8,284.2 902.0,288.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,271.8 611.6,273.5 756.8,278.3 902.0,279.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,250.6 611.6,249.0 756.8,267.6 902.0,293.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,314.6 611.6,249.7 756.8,171.5 902.0,130.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -140,16 +144,16 @@
   <circle cx="611.6" cy="302.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="289.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="270.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,300.3 611.6,193.8 756.8,97.7 902.0,38.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="300.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="193.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="97.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="38.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,295.7 611.6,218.6 756.8,111.7 902.0,25.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="295.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="218.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="111.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="25.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,286.1 611.6,277.6 756.8,236.5 902.0,49.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="286.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="277.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="236.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="49.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,300.0 611.6,284.8 756.8,110.9 902.0,43.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="300.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="284.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="110.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="43.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,321.4 611.6,265.8 756.8,236.1 902.0,224.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="321.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="265.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -175,7 +179,7 @@
   <text x="510" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="680" y1="391" x2="694" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="687" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="205" y1="411" x2="219" y2="411" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="212" cy="411" r="2.5" fill="#2563eb"/>
   <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/pushpull/tcp.svg
+++ b/doc/charts/pushpull/tcp.svg
@@ -19,14 +19,18 @@
   <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="368.4" y1="283.6" x2="372.4" y2="283.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="283.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="214.2" x2="372.4" y2="214.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="214.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="144.8" x2="372.4" y2="144.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="144.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="75.4" x2="372.4" y2="75.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="75.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="307.4" x2="372.4" y2="307.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="307.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="261.8" x2="372.4" y2="261.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="261.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="216.2" x2="372.4" y2="216.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="216.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="170.6" x2="372.4" y2="170.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="170.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="125.0" x2="372.4" y2="125.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="125.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="368.4" y1="79.4" x2="372.4" y2="79.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="79.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -38,45 +42,45 @@
   <polyline points="78.0,212.8 174.8,215.2 271.6,223.8 368.4,232.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,215.6 174.8,200.2 271.6,227.2 368.4,246.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,196.4 174.8,192.2 271.6,227.5 368.4,244.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,208.8 174.8,210.7 271.6,211.1 368.4,242.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,282.5 174.8,283.0 271.6,284.6 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,193.9 174.8,189.9 271.6,232.6 368.4,242.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,282.1 174.8,282.5 271.6,282.8 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,305.4 174.8,280.9 271.6,270.7 368.4,272.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,275.3 174.8,280.9 271.6,282.8 368.4,283.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,235.6 174.8,244.1 271.6,249.5 368.4,269.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="235.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="244.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="249.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="269.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,118.0 174.8,204.3 271.6,281.9 368.4,322.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="118.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="204.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="281.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="322.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,109.5 174.8,192.8 271.6,281.7 368.4,322.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="109.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="192.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="281.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="322.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,124.8 174.8,129.1 271.6,175.9 368.4,234.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="124.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="129.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="175.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="234.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,114.6 174.8,136.0 271.6,208.5 368.4,257.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="114.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="136.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="208.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="257.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,308.4 174.8,275.8 271.6,267.9 368.4,283.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="308.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="275.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="267.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="283.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,341.3 174.8,343.8 271.6,344.4 368.4,345.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="341.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="343.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="344.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="345.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,275.9 174.8,281.5 271.6,285.0 368.4,298.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="275.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="281.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="285.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="298.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,198.5 174.8,255.3 271.6,306.3 368.4,332.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="198.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="255.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="306.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="332.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,193.0 174.8,247.7 271.6,306.1 368.4,332.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="193.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="247.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="306.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="332.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,194.2 271.6,227.4 368.4,273.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="194.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="227.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="273.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,189.7 174.8,238.9 271.6,256.2 368.4,292.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="189.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="238.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="256.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="292.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,323.7 174.8,302.3 271.6,297.1 368.4,307.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="323.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="302.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="297.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="307.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,345.3 174.8,347.0 271.6,347.4 368.4,347.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="345.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="347.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="347.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="347.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -121,8 +125,8 @@
   <polyline points="466.4,223.8 611.6,232.4 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.2 611.6,246.9 756.8,265.5 902.0,262.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.5 611.6,244.7 756.8,266.9 902.0,265.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,211.1 611.6,242.4 756.8,252.7 902.0,271.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,284.6 611.6,283.0 756.8,283.2 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,232.6 611.6,242.9 756.8,275.8 902.0,294.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,282.8 611.6,283.0 756.8,284.6 902.0,294.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,270.7 611.6,272.7 756.8,267.6 902.0,284.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,282.8 611.6,283.0 756.8,283.2 902.0,283.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,317.4 611.6,238.2 756.8,157.9 902.0,108.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -140,16 +144,16 @@
   <circle cx="611.6" cy="310.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="301.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="298.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,292.0 611.6,189.2 756.8,95.2 902.0,93.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="292.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="189.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="95.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="93.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,303.3 611.6,220.9 756.8,147.1 902.0,89.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="303.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="220.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="147.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="89.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,287.2 611.6,186.3 756.8,128.6 902.0,139.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="287.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="186.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="128.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="139.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,302.3 611.6,226.8 756.8,133.1 902.0,132.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="302.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="226.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="133.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="132.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,323.7 611.6,257.8 756.8,197.5 902.0,207.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="323.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="257.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -175,7 +179,7 @@
   <text x="510" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="680" y1="391" x2="694" y2="391" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="687" cy="391" r="2.5" fill="#dc2626"/>
-  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="700" y="395" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="205" y1="411" x2="219" y2="411" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="212" cy="411" r="2.5" fill="#2563eb"/>
   <text x="225" y="415" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/reqrep/inproc.svg
+++ b/doc/charts/reqrep/inproc.svg
@@ -38,8 +38,8 @@
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,111.1 224.0,117.8 358.0,117.9 492.0,109.5 626.0,115.2 760.0,115.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,129.7 224.0,130.9 358.0,128.7 492.0,127.4 626.0,124.3 760.0,130.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,103.7 224.0,111.2 358.0,109.3 492.0,105.3 626.0,100.6 760.0,101.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,150.9 224.0,151.1 358.0,150.9 492.0,124.3 626.0,150.3 760.0,150.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,106.2 224.0,99.9 358.0,107.5 492.0,100.4 626.0,102.0 760.0,95.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,125.2 224.0,148.4 358.0,148.3 492.0,150.1 626.0,149.0 760.0,148.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,122.5 224.0,115.6 358.0,109.3 492.0,113.2 626.0,115.8 760.0,110.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,109.4 224.0,119.4 358.0,101.3 492.0,119.3 626.0,111.5 760.0,126.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="109.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
@@ -55,20 +55,20 @@
   <circle cx="492.0" cy="102.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="97.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="88.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,109.1 224.0,97.4 358.0,98.0 492.0,96.4 626.0,96.1 760.0,94.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="109.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="97.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="98.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="96.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="96.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="94.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,198.3 224.0,198.3 358.0,198.3 492.0,198.4 626.0,198.5 760.0,198.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="198.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="198.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="198.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="198.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,105.2 224.0,99.1 358.0,97.6 492.0,104.6 626.0,109.5 760.0,92.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="105.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="99.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="97.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="104.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="92.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,198.4 224.0,199.3 358.0,199.3 492.0,198.8 626.0,199.1 760.0,199.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="198.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="199.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="199.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="198.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="199.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="199.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,114.6 224.0,119.0 358.0,110.8 492.0,121.7 626.0,110.5 760.0,111.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="114.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="119.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -90,7 +90,7 @@
   <text x="350" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="520" y1="269" x2="534" y2="269" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="527" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="540" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="235" y1="289" x2="249" y2="289" stroke="#16a34a" stroke-width="2.5"/>
   <circle cx="242" cy="289" r="2.5" fill="#16a34a"/>
   <text x="255" y="293" fill="#374151" font-size="11" font-weight="500">rzmq v0.5.24 [6T]</text>

--- a/doc/charts/reqrep/ipc.svg
+++ b/doc/charts/reqrep/ipc.svg
@@ -37,8 +37,8 @@
   <polyline points="90.0,136.6 224.0,136.5 358.0,141.0 492.0,141.4 626.0,141.6 760.0,146.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,179.5 224.0,177.3 358.0,178.9 492.0,180.7 626.0,180.5 760.0,177.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,178.6 224.0,176.7 358.0,180.6 492.0,180.7 626.0,180.2 760.0,176.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,173.5 224.0,169.9 358.0,166.0 492.0,163.1 626.0,173.0 760.0,166.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,169.5 224.0,170.8 358.0,172.1 492.0,171.6 626.0,174.3 760.0,171.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,165.5 224.0,166.3 358.0,166.5 492.0,165.6 626.0,166.7 760.0,165.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,171.4 224.0,172.0 358.0,171.5 492.0,173.5 626.0,171.2 760.0,172.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,164.7 224.0,174.5 358.0,165.5 492.0,166.7 626.0,169.0 760.0,172.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,169.3 224.0,172.1 358.0,181.6 492.0,173.2 626.0,178.1 760.0,174.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,173.8 224.0,173.5 358.0,165.8 492.0,164.0 626.0,159.1 760.0,156.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -62,20 +62,20 @@
   <circle cx="492.0" cy="122.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="110.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="97.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,107.3 224.0,117.2 358.0,117.6 492.0,117.0 626.0,99.5 760.0,108.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="107.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="117.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="117.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="117.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="99.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="108.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,185.5 224.0,183.1 358.0,183.2 492.0,181.9 626.0,172.9 760.0,170.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="185.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="183.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="183.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="181.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="172.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,131.6 224.0,130.4 358.0,128.4 492.0,134.3 626.0,118.1 760.0,115.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="130.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="128.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="134.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="118.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="115.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,190.2 224.0,182.8 358.0,189.6 492.0,187.2 626.0,174.2 760.0,168.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="190.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="182.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="189.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="187.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="174.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="168.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,128.0 224.0,113.4 358.0,123.4 492.0,117.8 626.0,115.8 760.0,92.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="128.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="113.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -107,7 +107,7 @@
   <text x="445" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="615" y1="269" x2="629" y2="269" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="622" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="140" y1="289" x2="154" y2="289" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="147" cy="289" r="2.5" fill="#2563eb"/>
   <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/doc/charts/reqrep/tcp.svg
+++ b/doc/charts/reqrep/tcp.svg
@@ -37,8 +37,8 @@
   <polyline points="90.0,142.6 224.0,143.8 358.0,141.2 492.0,146.4 626.0,142.7 760.0,147.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,179.0 224.0,179.3 358.0,179.2 492.0,180.0 626.0,179.5 760.0,175.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,177.4 224.0,180.5 358.0,178.8 492.0,179.0 626.0,178.2 760.0,175.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,165.4 224.0,167.4 358.0,167.2 492.0,166.9 626.0,165.4 760.0,166.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,184.2 224.0,182.4 358.0,181.8 492.0,182.0 626.0,182.5 760.0,180.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,177.1 224.0,164.3 358.0,166.4 492.0,175.4 626.0,168.7 760.0,165.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,183.6 224.0,183.5 358.0,181.0 492.0,182.9 626.0,182.3 760.0,181.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,173.2 224.0,171.7 358.0,172.7 492.0,173.6 626.0,172.9 760.0,173.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,180.8 224.0,181.7 358.0,182.9 492.0,180.0 626.0,183.2 760.0,182.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,161.8 224.0,154.9 358.0,155.8 492.0,156.2 626.0,153.2 760.0,146.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -62,20 +62,20 @@
   <circle cx="492.0" cy="119.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="112.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="90.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,106.7 224.0,100.7 358.0,114.0 492.0,111.9 626.0,112.5 760.0,110.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="106.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="100.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="114.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="111.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="112.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="110.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,165.6 224.0,166.4 358.0,166.9 492.0,168.7 626.0,162.6 760.0,160.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="165.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="166.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="166.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="168.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="162.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="160.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,126.2 224.0,126.8 358.0,119.0 492.0,117.4 626.0,111.5 760.0,111.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="126.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="126.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="119.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="117.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="111.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="111.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,168.7 224.0,167.5 358.0,169.8 492.0,167.2 626.0,163.0 760.0,153.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="168.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="167.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="169.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="167.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="163.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="153.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,102.9 224.0,113.9 358.0,101.1 492.0,106.4 626.0,108.0 760.0,90.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="102.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="113.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -107,7 +107,7 @@
   <text x="445" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (1T)</text>
   <line x1="615" y1="269" x2="629" y2="269" stroke="#dc2626" stroke-width="2.5"/>
   <circle cx="622" cy="269" r="2.5" fill="#dc2626"/>
-  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (4T)</text>
+  <text x="635" y="273" fill="#374151" font-size="11" font-weight="500">omq-tokio (2T)</text>
   <line x1="140" y1="289" x2="154" y2="289" stroke="#2563eb" stroke-width="2.5"/>
   <circle cx="147" cy="289" r="2.5" fill="#2563eb"/>
   <text x="160" y="293" fill="#374151" font-size="11" font-weight="500">zmq.rs v0.6.0 [6T]</text>

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -283,11 +283,18 @@ impl Frame {
 }
 
 /// Maximum bytes stored inline in a `Message` (no heap, no refcount).
-/// 71 is the largest value that keeps `Message` at 80 bytes.
-pub const MAX_INLINE_MESSAGE: usize = 71;
+/// 55 is the largest value that keeps `Message` at 64 bytes (one cache line).
+///
+// Bench: PUSH/PULL TCP, 2T/3core (i7-8700B), msg/s:
+//   payload   64B msg (this)    80B msg         delta
+//     16 B     7.3M / 11.8M    6.3M /  9.7M    +15% / +21%
+//     32 B     7.0M / 11.4M    6.0M /  9.3M    +17% / +23%
+//     64 B     5.1M /  7.0M    6.1M /  9.1M    -17% / -23%  (heap threshold)
+//    128 B     4.6M /  6.8M    4.9M /  5.8M     -5% / +18%
+//    256 B     4.1M /  5.3M    4.4M /  4.7M     -6% / +12%
+pub const MAX_INLINE_MESSAGE: usize = 55;
 
-const _: () = assert!(MAX_INLINE_MESSAGE >= 64);
-const _: () = assert!(std::mem::size_of::<Message>() == 80);
+const _: () = assert!(std::mem::size_of::<Message>() == 64);
 
 pub(crate) enum MessageInner {
     Empty,

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1049,7 +1049,7 @@ async fn drain_pipeline(
     Ok(())
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables, clippy::needless_pass_by_value)]
 fn drain_offload_result(
     pool_enc: Option<MessageEncoder>,
     frames: Result<TransformedOut>,

--- a/scripts/bench_mechanism.py
+++ b/scripts/bench_mechanism.py
@@ -31,6 +31,9 @@ CHART_SIZES = [
 ]
 MECHANISMS = ["PLAIN", "CURVE", "BLAKE3ZMQ"]
 
+MEASURED_CPU = "0,1,2"
+OTHER_CPU = "3,4,5"
+
 DURATION = float(os.environ.get("OMQ_BENCH_DURATION", "2.0"))
 ROUNDS = int(os.environ.get("OMQ_BENCH_ROUNDS", "3"))
 
@@ -61,11 +64,15 @@ def cargo_build(backend: str):
     )
 
 
-def spawn(binary: str, *args: str, mechanism: str = "null") -> subprocess.Popen:
+def spawn(binary: str, *args: str, mechanism: str = "null",
+          cpu: str | None = None) -> subprocess.Popen:
     env = os.environ.copy()
     env["OMQ_BENCH_MECHANISM"] = mechanism
+    cmd = [binary, *args]
+    if cpu is not None:
+        cmd = ["taskset", "-c", cpu] + cmd
     return subprocess.Popen(
-        [binary, *args],
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         env=env,
@@ -99,11 +106,14 @@ def kill(proc: subprocess.Popen):
 
 
 def capture(binary: str, *args: str, mechanism: str = "null",
-            timeout: int = 15) -> str:
+            timeout: int = 15, cpu: str | None = None) -> str:
     env = os.environ.copy()
     env["OMQ_BENCH_MECHANISM"] = mechanism
+    cmd = [binary, *args]
+    if cpu is not None:
+        cmd = ["taskset", "-c", cpu] + cmd
     proc = subprocess.Popen(
-        [binary, *args],
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         env=env,
@@ -129,7 +139,7 @@ def run_cell(binary: str, mechanism: str, size: int) -> dict | None:
 
 def run_once(binary: str, mechanism: str, size: int) -> dict | None:
     push = spawn(binary, "push", "tcp://127.0.0.1:0", str(size),
-                 mechanism=mechanism)
+                 mechanism=mechanism, cpu=MEASURED_CPU)
     port = read_bound_port(push)
     if port is None:
         kill(push)
@@ -137,7 +147,8 @@ def run_once(binary: str, mechanism: str, size: int) -> dict | None:
     try:
         timeout_s = max(int(DURATION) + 10, 15)
         output = capture(binary, "pull", str(port), str(size), str(DURATION),
-                         mechanism=mechanism, timeout=timeout_s)
+                         mechanism=mechanism, timeout=timeout_s,
+                         cpu=OTHER_CPU)
     finally:
         kill(push)
     return parse_throughput(output, size)

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -204,8 +204,8 @@ def libzmq_version() -> str:
 
 # ── process management ────────────────────────────────────────────
 
-MEASURED_CPU = "0,1"
-OTHER_CPU = "2,3,4,5"
+MEASURED_CPU = "0,1,2"
+OTHER_CPU = "3,4,5"
 
 
 def spawn_process(binary: str, *args: str, env: dict | None = None,


### PR DESCRIPTION
- Reduce `MAX_INLINE_MESSAGE` from 71 to 55, fitting `Message` into one cache line (64 B)
- Inline threshold still ~20 B above libzmq
- PUSH/PULL TCP at 16-32 B: +15-23% msg/s in both ST and MT
- Bench config: pin measured process to 3 cores (0,1,2) instead of 2, eliminating high MT variance
- Regenerate all charts with new config
- Add `clippy::needless_pass_by_value` allow on `drain_offload_result`