### PR TITLE
Tune shared batch cap to 128 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Performance
+
+- Reduce the default shared-queue batch byte cap from 1 MiB to 128 KiB.
+  This bounds encode-before-write bursts. Refreshed turbo-off comparison
+  charts show steadier, slightly higher throughput in the current run.
+
 ## [omq-proto 0.22.0]
 
 ### Performance

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -156,6 +156,10 @@ python3 scripts/run_comparisons.py --omq --transport tcp --no-latency \
 python3 scripts/gen_comparison_chart.py
 ```
 
+The default `OMQ_BATCH_BYTES` cap is 128 KiB. Set the variable explicitly
+when comparing alternate caps; chart refreshes should use the same cap as
+the production default.
+
 Omit `--impl` to rebench all implementations when external baselines
 are stale. Full refresh after omq/rzmq changes:
 

--- a/doc/charts/main_tcp.svg
+++ b/doc/charts/main_tcp.svg
@@ -3,18 +3,18 @@
   <text x="475.0" y="16.0" text-anchor="middle" fill="#111827" font-size="14" font-weight="700">PUSH/PULL throughput, TCP loopback, 2-process</text>
   <text x="475.0" y="30.0" text-anchor="middle" fill="#9ca3af" font-size="9">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
   <text x="224.0" y="48.0" text-anchor="middle" fill="#111827" font-size="12" font-weight="700">small messages (higher is better)</text>
-  <line x1="70.0" y1="277.7" x2="378.0" y2="277.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="277.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
-  <line x1="70.0" y1="235.3" x2="378.0" y2="235.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="235.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
-  <line x1="70.0" y1="193.0" x2="378.0" y2="193.0" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="193.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
-  <line x1="70.0" y1="150.6" x2="378.0" y2="150.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="150.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
-  <line x1="70.0" y1="108.3" x2="378.0" y2="108.3" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="108.3" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">10 M msg/s</text>
-  <line x1="70.0" y1="65.9" x2="378.0" y2="65.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="62.0" y="65.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">12 M msg/s</text>
+  <line x1="70.0" y1="281.2" x2="378.0" y2="281.2" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="281.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">2 M msg/s</text>
+  <line x1="70.0" y1="242.4" x2="378.0" y2="242.4" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="242.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">4 M msg/s</text>
+  <line x1="70.0" y1="203.6" x2="378.0" y2="203.6" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="203.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">6 M msg/s</text>
+  <line x1="70.0" y1="164.7" x2="378.0" y2="164.7" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="164.7" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">8 M msg/s</text>
+  <line x1="70.0" y1="125.9" x2="378.0" y2="125.9" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="125.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">10 M msg/s</text>
+  <line x1="70.0" y1="87.1" x2="378.0" y2="87.1" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="62.0" y="87.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">12 M msg/s</text>
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="131.6" y1="60.0" x2="131.6" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -24,55 +24,55 @@
   <line x1="378.0" y1="60.0" x2="378.0" y2="320.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="70.0" y1="60.0" x2="70.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="70.0" y1="320.0" x2="378.0" y2="320.0" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="70.0,248.4 131.6,255.4 193.2,253.6 254.8,260.0 316.4,256.8 378.0,269.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="248.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="255.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="253.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="260.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="256.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="269.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,292.8 131.6,285.3 193.2,272.9 254.8,268.4 316.4,268.1 378.0,277.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="292.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="285.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="272.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="268.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="268.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="277.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,312.9 131.6,313.7 193.2,314.4 254.8,314.6 316.4,314.8 378.0,315.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="312.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="313.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="314.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="314.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="314.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="315.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,176.6 131.6,179.5 193.2,229.3 254.8,272.7 316.4,276.6 378.0,301.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="176.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="179.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="229.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="272.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="276.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="301.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,171.4 131.6,177.6 193.2,222.2 254.8,272.1 316.4,276.5 378.0,301.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="171.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="177.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="222.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="272.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="276.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="301.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,93.9 131.6,122.7 193.2,172.6 254.8,197.3 316.4,203.4 378.0,246.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="70.0,254.4 131.6,260.8 193.2,259.1 254.8,265.0 316.4,262.1 378.0,273.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="254.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="260.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="259.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="265.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="262.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="273.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,295.0 131.6,288.2 193.2,276.8 254.8,272.7 316.4,272.4 378.0,281.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="295.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="288.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="276.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="272.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="272.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="281.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,313.5 131.6,314.3 193.2,314.9 254.8,315.1 316.4,315.2 378.0,315.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="313.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="314.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="314.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="315.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="315.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="315.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,188.5 131.6,191.2 193.2,236.8 254.8,276.6 316.4,280.2 378.0,302.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="188.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="191.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="236.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="276.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="280.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="302.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,183.8 131.6,189.5 193.2,230.4 254.8,276.1 316.4,280.1 378.0,302.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="183.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="189.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="230.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="276.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="280.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="302.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,93.9 131.6,99.3 193.2,185.7 254.8,187.6 316.4,216.6 378.0,260.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="70.0" cy="93.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="122.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="172.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="197.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="203.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="246.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,168.4 131.6,193.7 193.2,214.0 254.8,216.3 316.4,230.1 378.0,264.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="70.0" cy="168.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="131.6" cy="193.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="193.2" cy="214.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="254.8" cy="216.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="316.4" cy="230.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="378.0" cy="264.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="99.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="185.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="187.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="216.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="260.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,177.2 131.6,180.9 193.2,223.5 254.8,232.0 316.4,239.2 378.0,272.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="70.0" cy="177.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="131.6" cy="180.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="193.2" cy="223.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="254.8" cy="232.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="316.4" cy="239.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="378.0" cy="272.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="70.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">16 B</text>
   <text x="131.6" y="333.0" text-anchor="middle" fill="#374151" font-size="8">32 B</text>
   <text x="193.2" y="333.0" text-anchor="middle" fill="#374151" font-size="8">64 B</text>
@@ -160,28 +160,28 @@
   <circle cx="777.3" cy="239.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="828.7" cy="149.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="133.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,259.1 469.3,234.3 520.7,165.8 572.0,158.2 623.3,112.4 674.7,131.6 726.0,122.2 777.3,127.0 828.7,125.4 880.0,127.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="259.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="234.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="165.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="158.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="112.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="122.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="127.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="125.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="127.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="418.0,273.1 469.3,239.5 520.7,203.2 572.0,166.8 623.3,116.6 674.7,137.1 726.0,115.9 777.3,124.0 828.7,122.0 880.0,124.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="418.0" cy="273.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="469.3" cy="239.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="520.7" cy="203.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="572.0" cy="166.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="623.3" cy="116.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="674.7" cy="137.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="726.0" cy="115.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="777.3" cy="124.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="828.7" cy="122.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="124.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,261.1 469.3,218.8 520.7,184.2 572.0,165.9 623.3,142.9 674.7,126.8 726.0,130.7 777.3,133.4 828.7,130.6 880.0,115.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="261.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="218.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="184.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="165.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="142.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="126.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="130.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="133.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="130.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="115.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="418.0,274.0 469.3,245.3 520.7,212.0 572.0,180.7 623.3,146.8 674.7,123.1 726.0,119.5 777.3,128.7 828.7,121.5 880.0,114.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="418.0" cy="274.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="469.3" cy="245.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="520.7" cy="212.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="572.0" cy="180.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="623.3" cy="146.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="674.7" cy="123.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="726.0" cy="119.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="777.3" cy="128.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="828.7" cy="121.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="114.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <text x="418.0" y="333.0" text-anchor="middle" fill="#374151" font-size="8">256 B</text>
   <text x="469.3" y="333.0" text-anchor="middle" fill="#374151" font-size="8">512 B</text>
   <text x="520.7" y="333.0" text-anchor="middle" fill="#374151" font-size="8">1 KiB</text>
@@ -224,20 +224,20 @@
   <circle cx="394.0" cy="433.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="718.0" cy="430.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="880.0" cy="435.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,444.9 232.0,437.6 394.0,445.8 556.0,438.0 718.0,435.4 880.0,433.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="70.0" cy="444.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="232.0" cy="437.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.0" cy="445.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="556.0" cy="438.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="718.0" cy="435.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="433.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="70.0,501.6 232.0,505.5 394.0,500.0 556.0,504.1 718.0,503.0 880.0,499.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="70.0" cy="501.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="232.0" cy="505.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.0" cy="500.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="556.0" cy="504.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="718.0" cy="503.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="880.0" cy="499.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,438.7 232.0,440.5 394.0,439.6 556.0,439.7 718.0,441.1 880.0,436.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="70.0" cy="438.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="232.0" cy="440.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.0" cy="439.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="556.0" cy="439.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="718.0" cy="441.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="436.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="70.0,506.0 232.0,500.5 394.0,504.0 556.0,501.2 718.0,500.4 880.0,503.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="70.0" cy="506.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="232.0" cy="500.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.0" cy="504.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="556.0" cy="501.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="718.0" cy="500.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="880.0" cy="503.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="70.0,413.9 232.0,395.2 394.0,428.6 556.0,382.6 718.0,411.4 880.0,418.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="70.0" cy="413.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="232.0" cy="395.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pubsub/tcp.svg
+++ b/doc/charts/pubsub/tcp.svg
@@ -36,8 +36,8 @@
   <polyline points="78.0,191.8 180.1,193.5 282.3,194.7 384.4,202.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,189.6 180.1,184.7 282.3,209.6 384.4,229.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,185.3 180.1,184.7 282.3,207.8 384.4,228.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,184.7 180.1,183.9 282.3,183.1 384.4,191.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,252.7 180.1,252.7 282.3,252.7 384.4,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,184.7 180.1,183.9 282.3,183.9 384.4,191.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,252.7 180.1,252.7 282.3,252.5 384.4,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,260.5 180.1,224.3 282.3,219.2 384.4,237.2" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,257.4 180.1,260.1 282.3,261.9 384.4,262.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,236.3 180.1,237.8 282.3,238.9 384.4,251.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
@@ -55,16 +55,16 @@
   <circle cx="180.1" cy="191.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="263.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="294.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,250.0 180.1,254.4 282.3,253.5 384.4,265.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="250.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="254.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="253.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="265.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,276.7 180.1,284.1 282.3,285.5 384.4,282.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="276.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="284.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="285.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="282.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,248.6 180.1,256.0 282.3,252.2 384.4,265.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="248.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="256.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="252.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="265.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,275.7 180.1,283.7 282.3,286.0 384.4,282.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="275.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="283.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="286.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="282.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="78.0,283.7 180.1,256.7 282.3,252.0 384.4,266.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="283.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="256.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -119,8 +119,8 @@
   <polyline points="482.4,194.7 635.6,202.3 788.8,228.8 942.0,242.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,209.6 635.6,229.0 788.8,246.4 942.0,244.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,207.8 635.6,228.4 788.8,246.0 942.0,245.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,183.1 635.6,191.2 788.8,189.2 942.0,189.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,252.7 635.6,252.7 788.8,252.7 942.0,252.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,183.9 635.6,191.0 788.8,189.8 942.0,190.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,252.5 635.6,252.7 788.8,252.7 942.0,252.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,219.2 635.6,237.2 788.8,239.6 942.0,252.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,261.9 635.6,262.3 788.8,262.5 942.0,263.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,295.4 635.6,233.8 788.8,169.9 942.0,116.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -138,16 +138,16 @@
   <circle cx="635.6" cy="288.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="788.8" cy="277.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="277.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,299.9 635.6,251.3 788.8,222.4 942.0,149.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="299.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="251.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="222.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="149.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,309.9 635.6,272.8 788.8,219.6 942.0,154.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="309.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="272.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="219.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="154.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,299.5 635.6,251.7 788.8,215.1 942.0,153.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="299.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="251.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="215.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="153.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,310.1 635.6,272.3 788.8,218.0 942.0,151.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="310.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="272.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="218.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="151.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="482.4,299.5 635.6,252.8 788.8,192.0 942.0,177.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="299.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="252.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -180,14 +180,14 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="585.2" x2="388.4" y2="585.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="585.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="532.5" x2="388.4" y2="532.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="532.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="479.7" x2="388.4" y2="479.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="479.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
-  <line x1="384.4" y1="427.0" x2="388.4" y2="427.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="427.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="585.6" x2="388.4" y2="585.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="585.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="533.2" x2="388.4" y2="533.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="533.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="480.8" x2="388.4" y2="480.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="480.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="428.3" x2="388.4" y2="428.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="428.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -199,44 +199,44 @@
   <polyline points="78.0,529.9 180.1,532.5 282.3,533.1 384.4,540.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,534.4 180.1,543.4 282.3,559.1 384.4,567.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,486.2 180.1,486.6 282.3,492.5 384.4,493.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,450.8 180.1,450.6 282.3,451.8 384.4,454.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,569.3 180.1,569.3 282.3,569.5 384.4,569.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,448.3 180.1,450.2 282.3,451.8 384.4,452.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,569.3 180.1,569.5 282.3,569.5 384.4,569.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,528.4 180.1,527.6 282.3,534.9 384.4,535.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,570.7 180.1,574.2 282.3,577.7 384.4,578.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,561.1 180.1,564.2 282.3,575.5 384.4,596.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="561.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="564.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="575.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="596.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,512.2 180.1,558.5 282.3,601.8 384.4,626.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="512.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="558.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="601.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="626.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,531.5 180.1,546.1 282.3,579.5 384.4,612.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="531.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="546.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="579.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="612.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,433.7 180.1,496.1 282.3,521.0 384.4,580.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,561.6 180.1,564.7 282.3,575.9 384.4,596.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="561.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="564.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="575.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="596.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,513.0 180.1,559.0 282.3,602.1 384.4,626.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="513.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="559.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="602.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="626.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,532.2 180.1,546.7 282.3,579.8 384.4,612.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="532.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="546.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="579.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="612.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,497.9 282.3,519.4 384.4,578.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="496.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="521.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="580.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,533.6 180.1,549.6 282.3,574.5 384.4,606.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="533.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="549.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="574.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="606.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,596.8 180.1,595.5 282.3,598.9 384.4,608.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="596.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="595.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="598.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="608.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,634.6 180.1,635.0 282.3,635.7 384.4,635.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="180.1" cy="497.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="519.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="578.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,535.0 180.1,550.4 282.3,573.8 384.4,606.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="535.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="550.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="573.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="606.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,597.1 180.1,595.8 282.3,599.2 384.4,608.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="597.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="595.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="599.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="608.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,634.6 180.1,635.0 282.3,635.8 384.4,635.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="635.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="635.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="635.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="635.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
@@ -259,16 +259,16 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="596.1" x2="946.0" y2="596.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="596.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="554.2" x2="946.0" y2="554.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="554.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="512.2" x2="946.0" y2="512.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="512.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="470.3" x2="946.0" y2="470.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="470.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="428.4" x2="946.0" y2="428.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="428.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="597.0" x2="946.0" y2="597.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="597.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="555.9" x2="946.0" y2="555.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="555.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="514.9" x2="946.0" y2="514.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="514.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="473.8" x2="946.0" y2="473.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="473.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="432.8" x2="946.0" y2="432.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="432.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -280,45 +280,45 @@
   <polyline points="482.4,533.1 635.6,540.0 788.8,556.4 942.0,565.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,559.1 635.6,567.9 788.8,570.5 942.0,569.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,492.5 635.6,493.7 788.8,503.9 942.0,496.1" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,451.8 635.6,454.0 788.8,460.7 942.0,453.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,569.5 635.6,569.3 788.8,569.5 942.0,569.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,451.8 635.6,452.0 788.8,454.4 942.0,452.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,569.5 635.6,569.5 788.8,569.5 942.0,569.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,534.9 635.6,535.9 788.8,526.7 942.0,520.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,577.7 635.6,578.7 788.8,579.1 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,612.6 635.6,570.3 788.8,523.8 942.0,507.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="612.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="570.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="523.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="507.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,623.3 635.6,619.8 788.8,618.6 942.0,616.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="623.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="619.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="618.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="616.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,614.2 635.6,596.4 788.8,593.1 942.0,589.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="614.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="596.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="593.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="589.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,590.4 635.6,544.3 788.8,506.5 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,613.1 635.6,571.8 788.8,526.2 942.0,509.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="613.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="571.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="526.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="509.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,623.6 635.6,620.1 788.8,619.0 942.0,616.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="623.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="620.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="619.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="616.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,614.7 635.6,597.3 788.8,594.1 942.0,590.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="614.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="597.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="594.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="590.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,590.4 635.6,543.1 788.8,500.8 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="590.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="544.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="506.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="543.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="500.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,612.2 635.6,586.4 788.8,547.0 942.0,525.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="612.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="586.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="547.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="525.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,622.1 635.6,589.6 788.8,543.3 942.0,516.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="622.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="589.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="543.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="516.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,637.1 635.6,634.6 788.8,625.6 942.0,600.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,612.3 635.6,587.5 788.8,548.2 942.0,527.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="587.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="548.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="527.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,622.4 635.6,590.6 788.8,545.3 942.0,518.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="622.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="590.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="545.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="518.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,637.1 635.6,634.6 788.8,625.9 942.0,600.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="637.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="635.6" cy="634.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="625.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="600.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="625.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="600.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -341,14 +341,14 @@
   <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="896.9" x2="388.4" y2="896.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="896.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
-  <line x1="384.4" y1="838.7" x2="388.4" y2="838.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="838.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
-  <line x1="384.4" y1="780.6" x2="388.4" y2="780.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="780.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">600k/s</text>
-  <line x1="384.4" y1="722.4" x2="388.4" y2="722.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="722.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">800k/s</text>
+  <line x1="384.4" y1="899.9" x2="388.4" y2="899.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="899.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">200k/s</text>
+  <line x1="384.4" y1="844.9" x2="388.4" y2="844.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="844.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">400k/s</text>
+  <line x1="384.4" y1="789.8" x2="388.4" y2="789.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="789.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">600k/s</text>
+  <line x1="384.4" y1="734.7" x2="388.4" y2="734.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="734.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">800k/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -360,44 +360,44 @@
   <polyline points="78.0,866.5 180.1,869.1 282.3,868.2 384.4,872.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,862.8 180.1,868.7 282.3,886.1 384.4,893.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,838.9 180.1,843.8 282.3,846.0 384.4,854.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,762.1 180.1,770.4 282.3,772.5 384.4,768.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,885.7 180.1,885.9 282.3,886.0 384.4,885.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,760.3 180.1,764.8 282.3,766.9 384.4,768.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,885.7 180.1,885.7 282.3,886.1 384.4,885.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,838.4 180.1,822.2 282.3,834.8 384.4,825.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,889.6 180.1,889.8 282.3,891.2 384.4,896.9" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,908.6 180.1,913.6 282.3,918.4 384.4,930.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="908.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="913.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="918.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="930.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,865.2 180.1,901.3 282.3,933.1 384.4,948.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="865.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="901.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="933.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="948.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,878.8 180.1,894.1 282.3,922.9 384.4,944.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="878.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="894.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="922.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="944.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,750.7 180.1,801.1 282.3,865.3 384.4,925.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,911.1 180.1,915.8 282.3,920.3 384.4,932.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="911.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="915.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="920.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="932.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,870.0 180.1,904.1 282.3,934.3 384.4,948.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="870.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="904.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="934.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="948.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,882.8 180.1,897.4 282.3,924.6 384.4,945.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="882.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="897.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="924.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="945.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,750.7 180.1,803.4 282.3,868.0 384.4,925.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="801.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="865.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="925.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,878.8 180.1,891.5 282.3,923.9 384.4,932.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="878.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="891.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="923.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="932.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,933.6 180.1,928.3 282.3,931.9 384.4,937.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="933.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="928.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="931.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="937.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,952.7 180.1,952.7 282.3,952.8 384.4,953.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="952.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="952.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="952.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="803.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="868.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="925.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,882.6 180.1,894.5 282.3,925.9 384.4,933.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="882.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="894.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="925.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="933.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,934.7 180.1,929.7 282.3,933.1 384.4,938.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="934.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="929.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="933.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="938.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,952.9 180.1,952.8 282.3,953.0 384.4,953.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="952.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="952.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="953.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="953.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
@@ -420,16 +420,14 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="909.0" x2="946.0" y2="909.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="909.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="863.1" x2="946.0" y2="863.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="863.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="817.1" x2="946.0" y2="817.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="817.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="771.1" x2="946.0" y2="771.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="771.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="725.2" x2="946.0" y2="725.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="725.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="907.6" x2="946.0" y2="907.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="907.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="860.2" x2="946.0" y2="860.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="860.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="812.8" x2="946.0" y2="812.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="812.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="765.4" x2="946.0" y2="765.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="765.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -441,45 +439,45 @@
   <polyline points="482.4,868.2 635.6,872.0 788.8,882.9 942.0,885.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,886.1 635.6,893.9 788.8,893.7 942.0,890.0" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,846.0 635.6,854.2 788.8,855.4 942.0,845.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,772.5 635.6,768.5 788.8,788.7 942.0,772.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,886.0 635.6,885.9 788.8,885.8 942.0,885.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,766.9 635.6,768.3 788.8,800.5 942.0,768.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,886.1 635.6,885.7 788.8,885.7 942.0,885.6" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,834.8 635.6,825.7 788.8,821.9 942.0,844.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,891.2 635.6,896.9 788.8,896.7 942.0,896.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,931.3 635.6,892.6 788.8,835.8 942.0,815.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="931.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="892.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="835.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="815.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,940.8 635.6,938.4 788.8,937.4 942.0,933.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="940.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="938.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="937.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="933.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,934.2 635.6,927.6 788.8,925.0 942.0,918.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="927.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="925.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="918.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,896.9 635.6,877.4 788.8,823.0 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="896.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="877.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="823.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,930.6 635.6,890.7 788.8,832.0 942.0,811.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="930.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="890.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="832.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="811.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,940.4 635.6,937.9 788.8,936.9 942.0,932.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="940.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="937.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="936.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="932.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,933.5 635.6,926.7 788.8,924.1 942.0,917.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="933.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="926.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="924.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="917.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,893.6 635.6,871.7 788.8,833.4 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="893.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="871.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="833.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,934.8 635.6,895.3 788.8,848.7 942.0,830.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="895.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="848.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="830.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,940.0 635.6,909.9 788.8,866.5 942.0,829.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="940.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="909.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="866.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="829.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,953.6 635.6,951.0 788.8,941.4 942.0,914.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="482.4,934.4 635.6,893.2 788.8,845.9 942.0,827.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="934.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="893.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="845.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="827.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,939.5 635.6,908.4 788.8,863.7 942.0,825.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="939.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="908.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="863.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="825.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,953.6 635.6,950.9 788.8,941.0 942.0,913.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="953.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="951.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="941.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="914.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="950.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="941.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="913.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>

--- a/doc/charts/pushpull/fanin/tcp.svg
+++ b/doc/charts/pushpull/fanin/tcp.svg
@@ -19,10 +19,10 @@
   <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="240.7" x2="388.4" y2="240.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="240.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="160.4" x2="388.4" y2="160.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="160.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="237.3" x2="388.4" y2="237.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="237.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="153.6" x2="388.4" y2="153.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="153.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -34,45 +34,45 @@
   <polyline points="78.0,231.6 180.1,237.6 282.3,233.4 384.4,224.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,205.2 180.1,204.5 282.3,206.1 384.4,208.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,195.9 180.1,194.4 282.3,200.8 384.4,166.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,205.2 180.1,217.0 282.3,199.6 384.4,178.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,213.7 180.1,208.8 282.3,198.4 384.4,178.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,202.3 180.1,207.3 282.3,217.9 384.4,216.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.0 180.1,261.8 282.3,262.4 384.4,261.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,269.9 180.1,279.3 282.3,275.4 384.4,281.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="269.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="279.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="275.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="281.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,189.8 180.1,213.1 282.3,256.6 384.4,296.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="189.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="213.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="256.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,191.9 180.1,210.0 282.3,259.4 384.4,292.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="191.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="210.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="259.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="292.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,116.7 180.1,217.7 282.3,192.8 384.4,222.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,267.8 180.1,277.5 282.3,273.4 384.4,280.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="267.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="277.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="273.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="280.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,184.2 180.1,208.5 282.3,253.9 384.4,295.4" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="184.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="208.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="253.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="295.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,186.4 180.1,205.3 282.3,256.8 384.4,291.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="186.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="205.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="256.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="291.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,116.7 180.1,184.5 282.3,164.6 384.4,217.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="217.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="192.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="222.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,132.4 180.1,196.8 282.3,235.0 384.4,273.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="132.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="196.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="235.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="184.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="164.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="217.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,118.4 180.1,191.4 282.3,233.2 384.4,273.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="118.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="191.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="233.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="273.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,290.8 180.1,268.7 282.3,266.1 384.4,275.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="290.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="268.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="266.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="275.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,307.0 180.1,312.0 282.3,313.0 384.4,313.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="307.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="312.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="313.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="313.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,289.5 180.1,266.5 282.3,263.7 384.4,273.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="289.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="266.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="263.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="273.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,306.4 180.1,311.7 282.3,312.6 384.4,313.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="306.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="311.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="312.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="313.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -94,16 +94,14 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="279.5" x2="946.0" y2="279.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="279.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="238.1" x2="946.0" y2="238.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="238.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="196.6" x2="946.0" y2="196.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="196.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="155.1" x2="946.0" y2="155.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="155.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="113.6" x2="946.0" y2="113.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="113.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="273.3" x2="946.0" y2="273.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="273.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="225.5" x2="946.0" y2="225.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="225.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="177.8" x2="946.0" y2="177.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="177.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="130.1" x2="946.0" y2="130.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="130.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -115,45 +113,45 @@
   <polyline points="482.4,233.4 635.6,224.5 788.8,232.6 942.0,235.5" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,206.1 635.6,208.2 788.8,207.3 942.0,223.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,200.8 635.6,166.4 788.8,164.4 942.0,178.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,199.6 635.6,178.8 788.8,180.9 942.0,182.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,198.4 635.6,178.2 788.8,187.9 942.0,187.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,217.9 635.6,216.7 788.8,215.3 942.0,208.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.4 635.6,261.6 788.8,254.4 942.0,258.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,305.9 635.6,269.3 788.8,234.3 942.0,205.9" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="305.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="269.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="234.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="205.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,299.7 635.6,288.5 788.8,284.2 942.0,277.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="299.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="288.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="284.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="277.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,300.6 635.6,283.4 788.8,275.5 942.0,273.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="300.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="283.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="275.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="273.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,278.6 635.6,190.7 788.8,116.7 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="278.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="190.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,303.6 635.6,261.5 788.8,221.2 942.0,188.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="303.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="261.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="221.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="188.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,296.5 635.6,283.7 788.8,278.6 942.0,270.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="283.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="278.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="270.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,297.6 635.6,277.7 788.8,268.6 942.0,266.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="297.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="277.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="268.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="266.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,263.9 635.6,170.2 788.8,142.8 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="263.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="170.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="142.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,292.6 635.6,257.5 788.8,232.5 942.0,250.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="292.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="257.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="232.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="250.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,302.8 635.6,260.8 788.8,215.1 942.0,194.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="302.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="260.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="215.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="194.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,318.3 635.6,311.3 788.8,273.2 942.0,258.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="318.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="311.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="273.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="258.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,289.0 635.6,250.9 788.8,223.7 942.0,213.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="289.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="250.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="223.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="213.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,300.1 635.6,251.7 788.8,199.2 942.0,175.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="300.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="251.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="199.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="175.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,317.9 635.6,309.9 788.8,266.0 942.0,249.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="317.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="309.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="266.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="249.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -176,12 +174,12 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="574.5" x2="388.4" y2="574.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="574.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="510.9" x2="388.4" y2="510.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="510.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="384.4" y1="447.4" x2="388.4" y2="447.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="447.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
+  <line x1="384.4" y1="569.4" x2="388.4" y2="569.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="569.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="500.7" x2="388.4" y2="500.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="500.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="432.1" x2="388.4" y2="432.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="432.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -193,45 +191,45 @@
   <polyline points="78.0,553.5 180.1,554.0 282.3,545.9 384.4,544.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,522.0 180.1,521.3 282.3,526.4 384.4,525.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,514.5 180.1,516.2 282.3,510.2 384.4,490.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,513.6 180.1,525.8 282.3,509.3 384.4,490.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.3 180.1,579.3 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,522.0 180.1,522.6 282.3,505.8 384.4,497.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.4 180.1,579.3 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,472.9 180.1,517.0 282.3,527.5 384.4,507.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.2 180.1,577.3 282.3,576.7 384.4,574.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,598.7 180.1,599.0 282.3,597.9 384.4,607.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="598.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="599.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="597.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="607.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,518.7 180.1,540.4 282.3,581.8 384.4,617.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="518.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="540.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="581.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="617.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,525.6 180.1,538.5 282.3,572.8 384.4,608.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="525.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="538.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="572.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="608.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,433.7 180.1,511.7 282.3,516.4 384.4,552.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,595.6 180.1,595.9 282.3,594.7 384.4,604.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="595.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="595.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="594.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="604.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,509.1 180.1,532.5 282.3,577.3 384.4,616.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="509.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="532.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="577.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="616.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,516.5 180.1,530.5 282.3,567.6 384.4,605.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="516.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="530.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="567.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="605.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,433.7 180.1,500.2 282.3,503.3 384.4,552.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="511.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="516.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="552.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,483.7 180.1,546.0 282.3,575.2 384.4,606.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="483.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="546.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="575.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="606.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,608.8 180.1,593.6 282.3,591.9 384.4,599.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="608.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="593.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="591.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="599.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,603.8 180.1,606.4 282.3,609.8 384.4,620.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="603.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="606.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="609.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="620.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="500.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="503.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="552.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,475.8 180.1,539.0 282.3,571.3 384.4,603.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="475.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="539.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="571.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="603.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,606.5 180.1,590.0 282.3,588.2 384.4,596.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="606.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="590.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="588.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="596.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,601.1 180.1,603.9 282.3,607.5 384.4,619.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="601.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="603.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="607.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="619.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -253,18 +251,18 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="602.7" x2="946.0" y2="602.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="602.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="567.5" x2="946.0" y2="567.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="567.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="532.2" x2="946.0" y2="532.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="532.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="497.0" x2="946.0" y2="497.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="497.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="461.7" x2="946.0" y2="461.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="461.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
-  <line x1="942.0" y1="426.4" x2="946.0" y2="426.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="426.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
+  <line x1="942.0" y1="599.7" x2="946.0" y2="599.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="599.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="561.4" x2="946.0" y2="561.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="561.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="523.1" x2="946.0" y2="523.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="523.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="484.8" x2="946.0" y2="484.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="484.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="446.5" x2="946.0" y2="446.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="446.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="408.1" x2="946.0" y2="408.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="408.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -276,45 +274,45 @@
   <polyline points="482.4,545.9 635.6,544.9 788.8,555.1 942.0,555.3" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,526.4 635.6,525.4 788.8,526.1 942.0,541.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,510.2 635.6,490.5 788.8,484.4 942.0,490.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,509.3 635.6,490.0 788.8,492.1 942.0,498.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,505.8 635.6,497.3 788.8,495.7 942.0,499.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.3 635.6,579.3 788.8,579.3 942.0,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,527.5 635.6,507.1 788.8,509.5 942.0,511.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,576.7 635.6,574.6 788.8,575.1 942.0,574.4" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,623.8 635.6,594.3 788.8,564.5 942.0,547.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="623.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="594.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="564.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="547.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,618.0 635.6,609.5 788.8,606.1 942.0,597.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="618.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="609.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="606.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="597.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,614.8 635.6,595.5 788.8,588.7 942.0,581.0" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="614.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="595.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="588.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="581.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,594.8 635.6,516.5 788.8,433.7 942.0,469.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="594.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="516.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="469.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,615.7 635.6,592.8 788.8,571.8 942.0,555.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="615.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="592.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="571.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="555.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,621.6 635.6,583.0 788.8,546.8 942.0,543.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="621.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="583.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="546.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="543.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,628.0 635.6,613.6 788.8,595.9 942.0,590.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="628.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="613.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="595.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="590.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,622.5 635.6,590.5 788.8,558.1 942.0,539.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="622.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="590.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="558.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="539.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,616.3 635.6,607.0 788.8,603.3 942.0,594.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="616.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="607.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="603.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="594.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,612.8 635.6,591.8 788.8,584.4 942.0,576.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="612.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="591.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="584.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="576.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,589.9 635.6,516.4 788.8,452.4 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="589.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="516.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="452.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,614.2 635.6,588.5 788.8,566.7 942.0,568.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="614.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="588.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="566.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="568.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,620.2 635.6,578.2 788.8,538.9 942.0,535.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="620.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="578.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="538.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="535.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,627.1 635.6,611.4 788.8,592.3 942.0,586.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="627.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="611.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="592.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="586.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -331,12 +329,12 @@
   <text x="70.0" y="767.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">500%</text>
-  <line x1="384.4" y1="894.8" x2="388.4" y2="894.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="894.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="834.6" x2="388.4" y2="834.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="834.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="384.4" y1="774.5" x2="388.4" y2="774.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="774.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
+  <line x1="384.4" y1="894.7" x2="388.4" y2="894.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="894.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="834.5" x2="388.4" y2="834.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="834.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="384.4" y1="774.2" x2="388.4" y2="774.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="774.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">15M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -348,45 +346,45 @@
   <polyline points="78.0,901.5 180.1,900.7 282.3,880.7 384.4,877.6" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,863.1 180.1,861.6 282.3,863.2 384.4,864.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,855.0 180.1,855.5 282.3,854.3 384.4,842.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,850.7 180.1,860.1 282.3,850.8 384.4,847.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,853.5 180.1,863.7 282.3,853.6 384.4,844.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,908.0 180.1,908.1 282.3,908.0 384.4,908.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,758.6 180.1,847.1 282.3,860.5 384.4,830.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,909.1 180.1,908.3 282.3,907.9 384.4,906.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,922.1 180.1,921.4 282.3,913.0 384.4,924.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="922.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,922.0 180.1,921.4 282.3,913.0 384.4,924.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="922.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="921.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="913.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="924.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,837.7 180.1,856.4 282.3,899.5 384.4,935.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="837.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="856.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="899.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="924.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,837.5 180.1,856.3 282.3,899.4 384.4,935.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="837.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="856.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="899.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="935.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,840.5 180.1,857.3 282.3,886.2 384.4,924.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="840.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="857.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="886.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,840.4 180.1,857.1 282.3,886.1 384.4,924.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="840.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="857.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="886.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="924.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,750.7 180.1,833.5 282.3,834.9 384.4,880.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,750.7 180.1,826.3 282.3,838.3 384.4,883.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="833.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="834.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="880.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,813.6 180.1,868.3 282.3,896.2 384.4,925.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="813.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="868.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="896.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="925.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,932.9 180.1,909.9 282.3,909.0 384.4,918.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="932.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="909.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="909.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="826.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="838.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="883.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,813.5 180.1,868.2 282.3,896.6 384.4,925.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="813.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="868.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="896.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="925.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,932.8 180.1,909.8 282.3,908.9 384.4,918.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="932.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="909.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="908.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="918.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,922.9 180.1,923.7 282.3,928.4 384.4,938.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="922.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="923.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,922.8 180.1,923.6 282.3,928.4 384.4,938.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="922.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="923.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="928.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="938.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="938.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -408,16 +406,18 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="914.5" x2="946.0" y2="914.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="914.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="874.0" x2="946.0" y2="874.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="874.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="833.6" x2="946.0" y2="833.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="833.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="793.1" x2="946.0" y2="793.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="793.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
-  <line x1="942.0" y1="752.6" x2="946.0" y2="752.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="752.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="916.1" x2="946.0" y2="916.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="916.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="877.2" x2="946.0" y2="877.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="877.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="838.3" x2="946.0" y2="838.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="838.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="799.4" x2="946.0" y2="799.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="799.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="760.5" x2="946.0" y2="760.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="760.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
+  <line x1="942.0" y1="721.6" x2="946.0" y2="721.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="721.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -429,45 +429,45 @@
   <polyline points="482.4,862.1 635.6,858.3 788.8,869.3 942.0,875.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,840.2 635.6,842.4 788.8,844.0 942.0,866.3" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,829.1 635.6,814.4 788.8,798.9 942.0,791.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,824.8 635.6,820.3 788.8,810.4 942.0,817.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,828.2 635.6,817.0 788.8,817.4 942.0,815.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.3 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,836.8 635.6,799.8 788.8,789.1 942.0,803.9" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.2 635.6,893.8 788.8,892.3 942.0,891.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,936.9 635.6,902.9 788.8,867.8 942.0,848.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="936.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="902.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="867.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="848.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,931.1 635.6,922.1 788.8,918.3 942.0,907.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="931.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="922.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="918.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="907.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,925.4 635.6,902.7 788.8,891.8 942.0,877.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="925.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="902.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="891.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="877.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,903.3 635.6,827.1 788.8,750.7 942.0,764.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="903.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="827.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="764.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,929.7 635.6,903.8 788.8,879.0 942.0,883.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="929.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="903.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="879.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="883.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,935.2 635.6,891.3 788.8,856.9 942.0,851.2" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="935.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="891.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="856.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="851.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="482.4,943.6 635.6,925.8 788.8,908.9 942.0,902.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="943.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="925.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="908.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="902.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,937.6 635.6,905.0 788.8,871.2 942.0,852.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="937.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="905.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="871.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="852.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,932.0 635.6,923.4 788.8,919.7 942.0,909.7" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="932.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="923.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="919.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="909.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,926.5 635.6,904.7 788.8,894.3 942.0,880.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="926.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="904.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="894.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="880.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,906.8 635.6,836.3 788.8,784.0 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="906.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="836.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="784.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,930.9 635.6,905.4 788.8,883.4 942.0,874.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="930.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="905.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="883.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="874.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,936.0 635.6,893.8 788.8,860.7 942.0,855.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="936.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="893.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="860.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="855.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="482.4,944.0 635.6,927.0 788.8,910.7 942.0,904.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="944.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="927.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="910.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="904.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>

--- a/doc/charts/pushpull/fanout/tcp.svg
+++ b/doc/charts/pushpull/fanout/tcp.svg
@@ -19,18 +19,18 @@
   <text x="70.0" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="86.0" x2="384.4" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="287.3" x2="388.4" y2="287.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="287.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="253.6" x2="388.4" y2="253.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="253.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="219.9" x2="388.4" y2="219.9" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="219.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
-  <line x1="384.4" y1="186.2" x2="388.4" y2="186.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="186.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="384.4" y1="152.5" x2="388.4" y2="152.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="152.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
-  <line x1="384.4" y1="118.8" x2="388.4" y2="118.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="118.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="384.4" y1="287.4" x2="388.4" y2="287.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="287.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="253.7" x2="388.4" y2="253.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="253.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="220.1" x2="388.4" y2="220.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="220.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
+  <line x1="384.4" y1="186.4" x2="388.4" y2="186.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="186.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="384.4" y1="152.8" x2="388.4" y2="152.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="152.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">5M/s</text>
+  <line x1="384.4" y1="119.1" x2="388.4" y2="119.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="119.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
   <line x1="78.0" y1="86.0" x2="78.0" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="86.0" x2="180.1" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="86.0" x2="282.3" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,112 +42,112 @@
   <polyline points="78.0,206.3 180.1,203.7 282.3,204.3 384.4,222.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,211.9 180.1,214.9 282.3,233.1 384.4,244.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,159.8 180.1,157.3 282.3,165.9 384.4,172.8" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,147.9 180.1,149.1 282.3,147.5 384.4,160.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,262.3 180.1,262.4 282.3,262.1 384.4,262.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,148.7 180.1,148.5 282.3,147.5 384.4,150.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,262.3 180.1,262.5 282.3,262.3 384.4,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,227.1 180.1,194.2 282.3,178.3 384.4,185.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,262.3 180.1,262.3 282.3,262.9 384.4,262.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="240.5" x2="78.0" y2="237.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="240.5" x2="82.0" y2="240.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="237.5" x2="82.0" y2="237.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="242.4" x2="180.1" y2="239.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="242.4" x2="184.1" y2="242.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="239.4" x2="184.1" y2="239.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="241.7" x2="282.3" y2="238.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="241.7" x2="286.3" y2="241.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="238.7" x2="286.3" y2="238.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="272.1" x2="384.4" y2="269.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="272.1" x2="388.4" y2="272.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="269.1" x2="388.4" y2="269.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,239.0 180.1,240.9 282.3,240.2 384.4,270.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="239.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="240.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="240.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="270.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="140.8" x2="78.0" y2="137.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="140.8" x2="82.0" y2="140.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="137.8" x2="82.0" y2="137.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="246.3" x2="180.1" y2="243.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="246.3" x2="184.1" y2="246.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="243.3" x2="184.1" y2="243.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="289.7" x2="282.3" y2="286.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="289.7" x2="286.3" y2="289.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="286.7" x2="286.3" y2="286.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="78.0" y1="240.6" x2="78.0" y2="237.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="240.6" x2="82.0" y2="240.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="237.6" x2="82.0" y2="237.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="242.5" x2="180.1" y2="239.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="242.5" x2="184.1" y2="242.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="239.5" x2="184.1" y2="239.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="241.8" x2="282.3" y2="238.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="241.8" x2="286.3" y2="241.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="238.8" x2="286.3" y2="238.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="272.2" x2="384.4" y2="269.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="272.2" x2="388.4" y2="272.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="269.2" x2="388.4" y2="269.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,239.1 180.1,241.0 282.3,240.3 384.4,270.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="239.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="241.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="240.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="270.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="141.1" x2="78.0" y2="138.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="141.1" x2="82.0" y2="141.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="138.1" x2="82.0" y2="138.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="246.4" x2="180.1" y2="243.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="246.4" x2="184.1" y2="246.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="243.4" x2="184.1" y2="243.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="289.8" x2="282.3" y2="286.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="289.8" x2="286.3" y2="289.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="286.8" x2="286.3" y2="286.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="384.4" y1="309.0" x2="384.4" y2="306.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="380.4" y1="309.0" x2="388.4" y2="309.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="380.4" y1="306.0" x2="388.4" y2="306.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,139.3 180.1,244.8 282.3,288.2 384.4,307.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="139.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="244.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="288.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,139.6 180.1,244.9 282.3,288.3 384.4,307.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="139.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="244.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="288.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="307.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="175.0" x2="78.0" y2="165.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="175.0" x2="82.0" y2="175.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="165.5" x2="82.0" y2="165.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="247.1" x2="180.1" y2="244.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="247.1" x2="184.1" y2="247.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="244.1" x2="184.1" y2="244.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="289.0" x2="282.3" y2="286.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="289.0" x2="286.3" y2="289.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="286.0" x2="286.3" y2="286.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="300.3" x2="384.4" y2="297.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="300.3" x2="388.4" y2="300.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="297.3" x2="388.4" y2="297.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,170.3 180.1,245.6 282.3,287.5 384.4,298.8" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="170.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="245.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="287.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="298.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="175.3" x2="78.0" y2="165.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="175.3" x2="82.0" y2="175.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="165.7" x2="82.0" y2="165.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="247.2" x2="180.1" y2="244.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="247.2" x2="184.1" y2="247.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="244.2" x2="184.1" y2="244.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="289.1" x2="282.3" y2="286.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="289.1" x2="286.3" y2="289.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="286.1" x2="286.3" y2="286.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="300.4" x2="384.4" y2="297.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="300.4" x2="388.4" y2="300.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="297.4" x2="388.4" y2="297.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,170.5 180.1,245.7 282.3,287.6 384.4,298.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="170.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="245.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="287.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="298.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="118.2" x2="78.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="118.2" x2="82.0" y2="118.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="115.2" x2="82.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="211.5" x2="180.1" y2="208.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="211.5" x2="184.1" y2="211.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="208.5" x2="184.1" y2="208.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="211.2" x2="282.3" y2="208.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="211.2" x2="286.3" y2="211.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="208.2" x2="286.3" y2="208.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="221.9" x2="384.4" y2="217.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="221.9" x2="388.4" y2="221.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="217.1" x2="388.4" y2="217.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,116.7 180.1,210.0 282.3,209.7 384.4,219.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="180.1" y1="207.3" x2="180.1" y2="204.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="207.3" x2="184.1" y2="207.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="204.3" x2="184.1" y2="204.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="209.9" x2="282.3" y2="206.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="209.9" x2="286.3" y2="209.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="206.9" x2="286.3" y2="206.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="218.6" x2="384.4" y2="214.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="218.6" x2="388.4" y2="218.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="214.0" x2="388.4" y2="214.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,116.7 180.1,205.8 282.3,208.4 384.4,216.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="210.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="209.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="219.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="201.5" x2="78.0" y2="198.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="201.5" x2="82.0" y2="201.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="198.5" x2="82.0" y2="198.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="239.1" x2="180.1" y2="236.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="239.1" x2="184.1" y2="239.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="236.1" x2="184.1" y2="236.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="253.2" x2="282.3" y2="250.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="253.2" x2="286.3" y2="253.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="250.2" x2="286.3" y2="250.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="278.7" x2="384.4" y2="275.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="278.7" x2="388.4" y2="278.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="275.7" x2="388.4" y2="275.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,200.0 180.1,237.6 282.3,251.7 384.4,277.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="200.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="237.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="251.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="277.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="286.3" x2="78.0" y2="283.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="286.3" x2="82.0" y2="286.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="283.3" x2="82.0" y2="283.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="180.1" cy="205.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="208.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="216.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="210.2" x2="78.0" y2="207.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="210.2" x2="82.0" y2="210.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="207.2" x2="82.0" y2="207.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="245.9" x2="180.1" y2="242.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="245.9" x2="184.1" y2="245.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="242.9" x2="184.1" y2="242.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="252.6" x2="282.3" y2="249.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="252.6" x2="286.3" y2="252.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="249.6" x2="286.3" y2="249.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="282.2" x2="384.4" y2="279.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="282.2" x2="388.4" y2="282.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="279.2" x2="388.4" y2="279.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,208.7 180.1,244.4 282.3,251.1 384.4,280.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="208.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="244.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="251.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="280.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="286.4" x2="78.0" y2="283.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="286.4" x2="82.0" y2="286.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="283.4" x2="82.0" y2="283.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
   <line x1="180.1" y1="268.4" x2="180.1" y2="261.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
   <line x1="176.1" y1="268.4" x2="184.1" y2="268.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
   <line x1="176.1" y1="261.0" x2="184.1" y2="261.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="256.6" x2="282.3" y2="253.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="256.6" x2="286.3" y2="256.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="253.6" x2="286.3" y2="253.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="263.4" x2="384.4" y2="260.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="263.4" x2="388.4" y2="263.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="260.4" x2="388.4" y2="260.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,284.8 180.1,264.7 282.3,255.1 384.4,261.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="284.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="282.3" y1="256.7" x2="282.3" y2="253.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="256.7" x2="286.3" y2="256.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="253.7" x2="286.3" y2="253.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="263.5" x2="384.4" y2="260.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="263.5" x2="388.4" y2="263.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="260.5" x2="388.4" y2="260.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,284.9 180.1,264.7 282.3,255.2 384.4,262.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="284.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="180.1" cy="264.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="255.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="261.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="255.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="262.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="318.2" x2="78.0" y2="315.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="318.2" x2="82.0" y2="318.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="315.2" x2="82.0" y2="315.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
@@ -186,14 +186,16 @@
   <text x="474.4" y="115.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="86.0" x2="942.0" y2="86.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="86.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="272.8" x2="946.0" y2="272.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="272.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="224.5" x2="946.0" y2="224.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="224.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="176.3" x2="946.0" y2="176.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="176.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="128.1" x2="946.0" y2="128.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="128.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="274.1" x2="946.0" y2="274.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="274.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="227.2" x2="946.0" y2="227.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="227.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="180.3" x2="946.0" y2="180.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="180.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="133.4" x2="946.0" y2="133.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="133.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="86.4" x2="946.0" y2="86.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="86.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="86.0" x2="482.4" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="86.0" x2="635.6" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="86.0" x2="788.8" y2="321.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -205,129 +207,129 @@
   <polyline points="482.4,204.3 635.6,222.1 788.8,245.6 942.0,257.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,233.1 635.6,244.4 788.8,255.4 942.0,257.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,165.9 635.6,172.8 788.8,188.6 942.0,193.9" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,147.5 635.6,160.6 788.8,212.1 942.0,226.7" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,262.1 635.6,262.5 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,147.5 635.6,150.2 788.8,196.9 942.0,199.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,262.3 635.6,262.3 788.8,262.3 942.0,262.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,178.3 635.6,185.7 788.8,205.1 942.0,206.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,262.9 635.6,262.5 788.8,262.3 942.0,262.7" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="292.9" x2="482.4" y2="289.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="292.9" x2="486.4" y2="292.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="289.9" x2="486.4" y2="289.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="248.6" x2="635.6" y2="245.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="248.6" x2="639.6" y2="248.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="245.6" x2="639.6" y2="245.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="198.9" x2="788.8" y2="195.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="198.9" x2="792.8" y2="198.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="195.9" x2="792.8" y2="195.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="173.5" x2="942.0" y2="170.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="173.5" x2="946.0" y2="173.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="170.5" x2="946.0" y2="170.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,291.4 635.6,247.1 788.8,197.4 942.0,172.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="291.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="247.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="197.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="172.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="310.5" x2="482.4" y2="307.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="310.5" x2="486.4" y2="310.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="307.5" x2="486.4" y2="307.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="302.7" x2="635.6" y2="299.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="302.7" x2="639.6" y2="302.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="299.7" x2="639.6" y2="299.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="297.6" x2="788.8" y2="294.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="297.6" x2="792.8" y2="297.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="294.6" x2="792.8" y2="294.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="298.0" x2="942.0" y2="295.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="298.0" x2="946.0" y2="298.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="295.0" x2="946.0" y2="295.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,309.0 635.6,301.2 788.8,296.1 942.0,296.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="309.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="301.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="296.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="296.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="310.2" x2="482.4" y2="307.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="310.2" x2="486.4" y2="310.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="307.2" x2="486.4" y2="307.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="290.0" x2="635.6" y2="287.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="290.0" x2="639.6" y2="290.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="287.0" x2="639.6" y2="287.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="273.6" x2="788.8" y2="270.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="273.6" x2="792.8" y2="273.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="270.6" x2="792.8" y2="270.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="268.4" x2="942.0" y2="265.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="268.4" x2="946.0" y2="268.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="265.4" x2="946.0" y2="265.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,308.7 635.6,288.5 788.8,272.1 942.0,266.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="308.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="288.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="272.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="266.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="281.7" x2="482.4" y2="278.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="281.7" x2="486.4" y2="281.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="278.7" x2="486.4" y2="278.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="175.7" x2="635.6" y2="168.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="175.7" x2="639.6" y2="175.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="168.7" x2="639.6" y2="168.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="151.1" x2="788.8" y2="148.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="151.1" x2="792.8" y2="151.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="148.1" x2="792.8" y2="148.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="121.1" x2="942.0" y2="112.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="121.1" x2="946.0" y2="121.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="112.2" x2="946.0" y2="112.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,280.2 635.6,172.2 788.8,149.6 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="280.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="172.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="149.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="293.7" x2="482.4" y2="290.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="293.7" x2="486.4" y2="293.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="290.7" x2="486.4" y2="290.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="250.6" x2="635.6" y2="247.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="250.6" x2="639.6" y2="250.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="247.6" x2="639.6" y2="247.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="202.3" x2="788.8" y2="199.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="202.3" x2="792.8" y2="202.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="199.3" x2="792.8" y2="199.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="177.6" x2="942.0" y2="174.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="177.6" x2="946.0" y2="177.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="174.6" x2="946.0" y2="174.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,292.2 635.6,249.1 788.8,200.8 942.0,176.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="292.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="249.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="200.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="176.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="310.8" x2="482.4" y2="307.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="310.8" x2="486.4" y2="310.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="307.8" x2="486.4" y2="307.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="303.3" x2="635.6" y2="300.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="303.3" x2="639.6" y2="303.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="300.3" x2="639.6" y2="300.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="298.3" x2="788.8" y2="295.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="298.3" x2="792.8" y2="298.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="295.3" x2="792.8" y2="295.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="298.7" x2="942.0" y2="295.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="298.7" x2="946.0" y2="298.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="295.7" x2="946.0" y2="295.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,309.3 635.6,301.8 788.8,296.8 942.0,297.2" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="309.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="301.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="296.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="297.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="310.6" x2="482.4" y2="307.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="310.6" x2="486.4" y2="310.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="307.6" x2="486.4" y2="307.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="290.9" x2="635.6" y2="287.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="290.9" x2="639.6" y2="290.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="287.9" x2="639.6" y2="287.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="274.9" x2="788.8" y2="271.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="274.9" x2="792.8" y2="274.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="271.9" x2="792.8" y2="271.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="269.9" x2="942.0" y2="266.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="269.9" x2="946.0" y2="269.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="266.9" x2="946.0" y2="266.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,309.1 635.6,289.4 788.8,273.4 942.0,268.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="309.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="289.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="273.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="268.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="282.3" x2="482.4" y2="279.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="282.3" x2="486.4" y2="282.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="279.3" x2="486.4" y2="279.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="174.8" x2="635.6" y2="168.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="174.8" x2="639.6" y2="174.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="168.2" x2="639.6" y2="168.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="152.3" x2="788.8" y2="149.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="152.3" x2="792.8" y2="152.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="149.3" x2="792.8" y2="149.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="118.2" x2="942.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="118.2" x2="946.0" y2="118.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="115.2" x2="946.0" y2="115.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,280.8 635.6,171.5 788.8,150.8 942.0,116.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="280.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="171.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="150.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="116.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="297.1" x2="482.4" y2="294.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="297.1" x2="486.4" y2="297.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="294.1" x2="486.4" y2="294.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="258.3" x2="635.6" y2="255.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="258.3" x2="639.6" y2="258.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="255.3" x2="639.6" y2="255.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="211.5" x2="788.8" y2="208.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="211.5" x2="792.8" y2="211.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="208.5" x2="792.8" y2="208.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="178.0" x2="942.0" y2="175.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="178.0" x2="946.0" y2="178.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="175.0" x2="946.0" y2="175.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,295.6 635.6,256.8 788.8,210.0 942.0,176.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="295.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="256.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="210.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="176.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="298.4" x2="482.4" y2="295.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="298.4" x2="486.4" y2="298.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="295.4" x2="486.4" y2="295.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="235.9" x2="635.6" y2="232.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="235.9" x2="639.6" y2="235.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="232.9" x2="639.6" y2="232.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="186.8" x2="788.8" y2="183.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="186.8" x2="792.8" y2="186.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="183.4" x2="792.8" y2="183.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="173.4" x2="942.0" y2="170.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="173.4" x2="946.0" y2="173.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="170.4" x2="946.0" y2="170.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,296.9 635.6,234.4 788.8,185.1 942.0,171.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="296.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="234.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="185.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="171.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="321.1" x2="482.4" y2="318.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="321.1" x2="486.4" y2="321.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="318.1" x2="486.4" y2="318.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="317.4" x2="635.6" y2="314.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="317.4" x2="639.6" y2="317.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="314.4" x2="639.6" y2="314.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="304.8" x2="788.8" y2="301.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="304.8" x2="792.8" y2="304.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="301.8" x2="792.8" y2="301.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="272.6" x2="942.0" y2="269.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="272.6" x2="946.0" y2="272.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="269.6" x2="946.0" y2="269.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,319.6 635.6,315.9 788.8,303.3 942.0,271.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="319.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="315.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="303.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="271.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="297.5" x2="482.4" y2="294.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="297.5" x2="486.4" y2="297.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="294.5" x2="486.4" y2="294.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="264.9" x2="635.6" y2="261.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="264.9" x2="639.6" y2="264.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="261.9" x2="639.6" y2="261.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="232.6" x2="788.8" y2="229.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="232.6" x2="792.8" y2="232.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="229.6" x2="792.8" y2="229.6" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="213.0" x2="942.0" y2="210.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="213.0" x2="946.0" y2="213.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="210.0" x2="946.0" y2="210.0" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,296.0 635.6,263.4 788.8,231.1 942.0,211.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="296.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="263.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="231.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="211.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="299.0" x2="482.4" y2="296.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="299.0" x2="486.4" y2="299.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="296.0" x2="486.4" y2="296.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="238.3" x2="635.6" y2="235.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="238.3" x2="639.6" y2="238.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="235.3" x2="639.6" y2="235.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="190.4" x2="788.8" y2="187.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="190.4" x2="792.8" y2="190.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="187.2" x2="792.8" y2="187.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="177.5" x2="942.0" y2="174.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="177.5" x2="946.0" y2="177.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="174.5" x2="946.0" y2="174.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,297.5 635.6,236.8 788.8,188.8 942.0,176.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="297.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="236.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="188.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="176.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="321.2" x2="482.4" y2="318.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="321.2" x2="486.4" y2="321.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="318.2" x2="486.4" y2="318.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="317.6" x2="635.6" y2="314.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="317.6" x2="639.6" y2="317.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="314.6" x2="639.6" y2="314.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="305.3" x2="788.8" y2="302.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="305.3" x2="792.8" y2="305.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="302.3" x2="792.8" y2="302.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="273.9" x2="942.0" y2="270.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="273.9" x2="946.0" y2="273.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="270.9" x2="946.0" y2="270.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,319.7 635.6,316.1 788.8,303.8 942.0,272.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="319.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="316.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="303.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="272.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="335.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -350,18 +352,18 @@
   <text x="70.0" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="403.0" x2="384.4" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="604.1" x2="388.4" y2="604.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="604.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="570.2" x2="388.4" y2="570.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="570.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="536.3" x2="388.4" y2="536.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="536.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
-  <line x1="384.4" y1="502.4" x2="388.4" y2="502.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="502.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="384.4" y1="468.5" x2="388.4" y2="468.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="468.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
-  <line x1="384.4" y1="434.6" x2="388.4" y2="434.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="434.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
+  <line x1="384.4" y1="604.2" x2="388.4" y2="604.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="604.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="570.3" x2="388.4" y2="570.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="570.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="536.5" x2="388.4" y2="536.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="536.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="502.7" x2="388.4" y2="502.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="502.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="384.4" y1="468.8" x2="388.4" y2="468.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="468.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2.5M/s</text>
+  <line x1="384.4" y1="435.0" x2="388.4" y2="435.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="435.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">3M/s</text>
   <line x1="78.0" y1="403.0" x2="78.0" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="403.0" x2="180.1" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="403.0" x2="282.3" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -373,112 +375,112 @@
   <polyline points="78.0,532.5 180.1,535.2 282.3,531.9 384.4,544.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,531.5 180.1,528.7 282.3,552.4 384.4,565.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,471.0 180.1,444.3 282.3,442.2 384.4,456.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,464.8 180.1,465.4 282.3,464.7 384.4,464.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,579.3 180.1,579.1 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,465.1 180.1,465.0 282.3,465.0 384.4,463.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,579.3 180.1,579.3 282.3,579.3 384.4,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,513.4 180.1,477.5 282.3,477.0 384.4,488.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,579.1 180.1,579.3 282.3,579.5 384.4,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="555.9" x2="78.0" y2="552.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="555.9" x2="82.0" y2="555.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="552.1" x2="82.0" y2="552.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="564.3" x2="180.1" y2="554.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="564.3" x2="184.1" y2="564.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="554.9" x2="184.1" y2="554.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="558.5" x2="282.3" y2="555.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="558.5" x2="286.3" y2="558.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="555.5" x2="286.3" y2="555.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="582.2" x2="384.4" y2="579.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="582.2" x2="388.4" y2="582.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="579.2" x2="388.4" y2="579.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,553.6 180.1,558.3 282.3,557.0 384.4,580.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="553.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="558.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="557.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="580.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="473.7" x2="78.0" y2="470.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="473.7" x2="82.0" y2="473.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="470.7" x2="82.0" y2="470.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="561.8" x2="180.1" y2="558.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="561.8" x2="184.1" y2="561.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="558.8" x2="184.1" y2="558.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="78.0" y1="556.1" x2="78.0" y2="552.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="556.1" x2="82.0" y2="556.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="552.3" x2="82.0" y2="552.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="564.4" x2="180.1" y2="555.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="564.4" x2="184.1" y2="564.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="555.1" x2="184.1" y2="555.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="558.6" x2="282.3" y2="555.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="558.6" x2="286.3" y2="558.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="555.6" x2="286.3" y2="555.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="582.3" x2="384.4" y2="579.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="582.3" x2="388.4" y2="582.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="579.3" x2="388.4" y2="579.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,553.8 180.1,558.4 282.3,557.2 384.4,580.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="553.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="558.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="557.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="580.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="474.1" x2="78.0" y2="471.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="474.1" x2="82.0" y2="474.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="471.1" x2="82.0" y2="471.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="561.9" x2="180.1" y2="558.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="561.9" x2="184.1" y2="561.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="558.9" x2="184.1" y2="558.9" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="282.3" y1="608.8" x2="282.3" y2="605.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="278.3" y1="608.8" x2="286.3" y2="608.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
   <line x1="278.3" y1="605.8" x2="286.3" y2="605.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="626.6" x2="384.4" y2="623.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="626.6" x2="388.4" y2="626.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="623.6" x2="388.4" y2="623.6" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,472.2 180.1,560.1 282.3,607.3 384.4,625.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="472.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="560.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="384.4" y1="626.7" x2="384.4" y2="623.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="626.7" x2="388.4" y2="626.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="623.7" x2="388.4" y2="623.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,472.6 180.1,560.3 282.3,607.3 384.4,625.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="472.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="560.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="607.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="625.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="523.0" x2="78.0" y2="492.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="523.0" x2="82.0" y2="523.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="492.8" x2="82.0" y2="492.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="581.6" x2="180.1" y2="576.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="581.6" x2="184.1" y2="581.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="576.5" x2="184.1" y2="576.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="78.0" y1="523.3" x2="78.0" y2="493.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="523.3" x2="82.0" y2="523.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="493.1" x2="82.0" y2="493.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="581.7" x2="180.1" y2="576.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="581.7" x2="184.1" y2="581.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="576.6" x2="184.1" y2="576.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
   <line x1="282.3" y1="611.7" x2="282.3" y2="608.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
   <line x1="278.3" y1="611.7" x2="286.3" y2="611.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
   <line x1="278.3" y1="608.7" x2="286.3" y2="608.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="619.0" x2="384.4" y2="616.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="619.0" x2="388.4" y2="619.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="616.0" x2="388.4" y2="616.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,504.7 180.1,578.2 282.3,610.3 384.4,617.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="504.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="578.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="384.4" y1="619.1" x2="384.4" y2="616.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="619.1" x2="388.4" y2="619.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="616.1" x2="388.4" y2="616.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,504.9 180.1,578.4 282.3,610.3 384.4,617.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="504.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="578.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="282.3" cy="610.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="384.4" cy="617.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="440.8" x2="78.0" y2="425.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="440.8" x2="82.0" y2="440.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="425.8" x2="82.0" y2="425.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="527.7" x2="180.1" y2="520.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="527.7" x2="184.1" y2="527.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="520.3" x2="184.1" y2="520.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="535.8" x2="282.3" y2="523.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="535.8" x2="286.3" y2="535.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="523.1" x2="286.3" y2="523.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="539.5" x2="384.4" y2="524.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="539.5" x2="388.4" y2="539.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="524.7" x2="388.4" y2="524.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,433.7 180.1,523.4 282.3,526.4 384.4,530.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="78.0" y1="444.7" x2="78.0" y2="422.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="444.7" x2="82.0" y2="444.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="422.5" x2="82.0" y2="422.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="530.9" x2="180.1" y2="521.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="530.9" x2="184.1" y2="530.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="521.8" x2="184.1" y2="521.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="531.3" x2="282.3" y2="522.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="531.3" x2="286.3" y2="531.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="522.8" x2="286.3" y2="522.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="544.3" x2="384.4" y2="523.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="544.3" x2="388.4" y2="544.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="523.5" x2="388.4" y2="523.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,433.7 180.1,525.8 282.3,527.1 384.4,534.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="523.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="526.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="530.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="513.5" x2="78.0" y2="510.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="513.5" x2="82.0" y2="513.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="510.5" x2="82.0" y2="510.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="554.4" x2="180.1" y2="551.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="554.4" x2="184.1" y2="554.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="551.4" x2="184.1" y2="551.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="568.8" x2="282.3" y2="565.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="568.8" x2="286.3" y2="568.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="565.8" x2="286.3" y2="565.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="596.7" x2="384.4" y2="593.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="596.7" x2="388.4" y2="596.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="593.7" x2="388.4" y2="593.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,512.0 180.1,553.0 282.3,567.3 384.4,595.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="512.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="553.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="567.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="595.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="585.5" x2="78.0" y2="581.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="585.5" x2="82.0" y2="585.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="581.7" x2="82.0" y2="581.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="580.5" x2="180.1" y2="575.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="580.5" x2="184.1" y2="580.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="575.2" x2="184.1" y2="575.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="580.8" x2="282.3" y2="577.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="580.8" x2="286.3" y2="580.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="577.8" x2="286.3" y2="577.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="587.8" x2="384.4" y2="584.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="587.8" x2="388.4" y2="587.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="584.8" x2="388.4" y2="584.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,583.2 180.1,577.6 282.3,579.7 384.4,586.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="583.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="577.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="579.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="586.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="525.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="527.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="534.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="514.2" x2="78.0" y2="511.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="514.2" x2="82.0" y2="514.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="511.2" x2="82.0" y2="511.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="554.1" x2="180.1" y2="551.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="554.1" x2="184.1" y2="554.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="551.1" x2="184.1" y2="551.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="568.4" x2="282.3" y2="565.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="568.4" x2="286.3" y2="568.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="565.4" x2="286.3" y2="565.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="598.1" x2="384.4" y2="595.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="598.1" x2="388.4" y2="598.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="595.1" x2="388.4" y2="595.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,512.7 180.1,552.6 282.3,567.0 384.4,596.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="512.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="552.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="567.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="596.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="585.6" x2="78.0" y2="581.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="585.6" x2="82.0" y2="585.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="581.9" x2="82.0" y2="581.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="580.6" x2="180.1" y2="575.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="580.6" x2="184.1" y2="580.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="575.3" x2="184.1" y2="575.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="580.9" x2="282.3" y2="577.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="580.9" x2="286.3" y2="580.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="577.9" x2="286.3" y2="577.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="587.9" x2="384.4" y2="584.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="587.9" x2="388.4" y2="587.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="584.9" x2="388.4" y2="584.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,583.4 180.1,577.7 282.3,579.9 384.4,586.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="583.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="577.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="579.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="586.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <line x1="78.0" y1="636.0" x2="78.0" y2="633.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="636.0" x2="82.0" y2="636.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="74.0" y1="633.0" x2="82.0" y2="633.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
@@ -517,14 +519,16 @@
   <text x="474.4" y="432.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="403.0" x2="942.0" y2="403.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="403.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="590.7" x2="946.0" y2="590.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="590.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="543.4" x2="946.0" y2="543.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="543.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="496.0" x2="946.0" y2="496.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="496.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="448.7" x2="946.0" y2="448.7" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="448.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="591.5" x2="946.0" y2="591.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="591.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="544.9" x2="946.0" y2="544.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="544.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="498.4" x2="946.0" y2="498.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="498.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="451.8" x2="946.0" y2="451.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="451.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="405.3" x2="946.0" y2="405.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="405.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="403.0" x2="482.4" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="403.0" x2="635.6" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="403.0" x2="788.8" y2="638.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -536,129 +540,129 @@
   <polyline points="482.4,531.9 635.6,544.2 788.8,562.4 942.0,573.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,552.4 635.6,565.5 788.8,573.2 942.0,574.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,442.2 635.6,456.7 788.8,478.8 942.0,484.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,464.7 635.6,464.4 788.8,523.9 942.0,526.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,579.3 635.6,579.3 788.8,580.9 942.0,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,465.0 635.6,463.3 788.8,518.5 942.0,518.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,579.3 635.6,579.3 788.8,579.1 942.0,579.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,477.0 635.6,488.3 788.8,524.4 942.0,516.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,579.5 635.6,579.3 788.8,579.5 942.0,579.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="610.5" x2="482.4" y2="607.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="610.5" x2="486.4" y2="610.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="607.5" x2="486.4" y2="607.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="557.6" x2="635.6" y2="554.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="557.6" x2="639.6" y2="557.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="554.6" x2="639.6" y2="554.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="512.6" x2="788.8" y2="509.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="512.6" x2="792.8" y2="512.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="509.6" x2="792.8" y2="509.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="488.3" x2="942.0" y2="485.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="488.3" x2="946.0" y2="488.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="485.3" x2="946.0" y2="485.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,609.1 635.6,555.8 788.8,511.0 942.0,486.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="609.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="555.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="511.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="486.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="628.5" x2="482.4" y2="625.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="628.5" x2="486.4" y2="628.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="625.5" x2="486.4" y2="625.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="621.1" x2="635.6" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="621.1" x2="639.6" y2="621.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="618.1" x2="639.6" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="618.1" x2="788.8" y2="615.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="618.1" x2="792.8" y2="618.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="615.1" x2="792.8" y2="615.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="616.1" x2="942.0" y2="613.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="616.1" x2="946.0" y2="616.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="613.1" x2="946.0" y2="613.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,627.0 635.6,619.5 788.8,616.6 942.0,614.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="627.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="619.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="616.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="614.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="629.6" x2="482.4" y2="626.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="629.6" x2="486.4" y2="629.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="626.6" x2="486.4" y2="626.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="610.3" x2="635.6" y2="607.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="610.3" x2="639.6" y2="610.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="607.3" x2="639.6" y2="607.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="588.0" x2="788.8" y2="579.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="588.0" x2="792.8" y2="588.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="579.7" x2="792.8" y2="579.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="581.5" x2="942.0" y2="567.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="581.5" x2="946.0" y2="581.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="567.0" x2="946.0" y2="567.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,628.1 635.6,608.6 788.8,583.7 942.0,571.3" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="628.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="608.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="583.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="571.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="601.5" x2="482.4" y2="596.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="601.5" x2="486.4" y2="601.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="596.9" x2="486.4" y2="596.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="497.2" x2="635.6" y2="476.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="497.2" x2="639.6" y2="497.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="476.1" x2="639.6" y2="476.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="494.0" x2="788.8" y2="439.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="494.0" x2="792.8" y2="494.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="439.8" x2="792.8" y2="439.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="482.9" x2="942.0" y2="394.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="482.9" x2="946.0" y2="482.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="394.4" x2="946.0" y2="394.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,598.1 635.6,484.6 788.8,466.6 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="598.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="484.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="466.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="611.0" x2="482.4" y2="608.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="611.0" x2="486.4" y2="611.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="608.0" x2="486.4" y2="608.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="559.0" x2="635.6" y2="556.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="559.0" x2="639.6" y2="559.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="556.0" x2="639.6" y2="556.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="514.6" x2="788.8" y2="511.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="514.6" x2="792.8" y2="514.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="511.6" x2="792.8" y2="511.6" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="490.8" x2="942.0" y2="487.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="490.8" x2="946.0" y2="490.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="487.8" x2="946.0" y2="487.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,609.5 635.6,557.2 788.8,513.1 942.0,489.3" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="609.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="557.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="513.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="489.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="628.7" x2="482.4" y2="625.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="628.7" x2="486.4" y2="628.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="625.7" x2="486.4" y2="625.7" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="621.4" x2="635.6" y2="618.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="621.4" x2="639.6" y2="621.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="618.4" x2="639.6" y2="618.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="618.4" x2="788.8" y2="615.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="618.4" x2="792.8" y2="618.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="615.4" x2="792.8" y2="615.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="616.5" x2="942.0" y2="613.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="616.5" x2="946.0" y2="616.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="613.5" x2="946.0" y2="613.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,627.2 635.6,619.8 788.8,616.9 942.0,615.0" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="627.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="619.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="616.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="615.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="629.7" x2="482.4" y2="626.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="629.7" x2="486.4" y2="629.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="626.7" x2="486.4" y2="626.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="610.7" x2="635.6" y2="607.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="610.7" x2="639.6" y2="610.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="607.7" x2="639.6" y2="607.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="588.9" x2="788.8" y2="580.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="588.9" x2="792.8" y2="588.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="580.6" x2="792.8" y2="580.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="582.5" x2="942.0" y2="568.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="582.5" x2="946.0" y2="582.5" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="568.1" x2="946.0" y2="568.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,628.3 635.6,609.1 788.8,584.6 942.0,572.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="628.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="609.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="584.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="572.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="600.4" x2="482.4" y2="597.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="600.4" x2="486.4" y2="600.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="597.4" x2="486.4" y2="597.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="506.0" x2="635.6" y2="476.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="506.0" x2="639.6" y2="506.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="476.7" x2="639.6" y2="476.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="490.8" x2="788.8" y2="469.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="490.8" x2="792.8" y2="490.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="469.8" x2="792.8" y2="469.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="442.6" x2="942.0" y2="429.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="442.6" x2="946.0" y2="442.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="429.0" x2="946.0" y2="429.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,598.9 635.6,492.4 788.8,477.3 942.0,433.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="598.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="492.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="477.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="433.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="614.2" x2="482.4" y2="611.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="614.2" x2="486.4" y2="614.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="611.2" x2="486.4" y2="611.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="578.4" x2="635.6" y2="575.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="578.4" x2="639.6" y2="578.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="575.4" x2="639.6" y2="575.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="534.1" x2="788.8" y2="531.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="534.1" x2="792.8" y2="534.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="531.1" x2="792.8" y2="531.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="498.2" x2="942.0" y2="495.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="498.2" x2="946.0" y2="498.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="495.1" x2="946.0" y2="495.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,612.7 635.6,576.9 788.8,532.9 942.0,496.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="612.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="576.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="532.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="496.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="618.5" x2="482.4" y2="615.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="618.5" x2="486.4" y2="618.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="615.5" x2="486.4" y2="615.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="565.6" x2="635.6" y2="562.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="565.6" x2="639.6" y2="565.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="562.5" x2="639.6" y2="562.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="515.5" x2="788.8" y2="512.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="515.5" x2="792.8" y2="515.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="512.4" x2="792.8" y2="512.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="494.6" x2="942.0" y2="490.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="494.6" x2="946.0" y2="494.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="490.8" x2="946.0" y2="490.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,617.2 635.6,563.7 788.8,513.7 942.0,492.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="617.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="563.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="513.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="492.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="614.5" x2="482.4" y2="611.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="614.5" x2="486.4" y2="614.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="611.5" x2="486.4" y2="611.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="581.2" x2="635.6" y2="578.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="581.2" x2="639.6" y2="581.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="578.2" x2="639.6" y2="578.2" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="550.7" x2="788.8" y2="547.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="550.7" x2="792.8" y2="550.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="547.7" x2="792.8" y2="547.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="533.1" x2="942.0" y2="530.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="533.1" x2="946.0" y2="533.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="530.1" x2="946.0" y2="530.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,613.0 635.6,579.7 788.8,549.1 942.0,531.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="613.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="579.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="549.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="531.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="618.9" x2="482.4" y2="615.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="618.9" x2="486.4" y2="618.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="615.9" x2="486.4" y2="615.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="566.8" x2="635.6" y2="563.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="566.8" x2="639.6" y2="566.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="563.7" x2="639.6" y2="563.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="517.5" x2="788.8" y2="514.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="517.5" x2="792.8" y2="517.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="514.4" x2="792.8" y2="514.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="496.9" x2="942.0" y2="493.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="496.9" x2="946.0" y2="496.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="493.2" x2="946.0" y2="493.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,617.5 635.6,564.9 788.8,515.7 942.0,494.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="617.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="564.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="515.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="494.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <line x1="482.4" y1="638.5" x2="482.4" y2="635.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="478.4" y1="638.5" x2="486.4" y2="638.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
   <line x1="478.4" y1="635.5" x2="486.4" y2="635.5" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="635.7" x2="635.6" y2="632.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="635.7" x2="639.6" y2="635.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="632.7" x2="639.6" y2="632.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="625.7" x2="788.8" y2="622.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="625.7" x2="792.8" y2="625.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="622.7" x2="792.8" y2="622.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="597.6" x2="942.0" y2="594.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="597.6" x2="946.0" y2="597.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="594.6" x2="946.0" y2="594.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,637.0 635.6,634.2 788.8,624.2 942.0,596.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="635.6" y1="635.8" x2="635.6" y2="632.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="635.8" x2="639.6" y2="635.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="632.8" x2="639.6" y2="632.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="625.9" x2="788.8" y2="622.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="625.9" x2="792.8" y2="625.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="622.9" x2="792.8" y2="622.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="598.3" x2="942.0" y2="595.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="598.3" x2="946.0" y2="598.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="595.3" x2="946.0" y2="595.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,637.0 635.6,634.3 788.8,624.4 942.0,596.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="482.4" cy="637.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="634.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="624.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="596.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="634.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="624.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="596.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="652.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
@@ -681,12 +685,12 @@
   <text x="70.0" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="720.0" x2="384.4" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="384.4" y1="882.8" x2="388.4" y2="882.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="882.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
-  <line x1="384.4" y1="810.5" x2="388.4" y2="810.5" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="810.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
-  <line x1="384.4" y1="738.3" x2="388.4" y2="738.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="392.4" y="738.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
+  <line x1="384.4" y1="885.0" x2="388.4" y2="885.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="885.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">500k/s</text>
+  <line x1="384.4" y1="815.0" x2="388.4" y2="815.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="815.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1M/s</text>
+  <line x1="384.4" y1="745.0" x2="388.4" y2="745.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="392.4" y="745.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">1.5M/s</text>
   <line x1="78.0" y1="720.0" x2="78.0" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="180.1" y1="720.0" x2="180.1" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="282.3" y1="720.0" x2="282.3" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -698,129 +702,129 @@
   <polyline points="78.0,860.0 180.1,860.1 282.3,858.2 384.4,860.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,848.5 180.1,850.4 282.3,872.0 384.4,884.7" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,810.5 180.1,789.6 282.3,780.8 384.4,800.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,781.6 180.1,781.2 282.3,780.8 384.4,780.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,896.3 180.1,896.1 282.3,896.3 384.4,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,781.0 180.1,781.4 282.3,780.6 384.4,780.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,896.5 180.1,896.3 282.3,896.3 384.4,896.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,822.3 180.1,806.7 282.3,796.9 384.4,804.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,896.5 180.1,896.3 282.3,896.5 384.4,896.1" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="78.0" y1="878.8" x2="78.0" y2="874.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="878.8" x2="82.0" y2="878.8" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="874.0" x2="82.0" y2="874.0" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="872.3" x2="180.1" y2="869.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="872.3" x2="184.1" y2="872.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="869.3" x2="184.1" y2="869.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="874.7" x2="282.3" y2="871.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="874.7" x2="286.3" y2="874.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="871.7" x2="286.3" y2="871.7" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="901.5" x2="384.4" y2="898.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="901.5" x2="388.4" y2="901.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="898.5" x2="388.4" y2="898.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,874.6 180.1,870.2 282.3,872.8 384.4,899.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="874.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="870.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="872.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="899.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="780.4" x2="78.0" y2="777.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="780.4" x2="82.0" y2="780.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="777.4" x2="82.0" y2="777.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="872.2" x2="180.1" y2="869.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="872.2" x2="184.1" y2="872.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="869.2" x2="184.1" y2="869.2" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="924.5" x2="282.3" y2="921.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="924.5" x2="286.3" y2="924.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="921.5" x2="286.3" y2="921.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="943.4" x2="384.4" y2="940.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="943.4" x2="388.4" y2="943.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="940.4" x2="388.4" y2="940.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,778.9 180.1,870.7 282.3,923.0 384.4,941.9" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="778.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="870.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="923.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="941.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="834.6" x2="78.0" y2="816.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="834.6" x2="82.0" y2="834.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="816.1" x2="82.0" y2="816.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="901.1" x2="180.1" y2="891.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="901.1" x2="184.1" y2="901.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="891.1" x2="184.1" y2="891.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="928.4" x2="282.3" y2="925.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="928.4" x2="286.3" y2="928.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="925.4" x2="286.3" y2="925.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="937.4" x2="384.4" y2="934.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="937.4" x2="388.4" y2="937.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="934.4" x2="388.4" y2="934.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,827.0 180.1,896.5 282.3,926.9 384.4,935.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="827.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="896.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="926.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="935.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="760.0" x2="78.0" y2="728.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="760.0" x2="82.0" y2="760.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="728.6" x2="82.0" y2="728.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="838.2" x2="180.1" y2="815.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="838.2" x2="184.1" y2="838.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="815.7" x2="184.1" y2="815.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="844.5" x2="282.3" y2="827.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="844.5" x2="286.3" y2="844.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="827.6" x2="286.3" y2="827.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="846.5" x2="384.4" y2="836.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="846.5" x2="388.4" y2="846.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="836.1" x2="388.4" y2="836.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,750.7 180.1,831.3 282.3,837.1 384.4,840.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <line x1="78.0" y1="881.2" x2="78.0" y2="876.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="881.2" x2="82.0" y2="881.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="876.5" x2="82.0" y2="876.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="874.9" x2="180.1" y2="871.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="874.9" x2="184.1" y2="874.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="871.9" x2="184.1" y2="871.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="877.3" x2="282.3" y2="874.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="877.3" x2="286.3" y2="877.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="874.3" x2="286.3" y2="874.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="903.2" x2="384.4" y2="900.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="903.2" x2="388.4" y2="903.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="900.2" x2="388.4" y2="900.2" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,877.1 180.1,872.8 282.3,875.4 384.4,901.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="877.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="872.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="875.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="901.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="785.8" x2="78.0" y2="782.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="785.8" x2="82.0" y2="785.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="782.8" x2="82.0" y2="782.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="874.8" x2="180.1" y2="871.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="874.8" x2="184.1" y2="874.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="871.8" x2="184.1" y2="871.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="925.5" x2="282.3" y2="922.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="925.5" x2="286.3" y2="925.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="922.5" x2="286.3" y2="922.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="943.8" x2="384.4" y2="940.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="943.8" x2="388.4" y2="943.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="940.8" x2="388.4" y2="940.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,784.3 180.1,873.3 282.3,924.0 384.4,942.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="784.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="873.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="924.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="942.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="838.3" x2="78.0" y2="820.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="838.3" x2="82.0" y2="838.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="820.4" x2="82.0" y2="820.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="902.8" x2="180.1" y2="893.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="902.8" x2="184.1" y2="902.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="893.1" x2="184.1" y2="893.1" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="929.3" x2="282.3" y2="926.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="929.3" x2="286.3" y2="929.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="926.3" x2="286.3" y2="926.3" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="938.0" x2="384.4" y2="935.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="938.0" x2="388.4" y2="938.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="935.0" x2="388.4" y2="935.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,830.9 180.1,898.3 282.3,927.8 384.4,936.5" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="830.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="898.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="927.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="936.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="755.0" x2="78.0" y2="744.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="755.0" x2="82.0" y2="755.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="744.6" x2="82.0" y2="744.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="841.6" x2="180.1" y2="831.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="841.6" x2="184.1" y2="841.6" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="831.3" x2="184.1" y2="831.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="845.2" x2="282.3" y2="833.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="845.2" x2="286.3" y2="845.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="833.1" x2="286.3" y2="833.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="856.7" x2="384.4" y2="834.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="856.7" x2="388.4" y2="856.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="834.1" x2="388.4" y2="834.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,750.7 180.1,836.7 282.3,839.0 384.4,846.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="831.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="837.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="840.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="818.1" x2="78.0" y2="815.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="818.1" x2="82.0" y2="818.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="815.1" x2="82.0" y2="815.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="862.3" x2="180.1" y2="859.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="862.3" x2="184.1" y2="862.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="859.3" x2="184.1" y2="859.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="880.3" x2="282.3" y2="877.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="880.3" x2="286.3" y2="880.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="877.3" x2="286.3" y2="877.3" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="911.8" x2="384.4" y2="908.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="911.8" x2="388.4" y2="911.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="908.8" x2="388.4" y2="908.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,817.0 180.1,861.2 282.3,879.1 384.4,910.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="817.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="861.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="879.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="910.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="900.0" x2="78.0" y2="896.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="900.0" x2="82.0" y2="900.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="896.1" x2="82.0" y2="896.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="898.9" x2="180.1" y2="892.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="898.9" x2="184.1" y2="898.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="892.9" x2="184.1" y2="892.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="899.8" x2="282.3" y2="895.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="899.8" x2="286.3" y2="899.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="895.2" x2="286.3" y2="895.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="906.8" x2="384.4" y2="903.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="906.8" x2="388.4" y2="906.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="903.2" x2="388.4" y2="903.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,897.5 180.1,894.5 282.3,897.4 384.4,905.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="897.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="894.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="897.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="905.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="78.0" y1="951.8" x2="78.0" y2="948.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="951.8" x2="82.0" y2="951.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="74.0" y1="948.8" x2="82.0" y2="948.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="180.1" y1="952.6" x2="180.1" y2="949.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="952.6" x2="184.1" y2="952.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="176.1" y1="949.6" x2="184.1" y2="949.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="282.3" y1="953.2" x2="282.3" y2="950.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="953.2" x2="286.3" y2="953.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="278.3" y1="950.2" x2="286.3" y2="950.2" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="384.4" y1="953.6" x2="384.4" y2="950.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="953.6" x2="388.4" y2="953.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="380.4" y1="950.6" x2="388.4" y2="950.6" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="78.0,950.3 180.1,951.1 282.3,951.7 384.4,952.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="950.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="180.1" cy="951.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="282.3" cy="951.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="384.4" cy="952.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="836.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="839.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="846.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="824.4" x2="78.0" y2="821.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="824.4" x2="82.0" y2="824.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="821.4" x2="82.0" y2="821.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="866.9" x2="180.1" y2="863.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="866.9" x2="184.1" y2="866.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="863.9" x2="184.1" y2="863.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="882.8" x2="282.3" y2="879.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="882.8" x2="286.3" y2="882.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="879.8" x2="286.3" y2="879.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="913.7" x2="384.4" y2="910.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="913.7" x2="388.4" y2="913.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="910.7" x2="388.4" y2="910.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,823.0 180.1,865.5 282.3,881.4 384.4,912.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="823.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="865.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="881.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="912.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="901.7" x2="78.0" y2="897.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="901.7" x2="82.0" y2="901.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="897.9" x2="82.0" y2="897.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="900.6" x2="180.1" y2="894.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="900.6" x2="184.1" y2="900.6" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="894.9" x2="184.1" y2="894.9" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="901.5" x2="282.3" y2="897.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="901.5" x2="286.3" y2="901.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="897.1" x2="286.3" y2="897.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="908.3" x2="384.4" y2="904.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="908.3" x2="388.4" y2="908.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="904.8" x2="388.4" y2="904.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,899.3 180.1,896.3 282.3,899.2 384.4,906.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="899.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="896.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="899.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="906.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="78.0" y1="951.9" x2="78.0" y2="948.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="951.9" x2="82.0" y2="951.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="74.0" y1="948.9" x2="82.0" y2="948.9" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="180.1" y1="952.7" x2="180.1" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="952.7" x2="184.1" y2="952.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="176.1" y1="949.7" x2="184.1" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="282.3" y1="953.3" x2="282.3" y2="950.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="953.3" x2="286.3" y2="953.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="278.3" y1="950.3" x2="286.3" y2="950.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="384.4" y1="953.7" x2="384.4" y2="950.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="953.7" x2="388.4" y2="953.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="380.4" y1="950.7" x2="388.4" y2="950.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="78.0,950.4 180.1,951.3 282.3,951.8 384.4,952.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="950.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="180.1" cy="951.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="282.3" cy="951.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="384.4" cy="952.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="180.1" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="282.3" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -842,14 +846,16 @@
   <text x="474.4" y="749.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="482.4" y1="720.0" x2="942.0" y2="720.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="474.4" y="720.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="942.0" y1="905.6" x2="946.0" y2="905.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="905.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
-  <line x1="942.0" y1="856.2" x2="946.0" y2="856.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="856.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
-  <line x1="942.0" y1="806.8" x2="946.0" y2="806.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="806.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
-  <line x1="942.0" y1="757.4" x2="946.0" y2="757.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="950.0" y="757.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="909.1" x2="946.0" y2="909.1" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="909.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2 GB/s</text>
+  <line x1="942.0" y1="863.2" x2="946.0" y2="863.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="863.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4 GB/s</text>
+  <line x1="942.0" y1="817.4" x2="946.0" y2="817.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="817.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6 GB/s</text>
+  <line x1="942.0" y1="771.5" x2="946.0" y2="771.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="771.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8 GB/s</text>
+  <line x1="942.0" y1="725.6" x2="946.0" y2="725.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="950.0" y="725.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10 GB/s</text>
   <line x1="482.4" y1="720.0" x2="482.4" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="635.6" y1="720.0" x2="635.6" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="788.8" y1="720.0" x2="788.8" y2="955.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -861,129 +867,129 @@
   <polyline points="482.4,858.2 635.6,860.9 788.8,879.4 942.0,891.0" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,872.0 635.6,884.7 788.8,891.8 942.0,892.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,780.8 635.6,800.5 788.8,809.7 942.0,815.6" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,780.8 635.6,780.3 788.8,833.5 942.0,845.0" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="482.4,896.3 635.6,896.3 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,780.6 635.6,780.5 788.8,833.5 942.0,834.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="482.4,896.3 635.6,896.5 788.8,896.3 942.0,896.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,796.9 635.6,804.4 788.8,825.5 942.0,825.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="482.4,896.5 635.6,896.1 788.8,896.4 942.0,896.5" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <line x1="482.4" y1="927.9" x2="482.4" y2="924.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="927.9" x2="486.4" y2="927.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="924.9" x2="486.4" y2="924.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="879.4" x2="635.6" y2="876.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="879.4" x2="639.6" y2="879.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="876.4" x2="639.6" y2="876.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="827.1" x2="788.8" y2="824.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="827.1" x2="792.8" y2="827.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="824.1" x2="792.8" y2="824.1" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="801.4" x2="942.0" y2="798.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="801.4" x2="946.0" y2="801.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="798.4" x2="946.0" y2="798.4" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,926.2 635.6,877.5 788.8,825.1 942.0,800.0" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="926.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="877.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="825.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="800.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="945.3" x2="482.4" y2="942.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="945.3" x2="486.4" y2="945.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="942.3" x2="486.4" y2="942.3" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="938.1" x2="635.6" y2="935.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="938.1" x2="639.6" y2="938.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="935.1" x2="639.6" y2="935.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="936.1" x2="788.8" y2="933.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="936.1" x2="792.8" y2="936.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="933.1" x2="792.8" y2="933.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="932.0" x2="942.0" y2="929.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="932.0" x2="946.0" y2="932.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="929.0" x2="946.0" y2="929.0" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,943.8 635.6,936.6 788.8,934.6 942.0,930.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="943.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="936.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="934.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="930.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="946.7" x2="482.4" y2="943.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="946.7" x2="486.4" y2="946.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="943.7" x2="486.4" y2="943.7" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="929.8" x2="635.6" y2="926.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="929.8" x2="639.6" y2="929.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="926.6" x2="639.6" y2="926.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="909.4" x2="788.8" y2="906.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="909.4" x2="792.8" y2="909.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="906.4" x2="792.8" y2="906.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="928.0" x2="942.0" y2="823.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="928.0" x2="946.0" y2="928.0" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="823.9" x2="946.0" y2="823.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,945.2 635.6,928.2 788.8,908.3 942.0,896.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="945.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="928.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="908.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="896.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="916.3" x2="482.4" y2="910.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="916.3" x2="486.4" y2="916.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="910.4" x2="486.4" y2="910.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="803.1" x2="635.6" y2="788.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="803.1" x2="639.6" y2="803.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="788.4" x2="639.6" y2="788.4" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="793.8" x2="788.8" y2="758.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="793.8" x2="792.8" y2="793.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="758.5" x2="792.8" y2="758.5" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="810.2" x2="942.0" y2="673.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="810.2" x2="946.0" y2="810.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="673.8" x2="946.0" y2="673.8" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,913.7 635.6,795.1 788.8,775.9 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="913.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="795.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="775.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="929.9" x2="482.4" y2="926.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="929.9" x2="486.4" y2="929.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="926.9" x2="486.4" y2="926.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="884.9" x2="635.6" y2="881.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="884.9" x2="639.6" y2="884.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="881.9" x2="639.6" y2="881.9" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="836.3" x2="788.8" y2="833.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="836.3" x2="792.8" y2="836.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="833.3" x2="792.8" y2="833.3" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="812.5" x2="942.0" y2="809.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="812.5" x2="946.0" y2="812.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="809.5" x2="946.0" y2="809.5" stroke="#15803d" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,928.3 635.6,883.0 788.8,834.4 942.0,811.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="928.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="883.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="834.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="811.1" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="946.1" x2="482.4" y2="943.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="946.1" x2="486.4" y2="946.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="943.1" x2="486.4" y2="943.1" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="939.4" x2="635.6" y2="936.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="939.4" x2="639.6" y2="939.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="936.4" x2="639.6" y2="936.4" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="937.5" x2="788.8" y2="934.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="937.5" x2="792.8" y2="937.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="934.5" x2="792.8" y2="934.5" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="933.8" x2="942.0" y2="930.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="933.8" x2="946.0" y2="933.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="930.8" x2="946.0" y2="930.8" stroke="#eab308" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,944.6 635.6,937.9 788.8,936.0 942.0,932.3" fill="none" stroke="#eab308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="944.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="937.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="936.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="932.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="947.4" x2="482.4" y2="944.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="947.4" x2="486.4" y2="947.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="944.4" x2="486.4" y2="944.4" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="931.6" x2="635.6" y2="928.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="931.6" x2="639.6" y2="931.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="928.6" x2="639.6" y2="928.6" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="912.8" x2="788.8" y2="909.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="912.8" x2="792.8" y2="912.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="909.8" x2="792.8" y2="909.8" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="929.9" x2="942.0" y2="833.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="929.9" x2="946.0" y2="929.9" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="833.2" x2="946.0" y2="833.2" stroke="#a16207" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,945.9 635.6,930.2 788.8,911.6 942.0,901.1" fill="none" stroke="#a16207" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="945.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="930.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="911.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="901.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="918.2" x2="482.4" y2="914.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="918.2" x2="486.4" y2="918.2" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="914.1" x2="486.4" y2="914.1" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="823.0" x2="635.6" y2="792.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="823.0" x2="639.6" y2="823.0" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="792.7" x2="639.6" y2="792.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="801.3" x2="788.8" y2="782.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="801.3" x2="792.8" y2="801.3" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="782.9" x2="792.8" y2="782.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="756.9" x2="942.0" y2="745.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="756.9" x2="946.0" y2="756.9" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="745.7" x2="946.0" y2="745.7" stroke="#dc2626" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,916.1 635.6,809.9 788.8,795.0 942.0,750.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="916.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="809.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="795.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="942.0" cy="750.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="929.8" x2="482.4" y2="926.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="929.8" x2="486.4" y2="929.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="926.8" x2="486.4" y2="926.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="893.8" x2="635.6" y2="890.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="893.8" x2="639.6" y2="893.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="890.8" x2="639.6" y2="890.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="844.5" x2="788.8" y2="840.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="844.5" x2="792.8" y2="844.5" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="840.9" x2="792.8" y2="840.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="813.4" x2="942.0" y2="803.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="813.4" x2="946.0" y2="813.4" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="803.7" x2="946.0" y2="803.7" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,928.4 635.6,892.5 788.8,842.1 942.0,807.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="928.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="892.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="842.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="807.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="936.4" x2="482.4" y2="933.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="936.4" x2="486.4" y2="936.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="933.4" x2="486.4" y2="933.4" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="887.5" x2="635.6" y2="882.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="887.5" x2="639.6" y2="887.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="882.5" x2="639.6" y2="882.5" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="828.2" x2="788.8" y2="821.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="828.2" x2="792.8" y2="828.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="821.7" x2="792.8" y2="821.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="808.2" x2="942.0" y2="803.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="808.2" x2="946.0" y2="808.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="803.1" x2="946.0" y2="803.1" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,934.8 635.6,885.3 788.8,825.3 942.0,805.3" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="934.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="885.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="825.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="805.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <line x1="482.4" y1="955.3" x2="482.4" y2="952.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="955.3" x2="486.4" y2="955.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="478.4" y1="952.3" x2="486.4" y2="952.3" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="635.6" y1="952.4" x2="635.6" y2="949.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="952.4" x2="639.6" y2="952.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="631.6" y1="949.4" x2="639.6" y2="949.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="788.8" y1="941.8" x2="788.8" y2="938.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="941.8" x2="792.8" y2="941.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="784.8" y1="938.8" x2="792.8" y2="938.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="942.0" y1="913.0" x2="942.0" y2="910.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="913.0" x2="946.0" y2="913.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <line x1="938.0" y1="910.0" x2="946.0" y2="910.0" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
-  <polyline points="482.4,953.8 635.6,951.0 788.8,940.3 942.0,911.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="482.4" cy="953.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="635.6" cy="951.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="788.8" cy="940.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="942.0" cy="911.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="931.8" x2="482.4" y2="928.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="931.8" x2="486.4" y2="931.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="928.8" x2="486.4" y2="928.8" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="899.1" x2="635.6" y2="896.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="899.1" x2="639.6" y2="899.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="896.1" x2="639.6" y2="896.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="872.1" x2="788.8" y2="867.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="872.1" x2="792.8" y2="872.1" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="867.9" x2="792.8" y2="867.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="853.9" x2="942.0" y2="850.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="853.9" x2="946.0" y2="853.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="850.9" x2="946.0" y2="850.9" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,930.3 635.6,897.6 788.8,869.5 942.0,852.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="930.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="897.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="869.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="852.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="937.8" x2="482.4" y2="934.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="937.8" x2="486.4" y2="937.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="934.8" x2="486.4" y2="934.8" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="892.3" x2="635.6" y2="887.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="892.3" x2="639.6" y2="892.3" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="887.7" x2="639.6" y2="887.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="837.2" x2="788.8" y2="831.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="837.2" x2="792.8" y2="837.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="831.2" x2="792.8" y2="831.2" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="818.7" x2="942.0" y2="814.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="818.7" x2="946.0" y2="818.7" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="814.0" x2="946.0" y2="814.0" stroke="#16a34a" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,936.3 635.6,890.3 788.8,834.5 942.0,816.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="936.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="890.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="834.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="816.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <line x1="482.4" y1="955.4" x2="482.4" y2="952.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="955.4" x2="486.4" y2="955.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="478.4" y1="952.4" x2="486.4" y2="952.4" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="635.6" y1="952.7" x2="635.6" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="952.7" x2="639.6" y2="952.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="631.6" y1="949.7" x2="639.6" y2="949.7" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="788.8" y1="942.8" x2="788.8" y2="939.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="942.8" x2="792.8" y2="942.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="784.8" y1="939.8" x2="792.8" y2="939.8" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="942.0" y1="916.1" x2="942.0" y2="913.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="916.1" x2="946.0" y2="916.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <line x1="938.0" y1="913.1" x2="946.0" y2="913.1" stroke="#2563eb" stroke-width="1.5" opacity="0.5"/>
+  <polyline points="482.4,953.9 635.6,951.2 788.8,941.4 942.0,914.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="482.4" cy="953.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="635.6" cy="951.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="788.8" cy="941.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="942.0" cy="914.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="482.4" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
   <text x="635.6" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
   <text x="788.8" y="969.0" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>

--- a/doc/charts/pushpull/inproc.svg
+++ b/doc/charts/pushpull/inproc.svg
@@ -37,7 +37,7 @@
   <text x="30.0" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,30.0,213.0)">CPU %</text>
   <polyline points="78.0,125.8 174.8,121.8 271.6,143.5 368.4,137.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,191.5 174.8,191.3 271.6,198.8 368.4,193.4" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,212.1 174.8,211.6 271.6,212.1 368.4,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,212.3 174.8,212.3 271.6,211.8 368.4,212.1" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,283.0 174.8,283.0 271.6,283.0 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,131.9 174.8,126.1 271.6,132.4 368.4,130.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,251.0 174.8,249.0 271.6,253.3 368.4,251.1" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
@@ -50,16 +50,16 @@
   <circle cx="174.8" cy="216.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="271.6" cy="289.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="368.4" cy="303.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,271.6 174.8,268.0 271.6,270.0 368.4,260.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="271.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="268.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="270.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="260.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,199.8 174.8,195.0 271.6,191.4 368.4,191.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="199.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="195.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="191.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="191.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,269.0 174.8,265.2 271.6,263.8 368.4,266.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="269.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="265.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="263.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="266.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,200.7 174.8,190.8 271.6,192.8 368.4,190.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="200.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="190.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="192.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="190.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="78.0,248.1 174.8,248.4 271.6,253.3 368.4,248.5" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="248.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="174.8" cy="248.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
@@ -106,7 +106,7 @@
   <text x="418.4" y="213.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,418.4,213.0)">CPU %</text>
   <polyline points="466.4,143.5 611.6,137.2 756.8,127.9 902.0,134.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,198.8 611.6,193.4 756.8,191.3 902.0,199.5" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,212.1 611.6,212.3 756.8,212.1 902.0,212.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,211.8 611.6,212.1 756.8,212.3 902.0,212.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,283.0 611.6,283.0 756.8,283.0 902.0,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,132.4 611.6,130.7 756.8,126.3 902.0,132.6" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,287.4 611.6,244.6 756.8,202.5 902.0,159.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -119,16 +119,16 @@
   <circle cx="611.6" cy="266.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="229.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="198.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,293.0 611.6,247.4 756.8,206.0 902.0,164.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="293.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="247.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="206.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="164.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,272.7 611.6,230.6 756.8,188.4 902.0,146.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="272.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="230.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="188.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="146.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,290.8 611.6,249.4 756.8,207.5 902.0,165.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="290.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="249.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="207.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="165.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,273.0 611.6,230.4 756.8,189.1 902.0,147.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="273.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="230.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="189.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="147.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,287.4 611.6,243.8 756.8,203.1 902.0,160.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="287.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="243.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/ipc.svg
+++ b/doc/charts/pushpull/ipc.svg
@@ -19,18 +19,18 @@
   <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="368.4" y1="311.1" x2="372.4" y2="311.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="311.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="269.1" x2="372.4" y2="269.1" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="269.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="227.2" x2="372.4" y2="227.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="227.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="185.3" x2="372.4" y2="185.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="185.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="368.4" y1="143.3" x2="372.4" y2="143.3" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="143.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="368.4" y1="101.4" x2="372.4" y2="101.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="101.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
+  <line x1="368.4" y1="310.2" x2="372.4" y2="310.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="310.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="267.3" x2="372.4" y2="267.3" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="267.3" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="224.5" x2="372.4" y2="224.5" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="224.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="181.7" x2="372.4" y2="181.7" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="181.7" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="138.9" x2="372.4" y2="138.9" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="138.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="368.4" y1="96.0" x2="372.4" y2="96.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="96.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,45 +42,45 @@
   <polyline points="78.0,224.2 174.8,221.0 271.6,220.3 368.4,233.1" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,213.2 174.8,197.1 271.6,214.4 368.4,243.8" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,245.7 174.8,194.6 271.6,215.3 368.4,245.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,184.3 174.8,181.0 271.6,242.9 368.4,301.2" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,282.8 174.8,283.0 271.6,283.0 368.4,314.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,190.1 174.8,182.0 271.6,239.8 368.4,302.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,282.8 174.8,283.0 271.6,282.8 368.4,306.3" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,279.0 174.8,266.2 271.6,271.8 368.4,273.5" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,251.0 174.8,252.4 271.6,250.6 368.4,249.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,291.2 174.8,289.3 271.6,285.6 368.4,307.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="291.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="289.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="285.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="307.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,204.1 174.8,257.3 271.6,305.7 368.4,331.1" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="204.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="257.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="305.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="331.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,208.9 174.8,256.9 271.6,305.9 368.4,330.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="208.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="256.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="305.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="330.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,109.5 174.8,207.2 271.6,235.6 368.4,319.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,289.9 174.8,288.0 271.6,284.2 368.4,306.7" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="289.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="288.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="284.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="306.7" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,200.9 174.8,255.2 271.6,304.7 368.4,330.6" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="200.9" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="255.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="304.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="330.6" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,205.8 174.8,254.9 271.6,304.9 368.4,330.4" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="205.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="254.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="304.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="330.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,204.8 271.6,230.1 368.4,319.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="207.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="235.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="319.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,199.9 174.8,245.6 271.6,260.0 368.4,323.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="199.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="245.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="260.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="323.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,305.2 174.8,296.3 271.6,297.6 368.4,314.7" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="305.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="296.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="297.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="314.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,341.3 174.8,341.5 271.6,342.0 368.4,342.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="341.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="341.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="342.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="342.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="204.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="230.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="319.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,193.3 174.8,243.7 271.6,257.9 368.4,314.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="193.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="243.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="257.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="314.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,304.2 174.8,295.0 271.6,296.4 368.4,313.9" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="304.2" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="295.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="296.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="313.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,341.0 174.8,341.2 271.6,341.8 368.4,342.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="341.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="341.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="341.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="342.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -125,8 +125,8 @@
   <polyline points="466.4,220.3 611.6,233.1 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,214.4 611.6,243.8 756.8,273.4 902.0,260.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,215.3 611.6,245.4 756.8,273.2 902.0,266.2" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,242.9 611.6,301.2 756.8,310.1 902.0,284.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,283.0 611.6,314.0 756.8,284.2 902.0,288.1" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,239.8 611.6,302.8 756.8,288.6 902.0,296.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,282.8 611.6,306.3 756.8,289.5 902.0,284.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,271.8 611.6,273.5 756.8,278.3 902.0,279.3" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,250.6 611.6,249.0 756.8,267.6 902.0,293.3" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,314.6 611.6,249.7 756.8,171.5 902.0,130.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -144,16 +144,16 @@
   <circle cx="611.6" cy="302.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="289.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="270.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,286.1 611.6,277.6 756.8,236.5 902.0,49.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="286.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="277.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="236.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="49.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,300.0 611.6,284.8 756.8,110.9 902.0,43.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="300.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="284.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="110.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="43.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,284.4 611.6,278.5 756.8,186.7 902.0,148.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="284.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="278.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="186.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="148.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,299.9 611.6,266.5 756.8,161.9 902.0,76.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="299.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="266.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="161.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="76.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,321.4 611.6,265.8 756.8,236.1 902.0,224.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="321.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="265.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/pushpull/tcp.svg
+++ b/doc/charts/pushpull/tcp.svg
@@ -19,18 +19,18 @@
   <text x="70.0" y="108.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">350%</text>
   <line x1="78.0" y1="73.0" x2="368.4" y2="73.0" stroke="#e5e7eb" stroke-width="1"/>
   <text x="70.0" y="73.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="8.5">400%</text>
-  <line x1="368.4" y1="307.4" x2="372.4" y2="307.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="307.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
-  <line x1="368.4" y1="261.8" x2="372.4" y2="261.8" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="261.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
-  <line x1="368.4" y1="216.2" x2="372.4" y2="216.2" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="216.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
-  <line x1="368.4" y1="170.6" x2="372.4" y2="170.6" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="170.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
-  <line x1="368.4" y1="125.0" x2="372.4" y2="125.0" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="125.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
-  <line x1="368.4" y1="79.4" x2="372.4" y2="79.4" stroke="#9ca3af" stroke-width="1"/>
-  <text x="376.4" y="79.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
+  <line x1="368.4" y1="311.2" x2="372.4" y2="311.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="311.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">2M/s</text>
+  <line x1="368.4" y1="269.4" x2="372.4" y2="269.4" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="269.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">4M/s</text>
+  <line x1="368.4" y1="227.6" x2="372.4" y2="227.6" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="227.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">6M/s</text>
+  <line x1="368.4" y1="185.8" x2="372.4" y2="185.8" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="185.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">8M/s</text>
+  <line x1="368.4" y1="144.0" x2="372.4" y2="144.0" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="144.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">10M/s</text>
+  <line x1="368.4" y1="102.2" x2="372.4" y2="102.2" stroke="#9ca3af" stroke-width="1"/>
+  <text x="376.4" y="102.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="8.5">12M/s</text>
   <line x1="78.0" y1="73.0" x2="78.0" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="174.8" y1="73.0" x2="174.8" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="271.6" y1="73.0" x2="271.6" y2="353.0" stroke="#e5e7eb" stroke-width="1"/>
@@ -42,45 +42,45 @@
   <polyline points="78.0,212.8 174.8,215.2 271.6,223.8 368.4,232.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,215.6 174.8,200.2 271.6,227.2 368.4,246.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,196.4 174.8,192.2 271.6,227.5 368.4,244.7" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,193.9 174.8,189.9 271.6,232.6 368.4,242.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,282.1 174.8,282.5 271.6,282.8 368.4,283.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,189.4 174.8,193.4 271.6,214.9 368.4,241.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="78.0,282.1 174.8,282.5 271.6,282.8 368.4,282.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,305.4 174.8,280.9 271.6,270.7 368.4,272.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="78.0,275.3 174.8,280.9 271.6,282.8 368.4,283.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="78.0,275.9 174.8,281.5 271.6,285.0 368.4,298.2" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="275.9" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="281.5" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="285.0" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="298.2" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,198.5 174.8,255.3 271.6,306.3 368.4,332.8" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="198.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="255.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="306.3" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="332.8" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,193.0 174.8,247.7 271.6,306.1 368.4,332.9" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="193.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="247.7" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="306.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="332.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,109.5 174.8,194.2 271.6,227.4 368.4,273.5" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <polyline points="78.0,282.3 174.8,287.4 271.6,290.6 368.4,302.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="282.3" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="287.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="290.6" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="302.8" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,211.4 174.8,263.4 271.6,310.2 368.4,334.5" fill="none" stroke="#eab308" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="211.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="263.4" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="310.2" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="334.5" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,206.3 174.8,256.5 271.6,310.1 368.4,334.6" fill="none" stroke="#a16207" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="206.3" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="256.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="310.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="334.6" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,109.5 174.8,208.4 271.6,241.7 368.4,288.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-dasharray="6,3"/>
   <circle cx="78.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="194.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="227.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="273.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,189.7 174.8,238.9 271.6,256.2 368.4,292.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="189.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="238.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="256.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="292.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,323.7 174.8,302.3 271.6,297.1 368.4,307.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="323.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="302.3" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="297.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="307.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
-  <polyline points="78.0,345.3 174.8,347.0 271.6,347.4 368.4,347.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
-  <circle cx="78.0" cy="345.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="174.8" cy="347.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="271.6" cy="347.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="368.4" cy="347.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="208.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="241.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="288.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,199.2 174.8,249.1 271.6,266.0 368.4,301.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="199.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="249.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="266.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="301.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,326.1 174.8,306.5 271.6,301.7 368.4,311.4" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="326.1" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="306.5" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="301.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="311.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
+  <polyline points="78.0,346.0 174.8,347.5 271.6,347.8 368.4,348.2" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-dasharray="6,3"/>
+  <circle cx="78.0" cy="346.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="174.8" cy="347.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="271.6" cy="347.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="368.4" cy="348.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="78.0" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="174.8" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
   <text x="271.6" y="367.0" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
@@ -125,8 +125,8 @@
   <polyline points="466.4,223.8 611.6,232.4 756.8,251.1 902.0,264.4" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.2 611.6,246.9 756.8,265.5 902.0,262.9" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,227.5 611.6,244.7 756.8,266.9 902.0,265.0" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,232.6 611.6,242.9 756.8,275.8 902.0,294.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="466.4,282.8 611.6,283.0 756.8,284.6 902.0,294.4" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,214.9 611.6,241.9 756.8,258.3 902.0,277.6" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="466.4,282.8 611.6,282.8 756.8,283.7 902.0,288.7" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,270.7 611.6,272.7 756.8,267.6 902.0,284.4" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,282.8 611.6,283.0 756.8,283.2 902.0,283.2" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="466.4,317.4 611.6,238.2 756.8,157.9 902.0,108.6" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -144,16 +144,16 @@
   <circle cx="611.6" cy="310.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="756.8" cy="301.2" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="902.0" cy="298.1" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,287.2 611.6,186.3 756.8,128.6 902.0,139.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="287.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="186.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="128.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="139.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="466.4,302.3 611.6,226.8 756.8,133.1 902.0,132.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="466.4" cy="302.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="611.6" cy="226.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="756.8" cy="133.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="902.0" cy="132.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,289.4 611.6,206.2 756.8,161.6 902.0,148.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="289.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="206.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="161.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="148.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="466.4,303.2 611.6,236.2 756.8,165.8 902.0,136.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="466.4" cy="303.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="611.6" cy="236.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="756.8" cy="165.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="902.0" cy="136.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="466.4,323.7 611.6,257.8 756.8,197.5 902.0,207.8" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="466.4" cy="323.7" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="611.6" cy="257.8" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/inproc.svg
+++ b/doc/charts/reqrep/inproc.svg
@@ -38,8 +38,8 @@
   <text x="40.0" y="139.0" text-anchor="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40.0,139.0)">p50 latency (µs)</text>
   <polyline points="90.0,111.1 224.0,117.8 358.0,117.9 492.0,109.5 626.0,115.2 760.0,115.2" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,129.7 224.0,130.9 358.0,128.7 492.0,127.4 626.0,124.3 760.0,130.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,106.2 224.0,99.9 358.0,107.5 492.0,100.4 626.0,102.0 760.0,95.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,125.2 224.0,148.4 358.0,148.3 492.0,150.1 626.0,149.0 760.0,148.9" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,109.6 224.0,112.1 358.0,106.3 492.0,94.4 626.0,91.3 760.0,97.3" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,122.9 224.0,147.4 358.0,148.1 492.0,148.9 626.0,147.5 760.0,123.2" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,122.5 224.0,115.6 358.0,109.3 492.0,113.2 626.0,115.8 760.0,110.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,109.4 224.0,119.4 358.0,101.3 492.0,119.3 626.0,111.5 760.0,126.4" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="109.4" r="3" fill="#15803d" stroke="white" stroke-width="1"/>
@@ -55,20 +55,20 @@
   <circle cx="492.0" cy="102.0" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="97.1" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="88.7" r="3" fill="#eab308" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,105.2 224.0,99.1 358.0,97.6 492.0,104.6 626.0,109.5 760.0,92.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="105.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="99.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="97.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="104.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="109.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="92.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,198.4 224.0,199.3 358.0,199.3 492.0,198.8 626.0,199.1 760.0,199.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="198.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="199.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="199.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="198.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="199.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="199.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,103.8 224.0,93.8 358.0,104.0 492.0,115.1 626.0,103.7 760.0,104.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="103.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="93.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="104.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="115.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="103.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="104.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,198.9 224.0,199.7 358.0,199.4 492.0,199.1 626.0,199.6 760.0,198.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="198.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="199.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="199.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="199.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="199.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="198.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,114.6 224.0,119.0 358.0,110.8 492.0,121.7 626.0,110.5 760.0,111.1" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="114.6" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="119.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/ipc.svg
+++ b/doc/charts/reqrep/ipc.svg
@@ -37,8 +37,8 @@
   <polyline points="90.0,136.6 224.0,136.5 358.0,141.0 492.0,141.4 626.0,141.6 760.0,146.7" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,179.5 224.0,177.3 358.0,178.9 492.0,180.7 626.0,180.5 760.0,177.2" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,178.6 224.0,176.7 358.0,180.6 492.0,180.7 626.0,180.2 760.0,176.5" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,165.5 224.0,166.3 358.0,166.5 492.0,165.6 626.0,166.7 760.0,165.8" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,171.4 224.0,172.0 358.0,171.5 492.0,173.5 626.0,171.2 760.0,172.0" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,167.2 224.0,164.3 358.0,166.0 492.0,165.2 626.0,163.7 760.0,165.4" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,172.8 224.0,172.5 358.0,172.1 492.0,172.4 626.0,169.2 760.0,171.8" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,164.7 224.0,174.5 358.0,165.5 492.0,166.7 626.0,169.0 760.0,172.1" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,169.3 224.0,172.1 358.0,181.6 492.0,173.2 626.0,178.1 760.0,174.6" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,173.8 224.0,173.5 358.0,165.8 492.0,164.0 626.0,159.1 760.0,156.8" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -62,20 +62,20 @@
   <circle cx="492.0" cy="122.5" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="110.9" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="97.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,131.6 224.0,130.4 358.0,128.4 492.0,134.3 626.0,118.1 760.0,115.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="130.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="128.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="134.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="118.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="115.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,190.2 224.0,182.8 358.0,189.6 492.0,187.2 626.0,174.2 760.0,168.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="190.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="182.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="189.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="187.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="174.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="168.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,132.3 224.0,132.7 358.0,131.6 492.0,132.5 626.0,122.6 760.0,118.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="132.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="132.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="131.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="132.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="122.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="118.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,187.5 224.0,190.0 358.0,186.2 492.0,181.9 626.0,173.4 760.0,163.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="187.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="190.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="186.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="181.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="173.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="163.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,128.0 224.0,113.4 358.0,123.4 492.0,117.8 626.0,115.8 760.0,92.6" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="128.0" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="113.4" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/doc/charts/reqrep/tcp.svg
+++ b/doc/charts/reqrep/tcp.svg
@@ -37,8 +37,8 @@
   <polyline points="90.0,142.6 224.0,143.8 358.0,141.2 492.0,146.4 626.0,142.7 760.0,147.9" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,179.0 224.0,179.3 358.0,179.2 492.0,180.0 626.0,179.5 760.0,175.1" fill="none" stroke="#eab308" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,177.4 224.0,180.5 358.0,178.8 492.0,179.0 626.0,178.2 760.0,175.4" fill="none" stroke="#a16207" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,177.1 224.0,164.3 358.0,166.4 492.0,175.4 626.0,168.7 760.0,165.5" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
-  <polyline points="90.0,183.6 224.0,183.5 358.0,181.0 492.0,182.9 626.0,182.3 760.0,181.5" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,167.7 224.0,165.9 358.0,170.7 492.0,168.2 626.0,168.9 760.0,166.9" fill="none" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
+  <polyline points="90.0,180.8 224.0,182.6 358.0,183.1 492.0,182.3 626.0,181.8 760.0,183.6" fill="none" stroke="#f97316" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,173.2 224.0,171.7 358.0,172.7 492.0,173.6 626.0,172.9 760.0,173.7" fill="none" stroke="#16a34a" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,180.8 224.0,181.7 358.0,182.9 492.0,180.0 626.0,183.2 760.0,182.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="2,5" opacity="0.85"/>
   <polyline points="90.0,161.8 224.0,154.9 358.0,155.8 492.0,156.2 626.0,153.2 760.0,146.5" fill="none" stroke="#15803d" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -62,20 +62,20 @@
   <circle cx="492.0" cy="119.0" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="626.0" cy="112.4" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="90.8" r="3" fill="#a16207" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,126.2 224.0,126.8 358.0,119.0 492.0,117.4 626.0,111.5 760.0,111.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="126.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="126.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="119.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="117.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="111.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="111.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,168.7 224.0,167.5 358.0,169.8 492.0,167.2 626.0,163.0 760.0,153.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="168.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="224.0" cy="167.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="358.0" cy="169.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="492.0" cy="167.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="626.0" cy="163.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="153.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,121.5 224.0,122.2 358.0,123.4 492.0,120.0 626.0,115.2 760.0,109.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="121.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="122.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="123.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="120.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="115.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="109.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,172.0 224.0,170.5 358.0,167.8 492.0,170.4 626.0,164.3 760.0,153.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="172.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="224.0" cy="170.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="358.0" cy="167.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="492.0" cy="170.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="626.0" cy="164.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="153.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,102.9 224.0,113.9 358.0,101.1 492.0,106.4 626.0,108.0 760.0,90.0" fill="none" stroke="#16a34a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="102.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>
   <circle cx="224.0" cy="113.9" r="3" fill="#16a34a" stroke="white" stroke-width="1"/>

--- a/omq-proto/src/flow.rs
+++ b/omq-proto/src/flow.rs
@@ -87,11 +87,9 @@ impl DrainBudget {
 
 /// Max bytes one shared-queue batch buffers before flushing.
 ///
-/// 1 MiB folds large messages into bigger writev calls without
-/// outgrowing typical kernel TCP send buffers. Smaller caps (e.g.
-/// 256 KiB) under-utilize writev for 32 KiB+ messages and let the
-/// per-syscall overhead dominate; larger caps add latency without extra
-/// throughput once the kernel send buffer is the bottleneck.
+/// 128 KiB bounds encode-before-write bursts while retaining enough data
+/// for efficient writev calls. Larger caps add latency without reliable
+/// throughput gains once the kernel send buffer is the bottleneck.
 ///
 /// Override at runtime via `OMQ_BATCH_BYTES`. Read once and cached.
 #[must_use]
@@ -101,7 +99,7 @@ pub fn max_batch_bytes() -> usize {
         std::env::var("OMQ_BATCH_BYTES")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(1024 * 1024)
+            .unwrap_or(128 * 1024)
     })
 }
 


### PR DESCRIPTION
- Reduce default `OMQ_BATCH_BYTES` from 1 MiB to 128 KiB to bound encode-before-write bursts
- Refresh all turbo-off comparison charts (TCP, IPC, inproc, latency, PUB/SUB, fan-out, fan-in)
- Document `OMQ_BATCH_BYTES` in `DEVELOPMENT.md`