### PR TITLE
Add Context API, IO paths, and benchmark infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ scripts/omq_libzmq_bench_peer
 perf.data*
 /TODO
 .chart_hw
+.perf_hw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ is covered by `tests/coverage_matrix.rs`.
 Three-layer split: `omq-proto` (sans-I/O ZMTP codec) -> `omq-tokio`
 backend -> user `Socket` API. Two queues per socket: one inbound,
 one outbound. Per-connection driver tasks bridge queues and wire.
+`Context` owns a tokio runtime on a dedicated OS thread (1 IO thread
+/ current_thread by default, multi_thread for N > 1).
+`Context::current()` wraps an existing runtime for embedded use.
 Full detail in `doc/`:
 [`architecture.md`](doc/architecture.md),
 [`libzmq/`](doc/libzmq/).

--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -29,6 +29,21 @@ Transport coverage differs by implementation. Missing lines mean that
 implementation does not expose a usable peer for that transport and
 pattern in this benchmark suite.
 
+## Runtime modes
+
+The charts benchmark three OMQ execution styles where relevant:
+`blocking::Socket` with dedicated IO threads, Tokio with two background IO
+threads, and Tokio current-thread (CT), where application and IO work share
+one runtime thread. The benchmark peer on the uninteresting side uses the
+blocking API.
+
+`Context::current()` embeds OMQ in an existing tokio runtime:
+
+- **CT** keeps application and IO work on one thread. Its benchmark sender
+  yields in batches so the IO driver progresses without destroying batching.
+- **background IO** keeps application code out of the IO runtime and scales
+  across independent IO threads.
+
 ## PUSH/PULL Throughput
 
 <p align="center">

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "blume",
+    "omq-bench",
     "omq-proto",
     "omq-tokio",
     "omq-libzmq",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Full sweep:
 
 ```sh
 ./scripts/test-all.sh
-OMQ_SKIP_FUZZ=1 ./scripts/test-all.sh
+OMQ_SKIP_PYOMQ=1 ./scripts/test-all.sh
 ```
 
 ## Fuzz Tests
@@ -68,9 +68,10 @@ throughput, WebSocket reconnect, large-message throughput, compression
 with lz4, PLAIN, CURVE, multi-socket, inproc cross-thread,
 and cancel safety.
 
-Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s). Set
-`OMQ_SOAK_TOKIO_RUNTIME=multi_thread` or `current_thread` to select the
-runtime flavor.
+Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s). `Context::new()`
+uses one dedicated background IO thread. `OMQ_IO_THREADS=N` selects N
+dedicated IO threads; `Context::current()` is the explicit current-thread
+Tokio integration mode.
 
 ```sh
 FEATURES="soak lz4 plain curve ws"
@@ -109,12 +110,13 @@ when a measured cell looks bad, don't hand-wave it as noise.
 
 ### Cross-implementation Comparison Benchmarks
 
-`scripts/run_comparisons.py` drives standalone `bench_peer` binaries:
+`omq-bench run comparisons` drives standalone `bench_peer` binaries:
 
 | binary | source | impls |
 |--------|--------|-------|
-| `bench_peer_tokio` | `omq-tokio/src/bin/bench_peer_tokio.rs` | omq-tokio, omq-tokio-mt |
-| `libzmq_bench_peer` | `scripts/libzmq_bench_peer.c` | libzmq, omq-libzmq |
+| `bench_peer_tokio` | `omq-tokio/src/bin/bench_peer_tokio.rs` | omq-tokio-ct, omq-tokio-2t |
+| `bench_peer_blocking` | `omq-tokio/src/bin/bench_peer_blocking.rs` | omq-tokio-1t |
+| `libzmq_bench_peer` | `scripts/libzmq_bench_peer.c` | libzmq, libzmq-2t |
 | `zmqrs_bench_peer` | `scripts/zmqrs_bench_peer/` | zmq.rs |
 | `rzmq_bench_peer` | `scripts/rzmq_bench_peer/` | rzmq, rzmq-iouring |
 
@@ -139,38 +141,53 @@ prefix=Linux VM on a 2018 Mac Mini
 postfix=performance governor, turbo off
 ```
 
-All `gen_*_chart.py` scripts read this file automatically via
-`scripts/chart_hw.py`.
+`omq-bench` reads `.chart_hw` automatically.
+
+### Main TCP Charts
+
+Refreshes `doc/charts/main_pushpull_tcp.svg` (PUSH/PULL throughput)
+and `doc/charts/main_reqrep_tcp.svg` (REQ/REP latency), TCP only.
+Rebench omq impls only, then regenerate:
+
+```sh
+cargo run --release -p omq-bench -- run comparisons \
+  --impl omq-tokio-ct --impl omq-tokio-1t --transport tcp --no-pubsub
+cargo run --release -p omq-bench -- chart comparisons
+```
+
+Rebench all impls (when external baselines are stale):
+
+```sh
+cargo run --release -p omq-bench -- run comparisons --transport tcp --no-pubsub
+cargo run --release -p omq-bench -- chart comparisons
+```
 
 ### Cross-library Comparison Charts
 
 Produces `doc/charts/{pushpull,pubsub,reqrep}/*.svg`,
 `doc/charts/pushpull/fan{out,in}/tcp.svg`,
-`doc/charts/main_tcp.svg`:
+`doc/charts/main_pushpull_tcp.svg`, `doc/charts/main_reqrep_tcp.svg`:
 
 ```sh
-python3 scripts/run_comparisons.py --omq
-python3 scripts/run_comparisons.py --omq --transport tcp --no-latency \
-  --no-pubsub --sizes 32,128,512,2048,8192,32768
-python3 scripts/gen_comparison_chart.py
+cargo run --release -p omq-bench -- run comparisons --omq
+cargo run --release -p omq-bench -- run comparisons --omq \
+  --transport tcp --no-latency --no-pubsub \
+  --sizes 32,128,512,2048,8192,32768 --allow-non-chart-sizes
+cargo run --release -p omq-bench -- chart comparisons
 ```
 
-The default `OMQ_BATCH_BYTES` cap is 128 KiB. Set the variable explicitly
-when comparing alternate caps; chart refreshes should use the same cap as
-the production default.
-
-Omit `--impl` to rebench all implementations when external baselines
-are stale. Full refresh after omq/rzmq changes:
+Full refresh after omq/rzmq changes (all impls, all transports):
 
 ```sh
 test -f .chart_hw
-python3 scripts/run_comparisons.py --transport tcp --transport ipc --transport inproc \
-  --fanout --fanin --pubsub-peers 1,8,32
-python3 scripts/gen_comparison_chart.py
+cargo run --release -p omq-bench -- run comparisons \
+  --transport tcp --transport ipc --transport inproc \
+  --fanout --fanin --pubsub-peers 4,64
+cargo run --release -p omq-bench -- chart comparisons
 ```
 
-Stop if `run_comparisons.py` prints any warning or timeout. Fix the
-bench peer or script first, then rerun before charting.
+Stop if any benchmark prints warnings or timeouts. Fix the bench peer
+first, then rerun before charting.
 
 **CPU% charting rule.** Charts show only the "interesting" process's
 CPU, not the sum of all processes:
@@ -187,25 +204,49 @@ The combined `cpu_time` field (sum of all processes) is still recorded
 for backwards compatibility. Chart loaders prefer the per-process
 field and fall back to `cpu_time` when it is absent.
 
+### CURVE PUB/SUB Chart
+
+Refreshes `doc/charts/pubsub/curve_tcp.svg`. The `--curve` flag
+auto-includes CURVE impls from the same family as the selected impls
+(e.g. `--omq --curve` adds `omq-curve-1t` and `omq-curve-2t`):
+
+```sh
+cargo run --release -p omq-bench -- run comparisons \
+  --omq --curve --transport tcp --no-throughput --no-latency
+cargo run --release -p omq-bench -- chart comparisons
+```
+
 ### Mechanism Chart
 
 ```sh
-python3 scripts/bench_mechanism.py tokio --chart-sizes
-python3 scripts/gen_mechanism_chart.py
+cargo run --release -p omq-bench -- run mechanism tokio --chart-sizes
+cargo run --release -p omq-bench -- chart mechanism
 ```
 
 ### PUB/SUB LZ4 Compression Chart
 
 ```sh
-python3 scripts/bench_pubsub_lz4.py --chart
-python3 scripts/gen_pubsub_lz4_chart.py
+cargo run --release -p omq-bench -- run pubsub-lz4 --chart
+```
+
+Or bench and chart separately:
+
+```sh
+cargo run --release -p omq-bench -- run pubsub-lz4
+cargo run --release -p omq-bench -- chart pubsub-lz4
 ```
 
 ### Compression Chart
 
 ```sh
-python3 scripts/bench_compression_tokio.py --chart
-python3 scripts/gen_compression_chart.py --backend tokio
+cargo run --release -p omq-bench -- run compression --chart
+```
+
+Or bench and chart separately:
+
+```sh
+cargo run --release -p omq-bench -- run compression
+cargo run --release -p omq-bench -- chart compression
 ```
 
 ### pyomq Bindings Charts

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 - Python binding ([pyomq](bindings/pyomq/)), C API ([omq-libzmq](omq-libzmq/))
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_pushpull_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
+</p>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_reqrep_tcp.svg" alt="REQ/REP latency: TCP implementations" width="950">
+</p>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_pubsub_tcp.svg" alt="PUB/SUB throughput: TCP implementations" width="950">
 </p>
 
 [Full comparison charts](COMPARISONS.md)

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "lz4rip"
-version = "0.9.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c929eba0e2d2e97a3dc4193a476d36fd7c343ef0623b69394b8c69a437c1fa"
+checksum = "c7f98b1380e382ff43bbeab40323ddbcd90eaba9293e166f8f21d5d458998375"
 dependencies = [
  "lz4rip-core",
  "lz4rip-decode",
@@ -413,24 +413,24 @@ dependencies = [
 
 [[package]]
 name = "lz4rip-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073502c94ff2f2073c3d7013fc018542d365089ac8cab6998e6aa4b68859ef83"
+checksum = "d2d5114cd4d615ffb90b111dc7eac57191eba2004a49830e577b8daab4610b75"
 
 [[package]]
 name = "lz4rip-decode"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57fce948bb22f5f0e055a61dfb69a84b7b60e4afd54a6eadc1d26cd120241d9"
+checksum = "1e82397fe986267ef8a26640c8265e776344e6606e9debc69a3fb1643fad01d3"
 dependencies = [
  "lz4rip-core",
 ]
 
 [[package]]
 name = "lz4rip-encode"
-version = "0.9.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76796529ac165094cec92c7eb2fe993d26759552e319d78c58a4ac9d4a4bf89"
+checksum = "002ccf86457fc2e44ee2e246ae05e7792097a1fa07b2bb79c63b9e9d6c0e04ba"
 dependencies = [
  "lz4rip-core",
 ]
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arc-swap",
  "blume",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "atomic-waker",
  "futures-core",

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -74,15 +74,15 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.29 M/s |  1.52 M/s | **1.50×** |
-| REQ/REP rt/s       |   7,215/s |   4,437/s | **1.63×** |
+| PUSH/PULL msg/s    |  2.08 M/s |  1.60 M/s | **1.30×** |
+| REQ/REP rt/s       |   8,140/s |   4,543/s | **1.79×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,
 no Python per-message overhead. pyzmq's `zmq.proxy()` calls libzmq's
 C-level `zmq_proxy`. PUSH/PULL forwarding is throughput-bound and pyomq is
-~1.4x faster. REQ/REP proxy is latency-bound (4 TCP hops per round-trip);
-pyomq is ~1.7x faster thanks to direct socket forwarding.
+~1.3x faster. REQ/REP proxy is latency-bound (4 TCP hops per round-trip);
+pyomq is ~1.8x faster thanks to direct socket forwarding.
 
 Run `scripts/update_perf.py` (after `maturin develop --release`) to re-measure, regenerate the chart, and update the proxy table.
 

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -43,66 +43,66 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,182.0 145.8,171.9 201.7,168.9 257.5,195.5 313.3,210.6 369.2,204.7 425.0,252.3 480.8,276.1 536.7,314.9 592.5,338.5 648.3,354.0 704.2,365.5 760.0,373.3" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,302.8 145.8,301.8 201.7,300.1 257.5,301.7 313.3,303.9 369.2,306.3 425.0,308.6 480.8,316.2 536.7,326.1 592.5,340.7 648.3,355.6 704.2,367.1 760.0,374.6" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,288.4 145.8,286.4 201.7,285.5 257.5,297.8 313.3,313.9 369.2,322.2 425.0,319.9 480.8,334.3 536.7,349.5 592.5,363.5 648.3,373.0 704.2,378.1 760.0,379.4" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,379.8 145.8,379.7 201.7,379.7 257.5,379.7 313.3,380.0 369.2,379.9 425.0,379.8 480.8,379.9 536.7,380.0 592.5,380.1 648.3,380.2 704.2,380.3 760.0,380.6" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.4 145.8,380.6 201.7,377.1 257.5,371.9 313.3,361.8 369.2,338.1 425.0,316.6 480.8,273.5 536.7,242.5 592.5,197.5 648.3,138.2 704.2,80.2 760.0,33.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="380.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="371.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="361.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="338.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="316.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="273.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="242.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="197.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="138.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="80.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="33.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.4 145.8,382.7 201.7,381.3 257.5,378.7 313.3,373.7 369.2,364.1 425.0,345.4 480.8,314.6 536.7,265.5 592.5,206.6 648.3,151.3 704.2,107.1 760.0,76.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,197.9 145.8,197.5 201.7,192.8 257.5,238.0 313.3,231.8 369.2,230.7 425.0,228.9 480.8,235.7 536.7,261.8 592.5,311.2 648.3,344.8 704.2,363.4 760.0,373.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,302.8 145.8,301.4 201.7,299.7 257.5,302.4 313.3,303.8 369.2,305.8 425.0,309.7 480.8,325.6 536.7,326.5 592.5,339.5 648.3,353.2 704.2,366.1 760.0,374.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,285.2 145.8,285.7 201.7,285.4 257.5,296.6 313.3,314.5 369.2,322.4 425.0,319.4 480.8,336.4 536.7,350.0 592.5,363.9 648.3,366.8 704.2,378.2 760.0,379.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,379.6 145.8,379.6 201.7,379.6 257.5,379.8 313.3,379.7 369.2,379.6 425.0,379.7 480.8,379.7 536.7,379.9 592.5,379.8 648.3,380.1 704.2,380.3 760.0,380.5" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,382.5 145.8,381.0 201.7,377.9 257.5,374.7 313.3,364.5 369.2,344.8 425.0,304.6 480.8,232.1 536.7,133.6 592.5,85.7 648.3,63.3 704.2,46.9 760.0,40.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="381.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="377.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="374.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="364.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="344.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="304.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="232.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="133.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="85.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="63.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="46.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="40.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.4 145.8,382.7 201.7,381.3 257.5,378.8 313.3,373.7 369.2,364.0 425.0,346.0 480.8,324.2 536.7,266.3 592.5,201.6 648.3,131.3 704.2,91.4 760.0,55.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="381.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="378.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="378.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="373.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="364.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="345.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="314.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="265.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="206.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="151.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="107.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="76.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.2 145.8,382.4 201.7,380.8 257.5,378.5 313.3,375.0 369.2,368.2 425.0,351.2 480.8,333.1 536.7,313.4 592.5,300.0 648.3,293.8 704.2,287.6 760.0,231.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="369.2" cy="364.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="346.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="324.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="266.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="131.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="91.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="55.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.2 145.8,382.4 201.7,380.8 257.5,378.4 313.3,375.1 369.2,368.2 425.0,350.9 480.8,335.2 536.7,314.4 592.5,301.5 648.3,243.1 704.2,289.7 760.0,227.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="380.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="378.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="375.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="378.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="375.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="368.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="351.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="333.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="313.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="300.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="293.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="287.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="231.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.7 313.3,383.5 369.2,382.9 425.0,381.8 480.8,379.8 536.7,375.7 592.5,367.9 648.3,352.7 704.2,323.1 760.0,272.9" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="425.0" cy="350.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="335.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="314.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="301.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="243.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="289.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="227.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.7 313.3,383.4 369.2,382.9 425.0,381.8 480.8,379.6 536.7,375.6 592.5,366.9 648.3,351.8 704.2,323.3 760.0,269.6" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="384.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="383.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="383.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="383.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="382.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="425.0" cy="381.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="379.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="375.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="367.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="352.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="323.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="272.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="379.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="375.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="366.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="351.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="323.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="269.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -153,62 +153,62 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,537.6 145.8,537.5 201.7,536.8 257.5,535.8 313.3,536.0 369.2,536.7 425.0,536.2 480.8,536.2 536.7,535.0 592.5,533.8 648.3,531.2 704.2,528.0 760.0,521.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="537.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="537.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="536.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="535.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="536.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="536.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="536.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="536.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="535.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="533.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="531.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="528.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="521.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,516.1 145.8,516.2 201.7,516.5 257.5,515.7 313.3,516.1 369.2,515.3 425.0,515.3 480.8,514.1 536.7,513.5 592.5,512.6 648.3,511.2 704.2,507.6 760.0,499.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="516.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="516.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="515.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="516.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="514.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="513.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="512.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="511.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="507.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="499.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,527.6 145.8,526.5 201.7,527.1 257.5,526.0 313.3,527.5 369.2,525.6 425.0,525.4 480.8,524.9 536.7,522.6 592.5,522.7 648.3,509.5 704.2,509.3 760.0,500.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="526.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="527.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="526.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="527.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="525.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="525.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="524.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="522.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="522.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="509.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="509.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="500.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,488.7 145.8,489.6 201.7,487.7 257.5,489.2 313.3,487.6 369.2,490.2 425.0,487.9 480.8,487.9 536.7,486.1 592.5,479.3 648.3,455.2 704.2,452.2 760.0,443.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="488.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="489.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="487.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="489.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="487.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="490.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="487.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="487.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="486.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="479.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="455.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="452.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="443.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,544.8 145.8,546.2 201.7,545.7 257.5,545.5 313.3,545.7 369.2,546.0 425.0,544.4 480.8,546.1 536.7,544.0 592.5,543.2 648.3,542.5 704.2,536.7 760.0,526.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="544.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="546.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="545.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="545.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="545.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="546.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="544.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="546.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="544.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="543.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="542.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="536.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="526.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,517.2 145.8,516.3 201.7,517.0 257.5,516.8 313.3,516.7 369.2,516.7 425.0,516.2 480.8,516.4 536.7,514.6 592.5,515.3 648.3,513.4 704.2,508.6 760.0,501.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="517.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="516.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="517.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="516.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="516.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="516.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="516.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="514.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="513.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="508.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="501.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,528.9 145.8,528.3 201.7,527.7 257.5,525.1 313.3,526.8 369.2,526.4 425.0,527.5 480.8,526.3 536.7,525.4 592.5,524.3 648.3,511.0 704.2,508.8 760.0,501.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="528.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="528.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="527.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="525.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="526.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="526.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="527.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="526.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="525.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="524.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="508.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="501.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,488.5 145.8,489.3 201.7,488.7 257.5,487.4 313.3,487.9 369.2,488.3 425.0,488.7 480.8,488.0 536.7,485.6 592.5,482.6 648.3,452.5 704.2,450.5 760.0,444.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="488.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="489.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="488.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="487.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="487.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="488.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="488.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="488.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="485.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="482.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="452.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="450.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="444.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -690,7 +690,7 @@ sys.stdout.flush(); os._exit(0)
 
 
 BENCH_PROXY_CLIENT = os.path.join(
-    os.path.dirname(__file__), "..", "..", "..", "target", "release",
+    os.path.dirname(__file__), "..", "target", "release",
     "bench_proxy_client",
 )
 

--- a/bindings/pyomq/src/dispatch.rs
+++ b/bindings/pyomq/src/dispatch.rs
@@ -24,6 +24,26 @@ where
     py.detach(|| ctx.with_socket(&sock, op)).map_err(map_err)
 }
 
+pub(crate) fn blocking_unit<F>(inner: &Arc<SocketInner>, py: Python<'_>, op: F) -> PyResult<()>
+where
+    F: FnOnce(omq_tokio::blocking::Socket) -> Result<(), PError> + Send + 'static,
+{
+    let sock = inner.ensure_blocking_socket()?;
+    py.detach(|| op(sock)).map_err(map_err)
+}
+
+pub(crate) fn blocking_string<F>(
+    inner: &Arc<SocketInner>,
+    py: Python<'_>,
+    op: F,
+) -> PyResult<String>
+where
+    F: FnOnce(omq_tokio::blocking::Socket) -> Result<String, PError> + Send + 'static,
+{
+    let sock = inner.ensure_blocking_socket()?;
+    py.detach(|| op(sock)).map_err(map_err)
+}
+
 /// Like `sync_unit` but returns a `String`.
 pub(crate) fn sync_string<F, Fut>(
     inner: &Arc<SocketInner>,

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -91,12 +91,12 @@ fn native_proxy(
 ) -> PyResult<()> {
     let fe = frontend.borrow().inner.clone();
     let be = backend.borrow().inner.clone();
-    fe.ensure_id()?;
-    be.ensure_id()?;
+    fe.ensure_blocking_id()?;
+    be.ensure_blocking_id()?;
     let cap = match capture {
         Some(c) => {
             let inner = c.borrow().inner.clone();
-            inner.ensure_id()?;
+            inner.ensure_blocking_id()?;
             Some(inner)
         }
         None => None,
@@ -104,13 +104,23 @@ fn native_proxy(
     let ctrl = match control {
         Some(c) => {
             let inner = c.borrow().inner.clone();
-            inner.ensure_id()?;
+            inner.ensure_blocking_id()?;
             Some(inner)
         }
         None => None,
     };
+    let fe_sock = fe.ensure_blocking_socket()?;
+    let be_sock = be.ensure_blocking_socket()?;
+    let cap_sock = cap
+        .as_ref()
+        .map(|inner| inner.ensure_blocking_socket())
+        .transpose()?;
+    let ctrl_sock = ctrl
+        .as_ref()
+        .map(|inner| inner.ensure_blocking_socket())
+        .transpose()?;
     let ctx = fe.ctx.clone();
-    py.detach(|| runtime::proxy(&ctx, fe, be, cap, ctrl));
+    py.detach(|| runtime::proxy_handles(&ctx, fe_sock, be_sock, cap_sock, ctrl_sock));
     Ok(())
 }
 

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -292,8 +292,18 @@ pub fn setsockopt(
         constants::SUBSCRIBE => {
             let v: &[u8] = value.extract()?;
             let bytes = Bytes::copy_from_slice(v);
-            let ctx = sock.ctx.clone();
+            sock.subscriptions.lock().unwrap().push(bytes.clone());
             drop(ov);
+            if let Some(s) = sock
+                .blocking_materialized
+                .read()
+                .unwrap()
+                .as_ref()
+                .map(|m| m.socket.clone())
+            {
+                return py.detach(|| s.subscribe(bytes)).map_err(map_err);
+            }
+            let ctx = sock.ctx.clone();
             let s = sock.ensure_socket()?;
             let r =
                 py.detach(|| ctx.with_socket(&s, move |s| async move { s.subscribe(bytes).await }));
@@ -302,8 +312,18 @@ pub fn setsockopt(
         constants::UNSUBSCRIBE => {
             let v: &[u8] = value.extract()?;
             let bytes = Bytes::copy_from_slice(v);
-            let ctx = sock.ctx.clone();
+            sock.subscriptions.lock().unwrap().retain(|p| p != &bytes);
             drop(ov);
+            if let Some(s) = sock
+                .blocking_materialized
+                .read()
+                .unwrap()
+                .as_ref()
+                .map(|m| m.socket.clone())
+            {
+                return py.detach(|| s.unsubscribe(bytes)).map_err(map_err);
+            }
+            let ctx = sock.ctx.clone();
             let s = sock.ensure_socket()?;
             let r = py
                 .detach(|| ctx.with_socket(&s, move |s| async move { s.unsubscribe(bytes).await }));

--- a/bindings/pyomq/src/peer_info.rs
+++ b/bindings/pyomq/src/peer_info.rs
@@ -24,5 +24,4 @@ impl PeerInfo {
             public_key: PyBytes::new(py, z85.as_bytes()).unbind(),
         }
     }
-
 }

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -1,7 +1,8 @@
 //! Per-context tokio runtime on a dedicated background thread.
 //!
-//! Each `ContextInner` owns one tokio runtime + background thread.
-//! `term()` shuts down that runtime (aborts all pumps, drops the handle).
+//! Each `ContextInner` owns an `omq_tokio::Context` which manages
+//! the tokio runtime and background thread. `term()` shuts it down
+//! (aborts all pumps, drops the handle).
 //!
 //! omq-tokio::Socket is Send + Sync, so Python-side wrappers hold an
 //! Arc<Socket> directly in SocketInner. However, the socket's internal
@@ -10,29 +11,25 @@
 //! progress. Python threads have no tokio runtime context, so they
 //! cannot call socket.send()/recv() directly.
 //!
-//! The yring SPSC relay bridges the two worlds: Python does a fast
-//! lock-free ring push/pop (no syscall, no async context needed), and
-//! pump tasks on the tokio thread relay between the rings and the
-//! actual socket.send()/recv().await calls.
+//! Asyncio sockets use a yring relay. Synchronous sockets use the
+//! blocking API from `omq_tokio`, which owns its receive pipe and IO
+//! thread directly.
 
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::Duration;
 
+use bytes::Bytes;
 use futures::FutureExt;
 use omq_tokio::Socket as InnerSocket;
 use pyo3::prelude::*;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
-type Job = Box<dyn FnOnce() + Send + 'static>;
-
 struct RuntimeState {
     pid: u32,
-    handle: Handle,
-    submit: flume::Sender<Job>,
+    ctx: omq_tokio::Context,
 }
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -75,7 +72,7 @@ impl ContextInner {
         })
     }
 
-    fn ensure_runtime(&self) -> PyResult<(Handle, flume::Sender<Job>)> {
+    fn ensure_runtime(&self) -> PyResult<Handle> {
         if self.terminated.load(Ordering::Acquire) {
             return Err(crate::error::map_err(omq_proto::error::Error::Closed));
         }
@@ -84,49 +81,48 @@ impl ContextInner {
         if let Some(rt) = guard.as_ref()
             && rt.pid == pid
         {
-            return Ok((rt.handle.clone(), rt.submit.clone()));
+            return Ok(rt.ctx.handle().clone());
         }
-        let (tx, rx) = flume::unbounded::<Job>();
-        let (handle_tx, handle_rx) = flume::bounded::<Handle>(1);
-        let n = self.io_threads;
-        thread::Builder::new()
-            .name("pyomq-tokio".into())
-            .spawn(move || {
-                let rt = if n <= 1 {
-                    tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .expect("pyomq: tokio runtime build")
-                } else {
-                    tokio::runtime::Builder::new_multi_thread()
-                        .worker_threads(n)
-                        .enable_all()
-                        .build()
-                        .expect("pyomq: tokio runtime build")
-                };
-                let _ = handle_tx.send(rt.handle().clone());
-                rt.block_on(async move {
-                    while let Ok(job) = rx.recv_async().await {
-                        job();
-                    }
-                });
-            })
-            .expect("pyomq: spawn tokio thread");
-        let handle = handle_rx.recv().expect("pyomq: runtime handle");
-        *guard = Some(RuntimeState {
-            pid,
-            handle: handle.clone(),
-            submit: tx.clone(),
+        let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig {
+            io_threads: self.io_threads,
         });
-        Ok((handle, tx))
+        let handle = ctx.handle().clone();
+        if let Some(stale) = guard.take() {
+            // In a forked child the inherited runtime threads no longer
+            // exist. Do not drop the context and try to join them.
+            std::mem::forget(stale);
+        }
+        *guard = Some(RuntimeState { pid, ctx });
+        Ok(handle)
     }
 
     pub fn runtime_handle(&self) -> PyResult<Handle> {
-        Ok(self.ensure_runtime()?.0)
+        self.ensure_runtime()
     }
 
-    fn submit_tx(&self) -> PyResult<flume::Sender<Job>> {
-        Ok(self.ensure_runtime()?.1)
+    /// Build a socket using omq-tokio's native blocking adapter.
+    pub fn materialize_blocking(
+        &self,
+        socket_type: omq_tokio::SocketType,
+        options: omq_tokio::Options,
+    ) -> PyResult<(u64, omq_tokio::blocking::Socket)> {
+        let handle = self.ensure_runtime()?;
+        let ctx = self
+            .state
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("runtime initialized")
+            .ctx
+            .clone();
+        let (otx, orx) = flume::bounded(1);
+        handle.spawn(async move {
+            let id = next_id();
+            let _ = otx.send((id, ctx.blocking_socket(socket_type, options)));
+        });
+        Ok(Python::attach(|py| {
+            py.detach(|| orx.recv().expect("pyomq: runtime dropped result"))
+        }))
     }
 
     /// Spawn a Send future on the tokio runtime and block until it completes.
@@ -157,9 +153,10 @@ impl ContextInner {
         send_notify: Arc<crate::socket::RecvNotify>,
         recv_space: Arc<tokio::sync::Notify>,
     ) -> PyResult<(u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>)> {
+        let handle = self.ensure_runtime()?;
         let (otx, orx) = flume::bounded(1);
         let grr = global_recv_ready();
-        let job: Job = Box::new(move || {
+        handle.spawn(async move {
             let id = next_id();
             let sock = Arc::new(InnerSocket::new(socket_type, options));
 
@@ -217,9 +214,6 @@ impl ContextInner {
 
             let _ = otx.send((id, sock, send_pump, recv_pump));
         });
-        self.submit_tx()?
-            .send(job)
-            .expect("pyomq: tokio runtime gone");
         Ok(Python::attach(|py| {
             py.detach(|| orx.recv().expect("pyomq: runtime dropped result"))
         }))
@@ -264,15 +258,14 @@ impl ContextInner {
         self.spawn_blocking(op(s))
     }
 
-    /// Shut down this context's runtime. Drops the job channel, which
-    /// causes the background thread to exit (runtime drops, tasks abort).
-    /// The thread is detached, not joined, to avoid blocking.
+    /// Shut down this context's runtime. Delegates to
+    /// `omq_tokio::Context::term()` which cancels the runtime's
+    /// shutdown token and joins the background thread.
     pub fn term(&self) {
         self.terminated.store(true, Ordering::Release);
         let state = self.state.lock().unwrap().take();
         if let Some(s) = state {
-            drop(s.submit);
-            drop(s.handle);
+            s.ctx.term();
         }
     }
 
@@ -320,11 +313,12 @@ impl ContextInner {
 impl Drop for ContextInner {
     fn drop(&mut self) {
         if let Some(s) = self.state.get_mut().unwrap().take() {
-            drop(s.submit);
+            s.ctx.term();
         }
     }
 }
 
+#[allow(dead_code)]
 fn drain_recv_ring(inner: &Arc<crate::socket::SocketInner>) -> Vec<omq_tokio::Message> {
     let mat = inner.materialized.read().unwrap();
     let Some(m) = mat.as_ref() else { return vec![] };
@@ -339,6 +333,7 @@ fn drain_recv_ring(inner: &Arc<crate::socket::SocketInner>) -> Vec<omq_tokio::Me
     msgs
 }
 
+#[allow(dead_code)]
 fn push_to_capture(cap: &Arc<crate::socket::SocketInner>, msg: &omq_tokio::Message) {
     let copy = omq_tokio::Message::multipart(msg.iter());
     let mat = cap.materialized.read().unwrap();
@@ -349,6 +344,7 @@ fn push_to_capture(cap: &Arc<crate::socket::SocketInner>, msg: &omq_tokio::Messa
 }
 
 /// Run a forwarding proxy between two sockets on the tokio thread.
+#[allow(dead_code)]
 pub fn proxy(
     ctx: &Arc<ContextInner>,
     fe_inner: Arc<crate::socket::SocketInner>,
@@ -403,8 +399,153 @@ pub fn proxy(
     });
 }
 
+/// Forward messages using the native blocking sockets. The synchronous
+/// Python proxy runs in its caller's thread, so this loop may block there.
+#[allow(dead_code)]
+pub fn blocking_proxy(
+    fe_inner: Arc<crate::socket::SocketInner>,
+    be_inner: Arc<crate::socket::SocketInner>,
+    cap_inner: Option<Arc<crate::socket::SocketInner>>,
+    ctrl_inner: Option<Arc<crate::socket::SocketInner>>,
+) {
+    let Ok(fe) = fe_inner.ensure_blocking_socket() else {
+        return;
+    };
+    let Ok(be) = be_inner.ensure_blocking_socket() else {
+        return;
+    };
+    let cap = cap_inner
+        .as_ref()
+        .and_then(|inner| inner.ensure_blocking_socket().ok());
+    let ctrl = ctrl_inner
+        .as_ref()
+        .and_then(|inner| inner.ensure_blocking_socket().ok());
+
+    let (tx, rx) = flume::unbounded();
+    for (side, socket) in [(0_u8, fe.clone()), (1, be.clone())] {
+        let tx = tx.clone();
+        std::thread::spawn(move || {
+            while let Ok(msg) = socket.recv() {
+                if tx.send((side, msg)).is_err() {
+                    break;
+                }
+            }
+        });
+    }
+    if let Some(socket) = ctrl.clone() {
+        let tx = tx.clone();
+        std::thread::spawn(move || {
+            while let Ok(msg) = socket.recv() {
+                if tx.send((2, msg)).is_err() {
+                    break;
+                }
+            }
+        });
+    }
+    drop(tx);
+
+    while let Ok((side, msg)) = rx.recv() {
+        if side == 2 {
+            let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
+            match command.as_slice() {
+                b"TERMINATE" | b"KILL" => return,
+                b"PAUSE" => loop {
+                    let Ok((_, msg)) = rx.recv() else { return };
+                    let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
+                    if command == b"RESUME" {
+                        break;
+                    }
+                    if command == b"TERMINATE" || command == b"KILL" {
+                        return;
+                    }
+                },
+                _ => {}
+            }
+        } else if side == 0 {
+            if let Some(capture) = &cap {
+                let _ = capture.send(msg.clone());
+            }
+            if be.send(msg).is_err() {
+                return;
+            }
+        } else {
+            if let Some(capture) = &cap {
+                let _ = capture.send(msg.clone());
+            }
+            if fe.send(msg).is_err() {
+                return;
+            }
+        }
+    }
+}
+
+pub fn proxy_handles(
+    ctx: &Arc<ContextInner>,
+    fe: omq_tokio::blocking::Socket,
+    be: omq_tokio::blocking::Socket,
+    cap: Option<omq_tokio::blocking::Socket>,
+    ctrl: Option<omq_tokio::blocking::Socket>,
+) {
+    let fe = Arc::new(fe.into_async());
+    let be = Arc::new(be.into_async());
+    let cap = cap.map(|s| Arc::new(s.into_async()));
+    let ctrl = ctrl.map(|s| Arc::new(s.into_async()));
+    ctx.spawn_blocking(async move {
+        let mut route_id: Option<Bytes> = None;
+        loop {
+            tokio::select! {
+                biased;
+                command = async {
+                    let Some(ctrl) = &ctrl else { futures::future::pending().await };
+                    ctrl.recv().await
+                } => {
+                    let Ok(msg) = command else { return; };
+                    let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
+                    match command.as_slice() {
+                        b"TERMINATE" | b"KILL" => return,
+                        b"PAUSE" => loop {
+                            let Some(ctrl) = &ctrl else { return; };
+                            let Ok(msg) = ctrl.recv().await else { return; };
+                            let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
+                            if command == b"RESUME" { break; }
+                            if command == b"TERMINATE" || command == b"KILL" { return; }
+                        },
+                        _ => {}
+                    }
+                }
+                msg = fe.recv() => {
+                    let Ok(msg) = msg else { return; };
+                    let parts: Vec<Bytes> = msg.iter().collect();
+                    let msg = if parts.len() >= 3 && parts[1].is_empty() {
+                        route_id = Some(parts[0].clone());
+                        omq_tokio::Message::multipart(parts[2..].to_vec())
+                    } else { msg };
+                    if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
+                    if be.send(msg).await.is_err() { return; }
+                }
+                msg = be.recv() => {
+                    let Ok(msg) = msg else { return; };
+                    let msg = if let Some(id) = &route_id {
+                        let mut parts: Vec<Bytes> = msg.iter().collect();
+                        if parts.first().is_some_and(Bytes::is_empty) {
+                            parts.remove(0);
+                        }
+                        let mut routed = vec![id.clone(), Bytes::new()];
+                        routed.extend(parts);
+                        omq_tokio::Message::multipart(routed)
+                    } else { msg };
+                    if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
+                    if fe.send(msg).await.is_err() { return; }
+                }
+            }
+        }
+    });
+}
+
+#[allow(dead_code)]
 const PROXY_BATCH: usize = 64;
 
+#[allow(dead_code)]
 async fn proxy_drain_and_forward(
     from: &Arc<InnerSocket>,
     to: &Arc<InnerSocket>,
@@ -429,6 +570,7 @@ async fn proxy_drain_and_forward(
     true
 }
 
+#[allow(dead_code)]
 async fn proxy_loop(
     fe: &Arc<InnerSocket>,
     be: &Arc<InnerSocket>,
@@ -526,12 +668,25 @@ pub fn wait_any(
                 if !inner.rxbuf.lock().unwrap().is_empty() {
                     return true;
                 }
+                if !inner.rxmsgs.lock().unwrap().is_empty() {
+                    return true;
+                }
                 let mat = inner.materialized.read().unwrap();
                 if let Some(m) = mat.as_ref() {
                     let cons = m.recv_cons.lock().unwrap();
                     !cons.is_empty()
                 } else {
-                    false
+                    drop(mat);
+                    let Ok(sock) = inner.ensure_blocking_socket() else {
+                        return false;
+                    };
+                    match sock.try_recv() {
+                        Ok(msg) => {
+                            inner.rxmsgs.lock().unwrap().push(msg);
+                            true
+                        }
+                        Err(_) => false,
+                    }
                 }
             })
             .map(|(id, _)| *id)
@@ -566,7 +721,10 @@ pub fn wait_any(
             None => Duration::from_millis(100),
         };
 
-        rr.wait_timeout(wait_dur);
+        // Native blocking sockets have thread wakeups, not an eventfd.
+        // Poll their try-recv path periodically while retaining the
+        // eventfd fast path for asyncio sockets.
+        rr.wait_timeout(wait_dur.min(Duration::from_millis(10)));
 
         let ready = poll_ready(&sockets);
         if !ready.is_empty() {

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -1,12 +1,8 @@
 //! Sync `Socket` Python class and the shared inner state used by both
 //! the sync and async wrappers.
 //!
-//! Hot path is queue-relayed: every `send` / `recv` goes through a
-//! per-socket yring SPSC ring buffer. Two pump tasks on the tokio
-//! thread bridge the rings to the actual `omq_tokio::Socket`'s async
-//! send/recv. The fast path (ring not full / not empty) does NOT call
-//! `Python::allow_threads`. The slow path (Full / Empty) releases the
-//! GIL and parks via spin+condvar.
+//! The synchronous wrapper uses `omq_tokio::blocking::Socket` directly.
+//! The asyncio wrapper retains its yring relay and eventfd adapter.
 
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -14,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use omq_proto::TrySendError;
 use omq_proto::error::Error as PError;
 use omq_tokio::MonitorEvent;
 use pyo3::prelude::*;
@@ -133,15 +130,24 @@ impl Drop for RecvNotify {
 use std::sync::atomic::AtomicU32;
 
 static FORK_GEN: AtomicU32 = AtomicU32::new(0);
+static PARENT_FORK_GEN: AtomicU32 = AtomicU32::new(0);
+static FORKED: AtomicBool = AtomicBool::new(false);
 static ATFORK_REGISTERED: std::sync::Once = std::sync::Once::new();
 
 extern "C" fn atfork_child() {
+    FORKED.store(true, Ordering::Relaxed);
     FORK_GEN.fetch_add(1, Ordering::Relaxed);
+}
+
+extern "C" fn atfork_parent() {
+    // The parent's runtime remains valid, but sockets materialized before
+    // fork need one safe receive to resynchronize with child-side peers.
+    PARENT_FORK_GEN.fetch_add(1, Ordering::Relaxed);
 }
 
 pub(crate) fn register_atfork() {
     ATFORK_REGISTERED.call_once(|| unsafe {
-        libc::pthread_atfork(None, None, Some(atfork_child));
+        libc::pthread_atfork(Some(atfork_parent), None, Some(atfork_child));
     });
 }
 
@@ -160,6 +166,12 @@ pub(crate) struct Materialized {
     pub recv_pump: JoinHandle<()>,
 }
 
+pub(crate) struct BlockingMaterialized {
+    pub id: u64,
+    fork_gen: u32,
+    pub socket: omq_tokio::blocking::Socket,
+}
+
 /// Shared state for sync (`Socket`) and async (`AsyncSocket`) wrappers.
 /// Both pyclasses hold an `Arc<SocketInner>` and route I/O through the
 /// helpers below.
@@ -167,9 +179,16 @@ pub(crate) struct SocketInner {
     pub ctx: Arc<ContextInner>,
     pub socket_type: omq_tokio::SocketType,
     pub overlay: Mutex<options::Overlay>,
+    pub subscriptions: Mutex<Vec<Bytes>>,
+    pub endpoints: Mutex<Vec<(omq_tokio::Endpoint, bool)>>,
+    has_tcp_endpoint: AtomicBool,
+    parent_fork_gen: AtomicU32,
+    post_fork: AtomicBool,
     pub sndbuf: Mutex<SendBuffer>,
     pub rxbuf: Mutex<Vec<Bytes>>,
+    pub rxmsgs: Mutex<Vec<omq_tokio::Message>>,
     pub materialized: std::sync::RwLock<Option<Materialized>>,
+    pub blocking_materialized: std::sync::RwLock<Option<BlockingMaterialized>>,
     closed: AtomicBool,
 }
 
@@ -181,9 +200,16 @@ impl SocketInner {
             ctx,
             socket_type,
             overlay: Mutex::new(overlay),
+            subscriptions: Mutex::new(Vec::new()),
+            endpoints: Mutex::new(Vec::new()),
+            has_tcp_endpoint: AtomicBool::new(false),
+            parent_fork_gen: AtomicU32::new(PARENT_FORK_GEN.load(Ordering::Relaxed)),
+            post_fork: AtomicBool::new(FORKED.load(Ordering::Relaxed)),
             sndbuf: Mutex::new(SendBuffer::default()),
             rxbuf: Mutex::new(Vec::new()),
+            rxmsgs: Mutex::new(Vec::new()),
             materialized: std::sync::RwLock::new(None),
+            blocking_materialized: std::sync::RwLock::new(None),
             closed: AtomicBool::new(false),
         })
     }
@@ -246,8 +272,77 @@ impl SocketInner {
     }
 
     pub fn ensure_id(&self) -> PyResult<u64> {
+        let fgen = FORK_GEN.load(Ordering::Relaxed);
+        if let Some(m) = self.blocking_materialized.read().unwrap().as_ref()
+            && m.fork_gen == fgen
+        {
+            return Ok(m.id);
+        }
         self.materialize()?;
         Ok(self.materialized.read().unwrap().as_ref().unwrap().id)
+    }
+
+    pub fn materialize_blocking(&self) -> PyResult<()> {
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(map_err(omq_proto::error::Error::Closed));
+        }
+        let fgen = FORK_GEN.load(Ordering::Relaxed);
+        if self
+            .blocking_materialized
+            .read()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|m| m.fork_gen == fgen)
+        {
+            return Ok(());
+        }
+        let mut slot = self.blocking_materialized.write().unwrap();
+        if slot.as_ref().is_some_and(|m| m.fork_gen == fgen) {
+            return Ok(());
+        }
+        // The inherited blocking socket owns the parent's runtime. Dropping
+        // it after fork would try to join threads that do not exist here.
+        if let Some(stale) = slot.take() {
+            std::mem::forget(stale);
+        }
+        let opts = self.overlay.lock().unwrap().to_options()?;
+        let (id, socket) = self.ctx.materialize_blocking(self.socket_type, opts)?;
+        for (endpoint, is_bind) in self.endpoints.lock().unwrap().clone() {
+            if is_bind {
+                socket.bind(endpoint).map_err(map_err)?;
+            } else {
+                socket.connect(endpoint).map_err(map_err)?;
+            }
+        }
+        *slot = Some(BlockingMaterialized {
+            id,
+            fork_gen: fgen,
+            socket,
+        });
+        Ok(())
+    }
+
+    pub fn ensure_blocking_socket(&self) -> PyResult<omq_tokio::blocking::Socket> {
+        self.materialize_blocking()?;
+        Ok(self
+            .blocking_materialized
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .socket
+            .clone())
+    }
+
+    pub fn ensure_blocking_id(&self) -> PyResult<u64> {
+        self.materialize_blocking()?;
+        Ok(self
+            .blocking_materialized
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .id)
     }
 
     /// Return the Arc<Socket> after materializing. Used by dispatch.
@@ -310,6 +405,11 @@ impl SocketInner {
             m.recv_notify.force_wake();
         }
         mat
+    }
+
+    pub fn take_blocking_materialized(&self) -> Option<BlockingMaterialized> {
+        self.closed.store(true, Ordering::Relaxed);
+        self.blocking_materialized.write().unwrap().take()
     }
 }
 
@@ -498,29 +598,55 @@ impl Socket {
 #[pymethods]
 impl Socket {
     fn socket_id(&self) -> PyResult<u64> {
-        self.inner.ensure_id()
+        self.inner.ensure_blocking_id()
     }
 
     fn bind(&self, py: Python<'_>, endpoint: &str) -> PyResult<String> {
         let ep = SocketInner::parse_endpoint(endpoint)?;
-        dispatch::sync_string(&self.inner, py, |s| async move {
-            s.bind(ep).await.map(|bound| bound.to_string())
-        })
+        let bound = dispatch::blocking_string(&self.inner, py, move |s| {
+            let bound = s.bind(ep.clone())?;
+            Ok(bound.to_string())
+        })?;
+        if let Ok(endpoint) = SocketInner::parse_endpoint(&bound) {
+            if endpoint.to_string().starts_with("tcp://") {
+                self.inner.has_tcp_endpoint.store(true, Ordering::Release);
+            }
+            self.inner.endpoints.lock().unwrap().push((endpoint, true));
+        }
+        Ok(bound)
     }
 
     fn connect(&self, py: Python<'_>, endpoint: &str) -> PyResult<()> {
         let ep = SocketInner::parse_endpoint(endpoint)?;
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.connect(ep).await })
+        let subscriptions = self.inner.subscriptions.lock().unwrap().clone();
+        let recorded_ep = ep.clone();
+        dispatch::blocking_unit(&self.inner, py, move |s| {
+            s.connect(ep)?;
+            for prefix in subscriptions {
+                s.subscribe(prefix)?;
+            }
+            Ok(())
+        })?;
+        let is_tcp = recorded_ep.to_string().starts_with("tcp://");
+        self.inner
+            .endpoints
+            .lock()
+            .unwrap()
+            .push((recorded_ep, false));
+        if is_tcp {
+            self.inner.has_tcp_endpoint.store(true, Ordering::Release);
+        }
+        Ok(())
     }
 
     fn unbind(&self, py: Python<'_>, endpoint: &str) -> PyResult<()> {
         let ep = SocketInner::parse_endpoint(endpoint)?;
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.unbind(ep).await })
+        dispatch::blocking_unit(&self.inner, py, move |s| s.unbind(ep))
     }
 
     fn disconnect(&self, py: Python<'_>, endpoint: &str) -> PyResult<()> {
         let ep = SocketInner::parse_endpoint(endpoint)?;
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.disconnect(ep).await })
+        dispatch::blocking_unit(&self.inner, py, move |s| s.disconnect(ep))
     }
 
     #[pyo3(signature = (payload, flags = 0))]
@@ -577,37 +703,31 @@ impl Socket {
 
     fn subscribe(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<()> {
         let bytes = Bytes::copy_from_slice(prefix.extract::<&[u8]>()?);
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.subscribe(bytes).await })
+        dispatch::blocking_unit(&self.inner, py, move |s| s.subscribe(bytes))
     }
 
     fn unsubscribe(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<()> {
         let bytes = Bytes::copy_from_slice(prefix.extract::<&[u8]>()?);
-        dispatch::sync_unit(
-            &self.inner,
-            py,
-            |s| async move { s.unsubscribe(bytes).await },
-        )
+        dispatch::blocking_unit(&self.inner, py, move |s| s.unsubscribe(bytes))
     }
 
     fn join(&self, py: Python<'_>, group: &Bound<'_, PyAny>) -> PyResult<()> {
         let bytes = Bytes::copy_from_slice(group.extract::<&[u8]>()?);
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.join(bytes).await })
+        dispatch::blocking_unit(&self.inner, py, move |s| s.join(bytes))
     }
 
     fn leave(&self, py: Python<'_>, group: &Bound<'_, PyAny>) -> PyResult<()> {
         let bytes = Bytes::copy_from_slice(group.extract::<&[u8]>()?);
-        dispatch::sync_unit(&self.inner, py, |s| async move { s.leave(bytes).await })
+        dispatch::blocking_unit(&self.inner, py, move |s| s.leave(bytes))
     }
 
     /// Return a list of dicts describing every live peer connection.
     fn connections<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
-        let sock = self.inner.ensure_socket()?;
-        let ctx = self.inner.ctx.clone();
         let statuses: Vec<omq_tokio::ConnectionStatus> = py.detach(|| {
-            ctx.with_socket(&sock, |s| async move {
-                s.connections().await.unwrap_or_default()
-            })
-        });
+            self.inner
+                .ensure_blocking_socket()
+                .map(|s| s.connections().unwrap_or_default())
+        })?;
         // Temporary allocation to be able to propagate errors
         let temp = statuses
             .iter()
@@ -623,12 +743,11 @@ impl Socket {
         py: Python<'py>,
         connection_id: u64,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let sock = self.inner.ensure_socket()?;
-        let ctx = self.inner.ctx.clone();
         let status: Option<omq_tokio::ConnectionStatus> = py.detach(|| {
-            ctx.with_socket(&sock, move |s| async move {
-                s.connection_info(connection_id).await.ok().flatten()
-            })
+            self.inner
+                .ensure_blocking_socket()
+                .ok()
+                .and_then(|s| s.connection_info(connection_id).ok().flatten())
         });
         match status {
             Some(cs) => connection_status_to_dict(py, &cs).map(|d| d.into_any()),
@@ -638,10 +757,9 @@ impl Socket {
 
     /// Return a `Monitor` that delivers connection-lifecycle events for
     /// this socket. Multiple monitors can be active simultaneously.
-    fn monitor(&self, py: Python<'_>) -> PyResult<Monitor> {
-        let sock = self.inner.ensure_socket()?;
-        let ctx = self.inner.ctx.clone();
-        let stream = py.detach(|| ctx.with_socket(&sock, |s| async move { s.monitor() }));
+    fn monitor(&self, _py: Python<'_>) -> PyResult<Monitor> {
+        let sock = self.inner.ensure_blocking_socket()?;
+        let stream = sock.monitor();
         Ok(Monitor::from_stream(&self.inner.ctx, stream))
     }
 
@@ -658,17 +776,15 @@ impl Socket {
         crate::auth::set_curve_auth_impl(&self.inner, auth)
     }
 
-
     #[pyo3(signature = (_linger=None))]
     fn close(&self, py: Python<'_>, _linger: Option<i64>) -> PyResult<()> {
-        let m = self.inner.take_materialized();
-        let Some(m) = m else {
-            return Ok(());
-        };
-        let ctx = self.inner.ctx.clone();
-        py.detach(|| {
-            ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump);
-        });
+        if let Some(m) = self.inner.take_blocking_materialized() {
+            py.detach(|| m.socket.close()).map_err(map_err)?;
+        }
+        if let Some(m) = self.inner.take_materialized() {
+            let ctx = self.inner.ctx.clone();
+            py.detach(|| ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump));
+        }
         Ok(())
     }
 
@@ -692,107 +808,112 @@ impl Socket {
 
 impl Socket {
     fn send_message(&self, py: Python<'_>, msg: omq_tokio::Message) -> PyResult<()> {
-        self.inner.materialize()?;
-        let result = {
-            let mat_guard = self.inner.materialized.read().unwrap();
-            let mat = mat_guard.as_ref().unwrap();
-            let mut prod = mat.send_prod.lock().unwrap();
-            prod.push_and_flush(msg)
-        };
-        match result {
-            Ok(_) => Ok(()),
-            Err(mut msg) => {
-                let send_notify = {
-                    let mat_guard = self.inner.materialized.read().unwrap();
-                    mat_guard.as_ref().unwrap().send_notify.clone()
-                };
-                let timeout = self.inner.overlay.lock().unwrap().sndtimeo;
-                py.detach(|| {
-                    let deadline = timeout.map(|t| Instant::now() + t);
-                    send_notify.park_begin();
+        let sock = self.inner.ensure_blocking_socket()?;
+        let timeout = self.inner.overlay.lock().unwrap().sndtimeo;
+        let post_fork = self.inner.post_fork.swap(false, Ordering::AcqRel);
+        if post_fork {
+            let tcp = self.inner.has_tcp_endpoint.load(Ordering::Acquire);
+            py.detach(|| {
+                if tcp {
+                    let _ = sock.wait_connected(1, Duration::from_secs(1));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            });
+        }
+
+        match sock.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Closed) => Err(map_err(PError::Closed)),
+            Err(TrySendError::Error(e)) => Err(map_err(e)),
+            Err(TrySendError::Full(msg)) => py.detach(|| match timeout {
+                None => sock.send(msg).map_err(map_err),
+                Some(timeout) => {
+                    let deadline = Instant::now() + timeout;
+                    let mut msg = msg;
                     loop {
-                        let push_result = {
-                            let mat_guard = self.inner.materialized.read().unwrap();
-                            let mat = mat_guard.as_ref().ok_or_else(|| {
-                                send_notify.park_end();
-                                map_err(PError::Closed)
-                            })?;
-                            let mut prod = mat.send_prod.lock().unwrap();
-                            prod.push_and_flush(msg)
-                        };
-                        match push_result {
-                            Ok(_) => {
-                                send_notify.park_end();
-                                return Ok(());
-                            }
-                            Err(returned) => msg = returned,
+                        match sock.try_send(msg) {
+                            Ok(()) => return Ok(()),
+                            Err(TrySendError::Full(returned)) => msg = returned,
+                            Err(TrySendError::Closed) => return Err(map_err(PError::Closed)),
+                            Err(TrySendError::Error(e)) => return Err(map_err(e)),
                         }
-                        if deadline.is_some_and(|d| Instant::now() >= d) {
-                            send_notify.park_end();
+                        if Instant::now() >= deadline {
                             return Err(timeout_err());
                         }
-                        let wait_dur = deadline
-                            .map(|d| d.saturating_duration_since(Instant::now()))
-                            .unwrap_or(Duration::from_millis(100));
-                        send_notify.wait_timeout(wait_dur);
+                        std::thread::sleep(Duration::from_millis(1));
                     }
-                })
-            }
+                }
+            }),
         }
     }
 
     fn recv_message(&self, py: Python<'_>) -> PyResult<omq_tokio::Message> {
-        self.inner.materialize()?;
-        let (recv_notify, recv_space) = {
-            let mat_guard = self.inner.materialized.read().unwrap();
-            let mat = mat_guard.as_ref().unwrap();
-            let mut cons = mat.recv_cons.lock().unwrap();
-            if let Some(m) = cons.prefetch_and_pop() {
-                mat.recv_space.notify_one();
-                return Ok(m);
+        let cached = {
+            let mut msgs = self.inner.rxmsgs.lock().unwrap();
+            if msgs.is_empty() {
+                None
+            } else {
+                Some(msgs.remove(0))
             }
-            (mat.recv_notify.clone(), mat.recv_space.clone())
         };
+        if let Some(msg) = cached {
+            return Ok(msg);
+        }
+        let sock = self.inner.ensure_blocking_socket()?;
         let timeout = self.inner.overlay.lock().unwrap().rcvtimeo;
-        py.detach(|| {
-            let deadline = timeout.map(|t| Instant::now() + t);
-
-            recv_notify.park_begin();
-            {
-                let mat_guard = self.inner.materialized.read().unwrap();
-                let mat = mat_guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
-                let mut cons = mat.recv_cons.lock().unwrap();
-                if let Some(m) = cons.prefetch_and_pop() {
-                    recv_notify.park_end();
-                    recv_space.notify_one();
-                    return Ok(m);
+        let parent_fork = self.inner.parent_fork_gen.load(Ordering::Acquire)
+            != PARENT_FORK_GEN.load(Ordering::Acquire);
+        if parent_fork {
+            self.inner
+                .parent_fork_gen
+                .store(PARENT_FORK_GEN.load(Ordering::Acquire), Ordering::Release);
+        }
+        let post_fork_recv = self.inner.post_fork.load(Ordering::Acquire)
+            || FORKED.load(Ordering::Acquire)
+            || parent_fork;
+        let tcp = self.inner.has_tcp_endpoint.load(Ordering::Acquire);
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Pull) && post_fork_recv && tcp {
+            let wait = timeout.unwrap_or(Duration::from_secs(1));
+            let _ = sock.wait_connected(1, wait);
+            let _ = sock.connections();
+        }
+        // Probe the backend pipe while holding the GIL. This is safe for
+        // sockets with any mix of inproc, ipc, and tcp endpoints.
+        if !post_fork_recv {
+            match sock.try_recv() {
+                Ok(msg) => return Ok(msg),
+                Err(omq_proto::error::Error::Closed) => {
+                    return Err(map_err(omq_proto::error::Error::Closed));
                 }
+                Err(_) => {}
             }
-
-            loop {
-                let wait_dur = match deadline {
-                    Some(d) => {
-                        let now = Instant::now();
-                        if now >= d {
-                            recv_notify.park_end();
-                            return Err(timeout_err());
-                        }
-                        d - now
+        }
+        py.detach(|| match timeout {
+            None if !post_fork_recv => sock.recv().map_err(map_err),
+            None => loop {
+                match sock.try_recv() {
+                    Ok(msg) => {
+                        self.inner.post_fork.store(false, Ordering::Release);
+                        break Ok(msg);
                     }
-                    None => Duration::from_millis(100),
-                };
-                recv_notify.wait_timeout(wait_dur);
-                {
-                    let mat_guard = self.inner.materialized.read().unwrap();
-                    let mat = mat_guard.as_ref().ok_or_else(|| {
-                        recv_notify.park_end();
-                        map_err(PError::Closed)
-                    })?;
-                    let mut cons = mat.recv_cons.lock().unwrap();
-                    if let Some(m) = cons.prefetch_and_pop() {
-                        recv_notify.park_end();
-                        recv_space.notify_one();
-                        return Ok(m);
+                    Err(omq_proto::error::Error::Closed) => {
+                        break Err(map_err(omq_proto::error::Error::Closed));
+                    }
+                    Err(_) => std::thread::sleep(Duration::from_millis(1)),
+                }
+            },
+            Some(timeout) => {
+                let deadline = Instant::now() + timeout;
+                loop {
+                    match sock.try_recv() {
+                        Ok(msg) => return Ok(msg),
+                        Err(omq_proto::error::Error::Closed) => {
+                            return Err(map_err(omq_proto::error::Error::Closed));
+                        }
+                        Err(_) if Instant::now() < deadline => {
+                            std::thread::sleep(Duration::from_millis(1));
+                        }
+                        Err(_) => return Err(timeout_err()),
                     }
                 }
             }
@@ -800,12 +921,18 @@ impl Socket {
     }
 
     fn try_recv_message(&self) -> PyResult<omq_tokio::Message> {
-        self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard.as_ref().unwrap();
-        let mut cons = mat.recv_cons.lock().unwrap();
-        let msg = cons.prefetch_and_pop().ok_or_else(timeout_err)?;
-        mat.recv_space.notify_one();
-        Ok(msg)
+        let cached = {
+            let mut msgs = self.inner.rxmsgs.lock().unwrap();
+            if msgs.is_empty() {
+                None
+            } else {
+                Some(msgs.remove(0))
+            }
+        };
+        if let Some(msg) = cached {
+            return Ok(msg);
+        }
+        let sock = self.inner.ensure_blocking_socket()?;
+        sock.try_recv().map_err(map_err)
     }
 }

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -269,7 +269,6 @@ impl AsyncSocket {
         crate::auth::set_curve_auth_impl(&self.inner, auth)
     }
 
-
     // ── Lifecycle ───────────────────────────────────────────────────
 
     #[pyo3(signature = (_linger=None))]

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -14,6 +14,81 @@ omq-tokio backend: SocketDriver, ConnectionDriver, transports, routing
 omq-proto core: Connection, frames, mechanisms, messages, options
 ```
 
+## Context and runtime management
+
+`Context` owns one or more independent `current_thread` tokio runtimes,
+each on its own OS thread. Each runtime has its own IO reactor (epoll /
+kqueue), timer wheel, and task scheduler. There is no cross-thread work
+stealing and no shared scheduler lock. Connections pinned to a thread
+run with zero contention from connections on other threads.
+
+- `Context::new()`: one IO thread. Default.
+- `Context::with_config(cfg)`: N IO threads. Each IO thread is a
+  separate `current_thread` runtime on a dedicated OS thread.
+  Connections are distributed across threads by least-load assignment.
+  Fan-out sockets (`PUB`, `XPUB`, `RADIO`) create one shard worker
+  per IO thread for parallel subscription matching and encoding.
+- `Context::current()`: wraps the caller's active tokio runtime
+  (works with both `current_thread` and `multi_thread`). No background
+  threads, no IO pool. All connections share the caller's runtime.
+  Shard count is always 1. This mode is useful for embedding omq in an
+  existing async application, and for single-connection benchmarks
+  where a `multi_thread` runtime can push a single TCP pipe to its
+  limit. It does not scale fan-out across threads.
+
+`Context::socket()` creates sockets whose driver tasks run on the
+context's runtime. `Context::block_on()` runs a future on the owned
+runtime and blocks the caller (not available on `Context::current()`).
+
+## Blocking API (background IO)
+
+`Context::blocking_socket()` creates a sync socket for callers with no
+async runtime. The application thread never touches tokio. The Context's
+IO thread handles all network I/O, connection management, encoding, and
+decoding. The application thread communicates with the IO thread through
+lock-free queues.
+
+**Send path.** `blocking::Socket::send()` tries `try_send()` first,
+which pushes the message into the send pipe (yring) on the caller's
+thread with no cross-thread hop. Only when the pipe is full does it
+fall back to `Context::block_on()`.
+
+**Recv path.** `blocking::Socket::recv()` calls `blocking_recv()`,
+which drains the recv pipe directly on the caller's thread via
+`try_drain()`. If no data is available, the thread parks via
+`std::thread::park()`. The IO thread's connection driver unparks
+the caller (via `BlockingRecvWaker`) when new data arrives.
+
+**Performance tradeoffs.** The blocking API pipelines I/O and
+application work across two threads: the IO thread reads from TCP,
+decodes frames, and pushes into the recv pipe while the application
+thread independently drains it. The async 1T path serializes these
+on one thread (connection driver and user recv take turns). This
+pipelining gives the blocking API roughly 2x throughput at small
+message sizes (16-128 B). At 4+ KiB, wire bandwidth saturates and
+the extra thread stops helping.
+
+Latency is worse: each message crosses a thread boundary (yring push
+plus `unpark()`), adding roughly 30 us per hop. In throughput mode
+this cost is amortized across batches; in request/reply it is paid
+on every round trip (roughly 80 us vs 47 us p50 at 16 B).
+
+| metric | async 1T | bg 1T | why |
+|--------|----------|-------|-----|
+| small-msg throughput | 7M msg/s | 14M msg/s | parallel I/O + app |
+| small-msg CPU (push) | 100% | 200% | 2 threads both saturated |
+| large-msg throughput | 5.5 GB/s | 5.2 GB/s | wire-limited |
+| REQ/REP latency | 47 us | 80 us | cross-thread signaling |
+
+When N > 1, accepted or connected TCP/IPC streams migrate from the
+accepting thread's reactor to the assigned thread's reactor via
+`into_std()` / `from_std()` re-registration. This is necessary because
+each `current_thread` runtime owns its own epoll fd; a socket registered
+on one reactor cannot be polled from another.
+
+The `OMQ_IO_THREADS` environment variable sets the default IO thread
+count for `ContextConfig::from_env()`.
+
 ## Crates
 
 `omq-proto` is pure protocol code. It has no file descriptors and no async
@@ -93,8 +168,10 @@ then calls `rearm_if_nonempty` to self-wake if data remains. For
 budget-interrupted drains, `reschedule` fires unconditionally.
 
 CURVE keeps per-connection nonce state, so encrypted traffic uses
-per-connection ordered transforms. LZ4 fan-out may encode once at socket level
-when wire bytes are identical for all matched subscribers.
+per-connection ordered transforms. CURVE encrypts and decrypts in place
+(`SalsaBox::encrypt_in_place_detached` / `decrypt_in_place_detached`) with one
+allocation per message. LZ4 fan-out may encode once at socket level when wire
+bytes are identical for all matched subscribers.
 
 ## Routing
 
@@ -107,16 +184,22 @@ waits on a rotating peer and `try_send` reports HWM backpressure.
 it before newer pipe-fed sends, so messages queued before handshake are not
 overtaken.
 
-Fan-out sockets (`PUB`, `XPUB`, `RADIO`) encode once and distribute matching
-wire bytes. Wide multi-thread fan-out uses shard workers. Each shard has
-split channels: a `yring` control channel for subscribe, cancel, add-peer,
-remove-peer, and shutdown commands, and a `yring` data channel for encoded
-dispatches. The worker drains all control commands unconditionally every
-iteration, then drains data dispatches up to `DrainBudget::WORKER` (256
-messages / 2 MiB). This separation guarantees control commands are reachable
-within bounded time regardless of data throughput. Fan-out sockets drop on
-mute; `OnMute::Block` does not make `PUB` or `XPUB` wait. `xpub_nodrop`
-stays on the direct backpressure path.
+Fan-out sockets (`PUB`, `XPUB`, `RADIO`) use shard workers for parallel
+subscription matching and encoding. With N IO threads, N shard workers run,
+one per IO thread. The caller pushes each message once to shard 1 (the
+distributor). Shard 1 processes its own peers, then distributes the batch to
+secondary shards. This keeps the caller's send path to a single `yring` push
+regardless of shard count. Each shard has split channels: a `yring` control
+channel for subscribe, cancel, add-peer, remove-peer, and shutdown commands,
+and a `yring` data channel for encoded dispatches. The worker drains all
+control commands unconditionally every iteration, then drains data dispatches
+up to `DrainBudget::WORKER` (256 messages / 2 MiB). This separation
+guarantees control commands are reachable within bounded time regardless of
+data throughput. Fan-out sockets drop on mute; `OnMute::Block` does not make
+`PUB` or `XPUB` wait. `xpub_nodrop` stays on the direct backpressure path.
+
+With `Context::current()` (borrowed runtime), fan-out always uses a single
+shard regardless of the runtime's thread count.
 
 Identity-routed sockets (`ROUTER`, `REP`, `SERVER`, `PEER`) route by peer
 identity. Exclusive sockets (`PAIR`, `CHANNEL`) target one peer. Fair-queue

--- a/doc/omq-bench-plan.md
+++ b/doc/omq-bench-plan.md
@@ -1,0 +1,509 @@
+# omq-bench: Rust rewrite plan
+
+Replace all Python benchmark and chart scripts with a single Rust
+binary `omq-bench`. Two phases: bench runners first, chart generation
+second.
+
+## Design decisions
+
+- Hand-rolled SVG. No plotters or external chart crate. Pixel-level
+  control, minimal output, same visual language as today.
+- No more triple Y-axis. CPU% becomes a single averaged number shown
+  next to each series in the legend (e.g. "omq-tokio (1T) 98%").
+  Eliminates the left CPU% axis, the dashed CPU lines, and the
+  line-type legend row.
+- Non-main charts compare omq vs libzmq only. Main chart keeps all
+  impls (zmq.rs, rzmq).
+- Append-only JSONL cache in `~/.cache/omq/` (unchanged).
+- Single binary, subcommand CLI via clap.
+
+## 1. Crate structure
+
+```
+omq-bench/
+  Cargo.toml          # [[bin]] name = "omq-bench"
+  src/
+    main.rs           # clap dispatch
+    cli.rs            # Args / subcommand enums
+    hw.rs             # hardware label detection
+    jsonl.rs          # JSONL read/append, row types
+    process.rs        # subprocess spawn, lifetime guard, CPU reading
+    parse.rs          # throughput/latency/multi-socket output parsers
+    bench/
+      mod.rs
+      comparisons.rs  # replaces run_comparisons.py
+      mechanism.rs    # replaces bench_mechanism.py
+      pubsub_lz4.rs   # replaces bench_pubsub_lz4.py
+      compression.rs  # replaces bench_compression_tokio.py
+    chart/
+      mod.rs
+      svg.rs          # shared SVG primitives module
+      comparison.rs   # replaces gen_comparison_chart.py
+      main_tcp.rs     # replaces gen_main_chart.py
+      mechanism.rs    # replaces gen_mechanism_chart.py
+      pubsub_lz4.rs   # replaces gen_pubsub_lz4_chart.py
+      compression.rs  # replaces gen_compression_chart.py
+```
+
+Add to workspace `Cargo.toml` members. The crate is `path = "omq-bench"`,
+not under `omq-tokio` or `omq-proto`. It has no dependency on the library
+crates (it shells out to `bench_peer_tokio`). This also means it
+doesn't slow down the main workspace build.
+
+## 2. Dependencies
+
+```toml
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+No async runtime, no tokio. The bench runner is synchronous subprocess
+management. Everything is `std::process::Command`,
+`std::thread::spawn` for the watchdog, `std::io` for pipe reading.
+
+## 3. Shared modules
+
+### 3.1 `hw.rs` — hardware detection
+
+Replaces `scripts/chart_hw.py` (82 lines).
+
+```rust
+pub fn detect_hardware() -> Option<String>
+```
+
+Read `/proc/cpuinfo` for model name, `num_cpus::get()` or
+`std::thread::available_parallelism()` for core count. Read sysfs
+for governor and turbo state. Override via `.chart_hw` file and env
+vars (`OMQ_HW_PREFIX`, `OMQ_HW_POSTFIX`, `OMQ_HW_EXTRAS`). Same
+precedence as Python.
+
+### 3.2 `jsonl.rs` — row types and I/O
+
+Replaces the scattered JSONL logic in all Python scripts.
+
+```rust
+/// Row in comparisons.jsonl
+#[derive(Serialize, Deserialize)]
+pub struct ComparisonRow {
+    pub run_id: String,
+    pub impl_name: String,       // "impl" in JSON (rename)
+    pub kind: String,            // throughput | latency | pub_sub | fan_out | fan_in
+    pub transport: String,
+    pub msg_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msgs_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pub_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p50_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p99_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p999_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_max: Option<f64>,
+    // ... other optional fields
+}
+
+/// Row in results_{backend}.jsonl (mechanism bench)
+#[derive(Serialize, Deserialize)]
+pub struct MechanismRow { ... }
+
+/// Row in results_pubsub_lz4.jsonl
+#[derive(Serialize, Deserialize)]
+pub struct PubsubLz4Row { ... }
+
+/// Row in results_compression_{backend}.jsonl
+#[derive(Serialize, Deserialize)]
+pub struct CompressionRow { ... }
+
+pub fn load_jsonl<T: DeserializeOwned>(path: &Path) -> Vec<(usize, T)>
+pub fn append_jsonl<T: Serialize>(path: &Path, row: &T)
+```
+
+Each JSONL file uses its own row type. `load_jsonl` returns `(seq, row)`
+tuples so the "last-writer-wins" dedup logic uses file-order sequence
+numbers, matching the Python `_seq` pattern.
+
+### 3.3 `process.rs` — subprocess management
+
+Replaces `run_comparisons.py` lines 35-330: process lifetime guard,
+watchdog thread, spawn/kill/capture helpers.
+
+```rust
+pub struct ProcessGuard { ... }  // RAII: kills on drop
+pub struct Reaper { ... }        // watchdog thread, MAX_PROC_LIFETIME
+
+pub fn spawn(cmd: &[&str], env: &[(&str, &str)], cpu: Option<&str>) -> ProcessGuard
+pub fn read_bound_port(proc: &mut ProcessGuard, timeout: Duration) -> Option<u16>
+pub fn capture_with_cpu(cmd: &[&str], ...) -> (String, f64)
+pub fn read_proc_cpu(pid: u32) -> f64
+```
+
+Key behavior from Python to preserve:
+- `start_new_session=True` → `pre_exec` with `setsid()`
+- Watchdog kills any process alive > 60s
+- `atexit` reaper kills all registered processes
+- Optional `taskset -c` CPU pinning via `OMQ_BENCH_TASKSET=1` and the
+  `MEASURED_CPU` / `OTHER_CPU` masks
+
+### 3.4 `parse.rs` — output parsers
+
+Replaces `parse_throughput`, `parse_latency`, `parse_multi_throughput`
+from `run_comparisons.py` lines 378-430.
+
+```rust
+pub struct ThroughputResult {
+    pub msgs_s: f64,
+    pub mbps: f64,
+    pub elapsed: f64,
+    pub pull_cpu: Option<f64>,
+}
+
+pub struct MultiThroughputResult {
+    pub msgs_s: f64,       // per-peer mean
+    pub mbps: f64,         // aggregate
+    pub elapsed: f64,
+    pub pull_cpu: Option<f64>,
+    pub peer_min: Option<f64>,
+    pub peer_max: Option<f64>,
+}
+
+pub struct LatencyResult {
+    pub p50_us: f64,
+    pub p99_us: f64,
+    pub p999_us: f64,
+    pub max_us: f64,
+    pub iterations: u64,
+    pub req_cpu: Option<f64>,
+    pub elapsed: Option<f64>,
+}
+
+pub fn parse_throughput(output: &str, size: u64) -> Option<ThroughputResult>
+pub fn parse_multi_throughput(output: &str, size: u64, peers: u64) -> Option<MultiThroughputResult>
+pub fn parse_latency(output: &str) -> Option<LatencyResult>
+```
+
+## 4. Phase 1: bench runner modules
+
+### 4.1 `bench/comparisons.rs`
+
+Replaces `scripts/run_comparisons.py` (~1770 lines). The largest
+module.
+
+#### Impl registry
+
+Replaces `IMPLS` dict (lines 896-1057). Use a static slice of structs:
+
+```rust
+pub struct ImplDef {
+    pub name: &'static str,
+    pub binary_from: Option<&'static str>,  // shares binary with this impl
+    pub prefix: &'static str,
+    pub class: ImplClass,                    // Classic, IoUring, Curve
+    pub transports: &'static [Transport],
+    pub inproc_tput_subcmd: &'static str,    // default "inproc"
+    pub inproc_lat_subcmd: &'static str,     // default "inproc-latency"
+    pub inproc_pubsub_subcmd: &'static str,  // default "inproc-pubsub"
+    pub pub_needs_peer_count: bool,
+    pub fanout_push_subcmd: &'static str,    // default "push"
+    pub fanio_needs_peer_count: bool,
+    pub supports_pubsub: bool,
+    pub env: &'static [(&'static str, &'static str)],
+}
+```
+
+#### Build step
+
+Replaces `build_peers()` (lines 1064-1113). Run `cargo build
+--release` for omq-tokio, `gcc` for libzmq, `cargo build` for
+zmq.rs/rzmq subdirectories. Return `HashMap<String, PathBuf>`.
+
+#### Cell functions
+
+Each returns the best-of-N result:
+
+- `run_throughput_cell()` — 1 push + 1 pull, 2-process. Lines 453-540.
+- `run_pubsub_cell()` — 1 pub + 1 multi-sub process. Lines 543-657.
+- `run_fanout_cell()` — 1 push + 1 multi-pull process. Lines 632-755.
+- `run_fanin_cell()` — 1 multi-push + 1 pull-bind process. Lines 758-773.
+- `run_latency_cell()` — 1 rep + 1 req, 2-process. Lines 776-908.
+
+#### Measurement integrity
+
+Replaces `MEASUREMENT_ISSUES` list and `_note`/`_flush_issues` (lines
+342-376). Track missing CPU fields per cell, abort the run if any
+best-of-N winner is incomplete.
+
+#### Top-level orchestration
+
+Replaces `run_benchmarks()` (lines 1116-1574) and `main()` (lines
+1578-1774). Iterate impls × transports × sizes, call cell functions,
+append JSONL, print table.
+
+### 4.2 `bench/mechanism.rs`
+
+Replaces `scripts/bench_mechanism.py` (240 lines). Simple 2-process
+PUSH/PULL with `OMQ_BENCH_MECHANISM` env var selecting PLAIN, CURVE,
+or CURVE. Writes to `~/.cache/omq/results_tokio.jsonl`.
+
+### 4.3 `bench/pubsub_lz4.rs`
+
+Replaces `scripts/bench_pubsub_lz4.py` (275 lines). 1 PUB → 32 SUBs
+with tcp vs lz4+tcp. Also runs `wire-size` and `train-dict`
+subcommands of `bench_peer_tokio` for dict sweeps. Writes to
+`~/.cache/omq/results_pubsub_lz4.jsonl`.
+
+### 4.4 `bench/compression.rs`
+
+Replaces `scripts/bench_compression_tokio.py` (241 lines). 2-process
+PUSH/PULL with JSON payloads, tcp vs lz4+tcp, with and without dict.
+Writes to `~/.cache/omq/results_compression_tokio.jsonl`.
+
+## 5. Phase 2: chart modules
+
+### 5.1 `chart/svg.rs` — shared SVG primitives
+
+The core module. Eliminates the copy-pasted SVG helpers across 5
+Python scripts.
+
+```rust
+pub struct SvgDoc {
+    width: f64,
+    height: f64,
+    lines: Vec<String>,
+}
+
+impl SvgDoc {
+    pub fn new(width: f64, height: f64) -> Self
+    pub fn rect(&mut self, x: f64, y: f64, w: f64, h: f64, fill: &str)
+    pub fn line(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, style: LineStyle)
+    pub fn polyline(&mut self, points: &[(f64, f64)], style: LineStyle)
+    pub fn circle(&mut self, cx: f64, cy: f64, r: f64, fill: &str)
+    pub fn x_mark(&mut self, cx: f64, cy: f64, r: f64, color: &str)
+    pub fn text(&mut self, x: f64, y: f64, content: &str, style: TextStyle)
+    pub fn whisker(&mut self, x: f64, y_lo: f64, y_hi: f64, color: &str)
+    pub fn finish(self) -> String
+}
+
+pub struct LineStyle {
+    pub color: &'static str,
+    pub width: f64,
+    pub dash: Option<&'static str>,  // e.g. "6,3"
+    pub opacity: Option<f64>,
+}
+
+pub struct TextStyle {
+    pub anchor: Anchor,      // Start, Middle, End
+    pub fill: &'static str,
+    pub size: f64,
+    pub weight: Option<&'static str>,
+    pub baseline: Option<&'static str>,
+    pub rotate: Option<f64>,
+}
+```
+
+Higher-level layout helpers:
+
+```rust
+/// Axis configuration
+pub struct Axis {
+    pub min: f64,
+    pub max: f64,
+    pub log: bool,
+}
+
+impl Axis {
+    pub fn map(&self, value: f64, pixel_lo: f64, pixel_hi: f64) -> f64
+    pub fn ticks(&self, target_count: usize) -> Vec<f64>
+}
+
+/// Draw gridlines + tick labels for a vertical axis
+pub fn draw_y_axis(doc: &mut SvgDoc, axis: &Axis, ...)
+
+/// Draw x-axis size labels
+pub fn draw_x_labels(doc: &mut SvgDoc, sizes: &[u64], xs: &[f64], y: f64)
+
+/// Draw impl legend with optional CPU% annotation
+pub fn draw_legend(
+    doc: &mut SvgDoc,
+    items: &[LegendItem],
+    mid_x: f64,
+    y: f64,
+) -> f64  // returns extra height consumed
+
+pub struct LegendItem {
+    pub color: &'static str,
+    pub label: String,
+    pub cpu_pct: Option<f64>,  // shown as "(98%)" suffix
+}
+```
+
+The `nice_step()` function (used by all chart scripts) lives here:
+
+```rust
+pub fn nice_step(max_val: f64, target_lines: usize) -> f64
+```
+
+### 5.2 Chart design changes
+
+**Before (triple axis):**
+- Left axis: CPU% (dashed lines per series per size)
+- Right axis 1: msg/s or GB/s (solid lines)
+- Right axis 2: msg/s (dashed lines, outer)
+- Line-type legend explaining dashed vs solid vs dotted
+
+**After (single axis + legend CPU%):**
+- Single metric axis (msg/s for small, GB/s for large)
+- Solid lines with dot markers
+- Whisker bars where applicable (fan-out)
+- CPU% as a suffix in the legend: "omq-tokio (1T) 98%"
+- No line-type legend needed
+
+This simplification applies to:
+- `pushpull/{tcp,ipc,inproc}.svg` — was 3-axis, becomes 1 metric axis
+- `reqrep/{tcp,ipc,inproc}.svg` — was 2-axis (latency + CPU%), becomes latency only
+- `pubsub/tcp.svg` — was 3-axis, becomes 1 metric axis
+- `pushpull/fanout/tcp.svg`, `fanin/tcp.svg` — was 3-axis, becomes 1 metric axis
+- `mechanism/tokio.svg` — was 2-axis (msg/s + GB/s, both log), keep both (dual Y, no CPU)
+- `compression/tokio.svg`, `pubsub/lz4_tcp.svg` — link-speed projection panels, keep throughput + msg/s (dual Y, no CPU)
+
+### 5.3 `chart/comparison.rs`
+
+Replaces `scripts/gen_comparison_chart.py` (1914 lines). Produces:
+
+| output | panel type |
+|--------|-----------|
+| `pushpull/{tcp,ipc,inproc}.svg` | split: small msg/s + large GB/s |
+| `reqrep/{tcp,ipc,inproc}.svg` | single: p50 latency |
+| `pubsub/tcp.svg` | multi-panel: 4p + 64p, split msg/s + GB/s |
+| `pubsub/curve_tcp.svg` | multi-panel: 16p, split msg/s + GB/s |
+| `pushpull/fanout/tcp.svg` | multi-panel: 4p + 64p, split msg/s + GB/s |
+| `pushpull/fanin/tcp.svg` | multi-panel: 4p + 64p, split msg/s + GB/s |
+
+Data loading: read `comparisons.jsonl`, dedup by `(impl, size)` keeping
+the latest row by file position. Group by transport/kind/peers.
+
+### 5.4 `chart/main_tcp.rs`
+
+Replaces `scripts/gen_main_chart.py` (508 lines). Produces the three
+focused main TCP charts: `main_pushpull_tcp.svg`,
+`main_reqrep_tcp.svg`, and `main_pubsub_tcp.svg`. Each chart contains
+only the implementations relevant to that workload.
+
+### 5.5 `chart/mechanism.rs`
+
+Replaces `scripts/gen_mechanism_chart.py` (347 lines). Dual log-scale
+axes (msg/s left, GB/s right). Two series: PLAIN, CURVE.
+No CPU% axis.
+
+### 5.6 `chart/pubsub_lz4.rs`
+
+Replaces `scripts/gen_pubsub_lz4_chart.py` (468 lines). Link-speed
+projection panels (1G, 100M, 10M). Two axes: aggregate throughput
+(log) + msg/s (log). Three series: tcp, lz4+tcp, lz4+tcp+dict.
+CPU% becomes legend annotation.
+
+### 5.7 `chart/compression.rs`
+
+Replaces `scripts/gen_compression_chart.py` (571 lines). Four
+link-speed panels (10G, 1G, 100M, 10M). Same axis structure as
+pubsub_lz4. CPU% becomes legend annotation.
+
+## 6. CLI design
+
+```
+omq-bench run comparisons [FLAGS]
+    --impl <name>...          # filter impls
+    --omq                     # shorthand: omq-tokio-ct + omq-tokio-2t
+    --transport <t>...        # tcp, ipc, inproc, ws
+    --sizes <list>
+    --duration <secs>
+    --rounds <n>
+    --no-throughput
+    --no-latency
+    --no-pubsub
+    --pubsub-peers <list>
+    --fanout / --fanin
+    --fanout-peers / --fanin-peers <list>
+    --curve
+    --quick-run
+
+omq-bench run mechanism [--chart-sizes] [--sizes <list>]
+omq-bench run pubsub-lz4 [--quick] [--chart]
+omq-bench run compression [--chart]
+
+omq-bench chart                    # regenerate all charts
+omq-bench chart comparisons        # just comparison + main
+omq-bench chart mechanism
+omq-bench chart pubsub-lz4
+omq-bench chart compression
+```
+
+## 7. Migration path
+
+### Phase 1 (bench runners)
+
+1. Create `omq-bench/` crate with shared modules (`hw`, `jsonl`,
+   `process`, `parse`) and `bench/comparisons.rs`.
+2. Validate: run side-by-side with Python, compare JSONL output.
+3. Port `bench/mechanism.rs`, `bench/pubsub_lz4.rs`,
+   `bench/compression.rs`.
+4. Update `DEVELOPMENT.md`: replace `python3 scripts/run_comparisons.py`
+   with `cargo run -p omq-bench --release -- run comparisons`.
+5. Keep Python scripts in-tree until phase 2 is done (chart gen still
+   needs them for `--chart` flags).
+
+### Phase 2 (chart generation)
+
+1. Implement `chart/svg.rs` with primitives. Test with a minimal chart.
+2. Port `chart/comparison.rs` (the big one). Compare SVG pixel-diff
+   against Python output.
+3. Port remaining chart modules.
+4. Update `DEVELOPMENT.md`: replace `python3 scripts/gen_*_chart.py`
+   with `cargo run -p omq-bench --release -- chart`.
+5. Delete all Python scripts: `run_comparisons.py`,
+   `bench_mechanism.py`, `bench_pubsub_lz4.py`,
+   `bench_compression_tokio.py`, `gen_comparison_chart.py`,
+   `gen_main_chart.py`, `gen_mechanism_chart.py`,
+   `gen_pubsub_lz4_chart.py`, `gen_compression_chart.py`,
+   `chart_hw.py`.
+6. Delete `scripts/zmqrs_bench_peer/`, `scripts/rzmq_bench_peer/`,
+   `scripts/libzmq_bench_peer.c` and `scripts/libzmq_bench_peer` only
+   if they are no longer needed (they are bench *peers*, not the
+   runner). They stay.
+
+## 8. JSONL file inventory
+
+| file | writer | reader |
+|------|--------|--------|
+| `comparisons.jsonl` | `bench/comparisons.rs` | `chart/comparison.rs`, `chart/main_tcp.rs` |
+| `results_tokio.jsonl` | `bench/mechanism.rs` | `chart/mechanism.rs` |
+| `results_pubsub_lz4.jsonl` | `bench/pubsub_lz4.rs` | `chart/pubsub_lz4.rs` |
+| `results_compression_tokio.jsonl` | `bench/compression.rs` | `chart/compression.rs` |
+
+All files are append-only. The chart reader always takes the latest row
+per dedup key (typically `(impl, msg_size)` or `(transport, msg_size)`
+by highest file-position sequence number). Existing Python-written
+rows remain readable; the Rust writer produces identical JSON field
+names.

--- a/doc/perf-verification.md
+++ b/doc/perf-verification.md
@@ -1,0 +1,42 @@
+# Performance verification
+
+Run the fast TCP core-path gate with:
+
+```text
+cargo run --release -p omq-tokio --bin perf_verify
+```
+
+The verifier measures CT REQ/REP latency at 256B, canonical 1-IO
+PUSH/PULL at 16B, 1KiB, and 16KiB, and canonical 1-IO PUB/SUB with four
+subscribers at 16B and 4KiB. It uses separate OMQ contexts and loopback TCP.
+Warmup and measurement windows are bounded. The normal run must finish in
+under 10 seconds.
+
+Thresholds are machine-specific. Create the ignored `.perf_hw` file in the
+repository root. Keys match the measurement names printed by the verifier:
+
+```text
+[reqrep_ct]
+p50_256b_us=50
+
+[pushpull_1io]
+16b_msgs_s=9500000
+1k_msgs_s=3000000
+16k_msgs_s=250000
+
+[pushpull_2io]
+16b_msgs_s=8000000
+1k_msgs_s=3000000
+16k_msgs_s=250000
+
+[pubsub_1io]
+16b_msgs_s=1500000
+4k_msgs_s=200000
+
+[pubsub_2io]
+16b_msgs_s=1100000
+4k_msgs_s=430000
+```
+
+Use measured local baselines for the ten throughput values. A missing file
+prints measurements without applying thresholds.

--- a/examples/zguide-tokio/01_req_rep/Cargo.toml
+++ b/examples/zguide-tokio/01_req_rep/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/01_req_rep/broker.rs
+++ b/examples/zguide-tokio/01_req_rep/broker.rs
@@ -5,43 +5,45 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin broker [frontend] [backend]
 
-use omq_tokio::{Endpoint, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
-    let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-01-backend");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
+        let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-01-backend");
 
-    let frontend = Socket::new(SocketType::Router, Options::default());
-    frontend.bind(frontend_ep.clone()).await.unwrap();
+        let frontend = Socket::new(SocketType::Router, Options::default());
+        frontend.bind(frontend_ep.clone()).await.unwrap();
 
-    let backend = Socket::new(SocketType::Dealer, Options::default());
-    backend.bind(backend_ep.clone()).await.unwrap();
+        let backend = Socket::new(SocketType::Dealer, Options::default());
+        backend.bind(backend_ep.clone()).await.unwrap();
 
-    println!("broker: frontend={frontend_ep} backend={backend_ep}");
+        println!("broker: frontend={frontend_ep} backend={backend_ep}");
 
-    let fe = frontend.clone();
-    let be = backend.clone();
-    let fwd = tokio::spawn(async move {
-        loop {
-            let msg = fe.recv().await.unwrap();
-            be.send(msg).await.unwrap();
-        }
+        let fe = frontend.clone();
+        let be = backend.clone();
+        let fwd = tokio::spawn(async move {
+            loop {
+                let msg = fe.recv().await.unwrap();
+                be.send(msg).await.unwrap();
+            }
+        });
+
+        let fe = frontend;
+        let be = backend;
+        let ret = tokio::spawn(async move {
+            loop {
+                let msg = be.recv().await.unwrap();
+                fe.send(msg).await.unwrap();
+            }
+        });
+
+        let _ = tokio::join!(fwd, ret);
     });
-
-    let fe = frontend;
-    let be = backend;
-    let ret = tokio::spawn(async move {
-        loop {
-            let msg = be.recv().await.unwrap();
-            fe.send(msg).await.unwrap();
-        }
-    });
-
-    let _ = tokio::join!(fwd, ret);
 }

--- a/examples/zguide-tokio/01_req_rep/client.rs
+++ b/examples/zguide-tokio/01_req_rep/client.rs
@@ -5,7 +5,7 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin client [frontend] [n_requests]
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -15,22 +15,24 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
-    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(9);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
+        let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(9);
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(frontend_ep).await.unwrap();
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(frontend_ep).await.unwrap();
 
-    for i in 0..n {
-        let request = format!("request-{i}");
-        req.send(Message::single(request.clone())).await.unwrap();
-        let reply = req.recv().await.unwrap();
-        let body = msg_str(&reply, 0);
-        println!("client: {request} -> {body}");
-    }
+        for i in 0..n {
+            let request = format!("request-{i}");
+            req.send(Message::single(request.clone())).await.unwrap();
+            let reply = req.recv().await.unwrap();
+            let body = msg_str(&reply, 0);
+            println!("client: {request} -> {body}");
+        }
 
-    println!("done: {n} replies");
+        println!("done: {n} replies");
+    });
 }

--- a/examples/zguide-tokio/01_req_rep/echo.rs
+++ b/examples/zguide-tokio/01_req_rep/echo.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -16,37 +16,39 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-echo");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-echo");
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(ep.clone()).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(ep.clone()).await.unwrap();
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(ep).await.unwrap();
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(ep).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let server = tokio::spawn(async move {
-        for _ in 0..3 {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            rep.send(Message::single(format!("echo:{body}")))
-                .await
-                .unwrap();
+        let server = tokio::spawn(async move {
+            for _ in 0..3 {
+                let msg = rep.recv().await.unwrap();
+                let body = msg_str(&msg, 0);
+                rep.send(Message::single(format!("echo:{body}")))
+                    .await
+                    .unwrap();
+            }
+        });
+
+        for i in 0..3 {
+            let request = format!("hello-{i}");
+            req.send(Message::single(request.clone())).await.unwrap();
+            let reply = req.recv().await.unwrap();
+            let body = msg_str(&reply, 0);
+            println!("client: {request} -> {body}");
         }
+
+        server.await.unwrap();
+        println!("done: 3 request-reply cycles");
     });
-
-    for i in 0..3 {
-        let request = format!("hello-{i}");
-        req.send(Message::single(request.clone())).await.unwrap();
-        let reply = req.recv().await.unwrap();
-        let body = msg_str(&reply, 0);
-        println!("client: {request} -> {body}");
-    }
-
-    server.await.unwrap();
-    println!("done: 3 request-reply cycles");
 }

--- a/examples/zguide-tokio/01_req_rep/worker.rs
+++ b/examples/zguide-tokio/01_req_rep/worker.rs
@@ -5,7 +5,7 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin worker [backend] [id]
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -15,22 +15,24 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-backend");
-    let id = args.get(2).map_or("0", |s| s.as_str());
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-backend");
+        let id = args.get(2).map_or("0", |s| s.as_str());
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.connect(backend_ep).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.connect(backend_ep).await.unwrap();
 
-    println!("worker-{id}: ready");
+        println!("worker-{id}: ready");
 
-    loop {
-        let msg = rep.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        let reply = format!("worker-{id}:{body}");
-        println!("worker-{id}: {body} -> {reply}");
-        rep.send(Message::single(reply)).await.unwrap();
-    }
+        loop {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            let reply = format!("worker-{id}:{body}");
+            println!("worker-{id}: {body} -> {reply}");
+            rep.send(Message::single(reply)).await.unwrap();
+        }
+    });
 }

--- a/examples/zguide-tokio/02_pub_sub/Cargo.toml
+++ b/examples/zguide-tokio/02_pub_sub/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/02_pub_sub/proxy.rs
+++ b/examples/zguide-tokio/02_pub_sub/proxy.rs
@@ -11,31 +11,33 @@
 //! NOTE: This uses SUB/PUB relay instead of the canonical XSUB/XPUB
 //! proxy because `XSUB.send()` is not yet supported.
 
-use omq_tokio::{Endpoint, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let upstream_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-upstream");
-    let downstream_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-02-downstream");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let upstream_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-upstream");
+        let downstream_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-02-downstream");
 
-    // Upstream: SUB connects to the publisher and subscribes to everything.
-    let upstream = Socket::new(SocketType::Sub, Options::default());
-    upstream.connect(upstream_ep.clone()).await.unwrap();
-    upstream.subscribe("").await.unwrap();
+        // Upstream: SUB connects to the publisher and subscribes to everything.
+        let upstream = Socket::new(SocketType::Sub, Options::default());
+        upstream.connect(upstream_ep.clone()).await.unwrap();
+        upstream.subscribe("").await.unwrap();
 
-    // Downstream: PUB binds so downstream subscribers can connect.
-    let downstream = Socket::new(SocketType::Pub, Options::default());
-    downstream.bind(downstream_ep.clone()).await.unwrap();
+        // Downstream: PUB binds so downstream subscribers can connect.
+        let downstream = Socket::new(SocketType::Pub, Options::default());
+        downstream.bind(downstream_ep.clone()).await.unwrap();
 
-    println!("proxy: upstream={upstream_ep} downstream={downstream_ep}");
+        println!("proxy: upstream={upstream_ep} downstream={downstream_ep}");
 
-    loop {
-        let msg = upstream.recv().await.unwrap();
-        downstream.send(msg).await.unwrap();
-    }
+        loop {
+            let msg = upstream.recv().await.unwrap();
+            downstream.send(msg).await.unwrap();
+        }
+    });
 }

--- a/examples/zguide-tokio/02_pub_sub/publisher.rs
+++ b/examples/zguide-tokio/02_pub_sub/publisher.rs
@@ -9,47 +9,49 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
-    let count: Option<usize> = args.get(2).and_then(|s| s.parse().ok());
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
+        let count: Option<usize> = args.get(2).and_then(|s| s.parse().ok());
 
-    let pub_ = Socket::new(SocketType::Pub, Options::default());
-    pub_.bind(ep.clone()).await.unwrap();
+        let pub_ = Socket::new(SocketType::Pub, Options::default());
+        pub_.bind(ep.clone()).await.unwrap();
 
-    println!("publisher: bound to {ep}");
+        println!("publisher: bound to {ep}");
 
-    // Give subscribers time to connect and send SUBSCRIBE commands.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+        // Give subscribers time to connect and send SUBSCRIBE commands.
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let rounds = count.unwrap_or(usize::MAX);
-    for i in 0..rounds {
-        let nyc_temp = 55 + (i % 30);
-        let sfo_temp = 60 + (i % 20);
-        let chi_temp = 40 + (i % 35);
+        let rounds = count.unwrap_or(usize::MAX);
+        for i in 0..rounds {
+            let nyc_temp = 55 + (i % 30);
+            let sfo_temp = 60 + (i % 20);
+            let chi_temp = 40 + (i % 35);
 
-        pub_.send(Message::single(format!("weather.nyc {nyc_temp}F")))
-            .await
-            .unwrap();
-        pub_.send(Message::single(format!("weather.sfo {sfo_temp}F")))
-            .await
-            .unwrap();
-        pub_.send(Message::single(format!("weather.chi {chi_temp}F")))
-            .await
-            .unwrap();
-        pub_.send(Message::single(format!("sports.nba score-{i}")))
-            .await
-            .unwrap();
+            pub_.send(Message::single(format!("weather.nyc {nyc_temp}F")))
+                .await
+                .unwrap();
+            pub_.send(Message::single(format!("weather.sfo {sfo_temp}F")))
+                .await
+                .unwrap();
+            pub_.send(Message::single(format!("weather.chi {chi_temp}F")))
+                .await
+                .unwrap();
+            pub_.send(Message::single(format!("sports.nba score-{i}")))
+                .await
+                .unwrap();
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
-    println!("publisher: done ({rounds} rounds)");
+        println!("publisher: done ({rounds} rounds)");
+    });
 }

--- a/examples/zguide-tokio/02_pub_sub/subscriber.rs
+++ b/examples/zguide-tokio/02_pub_sub/subscriber.rs
@@ -8,7 +8,7 @@
 //! If `count` is given, receives that many messages then exits.
 //! Otherwise runs indefinitely (Ctrl-C to stop).
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,28 +18,30 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
-    let topic: String = args
-        .get(2)
-        .cloned()
-        .unwrap_or_else(|| "weather.nyc".to_string());
-    let count: Option<usize> = args.get(3).and_then(|s| s.parse().ok());
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
+        let topic: String = args
+            .get(2)
+            .cloned()
+            .unwrap_or_else(|| "weather.nyc".to_string());
+        let count: Option<usize> = args.get(3).and_then(|s| s.parse().ok());
 
-    let sub = Socket::new(SocketType::Sub, Options::default());
-    sub.connect(ep.clone()).await.unwrap();
-    sub.subscribe(topic.clone()).await.unwrap();
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.connect(ep.clone()).await.unwrap();
+        sub.subscribe(topic.clone()).await.unwrap();
 
-    println!("subscriber: connected to {ep}, topic={topic:?}");
+        println!("subscriber: connected to {ep}, topic={topic:?}");
 
-    let limit = count.unwrap_or(usize::MAX);
-    for i in 0..limit {
-        let msg = sub.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        println!("subscriber[{topic}]: [{i}] {body}");
-    }
+        let limit = count.unwrap_or(usize::MAX);
+        for i in 0..limit {
+            let msg = sub.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            println!("subscriber[{topic}]: [{i}] {body}");
+        }
 
-    println!("subscriber: done ({limit} messages)");
+        println!("subscriber: done ({limit} messages)");
+    });
 }

--- a/examples/zguide-tokio/03_pipeline/Cargo.toml
+++ b/examples/zguide-tokio/03_pipeline/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/03_pipeline/sink.rs
+++ b/examples/zguide-tokio/03_pipeline/sink.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,36 +18,38 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let sink_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-sink");
-    let expected: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let sink_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-sink");
+        let expected: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
 
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    pull.bind(sink_ep.clone()).await.unwrap();
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        pull.bind(sink_ep.clone()).await.unwrap();
 
-    println!("sink: listening on {sink_ep}, expecting {expected} results");
+        println!("sink: listening on {sink_ep}, expecting {expected} results");
 
-    let mut counts: HashMap<String, usize> = HashMap::new();
+        let mut counts: HashMap<String, usize> = HashMap::new();
 
-    for i in 0..expected {
-        let msg = pull.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        let worker_id = body.split(':').next().unwrap_or("unknown").to_string();
-        *counts.entry(worker_id).or_default() += 1;
-        if (i + 1) % 25 == 0 || i + 1 == expected {
-            println!("sink: received {}/{expected}", i + 1);
+        for i in 0..expected {
+            let msg = pull.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            let worker_id = body.split(':').next().unwrap_or("unknown").to_string();
+            *counts.entry(worker_id).or_default() += 1;
+            if (i + 1) % 25 == 0 || i + 1 == expected {
+                println!("sink: received {}/{expected}", i + 1);
+            }
         }
-    }
 
-    println!(
-        "sink: done — {expected} results from {} workers",
-        counts.len()
-    );
-    let mut sorted: Vec<_> = counts.into_iter().collect();
-    sorted.sort();
-    for (worker, count) in &sorted {
-        println!("  {worker}: {count} items");
-    }
+        println!(
+            "sink: done — {expected} results from {} workers",
+            counts.len()
+        );
+        let mut sorted: Vec<_> = counts.into_iter().collect();
+        sorted.sort();
+        for (worker, count) in &sorted {
+            println!("  {worker}: {count} items");
+        }
+    });
 }

--- a/examples/zguide-tokio/03_pipeline/ventilator.rs
+++ b/examples/zguide-tokio/03_pipeline/ventilator.rs
@@ -7,32 +7,34 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
-    let n_tasks: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
+        let n_tasks: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
 
-    let push = Socket::new(
-        SocketType::Push,
-        Options::default().linger(Duration::from_secs(2)),
-    );
-    push.bind(vent_ep.clone()).await.unwrap();
+        let push = Socket::new(
+            SocketType::Push,
+            Options::default().linger(Duration::from_secs(2)),
+        );
+        push.bind(vent_ep.clone()).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
-    for i in 0..n_tasks {
-        push.send(Message::single(format!("task-{i}")))
-            .await
-            .unwrap();
-    }
+        for i in 0..n_tasks {
+            push.send(Message::single(format!("task-{i}")))
+                .await
+                .unwrap();
+        }
 
-    println!("ventilator: sent {n_tasks} tasks on {vent_ep}");
-    push.close().await.unwrap();
+        println!("ventilator: sent {n_tasks} tasks on {vent_ep}");
+        push.close().await.unwrap();
+    });
 }

--- a/examples/zguide-tokio/03_pipeline/worker.rs
+++ b/examples/zguide-tokio/03_pipeline/worker.rs
@@ -5,7 +5,7 @@
 //!
 //!     cargo run -p zguide-tokio-03-pipeline --bin worker [vent_ep] [sink_ep] [worker_id]
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -15,25 +15,27 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
-    let sink_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-03-sink");
-    let id = args.get(3).map_or("0", |s| s.as_str());
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
+        let sink_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-03-sink");
+        let id = args.get(3).map_or("0", |s| s.as_str());
 
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    pull.connect(vent_ep).await.unwrap();
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        pull.connect(vent_ep).await.unwrap();
 
-    let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(sink_ep).await.unwrap();
+        let push = Socket::new(SocketType::Push, Options::default());
+        push.connect(sink_ep).await.unwrap();
 
-    println!("worker-{id}: ready");
+        println!("worker-{id}: ready");
 
-    loop {
-        let msg = pull.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        let result = format!("worker-{id}:{body}");
-        push.send(Message::single(result)).await.unwrap();
-    }
+        loop {
+            let msg = pull.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            let result = format!("worker-{id}:{body}");
+            push.send(Message::single(result)).await.unwrap();
+        }
+    });
 }

--- a/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
+++ b/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/04_lazy_pirate/client.rs
+++ b/examples/zguide-tokio/04_lazy_pirate/client.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -27,50 +27,52 @@ async fn new_req(ep: &Endpoint) -> Socket {
     req
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
 
-    let max_retries = 3;
-    let mut total_retries: u32 = 0;
-    let mut replies: Vec<String> = Vec::new();
+        let max_retries = 3;
+        let mut total_retries: u32 = 0;
+        let mut replies: Vec<String> = Vec::new();
 
-    let mut req = new_req(&ep).await;
+        let mut req = new_req(&ep).await;
 
-    for seq in 0..5 {
-        let request = format!("request-{seq}");
-        let mut attempts = 0;
+        for seq in 0..5 {
+            let request = format!("request-{seq}");
+            let mut attempts = 0;
 
-        loop {
-            req.send(Message::single(request.clone())).await.unwrap();
+            loop {
+                req.send(Message::single(request.clone())).await.unwrap();
 
-            match tokio::time::timeout(Duration::from_millis(400), req.recv()).await {
-                Ok(Ok(reply)) => {
-                    let body = msg_str(&reply, 0);
-                    println!("client: {request} -> {body}");
-                    replies.push(body);
-                    break;
-                }
-                Ok(Err(e)) => {
-                    eprintln!("client: recv error on {request}: {e}");
-                    break;
-                }
-                Err(_) => {
-                    attempts += 1;
-                    total_retries += 1;
-                    println!("client: timeout on {request}, retry {attempts}");
-                    // Destroy and recreate the socket (Lazy Pirate pattern).
-                    let _ = req.close().await;
-                    req = new_req(&ep).await;
-                    if attempts >= max_retries {
-                        println!("client: giving up on {request}");
+                match tokio::time::timeout(Duration::from_millis(400), req.recv()).await {
+                    Ok(Ok(reply)) => {
+                        let body = msg_str(&reply, 0);
+                        println!("client: {request} -> {body}");
+                        replies.push(body);
                         break;
+                    }
+                    Ok(Err(e)) => {
+                        eprintln!("client: recv error on {request}: {e}");
+                        break;
+                    }
+                    Err(_) => {
+                        attempts += 1;
+                        total_retries += 1;
+                        println!("client: timeout on {request}, retry {attempts}");
+                        // Destroy and recreate the socket (Lazy Pirate pattern).
+                        let _ = req.close().await;
+                        req = new_req(&ep).await;
+                        if attempts >= max_retries {
+                            println!("client: giving up on {request}");
+                            break;
+                        }
                     }
                 }
             }
         }
-    }
 
-    println!("done: {} replies, {total_retries} retries", replies.len());
+        println!("done: {} replies, {total_retries} retries", replies.len());
+    });
 }

--- a/examples/zguide-tokio/04_lazy_pirate/server.rs
+++ b/examples/zguide-tokio/04_lazy_pirate/server.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,45 +18,47 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(ep).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(ep).await.unwrap();
 
-    let mut handled: u32 = 0;
-    loop {
-        let msg = match tokio::time::timeout(Duration::from_secs(3), rep.recv()).await {
-            Ok(Ok(msg)) => msg,
-            Ok(Err(e)) => {
-                eprintln!("server: recv error: {e}");
-                continue;
+        let mut handled: u32 = 0;
+        loop {
+            let msg = match tokio::time::timeout(Duration::from_secs(3), rep.recv()).await {
+                Ok(Ok(msg)) => msg,
+                Ok(Err(e)) => {
+                    eprintln!("server: recv error: {e}");
+                    continue;
+                }
+                Err(_) => {
+                    println!("server: no request for 3s, exiting");
+                    break;
+                }
+            };
+
+            handled += 1;
+            let body = msg_str(&msg, 0);
+
+            if handled == 3 {
+                println!("server: simulating crash on '{body}'");
+                tokio::time::sleep(Duration::from_millis(500)).await;
             }
-            Err(_) => {
-                println!("server: no request for 3s, exiting");
-                break;
+
+            let reply = format!("reply:{body}");
+            match rep.send(Message::single(reply)).await {
+                Ok(()) => println!("server: replied to {body}"),
+                Err(e) => {
+                    // Stale retry from client that already reconnected; skip it.
+                    eprintln!("server: send error for {body}: {e}");
+                }
             }
-        };
-
-        handled += 1;
-        let body = msg_str(&msg, 0);
-
-        if handled == 3 {
-            println!("server: simulating crash on '{body}'");
-            tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
-        let reply = format!("reply:{body}");
-        match rep.send(Message::single(reply)).await {
-            Ok(()) => println!("server: replied to {body}"),
-            Err(e) => {
-                // Stale retry from client that already reconnected; skip it.
-                eprintln!("server: send error for {body}: {e}");
-            }
-        }
-    }
-
-    println!("server: handled {handled} requests");
+        println!("server: handled {handled} requests");
+    });
 }

--- a/examples/zguide-tokio/05_heartbeat/Cargo.toml
+++ b/examples/zguide-tokio/05_heartbeat/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/05_heartbeat/monitor.rs
+++ b/examples/zguide-tokio/05_heartbeat/monitor.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -17,42 +17,44 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
 
-    let sub = Socket::new(SocketType::Sub, Options::default());
-    sub.connect(ep).await.unwrap();
-    sub.subscribe("HEARTBEAT").await.unwrap();
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.connect(ep).await.unwrap();
+        sub.subscribe("HEARTBEAT").await.unwrap();
 
-    let timeout = Duration::from_millis(150);
-    let mut alive = false;
-    let mut events: Vec<String> = Vec::new();
+        let timeout = Duration::from_millis(150);
+        let mut alive = false;
+        let mut events: Vec<String> = Vec::new();
 
-    for _ in 0..20 {
-        match tokio::time::timeout(timeout, sub.recv()).await {
-            Ok(Ok(msg)) => {
-                let body = msg_str(&msg, 0);
-                if !alive {
-                    events.push("alive".to_string());
-                    alive = true;
-                    println!("monitor: ALIVE ({body})");
+        for _ in 0..20 {
+            match tokio::time::timeout(timeout, sub.recv()).await {
+                Ok(Ok(msg)) => {
+                    let body = msg_str(&msg, 0);
+                    if !alive {
+                        events.push("alive".to_string());
+                        alive = true;
+                        println!("monitor: ALIVE ({body})");
+                    }
                 }
-            }
-            Ok(Err(e)) => {
-                eprintln!("monitor: recv error: {e}");
-                break;
-            }
-            Err(_) => {
-                if alive {
-                    events.push("dead".to_string());
-                    alive = false;
-                    println!("monitor: DEAD (timeout)");
+                Ok(Err(e)) => {
+                    eprintln!("monitor: recv error: {e}");
+                    break;
+                }
+                Err(_) => {
+                    if alive {
+                        events.push("dead".to_string());
+                        alive = false;
+                        println!("monitor: DEAD (timeout)");
+                    }
                 }
             }
         }
-    }
 
-    println!("monitor: events: {events:?}");
+        println!("monitor: events: {events:?}");
+    });
 }

--- a/examples/zguide-tokio/05_heartbeat/publisher.rs
+++ b/examples/zguide-tokio/05_heartbeat/publisher.rs
@@ -10,40 +10,42 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
 
-    let pub_socket = Socket::new(SocketType::Pub, Options::default());
-    pub_socket.bind(ep).await.unwrap();
+        let pub_socket = Socket::new(SocketType::Pub, Options::default());
+        pub_socket.bind(ep).await.unwrap();
 
-    // Brief pause for subscribers to connect.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+        // Brief pause for subscribers to connect.
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Phase 1: alive
-    for i in 0..8 {
-        pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
-        println!("publisher: heartbeat {i}");
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+        // Phase 1: alive
+        for i in 0..8 {
+            pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
+            println!("publisher: heartbeat {i}");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
-    // Phase 2: simulate failure
-    println!("publisher: simulating failure (300ms pause)");
-    tokio::time::sleep(Duration::from_millis(300)).await;
+        // Phase 2: simulate failure
+        println!("publisher: simulating failure (300ms pause)");
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
-    // Phase 3: recover
-    for i in 8..16 {
-        pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
-        println!("publisher: heartbeat {i}");
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+        // Phase 3: recover
+        for i in 8..16 {
+            pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
+            println!("publisher: heartbeat {i}");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
-    println!("publisher: done");
+        println!("publisher: done");
+    });
 }

--- a/examples/zguide-tokio/06_last_value_cache/Cargo.toml
+++ b/examples/zguide-tokio/06_last_value_cache/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/06_last_value_cache/cache.rs
+++ b/examples/zguide-tokio/06_last_value_cache/cache.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -19,69 +19,71 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
-    let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
-    let snapshot_ep = endpoint_or(&args, 3, "ipc://@omq-zguide-06-snapshot");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
+        let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
+        let snapshot_ep = endpoint_or(&args, 3, "ipc://@omq-zguide-06-snapshot");
 
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    pull.bind(pub_ep.clone()).await.unwrap();
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        pull.bind(pub_ep.clone()).await.unwrap();
 
-    let pub_ = Socket::new(SocketType::Pub, Options::default());
-    pub_.bind(sub_ep.clone()).await.unwrap();
+        let pub_ = Socket::new(SocketType::Pub, Options::default());
+        pub_.bind(sub_ep.clone()).await.unwrap();
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(snapshot_ep.clone()).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(snapshot_ep.clone()).await.unwrap();
 
-    println!("cache: PULL bound to {pub_ep}");
-    println!("cache: PUB  bound to {sub_ep}");
-    println!("cache: REP  bound to {snapshot_ep}");
+        println!("cache: PULL bound to {pub_ep}");
+        println!("cache: PUB  bound to {sub_ep}");
+        println!("cache: REP  bound to {snapshot_ep}");
 
-    let cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+        let cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
 
-    // Forward task: recv from PULL, cache, forward via PUB.
-    let cache_fwd = Arc::clone(&cache);
-    let forward = tokio::spawn(async move {
-        loop {
-            let msg = pull.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            if let Some((topic, value)) = body.split_once(' ') {
-                cache_fwd
-                    .lock()
-                    .unwrap()
-                    .insert(topic.to_owned(), value.to_owned());
-                println!("cache: cached {topic}={value}");
+        // Forward task: recv from PULL, cache, forward via PUB.
+        let cache_fwd = Arc::clone(&cache);
+        let forward = tokio::spawn(async move {
+            loop {
+                let msg = pull.recv().await.unwrap();
+                let body = msg_str(&msg, 0);
+                if let Some((topic, value)) = body.split_once(' ') {
+                    cache_fwd
+                        .lock()
+                        .unwrap()
+                        .insert(topic.to_owned(), value.to_owned());
+                    println!("cache: cached {topic}={value}");
+                }
+                pub_.send(Message::single(body)).await.unwrap();
             }
-            pub_.send(Message::single(body)).await.unwrap();
+        });
+
+        // Snapshot task: serve cached state on REQ/REP.
+        let cache_snap = Arc::clone(&cache);
+        let snapshot = tokio::spawn(async move {
+            loop {
+                let msg = rep.recv().await.unwrap();
+                let body = msg_str(&msg, 0);
+                if body == "SNAPSHOT" {
+                    let payload = {
+                        let locked = cache_snap.lock().unwrap();
+                        let p: String = locked
+                            .iter()
+                            .map(|(k, v)| format!("{k} {v}"))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        println!("cache: snapshot served ({} entries)", locked.len());
+                        p
+                    };
+                    rep.send(Message::single(payload)).await.unwrap();
+                }
+            }
+        });
+
+        tokio::select! {
+            r = forward => r.unwrap(),
+            r = snapshot => r.unwrap(),
         }
     });
-
-    // Snapshot task: serve cached state on REQ/REP.
-    let cache_snap = Arc::clone(&cache);
-    let snapshot = tokio::spawn(async move {
-        loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            if body == "SNAPSHOT" {
-                let payload = {
-                    let locked = cache_snap.lock().unwrap();
-                    let p: String = locked
-                        .iter()
-                        .map(|(k, v)| format!("{k} {v}"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    println!("cache: snapshot served ({} entries)", locked.len());
-                    p
-                };
-                rep.send(Message::single(payload)).await.unwrap();
-            }
-        }
-    });
-
-    tokio::select! {
-        r = forward => r.unwrap(),
-        r = snapshot => r.unwrap(),
-    }
 }

--- a/examples/zguide-tokio/06_last_value_cache/publisher.rs
+++ b/examples/zguide-tokio/06_last_value_cache/publisher.rs
@@ -7,36 +7,38 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
-    let count: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
+        let count: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
 
-    let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(pub_ep.clone()).await.unwrap();
+        let push = Socket::new(SocketType::Push, Options::default());
+        push.connect(pub_ep.clone()).await.unwrap();
 
-    println!("publisher: connected to {pub_ep}, sending {count} rounds");
+        println!("publisher: connected to {pub_ep}, sending {count} rounds");
 
-    // Let the connection establish.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+        // Let the connection establish.
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-    for i in 0..count {
-        let nyc = format!("weather.nyc {}F", 70 + i);
-        let sfo = format!("weather.sfo {}F", 60 + i);
+        for i in 0..count {
+            let nyc = format!("weather.nyc {}F", 70 + i);
+            let sfo = format!("weather.sfo {}F", 60 + i);
 
-        push.send(Message::single(nyc.clone())).await.unwrap();
-        push.send(Message::single(sfo.clone())).await.unwrap();
-        println!("publisher: {nyc}, {sfo}");
+            push.send(Message::single(nyc.clone())).await.unwrap();
+            push.send(Message::single(sfo.clone())).await.unwrap();
+            println!("publisher: {nyc}, {sfo}");
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
-    println!("publisher: done ({count} rounds)");
+        println!("publisher: done ({count} rounds)");
+    });
 }

--- a/examples/zguide-tokio/06_last_value_cache/subscriber.rs
+++ b/examples/zguide-tokio/06_last_value_cache/subscriber.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,50 +18,52 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let snapshot_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-snapshot");
-    let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let snapshot_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-snapshot");
+        let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
 
-    // Request snapshot from cache.
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(snapshot_ep.clone()).await.unwrap();
+        // Request snapshot from cache.
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(snapshot_ep.clone()).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    req.send(Message::single("SNAPSHOT")).await.unwrap();
-    let reply = req.recv().await.unwrap();
-    let body = msg_str(&reply, 0);
+        req.send(Message::single("SNAPSHOT")).await.unwrap();
+        let reply = req.recv().await.unwrap();
+        let body = msg_str(&reply, 0);
 
-    println!("subscriber: snapshot from cache:");
-    if body.is_empty() {
-        println!("  (empty)");
-    } else {
-        for line in body.lines() {
-            println!("  {line}");
-        }
-    }
-
-    // Subscribe for live updates.
-    let sub = Socket::new(SocketType::Sub, Options::default());
-    sub.connect(sub_ep.clone()).await.unwrap();
-    sub.subscribe("").await.unwrap();
-
-    println!("subscriber: listening for live updates (2s) ...");
-
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-    loop {
-        tokio::select! {
-            msg = sub.recv() => {
-                let body = msg_str(&msg.unwrap(), 0);
-                println!("  live: {body}");
-            }
-            () = tokio::time::sleep_until(deadline) => {
-                break;
+        println!("subscriber: snapshot from cache:");
+        if body.is_empty() {
+            println!("  (empty)");
+        } else {
+            for line in body.lines() {
+                println!("  {line}");
             }
         }
-    }
 
-    println!("subscriber: done");
+        // Subscribe for live updates.
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.connect(sub_ep.clone()).await.unwrap();
+        sub.subscribe("").await.unwrap();
+
+        println!("subscriber: listening for live updates (2s) ...");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            tokio::select! {
+                msg = sub.recv() => {
+                    let body = msg_str(&msg.unwrap(), 0);
+                    println!("  live: {body}");
+                }
+                () = tokio::time::sleep_until(deadline) => {
+                    break;
+                }
+            }
+        }
+
+        println!("subscriber: done");
+    });
 }

--- a/examples/zguide-tokio/07_clone/Cargo.toml
+++ b/examples/zguide-tokio/07_clone/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/07_clone/client.rs
+++ b/examples/zguide-tokio/07_clone/client.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -20,95 +20,97 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
-    let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
+        let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
 
-    // Subscribe for live updates first (before snapshot) so we don't
-    // miss anything published between snapshot reply and SUB connect.
-    let sub = Socket::new(SocketType::Sub, Options::default());
-    sub.connect(updates_ep.clone()).await.unwrap();
-    sub.subscribe("").await.unwrap();
-    println!("client: SUB connected to {updates_ep}");
+        // Subscribe for live updates first (before snapshot) so we don't
+        // miss anything published between snapshot reply and SUB connect.
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.connect(updates_ep.clone()).await.unwrap();
+        sub.subscribe("").await.unwrap();
+        println!("client: SUB connected to {updates_ep}");
 
-    // Buffer live updates in a background task.
-    let buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let buffer_tx = Arc::clone(&buffer);
-    let buffer_task = tokio::spawn(async move {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-        loop {
-            tokio::select! {
-                msg = sub.recv() => {
-                    let body = msg_str(&msg.unwrap(), 0);
-                    buffer_tx.lock().unwrap().push(body);
-                }
-                () = tokio::time::sleep_until(deadline) => {
-                    break;
+        // Buffer live updates in a background task.
+        let buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer_tx = Arc::clone(&buffer);
+        let buffer_task = tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+            loop {
+                tokio::select! {
+                    msg = sub.recv() => {
+                        let body = msg_str(&msg.unwrap(), 0);
+                        buffer_tx.lock().unwrap().push(body);
+                    }
+                    () = tokio::time::sleep_until(deadline) => {
+                        break;
+                    }
                 }
             }
-        }
-    });
+        });
 
-    // Give SUB time to connect and subscribe.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+        // Give SUB time to connect and subscribe.
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Request snapshot.
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(snapshot_ep.clone()).await.unwrap();
+        // Request snapshot.
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(snapshot_ep.clone()).await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    req.send(Message::single("SNAPSHOT")).await.unwrap();
-    let reply = req.recv().await.unwrap();
-    let snapshot_body = msg_str(&reply, 0);
+        req.send(Message::single("SNAPSHOT")).await.unwrap();
+        let reply = req.recv().await.unwrap();
+        let snapshot_body = msg_str(&reply, 0);
 
-    let mut store: HashMap<String, String> = HashMap::new();
-    let mut snapshot_seq: u64 = 0;
+        let mut store: HashMap<String, String> = HashMap::new();
+        let mut snapshot_seq: u64 = 0;
 
-    for line in snapshot_body.lines() {
-        if let Some((seq_str, rest)) = line.split_once('|')
-            && let Some((key, val)) = rest.split_once('|')
-        {
-            let s: u64 = seq_str.parse().unwrap_or(0);
-            store.insert(key.to_owned(), val.to_owned());
-            if s > snapshot_seq {
-                snapshot_seq = s;
-            }
-            println!("client (snapshot): {key}={val} seq={s}");
-        }
-    }
-    println!(
-        "client: snapshot has {} entries (up to seq={snapshot_seq})",
-        store.len()
-    );
-
-    // Wait for buffered updates to finish arriving.
-    buffer_task.await.unwrap();
-
-    // Apply buffered updates where seq > snapshot_seq.
-    let buffered = buffer.lock().unwrap();
-    for line in buffered.iter() {
-        if let Some((seq_str, rest)) = line.split_once('|')
-            && let Some((key, val)) = rest.split_once('|')
-        {
-            let s: u64 = seq_str.parse().unwrap_or(0);
-            if s > snapshot_seq {
+        for line in snapshot_body.lines() {
+            if let Some((seq_str, rest)) = line.split_once('|')
+                && let Some((key, val)) = rest.split_once('|')
+            {
+                let s: u64 = seq_str.parse().unwrap_or(0);
                 store.insert(key.to_owned(), val.to_owned());
-                println!("client (live): {key}={val} seq={s}");
-            } else {
-                println!("client (skip): {key}={val} seq={s} (already in snapshot)");
+                if s > snapshot_seq {
+                    snapshot_seq = s;
+                }
+                println!("client (snapshot): {key}={val} seq={s}");
             }
         }
-    }
+        println!(
+            "client: snapshot has {} entries (up to seq={snapshot_seq})",
+            store.len()
+        );
 
-    println!("client: final store ({} entries):", store.len());
-    let mut keys: Vec<_> = store.keys().collect();
-    keys.sort();
-    for k in keys {
-        println!("  {k} = {}", store[k]);
-    }
+        // Wait for buffered updates to finish arriving.
+        buffer_task.await.unwrap();
 
-    println!("client: done");
+        // Apply buffered updates where seq > snapshot_seq.
+        let buffered = buffer.lock().unwrap();
+        for line in buffered.iter() {
+            if let Some((seq_str, rest)) = line.split_once('|')
+                && let Some((key, val)) = rest.split_once('|')
+            {
+                let s: u64 = seq_str.parse().unwrap_or(0);
+                if s > snapshot_seq {
+                    store.insert(key.to_owned(), val.to_owned());
+                    println!("client (live): {key}={val} seq={s}");
+                } else {
+                    println!("client (skip): {key}={val} seq={s} (already in snapshot)");
+                }
+            }
+        }
+
+        println!("client: final store ({} entries):", store.len());
+        let mut keys: Vec<_> = store.keys().collect();
+        keys.sort();
+        for k in keys {
+            println!("  {k} = {}", store[k]);
+        }
+
+        println!("client: done");
+    });
 }

--- a/examples/zguide-tokio/07_clone/server.rs
+++ b/examples/zguide-tokio/07_clone/server.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -26,99 +26,101 @@ struct Entry {
     seq: u64,
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
-    let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
+        let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
 
-    let pub_ = Socket::new(SocketType::Pub, Options::default());
-    pub_.bind(updates_ep.clone()).await.unwrap();
+        let pub_ = Socket::new(SocketType::Pub, Options::default());
+        pub_.bind(updates_ep.clone()).await.unwrap();
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(snapshot_ep.clone()).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(snapshot_ep.clone()).await.unwrap();
 
-    println!("server: PUB bound to {updates_ep}");
-    println!("server: REP bound to {snapshot_ep}");
+        println!("server: PUB bound to {updates_ep}");
+        println!("server: REP bound to {snapshot_ep}");
 
-    let store: Arc<Mutex<HashMap<String, Entry>>> = Arc::new(Mutex::new(HashMap::new()));
-    let mut seq: u64 = 0;
+        let store: Arc<Mutex<HashMap<String, Entry>>> = Arc::new(Mutex::new(HashMap::new()));
+        let mut seq: u64 = 0;
 
-    // Snapshot task: serve snapshot requests.
-    let store_snap = Arc::clone(&store);
-    let snapshot_task = tokio::spawn(async move {
-        loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            if body == "SNAPSHOT" {
-                let payload = {
-                    let locked = store_snap.lock().unwrap();
-                    let p: String = locked
-                        .iter()
-                        .map(|(k, e)| format!("{}|{k}|{}", e.seq, e.value))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    println!("server: snapshot served ({} entries)", locked.len());
-                    p
-                };
-                rep.send(Message::single(payload)).await.unwrap();
+        // Snapshot task: serve snapshot requests.
+        let store_snap = Arc::clone(&store);
+        let snapshot_task = tokio::spawn(async move {
+            loop {
+                let msg = rep.recv().await.unwrap();
+                let body = msg_str(&msg, 0);
+                if body == "SNAPSHOT" {
+                    let payload = {
+                        let locked = store_snap.lock().unwrap();
+                        let p: String = locked
+                            .iter()
+                            .map(|(k, e)| format!("{}|{k}|{}", e.seq, e.value))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        println!("server: snapshot served ({} entries)", locked.len());
+                        p
+                    };
+                    rep.send(Message::single(payload)).await.unwrap();
+                }
+            }
+        });
+
+        // Give subscribers time to connect.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Publish initial updates.
+        for i in 0..5 {
+            seq += 1;
+            let cur = seq;
+
+            let key = format!("key-{i}");
+            let val = format!("val-{i}");
+            store.lock().unwrap().insert(
+                key.clone(),
+                Entry {
+                    value: val.clone(),
+                    seq: cur,
+                },
+            );
+
+            let msg = format!("{cur}|{key}|{val}");
+            pub_.send(Message::single(msg)).await.unwrap();
+            println!("server: published {key}={val} (seq={cur})");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Pause so client can request snapshot.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Publish post-snapshot updates.
+        for i in 0..3 {
+            seq += 1;
+            let cur = seq;
+
+            let key = format!("key-{i}");
+            let val = format!("updated-{i}");
+            store.lock().unwrap().insert(
+                key.clone(),
+                Entry {
+                    value: val.clone(),
+                    seq: cur,
+                },
+            );
+
+            let msg = format!("{cur}|{key}|{val}");
+            pub_.send(Message::single(msg)).await.unwrap();
+            println!("server: published {key}={val} (seq={cur})");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Keep serving snapshots briefly, then exit.
+        tokio::select! {
+            r = snapshot_task => r.unwrap(),
+            () = tokio::time::sleep(Duration::from_secs(3)) => {
+                println!("server: done");
             }
         }
     });
-
-    // Give subscribers time to connect.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Publish initial updates.
-    for i in 0..5 {
-        seq += 1;
-        let cur = seq;
-
-        let key = format!("key-{i}");
-        let val = format!("val-{i}");
-        store.lock().unwrap().insert(
-            key.clone(),
-            Entry {
-                value: val.clone(),
-                seq: cur,
-            },
-        );
-
-        let msg = format!("{cur}|{key}|{val}");
-        pub_.send(Message::single(msg)).await.unwrap();
-        println!("server: published {key}={val} (seq={cur})");
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-
-    // Pause so client can request snapshot.
-    tokio::time::sleep(Duration::from_millis(300)).await;
-
-    // Publish post-snapshot updates.
-    for i in 0..3 {
-        seq += 1;
-        let cur = seq;
-
-        let key = format!("key-{i}");
-        let val = format!("updated-{i}");
-        store.lock().unwrap().insert(
-            key.clone(),
-            Entry {
-                value: val.clone(),
-                seq: cur,
-            },
-        );
-
-        let msg = format!("{cur}|{key}|{val}");
-        pub_.send(Message::single(msg)).await.unwrap();
-        println!("server: published {key}={val} (seq={cur})");
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-
-    // Keep serving snapshots briefly, then exit.
-    tokio::select! {
-        r = snapshot_task => r.unwrap(),
-        () = tokio::time::sleep(Duration::from_secs(3)) => {
-            println!("server: done");
-        }
-    }
 }

--- a/examples/zguide-tokio/08_majordomo/Cargo.toml
+++ b/examples/zguide-tokio/08_majordomo/Cargo.toml
@@ -5,8 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/08_majordomo/broker.rs
+++ b/examples/zguide-tokio/08_majordomo/broker.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -20,92 +20,94 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
-    let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-08-backend");
-    let n_workers: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
+        let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-08-backend");
+        let n_workers: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
 
-    let frontend = Socket::new(SocketType::Router, Options::default());
-    frontend.bind(frontend_ep.clone()).await.unwrap();
+        let frontend = Socket::new(SocketType::Router, Options::default());
+        frontend.bind(frontend_ep.clone()).await.unwrap();
 
-    let backend = Socket::new(SocketType::Router, Options::default());
-    backend.bind(backend_ep.clone()).await.unwrap();
+        let backend = Socket::new(SocketType::Router, Options::default());
+        backend.bind(backend_ep.clone()).await.unwrap();
 
-    println!("broker: frontend={frontend_ep} backend={backend_ep} n_workers={n_workers}");
+        println!("broker: frontend={frontend_ep} backend={backend_ep} n_workers={n_workers}");
 
-    // Worker registration: service_name -> [worker_identity, ...]
-    let mut services: HashMap<String, Vec<Bytes>> = HashMap::new();
+        // Worker registration: service_name -> [worker_identity, ...]
+        let mut services: HashMap<String, Vec<Bytes>> = HashMap::new();
 
-    for _ in 0..n_workers {
-        let msg = backend.recv().await.unwrap();
-        let worker_id = msg.part_bytes(0).unwrap();
-        let command = msg_str(&msg, 1);
-        let service = msg_str(&msg, 2);
-        if command == "READY" {
+        for _ in 0..n_workers {
+            let msg = backend.recv().await.unwrap();
+            let worker_id = msg.part_bytes(0).unwrap();
+            let command = msg_str(&msg, 1);
+            let service = msg_str(&msg, 2);
+            if command == "READY" {
+                println!(
+                    "broker: worker '{}' registered for '{service}'",
+                    String::from_utf8_lossy(&worker_id)
+                );
+                services.entry(service).or_default().push(worker_id);
+            }
+        }
+
+        // Route requests: recv from frontend, dispatch to worker, relay reply.
+        loop {
+            let msg = frontend.recv().await.unwrap();
+            // REQ client -> ROUTER: [client_id, "", service, body]
+            let client_id = msg.part_bytes(0).unwrap();
+            // frame 1 is empty delimiter from REQ
+            let service = msg_str(&msg, 2);
+            let body = msg.part_bytes(3).unwrap();
+
+            let Some(worker_id) = services.get_mut(&service).and_then(|pool| {
+                if pool.is_empty() {
+                    None
+                } else {
+                    Some(pool.remove(0))
+                }
+            }) else {
+                println!("broker: no worker for service '{service}'");
+                continue;
+            };
+
             println!(
-                "broker: worker '{}' registered for '{service}'",
+                "broker: routing '{service}' request to {}",
                 String::from_utf8_lossy(&worker_id)
             );
-            services.entry(service).or_default().push(worker_id);
+
+            // Send to backend ROUTER: [worker_id, client_id, "", body]
+            backend
+                .send(Message::multipart([
+                    worker_id.clone(),
+                    client_id.clone(),
+                    Bytes::from_static(b""),
+                    body,
+                ]))
+                .await
+                .unwrap();
+
+            // Recv reply from backend: [worker_id, client_id, "", reply]
+            let reply_msg = backend.recv().await.unwrap();
+            let reply_worker_id = reply_msg.part_bytes(0).unwrap();
+            let reply_client_id = reply_msg.part_bytes(1).unwrap();
+            // frame 2 is empty delimiter
+            let reply_body = reply_msg.part_bytes(3).unwrap();
+
+            // Return worker to pool
+            services.entry(service).or_default().push(reply_worker_id);
+
+            // Forward to frontend ROUTER: [client_id, "", reply]
+            frontend
+                .send(Message::multipart([
+                    reply_client_id,
+                    Bytes::from_static(b""),
+                    reply_body,
+                ]))
+                .await
+                .unwrap();
         }
-    }
-
-    // Route requests: recv from frontend, dispatch to worker, relay reply.
-    loop {
-        let msg = frontend.recv().await.unwrap();
-        // REQ client -> ROUTER: [client_id, "", service, body]
-        let client_id = msg.part_bytes(0).unwrap();
-        // frame 1 is empty delimiter from REQ
-        let service = msg_str(&msg, 2);
-        let body = msg.part_bytes(3).unwrap();
-
-        let Some(worker_id) = services.get_mut(&service).and_then(|pool| {
-            if pool.is_empty() {
-                None
-            } else {
-                Some(pool.remove(0))
-            }
-        }) else {
-            println!("broker: no worker for service '{service}'");
-            continue;
-        };
-
-        println!(
-            "broker: routing '{service}' request to {}",
-            String::from_utf8_lossy(&worker_id)
-        );
-
-        // Send to backend ROUTER: [worker_id, client_id, "", body]
-        backend
-            .send(Message::multipart([
-                worker_id.clone(),
-                client_id.clone(),
-                Bytes::from_static(b""),
-                body,
-            ]))
-            .await
-            .unwrap();
-
-        // Recv reply from backend: [worker_id, client_id, "", reply]
-        let reply_msg = backend.recv().await.unwrap();
-        let reply_worker_id = reply_msg.part_bytes(0).unwrap();
-        let reply_client_id = reply_msg.part_bytes(1).unwrap();
-        // frame 2 is empty delimiter
-        let reply_body = reply_msg.part_bytes(3).unwrap();
-
-        // Return worker to pool
-        services.entry(service).or_default().push(reply_worker_id);
-
-        // Forward to frontend ROUTER: [client_id, "", reply]
-        frontend
-            .send(Message::multipart([
-                reply_client_id,
-                Bytes::from_static(b""),
-                reply_body,
-            ]))
-            .await
-            .unwrap();
-    }
+    });
 }

--- a/examples/zguide-tokio/08_majordomo/client.rs
+++ b/examples/zguide-tokio/08_majordomo/client.rs
@@ -5,7 +5,7 @@
 //!
 //!     cargo run -p zguide-tokio-08-majordomo --bin client [frontend_ep]
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -15,29 +15,31 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(frontend_ep).await.unwrap();
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(frontend_ep).await.unwrap();
 
-    let requests = [
-        ("echo", "hello"),
-        ("echo", "world"),
-        ("upper", "foo"),
-        ("echo", "test"),
-        ("upper", "bar"),
-        ("upper", "baz"),
-    ];
+        let requests = [
+            ("echo", "hello"),
+            ("echo", "world"),
+            ("upper", "foo"),
+            ("echo", "test"),
+            ("upper", "bar"),
+            ("upper", "baz"),
+        ];
 
-    for (service, body) in requests {
-        req.send(Message::multipart([service, body])).await.unwrap();
-        let reply = req.recv().await.unwrap();
-        let reply_body = msg_str(&reply, 0);
-        println!("client: {service}({body}) -> {reply_body}");
-    }
+        for (service, body) in requests {
+            req.send(Message::multipart([service, body])).await.unwrap();
+            let reply = req.recv().await.unwrap();
+            let reply_body = msg_str(&reply, 0);
+            println!("client: {service}({body}) -> {reply_body}");
+        }
 
-    println!("done: {} requests", requests.len());
+        println!("done: {} requests", requests.len());
+    });
 }

--- a/examples/zguide-tokio/08_majordomo/worker.rs
+++ b/examples/zguide-tokio/08_majordomo/worker.rs
@@ -7,7 +7,7 @@
 //!         [backend_ep] [service_name] [worker_id]
 
 use bytes::Bytes;
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -17,46 +17,48 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-backend");
-    let service: String = args.get(2).map_or_else(|| "echo".into(), Clone::clone);
-    let id: String = args.get(3).map_or_else(|| "0".into(), Clone::clone);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-backend");
+        let service: String = args.get(2).map_or_else(|| "echo".into(), Clone::clone);
+        let id: String = args.get(3).map_or_else(|| "0".into(), Clone::clone);
 
-    let identity = Bytes::from(format!("{service}-{id}"));
-    let dealer = Socket::new(SocketType::Dealer, Options::default().identity(identity));
-    dealer.connect(backend_ep).await.unwrap();
+        let identity = Bytes::from(format!("{service}-{id}"));
+        let dealer = Socket::new(SocketType::Dealer, Options::default().identity(identity));
+        dealer.connect(backend_ep).await.unwrap();
 
-    // Register with broker
-    dealer
-        .send(Message::multipart(["READY".to_string(), service.clone()]))
-        .await
-        .unwrap();
-    println!("worker({service}-{id}): ready");
-
-    // Process requests
-    loop {
-        let msg = dealer.recv().await.unwrap();
-        // DEALER sees: [client_id, "", body]
-        let client_id = msg.part_bytes(0).unwrap();
-        let body = msg_str(&msg, 2);
-
-        let reply = match service.as_str() {
-            "echo" => format!("echo:{body}"),
-            "upper" => body.to_uppercase(),
-            _ => body.clone(),
-        };
-
-        println!("worker({service}-{id}): {body} -> {reply}");
-
+        // Register with broker
         dealer
-            .send(Message::multipart([
-                client_id,
-                Bytes::from_static(b""),
-                Bytes::from(reply),
-            ]))
+            .send(Message::multipart(["READY".to_string(), service.clone()]))
             .await
             .unwrap();
-    }
+        println!("worker({service}-{id}): ready");
+
+        // Process requests
+        loop {
+            let msg = dealer.recv().await.unwrap();
+            // DEALER sees: [client_id, "", body]
+            let client_id = msg.part_bytes(0).unwrap();
+            let body = msg_str(&msg, 2);
+
+            let reply = match service.as_str() {
+                "echo" => format!("echo:{body}"),
+                "upper" => body.to_uppercase(),
+                _ => body.clone(),
+            };
+
+            println!("worker({service}-{id}): {body} -> {reply}");
+
+            dealer
+                .send(Message::multipart([
+                    client_id,
+                    Bytes::from_static(b""),
+                    Bytes::from(reply),
+                ]))
+                .await
+                .unwrap();
+        }
+    });
 }

--- a/examples/zguide-tokio/09_titanic/Cargo.toml
+++ b/examples/zguide-tokio/09_titanic/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/09_titanic/client.rs
+++ b/examples/zguide-tokio/09_titanic/client.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(
@@ -20,47 +20,49 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
 
-    let req = Socket::new(SocketType::Req, Options::default());
-    req.connect(frontend_ep).await.unwrap();
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(frontend_ep).await.unwrap();
 
-    let requests = [("echo", "hello"), ("upper", "world"), ("echo", "foo")];
+        let requests = [("echo", "hello"), ("upper", "world"), ("echo", "foo")];
 
-    // Submit requests, collect tickets.
-    let mut tickets = Vec::new();
-    for (service, body) in &requests {
-        req.send(Message::single(format!("SUBMIT|{service}|{body}")))
-            .await
-            .unwrap();
-        let reply = req.recv().await.unwrap();
-        let reply = msg_str(&reply, 0);
-        let (status, ticket) = reply.split_once('|').expect("bad reply");
-        assert_eq!(status, "TICKET");
-        println!("client: submitted {service}({body}) -> ticket {ticket}");
-        tickets.push(ticket.to_owned());
-    }
+        // Submit requests, collect tickets.
+        let mut tickets = Vec::new();
+        for (service, body) in &requests {
+            req.send(Message::single(format!("SUBMIT|{service}|{body}")))
+                .await
+                .unwrap();
+            let reply = req.recv().await.unwrap();
+            let reply = msg_str(&reply, 0);
+            let (status, ticket) = reply.split_once('|').expect("bad reply");
+            assert_eq!(status, "TICKET");
+            println!("client: submitted {service}({body}) -> ticket {ticket}");
+            tickets.push(ticket.to_owned());
+        }
 
-    // Give the dispatcher time to process.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+        // Give the dispatcher time to process.
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Poll for results.
-    for ticket in &tickets {
-        req.send(Message::single(format!("RESULT|{ticket}")))
-            .await
-            .unwrap();
-        let reply = req.recv().await.unwrap();
-        let reply = msg_str(&reply, 0);
-        let (status, result) = reply.split_once('|').expect("bad reply");
-        assert_eq!(status, "OK", "expected result for {ticket}");
-        println!("client: result for {ticket} -> {result}");
-    }
+        // Poll for results.
+        for ticket in &tickets {
+            req.send(Message::single(format!("RESULT|{ticket}")))
+                .await
+                .unwrap();
+            let reply = req.recv().await.unwrap();
+            let reply = msg_str(&reply, 0);
+            let (status, result) = reply.split_once('|').expect("bad reply");
+            assert_eq!(status, "OK", "expected result for {ticket}");
+            println!("client: result for {ticket} -> {result}");
+        }
 
-    println!(
-        "done: {} requests persisted, dispatched, and retrieved",
-        tickets.len()
-    );
+        println!(
+            "done: {} requests persisted, dispatched, and retrieved",
+            tickets.len()
+        );
+    });
 }

--- a/examples/zguide-tokio/09_titanic/dispatcher.rs
+++ b/examples/zguide-tokio/09_titanic/dispatcher.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(
@@ -22,41 +22,44 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let dispatch_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-dispatch");
-    let store_dir = args.get(2).map_or("/tmp/omq-titanic", String::as_str);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let dispatch_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-dispatch");
+        let store_dir = args.get(2).map_or("/tmp/omq-titanic", String::as_str);
 
-    let pull = Socket::new(SocketType::Pull, Options::default());
-    pull.connect(dispatch_ep.clone()).await.unwrap();
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        pull.connect(dispatch_ep.clone()).await.unwrap();
 
-    println!("dispatcher: {dispatch_ep} store={store_dir}");
+        println!("dispatcher: {dispatch_ep} store={store_dir}");
 
-    loop {
-        let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), pull.recv()).await else {
-            break;
-        };
-        let ticket = msg_str(&msg, 0);
-        let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
+        loop {
+            let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), pull.recv()).await
+            else {
+                break;
+            };
+            let ticket = msg_str(&msg, 0);
+            let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
 
-        let Ok(contents) = std::fs::read_to_string(&req_path) else {
-            continue;
-        };
+            let Ok(contents) = std::fs::read_to_string(&req_path) else {
+                continue;
+            };
 
-        let (service, body) = contents.split_once('|').unwrap_or(("", &contents));
+            let (service, body) = contents.split_once('|').unwrap_or(("", &contents));
 
-        let result = match service {
-            "echo" => format!("echo:{body}"),
-            "upper" => body.to_uppercase(),
-            _ => format!("unknown service: {service}"),
-        };
+            let result = match service {
+                "echo" => format!("echo:{body}"),
+                "upper" => body.to_uppercase(),
+                _ => format!("unknown service: {service}"),
+            };
 
-        let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
-        std::fs::write(&res_path, &result).expect("write .res failed");
+            let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
+            std::fs::write(&res_path, &result).expect("write .res failed");
 
-        println!("dispatcher: processed {ticket} -> {result}");
-    }
+            println!("dispatcher: processed {ticket} -> {result}");
+        }
 
-    println!("dispatcher: done (recv timeout)");
+        println!("dispatcher: done (recv timeout)");
+    });
 }

--- a/examples/zguide-tokio/09_titanic/frontend.rs
+++ b/examples/zguide-tokio/09_titanic/frontend.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 static NEXT: AtomicU64 = AtomicU64::new(1);
 
@@ -25,69 +25,73 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
-    let dispatch_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-09-dispatch");
-    let store_dir = args.get(3).map_or("/tmp/omq-titanic", String::as_str);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
+        let dispatch_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-09-dispatch");
+        let store_dir = args.get(3).map_or("/tmp/omq-titanic", String::as_str);
 
-    std::fs::create_dir_all(store_dir).expect("cannot create store dir");
+        std::fs::create_dir_all(store_dir).expect("cannot create store dir");
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(frontend_ep.clone()).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(frontend_ep.clone()).await.unwrap();
 
-    let push = Socket::new(SocketType::Push, Options::default());
-    push.bind(dispatch_ep.clone()).await.unwrap();
+        let push = Socket::new(SocketType::Push, Options::default());
+        push.bind(dispatch_ep.clone()).await.unwrap();
 
-    println!("frontend: {frontend_ep} dispatch={dispatch_ep} store={store_dir}");
+        println!("frontend: {frontend_ep} dispatch={dispatch_ep} store={store_dir}");
 
-    loop {
-        let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), rep.recv()).await else {
-            break;
-        };
-        let body = msg_str(&msg, 0);
-        let parts: Vec<&str> = body.splitn(3, '|').collect();
+        loop {
+            let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), rep.recv()).await
+            else {
+                break;
+            };
+            let body = msg_str(&msg, 0);
+            let parts: Vec<&str> = body.splitn(3, '|').collect();
 
-        match parts[0] {
-            "SUBMIT" if parts.len() == 3 => {
-                let service = parts[1];
-                let payload = parts[2];
-                let ticket = NEXT.fetch_add(1, Ordering::Relaxed);
-                let ticket = format!("{ticket:016x}");
+            match parts[0] {
+                "SUBMIT" if parts.len() == 3 => {
+                    let service = parts[1];
+                    let payload = parts[2];
+                    let ticket = NEXT.fetch_add(1, Ordering::Relaxed);
+                    let ticket = format!("{ticket:016x}");
 
-                let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
-                std::fs::write(&req_path, format!("{service}|{payload}"))
-                    .expect("write .req failed");
+                    let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
+                    std::fs::write(&req_path, format!("{service}|{payload}"))
+                        .expect("write .req failed");
 
-                rep.send(Message::single(format!("TICKET|{ticket}")))
-                    .await
-                    .unwrap();
-                push.send(Message::single(ticket.clone())).await.unwrap();
-
-                println!("frontend: accepted {ticket} for '{service}'");
-            }
-            "RESULT" if parts.len() >= 2 => {
-                let ticket = parts[1];
-                let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
-
-                if res_path.exists() {
-                    let contents = std::fs::read_to_string(&res_path).expect("read .res failed");
-                    rep.send(Message::single(format!("OK|{contents}")))
+                    rep.send(Message::single(format!("TICKET|{ticket}")))
                         .await
                         .unwrap();
-                    println!("frontend: served result for {ticket}");
-                } else {
-                    rep.send(Message::single("PENDING")).await.unwrap();
+                    push.send(Message::single(ticket.clone())).await.unwrap();
+
+                    println!("frontend: accepted {ticket} for '{service}'");
+                }
+                "RESULT" if parts.len() >= 2 => {
+                    let ticket = parts[1];
+                    let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
+
+                    if res_path.exists() {
+                        let contents =
+                            std::fs::read_to_string(&res_path).expect("read .res failed");
+                        rep.send(Message::single(format!("OK|{contents}")))
+                            .await
+                            .unwrap();
+                        println!("frontend: served result for {ticket}");
+                    } else {
+                        rep.send(Message::single("PENDING")).await.unwrap();
+                    }
+                }
+                _ => {
+                    rep.send(Message::single("ERROR|unknown command"))
+                        .await
+                        .unwrap();
                 }
             }
-            _ => {
-                rep.send(Message::single("ERROR|unknown command"))
-                    .await
-                    .unwrap();
-            }
         }
-    }
 
-    println!("frontend: done (recv timeout)");
+        println!("frontend: done (recv timeout)");
+    });
 }

--- a/examples/zguide-tokio/10_binary_star/Cargo.toml
+++ b/examples/zguide-tokio/10_binary_star/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["rt", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/10_binary_star/backup.rs
+++ b/examples/zguide-tokio/10_binary_star/backup.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,42 +18,44 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let heartbeat_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-heartbeat");
-    let service_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let heartbeat_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-heartbeat");
+        let service_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
 
-    let sub = Socket::new(SocketType::Sub, Options::default());
-    sub.connect(heartbeat_ep).await.unwrap();
-    sub.subscribe("HB").await.unwrap();
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.connect(heartbeat_ep).await.unwrap();
+        sub.subscribe("HB").await.unwrap();
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(service_ep).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(service_ep).await.unwrap();
 
-    // Phase 1: monitor heartbeats.
-    let timeout = Duration::from_millis(300);
-    loop {
-        match tokio::time::timeout(timeout, sub.recv()).await {
-            Ok(Ok(_)) => {} // heartbeat received, primary is alive
-            Ok(Err(e)) => {
-                eprintln!("backup: recv error: {e}");
-                return;
-            }
-            Err(_) => {
-                println!("backup: primary heartbeat lost -- taking over!");
-                break;
+        // Phase 1: monitor heartbeats.
+        let timeout = Duration::from_millis(300);
+        loop {
+            match tokio::time::timeout(timeout, sub.recv()).await {
+                Ok(Ok(_)) => {} // heartbeat received, primary is alive
+                Ok(Err(e)) => {
+                    eprintln!("backup: recv error: {e}");
+                    return;
+                }
+                Err(_) => {
+                    println!("backup: primary heartbeat lost -- taking over!");
+                    break;
+                }
             }
         }
-    }
 
-    // Phase 2: serve requests.
-    loop {
-        let msg = rep.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        println!("backup: served {body}");
-        rep.send(Message::single(format!("backup:{body}")))
-            .await
-            .unwrap();
-    }
+        // Phase 2: serve requests.
+        loop {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            println!("backup: served {body}");
+            rep.send(Message::single(format!("backup:{body}")))
+                .await
+                .unwrap();
+        }
+    });
 }

--- a/examples/zguide-tokio/10_binary_star/client.rs
+++ b/examples/zguide-tokio/10_binary_star/client.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,56 +18,58 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let primary_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
-    let backup_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
-    let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(4);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let primary_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
+        let backup_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
+        let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(4);
 
-    for i in 0..n {
-        let body = format!("req-{i}");
+        for i in 0..n {
+            let body = format!("req-{i}");
 
-        // Try primary first.
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(primary_ep.clone()).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
+            // Try primary first.
+            let req = Socket::new(SocketType::Req, Options::default());
+            req.connect(primary_ep.clone()).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
 
-        req.send(Message::single(body.clone())).await.unwrap();
+            req.send(Message::single(body.clone())).await.unwrap();
 
-        match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
-            Ok(Ok(reply)) => {
-                println!("client: {body} -> {}", msg_str(&reply, 0));
-                continue;
+            match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
+                Ok(Ok(reply)) => {
+                    println!("client: {body} -> {}", msg_str(&reply, 0));
+                    continue;
+                }
+                Ok(Err(e)) => {
+                    eprintln!("client: recv error from primary: {e}");
+                }
+                Err(_) => {
+                    println!("client: primary timeout for {body}, trying backup");
+                }
             }
-            Ok(Err(e)) => {
-                eprintln!("client: recv error from primary: {e}");
-            }
-            Err(_) => {
-                println!("client: primary timeout for {body}, trying backup");
+            drop(req);
+
+            // Fallback to backup.
+            let req = Socket::new(SocketType::Req, Options::default());
+            req.connect(backup_ep.clone()).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            req.send(Message::single(body.clone())).await.unwrap();
+
+            match tokio::time::timeout(Duration::from_secs(1), req.recv()).await {
+                Ok(Ok(reply)) => {
+                    println!("client: {body} -> {}", msg_str(&reply, 0));
+                }
+                Ok(Err(e)) => {
+                    eprintln!("client: recv error from backup: {e}");
+                }
+                Err(_) => {
+                    eprintln!("client: backup also timed out for {body}");
+                }
             }
         }
-        drop(req);
 
-        // Fallback to backup.
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(backup_ep.clone()).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
-
-        req.send(Message::single(body.clone())).await.unwrap();
-
-        match tokio::time::timeout(Duration::from_secs(1), req.recv()).await {
-            Ok(Ok(reply)) => {
-                println!("client: {body} -> {}", msg_str(&reply, 0));
-            }
-            Ok(Err(e)) => {
-                eprintln!("client: recv error from backup: {e}");
-            }
-            Err(_) => {
-                eprintln!("client: backup also timed out for {body}");
-            }
-        }
-    }
-
-    println!("client: done ({n} requests)");
+        println!("client: done ({n} requests)");
+    });
 }

--- a/examples/zguide-tokio/10_binary_star/primary.rs
+++ b/examples/zguide-tokio/10_binary_star/primary.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -18,33 +18,35 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let service_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
-    let heartbeat_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-heartbeat");
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let service_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
+        let heartbeat_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-heartbeat");
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(service_ep).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(service_ep).await.unwrap();
 
-    let pub_socket = Socket::new(SocketType::Pub, Options::default());
-    pub_socket.bind(heartbeat_ep).await.unwrap();
+        let pub_socket = Socket::new(SocketType::Pub, Options::default());
+        pub_socket.bind(heartbeat_ep).await.unwrap();
 
-    // Heartbeat task: send "HB" every 50ms.
-    tokio::spawn(async move {
+        // Heartbeat task: send "HB" every 50ms.
+        tokio::spawn(async move {
+            loop {
+                pub_socket.send(Message::single("HB")).await.unwrap();
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+
+        // Server task: recv on REP, reply with "primary:{body}".
         loop {
-            pub_socket.send(Message::single("HB")).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            println!("primary: served {body}");
+            rep.send(Message::single(format!("primary:{body}")))
+                .await
+                .unwrap();
         }
     });
-
-    // Server task: recv on REP, reply with "primary:{body}".
-    loop {
-        let msg = rep.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        println!("primary: served {body}");
-        rep.send(Message::single(format!("primary:{body}")))
-            .await
-            .unwrap();
-    }
 }

--- a/examples/zguide-tokio/11_freelance/Cargo.toml
+++ b/examples/zguide-tokio/11_freelance/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-omq-tokio = { version = "0.17.0", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+omq-tokio = { version = "0.18.0", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/11_freelance/client_sequential.rs
+++ b/examples/zguide-tokio/11_freelance/client_sequential.rs
@@ -8,58 +8,60 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let endpoints: Vec<Endpoint> = if args.len() > 1 {
-        args[1..]
-            .iter()
-            .map(|s| s.parse().expect("invalid endpoint"))
-            .collect()
-    } else {
-        vec![
-            "ipc://@omq-zguide-11-server1".parse().unwrap(),
-            "ipc://@omq-zguide-11-server2".parse().unwrap(),
-            "ipc://@omq-zguide-11-server3".parse().unwrap(),
-        ]
-    };
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let endpoints: Vec<Endpoint> = if args.len() > 1 {
+            args[1..]
+                .iter()
+                .map(|s| s.parse().expect("invalid endpoint"))
+                .collect()
+        } else {
+            vec![
+                "ipc://@omq-zguide-11-server1".parse().unwrap(),
+                "ipc://@omq-zguide-11-server2".parse().unwrap(),
+                "ipc://@omq-zguide-11-server3".parse().unwrap(),
+            ]
+        };
 
-    for i in 0..3 {
-        let body = format!("request-{i}");
-        let mut served = false;
+        for i in 0..3 {
+            let body = format!("request-{i}");
+            let mut served = false;
 
-        for ep in &endpoints {
-            let req = Socket::new(SocketType::Req, Options::default());
-            req.connect(ep.clone()).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            for ep in &endpoints {
+                let req = Socket::new(SocketType::Req, Options::default());
+                req.connect(ep.clone()).await.unwrap();
+                tokio::time::sleep(Duration::from_millis(20)).await;
 
-            req.send(Message::single(body.clone())).await.unwrap();
+                req.send(Message::single(body.clone())).await.unwrap();
 
-            match tokio::time::timeout(Duration::from_millis(150), req.recv()).await {
-                Ok(Ok(reply)) => {
-                    println!("client: {body} -> {}", msg_str(&reply, 0));
-                    served = true;
-                    break;
+                match tokio::time::timeout(Duration::from_millis(150), req.recv()).await {
+                    Ok(Ok(reply)) => {
+                        println!("client: {body} -> {}", msg_str(&reply, 0));
+                        served = true;
+                        break;
+                    }
+                    Ok(Err(e)) => {
+                        eprintln!("client: recv error on {ep}: {e}");
+                    }
+                    Err(_) => {
+                        println!("client: timeout on {ep}, trying next");
+                    }
                 }
-                Ok(Err(e)) => {
-                    eprintln!("client: recv error on {ep}: {e}");
-                }
-                Err(_) => {
-                    println!("client: timeout on {ep}, trying next");
-                }
+            }
+
+            if !served {
+                eprintln!("client: all endpoints failed for {body}");
             }
         }
 
-        if !served {
-            eprintln!("client: all endpoints failed for {body}");
-        }
-    }
-
-    println!("client: done (3 requests)");
+        println!("client: done (3 requests)");
+    });
 }

--- a/examples/zguide-tokio/11_freelance/client_shotgun.rs
+++ b/examples/zguide-tokio/11_freelance/client_shotgun.rs
@@ -7,56 +7,58 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let endpoints: Vec<Endpoint> = if args.len() > 1 {
-        args[1..]
-            .iter()
-            .map(|s| s.parse().expect("invalid endpoint"))
-            .collect()
-    } else {
-        vec![
-            "ipc://@omq-zguide-11-server1".parse().unwrap(),
-            "ipc://@omq-zguide-11-server2".parse().unwrap(),
-        ]
-    };
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let endpoints: Vec<Endpoint> = if args.len() > 1 {
+            args[1..]
+                .iter()
+                .map(|s| s.parse().expect("invalid endpoint"))
+                .collect()
+        } else {
+            vec![
+                "ipc://@omq-zguide-11-server1".parse().unwrap(),
+                "ipc://@omq-zguide-11-server2".parse().unwrap(),
+            ]
+        };
 
-    let dealer = Socket::new(SocketType::Dealer, Options::default());
-    for ep in &endpoints {
-        dealer.connect(ep.clone()).await.unwrap();
-    }
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Send one request per endpoint (empty delimiter + body).
-    for _ in &endpoints {
-        dealer
-            .send(Message::multipart(["", "shotgun-req"]))
-            .await
-            .unwrap();
-    }
-
-    // Take the first reply.
-    match tokio::time::timeout(Duration::from_secs(1), dealer.recv()).await {
-        Ok(Ok(reply)) => {
-            // Reply from REP via DEALER: [delimiter, body].
-            let n = reply.len();
-            let body = msg_str(&reply, n - 1);
-            println!("client: first reply = {body}");
+        let dealer = Socket::new(SocketType::Dealer, Options::default());
+        for ep in &endpoints {
+            dealer.connect(ep.clone()).await.unwrap();
         }
-        Ok(Err(e)) => {
-            eprintln!("client: recv error: {e}");
-        }
-        Err(_) => {
-            eprintln!("client: timeout waiting for reply");
-        }
-    }
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    println!("client: done");
+        // Send one request per endpoint (empty delimiter + body).
+        for _ in &endpoints {
+            dealer
+                .send(Message::multipart(["", "shotgun-req"]))
+                .await
+                .unwrap();
+        }
+
+        // Take the first reply.
+        match tokio::time::timeout(Duration::from_secs(1), dealer.recv()).await {
+            Ok(Ok(reply)) => {
+                // Reply from REP via DEALER: [delimiter, body].
+                let n = reply.len();
+                let body = msg_str(&reply, n - 1);
+                println!("client: first reply = {body}");
+            }
+            Ok(Err(e)) => {
+                eprintln!("client: recv error: {e}");
+            }
+            Err(_) => {
+                eprintln!("client: timeout waiting for reply");
+            }
+        }
+
+        println!("client: done");
+    });
 }

--- a/examples/zguide-tokio/11_freelance/client_tracked.rs
+++ b/examples/zguide-tokio/11_freelance/client_tracked.rs
@@ -11,81 +11,83 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let endpoints: Vec<Endpoint> = if args.len() > 1 {
-        args[1..]
-            .iter()
-            .map(|s| s.parse().expect("invalid endpoint"))
-            .collect()
-    } else {
-        vec![
-            "ipc://@omq-zguide-11-server1".parse().unwrap(),
-            "ipc://@omq-zguide-11-server2".parse().unwrap(),
-        ]
-    };
-
-    let mut known_good: Option<usize> = None;
-
-    for i in 0..6 {
-        let body = format!("request-{i}");
-
-        // Build try order: known_good first, then the rest.
-        let try_order: Vec<usize> = if let Some(kg) = known_good {
-            let mut order = vec![kg];
-            for idx in 0..endpoints.len() {
-                if idx != kg {
-                    order.push(idx);
-                }
-            }
-            order
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let endpoints: Vec<Endpoint> = if args.len() > 1 {
+            args[1..]
+                .iter()
+                .map(|s| s.parse().expect("invalid endpoint"))
+                .collect()
         } else {
-            (0..endpoints.len()).collect()
+            vec![
+                "ipc://@omq-zguide-11-server1".parse().unwrap(),
+                "ipc://@omq-zguide-11-server2".parse().unwrap(),
+            ]
         };
 
-        let mut served = false;
-        for &idx in &try_order {
-            let ep = &endpoints[idx];
-            let req = Socket::new(SocketType::Req, Options::default());
-            req.connect(ep.clone()).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(20)).await;
+        let mut known_good: Option<usize> = None;
 
-            req.send(Message::single(body.clone())).await.unwrap();
+        for i in 0..6 {
+            let body = format!("request-{i}");
 
-            match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
-                Ok(Ok(reply)) => {
-                    let reply_str = msg_str(&reply, 0);
-                    println!("client: {body} -> {reply_str} (via {ep})");
-                    known_good = Some(idx);
-                    served = true;
-                    break;
+            // Build try order: known_good first, then the rest.
+            let try_order: Vec<usize> = if let Some(kg) = known_good {
+                let mut order = vec![kg];
+                for idx in 0..endpoints.len() {
+                    if idx != kg {
+                        order.push(idx);
+                    }
                 }
-                Ok(Err(e)) => {
-                    eprintln!("client: recv error on {ep}: {e}");
-                }
-                Err(_) => {
-                    println!("client: {ep} timed out, rotating");
-                    if known_good == Some(idx) {
-                        known_good = None;
+                order
+            } else {
+                (0..endpoints.len()).collect()
+            };
+
+            let mut served = false;
+            for &idx in &try_order {
+                let ep = &endpoints[idx];
+                let req = Socket::new(SocketType::Req, Options::default());
+                req.connect(ep.clone()).await.unwrap();
+                tokio::time::sleep(Duration::from_millis(20)).await;
+
+                req.send(Message::single(body.clone())).await.unwrap();
+
+                match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
+                    Ok(Ok(reply)) => {
+                        let reply_str = msg_str(&reply, 0);
+                        println!("client: {body} -> {reply_str} (via {ep})");
+                        known_good = Some(idx);
+                        served = true;
+                        break;
+                    }
+                    Ok(Err(e)) => {
+                        eprintln!("client: recv error on {ep}: {e}");
+                    }
+                    Err(_) => {
+                        println!("client: {ep} timed out, rotating");
+                        if known_good == Some(idx) {
+                            known_good = None;
+                        }
                     }
                 }
             }
+
+            if !served {
+                eprintln!("client: all endpoints failed for {body}");
+            }
+
+            // Pace requests so run.sh can kill a server mid-run.
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        if !served {
-            eprintln!("client: all endpoints failed for {body}");
-        }
-
-        // Pace requests so run.sh can kill a server mid-run.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-
-    println!("client: done (6 requests)");
+        println!("client: done (6 requests)");
+    });
 }

--- a/examples/zguide-tokio/11_freelance/server.rs
+++ b/examples/zguide-tokio/11_freelance/server.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
@@ -17,25 +17,27 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-11-server1");
-    let name = args.get(2).cloned().unwrap_or_else(|| "server".to_string());
-    let delay_secs: f64 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let args: Vec<String> = std::env::args().collect();
+        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-11-server1");
+        let name = args.get(2).cloned().unwrap_or_else(|| "server".to_string());
+        let delay_secs: f64 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
 
-    let rep = Socket::new(SocketType::Rep, Options::default());
-    rep.bind(ep).await.unwrap();
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.bind(ep).await.unwrap();
 
-    loop {
-        let msg = rep.recv().await.unwrap();
-        let body = msg_str(&msg, 0);
-        if delay_secs > 0.0 {
-            tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
+        loop {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            if delay_secs > 0.0 {
+                tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
+            }
+            println!("{name}: served {body}");
+            rep.send(Message::single(format!("{name}:{body}")))
+                .await
+                .unwrap();
         }
-        println!("{name}: served {body}");
-        rep.send(Message::single(format!("{name}:{body}")))
-            .await
-            .unwrap();
-    }
+    });
 }

--- a/examples/zguide-tokio/Cargo.lock
+++ b/examples/zguide-tokio/Cargo.lock
@@ -21,18 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "blume"
 version = "0.4.5"
 dependencies = [
@@ -104,16 +92,6 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
  "pin-project-lite",
 ]
 
@@ -294,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bytes",
  "patricia_tree",
@@ -306,10 +284,9 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arc-swap",
- "async-channel",
  "blume",
  "bytes",
  "concurrent-queue",
@@ -636,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "loom",
 ]
@@ -710,7 +687,6 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "omq-tokio",
- "tokio",
 ]
 
 [[package]]

--- a/omq-bench/Cargo.toml
+++ b/omq-bench/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "omq-bench"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+publish = false
+
+[[bin]]
+name = "omq-bench"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+libc = "0.2"
+omq-tokio = { path = "../omq-tokio", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/omq-bench/src/bench/comparisons.rs
+++ b/omq-bench/src/bench/comparisons.rs
@@ -1,0 +1,2039 @@
+use crate::cli::ComparisonsArgs;
+use crate::coord::CoordSocket;
+use crate::jsonl::{self, ComparisonRow};
+use crate::parse;
+use crate::process;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const COMPARISON_CHART_SIZES: &[u64] = &[16, 64, 256, 1024, 4096, 16384];
+const MAIN_EXTRA_CHART_SIZES: &[u64] = &[32, 128, 512, 2048, 8192, 32768, 262_144, 4_194_304];
+const QUICK_SIZES: &[u64] = &[64, 1024, 4096];
+
+const LATENCY_MAX_SIZE: u64 = 32768;
+
+const DEFAULT_DURATION: f64 = 3.0;
+const QUICK_DURATION: f64 = 1.5;
+const DEFAULT_ROUNDS: u32 = 2;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ImplClass {
+    Classic,
+    IoUring,
+    Curve,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransportKind {
+    Tcp,
+    Ipc,
+    Inproc,
+    Ws,
+}
+
+impl TransportKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Ipc => "ipc",
+            Self::Inproc => "inproc",
+            Self::Ws => "ws",
+        }
+    }
+}
+
+#[expect(clippy::struct_excessive_bools)]
+pub(crate) struct ImplDef {
+    pub name: &'static str,
+    pub binary_from: Option<&'static str>,
+    pub prefix: &'static str,
+    pub class: Option<ImplClass>,
+    pub main: bool,
+    pub transports: &'static [TransportKind],
+    pub inproc_tput_subcmd: &'static str,
+    pub inproc_lat_subcmd: &'static str,
+    pub inproc_pubsub_subcmd: &'static str,
+    pub pub_needs_peer_count: bool,
+    pub fanout_subcmd: &'static str,
+    pub fanio_needs_peer_count: bool,
+    pub supports_pubsub: bool,
+    pub env: &'static [(&'static str, &'static str)],
+}
+
+use TransportKind::{Inproc, Ipc, Tcp, Ws};
+
+static IMPLS: &[ImplDef] = &[
+    ImplDef {
+        name: "omq-tokio-ct",
+        binary_from: None,
+        prefix: "t",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp, Inproc, Ipc, Ws],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "pub-fanout",
+        fanio_needs_peer_count: true,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
+        name: "omq-tokio-1t",
+        binary_from: None,
+        prefix: "b",
+        class: Some(ImplClass::Classic),
+        main: false,
+        transports: &[Tcp, Ipc],
+        inproc_tput_subcmd: "",
+        inproc_lat_subcmd: "",
+        inproc_pubsub_subcmd: "",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
+        name: "omq-tokio-2t",
+        binary_from: Some("omq-tokio-ct"),
+        prefix: "u",
+        class: Some(ImplClass::Classic),
+        main: false,
+        transports: &[Tcp, Inproc, Ipc, Ws],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: true,
+        supports_pubsub: true,
+        env: &[("OMQ_IO_THREADS", "2")],
+    },
+    ImplDef {
+        name: "libzmq",
+        binary_from: None,
+        prefix: "z",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp, Inproc, Ipc, Ws],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
+        name: "libzmq-2t",
+        binary_from: Some("libzmq"),
+        prefix: "Y",
+        class: Some(ImplClass::Classic),
+        main: false,
+        transports: &[Tcp, Ipc, Ws],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[("ZMQ_IO_THREADS", "2")],
+    },
+    ImplDef {
+        name: "zmq.rs",
+        binary_from: None,
+        prefix: "q",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp, Ipc],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
+        name: "rzmq",
+        binary_from: None,
+        prefix: "r",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp, Inproc, Ipc],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
+        name: "rzmq-iouring",
+        binary_from: Some("rzmq"),
+        prefix: "R",
+        class: Some(ImplClass::IoUring),
+        main: true,
+        transports: &[Tcp, Inproc, Ipc],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[("RZMQ_IO_URING", "1")],
+    },
+    ImplDef {
+        name: "libzmq-curve-1t",
+        binary_from: Some("libzmq"),
+        prefix: "lc1",
+        class: Some(ImplClass::Curve),
+        main: false,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[("ZMQ_IO_THREADS", "1"), ("ZMQ_BENCH_CURVE", "1")],
+    },
+    ImplDef {
+        name: "libzmq-curve-2t",
+        binary_from: Some("libzmq"),
+        prefix: "lc2",
+        class: Some(ImplClass::Curve),
+        main: false,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[("ZMQ_IO_THREADS", "2"), ("ZMQ_BENCH_CURVE", "1")],
+    },
+    ImplDef {
+        name: "omq-curve-1t",
+        binary_from: Some("omq-tokio-1t"),
+        prefix: "oc1",
+        class: Some(ImplClass::Curve),
+        main: false,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "",
+        inproc_lat_subcmd: "",
+        inproc_pubsub_subcmd: "",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "push",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[("OMQ_BENCH_MECHANISM", "curve")],
+    },
+    ImplDef {
+        name: "omq-curve-2t",
+        binary_from: Some("omq-tokio-ct"),
+        prefix: "oc2",
+        class: Some(ImplClass::Curve),
+        main: false,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "inproc",
+        inproc_lat_subcmd: "inproc-latency",
+        inproc_pubsub_subcmd: "inproc-pubsub",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "pub-fanout",
+        fanio_needs_peer_count: true,
+        supports_pubsub: true,
+        env: &[("OMQ_IO_THREADS", "2"), ("OMQ_BENCH_MECHANISM", "curve")],
+    },
+];
+
+fn find_impl(name: &str) -> Option<&'static ImplDef> {
+    IMPLS.iter().find(|i| i.name == name)
+}
+
+fn canonical_peer_binary<'a>(
+    binary: &'a Path,
+    def: &ImplDef,
+    binaries: &'a HashMap<String, PathBuf>,
+) -> &'a Path {
+    if def.binary_from.unwrap_or(def.name) == "omq-tokio-ct" {
+        &binaries["omq-tokio-1t"]
+    } else {
+        binary
+    }
+}
+
+fn all_chart_sizes() -> Vec<u64> {
+    let mut sizes: Vec<u64> = COMPARISON_CHART_SIZES.to_vec();
+    sizes.extend(MAIN_EXTRA_CHART_SIZES);
+    sizes.sort_unstable();
+    sizes.dedup();
+    sizes
+}
+
+// ---- Address generation ---------------------------------------------------
+
+use std::sync::atomic::{AtomicU64, Ordering};
+static ADDR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn next_addr_id() -> u64 {
+    ADDR_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+fn uses_filesystem_ipc(impl_name: &str) -> bool {
+    matches!(impl_name, "zmq.rs" | "rzmq" | "rzmq-iouring")
+}
+
+fn addr_for(
+    transport: TransportKind,
+    prefix: &str,
+    idx: u64,
+    base_port: u16,
+    impl_name: &str,
+) -> String {
+    let uid = next_addr_id();
+    match transport {
+        TransportKind::Tcp => "0".to_string(),
+        TransportKind::Ws => {
+            let offset: u16 = match prefix {
+                "t" => 0,
+                "u" => 100,
+                "z" => 200,
+                "Y" => 300,
+                "Z" => 400,
+                "q" => 500,
+                "r" => 600,
+                "R" => 700,
+                _ => 800,
+            };
+            let port = base_port + offset + idx as u16;
+            format!("ws://127.0.0.1:{port}/")
+        }
+        TransportKind::Ipc => {
+            if uses_filesystem_ipc(impl_name) {
+                format!("ipc:///tmp/omq-bench-cmp-{prefix}-{uid}")
+            } else {
+                format!("ipc://@omq-bench-cmp-{prefix}-{uid}")
+            }
+        }
+        TransportKind::Inproc => {
+            format!("bench-cmp-{prefix}-{uid}")
+        }
+    }
+}
+
+// ---- Build ----------------------------------------------------------------
+
+#[expect(clippy::too_many_lines)]
+fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMap<String, PathBuf> {
+    let mut binaries: HashMap<String, PathBuf> = HashMap::new();
+    let mut built: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut sources: Vec<&str> = impl_names
+        .iter()
+        .map(|&name| {
+            let def = find_impl(name).unwrap();
+            def.binary_from.unwrap_or(def.name)
+        })
+        .collect();
+    if sources.contains(&"omq-tokio-ct") && !sources.contains(&"omq-tokio-1t") {
+        sources.push("omq-tokio-1t");
+    }
+
+    for source in sources {
+        if built.contains(source) {
+            continue;
+        }
+        built.insert(source);
+
+        match source {
+            "omq-tokio-ct" => {
+                let mut features = Vec::new();
+                if needs_ws {
+                    features.push("ws");
+                }
+                if needs_curve {
+                    features.push("curve");
+                }
+                let mut cmd = vec![
+                    "cargo",
+                    "build",
+                    "--release",
+                    "-p",
+                    "omq-tokio",
+                    "--bin",
+                    "bench_peer_tokio",
+                    "-q",
+                ];
+                let feat_str;
+                if !features.is_empty() {
+                    feat_str = features.join(",");
+                    cmd.push("--features");
+                    cmd.push(&feat_str);
+                }
+                run_build(&cmd);
+                binaries.insert(
+                    source.to_string(),
+                    PathBuf::from("target/release/bench_peer_tokio"),
+                );
+            }
+            "omq-tokio-1t" => {
+                let mut cmd = vec![
+                    "cargo",
+                    "build",
+                    "--release",
+                    "-p",
+                    "omq-tokio",
+                    "--bin",
+                    "bench_peer_blocking",
+                    "-q",
+                ];
+                if needs_curve {
+                    cmd.push("--features");
+                    cmd.push("curve");
+                }
+                run_build(&cmd);
+                binaries.insert(
+                    source.to_string(),
+                    PathBuf::from("target/release/bench_peer_blocking"),
+                );
+            }
+            "libzmq" => {
+                let src = "scripts/libzmq_bench_peer.c";
+                let out = "scripts/libzmq_bench_peer";
+                run_build(&["gcc", "-O2", "-o", out, src, "-lzmq", "-lpthread"]);
+                binaries.insert(source.to_string(), PathBuf::from(out));
+            }
+            "zmq.rs" => {
+                run_build_in_dir(
+                    &["cargo", "build", "--release", "-q"],
+                    "scripts/zmqrs_bench_peer",
+                );
+                binaries.insert(
+                    source.to_string(),
+                    PathBuf::from("scripts/zmqrs_bench_peer/target/release/zmqrs_bench_peer"),
+                );
+            }
+            "rzmq" => {
+                run_build_in_dir(
+                    &["cargo", "build", "--release", "-q"],
+                    "scripts/rzmq_bench_peer",
+                );
+                binaries.insert(
+                    source.to_string(),
+                    PathBuf::from("scripts/rzmq_bench_peer/target/release/rzmq_bench_peer"),
+                );
+            }
+            _ => panic!("unknown impl source: {source}"),
+        }
+    }
+
+    // Map each impl name to its binary path.
+    let mut result = HashMap::new();
+    for &name in impl_names {
+        let def = find_impl(name).unwrap();
+        let source = def.binary_from.unwrap_or(def.name);
+        result.insert(name.to_string(), binaries[source].clone());
+    }
+    if binaries.contains_key("omq-tokio-1t") {
+        result.insert("omq-tokio-1t".to_string(), binaries["omq-tokio-1t"].clone());
+    }
+    result
+}
+
+fn run_build(cmd: &[&str]) {
+    eprintln!("  building: {}", cmd.join(" "));
+    let status = std::process::Command::new(cmd[0])
+        .args(&cmd[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run {cmd:?}: {e}"));
+    assert!(status.success(), "build failed: {cmd:?}");
+}
+
+fn run_build_in_dir(cmd: &[&str], dir: &str) {
+    eprintln!("  building: {} (in {dir})", cmd.join(" "));
+    let status = std::process::Command::new(cmd[0])
+        .args(&cmd[1..])
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run {cmd:?} in {dir}: {e}"));
+    assert!(status.success(), "build failed: {cmd:?} in {dir}");
+}
+
+// ---- Measurement integrity ------------------------------------------------
+
+struct MeasurementTracker {
+    issues: Vec<String>,
+}
+
+impl MeasurementTracker {
+    fn new() -> Self {
+        Self { issues: Vec::new() }
+    }
+
+    #[allow(dead_code)]
+    fn note(&mut self, present: bool, ctx: &str, what: &str) -> bool {
+        if !present {
+            self.issues.push(format!("{ctx}: missing {what}"));
+        }
+        present
+    }
+
+    fn check(&self) {
+        if !self.issues.is_empty() {
+            eprintln!("\nMeasurement issues:");
+            for issue in &self.issues {
+                eprintln!("  - {issue}");
+            }
+            std::process::exit(1);
+        }
+    }
+}
+
+// ---- Size formatting ------------------------------------------------------
+
+pub(crate) fn size_label(n: u64) -> String {
+    if n >= 1_048_576 {
+        format!("{} MiB", n / 1_048_576)
+    } else if n >= 1024 {
+        format!("{} KiB", n / 1024)
+    } else {
+        format!("{n} B")
+    }
+}
+
+// ---- Run ID ---------------------------------------------------------------
+
+fn make_run_id(name: Option<&str>) -> String {
+    let ts = chrono_like_utc_now();
+    match name {
+        Some(n) => format!("{ts}-{n}"),
+        None => ts,
+    }
+}
+
+fn chrono_like_utc_now() -> String {
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y%m%dT%H%M%SZ"])
+        .output()
+        .expect("failed to run date");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+// ---- Cell functions -------------------------------------------------------
+
+struct CellResult {
+    msgs_s: f64,
+    mbps: f64,
+    elapsed: f64,
+    push_cpu: Option<f64>,
+    pull_cpu: Option<f64>,
+    peer_min: Option<f64>,
+    peer_max: Option<f64>,
+    peer_p10: Option<f64>,
+    peer_p25: Option<f64>,
+    peer_median: Option<f64>,
+    peer_p75: Option<f64>,
+    peer_p90: Option<f64>,
+}
+
+fn zero_result(duration: f64) -> CellResult {
+    CellResult {
+        msgs_s: 0.0,
+        mbps: 0.0,
+        elapsed: duration,
+        push_cpu: None,
+        pull_cpu: None,
+        peer_min: None,
+        peer_max: None,
+        peer_p10: None,
+        peer_p25: None,
+        peer_median: None,
+        peer_p75: None,
+        peer_p90: None,
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn run_throughput_cell(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    duration: f64,
+    rounds: u32,
+    base_port: u16,
+) -> CellResult {
+    best_of(rounds, |_| {
+        run_throughput_once(
+            binary,
+            peer_binary,
+            def,
+            transport,
+            size,
+            duration,
+            base_port,
+        )
+    })
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_throughput_once(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    duration: f64,
+    base_port: u16,
+) -> CellResult {
+    let binary_str = binary.to_str().unwrap();
+    let peer_binary_str = peer_binary.to_str().unwrap();
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+
+    if transport == TransportKind::Inproc {
+        let name = addr_for(transport, def.prefix, 0, base_port, def.name);
+        let cmd = vec![
+            binary_str,
+            def.inproc_tput_subcmd,
+            &name,
+            &size_str,
+            &dur_str,
+        ];
+        let _ = cmd; // used below
+        let env: Vec<(&str, &str)> = def.env.to_vec();
+        if let Some((out, cpu)) = process::capture_with_cpu(
+            &[
+                binary_str,
+                def.inproc_tput_subcmd,
+                &name,
+                &size_str,
+                &dur_str,
+            ],
+            &env,
+            Some(process::MEASURED_CPU),
+            Duration::from_secs(duration as u64 + 30),
+        ) && let Some(r) = parse::parse_throughput(&out, size)
+        {
+            return CellResult {
+                msgs_s: r.msgs_s,
+                mbps: r.mbps,
+                elapsed: r.elapsed,
+                push_cpu: Some(cpu),
+                pull_cpu: None,
+                peer_min: None,
+                peer_max: None,
+                peer_p10: None,
+                peer_p25: None,
+                peer_median: None,
+                peer_p75: None,
+                peer_p90: None,
+            };
+        }
+        return zero_result(duration);
+    }
+
+    let addr = addr_for(transport, def.prefix, 0, base_port, def.name);
+    let connect_addr;
+
+    let push_env: Vec<(&str, &str)> = def.env.to_vec();
+    let mut pull_env: Vec<(&str, &str)> = vec![("OMQ_IO_THREADS", "1")];
+    // Copy mechanism/curve env to pull side.
+    for &(k, v) in def.env {
+        if k != "OMQ_IO_THREADS" && k != "ZMQ_IO_THREADS" {
+            pull_env.push((k, v));
+        }
+    }
+
+    let push_cmd: Vec<&str>;
+    let mut push_proc;
+    let mut _coord_socket = None;
+    match transport {
+        TransportKind::Tcp => {
+            let coord = CoordSocket::bind_new();
+            push_cmd = vec![binary_str, "push", "tcp://127.0.0.1:0", &size_str];
+            let mut env = push_env.clone();
+            env.push(("OMQ_BENCH_COORD", coord.endpoint()));
+            push_proc = process::spawn(&push_cmd, &env, Some(process::MEASURED_CPU));
+            let port = coord
+                .recv_ready_port(Duration::from_secs(10))
+                .expect("coord: no READY from push peer");
+            connect_addr = format!("tcp://127.0.0.1:{port}");
+            _coord_socket = Some(coord);
+        }
+        TransportKind::Ws => {
+            push_cmd = vec![binary_str, "push", &addr, &size_str];
+            push_proc = process::spawn(&push_cmd, &push_env, Some(process::MEASURED_CPU));
+            std::thread::sleep(Duration::from_millis(200));
+            connect_addr = addr.clone();
+        }
+        _ => {
+            push_cmd = vec![binary_str, "push", &addr, &size_str];
+            push_proc = process::spawn(&push_cmd, &push_env, Some(process::MEASURED_CPU));
+            std::thread::sleep(Duration::from_millis(100));
+            connect_addr = addr.clone();
+        }
+    }
+
+    let pull_output = process::capture(
+        &[peer_binary_str, "pull", &connect_addr, &size_str, &dur_str],
+        &pull_env,
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    );
+
+    let push_cpu = process::read_proc_cpu(push_proc.pid());
+    push_proc.kill();
+
+    if transport == TransportKind::Ipc {
+        cleanup_ipc_addr(&addr, def.name);
+    }
+
+    let Some(output) = pull_output else {
+        return zero_result(duration);
+    };
+
+    match parse::parse_throughput(&output, size) {
+        Some(r) => CellResult {
+            msgs_s: r.msgs_s,
+            mbps: r.mbps,
+            elapsed: r.elapsed,
+            push_cpu: Some(push_cpu),
+            pull_cpu: r.pull_cpu,
+            peer_min: None,
+            peer_max: None,
+            peer_p10: None,
+            peer_p25: None,
+            peer_median: None,
+            peer_p75: None,
+            peer_p90: None,
+        },
+        None => zero_result(duration),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn run_pubsub_cell(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    rounds: u32,
+    base_port: u16,
+) -> CellResult {
+    best_of(rounds, |_| {
+        run_pubsub_once(
+            binary,
+            peer_binary,
+            def,
+            transport,
+            size,
+            peers,
+            duration,
+            base_port,
+        )
+    })
+}
+
+#[allow(clippy::needless_late_init, clippy::too_many_lines)]
+#[expect(clippy::too_many_arguments)]
+fn run_pubsub_once(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    base_port: u16,
+) -> CellResult {
+    let binary_str = binary.to_str().unwrap();
+    let peer_binary_str = peer_binary.to_str().unwrap();
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let peers_str = peers.to_string();
+
+    if transport == TransportKind::Inproc {
+        let name = addr_for(transport, def.prefix, 0, base_port, def.name);
+        let cmd = vec![
+            binary_str,
+            def.inproc_pubsub_subcmd,
+            &name,
+            &size_str,
+            &dur_str,
+            &peers_str,
+        ];
+        let env: Vec<(&str, &str)> = def.env.to_vec();
+        if let Some((out, cpu)) = process::capture_with_cpu(
+            &cmd,
+            &env,
+            Some(process::MEASURED_CPU),
+            Duration::from_secs(duration as u64 + 30),
+        ) && let Some(r) = parse::parse_throughput(&out, size)
+        {
+            return CellResult {
+                msgs_s: r.msgs_s,
+                mbps: r.mbps,
+                elapsed: r.elapsed,
+                push_cpu: Some(cpu),
+                pull_cpu: None,
+                peer_min: None,
+                peer_max: None,
+                peer_p10: None,
+                peer_p25: None,
+                peer_median: None,
+                peer_p75: None,
+                peer_p90: None,
+            };
+        }
+        return zero_result(duration);
+    }
+
+    let addr = addr_for(transport, def.prefix, 0, base_port, def.name);
+    let connect_addr;
+
+    let mut pub_env: Vec<(&str, &str)> = def.env.to_vec();
+    let mut sub_env: Vec<(&str, &str)> = Vec::new();
+    for &(k, v) in def.env {
+        if k != "OMQ_IO_THREADS" && k != "ZMQ_IO_THREADS" {
+            sub_env.push((k, v));
+        }
+    }
+    let receiver_io_threads = std::env::var("OMQ_BENCH_RECEIVER_IO_THREADS")
+        .ok()
+        .or_else(|| {
+            def.env
+                .iter()
+                .find_map(|&(key, value)| (key == "OMQ_IO_THREADS").then_some(value.to_string()))
+        })
+        .unwrap_or_else(|| "1".to_string());
+    sub_env.push(("OMQ_IO_THREADS", &receiver_io_threads));
+    sub_env.push(("ZMQ_IO_THREADS", "1"));
+    let start_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_secs_f64()
+        + 2.0;
+    let start_at_str = format!("{start_at:.6}");
+    pub_env.push(("OMQ_BENCH_START_AT", &start_at_str));
+    sub_env.push(("OMQ_BENCH_START_AT", &start_at_str));
+    pub_env.push(("OMQ_BENCH_WARMUP_MS", "500"));
+    sub_env.push(("OMQ_BENCH_WARMUP_MS", "500"));
+
+    let mut pub_cmd: Vec<&str> = vec![binary_str, "pub"];
+    if transport == TransportKind::Tcp {
+        pub_cmd.extend(["tcp://127.0.0.1:0", &size_str]);
+    } else {
+        pub_cmd.extend([addr.as_str(), &size_str]);
+    }
+    if def.pub_needs_peer_count {
+        pub_cmd.push(&peers_str);
+    }
+
+    let coord = (transport == TransportKind::Tcp).then(CoordSocket::bind_new);
+    let mut spawn_env = pub_env.clone();
+    if let Some(ref c) = coord {
+        spawn_env.push(("OMQ_BENCH_COORD", c.endpoint()));
+    }
+    let mut pub_proc = process::spawn(&pub_cmd, &spawn_env, Some(process::MEASURED_CPU));
+
+    if let Some(ref c) = coord {
+        let port = c
+            .recv_ready_port(Duration::from_secs(10))
+            .expect("coord: no READY from pub peer");
+        connect_addr = format!("tcp://127.0.0.1:{port}");
+    } else {
+        std::thread::sleep(Duration::from_millis(100));
+        connect_addr = addr.clone();
+    }
+
+    let sub_dur_str = format!("{:.1}", duration + 3.0);
+    let sub_output = process::capture(
+        &[
+            peer_binary_str,
+            "multi-sub",
+            &connect_addr,
+            &size_str,
+            &sub_dur_str,
+            &peers_str,
+        ],
+        &sub_env,
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    );
+
+    let pub_cpu = process::read_proc_cpu(pub_proc.pid());
+    pub_proc.kill();
+
+    if transport == TransportKind::Ipc {
+        cleanup_ipc_addr(&addr, def.name);
+    }
+
+    let Some(output) = sub_output else {
+        return zero_result(duration);
+    };
+
+    match parse::parse_multi_throughput(&output, size, peers) {
+        Some(r) => CellResult {
+            msgs_s: r.msgs_s,
+            mbps: r.mbps,
+            elapsed: r.elapsed,
+            push_cpu: Some(pub_cpu),
+            pull_cpu: r.pull_cpu,
+            peer_min: r.peer_min,
+            peer_max: r.peer_max,
+            peer_p10: r.peer_p10,
+            peer_p25: r.peer_p25,
+            peer_median: r.peer_median,
+            peer_p75: r.peer_p75,
+            peer_p90: r.peer_p90,
+        },
+        None => zero_result(duration),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn run_fanout_cell(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    rounds: u32,
+    base_port: u16,
+) -> CellResult {
+    best_of(rounds, |_| {
+        run_fanout_once(
+            binary,
+            peer_binary,
+            def,
+            transport,
+            size,
+            peers,
+            duration,
+            base_port,
+        )
+    })
+}
+
+#[allow(clippy::needless_late_init)]
+#[expect(clippy::too_many_arguments)]
+#[expect(clippy::too_many_lines)]
+fn run_fanout_once(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    base_port: u16,
+) -> CellResult {
+    let binary_str = binary.to_str().unwrap();
+    let peer_binary_str = peer_binary.to_str().unwrap();
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let peers_str = peers.to_string();
+
+    let addr = addr_for(transport, def.prefix, 0, base_port, def.name);
+    let connect_addr;
+
+    let mut push_env: Vec<(&str, &str)> = def.env.to_vec();
+    let mut pull_env: Vec<(&str, &str)> = Vec::new();
+    for &(k, v) in def.env {
+        if k != "OMQ_IO_THREADS" && k != "ZMQ_IO_THREADS" {
+            pull_env.push((k, v));
+        }
+    }
+    let pull_io_threads =
+        std::env::var("OMQ_BENCH_RECEIVER_IO_THREADS").unwrap_or_else(|_| "1".to_string());
+    pull_env.push(("OMQ_IO_THREADS", &pull_io_threads));
+    pull_env.push(("ZMQ_IO_THREADS", &pull_io_threads));
+    let start_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_secs_f64()
+        + 2.0;
+    let start_at_str = format!("{start_at:.6}");
+    push_env.push(("OMQ_BENCH_START_AT", &start_at_str));
+    pull_env.push(("OMQ_BENCH_START_AT", &start_at_str));
+    push_env.push(("OMQ_BENCH_WARMUP_MS", "500"));
+    pull_env.push(("OMQ_BENCH_WARMUP_MS", "500"));
+
+    let fanout_subcmd = def.fanout_subcmd;
+    let mut push_cmd: Vec<&str> = vec![binary_str, fanout_subcmd];
+    if transport == TransportKind::Tcp {
+        push_cmd.extend(["tcp://127.0.0.1:0", &size_str]);
+    } else {
+        push_cmd.extend([addr.as_str(), &size_str]);
+    }
+    if def.fanio_needs_peer_count {
+        push_cmd.push(&peers_str);
+    }
+
+    let coord = (transport == TransportKind::Tcp).then(CoordSocket::bind_new);
+    let mut spawn_env = push_env.clone();
+    if let Some(ref c) = coord {
+        spawn_env.push(("OMQ_BENCH_COORD", c.endpoint()));
+    }
+    let mut push_proc = process::spawn(&push_cmd, &spawn_env, Some(process::MEASURED_CPU));
+
+    if let Some(ref c) = coord {
+        let port = c
+            .recv_ready_port(Duration::from_secs(10))
+            .expect("coord: no READY from push peer");
+        connect_addr = format!("tcp://127.0.0.1:{port}");
+    } else {
+        std::thread::sleep(Duration::from_millis(100));
+        connect_addr = addr.clone();
+    }
+
+    let receiver_processes = std::env::var("OMQ_BENCH_RECEIVER_PROCS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(1);
+    assert!(receiver_processes > 0 && peers.is_multiple_of(receiver_processes));
+    let peers_per_process = peers / receiver_processes;
+    let local_peers_str = peers_per_process.to_string();
+    let mut pull_procs = Vec::new();
+    for _ in 0..receiver_processes {
+        pull_procs.push(process::spawn(
+            &[
+                peer_binary_str,
+                "multi-pull",
+                &connect_addr,
+                &size_str,
+                &dur_str,
+                &local_peers_str,
+            ],
+            &pull_env,
+            Some(process::OTHER_CPU),
+        ));
+    }
+    let timeout = Duration::from_secs(duration as u64 + 30);
+    let mut pull_results = Vec::new();
+    for pull_proc in &mut pull_procs {
+        if let Some(output) = pull_proc.wait_with_output(timeout)
+            && let Some(result) = parse::parse_multi_throughput(&output, size, peers_per_process)
+        {
+            pull_results.push(result);
+        }
+    }
+
+    let push_cpu = process::read_proc_cpu(push_proc.pid());
+    push_proc.kill();
+
+    if transport == TransportKind::Ipc {
+        cleanup_ipc_addr(&addr, def.name);
+    }
+
+    if pull_results.is_empty() {
+        return zero_result(duration);
+    }
+
+    let total_msgs: f64 = pull_results
+        .iter()
+        .map(|r| r.msgs_s * peers_per_process as f64 * r.elapsed)
+        .sum();
+    let elapsed = pull_results.iter().map(|r| r.elapsed).fold(0.0, f64::max);
+    let mut peer_rates: Vec<f64> = pull_results
+        .iter()
+        .flat_map(|r| r.peer_rates.iter().copied())
+        .collect();
+    peer_rates.sort_unstable_by(f64::total_cmp);
+    let cpu: f64 = pull_results.iter().filter_map(|r| r.pull_cpu).sum();
+    let quantile = |p: f64| {
+        if peer_rates.is_empty() {
+            None
+        } else {
+            Some(peer_rates[((peer_rates.len() - 1) as f64 * p).round() as usize])
+        }
+    };
+
+    CellResult {
+        msgs_s: total_msgs / elapsed / peers as f64,
+        mbps: total_msgs * size as f64 / elapsed / 1_000_000.0,
+        elapsed,
+        push_cpu: Some(push_cpu),
+        pull_cpu: Some(cpu),
+        peer_min: quantile(0.0),
+        peer_max: quantile(1.0),
+        peer_p10: quantile(0.10),
+        peer_p25: quantile(0.25),
+        peer_median: quantile(0.50),
+        peer_p75: quantile(0.75),
+        peer_p90: quantile(0.90),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn run_fanin_cell(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    rounds: u32,
+    base_port: u16,
+) -> CellResult {
+    best_of(rounds, |_| {
+        run_fanin_once(
+            binary,
+            peer_binary,
+            def,
+            transport,
+            size,
+            peers,
+            duration,
+            base_port,
+        )
+    })
+}
+
+#[allow(clippy::needless_late_init)]
+#[expect(clippy::too_many_arguments)]
+fn run_fanin_once(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    base_port: u16,
+) -> CellResult {
+    let binary_str = binary.to_str().unwrap();
+    let peer_binary_str = peer_binary.to_str().unwrap();
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let peers_str = peers.to_string();
+
+    let addr = addr_for(transport, def.prefix, 0, base_port, def.name);
+    let connect_addr;
+
+    let pull_env: Vec<(&str, &str)> = def.env.to_vec();
+    let mut push_env: Vec<(&str, &str)> = Vec::new();
+    for &(k, v) in def.env {
+        if k != "OMQ_IO_THREADS" && k != "ZMQ_IO_THREADS" {
+            push_env.push((k, v));
+        }
+    }
+
+    // pull-bind binds on the measured CPU.
+    let mut pull_cmd = vec![binary_str, "pull-bind"];
+    if transport == TransportKind::Tcp {
+        pull_cmd.extend(["tcp://127.0.0.1:0", &size_str, &dur_str]);
+    } else {
+        pull_cmd.extend([addr.as_str(), &size_str, &dur_str]);
+    }
+
+    let coord = (transport == TransportKind::Tcp).then(CoordSocket::bind_new);
+    let mut spawn_env = pull_env.clone();
+    if let Some(ref c) = coord {
+        spawn_env.push(("OMQ_BENCH_COORD", c.endpoint()));
+    }
+    let mut pull_proc = process::spawn(&pull_cmd, &spawn_env, Some(process::MEASURED_CPU));
+
+    if let Some(c) = coord {
+        let port = c
+            .recv_ready_port(Duration::from_secs(10))
+            .expect("coord: no READY from pull-bind peer");
+        connect_addr = format!("tcp://127.0.0.1:{port}");
+    } else {
+        std::thread::sleep(Duration::from_millis(100));
+        connect_addr = addr.clone();
+    }
+
+    let mut push_proc = process::spawn(
+        &[
+            peer_binary_str,
+            "multi-push",
+            &connect_addr,
+            &size_str,
+            &peers_str,
+            &dur_str,
+        ],
+        &push_env,
+        Some(process::OTHER_CPU),
+    );
+
+    let pull_output = pull_proc.wait_with_output(Duration::from_secs(duration as u64 + 30));
+
+    let push_cpu = process::read_proc_cpu(push_proc.pid());
+    let timed_push =
+        def.name == "omq-tokio-1t" || def.name == "omq-tokio-ct" || def.name == "omq-tokio-2t";
+    let push_output = if timed_push {
+        push_proc.wait_with_output(Duration::from_secs(duration as u64 + 30))
+    } else {
+        push_proc.kill();
+        None
+    };
+
+    let pull_cpu_proc = process::read_proc_cpu(pull_proc.pid());
+    // pull_proc dropped by wait_with_output
+
+    if transport == TransportKind::Ipc {
+        cleanup_ipc_addr(&addr, def.name);
+    }
+
+    let Some(output) = pull_output else {
+        return zero_result(duration);
+    };
+
+    let Some(r) = parse::parse_throughput(&output, size) else {
+        return zero_result(duration);
+    };
+    let p = push_output
+        .as_deref()
+        .and_then(|output| parse::parse_multi_throughput(output, size, peers));
+    CellResult {
+        msgs_s: r.msgs_s,
+        mbps: r.mbps,
+        elapsed: r.elapsed,
+        push_cpu: Some(push_cpu),
+        pull_cpu: Some(r.pull_cpu.unwrap_or(pull_cpu_proc)),
+        peer_min: p.as_ref().and_then(|p| p.peer_min),
+        peer_max: p.as_ref().and_then(|p| p.peer_max),
+        peer_p10: p.as_ref().and_then(|p| p.peer_p10),
+        peer_p25: p.as_ref().and_then(|p| p.peer_p25),
+        peer_median: p.as_ref().and_then(|p| p.peer_median),
+        peer_p75: p.as_ref().and_then(|p| p.peer_p75),
+        peer_p90: p.as_ref().and_then(|p| p.peer_p90),
+    }
+}
+
+struct LatencyResult {
+    p50_us: f64,
+    p99_us: f64,
+    p999_us: f64,
+    max_us: f64,
+    iterations: u64,
+    cpu_time: Option<f64>,
+    req_cpu: Option<f64>,
+    elapsed: Option<f64>,
+}
+
+#[expect(clippy::too_many_arguments)]
+#[allow(clippy::needless_late_init, clippy::similar_names)]
+fn run_latency_cell(
+    binary: &Path,
+    peer_binary: &Path,
+    def: &ImplDef,
+    transport: TransportKind,
+    size: u64,
+    iterations: u64,
+    warmup: u64,
+    timeout: u64,
+    base_port: u16,
+) -> Option<LatencyResult> {
+    let binary_str = binary.to_str().unwrap();
+    let peer_binary_str = peer_binary.to_str().unwrap();
+    let size_str = size.to_string();
+    let iters_str = iterations.to_string();
+    let warmup_str = warmup.to_string();
+
+    if transport == TransportKind::Inproc {
+        let name = addr_for(transport, def.prefix, 0, base_port, def.name);
+        let env: Vec<(&str, &str)> = def.env.to_vec();
+        let (out, cpu) = process::capture_with_cpu(
+            &[
+                binary_str,
+                def.inproc_lat_subcmd,
+                &name,
+                &size_str,
+                &iters_str,
+                &warmup_str,
+            ],
+            &env,
+            Some(process::MEASURED_CPU),
+            Duration::from_secs(timeout + 30),
+        )?;
+        let r = parse::parse_latency(&out)?;
+        return Some(LatencyResult {
+            p50_us: r.p50_us,
+            p99_us: r.p99_us,
+            p999_us: r.p999_us,
+            max_us: r.max_us,
+            iterations: r.iterations,
+            cpu_time: Some(cpu),
+            req_cpu: Some(cpu),
+            elapsed: r.elapsed,
+        });
+    }
+
+    let addr = addr_for(transport, def.prefix, 0, base_port, def.name);
+    let connect_addr;
+
+    let rep_env: Vec<(&str, &str)> = def.env.to_vec();
+    let mut req_env: Vec<(&str, &str)> = Vec::new();
+    for &(k, v) in def.env {
+        if k != "OMQ_IO_THREADS" && k != "ZMQ_IO_THREADS" {
+            req_env.push((k, v));
+        }
+    }
+
+    let mut rep_cmd = vec![peer_binary_str, "rep"];
+    if transport == TransportKind::Tcp {
+        rep_cmd.extend(["tcp://127.0.0.1:0", &size_str]);
+    } else {
+        rep_cmd.extend([addr.as_str(), &size_str]);
+    }
+
+    let coord = (transport == TransportKind::Tcp).then(CoordSocket::bind_new);
+    let mut spawn_env = rep_env.clone();
+    if let Some(ref c) = coord {
+        spawn_env.push(("OMQ_BENCH_COORD", c.endpoint()));
+    }
+    let mut rep_proc = process::spawn(&rep_cmd, &spawn_env, Some(process::OTHER_CPU));
+
+    if let Some(c) = coord {
+        let port = c
+            .recv_ready_port(Duration::from_secs(10))
+            .expect("coord: no READY from rep peer");
+        connect_addr = format!("tcp://127.0.0.1:{port}");
+    } else {
+        std::thread::sleep(Duration::from_millis(100));
+        connect_addr = addr.clone();
+    }
+
+    let req_output = process::capture(
+        &[
+            binary_str,
+            "req",
+            &connect_addr,
+            &size_str,
+            &iters_str,
+            &warmup_str,
+        ],
+        &req_env,
+        Some(process::MEASURED_CPU),
+        Duration::from_secs(timeout + 30),
+    );
+
+    let rep_cpu = process::read_proc_cpu(rep_proc.pid());
+    rep_proc.kill();
+
+    if transport == TransportKind::Ipc {
+        cleanup_ipc_addr(&addr, def.name);
+    }
+
+    let output = req_output?;
+    let r = parse::parse_latency(&output)?;
+
+    let req_cpu = r.req_cpu;
+    let cpu_time = match (req_cpu, rep_cpu) {
+        (Some(rc), _) => Some(rc + rep_cpu),
+        _ => None,
+    };
+
+    Some(LatencyResult {
+        p50_us: r.p50_us,
+        p99_us: r.p99_us,
+        p999_us: r.p999_us,
+        max_us: r.max_us,
+        iterations: r.iterations,
+        cpu_time,
+        req_cpu,
+        elapsed: r.elapsed,
+    })
+}
+
+fn best_of(rounds: u32, mut f: impl FnMut(u32) -> CellResult) -> CellResult {
+    let mut best: Option<CellResult> = None;
+    for i in 0..rounds {
+        let result = f(i);
+        if best.as_ref().is_none_or(|b| result.msgs_s > b.msgs_s) {
+            best = Some(result);
+        }
+    }
+    best.unwrap_or_else(|| zero_result(0.0))
+}
+
+fn cleanup_ipc_addr(addr: &str, impl_name: &str) {
+    if uses_filesystem_ipc(impl_name)
+        && let Some(path) = addr.strip_prefix("ipc://")
+        && !path.starts_with('@')
+    {
+        std::fs::remove_file(path).ok();
+    }
+}
+
+// ---- Orchestration --------------------------------------------------------
+
+#[expect(clippy::too_many_lines)]
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn run(args: ComparisonsArgs) {
+    process::install_reaper();
+    process::cleanup_ipc_sockets();
+
+    let duration = if args.quick_run {
+        QUICK_DURATION
+    } else {
+        args.duration
+            .or_else(|| std::env::var("OMQ_BENCH_DURATION").ok()?.parse().ok())
+            .unwrap_or(DEFAULT_DURATION)
+    };
+
+    let rounds = if args.quick_run {
+        1
+    } else {
+        args.rounds
+            .or_else(|| std::env::var("OMQ_BENCH_ROUNDS").ok()?.parse().ok())
+            .unwrap_or(DEFAULT_ROUNDS)
+    };
+
+    let sizes = if let Some(ref s) = args.sizes {
+        s.clone()
+    } else if args.quick_run {
+        QUICK_SIZES.to_vec()
+    } else {
+        all_chart_sizes()
+    };
+
+    // Validate sizes against chart sizes if not allowed.
+    if !args.allow_non_chart_sizes {
+        let chart = all_chart_sizes();
+        for &s in &sizes {
+            if !chart.contains(&s) {
+                eprintln!(
+                    "warning: size {s} is not a chart size, use --allow-non-chart-sizes to override"
+                );
+            }
+        }
+    }
+
+    let mut impl_names: Vec<&str> = if args.omq {
+        vec!["omq-tokio-ct", "omq-tokio-2t"]
+    } else if !args.impls.is_empty() {
+        args.impls.iter().map(std::string::String::as_str).collect()
+    } else {
+        IMPLS.iter().filter(|i| i.main).map(|i| i.name).collect()
+    };
+
+    if args.curve {
+        let families: Vec<&str> = impl_names
+            .iter()
+            .filter_map(|name| name.split('-').next())
+            .collect();
+        for imp in IMPLS {
+            if imp.class == Some(ImplClass::Curve)
+                && !impl_names.contains(&imp.name)
+                && imp
+                    .name
+                    .split('-')
+                    .next()
+                    .is_some_and(|f| families.contains(&f))
+            {
+                impl_names.push(imp.name);
+            }
+        }
+    }
+
+    // Validate impl names.
+    for &name in &impl_names {
+        if find_impl(name).is_none() {
+            eprintln!("unknown impl: {name}");
+            eprintln!(
+                "available: {}",
+                IMPLS.iter().map(|i| i.name).collect::<Vec<_>>().join(", ")
+            );
+            std::process::exit(1);
+        }
+    }
+
+    let transports: Vec<TransportKind> = args
+        .transport
+        .iter()
+        .map(|t| match t {
+            crate::cli::Transport::Tcp => TransportKind::Tcp,
+            crate::cli::Transport::Ipc => TransportKind::Ipc,
+            crate::cli::Transport::Inproc => TransportKind::Inproc,
+            crate::cli::Transport::Ws => TransportKind::Ws,
+        })
+        .collect();
+
+    let needs_ws = transports.contains(&TransportKind::Ws);
+    let needs_curve = args.curve || impl_names.iter().any(|n| n.contains("curve"));
+
+    eprintln!("Building peers...");
+    let binaries = build_peers(&impl_names, needs_ws, needs_curve);
+
+    let base_port = args.base_port.unwrap_or_else(|| {
+        let mut buf = [0u8; 2];
+        std::fs::File::open("/dev/urandom")
+            .and_then(|mut f| {
+                use std::io::Read;
+                f.read_exact(&mut buf)?;
+                Ok(())
+            })
+            .ok();
+        let port = u16::from_le_bytes(buf);
+        20000 + (port % 20000)
+    });
+
+    let run_id = make_run_id(args.id.as_deref());
+    let jsonl_path = jsonl::cache_dir().join("comparisons.jsonl");
+
+    let tracker = MeasurementTracker::new();
+
+    let latency_iters = args.latency_iterations;
+    let latency_warmup = args.latency_warmup;
+    let latency_timeout = args.latency_timeout;
+
+    for &transport in &transports {
+        let transport_str = transport.as_str();
+        let active_impls: Vec<&str> = impl_names
+            .iter()
+            .filter(|&&name| {
+                let def = find_impl(name).unwrap();
+                def.transports.contains(&transport)
+            })
+            .copied()
+            .collect();
+
+        if active_impls.is_empty() {
+            continue;
+        }
+
+        // Throughput
+        if !args.no_throughput {
+            eprintln!("\n=== Throughput / {transport_str} ===");
+            print_throughput_header(&active_impls);
+
+            for &size in &sizes {
+                eprint!("{:>8}", size_label(size));
+                for &impl_name in &active_impls {
+                    let def = find_impl(impl_name).unwrap();
+                    let binary = &binaries[impl_name];
+                    let peer_binary = canonical_peer_binary(binary, def, &binaries);
+
+                    let result = run_throughput_cell(
+                        binary,
+                        peer_binary,
+                        def,
+                        transport,
+                        size,
+                        duration,
+                        rounds,
+                        base_port,
+                    );
+
+                    let cpu_time = match (result.push_cpu, result.pull_cpu) {
+                        (Some(pc), Some(rc)) => Some(pc + rc),
+                        (Some(pc), None) => Some(pc),
+                        _ => None,
+                    };
+
+                    let row = ComparisonRow {
+                        run_id: run_id.clone(),
+                        impl_name: impl_name.to_string(),
+                        kind: "throughput".to_string(),
+                        transport: transport_str.to_string(),
+                        msg_size: size,
+                        peers: None,
+                        msgs_s: Some(result.msgs_s),
+                        mbps: Some(result.mbps),
+                        elapsed: Some(result.elapsed),
+                        cpu_time,
+                        push_cpu_time: result.push_cpu,
+                        pull_cpu_time: result.pull_cpu,
+                        pub_cpu_time: None,
+                        req_cpu_time: None,
+                        p50_us: None,
+                        p99_us: None,
+                        p999_us: None,
+                        max_us: None,
+                        iterations: None,
+                        peer_min: None,
+                        peer_max: None,
+                        peer_p10: None,
+                        peer_p25: None,
+                        peer_median: None,
+                        peer_p75: None,
+                        peer_p90: None,
+                        zero_transport: if result.msgs_s == 0.0 {
+                            Some(true)
+                        } else {
+                            None
+                        },
+                    };
+                    jsonl::append_jsonl(&jsonl_path, &row);
+
+                    if size >= 1024 {
+                        eprint!("  {:>14}", fmt_gbps(result.mbps));
+                    } else {
+                        eprint!("  {:>14}", fmt_rate(result.msgs_s));
+                    }
+                }
+                eprintln!();
+            }
+        }
+
+        // Latency
+        if !args.no_latency {
+            let latency_sizes: Vec<u64> = sizes
+                .iter()
+                .copied()
+                .filter(|&s| s <= LATENCY_MAX_SIZE)
+                .collect();
+            eprintln!("\n=== Latency / {transport_str} ===");
+            print_latency_header(&active_impls);
+
+            for &size in &latency_sizes {
+                eprint!("{:>8}", size_label(size));
+                for &impl_name in &active_impls {
+                    let def = find_impl(impl_name).unwrap();
+                    let binary = &binaries[impl_name];
+
+                    let result = run_latency_cell(
+                        binary,
+                        binary,
+                        def,
+                        transport,
+                        size,
+                        latency_iters,
+                        latency_warmup,
+                        latency_timeout,
+                        base_port,
+                    );
+
+                    match result {
+                        Some(lat) => {
+                            let row = ComparisonRow {
+                                run_id: run_id.clone(),
+                                impl_name: impl_name.to_string(),
+                                kind: "latency".to_string(),
+                                transport: transport_str.to_string(),
+                                msg_size: size,
+                                peers: None,
+                                msgs_s: None,
+                                mbps: None,
+                                elapsed: lat.elapsed,
+                                cpu_time: lat.cpu_time,
+                                push_cpu_time: None,
+                                pull_cpu_time: None,
+                                pub_cpu_time: None,
+                                req_cpu_time: lat.req_cpu,
+                                p50_us: Some(lat.p50_us),
+                                p99_us: Some(lat.p99_us),
+                                p999_us: Some(lat.p999_us),
+                                max_us: Some(lat.max_us),
+                                iterations: Some(lat.iterations),
+                                peer_min: None,
+                                peer_max: None,
+                                peer_p10: None,
+                                peer_p25: None,
+                                peer_median: None,
+                                peer_p75: None,
+                                peer_p90: None,
+                                zero_transport: None,
+                            };
+                            jsonl::append_jsonl(&jsonl_path, &row);
+                            eprint!("  {:>14.1}", lat.p50_us);
+                        }
+                        None => {
+                            eprint!("  {:>14}", "-");
+                        }
+                    }
+                }
+                eprintln!();
+            }
+        }
+
+        // Pub/sub
+        if !args.no_pubsub && transport != TransportKind::Inproc {
+            let pubsub_impls: Vec<&str> = active_impls
+                .iter()
+                .filter(|&&name| {
+                    let def = find_impl(name).unwrap();
+                    def.supports_pubsub && def.class != Some(ImplClass::Curve)
+                })
+                .copied()
+                .collect();
+
+            for &peer_count in &args.pubsub_peers {
+                eprintln!("\n=== PubSub {peer_count}p / {transport_str} ===");
+                print_throughput_header(&pubsub_impls);
+
+                for &size in &sizes {
+                    eprint!("{:>8}", size_label(size));
+                    for &impl_name in &pubsub_impls {
+                        let def = find_impl(impl_name).unwrap();
+                        let binary = &binaries[impl_name];
+                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+
+                        let result = run_pubsub_cell(
+                            binary,
+                            peer_binary,
+                            def,
+                            transport,
+                            size,
+                            peer_count,
+                            duration,
+                            rounds,
+                            base_port,
+                        );
+
+                        let cpu_time = match (result.push_cpu, result.pull_cpu) {
+                            (Some(pc), Some(rc)) => Some(pc + rc),
+                            (Some(pc), None) => Some(pc),
+                            _ => None,
+                        };
+
+                        let row = ComparisonRow {
+                            run_id: run_id.clone(),
+                            impl_name: impl_name.to_string(),
+                            kind: "pub_sub".to_string(),
+                            transport: transport_str.to_string(),
+                            msg_size: size,
+                            peers: Some(peer_count),
+                            msgs_s: Some(result.msgs_s),
+                            mbps: Some(result.mbps),
+                            elapsed: Some(result.elapsed),
+                            cpu_time,
+                            push_cpu_time: None,
+                            pull_cpu_time: None,
+                            pub_cpu_time: result.push_cpu,
+                            req_cpu_time: None,
+                            p50_us: None,
+                            p99_us: None,
+                            p999_us: None,
+                            max_us: None,
+                            iterations: None,
+                            peer_min: result.peer_min,
+                            peer_max: result.peer_max,
+                            peer_p10: result.peer_p10,
+                            peer_p25: result.peer_p25,
+                            peer_median: result.peer_median,
+                            peer_p75: result.peer_p75,
+                            peer_p90: result.peer_p90,
+                            zero_transport: if result.msgs_s == 0.0 {
+                                Some(true)
+                            } else {
+                                None
+                            },
+                        };
+                        jsonl::append_jsonl(&jsonl_path, &row);
+
+                        if size >= 1024 {
+                            eprint!("  {:>8.1}", result.mbps / 1000.0);
+                        } else {
+                            eprint!("  {:>8.0}", result.msgs_s / 1000.0);
+                        }
+                    }
+                    eprintln!();
+                }
+            }
+        }
+
+        // Fan-out (TCP only)
+        if args.fanout && transport == TransportKind::Tcp {
+            let fanout_impls: Vec<&str> = active_impls
+                .iter()
+                .filter(|&&name| {
+                    let def = find_impl(name).unwrap();
+                    def.class != Some(ImplClass::Curve)
+                })
+                .copied()
+                .collect();
+
+            for &peer_count in &args.fanout_peers {
+                eprintln!("\n=== FanOut {peer_count}p / {transport_str} ===");
+                print_throughput_header(&fanout_impls);
+
+                for &size in &sizes {
+                    eprint!("{:>8}", size_label(size));
+                    for &impl_name in &fanout_impls {
+                        let def = find_impl(impl_name).unwrap();
+                        let binary = &binaries[impl_name];
+                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+
+                        let result = run_fanout_cell(
+                            binary,
+                            peer_binary,
+                            def,
+                            transport,
+                            size,
+                            peer_count,
+                            duration,
+                            rounds,
+                            base_port,
+                        );
+
+                        let row = ComparisonRow {
+                            run_id: run_id.clone(),
+                            impl_name: impl_name.to_string(),
+                            kind: "fan_out".to_string(),
+                            transport: transport_str.to_string(),
+                            msg_size: size,
+                            peers: Some(peer_count),
+                            msgs_s: Some(result.msgs_s),
+                            mbps: Some(result.mbps),
+                            elapsed: Some(result.elapsed),
+                            cpu_time: result.push_cpu,
+                            push_cpu_time: result.push_cpu,
+                            pull_cpu_time: result.pull_cpu,
+                            pub_cpu_time: None,
+                            req_cpu_time: None,
+                            p50_us: None,
+                            p99_us: None,
+                            p999_us: None,
+                            max_us: None,
+                            iterations: None,
+                            peer_min: result.peer_min,
+                            peer_max: result.peer_max,
+                            peer_p10: result.peer_p10,
+                            peer_p25: result.peer_p25,
+                            peer_median: result.peer_median,
+                            peer_p75: result.peer_p75,
+                            peer_p90: result.peer_p90,
+                            zero_transport: if result.msgs_s == 0.0 {
+                                Some(true)
+                            } else {
+                                None
+                            },
+                        };
+                        jsonl::append_jsonl(&jsonl_path, &row);
+
+                        if size >= 1024 {
+                            eprint!("  {:>8.1}", result.mbps / 1000.0);
+                        } else {
+                            eprint!("  {:>8.0}", result.msgs_s / 1000.0);
+                        }
+                    }
+                    eprintln!();
+                }
+            }
+        }
+
+        // Fan-in (TCP only)
+        if args.fanin && transport == TransportKind::Tcp {
+            let fanin_impls: Vec<&str> = active_impls
+                .iter()
+                .filter(|&&name| {
+                    let def = find_impl(name).unwrap();
+                    def.class != Some(ImplClass::Curve)
+                })
+                .copied()
+                .collect();
+
+            for &peer_count in &args.fanin_peers {
+                eprintln!("\n=== FanIn {peer_count}p / {transport_str} ===");
+                print_throughput_header(&fanin_impls);
+
+                for &size in &sizes {
+                    eprint!("{:>8}", size_label(size));
+                    for &impl_name in &fanin_impls {
+                        let def = find_impl(impl_name).unwrap();
+                        let binary = &binaries[impl_name];
+                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+
+                        let result = run_fanin_cell(
+                            binary,
+                            peer_binary,
+                            def,
+                            transport,
+                            size,
+                            peer_count,
+                            duration,
+                            rounds,
+                            base_port,
+                        );
+
+                        let cpu_time = match (result.push_cpu, result.pull_cpu) {
+                            (Some(pc), Some(rc)) => Some(pc + rc),
+                            _ => result.pull_cpu,
+                        };
+
+                        let row = ComparisonRow {
+                            run_id: run_id.clone(),
+                            impl_name: impl_name.to_string(),
+                            kind: "fan_in".to_string(),
+                            transport: transport_str.to_string(),
+                            msg_size: size,
+                            peers: Some(peer_count),
+                            msgs_s: Some(result.msgs_s),
+                            mbps: Some(result.mbps),
+                            elapsed: Some(result.elapsed),
+                            cpu_time,
+                            push_cpu_time: result.push_cpu,
+                            pull_cpu_time: result.pull_cpu,
+                            pub_cpu_time: None,
+                            req_cpu_time: None,
+                            p50_us: None,
+                            p99_us: None,
+                            p999_us: None,
+                            max_us: None,
+                            iterations: None,
+                            peer_min: result.peer_min,
+                            peer_max: result.peer_max,
+                            peer_p10: result.peer_p10,
+                            peer_p25: result.peer_p25,
+                            peer_median: result.peer_median,
+                            peer_p75: result.peer_p75,
+                            peer_p90: result.peer_p90,
+                            zero_transport: if result.msgs_s == 0.0 {
+                                Some(true)
+                            } else {
+                                None
+                            },
+                        };
+                        jsonl::append_jsonl(&jsonl_path, &row);
+
+                        if size >= 1024 {
+                            eprint!("  {:>8.1}", result.mbps / 1000.0);
+                        } else {
+                            eprint!("  {:>8.0}", result.msgs_s / 1000.0);
+                        }
+                    }
+                    eprintln!();
+                }
+            }
+        }
+    }
+
+    // CURVE pub/sub
+    if args.curve {
+        let curve_impls: Vec<&str> = impl_names
+            .iter()
+            .filter(|&&name| {
+                let def = find_impl(name).unwrap();
+                def.class == Some(ImplClass::Curve) && def.transports.contains(&TransportKind::Tcp)
+            })
+            .copied()
+            .collect();
+
+        if !curve_impls.is_empty() {
+            let peer_count = args.curve_peers;
+            eprintln!("\n=== CURVE PubSub {peer_count}p / tcp ===");
+            print_throughput_header(&curve_impls);
+
+            for &size in &sizes {
+                eprint!("{:>8}", size_label(size));
+                for &impl_name in &curve_impls {
+                    let def = find_impl(impl_name).unwrap();
+                    let binary = &binaries[impl_name];
+                    let peer_binary = canonical_peer_binary(binary, def, &binaries);
+
+                    let result = run_pubsub_cell(
+                        binary,
+                        peer_binary,
+                        def,
+                        TransportKind::Tcp,
+                        size,
+                        peer_count,
+                        duration,
+                        rounds,
+                        base_port,
+                    );
+
+                    let cpu_time = match (result.push_cpu, result.pull_cpu) {
+                        (Some(pc), Some(rc)) => Some(pc + rc),
+                        (Some(pc), None) => Some(pc),
+                        _ => None,
+                    };
+
+                    let row = ComparisonRow {
+                        run_id: run_id.clone(),
+                        impl_name: impl_name.to_string(),
+                        kind: "pub_sub".to_string(),
+                        transport: "tcp".to_string(),
+                        msg_size: size,
+                        peers: Some(peer_count),
+                        msgs_s: Some(result.msgs_s),
+                        mbps: Some(result.mbps),
+                        elapsed: Some(result.elapsed),
+                        cpu_time,
+                        push_cpu_time: None,
+                        pull_cpu_time: None,
+                        pub_cpu_time: result.push_cpu,
+                        req_cpu_time: None,
+                        p50_us: None,
+                        p99_us: None,
+                        p999_us: None,
+                        max_us: None,
+                        iterations: None,
+                        peer_min: result.peer_min,
+                        peer_max: result.peer_max,
+                        peer_p10: result.peer_p10,
+                        peer_p25: result.peer_p25,
+                        peer_median: result.peer_median,
+                        peer_p75: result.peer_p75,
+                        peer_p90: result.peer_p90,
+                        zero_transport: if result.msgs_s == 0.0 {
+                            Some(true)
+                        } else {
+                            None
+                        },
+                    };
+                    jsonl::append_jsonl(&jsonl_path, &row);
+
+                    if size >= 1024 {
+                        eprint!("  {:>14}", fmt_gbps(result.mbps));
+                    } else {
+                        eprint!("  {:>14}", fmt_rate(result.msgs_s));
+                    }
+                }
+                eprintln!();
+            }
+        }
+    }
+
+    tracker.check();
+
+    eprintln!("\nResults appended to {}", jsonl_path.display());
+}
+
+fn print_throughput_header(impls: &[&str]) {
+    eprint!("{:>8}", "");
+    for &name in impls {
+        eprint!("  {name:>14}");
+    }
+    eprintln!();
+}
+
+fn print_latency_header(impls: &[&str]) {
+    eprint!("{:>8}", "");
+    for &name in impls {
+        eprint!("  {name:>14}");
+    }
+    eprintln!("  (p50 us)");
+}
+
+fn fmt_rate(val: f64) -> String {
+    if val >= 1_000_000.0 {
+        format!("{:.2}M msg/s", val / 1_000_000.0)
+    } else if val >= 1000.0 {
+        format!("{:.0}K msg/s", val / 1000.0)
+    } else {
+        format!("{val:.0} msg/s")
+    }
+}
+
+fn fmt_gbps(val: f64) -> String {
+    if val >= 1000.0 {
+        format!("{:.2} GB/s", val / 1000.0)
+    } else {
+        format!("{val:.0} MB/s")
+    }
+}

--- a/omq-bench/src/bench/compression.rs
+++ b/omq-bench/src/bench/compression.rs
@@ -1,0 +1,244 @@
+use crate::cli::CompressionArgs;
+use crate::jsonl::{self, CompressionRow};
+use crate::process;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+const CHART_SIZES: &[u64] = &[
+    16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131_072, 262_144,
+    524_288,
+];
+
+static mut PORT_COUNTER: u16 = 18500;
+
+fn next_port() -> u16 {
+    unsafe {
+        let p = PORT_COUNTER;
+        PORT_COUNTER += 1;
+        p
+    }
+}
+
+fn size_label(n: u64) -> String {
+    if n >= 1_048_576 {
+        format!("{} MiB", n / 1_048_576)
+    } else if n >= 1024 {
+        format!("{} KiB", n / 1024)
+    } else {
+        format!("{n} B")
+    }
+}
+
+fn build_peer() -> PathBuf {
+    let bin = PathBuf::from("target/release/bench_peer_tokio");
+    if bin.exists() {
+        return bin;
+    }
+    eprintln!("  building bench_peer_tokio (lz4)...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "omq-tokio",
+            "--bin",
+            "bench_peer_tokio",
+            "--features",
+            "lz4",
+            "-q",
+        ])
+        .status()
+        .expect("failed to run cargo build");
+    assert!(status.success(), "build failed");
+    bin
+}
+
+fn get_wire_size(binary: &str, transport: &str, size: u64, dict_file: Option<&str>) -> u64 {
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+    let size_str = size.to_string();
+    let mut env = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    let output = process::capture(
+        &[binary, "wire-size", &ep, &size_str],
+        &env,
+        None,
+        Duration::from_secs(10),
+    )
+    .unwrap_or_default();
+    output.trim().parse().unwrap_or(size)
+}
+
+fn train_dict(binary: &str, path: &str, capacity: u64) {
+    let cap_str = capacity.to_string();
+    process::capture(
+        &[binary, "train-dict", path, &cap_str],
+        &[],
+        None,
+        Duration::from_secs(30),
+    );
+}
+
+fn run_cell(
+    binary: &str,
+    transport: &str,
+    size: u64,
+    duration: f64,
+    dict_file: Option<&str>,
+) -> Option<(f64, f64, f64)> {
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+
+    let mut env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+
+    let mut push_proc = process::spawn(
+        &[binary, "push", &ep, &size_str],
+        &env,
+        Some(process::MEASURED_CPU),
+    );
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let pull_output = process::capture(
+        &[binary, "pull", &ep, &size_str, &dur_str],
+        &env,
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    );
+
+    let push_cpu = process::read_proc_cpu(push_proc.pid());
+    push_proc.kill();
+
+    let output = pull_output?;
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let count: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    let pull_cpu: f64 = parts.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    if elapsed <= 0.0 || count <= 0.0 {
+        return None;
+    }
+    let msgs_s = count / elapsed;
+    let mbps = (count * size as f64) / elapsed / 1_000_000.0;
+    let cpu_time = push_cpu + pull_cpu;
+    Some((msgs_s, mbps, cpu_time))
+}
+
+fn make_run_id() -> String {
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y%m%dT%H%M%SZ"])
+        .output()
+        .expect("failed to run date");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn run(args: CompressionArgs) {
+    let sizes = if let Some(ref s) = args.sizes {
+        s.clone()
+    } else {
+        CHART_SIZES.to_vec()
+    };
+
+    let transports: Vec<&str> = args.transports.split(',').collect();
+    let binary = build_peer();
+    let binary_str = binary.to_str().unwrap();
+    let run_id = make_run_id();
+    let jsonl_path = jsonl::cache_dir().join("results_compression_tokio.jsonl");
+
+    eprintln!("Compression benchmark");
+
+    // Non-dict sweep.
+    run_sweep(
+        binary_str,
+        &transports,
+        &sizes,
+        args.duration,
+        &run_id,
+        None,
+        "compression_json",
+        None,
+        &jsonl_path,
+    );
+
+    // Dict sweeps.
+    for &dict_cap in &args.dict_sizes {
+        let dict_path = format!("/tmp/omq-bench-comp-dict-{dict_cap}.bin");
+        eprintln!("\nTraining dict (capacity={dict_cap})...");
+        train_dict(binary_str, &dict_path, dict_cap);
+
+        run_sweep(
+            binary_str,
+            &["lz4+tcp"],
+            &sizes,
+            args.duration,
+            &run_id,
+            Some(&dict_path),
+            "compression_json_dict",
+            Some(dict_cap),
+            &jsonl_path,
+        );
+
+        std::fs::remove_file(&dict_path).ok();
+    }
+
+    eprintln!("\nResults appended to {}", jsonl_path.display());
+}
+
+#[expect(clippy::too_many_arguments)]
+fn run_sweep(
+    binary: &str,
+    transports: &[&str],
+    sizes: &[u64],
+    duration: f64,
+    run_id: &str,
+    dict_file: Option<&str>,
+    pattern: &str,
+    dict_size: Option<u64>,
+    jsonl_path: &std::path::Path,
+) {
+    for transport in transports {
+        eprintln!("\n=== {transport} {pattern} ===");
+
+        for &size in sizes {
+            eprint!("{:>8}", size_label(size));
+
+            let wire_bytes = get_wire_size(binary, transport, size, dict_file);
+
+            match run_cell(binary, transport, size, duration, dict_file) {
+                Some((msgs_s, mbps, cpu_time)) => {
+                    let row = CompressionRow {
+                        run_id: run_id.to_string(),
+                        pattern: pattern.to_string(),
+                        transport: transport.to_string(),
+                        peers: 1,
+                        msg_size: size,
+                        wire_bytes,
+                        msg_count: Some(msgs_s * duration),
+                        elapsed: Some(duration),
+                        cpu_time: Some(cpu_time),
+                        mbps: Some(mbps),
+                        msgs_s: Some(msgs_s),
+                        dict_size,
+                    };
+                    jsonl::append_jsonl(jsonl_path, &row);
+                    eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s");
+                }
+                None => {
+                    eprint!("  {:>10}", "-");
+                }
+            }
+            eprintln!();
+        }
+    }
+}

--- a/omq-bench/src/bench/mechanism.rs
+++ b/omq-bench/src/bench/mechanism.rs
@@ -1,0 +1,178 @@
+use crate::cli::MechanismArgs;
+use crate::coord::CoordSocket;
+use crate::jsonl::{self, MechanismRow};
+use crate::process;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_SIZES: &[u64] = &[64, 1024, 16384];
+const CHART_SIZES: &[u64] = &[
+    16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131_072, 262_144,
+    524_288,
+];
+const MECHANISMS: &[&str] = &["PLAIN", "CURVE"];
+
+fn size_label(n: u64) -> String {
+    if n >= 1_048_576 {
+        format!("{} MiB", n / 1_048_576)
+    } else if n >= 1024 {
+        format!("{} KiB", n / 1024)
+    } else {
+        format!("{n} B")
+    }
+}
+
+fn build_peer(backend: &str) -> PathBuf {
+    let features = "plain,curve";
+    let bin_name = format!("bench_peer_{backend}");
+    let crate_name = format!("omq-{backend}");
+    eprintln!("  building {bin_name}...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            &crate_name,
+            "--bin",
+            &bin_name,
+            "--features",
+            features,
+            "-q",
+        ])
+        .status()
+        .expect("failed to run cargo build");
+    assert!(status.success(), "build failed");
+    PathBuf::from(format!("target/release/{bin_name}"))
+}
+
+fn run_cell(
+    binary: &str,
+    mechanism: &str,
+    size: u64,
+    duration: f64,
+    rounds: u32,
+) -> Option<(f64, f64)> {
+    let mut best: Option<(f64, f64)> = None;
+    for _ in 0..rounds {
+        if let Some(result) = run_once(binary, mechanism, size, duration)
+            && best.as_ref().is_none_or(|b| result.0 > b.0)
+        {
+            best = Some(result);
+        }
+    }
+    best
+}
+
+fn run_once(binary: &str, mechanism: &str, size: u64, duration: f64) -> Option<(f64, f64)> {
+    let size_str = size.to_string();
+    let coord = CoordSocket::bind_new();
+
+    let mut push_proc = process::spawn(
+        &[binary, "push", "tcp://127.0.0.1:0", &size_str],
+        &[
+            ("OMQ_BENCH_MECHANISM", mechanism),
+            ("OMQ_BENCH_COORD", coord.endpoint()),
+        ],
+        Some(process::MEASURED_CPU),
+    );
+
+    let port = coord.recv_ready_port(Duration::from_secs(10))?;
+
+    let dur_str = format!("{duration:.1}");
+    let addr = format!("tcp://127.0.0.1:{port}");
+
+    let output = process::capture(
+        &[binary, "pull", &addr, &size_str, &dur_str],
+        &[("OMQ_BENCH_MECHANISM", mechanism)],
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    )?;
+
+    push_proc.kill();
+
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let count: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    if elapsed <= 0.0 || count <= 0.0 {
+        return None;
+    }
+    let msgs_s = count / elapsed;
+    let mbps = (count * size as f64) / elapsed / 1_000_000.0;
+    Some((msgs_s, mbps))
+}
+
+fn make_run_id() -> String {
+    std::env::var("OMQ_BENCH_RUN_ID").unwrap_or_else(|_| {
+        let output = std::process::Command::new("date")
+            .args(["-u", "+%Y%m%dT%H%M%SZ"])
+            .output()
+            .expect("failed to run date");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    })
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn run(args: MechanismArgs) {
+    let sizes = if let Some(ref s) = args.sizes {
+        s.clone()
+    } else if args.chart_sizes {
+        CHART_SIZES.to_vec()
+    } else {
+        DEFAULT_SIZES.to_vec()
+    };
+
+    let binary = build_peer(&args.backend);
+    let binary_str = binary.to_str().unwrap();
+    let run_id = make_run_id();
+    let jsonl_path = jsonl::cache_dir().join(format!("results_{}.jsonl", args.backend));
+
+    eprintln!("Mechanism benchmark: {}", args.backend);
+    eprintln!(
+        "Sizes: {:?}",
+        sizes.iter().map(|s| size_label(*s)).collect::<Vec<_>>()
+    );
+
+    eprint!("{:>8}", "");
+    for &mech in MECHANISMS {
+        eprint!("  {mech:>12}");
+    }
+    eprintln!();
+
+    for &size in &sizes {
+        eprint!("{:>8}", size_label(size));
+        for &mechanism in MECHANISMS {
+            match run_cell(binary_str, mechanism, size, args.duration, args.rounds) {
+                Some((msgs_s, mbps)) => {
+                    let row = MechanismRow {
+                        run_id: run_id.clone(),
+                        pattern: "mechanism".to_string(),
+                        transport: mechanism.to_string(),
+                        peers: 1,
+                        msg_size: size,
+                        msg_count: msgs_s * args.duration,
+                        elapsed: args.duration,
+                        mbps,
+                        msgs_s,
+                    };
+                    jsonl::append_jsonl(&jsonl_path, &row);
+
+                    if size >= 1024 {
+                        eprint!("  {:>12.1}", mbps / 1000.0);
+                    } else {
+                        eprint!("  {:>12.0}", msgs_s / 1000.0);
+                    }
+                }
+                None => {
+                    eprint!("  {:>12}", "-");
+                }
+            }
+        }
+        eprintln!();
+    }
+
+    eprintln!("\nResults appended to {}", jsonl_path.display());
+}

--- a/omq-bench/src/bench/mod.rs
+++ b/omq-bench/src/bench/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod comparisons;
+pub(crate) mod compression;
+pub(crate) mod mechanism;
+pub(crate) mod pubsub_lz4;

--- a/omq-bench/src/bench/pubsub_lz4.rs
+++ b/omq-bench/src/bench/pubsub_lz4.rs
@@ -1,0 +1,272 @@
+use crate::cli::PubsubLz4Args;
+use crate::jsonl::{self, PubsubLz4Row};
+use crate::process;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+const CHART_SIZES: &[u64] = &[
+    16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131_072, 262_144,
+    524_288,
+];
+const QUICK_SIZES: &[u64] = &[64, 1024, 16384];
+const PEERS: u64 = 32;
+
+fn size_label(n: u64) -> String {
+    if n >= 1_048_576 {
+        format!("{} MiB", n / 1_048_576)
+    } else if n >= 1024 {
+        format!("{} KiB", n / 1024)
+    } else {
+        format!("{n} B")
+    }
+}
+
+static mut PORT_COUNTER: u16 = 17500;
+
+fn next_port() -> u16 {
+    unsafe {
+        let p = PORT_COUNTER;
+        PORT_COUNTER += 1;
+        p
+    }
+}
+
+fn build_peer() -> PathBuf {
+    eprintln!("  building bench_peer_tokio (lz4)...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "omq-tokio",
+            "--bin",
+            "bench_peer_tokio",
+            "--features",
+            "lz4",
+            "-q",
+        ])
+        .status()
+        .expect("failed to run cargo build");
+    assert!(status.success(), "build failed");
+    PathBuf::from("target/release/bench_peer_tokio")
+}
+
+fn get_wire_size(binary: &str, transport: &str, size: u64, dict_file: Option<&str>) -> u64 {
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+    let size_str = size.to_string();
+    let mut env = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    let output = process::capture(
+        &[binary, "wire-size", &ep, &size_str],
+        &env,
+        None,
+        Duration::from_secs(10),
+    )
+    .unwrap_or_default();
+    output.trim().parse().unwrap_or(size)
+}
+
+fn train_dict(binary: &str, path: &str, capacity: u64) {
+    let cap_str = capacity.to_string();
+    process::capture(
+        &[binary, "train-dict", path, &cap_str],
+        &[],
+        None,
+        Duration::from_secs(30),
+    );
+}
+
+fn run_cell(
+    binary: &str,
+    transport: &str,
+    size: u64,
+    peers: u64,
+    duration: f64,
+    dict_file: Option<&str>,
+) -> Option<(f64, f64, f64)> {
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let drain_dur_str = format!("{:.1}", duration + 3.0);
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+
+    let mut pub_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        pub_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+
+    let peers_str = peers.to_string();
+    let mut pub_proc = process::spawn(
+        &[binary, "pub", &ep, &size_str, &peers_str],
+        &pub_env,
+        Some(process::MEASURED_CPU),
+    );
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let drain_transport = if transport.contains("lz4") {
+        "tcp"
+    } else {
+        transport
+    };
+
+    // Spawn drain subscribers (peers - 1).
+    let mut drains = Vec::new();
+    for _ in 0..(peers - 1) {
+        let drain_ep = format!("{drain_transport}://127.0.0.1:{port}");
+        let proc = process::spawn(
+            &[binary, "sub", &drain_ep, &size_str, &drain_dur_str],
+            &[],
+            None,
+        );
+        drains.push(proc);
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Measured subscriber.
+    let mut sub_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        sub_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+
+    let output = process::capture(
+        &[binary, "sub", &ep, &size_str, &dur_str],
+        &sub_env,
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    );
+
+    let pub_cpu = process::read_proc_cpu(pub_proc.pid());
+    pub_proc.kill();
+
+    for mut d in drains {
+        d.kill();
+    }
+
+    let output = output?;
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let count: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    if elapsed <= 0.0 || count <= 0.0 {
+        return None;
+    }
+    let msgs_s = count / elapsed;
+    let mbps = (count * size as f64) / elapsed / 1_000_000.0;
+    let aggregate_mbps = mbps * peers as f64;
+    Some((msgs_s, aggregate_mbps, pub_cpu))
+}
+
+fn make_run_id() -> String {
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y%m%dT%H%M%SZ"])
+        .output()
+        .expect("failed to run date");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn run(args: PubsubLz4Args) {
+    let sizes = if let Some(ref s) = args.sizes {
+        s.clone()
+    } else if args.quick {
+        QUICK_SIZES.to_vec()
+    } else {
+        CHART_SIZES.to_vec()
+    };
+
+    let duration = if args.quick { 1.5 } else { args.duration };
+    let rounds = if args.quick { 1 } else { args.rounds };
+
+    let transports: Vec<&str> = args.transports.split(',').collect();
+    let binary = build_peer();
+    let binary_str = binary.to_str().unwrap();
+    let run_id = make_run_id();
+    let jsonl_path = jsonl::cache_dir().join("results_pubsub_lz4.jsonl");
+
+    eprintln!("PubSub LZ4 benchmark");
+    eprintln!(
+        "Transports: {transports:?}, sizes: {}, peers: {PEERS}, rounds: {rounds}",
+        sizes.len()
+    );
+
+    for transport in &transports {
+        eprintln!("\n=== {transport} ===");
+
+        for &size in &sizes {
+            eprint!("{:>8}", size_label(size));
+
+            let wire_bytes = get_wire_size(binary_str, transport, size, None);
+
+            let mut best: Option<(f64, f64, f64)> = None;
+            for _ in 0..rounds {
+                if let Some(result) = run_cell(binary_str, transport, size, PEERS, duration, None)
+                    && best.as_ref().is_none_or(|b| result.0 > b.0)
+                {
+                    best = Some(result);
+                }
+            }
+
+            if let Some((msgs_s, mbps, cpu_time)) = best {
+                let row = PubsubLz4Row {
+                    run_id: run_id.clone(),
+                    pattern: "pubsub_lz4".to_string(),
+                    transport: transport.to_string(),
+                    peers: PEERS,
+                    msg_size: size,
+                    wire_bytes,
+                    msg_count: Some(msgs_s * duration),
+                    elapsed: Some(duration),
+                    cpu_time: Some(cpu_time),
+                    msgs_s: Some(msgs_s),
+                    mbps: Some(mbps),
+                    dict_size: None,
+                };
+                jsonl::append_jsonl(&jsonl_path, &row);
+                eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s");
+            } else {
+                eprint!("  {:>10}", "-");
+            }
+            eprintln!();
+        }
+    }
+
+    // Dict wire-size sweep.
+    for &dict_cap in &args.dict_sizes {
+        let dict_path = format!("/tmp/omq-bench-dict-{dict_cap}.bin");
+        eprintln!("\nTraining dict (capacity={dict_cap})...");
+        train_dict(binary_str, &dict_path, dict_cap);
+
+        eprintln!("Dict wire sizes (dict_size={dict_cap}):");
+        for &size in &sizes {
+            let wire_bytes = get_wire_size(binary_str, "lz4+tcp", size, Some(&dict_path));
+            let row = PubsubLz4Row {
+                run_id: run_id.clone(),
+                pattern: "pubsub_lz4_dict".to_string(),
+                transport: "lz4+tcp".to_string(),
+                peers: PEERS,
+                msg_size: size,
+                wire_bytes,
+                msg_count: None,
+                elapsed: None,
+                cpu_time: None,
+                msgs_s: None,
+                mbps: None,
+                dict_size: Some(dict_cap),
+            };
+            jsonl::append_jsonl(&jsonl_path, &row);
+            eprintln!("  {}: {} -> {wire_bytes} bytes", size_label(size), size);
+        }
+
+        std::fs::remove_file(&dict_path).ok();
+    }
+
+    eprintln!("\nResults appended to {}", jsonl_path.display());
+}

--- a/omq-bench/src/cli.rs
+++ b/omq-bench/src/cli.rs
@@ -1,0 +1,219 @@
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Parser)]
+#[command(name = "omq-bench", about = "OMQ benchmark runner")]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    /// Run benchmarks.
+    Run {
+        #[command(subcommand)]
+        sub: RunSub,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum RunSub {
+    /// Cross-implementation comparisons.
+    Comparisons(ComparisonsArgs),
+    /// Security mechanism benchmarks.
+    Mechanism(MechanismArgs),
+    /// PUB/SUB with LZ4 compression.
+    PubsubLz4(PubsubLz4Args),
+    /// Push/pull compression benchmarks.
+    Compression(CompressionArgs),
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub(crate) enum Transport {
+    Tcp,
+    Ipc,
+    Inproc,
+    Ws,
+}
+
+impl Transport {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Ipc => "ipc",
+            Self::Inproc => "inproc",
+            Self::Ws => "ws",
+        }
+    }
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Parser)]
+#[expect(clippy::struct_excessive_bools)]
+pub(crate) struct ComparisonsArgs {
+    /// Implementations to benchmark (repeatable).
+    #[arg(long = "impl")]
+    pub impls: Vec<String>,
+
+    /// Shorthand: omq-tokio-ct + omq-tokio-2t.
+    #[arg(long)]
+    pub omq: bool,
+
+    /// Transports to test (repeatable).
+    #[arg(long, value_enum, default_values_t = [Transport::Tcp, Transport::Inproc, Transport::Ipc])]
+    pub transport: Vec<Transport>,
+
+    /// Message sizes (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub sizes: Option<Vec<u64>>,
+
+    /// Allow non-chart sizes.
+    #[arg(long)]
+    pub allow_non_chart_sizes: bool,
+
+    /// Duration per measurement in seconds.
+    #[arg(long)]
+    pub duration: Option<f64>,
+
+    /// Best-of-N rounds.
+    #[arg(long)]
+    pub rounds: Option<u32>,
+
+    /// Skip throughput measurements.
+    #[arg(long)]
+    pub no_throughput: bool,
+
+    /// Skip latency measurements.
+    #[arg(long)]
+    pub no_latency: bool,
+
+    /// Skip pub/sub measurements.
+    #[arg(long)]
+    pub no_pubsub: bool,
+
+    /// Pub/sub peer counts (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [4, 64])]
+    pub pubsub_peers: Vec<u64>,
+
+    /// Latency iterations.
+    #[arg(long, default_value_t = 5000)]
+    pub latency_iterations: u64,
+
+    /// Latency warmup iterations.
+    #[arg(long, default_value_t = 500)]
+    pub latency_warmup: u64,
+
+    /// Latency timeout in seconds.
+    #[arg(long, default_value_t = 15)]
+    pub latency_timeout: u64,
+
+    /// Enable fan-out benchmarks.
+    #[arg(long)]
+    pub fanout: bool,
+
+    /// Fan-out peer counts (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [4, 64])]
+    pub fanout_peers: Vec<u64>,
+
+    /// Enable fan-in benchmarks.
+    #[arg(long)]
+    pub fanin: bool,
+
+    /// Fan-in peer counts (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [4, 64])]
+    pub fanin_peers: Vec<u64>,
+
+    /// Enable CURVE benchmarks.
+    #[arg(long)]
+    pub curve: bool,
+
+    /// CURVE pub/sub peer count.
+    #[arg(long, default_value_t = 16)]
+    pub curve_peers: u64,
+
+    /// Base port for WS transport.
+    #[arg(long)]
+    pub base_port: Option<u16>,
+
+    /// Run ID suffix.
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// Quick run: 3 sizes, 1 round, 1.5s.
+    #[arg(long)]
+    pub quick_run: bool,
+}
+
+#[derive(Parser)]
+pub(crate) struct MechanismArgs {
+    /// Backend name.
+    #[arg(default_value = "tokio")]
+    pub backend: String,
+
+    /// Use full chart-size list (16 sizes).
+    #[arg(long)]
+    pub chart_sizes: bool,
+
+    /// Custom sizes (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub sizes: Option<Vec<u64>>,
+
+    /// Duration per measurement in seconds.
+    #[arg(long, default_value_t = 3.0)]
+    pub duration: f64,
+
+    /// Best-of-N rounds.
+    #[arg(long, default_value_t = 3)]
+    pub rounds: u32,
+}
+
+#[derive(Parser)]
+pub(crate) struct PubsubLz4Args {
+    /// Transports (comma-separated).
+    #[arg(long, default_value = "tcp,lz4+tcp")]
+    pub transports: String,
+
+    /// Message sizes (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub sizes: Option<Vec<u64>>,
+
+    /// Duration per measurement in seconds.
+    #[arg(long, default_value_t = 2.0)]
+    pub duration: f64,
+
+    /// Best-of-N rounds.
+    #[arg(long, default_value_t = 3)]
+    pub rounds: u32,
+
+    /// Quick mode: 3 sizes, 1 round, 1.5s.
+    #[arg(long)]
+    pub quick: bool,
+
+    /// Dict sizes to train (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [2048])]
+    pub dict_sizes: Vec<u64>,
+}
+
+#[derive(Parser)]
+pub(crate) struct CompressionArgs {
+    /// Transports (comma-separated).
+    #[arg(long, default_value = "tcp,lz4+tcp")]
+    pub transports: String,
+
+    /// Message sizes (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub sizes: Option<Vec<u64>>,
+
+    /// Duration per measurement in seconds.
+    #[arg(long, default_value_t = 2.0)]
+    pub duration: f64,
+
+    /// Dict sizes to train (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [2048])]
+    pub dict_sizes: Vec<u64>,
+}

--- a/omq-bench/src/coord.rs
+++ b/omq-bench/src/coord.rs
@@ -1,0 +1,64 @@
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use omq_tokio::blocking::Socket;
+use omq_tokio::{Context, Message, Options, SocketType};
+
+static COORD_CTX: OnceLock<Context> = OnceLock::new();
+static COORD_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn coord_ctx() -> &'static Context {
+    COORD_CTX.get_or_init(Context::new)
+}
+
+fn coord_ipc_endpoint() -> String {
+    let pid = std::process::id();
+    let n = COORD_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("ipc:///tmp/omq-bench-coord-{pid}-{n}")
+}
+
+pub(crate) struct CoordSocket {
+    sock: Socket,
+    endpoint: String,
+}
+
+impl CoordSocket {
+    pub(crate) fn bind_new() -> Self {
+        let sock = coord_ctx().blocking_socket(SocketType::Pull, Options::default());
+        let endpoint = coord_ipc_endpoint();
+        let ep: omq_tokio::Endpoint = endpoint.parse().unwrap();
+        sock.bind(ep).expect("coord bind");
+        Self { sock, endpoint }
+    }
+
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub(crate) fn recv_ready_port(&self, timeout: Duration) -> Option<u16> {
+        let sock = self.sock.clone();
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            if let Ok(msg) = sock.recv() {
+                tx.send(msg).ok();
+            }
+        });
+        let msg = rx.recv_timeout(timeout).ok()?;
+        parse_ready_port(&msg)
+    }
+}
+
+impl Drop for CoordSocket {
+    fn drop(&mut self) {
+        if let Some(path) = self.endpoint.strip_prefix("ipc://") {
+            std::fs::remove_file(path).ok();
+        }
+    }
+}
+
+fn parse_ready_port(msg: &Message) -> Option<u16> {
+    let bytes = msg.part_bytes(0)?;
+    let text = std::str::from_utf8(&bytes).ok()?;
+    text.strip_prefix("READY ")?.trim().parse().ok()
+}

--- a/omq-bench/src/jsonl.rs
+++ b/omq-bench/src/jsonl.rs
@@ -1,0 +1,152 @@
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn cache_dir() -> PathBuf {
+    let base = std::env::var("XDG_CACHE_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            format!("{home}/.cache")
+        });
+    PathBuf::from(base).join("omq")
+}
+
+/// Append a single row to a JSONL file, creating directories as needed.
+pub(crate) fn append_jsonl<T: Serialize>(path: &Path, row: &T) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("failed to open JSONL file");
+    let json = serde_json::to_string(row).expect("failed to serialize row");
+    writeln!(file, "{json}").expect("failed to write JSONL row");
+    file.flush().ok();
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        unsafe {
+            libc::fsync(file.as_raw_fd());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ComparisonRow {
+    pub run_id: String,
+    #[serde(rename = "impl")]
+    pub impl_name: String,
+    pub kind: String,
+    pub transport: String,
+    pub msg_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msgs_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pub_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p50_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p99_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p999_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterations: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_max: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_p10: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_p25: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_median: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_p75: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_p90: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zero_transport: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MechanismRow {
+    pub run_id: String,
+    pub pattern: String,
+    pub transport: String,
+    pub peers: u64,
+    pub msg_size: u64,
+    pub msg_count: f64,
+    pub elapsed: f64,
+    pub mbps: f64,
+    pub msgs_s: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PubsubLz4Row {
+    pub run_id: String,
+    pub pattern: String,
+    pub transport: String,
+    pub peers: u64,
+    pub msg_size: u64,
+    pub wire_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msg_count: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msgs_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dict_size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CompressionRow {
+    pub run_id: String,
+    pub pattern: String,
+    pub transport: String,
+    pub peers: u64,
+    pub msg_size: u64,
+    pub wire_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msg_count: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mbps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msgs_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dict_size: Option<u64>,
+}

--- a/omq-bench/src/main.rs
+++ b/omq-bench/src/main.rs
@@ -1,0 +1,29 @@
+mod bench;
+mod cli;
+mod coord;
+mod jsonl;
+mod parse;
+mod process;
+
+use clap::Parser;
+use cli::{Command, RunSub};
+
+fn main() {
+    let cli = cli::Cli::parse();
+    process::install_reaper();
+
+    let result = std::panic::catch_unwind(|| match cli.command {
+        Command::Run { sub } => match sub {
+            RunSub::Comparisons(args) => bench::comparisons::run(args),
+            RunSub::Mechanism(args) => bench::mechanism::run(args),
+            RunSub::PubsubLz4(args) => bench::pubsub_lz4::run(args),
+            RunSub::Compression(args) => bench::compression::run(args),
+        },
+    });
+
+    process::reap_all();
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}

--- a/omq-bench/src/parse.rs
+++ b/omq-bench/src/parse.rs
@@ -1,0 +1,127 @@
+pub(crate) struct ThroughputResult {
+    pub msgs_s: f64,
+    pub mbps: f64,
+    pub elapsed: f64,
+    pub pull_cpu: Option<f64>,
+}
+
+pub(crate) struct MultiThroughputResult {
+    pub msgs_s: f64,
+    pub mbps: f64,
+    pub elapsed: f64,
+    pub pull_cpu: Option<f64>,
+    pub peer_min: Option<f64>,
+    pub peer_max: Option<f64>,
+    pub peer_p10: Option<f64>,
+    pub peer_p25: Option<f64>,
+    pub peer_median: Option<f64>,
+    pub peer_p75: Option<f64>,
+    pub peer_p90: Option<f64>,
+    pub peer_rates: Vec<f64>,
+}
+
+pub(crate) struct LatencyResult {
+    pub p50_us: f64,
+    pub p99_us: f64,
+    pub p999_us: f64,
+    pub max_us: f64,
+    pub iterations: u64,
+    pub req_cpu: Option<f64>,
+    pub elapsed: Option<f64>,
+}
+
+/// Parse single-stream throughput output.
+///
+/// Format: `count elapsed size [cpu]`
+pub(crate) fn parse_throughput(output: &str, size: u64) -> Option<ThroughputResult> {
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let count: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    if elapsed <= 0.0 || count <= 0.0 {
+        return None;
+    }
+    let pull_cpu: Option<f64> = parts.get(3).and_then(|s| s.parse().ok());
+    let msgs_s = count / elapsed;
+    let mbps = (count * size as f64) / elapsed / 1_000_000.0;
+    Some(ThroughputResult {
+        msgs_s,
+        mbps,
+        elapsed,
+        pull_cpu,
+    })
+}
+
+/// Parse multi-socket throughput output.
+///
+/// Format: `total elapsed size cpu sockets min_rate max_rate`
+pub(crate) fn parse_multi_throughput(
+    output: &str,
+    size: u64,
+    peers: u64,
+) -> Option<MultiThroughputResult> {
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 7 {
+        return None;
+    }
+    let total: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    let cpu: f64 = parts[3].parse().ok()?;
+    let min_rate: f64 = parts[5].parse().ok()?;
+    let max_rate: f64 = parts[6].parse().ok()?;
+    let percentile = |i: usize| parts.get(i).and_then(|s| s.parse().ok());
+    if elapsed <= 0.0 || total <= 0.0 {
+        return None;
+    }
+    let peers_f = peers as f64;
+    let msgs_s = total / elapsed / peers_f;
+    let mbps = (total * size as f64) / elapsed / 1_000_000.0;
+    Some(MultiThroughputResult {
+        msgs_s,
+        mbps,
+        elapsed,
+        pull_cpu: Some(cpu),
+        peer_min: Some(min_rate),
+        peer_max: Some(max_rate),
+        peer_p10: percentile(7),
+        peer_p25: percentile(8),
+        peer_median: percentile(9),
+        peer_p75: percentile(10),
+        peer_p90: percentile(11),
+        peer_rates: parts
+            .get(12..)
+            .unwrap_or(&[])
+            .iter()
+            .filter_map(|s| s.parse().ok())
+            .collect(),
+    })
+}
+
+/// Parse latency output.
+///
+/// Format: `p50 p99 p999 max iterations [cpu] [elapsed]`
+#[allow(clippy::similar_names)]
+pub(crate) fn parse_latency(output: &str) -> Option<LatencyResult> {
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    let p50_us: f64 = parts[0].parse().ok()?;
+    let p99_us: f64 = parts[1].parse().ok()?;
+    let p999_us: f64 = parts[2].parse().ok()?;
+    let max_us: f64 = parts[3].parse().ok()?;
+    let iterations: u64 = parts[4].parse().ok()?;
+    let req_cpu: Option<f64> = parts.get(5).and_then(|s| s.parse().ok());
+    let elapsed: Option<f64> = parts.get(6).and_then(|s| s.parse().ok());
+    Some(LatencyResult {
+        p50_us,
+        p99_us,
+        p999_us,
+        max_us,
+        iterations,
+        req_cpu,
+        elapsed,
+    })
+}

--- a/omq-bench/src/process.rs
+++ b/omq-bench/src/process.rs
@@ -1,0 +1,300 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+// Optional legacy affinity masks. Disabled unless OMQ_BENCH_TASKSET is set.
+pub(crate) const MEASURED_CPU: &str = "0-2";
+pub(crate) const OTHER_CPU: &str = "3-5";
+const MAX_PROC_LIFETIME: Duration = Duration::from_mins(1);
+
+static LIVE_PROCS: OnceLock<Mutex<HashMap<u32, Instant>>> = OnceLock::new();
+static REAPER_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+fn live_procs() -> &'static Mutex<HashMap<u32, Instant>> {
+    LIVE_PROCS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_proc(pid: u32) {
+    live_procs().lock().unwrap().insert(pid, Instant::now());
+}
+
+fn deregister_proc(pid: u32) {
+    live_procs().lock().unwrap().remove(&pid);
+}
+
+/// Install the process reaper: atexit cleanup + watchdog thread.
+pub(crate) fn install_reaper() {
+    if REAPER_INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    // Watchdog thread kills any process alive longer than MAX_PROC_LIFETIME.
+    std::thread::Builder::new()
+        .name("watchdog".into())
+        .spawn(|| {
+            loop {
+                std::thread::sleep(Duration::from_secs(1));
+                let now = Instant::now();
+                let pids: Vec<u32> = {
+                    let map = live_procs().lock().unwrap();
+                    map.iter()
+                        .filter(|(_, started)| now.duration_since(**started) > MAX_PROC_LIFETIME)
+                        .map(|(pid, _)| *pid)
+                        .collect()
+                };
+                for pid in pids {
+                    eprintln!("[watchdog] killing pid {pid} (exceeded {MAX_PROC_LIFETIME:?})");
+                    hard_kill_pid(pid);
+                    deregister_proc(pid);
+                }
+            }
+        })
+        .ok();
+}
+
+/// Kill all registered processes. Called on exit.
+pub(crate) fn reap_all() {
+    let pids: Vec<u32> = {
+        let map = live_procs().lock().unwrap();
+        map.keys().copied().collect()
+    };
+    for pid in pids {
+        hard_kill_pid(pid);
+        deregister_proc(pid);
+    }
+}
+
+#[allow(clippy::cast_possible_wrap, clippy::similar_names)]
+fn hard_kill_pid(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        let pgid = libc::getpgid(pid as libc::pid_t);
+        if pgid > 0 {
+            libc::kill(-pgid, libc::SIGKILL);
+        } else {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+        libc::waitpid(pid as libc::pid_t, std::ptr::null_mut(), libc::WNOHANG);
+    }
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
+/// RAII guard that kills its process on drop.
+pub(crate) struct ProcessGuard {
+    child: Option<Child>,
+    pid: u32,
+}
+
+impl ProcessGuard {
+    fn new(child: Child) -> Self {
+        let pid = child.id();
+        register_proc(pid);
+        Self {
+            child: Some(child),
+            pid,
+        }
+    }
+
+    pub(crate) fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub(crate) fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().unwrap()
+    }
+
+    /// Kill the process (SIGTERM, wait, SIGKILL).
+    #[allow(clippy::cast_possible_wrap, clippy::similar_names)]
+    pub(crate) fn kill(&mut self) {
+        if let Some(ref mut child) = self.child {
+            #[cfg(unix)]
+            {
+                let raw_pid = child.id() as libc::pid_t;
+                unsafe {
+                    let pgid = libc::getpgid(raw_pid);
+                    if pgid > 0 {
+                        libc::kill(-pgid, libc::SIGTERM);
+                    } else {
+                        libc::kill(raw_pid, libc::SIGTERM);
+                    }
+                }
+            }
+            if let Ok(Some(_)) = child.wait_timeout(Duration::from_secs(5)) {
+            } else {
+                hard_kill_pid(self.pid);
+                child.wait().ok();
+            }
+        }
+        deregister_proc(self.pid);
+    }
+
+    /// Wait for the process to finish, returning stdout contents.
+    pub(crate) fn wait_with_output(&mut self, timeout: Duration) -> Option<String> {
+        let child = self.child.as_mut()?;
+        if let Ok(Some(_)) = child.wait_timeout(timeout) {
+            let mut out = String::new();
+            if let Some(ref mut stdout) = child.stdout {
+                stdout.read_to_string(&mut out).ok();
+            }
+            deregister_proc(self.pid);
+            Some(out)
+        } else {
+            self.kill();
+            None
+        }
+    }
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+/// Spawn a subprocess. CPU pinning is opt-in via `OMQ_BENCH_TASKSET=1`.
+pub(crate) fn spawn(cmd: &[&str], env: &[(&str, &str)], cpu: Option<&str>) -> ProcessGuard {
+    let mut args: Vec<&str> = Vec::new();
+    if std::env::var_os("OMQ_BENCH_TASKSET").is_some()
+        && let Some(cpus) = cpu
+    {
+        args.extend(["taskset", "-c", cpus]);
+    }
+    args.extend(cmd);
+
+    let mut command = Command::new(args[0]);
+    command.args(&args[1..]);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::null());
+    for &(k, v) in env {
+        command.env(k, v);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+
+    let child = command.spawn().unwrap_or_else(|e| {
+        panic!("failed to spawn {args:?}: {e}");
+    });
+    ProcessGuard::new(child)
+}
+
+/// Run a process to completion, capturing stdout and reading CPU time from /proc.
+pub(crate) fn capture_with_cpu(
+    cmd: &[&str],
+    env: &[(&str, &str)],
+    cpu: Option<&str>,
+    timeout: Duration,
+) -> Option<(String, f64)> {
+    let mut proc = spawn(cmd, env, cpu);
+    let pid = proc.pid();
+    let child = proc.child_mut();
+
+    let mut stdout_content = String::new();
+    if let Some(ref mut stdout) = child.stdout {
+        stdout.read_to_string(&mut stdout_content).ok();
+    }
+
+    let cpu_secs = read_proc_cpu(pid);
+
+    if let Ok(Some(_)) = child.wait_timeout(timeout) {
+        deregister_proc(pid);
+        // Prevent the Drop from killing again.
+        std::mem::forget(proc);
+        Some((stdout_content, cpu_secs))
+    } else {
+        drop(proc);
+        None
+    }
+}
+
+/// Run a process to completion, capturing stdout.
+pub(crate) fn capture(
+    cmd: &[&str],
+    env: &[(&str, &str)],
+    cpu: Option<&str>,
+    timeout: Duration,
+) -> Option<String> {
+    let mut proc = spawn(cmd, env, cpu);
+    proc.wait_with_output(timeout)
+}
+
+/// Read CPU time (user + system) for a process from /proc.
+pub(crate) fn read_proc_cpu(pid: u32) -> f64 {
+    let path = format!("/proc/{pid}/stat");
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return 0.0;
+    };
+    let fields: Vec<&str> = contents.split_whitespace().collect();
+    if fields.len() < 15 {
+        return 0.0;
+    }
+    let utime: f64 = fields[13].parse().unwrap_or(0.0);
+    let stime: f64 = fields[14].parse().unwrap_or(0.0);
+    let clk_tck = clk_tck();
+    (utime + stime) / clk_tck
+}
+
+fn clk_tck() -> f64 {
+    #[cfg(unix)]
+    {
+        let tck = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if tck > 0 {
+            return tck as f64;
+        }
+    }
+    100.0
+}
+
+/// Cleanup IPC socket files matching the benchmark pattern.
+pub(crate) fn cleanup_ipc_sockets() {
+    let pattern = "/tmp/omq-bench-cmp-*";
+    if let Ok(entries) = glob_paths(pattern) {
+        for path in entries {
+            std::fs::remove_file(&path).ok();
+        }
+    }
+}
+
+fn glob_paths(pattern: &str) -> Result<Vec<String>, ()> {
+    let output = Command::new("sh")
+        .args(["-c", &format!("ls -1 {pattern} 2>/dev/null")])
+        .output()
+        .map_err(|_| ())?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(String::from)
+        .collect())
+}
+
+// std::process::Child doesn't have wait_timeout in stable Rust.
+// Polyfill it.
+trait WaitTimeout {
+    fn wait_timeout(&mut self, dur: Duration) -> std::io::Result<Option<std::process::ExitStatus>>;
+}
+
+impl WaitTimeout for Child {
+    fn wait_timeout(&mut self, dur: Duration) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let start = Instant::now();
+        loop {
+            if let Some(status) = self.try_wait()? {
+                return Ok(Some(status));
+            }
+            if start.elapsed() >= dur {
+                return Ok(None);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}

--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 omq-tokio = { path = "../omq-tokio", version = "0.18.0", features = ["plain", "curve", "lz4"] }
 yring = { path = "../yring", version = "0.3.7" }
-tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.52", features = ["rt", "sync", "time"] }
 bytes = "1.12.0"
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rustc-hash = "2.1.0"

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -3,25 +3,14 @@
 use std::ffi::c_int;
 
 use rustc_hash::FxHashMap;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
-use std::thread;
 
 use tokio::runtime::Handle;
 
-type Job = Box<dyn FnOnce() + Send + 'static>;
-
-pub(crate) struct IoThread {
-    pub handle: Handle,
-    pub submit: flume::Sender<Job>,
-    #[expect(dead_code)]
-    join: Option<thread::JoinHandle<()>>,
-}
-
-/// Per-context: one tokio runtime per io thread.
+/// Per-context: a single `omq_tokio::Context` managing the tokio runtime.
 pub(crate) struct OmqContext {
-    pub(crate) io_threads: Vec<IoThread>,
-    pub next_thread: AtomicUsize,
+    pub(crate) ctx: omq_tokio::Context,
     pub terminated: Arc<AtomicBool>,
     pub socket_count: AtomicI32,
     socket_notify: (Mutex<()>, Condvar),
@@ -41,61 +30,23 @@ pub(crate) fn next_socket_id() -> u64 {
 }
 
 impl OmqContext {
-    fn new(n_io_threads: usize) -> Option<Arc<Self>> {
+    fn new(n_io_threads: usize) -> Arc<Self> {
         let n = n_io_threads.max(1);
-        let terminated = Arc::new(AtomicBool::new(false));
-        let mut io_threads = Vec::with_capacity(n);
-        for i in 0..n {
-            let (tx, rx) = flume::unbounded::<Job>();
-            let (handle_tx, handle_rx) = flume::bounded::<Handle>(1);
-            let name = format!("omq-libzmq-io-{i}");
-            let join = thread::Builder::new()
-                .name(name)
-                .spawn(move || {
-                    let rt = tokio::runtime::Builder::new_multi_thread()
-                        .worker_threads(1)
-                        .enable_all()
-                        .build()
-                        .expect("omq-libzmq: tokio runtime");
-                    let _ = handle_tx.send(rt.handle().clone());
-                    rt.block_on(async move {
-                        while let Ok(job) = rx.recv_async().await {
-                            job();
-                        }
-                    });
-                })
-                .ok()?;
-            let handle = handle_rx.recv().ok()?;
-            io_threads.push(IoThread {
-                handle,
-                submit: tx,
-                join: Some(join),
-            });
-        }
-        Some(Arc::new(Self {
-            io_threads,
-            next_thread: AtomicUsize::new(0),
-            terminated,
+        let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig { io_threads: n });
+        Arc::new(Self {
+            ctx,
+            terminated: Arc::new(AtomicBool::new(false)),
             socket_count: AtomicI32::new(0),
             socket_notify: (Mutex::new(()), Condvar::new()),
             max_sockets: AtomicI32::new(1023),
             max_msg_size: AtomicI64::new(-1),
             inproc_binds: Mutex::new(FxHashMap::default()),
             inproc_waiting: Mutex::new(FxHashMap::default()),
-        }))
+        })
     }
 
-    pub(crate) fn assign_thread(&self) -> usize {
-        let n = self.io_threads.len();
-        self.next_thread.fetch_add(1, Ordering::Relaxed) % n
-    }
-
-    pub(crate) fn submit(&self, thread_idx: usize, job: Job) {
-        let _ = self.io_threads[thread_idx].submit.send(job);
-    }
-
-    pub(crate) fn handle(&self, thread_idx: usize) -> &Handle {
-        &self.io_threads[thread_idx].handle
+    pub(crate) fn handle(&self) -> &Handle {
+        self.ctx.handle()
     }
 
     pub(crate) fn socket_opened(&self) {
@@ -114,7 +65,7 @@ impl OmqContext {
 impl std::fmt::Debug for OmqContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OmqContext")
-            .field("io_threads", &self.io_threads.len())
+            .field("ctx", &self.ctx)
             .field("terminated", &self.terminated.load(Ordering::Relaxed))
             .field("socket_count", &self.socket_count.load(Ordering::Relaxed))
             .field("max_sockets", &self.max_sockets.load(Ordering::Relaxed))
@@ -127,16 +78,15 @@ impl std::fmt::Debug for OmqContext {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_ctx_new() -> *mut libc::c_void {
-    let Some(arc) = OmqContext::new(1) else {
-        crate::error::set_errno(libc::EAGAIN);
-        return std::ptr::null_mut();
-    };
+    let arc = OmqContext::new(1);
     Box::into_raw(Box::new(arc)).cast()
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn zmq_init(_io_threads: c_int) -> *mut libc::c_void {
-    zmq_ctx_new()
+pub extern "C" fn zmq_init(io_threads: c_int) -> *mut libc::c_void {
+    let n = (io_threads as usize).max(1);
+    let arc = OmqContext::new(n);
+    Box::into_raw(Box::new(arc)).cast()
 }
 
 #[unsafe(no_mangle)]
@@ -230,7 +180,7 @@ pub extern "C" fn zmq_ctx_get(ctx_ptr: *mut libc::c_void, option: c_int) -> c_in
     // SAFETY: caller guarantees ctx_ptr is a valid context from zmq_ctx_new.
     let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
     match option {
-        ZMQ_IO_THREADS => c_int::try_from(ctx.io_threads.len()).unwrap_or(c_int::MAX),
+        ZMQ_IO_THREADS => c_int::try_from(ctx.ctx.io_threads()).unwrap_or(c_int::MAX),
         ZMQ_MAX_SOCKETS | ZMQ_SOCKET_LIMIT => ctx.max_sockets.load(Ordering::Relaxed),
         ZMQ_MAX_MSGSZ => ctx.max_msg_size.load(Ordering::Relaxed) as c_int,
         ZMQ_IPV6_CTX => 0,

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -748,19 +748,13 @@ fn do_subscribe(
         return crate::error::fail(crate::error::ETERM);
     };
     let result = if subscribe {
-        crate::socket::with_socket(
-            &sock_arc.ctx,
-            sock_arc.thread_idx,
-            inner,
-            move |s| async move { s.subscribe(prefix).await },
-        )
+        crate::socket::with_socket(&sock_arc.ctx, inner, move |s| async move {
+            s.subscribe(prefix).await
+        })
     } else {
-        crate::socket::with_socket(
-            &sock_arc.ctx,
-            sock_arc.thread_idx,
-            inner,
-            move |s| async move { s.unsubscribe(prefix).await },
-        )
+        crate::socket::with_socket(&sock_arc.ctx, inner, move |s| async move {
+            s.unsubscribe(prefix).await
+        })
     };
     match result {
         Ok(Ok(())) => 0,

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -134,14 +134,13 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
             0x00 => (false, bytes.slice(1..)),
             _ => (true, bytes),
         };
-        let result =
-            crate::socket::with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
-                if subscribe {
-                    s.subscribe(prefix).await
-                } else {
-                    s.unsubscribe(prefix).await
-                }
-            });
+        let result = crate::socket::with_socket(&sock.ctx, inner, move |s| async move {
+            if subscribe {
+                s.subscribe(prefix).await
+            } else {
+                s.unsubscribe(prefix).await
+            }
+        });
         return match result {
             Ok(Ok(())) => ret_len,
             Ok(Err(ref e)) => fail(crate::error::map_omq_err(e)),
@@ -218,7 +217,7 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
                     Err(omq_tokio::TrySendError::Full(returned)) => msg = returned,
                 }
             }
-            let handle = sock.ctx.handle(sock.thread_idx);
+            let handle = sock.ctx.handle();
             let s = inner.clone();
             if sndtimeo > 0 {
                 let timeout = Duration::from_millis(sndtimeo as u64);

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -51,7 +51,6 @@ pub(crate) struct RecvConsumers {
 #[derive(Debug)]
 pub(crate) struct OmqSocket {
     pub id: u64,
-    pub thread_idx: usize,
     pub ctx: Arc<OmqContext>,
     pub socket_type: SocketType,
     pub overlay: Mutex<SocketOverlay>,
@@ -115,11 +114,10 @@ fn map_socket_type(t: c_int) -> Option<SocketType> {
 }
 
 /// Run an async op against the socket's inner Arc and return the result.
-/// Spawns the future on the io thread's tokio runtime and blocks the
+/// Spawns the future on the context's tokio runtime and blocks the
 /// calling thread until completion.
 pub(crate) fn with_socket<F, Fut, T>(
     ctx: &Arc<OmqContext>,
-    thread_idx: usize,
     inner: &Arc<omq_tokio::Socket>,
     op: F,
 ) -> Result<T, ()>
@@ -130,7 +128,7 @@ where
 {
     let (otx, orx) = flume::bounded::<T>(1);
     let s = inner.clone();
-    ctx.handle(thread_idx).spawn(async move {
+    ctx.handle().spawn(async move {
         let out = op(s).await;
         let _ = otx.send(out);
     });
@@ -247,7 +245,6 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
         set_errno(libc::EMFILE);
         return std::ptr::null_mut();
     };
-    let thread_idx = ctx.assign_thread();
     let id = next_socket_id();
 
     let ctx_arc = ctx.clone();
@@ -255,7 +252,6 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
 
     let sock = Arc::new(OmqSocket {
         id,
-        thread_idx,
         ctx: ctx_arc,
         socket_type,
         overlay: Mutex::new(SocketOverlay::default()),
@@ -299,7 +295,9 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
     let Ok(overlay) = sock.overlay.lock() else {
         return;
     };
-    let opts = overlay.to_options();
+    let opts = overlay
+        .to_options()
+        .workload_profile(omq_tokio::options::WorkloadProfile::Throughput);
     let recv_hwm = overlay.recv_hwm.unwrap_or(DEFAULT_HWM as u32) as usize;
     drop(overlay);
 
@@ -335,37 +333,28 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
     ));
     let _ = sock.recv_sink_config.set(recv_sink_cfg.clone());
 
-    // Build the inner socket ON the tokio io thread.
-    // Socket::new() calls tokio::spawn internally (spawn_driver), so it
-    // must run within a tokio runtime context.
-    let (otx, orx) = flume::bounded(1);
-    sock.ctx.submit(
-        sock.thread_idx,
-        Box::new(move || {
-            let inner = Arc::new(omq_tokio::Socket::new_with_recv_sink_config(
-                socket_type,
-                opts,
-                recv_sink_cfg,
-            ));
+    // Enter the tokio runtime context so that Socket::new (which calls
+    // tokio::spawn internally for its driver task) and the recv pump
+    // spawn below are scheduled on the context's runtime.
+    let _guard = sock.ctx.handle().enter();
 
-            // Recv pump: relay from async_channel into the pump yring.
-            // Handles second+ peers whose drivers push to async_channel.
-            // For the single-peer case, the async_channel stays empty
-            // and this task idles.
-            let s_recv = inner.clone();
-            let recv_pump = tokio::spawn(async move {
-                while let Ok(msg) = s_recv.recv().await {
-                    push_to_pump(&mut pump_prod, msg, recv_notify, &recv_space).await;
-                }
-            });
+    let inner = Arc::new(omq_tokio::Socket::new_with_recv_sink_config(
+        socket_type,
+        opts,
+        recv_sink_cfg,
+    ));
 
-            let _ = otx.send((inner, recv_pump));
-        }),
-    );
+    // Recv pump: relay from async_channel into the pump yring.
+    // Handles second+ peers whose drivers push to async_channel.
+    // For the single-peer case, the async_channel stays empty
+    // and this task idles.
+    let s_recv = inner.clone();
+    let recv_pump = tokio::spawn(async move {
+        while let Ok(msg) = s_recv.recv().await {
+            push_to_pump(&mut pump_prod, msg, recv_notify, &recv_space).await;
+        }
+    });
 
-    let Ok((inner, recv_pump)) = orx.recv() else {
-        return;
-    };
     let _ = sock.inner.set(inner);
     let _ = sock.recv_pump.set(recv_pump);
 }
@@ -385,7 +374,7 @@ pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
     // Enter the tokio runtime context so that dropping OmqSocket (and
     // the Arc<omq_tokio::Socket> it holds) doesn't panic from missing
     // reactor.
-    let _guard = arc.ctx.handle(arc.thread_idx).enter();
+    let _guard = arc.ctx.handle().enter();
 
     arc.notify.close();
     arc.ctx.socket_closed();
@@ -481,7 +470,7 @@ pub extern "C" fn zmq_bind(sock_ptr: *mut c_void, addr: *const libc::c_char) -> 
         return fail(ETERM);
     };
 
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
+    let result = with_socket(&sock.ctx, inner, move |s| async move {
         s.bind(endpoint.clone()).await?;
         let resolved = s.last_bound_endpoint().map(|ep| ep.to_string());
         Ok::<_, omq_tokio::error::Error>(resolved)
@@ -515,7 +504,7 @@ pub extern "C" fn zmq_connect(sock_ptr: *mut c_void, addr: *const libc::c_char) 
         return fail(ETERM);
     };
 
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
+    let result = with_socket(&sock.ctx, inner, move |s| async move {
         s.connect(endpoint).await
     });
 
@@ -545,7 +534,7 @@ pub extern "C" fn zmq_unbind(sock_ptr: *mut c_void, addr: *const libc::c_char) -
         return fail(ETERM);
     };
 
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
+    let result = with_socket(&sock.ctx, inner, move |s| async move {
         s.unbind(endpoint).await
     });
 
@@ -563,7 +552,7 @@ pub extern "C" fn zmq_disconnect(sock_ptr: *mut c_void, addr: *const libc::c_cha
         return fail(ETERM);
     };
 
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
+    let result = with_socket(&sock.ctx, inner, move |s| async move {
         s.disconnect(endpoint).await
     });
 
@@ -580,9 +569,7 @@ pub extern "C" fn zmq_join(sock_ptr: *mut c_void, group: *const libc::c_char) ->
     let Some(inner) = sock.inner.get() else {
         return fail(ETERM);
     };
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
-        s.join(g).await
-    });
+    let result = with_socket(&sock.ctx, inner, move |s| async move { s.join(g).await });
     result_to_rc(&result)
 }
 
@@ -596,9 +583,7 @@ pub extern "C" fn zmq_leave(sock_ptr: *mut c_void, group: *const libc::c_char) -
     let Some(inner) = sock.inner.get() else {
         return fail(ETERM);
     };
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
-        s.leave(g).await
-    });
+    let result = with_socket(&sock.ctx, inner, move |s| async move { s.leave(g).await });
     result_to_rc(&result)
 }
 
@@ -636,7 +621,7 @@ pub extern "C" fn zmq_socket_monitor(
         return fail(ETERM);
     };
 
-    let result = with_socket(&sock.ctx, sock.thread_idx, inner, move |s| async move {
+    let result = with_socket(&sock.ctx, inner, move |s| async move {
         let mut stream = s.monitor();
 
         // Create a PAIR socket for publishing events, bind it to addr.

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -28,7 +28,7 @@ soak = []
 
 [dependencies]
 bytes = "1.12.0"
-crypto_box = { version = "0.9", features = ["std"], optional = true }
+crypto_box = { version = "0.9", optional = true }
 crypto_secretbox = { version = "0.1", optional = true }
 subtle = { version = "2.6", optional = true }
 x25519-dalek = { version = "2", features = ["static_secrets", "getrandom"], optional = true }

--- a/omq-proto/benches/mechanism_frame.rs
+++ b/omq-proto/benches/mechanism_frame.rs
@@ -1,106 +1,23 @@
 //! Per-frame CURVE overhead microbench.
-//!
-//! Measures the raw cryptographic cost of sealing one ZMTP frame
-//! payload under CURVE. Wrapper overhead (nonce assembly,
-//! counter increment, AAD construction) is sub-nanosecond and not
-//! distinguished here - we go straight at the primitive:
-//!
-//! - **CURVE**      one `crypto_box::SalsaBox` seal (XSalsa20 +
-//!   Poly1305 16-byte tag, RFC 26).
-//!
-//! Run: `cargo bench -p omq-proto --bench mechanism_frame --features 'curve'`
 
 use std::hint::black_box;
 use std::time::Instant;
 
-use crypto_box::{SalsaBox, SecretKey, aead::Aead};
-
-const DEFAULT_SIZES: &[usize] = &[128, 2_048, 8_192];
-const ALL_SIZES: &[usize] = &[32, 128, 512, 2_048, 8_192, 32_768, 131_072];
-
-fn sizes() -> Vec<usize> {
-    if let Ok(s) = std::env::var("OMQ_BENCH_SIZES") {
-        return s.split(',').filter_map(|t| t.trim().parse().ok()).collect();
-    }
-    if std::env::args().any(|a| a == "--all-sizes") {
-        return ALL_SIZES.to_vec();
-    }
-    DEFAULT_SIZES.to_vec()
-}
-
-/// Target wall-time per cell. The bench picks an iteration count that
-/// roughly hits this - large payloads run fewer iters, small ones run
-/// more, so each cell takes ~the same time and the table doesn't
-/// stretch out into 30-minute territory.
-const TARGET_NS_PER_CELL: u64 = 200_000_000; // 200 ms
+use crypto_box::aead::Aead;
+use crypto_box::aead::generic_array::GenericArray;
 
 fn main() {
-    println!("CURVE per-frame microbench (XSalsa20Poly1305)");
-    println!(
-        "target wall-time per cell: ~{} ms\n",
-        TARGET_NS_PER_CELL / 1_000_000
-    );
-
-    println!("  {:>6} | {:>14}", "size", "CURVE ns/op");
-    println!("  {}", "-".repeat(24));
-
-    let secret_a = SecretKey::generate(&mut crypto_box::aead::OsRng);
-    let secret_b = SecretKey::generate(&mut crypto_box::aead::OsRng);
-    let salsa = SalsaBox::new(&secret_b.public_key(), &secret_a);
-    let nonce_curve = crypto_box::Nonce::from(black_box([0x22u8; 24]));
-
-    let active_sizes = sizes();
-    let mut rows = Vec::with_capacity(active_sizes.len());
-    for size in active_sizes {
-        let plain = vec![0xACu8; size];
-
-        let curve_ns = bench(|| {
-            black_box(
-                salsa
-                    .encrypt(&nonce_curve, black_box(plain.as_slice()))
-                    .unwrap(),
-            );
-        });
-
-        println!("  {:>6} | {:>14}", size, format!("{curve_ns:>5} ns"));
-        rows.push((size, curve_ns));
-    }
-
-    println!();
-    println!("  {:>6} | {:>14}", "size", "CURVE MiB/s");
-    println!("  {}", "-".repeat(24));
-    for (size, curve_ns) in rows {
-        println!("  {:>6} | {:>14}", size, mibps(size, curve_ns));
-    }
-}
-
-fn bench(mut f: impl FnMut()) -> u64 {
-    // Warm up + size-up: keep doubling until one batch takes ~10 ms,
-    // then run enough batches to hit TARGET_NS_PER_CELL total.
-    let mut iters: u64 = 1;
-    loop {
+    let secret = crypto_box::SecretKey::from([0x42; 32]);
+    let peer = crypto_box::PublicKey::from([0x43; 32]);
+    let cipher = crypto_box::SalsaBox::new(&peer, &secret);
+    let nonce = GenericArray::from_slice(&[0x11; 24]);
+    for size in [128, 2_048, 8_192] {
+        let payload = vec![0xAC; size];
         let start = Instant::now();
-        for _ in 0..iters {
-            f();
+        for _ in 0..1000 {
+            black_box(cipher.encrypt(nonce, black_box(&payload[..])).unwrap());
         }
-        let probe = start.elapsed().as_nanos() as u64;
-        if probe > 10_000_000 || iters > 1 << 24 {
-            let total_iters = ((TARGET_NS_PER_CELL / probe.max(1)).max(1) * iters).max(iters);
-            let start = Instant::now();
-            for _ in 0..total_iters {
-                f();
-            }
-            let elapsed = start.elapsed().as_nanos() as u64;
-            return elapsed / total_iters.max(1);
-        }
-        iters *= 2;
+        let ns = start.elapsed().as_nanos() / 1000;
+        println!("{size:>6} bytes: {ns:>8} ns/op");
     }
-}
-
-fn mibps(size: usize, ns: u64) -> String {
-    if ns == 0 {
-        return "    -    ".into();
-    }
-    let bytes_per_sec = (size as f64) / (ns as f64) * 1e9;
-    format!("{:>9.0}", bytes_per_sec / (1024.0 * 1024.0))
 }

--- a/omq-proto/src/frame_buffer.rs
+++ b/omq-proto/src/frame_buffer.rs
@@ -123,7 +123,8 @@ impl FrameBuffer {
     }
 
     pub fn take_arena_bytes(&mut self) -> Bytes {
-        let frozen = self.arena.split().freeze();
+        let frozen = Bytes::copy_from_slice(&self.arena);
+        self.arena.clear();
         self.arena_mark = 0;
         self.total_bytes = 0;
         frozen
@@ -198,6 +199,34 @@ impl FrameBuffer {
         }
     }
 
+    /// Frame a REP reply without first materializing its routing envelope as
+    /// a `Message`. The peer identity is local routing metadata; the wire
+    /// shape is `[empty delimiter, body...]`.
+    pub fn frame_rep(&mut self, _identity: &Bytes, msg: &Message) {
+        self.frame_rep_gather(msg);
+    }
+
+    fn frame_rep_gather(&mut self, msg: &Message) {
+        let before = self.arena.len();
+        frame::write_frame_header(&mut self.arena, !msg.is_empty(), 0);
+        self.total_bytes += self.arena.len() - before;
+        if msg.is_empty() {
+            return;
+        }
+        let parts = msg.parts_payload();
+        for (i, part) in parts.iter().enumerate() {
+            let before = self.arena.len();
+            frame::write_frame_header(&mut self.arena, i + 1 < parts.len(), part.len());
+            self.total_bytes += self.arena.len() - before;
+            self.commit_arena_range();
+            let bytes = part.as_bytes();
+            if !bytes.is_empty() {
+                self.total_bytes += bytes.len();
+                self.entries.push_back(Entry::External(bytes));
+            }
+        }
+    }
+
     pub fn frame_prefixed(&mut self, prefix: &Bytes, msg: &Message) {
         if msg.byte_len() + prefix.len() * msg.len() < self.arena_threshold {
             self.frame_prefixed_inline(prefix, msg);
@@ -254,10 +283,13 @@ impl FrameBuffer {
             if cap > self.arena_peak_cap {
                 self.arena_peak_cap = cap;
             }
-            let frozen = self.arena.split().freeze();
-            if self.arena.capacity() < self.arena_peak_cap {
-                self.arena.reserve(self.arena_peak_cap);
-            }
+            // Copy the arena content and clear() to preserve the backing
+            // allocation. The alternative (split().freeze()) transfers the
+            // entire backing to the frozen Bytes, forcing a fresh
+            // reserve() that causes page-fault storms on glibc's
+            // per-thread arenas.
+            let frozen = Bytes::copy_from_slice(&self.arena);
+            self.arena.clear();
             Some(frozen)
         };
 
@@ -430,6 +462,25 @@ mod tests {
         let large = Message::from(Bytes::from(vec![0xBB; 128 * 1024]));
         eq.frame(&large);
         assert!(!eq.has_arena_only());
+    }
+
+    #[test]
+    fn rep_frame_keeps_identity_off_wire() {
+        let mut eq = FrameBuffer::one_shot();
+        let body = Message::single(Bytes::from_static(b"reply"));
+        eq.frame_rep(&Bytes::from_static(b"peer-id"), &body);
+
+        let mut actual = Vec::new();
+        eq.drain(&mut actual, 1024);
+        let actual: Vec<u8> = actual
+            .into_iter()
+            .flat_map(|chunk| chunk.to_vec())
+            .collect();
+
+        let expected_message = Message::multipart([Bytes::new(), Bytes::from_static(b"reply")]);
+        let mut expected = BytesMut::new();
+        crate::proto::frame::encode_message_flat(&expected_message, &mut expected);
+        assert_eq!(actual, expected.as_ref());
     }
 
     #[test]

--- a/omq-proto/src/lib.rs
+++ b/omq-proto/src/lib.rs
@@ -35,7 +35,7 @@ pub use monitor::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorTryRecvError,
     PeerCommandKind, PeerIdent, PeerInfo,
 };
-pub use options::{KeepAlive, MechanismConfig, OnMute, Options, ReconnectPolicy};
+pub use options::{KeepAlive, MechanismConfig, OnMute, Options, ReconnectPolicy, WorkloadProfile};
 pub use proto::mechanism::MechanismSetup;
 #[cfg(any(feature = "curve", feature = "plain"))]
 pub use proto::mechanism::{Authenticator, MechanismPeerInfo};

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -295,6 +295,7 @@ impl Frame {
 pub const MAX_INLINE_MESSAGE: usize = 55;
 
 const _: () = assert!(std::mem::size_of::<Message>() == 64);
+const INLINE_DELIMITED_FLAG: u8 = 0x80;
 
 pub(crate) enum MessageInner {
     Empty,
@@ -303,6 +304,8 @@ pub(crate) enum MessageInner {
         data: [u8; MAX_INLINE_MESSAGE],
     },
     Single(Payload),
+    /// Empty delimiter followed by one heap-backed body frame.
+    EmptyDelimitedBytes(Bytes),
     Multi(Vec<Payload>),
 }
 
@@ -376,7 +379,15 @@ impl Message {
     pub fn len(&self) -> usize {
         match &self.inner {
             MessageInner::Empty => 0,
-            MessageInner::Inline { .. } | MessageInner::Single(_) => 1,
+            MessageInner::Inline { len, .. } => {
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    2
+                } else {
+                    1
+                }
+            }
+            MessageInner::Single(_) => 1,
+            MessageInner::EmptyDelimitedBytes(_) => 2,
             MessageInner::Multi(v) => v.len(),
         }
     }
@@ -390,15 +401,22 @@ impl Message {
     pub fn byte_len(&self) -> usize {
         match &self.inner {
             MessageInner::Empty => 0,
-            MessageInner::Inline { len, .. } => *len as usize,
+            MessageInner::Inline { len, .. } => (len & !INLINE_DELIMITED_FLAG) as usize,
             MessageInner::Single(p) => p.len(),
+            MessageInner::EmptyDelimitedBytes(p) => p.len(),
             MessageInner::Multi(v) => v.iter().map(Payload::len).sum(),
         }
     }
 
     /// Whether this is a multi-part message (more than one frame).
     pub fn is_multipart(&self) -> bool {
-        matches!(self.inner, MessageInner::Multi(_))
+        matches!(
+            self.inner,
+            MessageInner::Inline { len, .. } if len & INLINE_DELIMITED_FLAG != 0
+        ) || matches!(
+            self.inner,
+            MessageInner::EmptyDelimitedBytes(_) | MessageInner::Multi(_)
+        )
     }
 
     /// Get a single part as `Bytes` by index.
@@ -407,7 +425,15 @@ impl Message {
         match &self.inner {
             MessageInner::Empty => None,
             MessageInner::Inline { len, data } => {
-                if index == 0 {
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    match index {
+                        0 => Some(Bytes::new()),
+                        1 => Some(Bytes::copy_from_slice(
+                            &data[..(len & !INLINE_DELIMITED_FLAG) as usize],
+                        )),
+                        _ => None,
+                    }
+                } else if index == 0 {
                     Some(Bytes::copy_from_slice(&data[..*len as usize]))
                 } else {
                     None
@@ -420,6 +446,11 @@ impl Message {
                     None
                 }
             }
+            MessageInner::EmptyDelimitedBytes(p) => match index {
+                0 => Some(Bytes::new()),
+                1 => Some(p.clone()),
+                _ => None,
+            },
             MessageInner::Multi(v) => v.get(index).map(Payload::as_bytes),
         }
     }
@@ -456,9 +487,21 @@ impl Message {
         match std::mem::replace(&mut self.inner, MessageInner::Empty) {
             MessageInner::Empty => None,
             MessageInner::Inline { len, data } => {
-                Some(Bytes::copy_from_slice(&data[..len as usize]))
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    self.inner = MessageInner::Inline {
+                        len: len & !INLINE_DELIMITED_FLAG,
+                        data,
+                    };
+                    Some(Bytes::new())
+                } else {
+                    Some(Bytes::copy_from_slice(&data[..len as usize]))
+                }
             }
             MessageInner::Single(p) => Some(p.as_bytes()),
+            MessageInner::EmptyDelimitedBytes(p) => {
+                self.inner = MessageInner::Single(Payload::from_bytes(p));
+                Some(Bytes::new())
+            }
             MessageInner::Multi(mut v) => {
                 if v.is_empty() {
                     return None;
@@ -478,14 +521,26 @@ impl Message {
     /// parts. Used by identity-routing sockets (ROUTER/REP) to prepend the
     /// peer identity frame.
     pub fn with_prefix(prefix: Bytes, body: Self) -> Self {
+        if prefix.is_empty() {
+            return body.prepend_empty_delimiter();
+        }
         let mut parts = Vec::with_capacity(1 + body.len());
         parts.push(Payload::from_bytes(prefix));
         match body.inner {
             MessageInner::Empty => {}
             MessageInner::Inline { len, data } => {
-                parts.push(Payload::from_slice(&data[..len as usize]));
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    parts.push(Payload::from_bytes(Bytes::new()));
+                }
+                parts.push(Payload::from_slice(
+                    &data[..(len & !INLINE_DELIMITED_FLAG) as usize],
+                ));
             }
             MessageInner::Single(p) => parts.push(p),
+            MessageInner::EmptyDelimitedBytes(p) => {
+                parts.push(Payload::from_bytes(Bytes::new()));
+                parts.push(Payload::from_bytes(p));
+            }
             MessageInner::Multi(v) => parts.extend(v),
         }
         Self {
@@ -493,17 +548,55 @@ impl Message {
         }
     }
 
+    /// Build a REP reply from its saved routing envelope. The envelope is
+    /// already in the compact form used by [`TypeState`](crate::type_state::TypeState),
+    /// so this performs one parts-vector allocation for the wire message.
+    pub(crate) fn with_rep_envelope(envelope: smallvec::SmallVec<[Bytes; 2]>, body: Self) -> Self {
+        let mut parts = Vec::with_capacity(envelope.len() + 1 + body.len());
+        parts.extend(envelope.into_iter().map(Payload::from_bytes));
+        parts.push(Payload::from_bytes(Bytes::new()));
+        match body.inner {
+            MessageInner::Empty => {}
+            MessageInner::Inline { len, data } => {
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    parts.push(Payload::from_bytes(Bytes::new()));
+                }
+                parts.push(Payload::from_slice(
+                    &data[..(len & !INLINE_DELIMITED_FLAG) as usize],
+                ));
+            }
+            MessageInner::Single(p) => parts.push(p),
+            MessageInner::EmptyDelimitedBytes(p) => {
+                parts.push(Payload::from_bytes(Bytes::new()));
+                parts.push(Payload::from_bytes(p));
+            }
+            MessageInner::Multi(v) => parts.extend(v),
+        }
+        Self::from_payloads_vec(parts)
+    }
+
     // ---- pub(crate) API for codec / type_state / transforms ----
 
+    #[allow(dead_code)]
     #[inline]
     pub(crate) fn push_part_payload(&mut self, part: Payload) {
         self.inner = match std::mem::replace(&mut self.inner, MessageInner::Empty) {
             MessageInner::Empty => MessageInner::Single(part),
             MessageInner::Inline { len, data } => {
-                let existing = Payload::from_slice(&data[..len as usize]);
-                MessageInner::Multi(vec![existing, part])
+                let existing =
+                    Payload::from_slice(&data[..(len & !INLINE_DELIMITED_FLAG) as usize]);
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    MessageInner::Multi(vec![Payload::from_bytes(Bytes::new()), existing, part])
+                } else {
+                    MessageInner::Multi(vec![existing, part])
+                }
             }
             MessageInner::Single(existing) => MessageInner::Multi(vec![existing, part]),
+            MessageInner::EmptyDelimitedBytes(existing) => MessageInner::Multi(vec![
+                Payload::from_bytes(Bytes::new()),
+                Payload::from_bytes(existing),
+                part,
+            ]),
             MessageInner::Multi(mut v) => {
                 v.push(part);
                 MessageInner::Multi(v)
@@ -511,13 +604,24 @@ impl Message {
         };
     }
 
-    pub(crate) fn parts_payload(&self) -> SmallVec<[Payload; 1]> {
+    pub(crate) fn parts_payload(&self) -> SmallVec<[Payload; 2]> {
         match &self.inner {
             MessageInner::Empty => SmallVec::new(),
             MessageInner::Inline { len, data } => {
-                SmallVec::from_buf([Payload::from_slice(&data[..*len as usize])])
+                let body = Payload::from_slice(&data[..(*len & !INLINE_DELIMITED_FLAG) as usize]);
+                if *len & INLINE_DELIMITED_FLAG != 0 {
+                    smallvec::smallvec![Payload::from_bytes(Bytes::new()), body]
+                } else {
+                    smallvec::smallvec![body]
+                }
             }
-            MessageInner::Single(p) => SmallVec::from_buf([p.clone()]),
+            MessageInner::Single(p) => smallvec::smallvec![p.clone()],
+            MessageInner::EmptyDelimitedBytes(p) => {
+                smallvec::smallvec![
+                    Payload::from_bytes(Bytes::new()),
+                    Payload::from_bytes(p.clone())
+                ]
+            }
             MessageInner::Multi(v) => v.iter().cloned().collect(),
         }
     }
@@ -527,9 +631,16 @@ impl Message {
         match &self.inner {
             MessageInner::Empty => {}
             MessageInner::Inline { len, data } => {
-                f(&data[..*len as usize]);
+                if *len & INLINE_DELIMITED_FLAG != 0 {
+                    f(&[]);
+                }
+                f(&data[..(*len & !INLINE_DELIMITED_FLAG) as usize]);
             }
             MessageInner::Single(p) => f(p.as_slice()),
+            MessageInner::EmptyDelimitedBytes(p) => {
+                f(&[]);
+                f(p.as_ref());
+            }
             MessageInner::Multi(v) => {
                 for p in v {
                     f(p.as_slice());
@@ -542,9 +653,17 @@ impl Message {
         match self.inner {
             MessageInner::Empty => Vec::new(),
             MessageInner::Inline { len, data } => {
-                vec![Payload::from_slice(&data[..len as usize])]
+                let body = Payload::from_slice(&data[..(len & !INLINE_DELIMITED_FLAG) as usize]);
+                if len & INLINE_DELIMITED_FLAG != 0 {
+                    vec![Payload::from_bytes(Bytes::new()), body]
+                } else {
+                    vec![body]
+                }
             }
             MessageInner::Single(p) => vec![p],
+            MessageInner::EmptyDelimitedBytes(p) => {
+                vec![Payload::from_bytes(Bytes::new()), Payload::from_bytes(p)]
+            }
             MessageInner::Multi(v) => v,
         }
     }
@@ -576,14 +695,17 @@ impl Message {
             MessageInner::Empty => Self {
                 inner: MessageInner::Single(empty),
             },
-            MessageInner::Inline { len, data } => {
-                let body = Payload::from_slice(&data[..len as usize]);
-                Self {
-                    inner: MessageInner::Multi(vec![empty, body]),
-                }
-            }
+            MessageInner::Inline { len, data } => Self {
+                inner: MessageInner::Inline {
+                    len: (len & !INLINE_DELIMITED_FLAG) | INLINE_DELIMITED_FLAG,
+                    data,
+                },
+            },
             MessageInner::Single(p) => Self {
-                inner: MessageInner::Multi(vec![empty, p]),
+                inner: MessageInner::EmptyDelimitedBytes(p.as_bytes()),
+            },
+            MessageInner::EmptyDelimitedBytes(p) => Self {
+                inner: MessageInner::Multi(vec![empty, Payload::from_bytes(p)]),
             },
             MessageInner::Multi(mut v) => {
                 v.insert(0, empty);
@@ -660,6 +782,9 @@ impl Clone for Message {
                     data: *data,
                 },
                 MessageInner::Single(p) => MessageInner::Single(p.clone()),
+                MessageInner::EmptyDelimitedBytes(p) => {
+                    MessageInner::EmptyDelimitedBytes(p.clone())
+                }
                 MessageInner::Multi(v) => MessageInner::Multi(v.clone()),
             },
         }
@@ -699,7 +824,13 @@ impl Message {
         match &self.inner {
             MessageInner::Empty => None,
             MessageInner::Inline { len, data } => {
-                if index == 0 {
+                if *len & INLINE_DELIMITED_FLAG != 0 {
+                    match index {
+                        0 => Some(&[]),
+                        1 => Some(&data[..(*len & !INLINE_DELIMITED_FLAG) as usize]),
+                        _ => None,
+                    }
+                } else if index == 0 {
                     Some(&data[..*len as usize])
                 } else {
                     None
@@ -712,6 +843,11 @@ impl Message {
                     None
                 }
             }
+            MessageInner::EmptyDelimitedBytes(p) => match index {
+                0 => Some(&[]),
+                1 => Some(p.as_ref()),
+                _ => None,
+            },
             MessageInner::Multi(v) => v.get(index).map(Payload::as_slice),
         }
     }
@@ -1093,6 +1229,19 @@ mod tests {
         let body = Message::multipart(["", "data"]);
         let m = Message::with_prefix(Bytes::from_static(b"id"), body);
         assert_eq!(m, Message::multipart([&b"id"[..], &b""[..], &b"data"[..]]));
+    }
+
+    #[test]
+    fn message_empty_delimiter_keeps_two_parts_without_vec() {
+        let m = Message::with_prefix(Bytes::new(), Message::single("hello"));
+        assert_eq!(m.len(), 2);
+        assert!(m.is_multipart());
+        assert_eq!(m.part_bytes(0).unwrap(), &b""[..]);
+        assert_eq!(m.part_bytes(1).unwrap(), &b"hello"[..]);
+        assert_eq!(
+            m.into_iter().collect::<Vec<_>>(),
+            vec![Bytes::new(), Bytes::from_static(b"hello")]
+        );
     }
 
     #[test]

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -25,6 +25,14 @@ const COMPRESSION_DICT_MAX: usize = 8 * 1024;
 #[derive(Clone, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Options {
+    /// Scheduling profile for this socket.
+    ///
+    /// `None` selects the socket-type default: REQ and REP use the
+    /// latency profile; all other socket types use the throughput profile.
+    /// For ping-pong SERVER/CLIENT or ROUTER/DEALER workloads, set this
+    /// explicitly on both endpoints.
+    pub workload_profile: Option<WorkloadProfile>,
+
     /// Send-side high-water mark, total for the socket. `None` = unbounded.
     pub send_hwm: Option<u32>,
 
@@ -191,6 +199,7 @@ pub type MechanismConfig = MechanismSetup;
 impl Default for Options {
     fn default() -> Self {
         Self {
+            workload_profile: None,
             send_hwm: Some(1000),
             recv_hwm: Some(1000),
             linger: Some(Duration::ZERO),
@@ -232,6 +241,13 @@ impl Options {
     /// Create options with default values.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Select the scheduling profile used by this socket's I/O driver.
+    #[must_use]
+    pub fn workload_profile(mut self, profile: WorkloadProfile) -> Self {
+        self.workload_profile = Some(profile);
+        self
     }
 
     /// Check ZMTP protocol limits that would cause hard-to-debug wire
@@ -583,6 +599,15 @@ impl Options {
     }
 }
 
+/// Scheduling tradeoff for a socket's I/O driver.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkloadProfile {
+    /// Prefer batching and throughput.
+    Throughput,
+    /// Prefer promptly handing messages to the application.
+    Latency,
+}
+
 impl From<Bytes> for Options {
     /// Convenience: build options with a given identity, defaults for the rest.
     fn from(identity: Bytes) -> Self {
@@ -755,6 +780,7 @@ mod tests {
     #[test]
     fn builder_chaining() {
         let o = Options::new()
+            .workload_profile(WorkloadProfile::Latency)
             .send_hwm(42)
             .recv_hwm(99)
             .linger(Duration::from_secs(5))
@@ -765,6 +791,7 @@ mod tests {
             .router_mandatory(true)
             .on_mute(OnMute::DropNewest);
         assert_eq!(o.send_hwm, Some(42));
+        assert_eq!(o.workload_profile, Some(WorkloadProfile::Latency));
         assert_eq!(o.recv_hwm, Some(99));
         assert_eq!(o.linger, Some(Duration::from_secs(5)));
         assert_eq!(o.identity, &b"router-id"[..]);
@@ -773,6 +800,17 @@ mod tests {
         assert!(o.conflate);
         assert!(o.router_mandatory);
         assert_eq!(o.on_mute, OnMute::DropNewest);
+    }
+
+    #[test]
+    fn workload_profile_defaults_to_socket_type_selection() {
+        assert_eq!(Options::default().workload_profile, None);
+        assert_eq!(
+            Options::new()
+                .workload_profile(WorkloadProfile::Throughput)
+                .workload_profile,
+            Some(WorkloadProfile::Throughput)
+        );
     }
 
     #[test]

--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -1,9 +1,8 @@
 //! CURVE mechanism: 4-message handshake (HELLO / WELCOME / INITIATE /
 //! READY) plus per-frame MESSAGE encryption. Wire format follows RFC 26.
 //!
-//! The actual crypto is done by `crypto_box::SalsaBox` (Curve25519
-//! XSalsa20-Poly1305). This module is just protocol layout + state
-//! machine.
+//! Crypto: X25519 DH + XSalsa20-Poly1305 via `crypto_box::SalsaBox`.
+//! This module is just protocol layout + state machine.
 //!
 //!
 //! Internally split into [`CurveClient`] and [`CurveServer`] so each
@@ -19,14 +18,75 @@
 
 use std::sync::Arc;
 
-use bytes::{BufMut, Bytes, BytesMut};
-use crypto_box::aead::rand_core::{OsRng, RngCore};
-use crypto_box::{PublicKey, SalsaBox, SecretKey, aead::Aead};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use crypto_box::SalsaBox;
+use crypto_box::aead::generic_array::GenericArray;
+use crypto_box::aead::{Aead, AeadInPlace};
+use rand::Rng;
+use x25519_dalek::{PublicKey, StaticSecret};
 
 use super::curve_cookie::CurveCookieKeyring;
 use super::{CurveKeypair, CurvePublicKey, MechanismStep, try_error_command};
 use crate::error::{Error, Result};
 use crate::proto::command::{self, Command, PeerProperties};
+
+/// `NaCl` `crypto_box` construction via the `crypto_box` crate: X25519
+/// DH + `HSalsa20` key derivation + XSalsa20-Poly1305 AEAD.
+struct CurveBox {
+    inner: SalsaBox,
+}
+
+impl CurveBox {
+    fn new(peer_public: &PublicKey, our_secret: &StaticSecret) -> Self {
+        let cb_public = crypto_box::PublicKey::from(*peer_public.as_bytes());
+        let cb_secret = crypto_box::SecretKey::from(our_secret.to_bytes());
+        Self {
+            inner: SalsaBox::new(&cb_public, &cb_secret),
+        }
+    }
+
+    fn encrypt(&self, nonce: &[u8; 24], plaintext: &[u8]) -> Vec<u8> {
+        self.inner
+            .encrypt(GenericArray::from_slice(nonce), plaintext)
+            .expect("SalsaBox::encrypt infallible without AAD")
+    }
+
+    fn decrypt(
+        &self,
+        nonce: &[u8; 24],
+        ciphertext: &[u8],
+    ) -> core::result::Result<Vec<u8>, crypto_box::aead::Error> {
+        self.inner
+            .decrypt(GenericArray::from_slice(nonce), ciphertext)
+    }
+
+    fn encrypt_in_place_detached(&self, nonce: &[u8; 24], buf: &mut [u8]) -> [u8; 16] {
+        self.inner
+            .encrypt_in_place_detached(GenericArray::from_slice(nonce), b"", buf)
+            .expect("SalsaBox::encrypt infallible without AAD")
+            .into()
+    }
+
+    fn decrypt_in_place_detached(
+        &self,
+        nonce: &[u8; 24],
+        buf: &mut [u8],
+        tag: &[u8; 16],
+    ) -> core::result::Result<(), crypto_box::aead::Error> {
+        self.inner.decrypt_in_place_detached(
+            GenericArray::from_slice(nonce),
+            b"",
+            buf,
+            GenericArray::from_slice(tag),
+        )
+    }
+}
+
+impl std::fmt::Debug for CurveBox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("CurveBox")
+    }
+}
 
 const NONCE_HELLO: &[u8; 16] = b"CurveZMQHELLO---";
 const NONCE_INITIATE: &[u8; 16] = b"CurveZMQINITIATE";
@@ -55,10 +115,14 @@ fn nonce_long(prefix: &[u8; 8], suffix: &[u8; 16]) -> [u8; 24] {
 
 /// Reject low-order Curve25519 public keys that force the X25519 shared
 /// secret to all-zeros, making session encryption predictable.
-fn validate_dh_not_zero(our_secret: &SecretKey, peer_public: &[u8; 32]) -> Result<()> {
-    let sec = x25519_dalek::StaticSecret::from(our_secret.to_bytes());
-    let pub_ = x25519_dalek::PublicKey::from(*peer_public);
-    if sec.diffie_hellman(&pub_).to_bytes().iter().all(|&b| b == 0) {
+fn validate_dh_not_zero(our_secret: &StaticSecret, peer_public: &[u8; 32]) -> Result<()> {
+    let pub_ = PublicKey::from(*peer_public);
+    if our_secret
+        .diffie_hellman(&pub_)
+        .to_bytes()
+        .iter()
+        .all(|&b| b == 0)
+    {
         return Err(Error::HandshakeFailed(
             "X25519 produced all-zero shared secret (low-order public key)".into(),
         ));
@@ -70,7 +134,7 @@ fn validate_dh_not_zero(our_secret: &SecretKey, peer_public: &[u8; 32]) -> Resul
 /// MESSAGE commands, decrypts incoming MESSAGE commands.
 pub struct CurveTransform {
     /// Box keyed on (our transient secret, peer transient public).
-    salsa: SalsaBox,
+    salsa: CurveBox,
     /// Outgoing MESSAGE nonce counter.
     out_counter: u64,
     /// Incoming MESSAGE nonce counter. Must increase monotonically (RFC 26).
@@ -108,17 +172,18 @@ impl CurveTransform {
             .checked_add(1)
             .ok_or_else(|| Error::Protocol("CURVE outbound nonce counter exhausted".into()))?;
         let nonce = nonce_short(&self.out_prefix, self.out_counter);
-        let mut pt = Vec::with_capacity(1 + plaintext.len());
-        pt.push(u8::from(more) | (u8::from(command) << 1));
-        pt.extend_from_slice(plaintext);
-        let ct = self
+        let pt_len = 1 + plaintext.len();
+        // NaCl wire layout: nonce(8) || tag(16) || ciphertext.
+        let mut buf = BytesMut::with_capacity(8 + 16 + pt_len);
+        buf.put_slice(&self.out_counter.to_be_bytes());
+        buf.put_slice(&[0u8; 16]); // placeholder for tag
+        buf.put_u8(u8::from(more) | (u8::from(command) << 1));
+        buf.extend_from_slice(plaintext);
+        let tag = self
             .salsa
-            .encrypt(&nonce.into(), pt.as_slice())
-            .map_err(|_| Error::Protocol("CURVE encrypt failed".into()))?;
-        let mut body = BytesMut::with_capacity(8 + ct.len());
-        body.put_slice(&self.out_counter.to_be_bytes());
-        body.put_slice(&ct);
-        Ok(body.freeze())
+            .encrypt_in_place_detached(&nonce, &mut buf[8 + 16..]);
+        buf[8..8 + 16].copy_from_slice(&tag);
+        Ok(buf.freeze())
     }
 
     /// Wrap an encrypted body in the `\x07MESSAGE` ZMTP command frame.
@@ -145,31 +210,35 @@ impl CurveTransform {
                 "CURVE MESSAGE nonce counter not monotonically increasing".into(),
             ));
         }
-        let ct = &body[8..];
+        // NaCl wire layout: nonce(8) || tag(16) || ciphertext.
         let nonce = nonce_short(&self.in_prefix, counter);
-        let pt = self
-            .salsa
-            .decrypt(&nonce.into(), ct)
+        let tag: [u8; 16] = body[8..8 + 16].try_into().unwrap();
+        let ct = &body[8 + 16..];
+        let mut buf = BytesMut::with_capacity(ct.len());
+        buf.extend_from_slice(ct);
+        self.salsa
+            .decrypt_in_place_detached(&nonce, &mut buf, &tag)
             .map_err(|_| Error::Protocol("CURVE decrypt failed".into()))?;
-        if pt.is_empty() {
+        if buf.is_empty() {
             return Err(Error::Protocol(
                 "CURVE MESSAGE plaintext missing flags".into(),
             ));
         }
-        let more = pt[0] & 0x01 != 0;
-        let command = pt[0] & 0x02 != 0;
+        let more = buf[0] & 0x01 != 0;
+        let command = buf[0] & 0x02 != 0;
         self.in_counter = counter;
-        Ok((more, command, Bytes::copy_from_slice(&pt[1..])))
+        buf.advance(1);
+        Ok((more, command, buf.freeze()))
     }
 }
 
 fn build_transform(
-    our_eph_secret: &SecretKey,
+    our_eph_secret: &StaticSecret,
     peer_eph_public: &PublicKey,
     out_counter: u64,
     is_server: bool,
 ) -> CurveTransform {
-    let salsa = SalsaBox::new(peer_eph_public, our_eph_secret);
+    let salsa = CurveBox::new(peer_eph_public, our_eph_secret);
     let (out_prefix, in_prefix) = if is_server {
         (*NONCE_MESSAGE_S, *NONCE_MESSAGE_C)
     } else {
@@ -244,9 +313,8 @@ impl CurveMechanism {
 // CurveClient
 // =====================================================================
 
-#[derive(Debug)]
 pub(crate) struct CurveClient {
-    our_lt_secret: SecretKey,
+    our_lt_secret: StaticSecret,
     our_lt_public: PublicKey,
     peer_lt_public: PublicKey,
     our_props: PeerProperties,
@@ -255,21 +323,29 @@ pub(crate) struct CurveClient {
     state: Option<CurveClientState>,
 }
 
+impl std::fmt::Debug for CurveClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CurveClient")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
 enum CurveClientState {
     Init {
-        our_eph_secret: SecretKey,
+        our_eph_secret: StaticSecret,
         our_eph_public: PublicKey,
     },
     AwaitingWelcome {
-        our_eph_secret: SecretKey,
+        our_eph_secret: StaticSecret,
         our_eph_public: PublicKey,
     },
     AwaitingReady {
-        our_eph_secret: SecretKey,
+        our_eph_secret: StaticSecret,
         peer_eph_public: PublicKey,
     },
     Done {
-        our_eph_secret: SecretKey,
+        our_eph_secret: StaticSecret,
         peer_eph_public: PublicKey,
     },
 }
@@ -288,11 +364,11 @@ impl std::fmt::Debug for CurveClientState {
 impl CurveClient {
     #[expect(clippy::needless_pass_by_value)]
     fn new(our_keypair: CurveKeypair, server_public: CurvePublicKey) -> Self {
-        let our_lt_secret = SecretKey::from_bytes(*our_keypair.secret.as_bytes());
-        let our_lt_public = PublicKey::from_bytes(*our_keypair.public.as_bytes());
-        let peer_lt_public = PublicKey::from_bytes(*server_public.as_bytes());
-        let our_eph_secret = SecretKey::generate(&mut OsRng);
-        let our_eph_public = our_eph_secret.public_key();
+        let our_lt_secret = StaticSecret::from(*our_keypair.secret.as_bytes());
+        let our_lt_public = PublicKey::from(*our_keypair.public.as_bytes());
+        let peer_lt_public = PublicKey::from(*server_public.as_bytes());
+        let our_eph_secret = StaticSecret::random();
+        let our_eph_public = PublicKey::from(&our_eph_secret);
         Self {
             our_lt_secret,
             our_lt_public,
@@ -370,7 +446,7 @@ impl CurveClient {
         }
     }
 
-    fn eph_secret(&self) -> &SecretKey {
+    fn eph_secret(&self) -> &StaticSecret {
         match self.state.as_ref().unwrap() {
             CurveClientState::Init { our_eph_secret, .. }
             | CurveClientState::AwaitingWelcome { our_eph_secret, .. }
@@ -392,9 +468,8 @@ impl CurveClient {
     fn build_hello(&mut self) -> Result<Bytes> {
         let counter = self.next_out_counter()?;
         let nonce = nonce_short(NONCE_HELLO, counter);
-        let signature_box = SalsaBox::new(&self.peer_lt_public, self.eph_secret())
-            .encrypt(&nonce.into(), &[0u8; 64][..])
-            .map_err(|_| Error::Protocol("CURVE HELLO encrypt failed".into()))?;
+        let signature_box =
+            CurveBox::new(&self.peer_lt_public, self.eph_secret()).encrypt(&nonce, &[0u8; 64][..]);
         let mut body = BytesMut::with_capacity(194);
         body.put_u8(0x01);
         body.put_u8(0x00);
@@ -415,8 +490,8 @@ impl CurveClient {
         let welcome_suffix: [u8; 16] = body[..16].try_into().unwrap();
         let welcome_box = &body[16..];
         let nonce = nonce_long(NONCE_WELCOME_PREFIX, &welcome_suffix);
-        let pt = SalsaBox::new(&self.peer_lt_public, self.eph_secret())
-            .decrypt(&nonce.into(), welcome_box)
+        let pt = CurveBox::new(&self.peer_lt_public, self.eph_secret())
+            .decrypt(&nonce, welcome_box)
             .map_err(|_| Error::HandshakeFailed("CURVE WELCOME decrypt failed".into()))?;
         if pt.len() != 128 {
             return Err(Error::HandshakeFailed(format!(
@@ -430,7 +505,7 @@ impl CurveClient {
 
         validate_dh_not_zero(self.eph_secret(), &sp_bytes)?;
 
-        let peer_eph_public = PublicKey::from_bytes(sp_bytes);
+        let peer_eph_public = PublicKey::from(sp_bytes);
 
         // Transition: AwaitingWelcome -> AwaitingReady, moving ephemeral secret
         let CurveClientState::AwaitingWelcome { our_eph_secret, .. } = self.state.take().unwrap()
@@ -463,16 +538,15 @@ impl CurveClient {
         // Vouch box: Box[Cp(32) + S_long(32)](C_long_secret -> Sp,
         // "VOUCH---" + 16-byte vouch-nonce suffix).
         let mut vouch_suffix = [0u8; 16];
-        OsRng.fill_bytes(&mut vouch_suffix);
+        rand::rng().fill_bytes(&mut vouch_suffix);
         let vouch_nonce = nonce_long(NONCE_VOUCH_PREFIX, &vouch_suffix);
         let mut vouch_pt = [0u8; 64];
-        vouch_pt[..32].copy_from_slice(our_eph_secret.public_key().as_bytes());
+        vouch_pt[..32].copy_from_slice(PublicKey::from(our_eph_secret).as_bytes());
         vouch_pt[32..].copy_from_slice(self.peer_lt_public.as_bytes());
         // RFC 26: vouch box is sealed by the client's long-term secret to
         // the SERVER'S TRANSIENT public key (S_eph), NOT the long-term one.
-        let vouch_box = SalsaBox::new(peer_eph_public, &self.our_lt_secret)
-            .encrypt(&vouch_nonce.into(), &vouch_pt[..])
-            .map_err(|_| Error::Protocol("CURVE VOUCH encrypt failed".into()))?;
+        let vouch_box = CurveBox::new(peer_eph_public, &self.our_lt_secret)
+            .encrypt(&vouch_nonce, &vouch_pt[..]);
 
         // Initiate plaintext = C_long_pub(32) + vouch_suffix(16) + vouch_box(80) + metadata.
         let metadata = encode_metadata(&our_props)?;
@@ -483,9 +557,8 @@ impl CurveClient {
         init_pt.extend_from_slice(&metadata);
 
         let nonce = nonce_short(NONCE_INITIATE, counter);
-        let init_box = SalsaBox::new(peer_eph_public, our_eph_secret)
-            .encrypt(&nonce.into(), init_pt.as_slice())
-            .map_err(|_| Error::Protocol("CURVE INITIATE encrypt failed".into()))?;
+        let init_box =
+            CurveBox::new(peer_eph_public, our_eph_secret).encrypt(&nonce, init_pt.as_slice());
 
         let mut body = BytesMut::with_capacity(96 + 8 + init_box.len());
         body.put_slice(&self.received_cookie);
@@ -508,8 +581,8 @@ impl CurveClient {
             unreachable!();
         };
         let nonce = nonce_short(NONCE_READY, counter);
-        let pt = SalsaBox::new(peer_eph_public, our_eph_secret)
-            .decrypt(&nonce.into(), ready_box)
+        let pt = CurveBox::new(peer_eph_public, our_eph_secret)
+            .decrypt(&nonce, ready_box)
             .map_err(|_| Error::HandshakeFailed("CURVE READY decrypt failed".into()))?;
         let props = decode_metadata(&pt)?;
 
@@ -551,9 +624,8 @@ impl CurveClient {
 // CurveServer
 // =====================================================================
 
-#[derive(Debug)]
 pub(crate) struct CurveServer {
-    our_lt_secret: SecretKey,
+    our_lt_secret: StaticSecret,
     our_lt_public: PublicKey,
     cookie_keyring: Arc<CurveCookieKeyring>,
     authenticator: Option<super::Authenticator>,
@@ -562,11 +634,19 @@ pub(crate) struct CurveServer {
     state: CurveServerState,
 }
 
+impl std::fmt::Debug for CurveServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CurveServer")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
 enum CurveServerState {
     Init,
     AwaitingInitiate,
     Done {
-        our_eph_secret: SecretKey,
+        our_eph_secret: StaticSecret,
         peer_eph_public: PublicKey,
     },
 }
@@ -588,8 +668,8 @@ impl CurveServer {
         cookie_keyring: Arc<CurveCookieKeyring>,
         authenticator: Option<super::Authenticator>,
     ) -> Self {
-        let our_lt_secret = SecretKey::from_bytes(*our_keypair.secret.as_bytes());
-        let our_lt_public = PublicKey::from_bytes(*our_keypair.public.as_bytes());
+        let our_lt_secret = StaticSecret::from(*our_keypair.secret.as_bytes());
+        let our_lt_public = PublicKey::from(*our_keypair.public.as_bytes());
         Self {
             our_lt_secret,
             our_lt_public,
@@ -627,7 +707,7 @@ impl CurveServer {
         match (name.as_ref(), &self.state) {
             (b"HELLO", CurveServerState::Init) => {
                 let (our_eph_secret, peer_eph_public) = self.parse_hello(&body)?;
-                let welcome = self.build_welcome(&our_eph_secret, &peer_eph_public)?;
+                let welcome = self.build_welcome(&our_eph_secret, &peer_eph_public);
                 out.push(Command::Unknown {
                     name: Bytes::from_static(b"WELCOME"),
                     body: welcome,
@@ -656,7 +736,7 @@ impl CurveServer {
         }
     }
 
-    fn parse_hello(&mut self, body: &[u8]) -> Result<(SecretKey, PublicKey)> {
+    fn parse_hello(&mut self, body: &[u8]) -> Result<(StaticSecret, PublicKey)> {
         if body.len() != 194 {
             return Err(Error::HandshakeFailed(format!(
                 "CURVE HELLO has wrong length {}",
@@ -676,10 +756,10 @@ impl CurveServer {
 
         validate_dh_not_zero(&self.our_lt_secret, &cp_bytes)?;
 
-        let cp = PublicKey::from_bytes(cp_bytes);
+        let cp = PublicKey::from(cp_bytes);
         let nonce = nonce_short(NONCE_HELLO, counter);
-        let pt = SalsaBox::new(&cp, &self.our_lt_secret)
-            .decrypt(&nonce.into(), signature_box)
+        let pt = CurveBox::new(&cp, &self.our_lt_secret)
+            .decrypt(&nonce, signature_box)
             .map_err(|_| Error::HandshakeFailed("CURVE HELLO signature invalid".into()))?;
         if pt.len() != 64 || pt.iter().any(|&b| b != 0) {
             return Err(Error::HandshakeFailed(
@@ -687,18 +767,18 @@ impl CurveServer {
             ));
         }
 
-        let our_eph_secret = SecretKey::generate(&mut OsRng);
+        let our_eph_secret = StaticSecret::random();
         Ok((our_eph_secret, cp))
     }
 
     fn build_welcome(
         &mut self,
-        our_eph_secret: &SecretKey,
+        our_eph_secret: &StaticSecret,
         peer_eph_public: &PublicKey,
-    ) -> Result<Bytes> {
-        let our_eph_public = our_eph_secret.public_key();
+    ) -> Bytes {
+        let our_eph_public = PublicKey::from(our_eph_secret);
         let mut welcome_suffix = [0u8; 16];
-        OsRng.fill_bytes(&mut welcome_suffix);
+        rand::rng().fill_bytes(&mut welcome_suffix);
         let welcome_nonce = nonce_long(NONCE_WELCOME_PREFIX, &welcome_suffix);
 
         let cookie = self
@@ -709,15 +789,14 @@ impl CurveServer {
         let mut welcome_pt = Vec::with_capacity(128);
         welcome_pt.extend_from_slice(our_eph_public.as_bytes());
         welcome_pt.extend_from_slice(&cookie);
-        let welcome_box = SalsaBox::new(peer_eph_public, &self.our_lt_secret)
-            .encrypt(&welcome_nonce.into(), welcome_pt.as_slice())
-            .map_err(|_| Error::Protocol("CURVE WELCOME encrypt failed".into()))?;
+        let welcome_box = CurveBox::new(peer_eph_public, &self.our_lt_secret)
+            .encrypt(&welcome_nonce, welcome_pt.as_slice());
 
         let mut body = BytesMut::with_capacity(160);
         body.put_slice(&welcome_suffix);
         body.put_slice(&welcome_box);
 
-        Ok(body.freeze())
+        body.freeze()
     }
 
     fn parse_initiate(&mut self, body: &[u8]) -> Result<PeerProperties> {
@@ -730,12 +809,12 @@ impl CurveServer {
 
         // Recover ephemeral state from the cookie (stateless-server).
         let (cp_bytes, sn_secret_bytes) = self.cookie_keyring.decrypt_cookie(cookie_bytes)?;
-        let sn_secret = SecretKey::from_bytes(sn_secret_bytes);
-        let cp = PublicKey::from_bytes(cp_bytes);
+        let sn_secret = StaticSecret::from(sn_secret_bytes);
+        let cp = PublicKey::from(cp_bytes);
 
         let nonce = nonce_short(NONCE_INITIATE, counter);
-        let init_pt = SalsaBox::new(&cp, &sn_secret)
-            .decrypt(&nonce.into(), init_box)
+        let init_pt = CurveBox::new(&cp, &sn_secret)
+            .decrypt(&nonce, init_box)
             .map_err(|_| Error::HandshakeFailed("CURVE INITIATE decrypt failed".into()))?;
         if init_pt.len() < 32 + 16 + 80 {
             return Err(Error::HandshakeFailed(
@@ -749,7 +828,7 @@ impl CurveServer {
 
         validate_dh_not_zero(&sn_secret, &client_lt_bytes)?;
 
-        let cl = PublicKey::from_bytes(client_lt_bytes);
+        let cl = PublicKey::from(client_lt_bytes);
         Self::verify_vouch(
             &sn_secret,
             &self.our_lt_public,
@@ -783,7 +862,7 @@ impl CurveServer {
     }
 
     fn verify_vouch(
-        our_eph_secret: &SecretKey,
+        our_eph_secret: &StaticSecret,
         our_lt_public: &PublicKey,
         vouch_suffix: &[u8; 16],
         vouch_box: &[u8],
@@ -791,8 +870,8 @@ impl CurveServer {
         expected_cp: &PublicKey,
     ) -> Result<()> {
         let vouch_nonce = nonce_long(NONCE_VOUCH_PREFIX, vouch_suffix);
-        let vouch_pt = SalsaBox::new(cl, our_eph_secret)
-            .decrypt(&vouch_nonce.into(), vouch_box)
+        let vouch_pt = CurveBox::new(cl, our_eph_secret)
+            .decrypt(&vouch_nonce, vouch_box)
             .map_err(|_| Error::HandshakeFailed("CURVE VOUCH invalid".into()))?;
         if vouch_pt.len() != 64
             || &vouch_pt[..32] != expected_cp.as_bytes()
@@ -819,9 +898,8 @@ impl CurveServer {
         };
         let nonce = nonce_short(NONCE_READY, counter);
         let metadata = encode_metadata(&self.our_props)?;
-        let ready_box = SalsaBox::new(peer_eph_public, our_eph_secret)
-            .encrypt(&nonce.into(), metadata.as_slice())
-            .map_err(|_| Error::Protocol("CURVE READY encrypt failed".into()))?;
+        let ready_box =
+            CurveBox::new(peer_eph_public, our_eph_secret).encrypt(&nonce, metadata.as_slice());
         let mut body = BytesMut::with_capacity(8 + ready_box.len());
         body.put_slice(&counter.to_be_bytes());
         body.put_slice(&ready_box);

--- a/omq-proto/src/proto/mechanism/curve_cookie.rs
+++ b/omq-proto/src/proto/mechanism/curve_cookie.rs
@@ -9,6 +9,7 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crypto_secretbox::XSalsa20Poly1305;
+use crypto_secretbox::aead::generic_array::GenericArray;
 use crypto_secretbox::aead::{Aead, KeyInit};
 use rand::Rng;
 use zeroize::Zeroizing;
@@ -77,9 +78,9 @@ impl CurveCookieKeyring {
         let mut plaintext = [0u8; 64];
         plaintext[..32].copy_from_slice(cp);
         plaintext[32..].copy_from_slice(sn_secret);
-        let ciphertext = XSalsa20Poly1305::new(&(*key).into())
-            .encrypt(&nonce.into(), &plaintext[..])
-            .expect("XSalsa20Poly1305 encrypt never fails for valid inputs");
+        let ciphertext = XSalsa20Poly1305::new(GenericArray::from_slice(&*key))
+            .encrypt(GenericArray::from_slice(&nonce), &plaintext[..])
+            .expect("cookie encrypt infallible");
         let mut out = Vec::with_capacity(96);
         out.extend_from_slice(&suffix);
         out.extend_from_slice(&ciphertext);
@@ -119,8 +120,8 @@ impl CurveCookieKeyring {
     }
 
     fn try_decrypt(key: &[u8; 32], nonce: &[u8; 24], ciphertext: &[u8]) -> Result<Vec<u8>> {
-        XSalsa20Poly1305::new(&(*key).into())
-            .decrypt(&(*nonce).into(), ciphertext)
+        XSalsa20Poly1305::new(GenericArray::from_slice(key))
+            .decrypt(GenericArray::from_slice(nonce), ciphertext)
             .map_err(|_| Error::HandshakeFailed("CURVE cookie invalid".into()))
     }
 

--- a/omq-proto/src/proto/mechanism/curve_keys.rs
+++ b/omq-proto/src/proto/mechanism/curve_keys.rs
@@ -1,6 +1,5 @@
 //! CURVE Curve25519 keypair: long-term keys + Z85 helpers.
 
-use crypto_box::aead::OsRng;
 use subtle::ConstantTimeEq;
 use zeroize::ZeroizeOnDrop;
 
@@ -87,8 +86,8 @@ impl CurveSecretKey {
 
     /// Derive the corresponding public key from this secret key.
     pub fn derive_public(&self) -> CurvePublicKey {
-        let sk = crypto_box::SecretKey::from(self.0);
-        CurvePublicKey::from_bytes(*sk.public_key().as_bytes())
+        let sk = x25519_dalek::StaticSecret::from(self.0);
+        CurvePublicKey::from_bytes(*x25519_dalek::PublicKey::from(&sk).as_bytes())
     }
 }
 
@@ -110,11 +109,8 @@ impl Eq for CurveSecretKey {}
 impl CurveKeypair {
     /// Generate a fresh long-term keypair using the OS RNG.
     pub fn generate() -> Self {
-        // crypto_box::SecretKey wraps an X25519 secret key; we derive the
-        // public key via its `public_key()`. We unwrap into raw bytes for
-        // our own storage so callers don't need crypto_box in their API.
-        let sec = crypto_box::SecretKey::generate(&mut OsRng);
-        let pub_ = sec.public_key();
+        let sec = x25519_dalek::StaticSecret::random();
+        let pub_ = x25519_dalek::PublicKey::from(&sec);
         Self {
             secret: CurveSecretKey::from_bytes(sec.to_bytes()),
             public: CurvePublicKey::from_bytes(*pub_.as_bytes()),

--- a/omq-proto/src/type_state.rs
+++ b/omq-proto/src/type_state.rs
@@ -13,6 +13,7 @@
 //! Socket model.
 
 use bytes::Bytes;
+use smallvec::SmallVec;
 
 use crate::error::{Error, Result};
 use crate::message::{Message, Payload};
@@ -23,9 +24,9 @@ use crate::proto::SocketType;
 pub struct TypeState {
     /// REQ: true after send, clears on recv. Enforces alternation.
     req_awaiting_reply: bool,
-    /// REP: saved envelope (frames before the first empty delimiter).
-    /// Populated on recv, consumed on send.
-    rep_envelope: Option<Vec<Bytes>>,
+    /// REP: saved envelope (frames before the empty delimiter).
+    /// Populated on recv, consumed by send.
+    rep_envelope: Option<SmallVec<[Bytes; 2]>>,
 }
 
 impl TypeState {
@@ -84,15 +85,7 @@ impl TypeState {
                         "REP socket must receive a request before replying".into(),
                     ));
                 };
-                let mut new_msg = Message::new();
-                for frame in envelope {
-                    new_msg.push_part_payload(Payload::from_bytes(frame));
-                }
-                new_msg.push_part_payload(Payload::from_bytes(Bytes::new()));
-                for p in msg.into_parts_payload() {
-                    new_msg.push_part_payload(p);
-                }
-                Ok(new_msg)
+                Ok(Message::with_rep_envelope(envelope, msg))
             }
             _ => Ok(msg),
         }
@@ -142,13 +135,14 @@ impl TypeState {
                 let Some(delim_idx) = parts.iter().position(Payload::is_empty) else {
                     return Ok(None);
                 };
-                let mut envelope = Vec::with_capacity(delim_idx);
+                let mut envelope = SmallVec::with_capacity(delim_idx);
                 for p in parts.iter().take(delim_idx) {
                     envelope.push(p.as_bytes());
                 }
-                let body_parts: Vec<Payload> = parts.into_iter().skip(delim_idx + 1).collect();
+                let mut parts = parts;
+                parts.drain(..=delim_idx);
                 self.rep_envelope = Some(envelope);
-                Ok(Some(Message::from_payloads_vec(body_parts)))
+                Ok(Some(Message::from_payloads_vec(parts)))
             }
             _ => Ok(Some(msg)),
         }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -26,7 +26,6 @@ ws = ["omq-proto/ws", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfi
 # Enables the fuzz test suites (`tests/fuzz_*.rs`). Off by default -
 # those targets do ~1 M iterations each and dominate runtime of
 # `cargo test`. Run with `cargo test --features fuzz`.
-rt-multi-thread = ["tokio/rt-multi-thread"]
 fuzz = []
 soak = []
 
@@ -62,8 +61,16 @@ name = "bench_peer_tokio"
 path = "src/bin/bench_peer_tokio.rs"
 
 [[bin]]
+name = "bench_peer_blocking"
+path = "src/bin/bench_peer_blocking.rs"
+
+[[bin]]
 name = "bench_proxy_client"
 path = "src/bin/bench_proxy_client.rs"
+
+[[bin]]
+name = "perf_verify"
+path = "src/bin/perf_verify.rs"
 
 [[example]]
 name = "pub_sub_lz4"

--- a/omq-tokio/benches/client_server_latency.rs
+++ b/omq-tokio/benches/client_server_latency.rs
@@ -15,8 +15,8 @@ const WARMUP_ITERS: usize = 1_000;
 const ITERS: usize = 10_000;
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("CLIENT/SERVER Latency (serial ping-pong)");
         let mut seq = 0usize;
         for transport in common::transports() {

--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -443,29 +443,15 @@ fn rustc_version_runtime() -> String {
         .to_string()
 }
 
-/// Build the benchmark runtime. Set `OMQ_BENCH_TOKIO_THREADS=N` to
-/// control the thread count: 1 = `current_thread`, 2+ = `multi_thread`.
-/// Defaults to multi-thread with one worker per available CPU.
-pub(crate) fn build_runtime() -> tokio::runtime::Runtime {
-    let threads: usize = std::env::var("OMQ_BENCH_TOKIO_THREADS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&v| v > 0)
-        .unwrap_or_else(|| std::thread::available_parallelism().map_or(2, std::num::NonZero::get));
+pub(crate) fn build_context() -> omq_tokio::Context {
+    let config = omq_tokio::ContextConfig::from_env();
+    let threads = config.io_threads;
     if threads <= 1 {
         println!("runtime: current_thread\n");
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("bench: tokio runtime")
     } else {
-        println!("runtime: multi_thread ({threads} workers)\n");
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(threads)
-            .enable_all()
-            .build()
-            .expect("bench: tokio runtime")
+        println!("runtime: {threads} x current_thread\n");
     }
+    omq_tokio::Context::with_config(config)
 }
 
 /// Thin wrapper around `tokio::time::timeout` to enforce the per-cell

--- a/omq-tokio/benches/compression.rs
+++ b/omq-tokio/benches/compression.rs
@@ -69,8 +69,8 @@ mod inner {
     }
 
     pub(super) fn tokio_main() {
-        let rt = common::build_runtime();
-        rt.block_on(async {
+        let ctx = common::build_context();
+        ctx.block_on(async {
             let transports = active_transports();
             if transports.is_empty() {
                 return;

--- a/omq-tokio/benches/latency.rs
+++ b/omq-tokio/benches/latency.rs
@@ -15,8 +15,8 @@ const WARMUP_ITERS: usize = 1_000;
 const ITERS: usize = 10_000;
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("REQ/REP Latency (serial ping-pong)");
         let mut seq = 0usize;
         for transport in common::transports() {

--- a/omq-tokio/benches/mechanism.rs
+++ b/omq-tokio/benches/mechanism.rs
@@ -22,8 +22,8 @@ fn accept_all(_: &omq_tokio::MechanismPeerInfo) -> bool {
 }
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("PUSH/PULL mechanism (tcp)");
 
         let sizes = common::sizes();

--- a/omq-tokio/benches/pair.rs
+++ b/omq-tokio/benches/pair.rs
@@ -9,8 +9,8 @@ const PATTERN: &str = "pair";
 const PEER_COUNTS: &[usize] = &[1];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("PAIR");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/benches/pub_sub.rs
+++ b/omq-tokio/benches/pub_sub.rs
@@ -15,8 +15,8 @@ const PATTERN: &str = "pub_sub";
 const PEER_COUNTS: &[usize] = &[3];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("PUB/SUB");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/benches/push_pull.rs
+++ b/omq-tokio/benches/push_pull.rs
@@ -11,8 +11,8 @@ const PATTERN: &str = "push_pull";
 const PEER_COUNTS: &[usize] = &[1, 8];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("PUSH/PULL");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/benches/push_pull_fanout.rs
+++ b/omq-tokio/benches/push_pull_fanout.rs
@@ -16,8 +16,8 @@ const PATTERN: &str = "push_pull_fanout";
 const PEER_COUNTS: &[usize] = &[1, 8];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("PUSH/PULL fan-out");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/benches/req_rep.rs
+++ b/omq-tokio/benches/req_rep.rs
@@ -11,8 +11,8 @@ const PATTERN: &str = "req_rep";
 const PEER_COUNTS: &[usize] = &[1];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("REQ/REP");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/benches/router_dealer.rs
+++ b/omq-tokio/benches/router_dealer.rs
@@ -10,8 +10,8 @@ const PATTERN: &str = "router_dealer";
 const PEER_COUNTS: &[usize] = &[3];
 
 fn main() {
-    let rt = common::build_runtime();
-    rt.block_on(async {
+    let ctx = common::build_context();
+    ctx.block_on(async {
         common::print_header("ROUTER/DEALER");
         let peer_counts = common::peers_override();
         let peer_counts = peer_counts.as_deref().unwrap_or(PEER_COUNTS);

--- a/omq-tokio/examples/bench_1push_8pull.rs
+++ b/omq-tokio/examples/bench_1push_8pull.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
 
 const PEERS: usize = 8;
 const SIZE: usize = 128;
@@ -14,85 +14,87 @@ const WARMUP_MSGS: usize = 50_000;
 const ROUNDS: usize = 5;
 const ROUND_MSGS: usize = 500_000;
 
-#[tokio::main]
-async fn main() {
-    let port = {
-        let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
-        l.local_addr().unwrap().port()
-    };
-    let ep = Endpoint::Tcp {
-        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
-        port,
-    };
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let port = {
+            let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let ep = Endpoint::Tcp {
+            host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+            port,
+        };
 
-    let push = Socket::new(SocketType::Push, Options::default());
-    push.bind(ep.clone()).await.unwrap();
+        let push = Socket::new(SocketType::Push, Options::default());
+        push.bind(ep.clone()).await.unwrap();
 
-    let pulls: Vec<Arc<Socket>> = (0..PEERS)
-        .map(|_| {
-            let s = Socket::new(SocketType::Pull, Options::default());
-            Arc::new(s)
-        })
-        .collect();
+        let pulls: Vec<Arc<Socket>> = (0..PEERS)
+            .map(|_| {
+                let s = Socket::new(SocketType::Pull, Options::default());
+                Arc::new(s)
+            })
+            .collect();
 
-    for p in &pulls {
-        p.connect(ep.clone()).await.unwrap();
-    }
-
-    // Wait for all connections to complete ZMTP handshake.
-    let deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        let conns = push.connections().await.unwrap_or_default();
-        if conns.iter().filter(|c| c.peer_info.is_some()).count() == PEERS {
-            break;
+        for p in &pulls {
+            p.connect(ep.clone()).await.unwrap();
         }
-        assert!(Instant::now() < deadline, "peers never connected");
-        tokio::time::sleep(Duration::from_millis(5)).await;
-    }
 
-    let payload = Bytes::from(vec![0u8; SIZE]);
+        // Wait for all connections to complete ZMTP handshake.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let conns = push.connections().await.unwrap_or_default();
+            if conns.iter().filter(|c| c.peer_info.is_some()).count() == PEERS {
+                break;
+            }
+            assert!(Instant::now() < deadline, "peers never connected");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
 
-    // Spawn one recv task per PULL.
-    let recv_handles: Vec<_> = pulls
-        .iter()
-        .map(|p| {
-            let p = p.clone();
-            tokio::spawn(async move { while p.recv().await.is_ok() {} })
-        })
-        .collect();
+        let payload = Bytes::from(vec![0u8; SIZE]);
 
-    let push = Arc::new(push);
+        // Spawn one recv task per PULL.
+        let recv_handles: Vec<_> = pulls
+            .iter()
+            .map(|p| {
+                let p = p.clone();
+                tokio::spawn(async move { while p.recv().await.is_ok() {} })
+            })
+            .collect();
 
-    // Warmup.
-    for _ in 0..WARMUP_MSGS {
-        push.send(Message::single(payload.clone())).await.unwrap();
-    }
-    // Give receivers a moment to drain.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+        let push = Arc::new(push);
 
-    // Timed rounds.
-    let mut best_mbps = 0.0f64;
-    for _ in 0..ROUNDS {
-        let n = ROUND_MSGS;
-        let t = Instant::now();
-        for _ in 0..n {
+        // Warmup.
+        for _ in 0..WARMUP_MSGS {
             push.send(Message::single(payload.clone())).await.unwrap();
         }
-        let elapsed = t.elapsed();
-        let mbps = (n * SIZE) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
-        let msgs_s = n as f64 / elapsed.as_secs_f64();
-        println!(
-            "  {SIZE}B  {mbps:.1} MB/s  {msgs_s:.0} msg/s  ({:.3}s, n={n})",
-            elapsed.as_secs_f64()
-        );
-        if mbps > best_mbps {
-            best_mbps = mbps;
-        }
-    }
-    println!("best: {best_mbps:.1} MB/s");
+        // Give receivers a moment to drain.
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Cleanup.
-    for h in recv_handles {
-        h.abort();
-    }
+        // Timed rounds.
+        let mut best_mbps = 0.0f64;
+        for _ in 0..ROUNDS {
+            let n = ROUND_MSGS;
+            let t = Instant::now();
+            for _ in 0..n {
+                push.send(Message::single(payload.clone())).await.unwrap();
+            }
+            let elapsed = t.elapsed();
+            let mbps = (n * SIZE) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+            let msgs_s = n as f64 / elapsed.as_secs_f64();
+            println!(
+                "  {SIZE}B  {mbps:.1} MB/s  {msgs_s:.0} msg/s  ({:.3}s, n={n})",
+                elapsed.as_secs_f64()
+            );
+            if mbps > best_mbps {
+                best_mbps = mbps;
+            }
+        }
+        println!("best: {best_mbps:.1} MB/s");
+
+        // Cleanup.
+        for h in recv_handles {
+            h.abort();
+        }
+    });
 }

--- a/omq-tokio/examples/pub_sub_lz4.rs
+++ b/omq-tokio/examples/pub_sub_lz4.rs
@@ -5,40 +5,46 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Message, Options, Socket, SocketType};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let publisher = Socket::new(SocketType::Pub, Options::default());
-    publisher.bind("lz4+tcp://127.0.0.1:5556".parse()?).await?;
+fn main() {
+    let ctx = Context::new();
+    ctx.block_on(async move {
+        let publisher = Socket::new(SocketType::Pub, Options::default());
+        publisher
+            .bind("lz4+tcp://127.0.0.1:5556".parse().unwrap())
+            .await
+            .unwrap();
 
-    let subscriber = Socket::new(SocketType::Sub, Options::default());
-    subscriber
-        .connect("lz4+tcp://127.0.0.1:5556".parse()?)
-        .await?;
-    subscriber.subscribe("news.").await?; // prefix match
+        let subscriber = Socket::new(SocketType::Sub, Options::default());
+        subscriber
+            .connect("lz4+tcp://127.0.0.1:5556".parse().unwrap())
+            .await
+            .unwrap();
+        subscriber.subscribe("news.").await.unwrap(); // prefix match
 
-    // SUBSCRIBE travels from sub to pub over the wire; give it a moment.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        // SUBSCRIBE travels from sub to pub over the wire; give it a moment.
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    publisher
-        .send(Message::multipart(["news.sports", "ball scores"]))
-        .await?;
-    publisher
-        .send(Message::multipart(["weather", "sunny"]))
-        .await?; // filtered out
+        publisher
+            .send(Message::multipart(["news.sports", "ball scores"]))
+            .await
+            .unwrap();
+        publisher
+            .send(Message::multipart(["weather", "sunny"]))
+            .await
+            .unwrap(); // filtered out
 
-    let m = subscriber.recv().await?; // only "news.sports" arrives
-    let topic = m.part_bytes(0).unwrap();
-    let body = m.part_bytes(1).unwrap();
-    assert_eq!(&*topic, b"news.sports");
-    assert_eq!(&*body, b"ball scores");
+        let m = subscriber.recv().await.unwrap(); // only "news.sports" arrives
+        let topic = m.part_bytes(0).unwrap();
+        let body = m.part_bytes(1).unwrap();
+        assert_eq!(&*topic, b"news.sports");
+        assert_eq!(&*body, b"ball scores");
 
-    println!(
-        "{}: {}",
-        String::from_utf8_lossy(&topic),
-        String::from_utf8_lossy(&body),
-    );
-
-    Ok(())
+        println!(
+            "{}: {}",
+            String::from_utf8_lossy(&topic),
+            String::from_utf8_lossy(&body),
+        );
+    });
 }

--- a/omq-tokio/src/bin/bench_peer_blocking.rs
+++ b/omq-tokio/src/bin/bench_peer_blocking.rs
@@ -1,0 +1,688 @@
+//! Blocking bench peer: background IO thread, sync application code.
+//!
+//! Same interface as `bench_peer_tokio` but uses `blocking::Socket`.
+//! The application thread never touches tokio. The Context spawns its
+//! own IO thread; send/recv block the calling thread via
+//! `Context::block_on`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, Options, SocketType, TrySendError, blocking};
+use std::net::Ipv4Addr;
+
+fn multi_pull_drain_batch(size: usize) -> usize {
+    if let Some(batch) = std::env::var("OMQ_BENCH_DRAIN_BATCH")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+    {
+        return batch.max(1);
+    }
+    if size <= 1024 { 64 } else { 256 }
+}
+
+fn parse_ep(s: &str) -> Endpoint {
+    if let Ok(port) = s.parse::<u16>() {
+        return Endpoint::Tcp {
+            host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+            port,
+        };
+    }
+    if let Some((ip, port_str)) = s.split_once(':')
+        && let Ok(addr) = ip.parse::<Ipv4Addr>()
+        && let Ok(port) = port_str.parse::<u16>()
+    {
+        return Endpoint::Tcp {
+            host: Host::Ip(addr.into()),
+            port,
+        };
+    }
+    s.parse()
+        .expect("valid endpoint (port, ip:port, or full URI)")
+}
+
+static COORD_SOCK: std::sync::OnceLock<blocking::Socket> = std::sync::OnceLock::new();
+
+fn report_bound_port(ctx: &omq_tokio::Context, ep: &Endpoint) {
+    let Endpoint::Tcp { port, .. } = ep else {
+        return;
+    };
+    let Ok(coord_ep) = std::env::var("OMQ_BENCH_COORD") else {
+        return;
+    };
+    let coord = COORD_SOCK.get_or_init(|| {
+        let s = ctx.blocking_socket(SocketType::Push, Options::default());
+        s.connect(coord_ep.parse().expect("valid coord endpoint"))
+            .unwrap();
+        s.wait_connected(1, Duration::from_secs(5)).unwrap();
+        s
+    });
+    let msg = format!("READY {port}");
+    coord.send(Message::from_slice(msg.as_bytes())).unwrap();
+}
+
+#[cfg(unix)]
+extern "C" fn exit_on_signal(_sig: libc::c_int) {
+    unsafe { libc::_exit(0) };
+}
+
+fn install_signals() {
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            exit_on_signal as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            exit_on_signal as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGALRM,
+            exit_on_signal as *const () as libc::sighandler_t,
+        );
+        libc::alarm(60);
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig::from_env());
+    let n = ctx.io_threads();
+    eprintln!("runtime: blocking, {n} IO thread(s)");
+    install_signals();
+
+    match args.get(1).map(String::as_str) {
+        Some("push") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            run_push(&ctx, ep, size);
+        }
+        Some("pull") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            run_pull(&ctx, ep, size, Duration::from_secs_f64(duration));
+        }
+        Some("pull-bind") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            run_pull_bind(&ctx, ep, size, Duration::from_secs_f64(duration));
+        }
+        Some("multi-pull") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_pull(&ctx, ep, size, Duration::from_secs_f64(duration), count);
+        }
+        Some("multi-push") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let count: usize = args[4].parse().expect("socket_count");
+            let duration = args.get(5).and_then(|s| s.parse().ok());
+            run_multi_push(&ctx, ep, size, count, duration);
+        }
+        Some("pub") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let peers: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0);
+            run_pub(&ctx, ep, size, peers);
+        }
+        Some("multi-sub") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_sub(&ctx, ep, size, Duration::from_secs_f64(duration), count);
+        }
+        Some("rep") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            run_rep(&ctx, ep, size);
+        }
+        Some("req") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let iterations: usize = args[4].parse().expect("iterations");
+            let warmup: usize = args[5].parse().expect("warmup");
+            run_req(&ctx, ep, size, iterations, warmup);
+        }
+        _ => {
+            eprintln!("usage: bench_peer_blocking push <addr> <size>");
+            eprintln!("       bench_peer_blocking pull <addr> <size> <duration_secs>");
+            eprintln!("       bench_peer_blocking pull-bind <addr> <size> <duration_secs>");
+            eprintln!(
+                "       bench_peer_blocking multi-pull <addr> <size> <duration_secs> <count>"
+            );
+            eprintln!("       bench_peer_blocking multi-push <addr> <size> <count>");
+            eprintln!("       bench_peer_blocking pub <addr> <size>");
+            eprintln!("       bench_peer_blocking multi-sub <addr> <size> <duration_secs> <count>");
+            eprintln!("       bench_peer_blocking rep <addr> <size>");
+            eprintln!("       bench_peer_blocking req <addr> <size> <iterations> <warmup>");
+            std::process::exit(1);
+        }
+    }
+}
+
+// --- Options -----------------------------------------------------------------
+
+fn bench_options(msg_size: usize) -> Options {
+    let mut o = Options::default();
+    if msg_size >= 2 * 1024 * 1024 {
+        let buf = msg_size * 2;
+        o = o.recv_buffer_size(buf).send_buffer_size(buf);
+    }
+    o
+}
+
+fn mechanism_env() -> Option<String> {
+    std::env::var("OMQ_BENCH_MECHANISM")
+        .ok()
+        .map(|s| s.to_ascii_lowercase())
+}
+
+fn bench_options_server(msg_size: usize) -> Options {
+    let o = bench_options(msg_size);
+    match mechanism_env().as_deref() {
+        None | Some("null") => o,
+        #[cfg(feature = "curve")]
+        Some("curve") => o.curve_server(bench_curve_server_keypair()),
+        Some(other) => panic!("unknown OMQ_BENCH_MECHANISM: {other}"),
+    }
+}
+
+fn bench_options_client(msg_size: usize) -> Options {
+    let o = bench_options(msg_size);
+    match mechanism_env().as_deref() {
+        None | Some("null") => o,
+        #[cfg(feature = "curve")]
+        Some("curve") => {
+            let client_kp = bench_curve_client_keypair();
+            let server_pub = bench_curve_server_keypair().public;
+            o.curve_client(client_kp, server_pub)
+        }
+        Some(other) => panic!("unknown OMQ_BENCH_MECHANISM: {other}"),
+    }
+}
+
+#[cfg(feature = "curve")]
+fn bench_curve_server_keypair() -> omq_tokio::CurveKeypair {
+    let secret = omq_tokio::CurveSecretKey::from_bytes([0x01; 32]);
+    let public = secret.derive_public();
+    omq_tokio::CurveKeypair { public, secret }
+}
+
+#[cfg(feature = "curve")]
+fn bench_curve_client_keypair() -> omq_tokio::CurveKeypair {
+    let secret = omq_tokio::CurveSecretKey::from_bytes([0x02; 32]);
+    let public = secret.derive_public();
+    omq_tokio::CurveKeypair { public, secret }
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+fn send_fast(sock: &blocking::Socket, msg: Message) {
+    match sock.try_send(msg) {
+        Ok(()) => {}
+        Err(TrySendError::Full(msg)) => sock.send(msg).unwrap(),
+        Err(e) => panic!("try_send failed: {e}"),
+    }
+}
+
+fn bench_payload(size: usize) -> Bytes {
+    Bytes::from(vec![b'x'; size])
+}
+
+fn quantile(sorted: &[f64], probability: f64) -> f64 {
+    let index = ((sorted.len().saturating_sub(1)) as f64 * probability).round() as usize;
+    sorted[index.min(sorted.len().saturating_sub(1))]
+}
+
+fn wait_for_start_barrier() {
+    let Some(start_at) = std::env::var("OMQ_BENCH_START_AT")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+    else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64());
+    if start_at > now {
+        std::thread::sleep(Duration::from_secs_f64(start_at - now));
+    }
+}
+
+fn warmup_duration() -> Duration {
+    std::env::var("OMQ_BENCH_WARMUP_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::ZERO, Duration::from_millis)
+}
+
+fn recv_loop(sock: &blocking::Socket, duration: Duration) -> (u64, f64) {
+    std::thread::sleep(Duration::from_millis(500));
+    wait_for_start_barrier();
+    drain_warmup(sock);
+
+    let t0 = Instant::now();
+    let deadline = t0 + duration;
+    let mut count: u64 = 0;
+    loop {
+        if Instant::now() >= deadline {
+            break;
+        }
+        if sock.try_recv().is_ok() {
+            count += 1;
+            while Instant::now() < deadline && sock.try_recv().is_ok() {
+                count += 1;
+            }
+        } else {
+            std::thread::yield_now();
+        }
+    }
+    (count, t0.elapsed().as_secs_f64())
+}
+
+fn drain_warmup(sock: &blocking::Socket) {
+    let deadline = Instant::now() + Duration::from_millis(2);
+    for _ in 0..256 {
+        if Instant::now() >= deadline || sock.try_recv().is_err() {
+            break;
+        }
+    }
+}
+
+// --- Subcommands -------------------------------------------------------------
+
+fn run_push(ctx: &omq_tokio::Context, ep: Endpoint, size: usize) {
+    let push = ctx.blocking_socket(SocketType::Push, bench_options_server(size));
+    let bound = push.bind(ep).expect("push bind");
+    report_bound_port(ctx, &bound);
+
+    let payload = bench_payload(size);
+    if payload.len() <= omq_tokio::message::MAX_INLINE_MESSAGE {
+        loop {
+            send_fast(&push, Message::from_slice(&payload));
+        }
+    } else {
+        let msg = Message::single(payload.clone());
+        loop {
+            send_fast(&push, msg.clone());
+        }
+    }
+}
+
+fn run_pull(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
+    let pull = ctx.blocking_socket(SocketType::Pull, bench_options_client(size));
+    pull.connect(ep).expect("pull connect");
+
+    let cpu_before = cpu_time_secs();
+    let (count, elapsed) = recv_loop(&pull, duration);
+    let cpu = cpu_time_secs() - cpu_before;
+    println!("{count} {elapsed:.6} {size} {cpu:.6}");
+}
+
+fn run_pull_bind(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
+    let pull = ctx.blocking_socket(SocketType::Pull, bench_options_server(size));
+    let bound = pull.bind(ep).expect("pull bind");
+    report_bound_port(ctx, &bound);
+
+    let cpu_before = cpu_time_secs();
+    let (count, elapsed) = recv_loop(&pull, duration);
+    let cpu = cpu_time_secs() - cpu_before;
+    println!("{count} {elapsed:.6} {size} {cpu:.6}");
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[allow(clippy::needless_pass_by_value)]
+fn run_multi_pull(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    duration: Duration,
+    socket_count: usize,
+) {
+    let drain_batch = multi_pull_drain_batch(size);
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.blocking_socket(SocketType::Pull, bench_options_client(size));
+        s.connect(ep.clone()).expect("pull connect");
+        sockets.push(s);
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+    wait_for_start_barrier();
+    for s in &sockets {
+        drain_warmup(s);
+    }
+
+    let counters: Vec<Arc<AtomicU64>> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+    let started = Arc::new(AtomicBool::new(false));
+    let stop = Arc::new(AtomicBool::new(false));
+    let cpu_before = cpu_time_secs();
+
+    let handles: Vec<_> = sockets
+        .into_iter()
+        .zip(counters.iter().cloned())
+        .map(|(sock, counter)| {
+            let started = Arc::clone(&started);
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                loop {
+                    if stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if sock.try_recv().is_err() {
+                        std::thread::yield_now();
+                        continue;
+                    }
+                    for _ in 1..drain_batch {
+                        if sock.try_recv().is_err() {
+                            break;
+                        }
+                        if started.load(Ordering::Relaxed) {
+                            counter.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    if started.load(Ordering::Relaxed) {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            })
+        })
+        .collect();
+
+    std::thread::sleep(Duration::from_millis(500));
+    started.store(true, Ordering::Release);
+    let t0 = Instant::now();
+    std::thread::sleep(duration);
+    let elapsed = t0.elapsed().as_secs_f64();
+    stop.store(true, Ordering::Release);
+    for h in handles {
+        h.join().unwrap();
+    }
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    let mut rates: Vec<f64> = per_socket
+        .iter()
+        .map(|&count| count as f64 / elapsed)
+        .collect();
+    rates.sort_unstable_by(f64::total_cmp);
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} \
+         {per_max_rate:.1} {:.1} {:.1} {:.1} {:.1} {:.1}",
+        quantile(&rates, 0.10),
+        quantile(&rates, 0.25),
+        quantile(&rates, 0.50),
+        quantile(&rates, 0.75),
+        quantile(&rates, 0.90),
+    );
+    print!(" ");
+    for rate in &rates {
+        print!("{rate:.1} ");
+    }
+    println!();
+    eprintln!(
+        "multi-pull: {socket_count} sockets, {:.0} msg/s total, \
+         per-socket [{per_min_rate:.0}, {per_max_rate:.0}] msg/s",
+        total as f64 / elapsed,
+    );
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn run_multi_push(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    socket_count: usize,
+    duration: Option<f64>,
+) {
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.blocking_socket(SocketType::Push, bench_options_client(size));
+        s.connect(ep.clone()).expect("push connect");
+        sockets.push(s);
+    }
+
+    let payload = bench_payload(size);
+    let counters: Vec<_> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+    wait_for_start_barrier();
+    let _handles: Vec<_> = sockets
+        .into_iter()
+        .zip(counters.iter().cloned())
+        .map(|(sock, counter)| {
+            let p = payload.clone();
+            std::thread::spawn(move || {
+                if p.len() <= omq_tokio::message::MAX_INLINE_MESSAGE {
+                    loop {
+                        send_fast(&sock, Message::from_slice(&p));
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                } else {
+                    let msg = Message::single(p);
+                    loop {
+                        send_fast(&sock, msg.clone());
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            })
+        })
+        .collect();
+    let Some(duration) = duration else {
+        std::thread::park();
+        return;
+    };
+    std::thread::sleep(Duration::from_secs_f64(duration));
+    let elapsed = duration;
+    let rates: Vec<f64> = counters
+        .iter()
+        .map(|c| c.load(Ordering::Relaxed) as f64 / elapsed)
+        .collect();
+    let total: u64 = counters.iter().map(|c| c.load(Ordering::Relaxed)).sum();
+    let mut sorted = rates.clone();
+    sorted.sort_unstable_by(f64::total_cmp);
+    println!(
+        "{total} {elapsed:.6} {size} {:.6} {socket_count} {:.1} {:.1} {:.1} {:.1} {:.1} {:.1} {:.1}",
+        cpu_time_secs(),
+        sorted[0],
+        sorted[socket_count - 1],
+        quantile(&sorted, 0.10),
+        quantile(&sorted, 0.25),
+        quantile(&sorted, 0.50),
+        quantile(&sorted, 0.75),
+        quantile(&sorted, 0.90),
+    );
+}
+
+fn run_pub(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, peers: usize) {
+    let mut opts = bench_options_server(size);
+    opts.xpub_nodrop = true;
+    let pub_ = ctx.blocking_socket(SocketType::Pub, opts);
+    let bound = pub_.bind(ep).expect("pub bind");
+    report_bound_port(ctx, &bound);
+    if peers > 0 {
+        let timeout = if peers > 64 { 20 } else { 10 };
+        pub_.wait_connected(peers, Duration::from_secs(timeout))
+            .expect("wait for subscribers");
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    let payload = bench_payload(size);
+    let warmup_deadline = Instant::now() + warmup_duration();
+    while Instant::now() < warmup_deadline {
+        send_fast(&pub_, Message::from_slice(&payload));
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    wait_for_start_barrier();
+    if payload.len() <= omq_tokio::message::MAX_INLINE_MESSAGE {
+        loop {
+            send_fast(&pub_, Message::from_slice(&payload));
+        }
+    } else {
+        let msg = Message::single(payload.clone());
+        loop {
+            send_fast(&pub_, msg.clone());
+        }
+    }
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[allow(clippy::needless_pass_by_value)]
+fn run_multi_sub(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    duration: Duration,
+    socket_count: usize,
+) {
+    let drain_batch = multi_pull_drain_batch(size);
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.blocking_socket(SocketType::Sub, bench_options_client(size));
+        s.connect(ep.clone()).expect("sub connect");
+        s.subscribe(Bytes::new()).expect("subscribe");
+        sockets.push(s);
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+    wait_for_start_barrier();
+
+    let counters: Vec<Arc<AtomicU64>> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+    let deadline = t0 + duration;
+
+    let handles: Vec<_> = sockets
+        .into_iter()
+        .zip(counters.iter().cloned())
+        .map(|(sock, counter)| {
+            std::thread::spawn(move || {
+                let mut n: u64 = 0;
+                loop {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    if sock.try_recv().is_err() {
+                        std::thread::yield_now();
+                        continue;
+                    }
+                    n += 1;
+                    for _ in 1..drain_batch {
+                        if sock.try_recv().is_err() {
+                            break;
+                        }
+                        n += 1;
+                    }
+                }
+                counter.store(n, Ordering::Relaxed);
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}"
+    );
+    eprintln!(
+        "multi-sub: {socket_count} sockets, {:.0} msg/s total, \
+         per-socket [{per_min_rate:.0}, {per_max_rate:.0}] msg/s",
+        total as f64 / elapsed,
+    );
+}
+
+fn run_rep(ctx: &omq_tokio::Context, ep: Endpoint, size: usize) {
+    let rep = ctx.blocking_socket(SocketType::Rep, bench_options_server(size));
+    let bound = rep.bind(ep).expect("rep bind");
+    report_bound_port(ctx, &bound);
+    loop {
+        let msg = rep.recv().unwrap();
+        rep.send(msg).unwrap();
+    }
+}
+
+fn run_req(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
+    let req = ctx.blocking_socket(SocketType::Req, bench_options_client(size));
+    req.connect(ep).expect("req connect");
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let payload = Bytes::from(vec![b'x'; size]);
+    let msg = Message::single(payload);
+
+    for _ in 0..warmup {
+        req.send(msg.clone()).unwrap();
+        req.recv().unwrap();
+    }
+
+    let t_wall = Instant::now();
+    let cpu_before = cpu_time_secs();
+    let mut rtts = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let t0 = Instant::now();
+        req.send(msg.clone()).unwrap();
+        req.recv().unwrap();
+        rtts.push(t0.elapsed().as_nanos() as u64);
+    }
+    let cpu = cpu_time_secs() - cpu_before;
+    let elapsed = t_wall.elapsed().as_secs_f64();
+
+    rtts.sort_unstable();
+    let p50 = percentile(&rtts, 50.0);
+    let p99 = percentile(&rtts, 99.0);
+    let p999 = percentile(&rtts, 99.9);
+    let max = percentile(&rtts, 100.0);
+    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations} {cpu:.6} {elapsed:.6}");
+}
+
+fn percentile(sorted: &[u64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted.len() as f64 * p / 100.0) as usize).min(sorted.len() - 1);
+    sorted[idx] as f64 / 1_000.0
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[cfg(unix)]
+fn cpu_time_secs() -> f64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    unsafe {
+        libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr());
+        let usage = usage.assume_init();
+        let user = usage.ru_utime.tv_sec as f64 + usage.ru_utime.tv_usec as f64 / 1e6;
+        let sys = usage.ru_stime.tv_sec as f64 + usage.ru_stime.tv_usec as f64 / 1e6;
+        user + sys
+    }
+}
+
+#[cfg(windows)]
+fn cpu_time_secs() -> f64 {
+    0.0
+}

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -23,6 +23,13 @@
 use std::fmt::Write as _;
 use std::time::{Duration, Instant};
 
+const MULTI_PULL_DRAIN_BATCH: usize = 64;
+
+fn quantile(sorted: &[f64], probability: f64) -> f64 {
+    let index = ((sorted.len().saturating_sub(1)) as f64 * probability).round() as usize;
+    sorted[index.min(sorted.len().saturating_sub(1))]
+}
+
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
@@ -48,10 +55,31 @@ fn parse_ep(s: &str) -> Endpoint {
         .expect("valid endpoint (port, ip:port, or full URI)")
 }
 
-fn print_bound_port(ep: &Endpoint) {
-    if let Endpoint::Tcp { port, .. } = ep {
+async fn report_bound_port(ctx: &omq_tokio::Context, ep: &Endpoint) {
+    let Endpoint::Tcp { port, .. } = ep else {
+        return;
+    };
+    let Ok(coord_ep) = std::env::var("OMQ_BENCH_COORD") else {
         println!("PORT {port}");
-    }
+        return;
+    };
+    let coord = ctx.socket(SocketType::Push, Options::default());
+    coord
+        .connect(coord_ep.parse().expect("valid coord endpoint"))
+        .await
+        .unwrap();
+    coord
+        .wait_connected(1, Duration::from_secs(5))
+        .await
+        .unwrap();
+    let msg = format!("READY {port}");
+    coord
+        .send(Message::from_slice(msg.as_bytes()))
+        .await
+        .unwrap();
+    // Keep the socket alive so the driver task flushes the message.
+    // The bench process exits via SIGTERM/SIGALRM anyway.
+    std::mem::forget(coord);
 }
 
 #[cfg(unix)]
@@ -61,35 +89,31 @@ extern "C" fn exit_on_signal(_sig: libc::c_int) {
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let threads: usize = std::env::var("OMQ_BENCH_TOKIO_THREADS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&v| v > 0)
-        .unwrap_or(1);
-    let rt = if threads > 1 {
-        #[cfg(feature = "rt-multi-thread")]
-        {
-            eprintln!("runtime: multi_thread ({threads} workers)");
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(threads)
-                .enable_all()
-                .build()
-                .expect("tokio runtime")
-        }
-        #[cfg(not(feature = "rt-multi-thread"))]
-        panic!("multi_thread runtime requires --features rt-multi-thread")
-    } else {
-        eprintln!("runtime: current_thread");
-        tokio::runtime::Builder::new_current_thread()
+
+    if std::env::var("OMQ_IO_THREADS").is_ok() {
+        let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig::from_env());
+        let n = ctx.io_threads();
+        eprintln!("runtime: {n} x current_thread (dedicated)");
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("tokio runtime")
-    };
-    rt.block_on(async_main(args));
+            .unwrap();
+        rt.block_on(async_main(args, ctx));
+    } else {
+        eprintln!("runtime: current_thread");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let ctx = omq_tokio::Context::current();
+            async_main(args, ctx).await;
+        });
+    }
 }
 
 #[expect(clippy::too_many_lines)]
-async fn async_main(args: Vec<String>) {
+async fn async_main(args: Vec<String>, ctx: omq_tokio::Context) {
     #[cfg(unix)]
     unsafe {
         libc::signal(
@@ -110,19 +134,20 @@ async fn async_main(args: Vec<String>) {
         Some("push") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_push(ep, size).await;
+            let peers = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0);
+            run_push(&ctx, ep, size, peers).await;
         }
-        Some("push-fanout") => {
+        Some("pub-fanout") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let peers: usize = args[4].parse().expect("peers");
-            run_push_fanout(ep, size, peers).await;
+            run_push_fanout(&ctx, ep, size, peers).await;
         }
         Some("pull") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
-            run_pull(ep, size, Duration::from_secs_f64(duration)).await;
+            run_pull(&ctx, ep, size, Duration::from_secs_f64(duration)).await;
         }
         Some("inproc") => {
             let name = args[2].clone();
@@ -133,26 +158,26 @@ async fn async_main(args: Vec<String>) {
         Some("rep") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_rep(ep, size).await;
+            run_rep(&ctx, ep, size).await;
         }
         Some("req") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let iterations: usize = args[4].parse().expect("iterations");
             let warmup: usize = args[5].parse().expect("warmup");
-            run_req(ep, size, iterations, warmup).await;
+            run_req(&ctx, ep, size, iterations, warmup).await;
         }
         Some("pub") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let peers: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0);
-            run_pub(ep, size, peers).await;
+            run_pub(&ctx, ep, size, peers).await;
         }
         Some("sub") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
-            run_sub(ep, size, Duration::from_secs_f64(duration)).await;
+            run_sub(&ctx, ep, size, Duration::from_secs_f64(duration)).await;
         }
         Some("inproc-pubsub") => {
             let name = args[2].clone();
@@ -164,13 +189,13 @@ async fn async_main(args: Vec<String>) {
         Some("push-connect") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_push_connect(ep, size).await;
+            run_push_connect(&ctx, ep, size).await;
         }
         Some("pull-bind") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
-            run_pull_bind(ep, size, Duration::from_secs_f64(duration)).await;
+            run_pull_bind(&ctx, ep, size, Duration::from_secs_f64(duration)).await;
         }
         Some("wire-size") => {
             let ep = parse_ep(&args[2]);
@@ -192,10 +217,33 @@ async fn async_main(args: Vec<String>) {
             let warmup: usize = args[5].parse().expect("warmup");
             run_inproc_latency(name, size, iterations, warmup).await;
         }
+        Some("multi-pull") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_pull(&ctx, ep, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-sub") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_sub(&ctx, ep, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-push") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let count: usize = args[4].parse().expect("socket_count");
+            run_multi_push(&ctx, ep, size, count).await;
+        }
         _ => {
             eprintln!("usage: bench_peer_tokio push <addr> <size>");
-            eprintln!("       bench_peer_tokio push-fanout <addr> <size> <peers>");
+            eprintln!("       bench_peer_tokio pub-fanout <addr> <size> <peers>");
             eprintln!("       bench_peer_tokio pull <addr> <size> <duration_secs>");
+            eprintln!("       bench_peer_tokio multi-pull <addr> <size> <duration_secs> <count>");
+            eprintln!("       bench_peer_tokio multi-sub <addr> <size> <duration_secs> <count>");
+            eprintln!("       bench_peer_tokio multi-push <addr> <size> <count>");
             eprintln!("       bench_peer_tokio inproc <name> <size> <duration_secs>");
             eprintln!("       bench_peer_tokio rep <addr> <size>");
             eprintln!("       bench_peer_tokio req <addr> <size> <iterations> <warmup>");
@@ -206,15 +254,15 @@ async fn async_main(args: Vec<String>) {
     }
 }
 
-async fn run_pub(ep: Endpoint, size: usize, peers: usize) {
-    let mut opts = bench_options(size);
+async fn run_pub(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, peers: usize) {
+    let mut opts = bench_options_server(size);
     opts.xpub_nodrop = true;
-    let pub_ = Socket::new(SocketType::Pub, opts);
+    let pub_ = ctx.socket(SocketType::Pub, opts);
     let monitor = pub_.monitor();
     let bound = pub_.bind(ep).await.expect("pub bind");
-    print_bound_port(&bound);
+    report_bound_port(ctx, &bound).await;
     if peers > 0 {
-        wait_for_subscribes(monitor, peers).await;
+        wait_for_subscribes(&pub_, monitor, peers).await;
     }
     wait_for_start_barrier().await;
     let payload = bench_payload(size);
@@ -245,6 +293,30 @@ async fn wait_for_start_barrier() {
     }
 }
 
+async fn wait_for_warmup_barrier() {
+    let warmup = std::env::var("OMQ_BENCH_WARMUP_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis);
+    let Some(warmup) = warmup else {
+        wait_for_start_barrier().await;
+        return;
+    };
+    let Some(start_at) = std::env::var("OMQ_BENCH_START_AT")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+    else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64());
+    let warmup_at = start_at - warmup.as_secs_f64();
+    if warmup_at > now {
+        tokio::time::sleep(Duration::from_secs_f64(warmup_at - now)).await;
+    }
+}
+
 async fn wait_for_handshakes(sock: &Socket, mut monitor: omq_tokio::MonitorStream, peers: usize) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
@@ -267,36 +339,54 @@ async fn wait_for_handshakes(sock: &Socket, mut monitor: omq_tokio::MonitorStrea
     }
 }
 
-async fn wait_for_subscribes(mut monitor: omq_tokio::MonitorStream, peers: usize) {
-    // TODO: Bench readiness should not depend only on monitor delivery. Use
-    // connection snapshots plus a data-plane subscription probe so monitor lag
-    // cannot invalidate a run.
-    let deadline = Instant::now() + Duration::from_secs(10);
+async fn wait_for_subscribes(sock: &Socket, mut monitor: omq_tokio::MonitorStream, peers: usize) {
+    let timeout_secs = if peers > 64 { 20 } else { 10 };
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     let mut subscribed = 0;
     while subscribed < peers {
         let now = Instant::now();
-        assert!(now < deadline, "timed out waiting for {peers} subscribers");
+        assert!(
+            now < deadline,
+            "timed out waiting for {peers} subscribers ({subscribed} so far)"
+        );
         match tokio::time::timeout(deadline - now, monitor.recv()).await {
             Ok(Ok(MonitorEvent::SubscribeReceived { .. })) => subscribed += 1,
             Ok(Ok(_)) => {}
+            Ok(Err(omq_tokio::MonitorRecvError::Lagged(n))) => {
+                // Monitor buffer overflowed. The skipped events likely
+                // include subscribes. Use handshaked connection count as
+                // the new floor and keep polling.
+                let connected = sock.connections().await.map_or(0, |c| {
+                    c.into_iter().filter(|c| c.peer_info.is_some()).count()
+                });
+                subscribed = subscribed.max(connected);
+                eprintln!(
+                    "monitor lagged {n}, connections={connected}, \
+                     subscribed={subscribed}/{peers}"
+                );
+            }
             Ok(Err(e)) => panic!("monitor closed while waiting for subscribers: {e:?}"),
             Err(e) => panic!("timed out waiting for {peers} subscribers: {e:?}"),
         }
     }
+    // Let any remaining subscribe commands finish processing.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
-async fn run_push_fanout(ep: Endpoint, size: usize, peers: usize) {
-    let push = Socket::new(SocketType::Push, bench_options(size));
+async fn run_push_fanout(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, peers: usize) {
+    let push = ctx.socket(SocketType::Push, bench_options(size));
     let monitor = push.monitor();
     let bound = push.bind(ep).await.expect("push bind");
-    print_bound_port(&bound);
+    report_bound_port(ctx, &bound).await;
     wait_for_handshakes(&push, monitor, peers).await;
-    wait_for_start_barrier().await;
-
     let payload = bench_payload(size);
+    wait_for_warmup_barrier().await;
+    run_push_warmup(&push, &payload).await;
+    wait_for_start_barrier().await;
     run_push_loop(&push, &payload).await;
 }
 
+#[allow(clippy::verbose_bit_mask)]
 async fn send_fast(sock: &Socket, msg: Message) {
     match sock.try_send(msg) {
         Ok(()) => {}
@@ -318,6 +408,18 @@ async fn run_push_loop(sock: &Socket, payload: &Bytes) {
     }
 }
 
+async fn run_push_warmup(sock: &Socket, payload: &Bytes) {
+    let duration = std::env::var("OMQ_BENCH_WARMUP_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::ZERO, Duration::from_millis);
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        send_fast(sock, Message::from_slice(payload)).await;
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
 /// Deadline-bounded blocking recv. Returns `true` when a message arrived,
 /// `false` if the deadline elapsed first or the socket closed. Bounding the
 /// blocking recv keeps a measured loop from hanging forever when a peer
@@ -334,8 +436,8 @@ async fn recv_before_deadline(sock: &Socket, deadline: Instant) -> bool {
     )
 }
 
-async fn run_sub(ep: Endpoint, size: usize, duration: Duration) {
-    let sub = Socket::new(SocketType::Sub, bench_options(size));
+async fn run_sub(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
+    let sub = ctx.socket(SocketType::Sub, bench_options_client(size));
     sub.connect(ep.clone()).await.expect("sub connect");
     sub.subscribe(Bytes::new()).await.expect("subscribe");
 
@@ -494,26 +596,32 @@ fn bench_curve_client_keypair() -> omq_tokio::CurveKeypair {
     omq_tokio::CurveKeypair { public, secret }
 }
 
-async fn run_push(ep: Endpoint, size: usize) {
-    let push = Socket::new(SocketType::Push, bench_options_server(size));
+async fn run_push(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, peers: usize) {
+    let push = ctx.socket(SocketType::Push, bench_options_server(size));
+    let monitor = push.monitor();
     let bound = push.bind(ep).await.expect("push bind");
-    print_bound_port(&bound);
-    wait_for_start_barrier().await;
+    report_bound_port(ctx, &bound).await;
+    if peers > 0 {
+        wait_for_handshakes(&push, monitor, peers).await;
+    }
     let payload = bench_payload(size);
+    wait_for_warmup_barrier().await;
+    run_push_warmup(&push, &payload).await;
+    wait_for_start_barrier().await;
     run_push_loop(&push, &payload).await;
 }
 
-async fn run_push_connect(ep: Endpoint, size: usize) {
-    let push = Socket::new(SocketType::Push, bench_options_client(size));
+async fn run_push_connect(ctx: &omq_tokio::Context, ep: Endpoint, size: usize) {
+    let push = ctx.socket(SocketType::Push, bench_options_client(size));
     push.connect(ep).await.expect("push connect");
     let payload = bench_payload(size);
     run_push_loop(&push, &payload).await;
 }
 
-async fn run_pull_bind(ep: Endpoint, size: usize, duration: Duration) {
-    let pull = Socket::new(SocketType::Pull, bench_options_server(size));
+async fn run_pull_bind(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
+    let pull = ctx.socket(SocketType::Pull, bench_options_server(size));
     let bound = pull.bind(ep.clone()).await.expect("pull bind");
-    print_bound_port(&bound);
+    report_bound_port(ctx, &bound).await;
 
     wait_for_start_barrier().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -528,11 +636,8 @@ async fn run_pull_bind(ep: Endpoint, size: usize, duration: Duration) {
             break;
         }
         count += 1;
-        while pull.try_recv().is_ok() {
+        while Instant::now() < deadline && pull.try_recv().is_ok() {
             count += 1;
-        }
-        if Instant::now() >= deadline {
-            break;
         }
     }
     let elapsed = t0.elapsed().as_secs_f64();
@@ -567,19 +672,16 @@ async fn run_inproc(name: String, size: usize, duration: Duration) {
             break;
         }
         count += 1;
-        while pull.try_recv().is_ok() {
+        while Instant::now() < deadline && pull.try_recv().is_ok() {
             count += 1;
-        }
-        if Instant::now() >= deadline {
-            break;
         }
     }
     let elapsed = t0.elapsed().as_secs_f64();
     println!("{count} {elapsed:.6} {size}");
 }
 
-async fn run_pull(ep: Endpoint, size: usize, duration: Duration) {
-    let pull = Socket::new(SocketType::Pull, bench_options_client(size));
+async fn run_pull(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
+    let pull = ctx.socket(SocketType::Pull, bench_options_client(size));
     pull.connect(ep.clone()).await.expect("pull connect");
 
     wait_for_start_barrier().await;
@@ -608,8 +710,211 @@ async fn run_pull(ep: Endpoint, size: usize, duration: Duration) {
     eprint_pull_summary(&ep, count, elapsed, size);
 }
 
+#[expect(clippy::cast_precision_loss)]
+async fn run_multi_pull(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    duration: Duration,
+    socket_count: usize,
+) {
+    use std::sync::atomic::{AtomicU64, Ordering as AO};
+
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Pull, bench_options_client(size));
+        s.connect(ep.clone()).await.expect("pull connect");
+        sockets.push(s);
+    }
+
+    wait_for_warmup_barrier().await;
+    let warmup_deadline = Instant::now()
+        + std::env::var("OMQ_BENCH_WARMUP_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map_or(Duration::ZERO, Duration::from_millis);
+    let mut warmup_handles = Vec::with_capacity(socket_count);
+    for sock in &sockets {
+        let sock = sock.clone();
+        warmup_handles.push(tokio::spawn(async move {
+            while Instant::now() < warmup_deadline {
+                while sock.try_recv().is_ok() {}
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
+    for h in warmup_handles {
+        let _ = h.await;
+    }
+    wait_for_start_barrier().await;
+
+    let counters: Vec<_> = (0..socket_count)
+        .map(|_| std::sync::Arc::new(AtomicU64::new(0)))
+        .collect();
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+    let deadline = t0 + duration;
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            let mut n: u64 = 0;
+            loop {
+                if !recv_before_deadline(&sock, deadline).await {
+                    break;
+                }
+                n += 1;
+                for _ in 1..MULTI_PULL_DRAIN_BATCH {
+                    if sock.try_recv().is_err() {
+                        break;
+                    }
+                    n += 1;
+                }
+                tokio::task::yield_now().await;
+                if Instant::now() >= deadline {
+                    break;
+                }
+            }
+            counter.store(n, AO::Relaxed);
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(AO::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    let mut rates: Vec<f64> = per_socket
+        .iter()
+        .map(|&count| count as f64 / elapsed)
+        .collect();
+    rates.sort_unstable_by(f64::total_cmp);
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} \
+         {per_max_rate:.1} {:.1} {:.1} {:.1} {:.1} {:.1}",
+        quantile(&rates, 0.10),
+        quantile(&rates, 0.25),
+        quantile(&rates, 0.50),
+        quantile(&rates, 0.75),
+        quantile(&rates, 0.90),
+    );
+    print!(" ");
+    for rate in &rates {
+        print!("{rate:.1} ");
+    }
+    println!();
+    eprintln!(
+        "multi-pull: {socket_count} sockets, {:.0} msg/s total, \
+         per-socket [{per_min_rate:.0}, {per_max_rate:.0}] msg/s",
+        total as f64 / elapsed,
+    );
+}
+
+#[expect(clippy::cast_precision_loss)]
+async fn run_multi_sub(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    duration: Duration,
+    socket_count: usize,
+) {
+    use std::sync::atomic::{AtomicU64, Ordering as AO};
+
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Sub, bench_options_client(size));
+        s.connect(ep.clone()).await.expect("sub connect");
+        s.subscribe(Bytes::new()).await.expect("subscribe");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let counters: Vec<_> = (0..socket_count)
+        .map(|_| std::sync::Arc::new(AtomicU64::new(0)))
+        .collect();
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+    let deadline = t0 + duration;
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            let mut n: u64 = 0;
+            loop {
+                if !recv_before_deadline(&sock, deadline).await {
+                    break;
+                }
+                n += 1;
+                while sock.try_recv().is_ok() {
+                    n += 1;
+                }
+                if Instant::now() >= deadline {
+                    break;
+                }
+            }
+            counter.store(n, AO::Relaxed);
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(AO::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}"
+    );
+    eprintln!(
+        "multi-sub: {socket_count} sockets, {:.0} msg/s total, \
+         per-socket [{per_min_rate:.0}, {per_max_rate:.0}] msg/s",
+        total as f64 / elapsed,
+    );
+}
+
+async fn run_multi_push(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, socket_count: usize) {
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Push, bench_options_client(size));
+        s.connect(ep.clone()).await.expect("push connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+
+    let payload = bench_payload(size);
+    let mut handles = Vec::with_capacity(socket_count);
+    for sock in sockets {
+        let p = payload.clone();
+        handles.push(tokio::spawn(async move {
+            run_push_loop(&sock, &p).await;
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+}
+
 fn drain_pending(sock: &Socket) {
-    while sock.try_recv().is_ok() {}
+    let deadline = Instant::now() + Duration::from_millis(2);
+    for _ in 0..256 {
+        if Instant::now() >= deadline || sock.try_recv().is_err() {
+            break;
+        }
+    }
 }
 
 #[expect(clippy::cast_precision_loss)]
@@ -679,9 +984,10 @@ async fn run_inproc_latency(name: String, size: usize, iterations: usize, warmup
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let payload = Bytes::from(vec![b'x'; size]);
+    let msg = Message::single(payload);
 
     for _ in 0..warmup {
-        req.send(Message::single(payload.clone())).await.unwrap();
+        req.send(msg.clone()).await.unwrap();
         req.recv().await.unwrap();
     }
 
@@ -689,7 +995,7 @@ async fn run_inproc_latency(name: String, size: usize, iterations: usize, warmup
     let wall_start = Instant::now();
     for _ in 0..iterations {
         let t0 = Instant::now();
-        req.send(Message::single(payload.clone())).await.unwrap();
+        req.send(msg.clone()).await.unwrap();
         req.recv().await.unwrap();
         rtts.push(t0.elapsed().as_nanos() as u64);
     }
@@ -703,18 +1009,24 @@ async fn run_inproc_latency(name: String, size: usize, iterations: usize, warmup
     println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations} 0 {elapsed:.6}");
 }
 
-async fn run_rep(ep: Endpoint, size: usize) {
-    let rep = Socket::new(SocketType::Rep, bench_options(size));
+async fn run_rep(ctx: &omq_tokio::Context, ep: Endpoint, size: usize) {
+    let rep = ctx.socket(SocketType::Rep, bench_options(size));
     let bound = rep.bind(ep).await.expect("rep bind");
-    print_bound_port(&bound);
+    report_bound_port(ctx, &bound).await;
     loop {
         let msg = rep.recv().await.unwrap();
         rep.send(msg).await.unwrap();
     }
 }
 
-async fn run_req(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
-    let req = Socket::new(SocketType::Req, bench_options(size));
+async fn run_req(
+    ctx: &omq_tokio::Context,
+    ep: Endpoint,
+    size: usize,
+    iterations: usize,
+    warmup: usize,
+) {
+    let req = ctx.socket(SocketType::Req, bench_options(size));
     req.connect(ep).await.expect("req connect");
 
     tokio::time::sleep(Duration::from_millis(200)).await;

--- a/omq-tokio/src/bin/bench_proxy_client.rs
+++ b/omq-tokio/src/bin/bench_proxy_client.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Endpoint, Message, Options, SocketType};
 
 fn tcp_ep(port: u16) -> Endpoint {
     Endpoint::Tcp {
@@ -20,8 +20,16 @@ fn tcp_ep(port: u16) -> Endpoint {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
+fn main() {
+    let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig::from_env());
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async_main(ctx));
+}
+
+async fn async_main(ctx: omq_tokio::Context) {
     let args: Vec<String> = std::env::args().collect();
     let fe_port: u16 = args[1].parse().expect("fe_port");
     let be_port: u16 = args[2].parse().expect("be_port");
@@ -32,8 +40,9 @@ async fn main() {
     let stop = Arc::new(AtomicBool::new(false));
 
     let stop2 = stop.clone();
+    let push_ctx = ctx.clone();
     tokio::spawn(async move {
-        let push = Socket::new(SocketType::Push, Options::default());
+        let push = push_ctx.socket(SocketType::Push, Options::default());
         push.connect(tcp_ep(fe_port)).await.expect("push connect");
         let payload = if size <= omq_proto::message::MAX_INLINE_MESSAGE {
             Message::from_slice(&vec![b'x'; size])
@@ -47,7 +56,7 @@ async fn main() {
         }
     });
 
-    let pull = Socket::new(SocketType::Pull, Options::default());
+    let pull = ctx.socket(SocketType::Pull, Options::default());
     pull.connect(tcp_ep(be_port)).await.expect("pull connect");
 
     tokio::time::sleep(Duration::from_millis(500)).await;

--- a/omq-tokio/src/bin/perf_verify.rs
+++ b/omq-tokio/src/bin/perf_verify.rs
@@ -1,0 +1,329 @@
+//! Fast local performance gate for the core TCP paths.
+//!
+//! Thresholds are read from `.perf_hw`, which is intentionally ignored.
+//! Without that file, this command reports measurements but does not fail.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType};
+
+const WARMUP: Duration = Duration::from_millis(100);
+const MEASURE: Duration = Duration::from_millis(750);
+
+#[derive(Clone)]
+struct Sample {
+    name: String,
+    value: f64,
+    unit: &'static str,
+}
+
+fn payload(size: usize) -> Message {
+    let bytes = vec![0x5a; size];
+    if size <= omq_tokio::message::MAX_INLINE_MESSAGE {
+        Message::from_slice(&bytes)
+    } else {
+        Message::single(Bytes::from(bytes))
+    }
+}
+
+fn tcp_zero() -> Endpoint {
+    "tcp://127.0.0.1:0".parse().expect("valid TCP endpoint")
+}
+
+fn read_thresholds() -> HashMap<String, f64> {
+    let Ok(contents) = std::fs::read_to_string(".perf_hw") else {
+        return HashMap::new();
+    };
+    let mut section = String::new();
+    let mut thresholds = HashMap::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            section = name.trim().to_string();
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if let Ok(value) = value.trim().parse() {
+            thresholds.insert(format!("{section}.{}", key.trim()), value);
+        }
+    }
+    thresholds
+}
+
+async fn reqrep_latency() -> f64 {
+    let req_ctx = Context::current();
+    let rep_ctx = Context::current();
+    let rep = rep_ctx.socket(SocketType::Rep, Options::default());
+    let req = req_ctx.socket(SocketType::Req, Options::default());
+    let endpoint = rep.bind(tcp_zero()).await.expect("REP bind");
+    req.connect(endpoint).await.expect("REQ connect");
+    req.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("REQ connect timeout");
+
+    let echo = tokio::spawn(async move {
+        loop {
+            let msg = rep.recv().await.expect("REP recv");
+            rep.send(msg).await.expect("REP send");
+        }
+    });
+    let msg = payload(256);
+    for _ in 0..100 {
+        req.send(msg.clone()).await.expect("REQ warmup send");
+        req.recv().await.expect("REQ warmup recv");
+    }
+    let mut samples = Vec::with_capacity(500);
+    for _ in 0..500 {
+        let start = Instant::now();
+        req.send(msg.clone()).await.expect("REQ send");
+        req.recv().await.expect("REQ recv");
+        samples.push(start.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+    echo.abort();
+    samples.sort_by(f64::total_cmp);
+    samples[samples.len() / 2]
+}
+
+async fn try_send_until(sock: &omq_tokio::Socket, mut msg: Message, deadline: Instant) -> bool {
+    loop {
+        match sock.try_send(msg) {
+            Ok(()) => return true,
+            Err(omq_tokio::TrySendError::Full(returned)) => {
+                msg = returned;
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                tokio::task::yield_now().await;
+            }
+            Err(error) => panic!("perf send failed: {error}"),
+        }
+    }
+}
+
+async fn count_messages(sock: omq_tokio::Socket, deadline: Instant) -> u64 {
+    let mut count = 0_u64;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if !matches!(
+            tokio::time::timeout(remaining, sock.recv()).await,
+            Ok(Ok(_))
+        ) {
+            break;
+        }
+        count += 1;
+        while sock.try_recv().is_ok() {
+            count += 1;
+        }
+        tokio::task::yield_now().await;
+    }
+    count
+}
+
+async fn pushpull(size: usize, io_threads: usize) -> f64 {
+    tokio::task::spawn_blocking(move || {
+        let pull_ctx = Context::with_config(ContextConfig { io_threads });
+        let push_ctx = Context::with_config(ContextConfig { io_threads });
+        let pull = pull_ctx.blocking_socket(SocketType::Pull, Options::default());
+        let push = push_ctx.blocking_socket(SocketType::Push, Options::default());
+        let endpoint = pull.bind(tcp_zero()).expect("PULL bind");
+        push.connect(endpoint).expect("PUSH connect");
+        pull.wait_connected(1, Duration::from_secs(1))
+            .expect("PULL connect timeout");
+
+        let done = Arc::new(AtomicBool::new(false));
+        let receiver_done = done.clone();
+        let receiver = thread::spawn(move || {
+            thread::sleep(WARMUP);
+            let mut count = 0_u64;
+            loop {
+                match pull.try_recv() {
+                    Ok(_) => {
+                        count += 1;
+                        while pull.try_recv().is_ok() {
+                            count += 1;
+                        }
+                    }
+                    Err(_) if receiver_done.load(Ordering::Acquire) => break,
+                    Err(_) => thread::yield_now(),
+                }
+            }
+            count
+        });
+
+        thread::sleep(WARMUP);
+        let msg = payload(size);
+        let deadline = Instant::now() + MEASURE;
+        while Instant::now() < deadline {
+            let mut pending = msg.clone();
+            loop {
+                match push.try_send(pending) {
+                    Ok(()) => break,
+                    Err(omq_tokio::TrySendError::Full(returned)) => {
+                        pending = returned;
+                        thread::yield_now();
+                    }
+                    Err(error) => panic!("PUSH send failed: {error}"),
+                }
+            }
+        }
+        push.send(msg).expect("PUSH wakeup send");
+        done.store(true, Ordering::Release);
+        let count = receiver.join().expect("PULL thread");
+        push_ctx.term();
+        pull_ctx.term();
+        count as f64 / MEASURE.as_secs_f64()
+    })
+    .await
+    .expect("PUSH/PULL task")
+}
+
+async fn pubsub(size: usize, io_threads: usize) -> f64 {
+    const PEERS: usize = 4;
+    let pub_ctx = Context::with_config(ContextConfig { io_threads });
+    let sub_ctx = Context::with_config(ContextConfig { io_threads });
+    let publisher = pub_ctx.socket(SocketType::Pub, Options::default());
+    let endpoint = publisher.bind(tcp_zero()).await.expect("PUB bind");
+    let mut subscribers = Vec::with_capacity(PEERS);
+    for _ in 0..PEERS {
+        let subscriber = sub_ctx.socket(SocketType::Sub, Options::default());
+        subscriber
+            .connect(endpoint.clone())
+            .await
+            .expect("SUB connect");
+        subscriber
+            .subscribe(Bytes::new())
+            .await
+            .expect("SUB subscribe");
+        subscribers.push(subscriber);
+    }
+    publisher
+        .wait_subscribed(PEERS as u64, Duration::from_secs(1))
+        .await
+        .expect("SUB subscribe timeout");
+
+    let mut receivers = Vec::with_capacity(PEERS);
+    for subscriber in subscribers {
+        receivers.push(tokio::spawn(count_messages(
+            subscriber,
+            Instant::now() + WARMUP + MEASURE,
+        )));
+    }
+    let msg = payload(size);
+    let warmup_deadline = Instant::now() + WARMUP;
+    'warmup: loop {
+        for _ in 0..256 {
+            if !try_send_until(&publisher, msg.clone(), warmup_deadline).await {
+                break 'warmup;
+            }
+        }
+        if Instant::now() >= warmup_deadline {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    let deadline = Instant::now() + MEASURE;
+    'measure: loop {
+        for _ in 0..256 {
+            if !try_send_until(&publisher, msg.clone(), deadline).await {
+                break 'measure;
+            }
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    let mut rx_count = 0;
+    for receiver in receivers {
+        rx_count += receiver.await.expect("SUB task");
+    }
+    pub_ctx.term();
+    sub_ctx.term();
+    rx_count as f64 / MEASURE.as_secs_f64()
+}
+
+fn verify(sample: &Sample, thresholds: &HashMap<String, f64>) -> bool {
+    let key = &sample.name;
+    println!("{:<24} {:>12.2} {}", sample.name, sample.value, sample.unit);
+    match thresholds.get(key) {
+        Some(limit) if sample.unit == "us" && sample.value > *limit => {
+            eprintln!(
+                "FAIL {key}: {:.2} above configured {:.2} {}",
+                sample.value, limit, sample.unit
+            );
+            false
+        }
+        Some(limit) if sample.unit == "us" => {
+            println!("  threshold (max): {:.2} {}", limit, sample.unit);
+            true
+        }
+        Some(limit) if sample.value < *limit => {
+            eprintln!(
+                "FAIL {key}: {:.2} below configured {:.2} {}",
+                sample.value, limit, sample.unit
+            );
+            false
+        }
+        Some(limit) => {
+            let direction = if sample.unit == "us" { "max" } else { "min" };
+            println!("  threshold ({direction}): {:.2} {}", limit, sample.unit);
+            true
+        }
+        None => true,
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let thresholds = read_thresholds();
+    let mut ok = true;
+    let latency = reqrep_latency().await;
+    ok &= verify(
+        &Sample {
+            name: "reqrep_ct.p50_256b_us".to_string(),
+            value: latency,
+            unit: "us",
+        },
+        &thresholds,
+    );
+    for io_threads in [1, 2] {
+        for (size, suffix) in [(16, "16b"), (1024, "1k"), (16 * 1024, "16k")] {
+            let value = pushpull(size, io_threads).await;
+            ok &= verify(
+                &Sample {
+                    name: format!("pushpull_{io_threads}io.{suffix}_msgs_s"),
+                    value,
+                    unit: "msg/s",
+                },
+                &thresholds,
+            );
+        }
+        for (size, suffix) in [(16, "16b"), (4096, "4k")] {
+            let value = pubsub(size, io_threads).await;
+            ok &= verify(
+                &Sample {
+                    name: format!("pubsub_{io_threads}io.{suffix}_msgs_s"),
+                    value,
+                    unit: "msg/s",
+                },
+                &thresholds,
+            );
+        }
+    }
+    if thresholds.is_empty() {
+        eprintln!("warning: .perf_hw missing; measurements not threshold-checked");
+    }
+    if !ok {
+        std::process::exit(1);
+    }
+}

--- a/omq-tokio/src/blocking.rs
+++ b/omq-tokio/src/blocking.rs
@@ -1,0 +1,165 @@
+//! Blocking socket API for sync callers.
+//!
+//! [`Socket`] wraps an async [`crate::socket::handle::Socket`] and a
+//! [`Context`](crate::Context). Each method blocks the calling thread
+//! via [`Context::block_on`](crate::Context::block_on).
+//!
+//! ```no_run
+//! use omq_tokio::{blocking, Context, Message, Options, SocketType};
+//!
+//! let ctx = Context::new();
+//! let push = ctx.blocking_socket(SocketType::Push, Options::default());
+//! push.bind("tcp://*:5555".parse().unwrap()).unwrap();
+//! push.send(Message::from("hello")).unwrap();
+//! ```
+
+use std::time::Duration;
+
+use omq_proto::TrySendError;
+use omq_proto::endpoint::Endpoint;
+use omq_proto::error::Result;
+use omq_proto::message::Message;
+
+use crate::context::Context;
+use crate::socket::handle::Socket as AsyncSocket;
+use crate::socket::monitor::{ConnectionStatus, MonitorStream};
+
+/// Blocking socket handle.
+///
+/// Created by [`Context::blocking_socket()`]. All async operations
+/// block the calling thread via the context's owned runtime.
+///
+/// For async usage inside an existing tokio runtime, use the async
+/// [`Socket`](crate::Socket) via [`Context::socket()`].
+///
+/// # Panics
+///
+/// Methods panic if the context was created with
+/// [`Context::current()`] (use the async [`Socket`](crate::Socket)
+/// instead).
+#[derive(Clone, Debug)]
+pub struct Socket {
+    inner: AsyncSocket,
+    ctx: Context,
+}
+
+impl Socket {
+    pub(crate) fn new(inner: AsyncSocket, ctx: Context) -> Self {
+        inner.register_blocking_recv();
+        Self { inner, ctx }
+    }
+
+    /// The underlying async socket.
+    pub fn into_async(self) -> AsyncSocket {
+        self.inner
+    }
+
+    pub fn socket_type(&self) -> omq_proto::proto::SocketType {
+        self.inner.socket_type()
+    }
+
+    pub fn monitor(&self) -> MonitorStream {
+        self.inner.monitor()
+    }
+
+    pub fn last_bound_endpoint(&self) -> Option<Endpoint> {
+        self.inner.last_bound_endpoint()
+    }
+
+    pub fn bind(&self, endpoint: Endpoint) -> Result<Endpoint> {
+        let s = self.inner.clone();
+        self.ctx.block_on(async move { s.bind(endpoint).await })
+    }
+
+    pub fn connect(&self, endpoint: Endpoint) -> Result<()> {
+        let s = self.inner.clone();
+        self.ctx.block_on(async move { s.connect(endpoint).await })
+    }
+
+    pub fn send(&self, msg: Message) -> Result<()> {
+        match self.inner.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(msg)) => {
+                let s = self.inner.clone();
+                self.ctx.block_on(async move { s.send(msg).await })
+            }
+            Err(TrySendError::Closed) => Err(omq_proto::error::Error::Closed),
+            Err(TrySendError::Error(e)) => Err(e),
+        }
+    }
+
+    pub fn try_send(&self, msg: Message) -> core::result::Result<(), TrySendError> {
+        self.inner.try_send(msg)
+    }
+
+    pub fn recv(&self) -> Result<Message> {
+        self.inner.blocking_recv()
+    }
+
+    pub fn try_recv(&self) -> Result<Message> {
+        self.inner.try_recv()
+    }
+
+    pub fn subscribe(&self, prefix: impl Into<bytes::Bytes>) -> Result<()> {
+        let s = self.inner.clone();
+        let p = prefix.into();
+        self.ctx.block_on(async move { s.subscribe(p).await })
+    }
+
+    pub fn unsubscribe(&self, prefix: impl Into<bytes::Bytes>) -> Result<()> {
+        let s = self.inner.clone();
+        let p = prefix.into();
+        self.ctx.block_on(async move { s.unsubscribe(p).await })
+    }
+
+    pub fn join(&self, group: impl Into<bytes::Bytes>) -> Result<()> {
+        let s = self.inner.clone();
+        let g = group.into();
+        self.ctx.block_on(async move { s.join(g).await })
+    }
+
+    pub fn leave(&self, group: impl Into<bytes::Bytes>) -> Result<()> {
+        let s = self.inner.clone();
+        let g = group.into();
+        self.ctx.block_on(async move { s.leave(g).await })
+    }
+
+    pub fn unbind(&self, endpoint: Endpoint) -> Result<()> {
+        let s = self.inner.clone();
+        self.ctx.block_on(async move { s.unbind(endpoint).await })
+    }
+
+    pub fn disconnect(&self, endpoint: Endpoint) -> Result<()> {
+        let s = self.inner.clone();
+        self.ctx
+            .block_on(async move { s.disconnect(endpoint).await })
+    }
+
+    pub fn connection_info(&self, connection_id: u64) -> Result<Option<ConnectionStatus>> {
+        let s = self.inner.clone();
+        self.ctx
+            .block_on(async move { s.connection_info(connection_id).await })
+    }
+
+    pub fn wait_connected(&self, min_peers: usize, timeout: Duration) -> Result<usize> {
+        let s = self.inner.clone();
+        self.ctx
+            .block_on(async move { s.wait_connected(min_peers, timeout).await })
+    }
+
+    pub fn wait_subscribed(&self, min_subscriptions: u64, timeout: Duration) -> Result<u64> {
+        let s = self.inner.clone();
+        self.ctx
+            .block_on(async move { s.wait_subscribed(min_subscriptions, timeout).await })
+    }
+
+    pub fn connections(&self) -> Result<Vec<ConnectionStatus>> {
+        let s = self.inner.clone();
+        self.ctx.block_on(async move { s.connections().await })
+    }
+
+    pub fn close(self) -> Result<()> {
+        let s = self.inner;
+        self.ctx.block_on(async move { s.close().await })
+    }
+}

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -1,0 +1,484 @@
+//! Runtime-owning context for omq sockets.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+
+use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
+
+use omq_proto::options::Options;
+use omq_proto::proto::SocketType;
+
+use crate::Socket;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Configuration for a [`Context`] that owns its own tokio runtime.
+///
+/// ```
+/// use omq_tokio::ContextConfig;
+///
+/// // 4 IO threads (4 independent `current_thread` runtimes).
+/// let cfg = ContextConfig { io_threads: 4 };
+///
+/// // Read from OMQ_IO_THREADS env var, default 1.
+/// let cfg = ContextConfig::from_env();
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct ContextConfig {
+    /// Number of IO threads. Each IO thread runs an independent
+    /// `current_thread` tokio runtime on its own OS thread.
+    /// Default: 1.
+    pub io_threads: usize,
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self { io_threads: 1 }
+    }
+}
+
+impl ContextConfig {
+    /// Read configuration from environment variables.
+    ///
+    /// - `OMQ_IO_THREADS`: number of IO threads (default 1).
+    pub fn from_env() -> Self {
+        let io_threads = std::env::var("OMQ_IO_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v: &usize| v > 0)
+            .unwrap_or(1);
+        Self { io_threads }
+    }
+
+    /// Build a single `current_thread` tokio
+    /// [`Runtime`](tokio::runtime::Runtime). Useful for benchmarks
+    /// that need direct `rt.block_on()` without the `Context`
+    /// background-thread overhead.
+    pub fn build_runtime(self) -> tokio::runtime::Runtime {
+        build_current_thread_runtime()
+    }
+}
+
+// ---- IO thread pool (private) ------------------------------------------------
+
+struct IoThread {
+    handle: Handle,
+    load: AtomicUsize,
+}
+
+struct IoThreadPool {
+    threads: Vec<IoThread>,
+    primary_job_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<BoxFuture>>>,
+    cancel: CancellationToken,
+    joins: Mutex<Vec<Option<thread::JoinHandle<()>>>>,
+}
+
+impl IoThreadPool {
+    fn new(n: usize) -> Arc<Self> {
+        assert!(n >= 1);
+        let cancel = CancellationToken::new();
+        let mut threads = Vec::with_capacity(n);
+        let mut joins = Vec::with_capacity(n);
+        let mut primary_job_tx = None;
+
+        for i in 0..n {
+            let (handle_tx, handle_rx) = mpsc::channel::<Handle>();
+            let cancel_i = cancel.clone();
+
+            let join = if i == 0 {
+                let (job_tx, mut job_rx) = tokio::sync::mpsc::unbounded_channel::<BoxFuture>();
+                primary_job_tx = Some(job_tx);
+                thread::Builder::new()
+                    .name("omq-io-0".into())
+                    .spawn(move || {
+                        let rt = build_current_thread_runtime();
+                        let _ = handle_tx.send(rt.handle().clone());
+                        rt.block_on(async move {
+                            while let Some(fut) = job_rx.recv().await {
+                                fut.await;
+                            }
+                        });
+                    })
+                    .expect("omq: failed to spawn primary IO thread")
+            } else {
+                let name = format!("omq-io-{i}");
+                thread::Builder::new()
+                    .name(name)
+                    .spawn(move || {
+                        let rt = build_current_thread_runtime();
+                        let _ = handle_tx.send(rt.handle().clone());
+                        rt.block_on(cancel_i.cancelled());
+                    })
+                    .expect("omq: failed to spawn IO thread")
+            };
+
+            let handle = handle_rx.recv().expect("omq: runtime handle");
+            threads.push(IoThread {
+                handle,
+                load: AtomicUsize::new(0),
+            });
+            joins.push(Some(join));
+        }
+
+        Arc::new(Self {
+            threads,
+            primary_job_tx: Mutex::new(primary_job_tx),
+            cancel,
+            joins: Mutex::new(joins),
+        })
+    }
+
+    fn primary_handle(&self) -> &Handle {
+        &self.threads[0].handle
+    }
+
+    fn thread_count(&self) -> usize {
+        self.threads.len()
+    }
+
+    fn assign_thread(&self) -> usize {
+        let best = self
+            .threads
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, t)| t.load.load(Ordering::Relaxed))
+            .map_or(0, |(i, _)| i);
+        self.threads[best].load.fetch_add(1, Ordering::Relaxed);
+        best
+    }
+
+    fn release_thread(&self, index: usize) {
+        self.threads[index].load.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    fn shutdown(&self) {
+        self.cancel.cancel();
+        *self.primary_job_tx.lock().expect("job_tx poisoned") = None;
+        let mut joins = self.joins.lock().expect("joins poisoned");
+        for j in joins.iter_mut() {
+            if let Some(handle) = j.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for IoThreadPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IoThreadPool")
+            .field("thread_count", &self.threads.len())
+            .finish_non_exhaustive()
+    }
+}
+
+// ---- IoPoolHandle (pub(crate)) -----------------------------------------------
+
+/// Handle to the IO thread pool for spawning tasks on specific IO
+/// threads. When the inner pool is `None`, all spawning uses bare
+/// `tokio::spawn()` (single-thread or borrowed-runtime mode).
+#[derive(Clone, Debug)]
+pub(crate) struct IoPoolHandle {
+    pool: Option<Arc<IoThreadPool>>,
+}
+
+impl IoPoolHandle {
+    pub(crate) fn none() -> Self {
+        Self { pool: None }
+    }
+
+    /// Spawn a future on the primary IO thread (index 0).
+    pub(crate) fn spawn_primary<F>(&self, fut: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future<Output: Send> + Send + 'static,
+    {
+        match &self.pool {
+            None => tokio::spawn(fut),
+            Some(pool) => pool.threads[0].handle.spawn(fut),
+        }
+    }
+
+    /// Spawn a future on a specific IO thread.
+    pub(crate) fn spawn_on<F>(&self, index: usize, fut: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future<Output: Send> + Send + 'static,
+    {
+        match &self.pool {
+            None => tokio::spawn(fut),
+            Some(pool) => pool.threads[index].handle.spawn(fut),
+        }
+    }
+
+    /// Pick the least-loaded IO thread, increment its load, return
+    /// the thread index.
+    pub(crate) fn assign_thread(&self) -> usize {
+        match &self.pool {
+            None => 0,
+            Some(pool) => pool.assign_thread(),
+        }
+    }
+
+    /// Decrement load on a thread (peer removed).
+    pub(crate) fn release_thread(&self, index: usize) {
+        if let Some(pool) = &self.pool {
+            pool.release_thread(index);
+        }
+    }
+
+    /// Number of IO threads.
+    pub(crate) fn thread_count(&self) -> usize {
+        match &self.pool {
+            None => tokio::runtime::Handle::current()
+                .metrics()
+                .num_workers()
+                .max(1),
+            Some(pool) => pool.thread_count(),
+        }
+    }
+}
+
+// ---- Context -----------------------------------------------------------------
+
+/// A runtime context for omq sockets.
+///
+/// # Owned runtime (default)
+///
+/// `Context::new()` and `Context::with_config()` spawn dedicated OS
+/// threads, each running an independent `current_thread` tokio runtime.
+/// Sockets created via [`Context::socket()`] have their driver tasks on
+/// those runtimes. The user does not need tokio in their own
+/// `Cargo.toml`.
+///
+/// ```no_run
+/// use omq_tokio::{Context, SocketType, Options, Message};
+///
+/// let ctx = Context::new();
+/// let sock = ctx.socket(SocketType::Push, Options::default());
+/// ctx.block_on(async move {
+///     sock.bind("tcp://*:5555".parse().unwrap()).await.unwrap();
+///     sock.send(Message::from("hello")).await.unwrap();
+/// });
+/// ```
+///
+/// # Embedded in an existing runtime
+///
+/// `Context::current()` wraps the caller's active tokio runtime.
+/// No background thread is spawned.
+///
+/// ```no_run
+/// use omq_tokio::{Context, SocketType, Options};
+///
+/// # async fn example() {
+/// let ctx = Context::current();
+/// let sock = ctx.socket(SocketType::Pull, Options::default());
+/// let msg = sock.recv().await.unwrap();
+/// # }
+/// ```
+#[derive(Clone, Debug)]
+pub struct Context {
+    inner: Arc<ContextInner>,
+}
+
+enum RuntimeOwnership {
+    Owned { pool: Arc<IoThreadPool> },
+    Borrowed { handle: Handle },
+}
+
+struct ContextInner {
+    ownership: RuntimeOwnership,
+    io_threads: usize,
+    terminated: AtomicBool,
+}
+
+impl std::fmt::Debug for ContextInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContextInner")
+            .field("io_threads", &self.io_threads)
+            .field(
+                "owned",
+                &matches!(self.ownership, RuntimeOwnership::Owned { .. }),
+            )
+            .field("terminated", &self.terminated.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl ContextInner {
+    fn primary_handle(&self) -> &Handle {
+        match &self.ownership {
+            RuntimeOwnership::Owned { pool } => pool.primary_handle(),
+            RuntimeOwnership::Borrowed { handle } => handle,
+        }
+    }
+
+    fn io_pool_handle(&self) -> IoPoolHandle {
+        match &self.ownership {
+            RuntimeOwnership::Owned { pool } if pool.thread_count() > 1 => IoPoolHandle {
+                pool: Some(pool.clone()),
+            },
+            _ => IoPoolHandle::none(),
+        }
+    }
+}
+
+impl Context {
+    /// Create a context with 1 IO thread (`current_thread` runtime on a
+    /// dedicated OS thread). This is the libzmq-like default.
+    pub fn new() -> Self {
+        Self::with_config(ContextConfig::default())
+    }
+
+    /// Create a context with custom configuration.
+    ///
+    /// Each IO thread runs an independent `current_thread` tokio
+    /// runtime on its own OS thread. Connections are pinned to an
+    /// IO thread for life (least-loaded assignment at connect/accept
+    /// time).
+    pub fn with_config(config: ContextConfig) -> Self {
+        let io_threads = config.io_threads.max(1);
+        let pool = IoThreadPool::new(io_threads);
+        Self {
+            inner: Arc::new(ContextInner {
+                ownership: RuntimeOwnership::Owned { pool },
+                io_threads,
+                terminated: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Wrap the caller's active tokio runtime. No background thread is
+    /// spawned; the context borrows the existing runtime.
+    ///
+    /// [`block_on()`](Self::block_on) panics on a borrowed context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a tokio runtime context.
+    pub fn current() -> Self {
+        let handle =
+            Handle::try_current().expect("Context::current() called outside a tokio runtime");
+        Self {
+            inner: Arc::new(ContextInner {
+                ownership: RuntimeOwnership::Borrowed { handle },
+                io_threads: 0,
+                terminated: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Create a blocking socket on this context's runtime.
+    ///
+    /// Each method blocks the calling thread via
+    /// [`block_on`](Self::block_on). For async usage, use
+    /// [`socket()`](Self::socket).
+    ///
+    /// # Panics
+    ///
+    /// Panics on a borrowed context ([`Context::current()`]).
+    pub fn blocking_socket(
+        &self,
+        socket_type: SocketType,
+        options: Options,
+    ) -> crate::blocking::Socket {
+        crate::blocking::Socket::new(self.socket(socket_type, options), self.clone())
+    }
+
+    /// Create an async socket on this context's runtime.
+    pub fn socket(&self, socket_type: SocketType, options: Options) -> Socket {
+        assert!(
+            !self.inner.terminated.load(Ordering::Acquire),
+            "Context::socket() called on a terminated context"
+        );
+        let _guard = self.inner.primary_handle().enter();
+        let io_pool = self.inner.io_pool_handle();
+        Socket::new_with_io_pool(socket_type, options, &io_pool)
+    }
+
+    /// Run a future on this context's runtime, blocking the calling
+    /// thread until it completes. The future runs inline on the
+    /// primary IO thread with the same priority as spawned driver tasks.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the context was created with [`Context::current()`]
+    /// (the caller is already async; just `.await` directly).
+    pub fn block_on<F, T>(&self, f: F) -> T
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let RuntimeOwnership::Owned { ref pool } = self.inner.ownership else {
+            panic!(
+                "Context::block_on() is not available on a borrowed context \
+                 (created with Context::current())"
+            );
+        };
+        assert!(
+            !self.inner.terminated.load(Ordering::Acquire),
+            "Context::block_on() called on a terminated context"
+        );
+        let guard = pool.primary_job_tx.lock().expect("job_tx poisoned");
+        let job_tx = guard
+            .as_ref()
+            .expect("Context::block_on() called on a terminated context");
+        let (result_tx, result_rx) = mpsc::channel();
+        let fut: BoxFuture = Box::pin(async move {
+            let result = f.await;
+            let _ = result_tx.send(result);
+        });
+        job_tx.send(fut).expect("omq: context runtime exited");
+        drop(guard);
+        result_rx
+            .recv()
+            .expect("omq: context runtime exited unexpectedly")
+    }
+
+    /// Return the tokio runtime handle for the primary IO thread.
+    pub fn handle(&self) -> &Handle {
+        self.inner.primary_handle()
+    }
+
+    /// Number of IO threads. Returns 0 for a borrowed context
+    /// ([`Context::current()`]).
+    pub fn io_threads(&self) -> usize {
+        self.inner.io_threads
+    }
+
+    /// Shut down this context's runtime. All spawned driver tasks are
+    /// aborted and the background threads exit.
+    ///
+    /// No-op for a borrowed context ([`Context::current()`]).
+    /// No-op if already terminated.
+    pub fn term(&self) {
+        if self.inner.terminated.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if let RuntimeOwnership::Owned { ref pool } = self.inner.ownership {
+            pool.shutdown();
+        }
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ContextInner {
+    fn drop(&mut self) {
+        if let RuntimeOwnership::Owned { ref pool } = self.ownership {
+            pool.shutdown();
+        }
+    }
+}
+
+fn build_current_thread_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("omq: failed to build current_thread runtime")
+}

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1,5 +1,6 @@
 //! Per-connection driver: one tokio task per live peer connection.
 
+use std::collections::VecDeque;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -7,11 +8,12 @@ use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use smallvec::SmallVec;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, split};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use futures::stream::FuturesOrdered;
+use omq_proto::WorkloadProfile;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 use omq_proto::proto::transform::{MessageDecoder, MessageEncoder, TransformedOut};
@@ -21,7 +23,90 @@ use super::compression_pool::CompressionPool;
 use super::send_pipe::{SendPipeConsumer, SendPipeProducerHandle};
 use super::transmit_slot::PeerTransmitSlot;
 use crate::routing::fallback_queue::FallbackReceiver;
+use crate::socket::dispatch::{AnyReadHalf, AnyStream, AnyWriteHalf};
+use omq_proto::flow::{DrainBudget, max_batch_bytes};
 use omq_proto::frame_buffer::FrameBuffer;
+
+const RECV_SMALL_MSG: usize = 1024;
+const RECV_MEDIUM_MSG: usize = 4096;
+const RECV_SMALL_BYTES: usize = 64 * 1024;
+const RECV_MEDIUM_BYTES: usize = 1024 * 1024;
+const RECV_LARGE_BYTES: usize = 1024 * 1024;
+const RECV_MEDIUM_TIME: Duration = Duration::from_micros(200);
+const RECV_LARGE_TIME: Duration = Duration::from_micros(200);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiveProfile {
+    Latency,
+    LatencyReq,
+    Throughput,
+}
+
+/// Stream abstraction allowing production TCP streams to use owned halves.
+pub trait DriverStream: Sized {
+    type Reader: AsyncRead + Send + Unpin + 'static;
+    type Writer: AsyncWrite + Send + Unpin + 'static;
+
+    fn split(self, fast_write: bool) -> (Self::Reader, Self::Writer);
+}
+
+impl DriverStream for AnyStream {
+    type Reader = AnyReadHalf;
+    type Writer = AnyWriteHalf;
+
+    fn split(self, fast_write: bool) -> (Self::Reader, Self::Writer) {
+        AnyStream::split(self, fast_write)
+    }
+}
+
+impl DriverStream for tokio::net::TcpStream {
+    type Reader = tokio::net::tcp::OwnedReadHalf;
+    type Writer = tokio::net::tcp::OwnedWriteHalf;
+
+    fn split(self, _fast_write: bool) -> (Self::Reader, Self::Writer) {
+        self.into_split()
+    }
+}
+
+impl ReceiveProfile {
+    pub(crate) fn from_workload_for_socket(
+        profile: WorkloadProfile,
+        socket_type: omq_proto::SocketType,
+    ) -> Self {
+        match (profile, socket_type) {
+            (WorkloadProfile::Latency, omq_proto::SocketType::Req) => Self::LatencyReq,
+            (WorkloadProfile::Latency, _) => Self::Latency,
+            (WorkloadProfile::Throughput, _) => Self::Throughput,
+        }
+    }
+
+    fn budget(self, msg_bytes: usize) -> DrainBudget {
+        match self {
+            Self::Latency | Self::LatencyReq => DrainBudget::new(8, 16 * 1024),
+            Self::Throughput => {
+                let (max_msgs, max_bytes) = if msg_bytes <= RECV_SMALL_MSG {
+                    (256, RECV_SMALL_BYTES)
+                } else if msg_bytes <= RECV_MEDIUM_MSG {
+                    (256, RECV_MEDIUM_BYTES)
+                } else {
+                    (256, RECV_LARGE_BYTES)
+                };
+                DrainBudget::new(max_msgs, max_bytes)
+            }
+        }
+    }
+
+    fn time(self, msg_bytes: usize) -> Option<Duration> {
+        match self {
+            Self::Latency | Self::LatencyReq => Some(Duration::from_micros(5)),
+            // The small profile already has tight message/byte bounds. Avoid
+            // clock reads here; this is the hot path for tiny messages.
+            Self::Throughput if msg_bytes <= RECV_SMALL_MSG => None,
+            Self::Throughput if msg_bytes <= RECV_MEDIUM_MSG => Some(RECV_MEDIUM_TIME),
+            Self::Throughput => Some(RECV_LARGE_TIME),
+        }
+    }
+}
 
 /// Where the driver routes decoded inbound messages.
 ///
@@ -32,6 +117,17 @@ use omq_proto::frame_buffer::FrameBuffer;
 pub enum RecvSink {
     Channel(Arc<crate::socket::recv::SharedRecvPipe>),
     Yring(YringSink),
+    Rep(RepRecvSink),
+}
+
+/// REP's latency receive path: perform identity/envelope handling in the
+/// connection driver, before the message reaches the socket actor.
+#[derive(Debug)]
+pub struct RepRecvSink {
+    sink: Box<RecvSink>,
+    identity: std::sync::Arc<std::sync::Mutex<Option<bytes::Bytes>>>,
+    pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, bytes::Bytes)>>>,
+    peer_id: u64,
 }
 
 /// Yring-based recv sink. Pushes decoded messages directly into a
@@ -118,6 +214,7 @@ impl std::fmt::Debug for RecvSink {
                 .debug_struct("Yring")
                 .field("producer", &y.producer)
                 .finish_non_exhaustive(),
+            Self::Rep(_) => f.debug_tuple("Rep").finish_non_exhaustive(),
         }
     }
 }
@@ -142,6 +239,26 @@ impl YringSink {
 }
 
 impl RecvSink {
+    pub(crate) fn set_rep_identity(&mut self, identity: bytes::Bytes) {
+        if let Self::Rep(rep) = self {
+            *rep.identity.lock().expect("rep identity") = Some(identity);
+        }
+    }
+
+    pub(crate) fn rep(
+        sink: RecvSink,
+        identity: std::sync::Arc<std::sync::Mutex<Option<bytes::Bytes>>>,
+        pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, bytes::Bytes)>>>,
+        peer_id: u64,
+    ) -> Self {
+        Self::Rep(RepRecvSink {
+            sink: Box::new(sink),
+            identity,
+            pending,
+            peer_id,
+        })
+    }
+
     /// Non-blocking push. Returns the message back if the yring is full.
     /// Channel variant always succeeds (awaits space).
     pub(crate) async fn try_send(&mut self, m: Message) -> Option<Message> {
@@ -157,10 +274,11 @@ impl RecvSink {
                 }
                 Err(returned) => Some(returned),
             },
+            Self::Rep(_) => unreachable!("REP uses the blocking direct path"),
         }
     }
 
-    async fn send(&mut self, m: Message) -> bool {
+    async fn send_plain(&mut self, m: Message) -> bool {
         match self {
             Self::Channel(pipe) => pipe.send(m).await.is_ok(),
             Self::Yring(sink) => {
@@ -198,7 +316,37 @@ impl RecvSink {
                     return true;
                 }
             }
+            Self::Rep(_) => unreachable!("plain send on REP sink"),
         }
+    }
+
+    async fn send(&mut self, m: Message) -> bool {
+        if let Self::Rep(rep) = self {
+            let mut m = m;
+            let identity =
+                if let Some(identity) = rep.identity.lock().expect("rep identity").clone() {
+                    if m.part_bytes(0).is_some_and(|part| part.is_empty()) {
+                        m.pop_front();
+                    }
+                    identity
+                } else if m.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let Some(identity) = m.pop_front() else {
+                        return false;
+                    };
+                    m.pop_front();
+                    identity
+                } else {
+                    bytes::Bytes::new()
+                };
+            rep.pending
+                .lock()
+                .expect("rep pending")
+                .push_back((rep.peer_id, identity.clone()));
+            let wrapped =
+                Message::with_prefix(identity, Message::with_prefix(bytes::Bytes::new(), m));
+            return rep.sink.send_plain(wrapped).await;
+        }
+        self.send_plain(m).await
     }
 }
 
@@ -271,7 +419,6 @@ async fn batch_encode(
 const READ_BUF_SIZE: usize = 128 * 1024;
 
 use crate::routing::SHARED_MAX_BATCH_MSGS;
-use omq_proto::flow::{DrainBudget, max_batch_bytes};
 
 /// Driver-level timing configuration: handshake deadline, heartbeat
 /// cadence, idle-close timeout.
@@ -315,6 +462,7 @@ pub struct PeerDriverHandle {
     pub inbox: mpsc::Sender<PeerDriverCommand>,
     pub cancel: CancellationToken,
     pub(crate) transmit_slot: Option<Arc<PeerTransmitSlot>>,
+    pub(crate) direct_tcp_writer: Option<Arc<crate::socket::dispatch::DirectTcpWriter>>,
     pub(crate) send_pipe: Option<SendPipeProducerHandle>,
 }
 
@@ -334,7 +482,7 @@ pub enum PeerEvent {
 #[derive(Debug)]
 pub struct ConnectionDriver<T>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    T: DriverStream,
 {
     stream: T,
     codec: Connection,
@@ -372,11 +520,12 @@ where
     send_pipe_rx: Option<SendPipeConsumer>,
     arena_threshold: usize,
     arena_cap: usize,
+    receive_profile: ReceiveProfile,
 }
 
 impl<T> ConnectionDriver<T>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    T: DriverStream,
 {
     pub fn new(
         stream: T,
@@ -424,6 +573,7 @@ where
             send_pipe_rx: None,
             arena_threshold: omq_proto::frame_buffer::ARENA_THRESHOLD,
             arena_cap: omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            receive_profile: ReceiveProfile::Throughput,
         }
     }
 
@@ -512,6 +662,22 @@ where
         self
     }
 
+    pub(crate) fn with_receive_profile(mut self, profile: ReceiveProfile) -> Self {
+        self.receive_profile = profile;
+        self
+    }
+
+    /// Re-register the stream with the current thread's reactor. Call
+    /// at the top of a future spawned on the target IO thread so the
+    /// fd is polled by that thread, not the one that accepted/connected.
+    pub(crate) fn migrate_stream(mut self) -> io::Result<Self>
+    where
+        T: crate::socket::dispatch::Migratable,
+    {
+        self.stream = self.stream.migrate()?;
+        Ok(self)
+    }
+
     /// Run the driver to completion. Returns:
     /// - `Ok(())` on clean shutdown (peer EOF, canceled, `Close` command,
     ///   inbox dropped).
@@ -550,12 +716,14 @@ where
             mut send_pipe_rx,
             arena_threshold,
             arena_cap,
+            receive_profile,
         } = self;
         let passthrough = encoder.as_ref().and_then(MessageEncoder::passthrough_info);
         let mut offload_pipeline: OffloadPipeline = FuturesOrdered::new();
-        let (mut reader, mut writer) = split(stream);
+        let latency_profile = !matches!(receive_profile, ReceiveProfile::Throughput);
+        let (mut reader, mut writer) = stream.split(latency_profile);
         let mut read_buf = BytesMut::with_capacity(READ_BUF_SIZE);
-        let mut large_recv_buf = BytesMut::new();
+        let recv_pool = RecvBufPool::new();
         let mut eq = FrameBuffer::with_config(arena_threshold, arena_cap);
         let mut drain_buf: Vec<Bytes> = Vec::with_capacity(64);
         let mut arena_buf: Vec<u8> = Vec::with_capacity(4096);
@@ -581,6 +749,18 @@ where
             }
 
             while let Some(ev) = codec.poll_event() {
+                if let Event::HandshakeSucceeded {
+                    peer_properties, ..
+                } = &ev
+                {
+                    let identity = peer_properties
+                        .identity
+                        .clone()
+                        .unwrap_or_else(|| omq_proto::message::generated_identity(peer_id));
+                    if let Some(sink) = recv_direct.as_mut() {
+                        sink.set_rep_identity(identity);
+                    }
+                }
                 if peer_out
                     .send((peer_id, PeerEvent::Event(ev)))
                     .await
@@ -589,6 +769,10 @@ where
                     return Ok(());
                 }
             }
+            let recv_batch_start = Instant::now();
+            let mut recv_budget = None;
+            let mut recv_batch_time = None;
+            let mut recv_budget_exhausted = false;
             while let Some(m) = codec.poll_message() {
                 let m = match decoder.as_mut() {
                     Some(dec) => match dec.decode(m)? {
@@ -597,9 +781,27 @@ where
                     },
                     None => m,
                 };
+                let msg_bytes = m.byte_len();
+                let budget = recv_budget.get_or_insert_with(|| {
+                    recv_batch_time = receive_profile.time(msg_bytes);
+                    receive_profile.budget(msg_bytes)
+                });
                 if !route_message(m, &mut recv_direct, &peer_out, peer_id).await {
                     return Ok(());
                 }
+                let budget_remains = budget.account(msg_bytes);
+                let time_check = budget.msgs().is_multiple_of(32);
+                if !budget_remains
+                    || (time_check
+                        && recv_batch_time.is_some_and(|limit| recv_batch_start.elapsed() >= limit))
+                {
+                    recv_budget_exhausted = true;
+                    break;
+                }
+            }
+            if recv_budget_exhausted {
+                tokio::task::yield_now().await;
+                continue;
             }
 
             // Set handshake_done on the encode slot once the handshake
@@ -616,6 +818,20 @@ where
             let want_write = codec.has_pending_transmit() || !eq.is_empty();
             let hb_enabled = hb_interval.is_some() && codec.is_ready();
 
+            // Latency-routed REQ/REP sends are encoded into the wire slot by
+            // the caller. Drain that already-queued work before polling the
+            // reader, avoiding an extra zero-time reactor roundtrip.
+            if latency_profile && transmit_slot.as_ref().is_some_and(|slot| !slot.is_empty()) {
+                drain_transmit_slot(
+                    transmit_slot.as_ref().unwrap(),
+                    &mut drain_buf,
+                    &mut arena_buf,
+                    &mut writer,
+                )
+                .await?;
+                continue;
+            }
+
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
@@ -625,12 +841,29 @@ where
                     return Ok(());
                 }
 
+                // Latency-routed sends are written by the socket handle into
+                // the slot. Poll this wakeup before the reader: otherwise a
+                // reply can cause an unnecessary zero-time reactor poll
+                // before the next request is written.
+                () = async {
+                    transmit_slot.as_ref().unwrap().data_signal.notified().await;
+                }, if latency_profile && transmit_slot.as_ref().is_some_and(|s| {
+                    s.handshake_done.load(Ordering::Acquire)
+                }) => {
+                    drain_transmit_slot(
+                        transmit_slot.as_ref().unwrap(), &mut drain_buf,
+                        &mut arena_buf, &mut writer,
+                    ).await?;
+                    if latency_profile {
+                    }
+                }
+
                 // Handshake deadline; disabled once handshake completes.
                 () = sleep_until_opt(handshake_deadline), if handshake_deadline.is_some() => {
                     return Err(Error::HandshakeFailed("handshake timeout".into()));
                 }
 
-                res = reader.read_buf(&mut read_buf) => {
+                res = reader.read_buf(&mut read_buf), if !latency_profile || inbox.is_empty() => {
                     last_input = Instant::now();
                     let n = res?;
                     if n == 0 {
@@ -641,10 +874,7 @@ where
                         inbox.close();
                         return Ok(());
                     }
-                    // Copy + clear: allocates proportional to actual
-                    // data, preserves the 128 KiB read buffer capacity.
-                    let chunk = Bytes::copy_from_slice(&read_buf);
-                    read_buf.clear();
+                    let chunk = read_buf.split().freeze();
                     if let Err(e) = codec.handle_input(chunk) {
                         while let Some(ev) = codec.poll_event() {
                             let _ = peer_out
@@ -655,7 +885,7 @@ where
                     }
                     handle_large_messages(
                         &mut codec, &mut reader, &config, &mut last_input,
-                        &mut large_recv_buf,
+                        &recv_pool,
                     ).await?;
                 }
 
@@ -675,7 +905,8 @@ where
                     res?;
                 }
 
-                cmd = inbox.recv() => match cmd {
+                cmd = inbox.recv() => {
+                    match cmd {
                     Some(PeerDriverCommand::SendMessage(first)) => {
                         // TODO: Give driver control commands an explicit
                         // msg/byte/time budget. Current mixed inbox batches
@@ -715,15 +946,24 @@ where
                             drain_writes(&mut writer, &mut codec).await.ok();
                             return Ok(());
                         }
+                        if latency_profile {
+                        }
                     }
                     Some(PeerDriverCommand::SendEncoded(chunks)) => {
                         eq.push_shared_chunks(&chunks);
                         flush_frame_buffer(&mut writer, &mut eq, &mut drain_buf).await?;
+                        if latency_profile {
+                        }
                     }
-                    Some(PeerDriverCommand::SendCommand(c)) => codec.send_command(&c)?,
+                    Some(PeerDriverCommand::SendCommand(c)) => {
+                        codec.send_command(&c)?;
+                        if latency_profile {
+                        }
+                    }
                     Some(PeerDriverCommand::Close) | None => {
                         drain_writes(&mut writer, &mut codec).await.ok();
                         return Ok(());
+                    }
                     }
                 },
 
@@ -786,7 +1026,7 @@ where
                 // directly, bypassing the local FrameBuffer.
                 () = async {
                     transmit_slot.as_ref().unwrap().data_signal.notified().await;
-                }, if transmit_slot.as_ref().is_some_and(|s| {
+                }, if !latency_profile && transmit_slot.as_ref().is_some_and(|s| {
                     s.handshake_done.load(Ordering::Acquire)
                 }) => {
                     drain_transmit_slot(
@@ -950,20 +1190,65 @@ async fn drain_send_pipe_batch<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// After reading bytes from the wire, check for large frames whose
-/// payload exceeds the threshold and read them directly into a
-/// pre-sized buffer (bypasses the fixed `read_buf` -> codec copy path).
-///
-/// `reuse_buf` is kept across calls so the allocation is reused. Once
-/// grown to the largest frame size seen on a connection it stays there,
-/// avoiding per-message mmap/munmap for payloads above glibc's 128 KiB
-/// mmap threshold.
+// -- Recv buffer pool --------------------------------------------------------
+//
+// Large messages (above the arena threshold) need their own allocation.
+// Without pooling, each message triggers mmap + page faults for fresh
+// zeroed pages. The pool recycles buffers: pages stay warm, no syscall
+// per message after warmup.
+
+#[derive(Debug)]
+struct RecvBufPool(std::sync::Mutex<Vec<Vec<u8>>>);
+
+impl RecvBufPool {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(std::sync::Mutex::new(Vec::new())))
+    }
+
+    fn take(&self, capacity: usize) -> Vec<u8> {
+        let mut pool = self.0.lock().expect("recv buf pool");
+        if let Some(mut buf) = pool.pop() {
+            if buf.capacity() < capacity {
+                buf.reserve(capacity - buf.capacity());
+            }
+            buf
+        } else {
+            Vec::with_capacity(capacity)
+        }
+    }
+
+    fn give(&self, buf: Vec<u8>) {
+        self.0.lock().expect("recv buf pool").push(buf);
+    }
+}
+
+struct PooledRecvBuf {
+    buf: Vec<u8>,
+    pool: Arc<RecvBufPool>,
+}
+
+impl AsRef<[u8]> for PooledRecvBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
+impl Drop for PooledRecvBuf {
+    fn drop(&mut self) {
+        let buf = std::mem::take(&mut self.buf);
+        self.pool.give(buf);
+    }
+}
+
+/// Read large frames directly into pooled buffers (bypasses the fixed
+/// `read_buf` -> codec copy path). The pool recycles allocations so
+/// pages stay warm across messages.
 async fn handle_large_messages<R: AsyncRead + Unpin>(
     codec: &mut Connection,
     reader: &mut R,
     config: &PeerDriverConfig,
     last_input: &mut Instant,
-    reuse_buf: &mut BytesMut,
+    recv_pool: &Arc<RecvBufPool>,
 ) -> Result<()> {
     #[cfg(feature = "ws")]
     let skip_large = codec.is_ws();
@@ -979,13 +1264,17 @@ async fn handle_large_messages<R: AsyncRead + Unpin>(
         let Some((plen, prefix)) = codec.begin_supplied_payload_with_prefix() else {
             break;
         };
-        reuse_buf.resize(plen, 0);
-        reuse_buf[..prefix.len()].copy_from_slice(prefix.as_slice());
+        let mut buf = recv_pool.take(plen);
+        buf.resize(plen, 0);
+        buf[..prefix.len()].copy_from_slice(prefix.as_slice());
         if prefix.len() < plen {
-            reader.read_exact(&mut reuse_buf[prefix.len()..]).await?;
+            reader.read_exact(&mut buf[prefix.len()..plen]).await?;
         }
         *last_input = Instant::now();
-        let payload = reuse_buf.split().freeze();
+        let payload = Bytes::from_owner(PooledRecvBuf {
+            buf,
+            pool: Arc::clone(recv_pool),
+        });
         codec.supply_payload(payload)?;
     }
     Ok(())
@@ -1274,11 +1563,21 @@ where
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use tokio::io::DuplexStream;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
     use omq_proto::proto::connection::{ConnectionConfig, Role};
     use omq_proto::proto::{Event, SocketType};
+
+    impl DriverStream for DuplexStream {
+        type Reader = tokio::io::ReadHalf<Self>;
+        type Writer = tokio::io::WriteHalf<Self>;
+
+        fn split(self, _fast_write: bool) -> (Self::Reader, Self::Writer) {
+            tokio::io::split(self)
+        }
+    }
 
     /// Adapter: pull `(u64, PeerEvent::Event)` off the shared peer-out
     /// channel and yield bare `Event` values, matching the older
@@ -1352,6 +1651,7 @@ mod tests {
                 inbox: c_inbox_tx,
                 cancel: c_cancel,
                 transmit_slot: None,
+                direct_tcp_writer: None,
                 send_pipe: None,
             },
             EventAdapter { rx: c_evt_rx },
@@ -1359,6 +1659,7 @@ mod tests {
                 inbox: s_inbox_tx,
                 cancel: s_cancel,
                 transmit_slot: None,
+                direct_tcp_writer: None,
                 send_pipe: None,
             },
             EventAdapter { rx: s_evt_rx },

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -38,7 +38,7 @@ pub(crate) struct PeerTransmitSlot {
     cap: usize,
     msg_cap: usize,
     pub(crate) data_signal: DataSignal,
-    pub(crate) space_available: Notify,
+    pub(crate) space_available: Arc<Notify>,
     pub(crate) handshake_done: AtomicBool,
     pub(crate) has_transform: bool,
     pub(crate) transform_passthrough: Option<(Bytes, usize)>,
@@ -91,7 +91,7 @@ impl PeerTransmitSlot {
             cap,
             msg_cap: msg_cap.max(1),
             data_signal: DataSignal::new(),
-            space_available: Notify::new(),
+            space_available: Arc::new(Notify::new()),
             handshake_done: AtomicBool::new(false),
             has_transform,
             transform_passthrough,
@@ -158,6 +158,28 @@ impl PeerTransmitSlot {
             }
             HandleFrameDecision::Ineligible => return TryFrameResult::Ineligible,
         }
+        self.queued_msgs.fetch_add(1, Ordering::Relaxed);
+        self.mark_above_lwm_if_needed(eq.total_bytes(), self.queued_msgs.load(Ordering::Relaxed));
+        drop(eq);
+        self.signal_encoded();
+        TryFrameResult::Ok
+    }
+
+    /// Encode a REP reply directly with its routing identity. Avoids building
+    /// a temporary multipart `Message` on the latency path.
+    pub(crate) fn try_encode_rep(&self, identity: &Bytes, msg: &Message) -> TryFrameResult {
+        if self.dead.load(Ordering::Acquire) {
+            return TryFrameResult::Dead;
+        }
+        if !self.handshake_done.load(Ordering::Acquire) {
+            return TryFrameResult::Ineligible;
+        }
+        let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
+        if self.is_full(&eq) {
+            self.above_lwm.store(true, Ordering::Relaxed);
+            return TryFrameResult::Full;
+        }
+        eq.frame_rep(identity, msg);
         self.queued_msgs.fetch_add(1, Ordering::Relaxed);
         self.mark_above_lwm_if_needed(eq.total_bytes(), self.queued_msgs.load(Ordering::Relaxed));
         drop(eq);

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -10,6 +10,8 @@
 //! transport implementations, and the public `Socket` actor.
 #![forbid(unsafe_code)]
 
+pub mod blocking;
+pub mod context;
 pub mod engine;
 pub(crate) mod routing;
 pub mod socket;
@@ -38,6 +40,7 @@ pub use omq_proto::message;
 pub use omq_proto::options;
 pub use omq_proto::proto;
 
+pub use context::{Context, ContextConfig};
 pub use socket::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorStream,
     MonitorTryRecvError, PeerCommandKind, PeerIdent, PeerInfo, Socket,

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -129,11 +129,19 @@ struct ShardPeer {
 }
 
 struct ShardEndpoint {
-    data_tx: yring::Producer<ShardDispatch>,
     ctrl_tx: yring::Producer<ShardControl>,
-    data_signal: Arc<DataSignal>,
     ctrl_notify: Arc<Notify>,
     load: usize,
+}
+
+struct DistributorEndpoint {
+    data_tx: yring::Producer<ShardDispatch>,
+    data_signal: Arc<DataSignal>,
+}
+
+struct DistributionTarget {
+    data_tx: yring::Producer<ShardDispatch>,
+    data_signal: Arc<DataSignal>,
 }
 
 struct FanOutShardState {
@@ -144,7 +152,21 @@ struct FanOutShardState {
 
 struct FanOutShards {
     state: Mutex<FanOutShardState>,
-    active_mask: AtomicU8,
+    active_mask: Arc<AtomicU8>,
+    distributor: Mutex<DistributorEndpoint>,
+}
+
+impl std::fmt::Debug for DistributorEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DistributorEndpoint")
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for DistributionTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DistributionTarget").finish_non_exhaustive()
+    }
 }
 
 impl std::fmt::Debug for FanOutShards {
@@ -159,11 +181,10 @@ impl std::fmt::Debug for FanOutShards {
                 "worker_loads",
                 &state.endpoints.iter().map(|s| s.load).collect::<Vec<_>>(),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
-#[derive(Debug)]
 struct ShardWorker {
     data_rx: yring::Consumer<ShardDispatch>,
     ctrl_rx: yring::Consumer<ShardControl>,
@@ -176,6 +197,19 @@ struct ShardWorker {
     chunks: Vec<Bytes>,
     #[cfg(feature = "lz4")]
     encoder: Option<MessageEncoder>,
+    distribution_targets: Vec<DistributionTarget>,
+    active_mask: Option<Arc<AtomicU8>>,
+}
+
+impl std::fmt::Debug for ShardWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShardWorker")
+            .field("mode", &self.mode)
+            .field("lossy", &self.lossy)
+            .field("peers", &self.peers.len())
+            .field("distribution_targets", &self.distribution_targets.len())
+            .finish_non_exhaustive()
+    }
 }
 
 #[cfg(feature = "lz4")]
@@ -227,25 +261,78 @@ impl Clone for Submitter {
 }
 
 impl FanOutShards {
-    fn spawn(options: &Options, mode: FanOutMode) -> Arc<Self> {
+    fn spawn(
+        options: &Options,
+        mode: FanOutMode,
+        io_pool: &crate::context::IoPoolHandle,
+    ) -> Arc<Self> {
         let pipe_cap = options.send_hwm.unwrap_or(1000).max(16) as usize;
-        let runtime_workers = tokio::runtime::Handle::current()
-            .metrics()
-            .num_workers()
-            .max(1);
+        let worker_shards = Self::worker_shard_count(io_pool.thread_count());
         let lossy = fan_out_is_lossy(options);
-        let worker_shards = Self::worker_shard_count(runtime_workers);
+        let active_mask = Arc::new(AtomicU8::new(0));
+
+        // Create all channels up front.
+        let mut data_channels: Vec<_> = (0..worker_shards)
+            .map(|_| {
+                let (tx, rx) = yring::spsc(pipe_cap);
+                let sig = Arc::new(DataSignal::new());
+                (tx, rx, sig)
+            })
+            .collect();
+        let mut ctrl_channels: Vec<_> = (0..worker_shards)
+            .map(|_| {
+                let (tx, rx) = yring::spsc(SHARD_CTRL_RING_CAP);
+                let notify = Arc::new(Notify::new());
+                (tx, rx, notify)
+            })
+            .collect();
+
+        // Channel 0 (shard 1): data Producer goes into the distributor
+        // endpoint. Channels 1..N-1 (shards 2..N): data Producers go
+        // into distribution targets owned by shard worker 1.
+        let (dist_tx, dist_rx, dist_signal) = data_channels.remove(0);
+        let distributor = DistributorEndpoint {
+            data_tx: dist_tx,
+            data_signal: Arc::clone(&dist_signal),
+        };
+
+        let mut distribution_targets: Vec<DistributionTarget> =
+            Vec::with_capacity(data_channels.len());
+        let mut secondary_data: Vec<(yring::Consumer<ShardDispatch>, Arc<DataSignal>)> =
+            Vec::with_capacity(data_channels.len());
+        for (tx, rx, sig) in data_channels {
+            distribution_targets.push(DistributionTarget {
+                data_tx: tx,
+                data_signal: Arc::clone(&sig),
+            });
+            secondary_data.push((rx, sig));
+        }
+
+        // Build endpoints (ctrl only) and spawn workers.
+        let mut dist_rx = Some(dist_rx);
+        let mut dist_signal = Some(dist_signal);
         let mut endpoints = Vec::with_capacity(worker_shards);
-        for _ in 0..worker_shards {
-            let (data_tx, data_rx) = yring::spsc(pipe_cap);
-            let (ctrl_tx, ctrl_rx) = yring::spsc(SHARD_CTRL_RING_CAP);
-            let data_signal = Arc::new(DataSignal::new());
-            let ctrl_notify = Arc::new(Notify::new());
-            tokio::spawn(
+        for i in 0..worker_shards {
+            let (ctrl_tx, ctrl_rx, ctrl_notify) = ctrl_channels.remove(0);
+
+            let (data_rx, data_signal, dist_targets, mask) = if i == 0 {
+                (
+                    dist_rx.take().expect("shard 0 data_rx"),
+                    dist_signal.take().expect("shard 0 data_signal"),
+                    std::mem::take(&mut distribution_targets),
+                    Some(Arc::clone(&active_mask)),
+                )
+            } else {
+                let (rx, sig) = secondary_data.remove(0);
+                (rx, sig, Vec::new(), None)
+            };
+
+            io_pool.spawn_on(
+                i,
                 ShardWorker {
                     data_rx,
                     ctrl_rx,
-                    data_signal: data_signal.clone(),
+                    data_signal,
                     ctrl_notify: ctrl_notify.clone(),
                     mode,
                     lossy,
@@ -254,13 +341,13 @@ impl FanOutShards {
                     chunks: Vec::new(),
                     #[cfg(feature = "lz4")]
                     encoder: None,
+                    distribution_targets: dist_targets,
+                    active_mask: mask,
                 }
                 .run(),
             );
             endpoints.push(ShardEndpoint {
-                data_tx,
                 ctrl_tx,
-                data_signal,
                 ctrl_notify,
                 load: 0,
             });
@@ -271,7 +358,8 @@ impl FanOutShards {
                 eligible_peers: 0,
                 active_limit: 0,
             }),
-            active_mask: AtomicU8::new(0),
+            active_mask,
+            distributor: Mutex::new(distributor),
         })
     }
 
@@ -313,17 +401,6 @@ impl FanOutShards {
     }
 
     fn push_control(endpoint: &mut ShardEndpoint, cmd: ShardControl) {
-        #[cfg(feature = "rt-multi-thread")]
-        if let Ok(handle) = tokio::runtime::Handle::try_current()
-            && matches!(
-                handle.runtime_flavor(),
-                tokio::runtime::RuntimeFlavor::MultiThread
-            )
-        {
-            tokio::task::block_in_place(|| Self::push_control_spinning(endpoint, cmd));
-            return;
-        }
-
         Self::push_control_spinning(endpoint, cmd);
     }
 
@@ -395,30 +472,13 @@ impl FanOutShards {
         }
     }
 
-    /// Push a raw message to every active shard's data ring. If a
-    /// shard's ring is full, the message is silently dropped for that
-    /// shard's peer set.
+    /// Push a raw message into shard 1's data ring. Shard worker 1
+    /// distributes to secondary shards in batches.
     fn dispatch(&self, dispatch: &ShardDispatch) {
-        let mask = self.active_mask.load(Ordering::Acquire);
-        if mask == 0 {
-            return;
-        }
-        let mut state = self.state.lock().expect("fanout shards poisoned");
-        let mut touched = SmallVec::<[usize; 8]>::new();
-        let mut m = mask;
-        while m != 0 {
-            let idx = m.trailing_zeros() as usize;
-            m &= m - 1;
-            if let Some(endpoint) = state.endpoints.get_mut(idx)
-                && endpoint.data_tx.push(dispatch.clone()).is_ok()
-            {
-                touched.push(idx);
-            }
-        }
-        for idx in touched {
-            let endpoint = &mut state.endpoints[idx];
-            endpoint.data_tx.flush();
-            endpoint.data_signal.mark();
+        let mut dist = self.distributor.lock().expect("distributor poisoned");
+        if dist.data_tx.push(dispatch.clone()).is_ok() {
+            dist.data_tx.flush();
+            dist.data_signal.mark();
         }
     }
 
@@ -434,12 +494,17 @@ impl FanOutShards {
     }
 
     fn is_empty(&self) -> bool {
-        self.state
-            .lock()
-            .expect("fanout shards poisoned")
-            .endpoints
-            .iter()
-            .all(|endpoint| endpoint.data_tx.is_empty() && endpoint.ctrl_tx.is_empty())
+        let dist = self.distributor.lock().expect("distributor poisoned");
+        let dist_empty = dist.data_tx.is_empty();
+        drop(dist);
+        dist_empty
+            && self
+                .state
+                .lock()
+                .expect("fanout shards poisoned")
+                .endpoints
+                .iter()
+                .all(|endpoint| endpoint.ctrl_tx.is_empty())
     }
 }
 
@@ -471,19 +536,44 @@ impl ShardWorker {
                 return;
             }
 
-            // 2. Data up to budget.
+            // 2. Data up to budget. The distributor shard drains into
+            //    a batch, distributes to secondary shards FIRST (so
+            //    they can start encoding in parallel), then processes
+            //    its own peers.
             budget.reset();
             let mut drained = false;
-            self.data_rx.prefetch();
-            while let Some(dispatch) = self.data_rx.pop() {
-                drained = true;
-                let msg_bytes = dispatch.msg.byte_len();
-                self.dispatch(&dispatch, &mut touched).await;
-                if !budget.account(msg_bytes) {
-                    break;
+            let is_distributor = !self.distribution_targets.is_empty();
+            if is_distributor {
+                let mut batch: SmallVec<[ShardDispatch; 32]> = SmallVec::new();
+                self.data_rx.prefetch();
+                while let Some(dispatch) = self.data_rx.pop() {
+                    drained = true;
+                    if !budget.account(dispatch.msg.byte_len()) {
+                        batch.push(dispatch);
+                        break;
+                    }
+                    batch.push(dispatch);
                 }
+                self.data_rx.release();
+
+                if !batch.is_empty() {
+                    self.distribute_batch(&batch);
+                    for dispatch in &batch {
+                        self.dispatch(dispatch, &mut touched).await;
+                    }
+                }
+            } else {
+                self.data_rx.prefetch();
+                while let Some(dispatch) = self.data_rx.pop() {
+                    drained = true;
+                    let msg_bytes = dispatch.msg.byte_len();
+                    self.dispatch(&dispatch, &mut touched).await;
+                    if !budget.account(msg_bytes) {
+                        break;
+                    }
+                }
+                self.data_rx.release();
             }
-            self.data_rx.release();
 
             self.flush_touched(&mut touched);
             if drained {
@@ -496,6 +586,24 @@ impl ShardWorker {
                 () = self.ctrl_notify.notified() => {}
                 () = self.data_signal.notified() => {}
             }
+        }
+    }
+
+    fn distribute_batch(&mut self, batch: &[ShardDispatch]) {
+        let Some(ref active_mask) = self.active_mask else {
+            return;
+        };
+        let mask = active_mask.load(Ordering::Acquire);
+        for (i, target) in self.distribution_targets.iter_mut().enumerate() {
+            // targets[0] = shard 2 (bit 1), targets[1] = shard 3 (bit 2), ...
+            if mask & (1 << (i + 1)) == 0 {
+                continue;
+            }
+            for dispatch in batch {
+                let _ = target.data_tx.push(dispatch.clone());
+            }
+            target.data_tx.flush();
+            target.data_signal.mark();
         }
     }
 
@@ -1000,8 +1108,12 @@ impl FanOutInner {
 }
 
 impl FanOutSend {
-    pub(crate) fn new(options: &Options, mode: FanOutMode) -> Self {
-        let shards = Some(FanOutShards::spawn(options, mode));
+    pub(crate) fn new(
+        options: &Options,
+        mode: FanOutMode,
+        io_pool: &crate::context::IoPoolHandle,
+    ) -> Self {
+        let shards = Some(FanOutShards::spawn(options, mode, io_pool));
         let inner = Arc::new(Mutex::new(FanOutInner {
             peers: FxHashMap::default(),
             all_subscribe_all: false,
@@ -1419,14 +1531,14 @@ fn first_frame_bytes(msg: &Message) -> Bytes {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use std::sync::atomic::AtomicU8;
+    use std::sync::{Arc, Mutex};
 
     use tokio::sync::Notify;
 
     use super::{
-        FanOutShardState, FanOutShards, MAX_FAN_OUT_WORKER_SHARDS, ShardEndpoint,
-        WORKER_SHARD_PEER_CAP, yield_interval,
+        DistributorEndpoint, FanOutShardState, FanOutShards, MAX_FAN_OUT_WORKER_SHARDS,
+        ShardDispatch, ShardEndpoint, WORKER_SHARD_PEER_CAP, yield_interval,
     };
 
     const TEST_MAX_LOGICAL_SHARDS: usize = MAX_FAN_OUT_WORKER_SHARDS + 1;
@@ -1519,7 +1631,8 @@ mod tests {
                 eligible_peers: 0,
                 active_limit: 0,
             }),
-            active_mask: AtomicU8::new(0),
+            active_mask: Arc::new(AtomicU8::new(0)),
+            distributor: test_distributor(),
         };
 
         let assigned: Vec<_> = (0..WORKER_SHARD_PEER_CAP)
@@ -1539,7 +1652,8 @@ mod tests {
                 eligible_peers: 0,
                 active_limit: 0,
             }),
-            active_mask: AtomicU8::new(0),
+            active_mask: Arc::new(AtomicU8::new(0)),
+            distributor: test_distributor(),
         };
 
         let mut loads = [0usize; WORKER_SHARD_PEER_CAP + 1];
@@ -1559,14 +1673,19 @@ mod tests {
     }
 
     fn test_endpoint() -> ShardEndpoint {
-        let (data_tx, _data_rx) = yring::spsc(4);
         let (ctrl_tx, _ctrl_rx) = yring::spsc(4);
         ShardEndpoint {
-            data_tx,
             ctrl_tx,
-            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
             ctrl_notify: Arc::new(Notify::new()),
             load: 0,
         }
+    }
+
+    fn test_distributor() -> Mutex<DistributorEndpoint> {
+        let (data_tx, _data_rx) = yring::spsc::<ShardDispatch>(4);
+        Mutex::new(DistributorEndpoint {
+            data_tx,
+            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
+        })
     }
 }

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -20,10 +20,13 @@ use rustc_hash::FxHashMap;
 
 use bytes::Bytes;
 
+use crate::engine::transmit_slot::TryFrameResult;
 use crate::engine::{PeerDriverCommand, PeerDriverHandle, SendPipeError, SendPipeProducer};
-use omq_proto::error::{Error, Result};
+use crate::routing::peer_outbound::PeerOutbound;
+use omq_proto::error::{Error, Result, TrySendError};
 use omq_proto::message::Message;
 use omq_proto::options::Options;
+use omq_proto::proto::SocketType;
 
 enum SendRetry {
     Full(Message, Arc<Notify>),
@@ -34,13 +37,21 @@ enum SendRetry {
 #[derive(Debug)]
 enum PeerTarget {
     Pipe(SendPipeProducer),
+    RepInproc(SendPipeProducer),
+    Direct(PeerOutbound),
     Inbox(tokio::sync::mpsc::Sender<PeerDriverCommand>),
 }
 
 impl PeerTarget {
     fn try_send(&mut self, msg: Message) -> core::result::Result<(), SendPipeError> {
         match self {
-            Self::Pipe(p) => p.try_send(msg),
+            Self::Pipe(p) | Self::RepInproc(p) => p.try_send(msg),
+            Self::Direct(target) => match target.try_encode(&msg) {
+                TryFrameResult::Ok => Ok(()),
+                TryFrameResult::Full => Err(SendPipeError::Full(msg)),
+                TryFrameResult::Dead => Err(SendPipeError::Closed(msg)),
+                TryFrameResult::Ineligible => unreachable!("direct target handles ineligible"),
+            },
             Self::Inbox(tx) => match tx.try_send(PeerDriverCommand::SendMessage(msg)) {
                 Ok(()) => Ok(()),
                 Err(tokio::sync::mpsc::error::TrySendError::Full(
@@ -53,14 +64,55 @@ impl PeerTarget {
 
     fn space_available(&self) -> Option<Arc<Notify>> {
         match self {
-            Self::Pipe(p) => Some(p.space_available()),
+            Self::Pipe(p) | Self::RepInproc(p) => Some(p.space_available()),
+            Self::Direct(target) => target.space_available(),
             Self::Inbox(_) => None,
+        }
+    }
+
+    pub(crate) fn try_send_rep(
+        &mut self,
+        identity: &Bytes,
+        msg: Message,
+    ) -> core::result::Result<(), SendPipeError> {
+        match self {
+            Self::Direct(target) => match target.try_encode_rep(identity, &msg) {
+                TryFrameResult::Ok => Ok(()),
+                TryFrameResult::Full => Err(SendPipeError::Full(msg)),
+                TryFrameResult::Dead => Err(SendPipeError::Closed(msg)),
+                TryFrameResult::Ineligible => unreachable!(),
+            },
+            Self::Pipe(p) => {
+                let wrapped =
+                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg));
+                p.try_send(wrapped)
+            }
+            Self::RepInproc(p) => {
+                let msg = if identity.is_empty() {
+                    Message::with_prefix(Bytes::new(), msg)
+                } else {
+                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg))
+                };
+                p.try_send(msg)
+            }
+            Self::Inbox(tx) => {
+                let wrapped =
+                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg));
+                match tx.try_send(PeerDriverCommand::SendMessage(wrapped)) {
+                    Ok(()) => Ok(()),
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(
+                        PeerDriverCommand::SendMessage(m),
+                    )) => Err(SendPipeError::Full(m)),
+                    Err(_) => Err(SendPipeError::Closed(Message::default())),
+                }
+            }
         }
     }
 
     fn is_empty(&self) -> bool {
         match self {
-            Self::Pipe(p) => p.is_empty(),
+            Self::Pipe(p) | Self::RepInproc(p) => p.is_empty(),
+            Self::Direct(target) => target.is_empty(),
             Self::Inbox(_) => true,
         }
     }
@@ -133,6 +185,41 @@ impl Submitter {
         }
     }
 
+    pub(crate) async fn send_rep(
+        &self,
+        peer_id: u64,
+        identity: &Bytes,
+        mut msg: Message,
+    ) -> Result<()> {
+        loop {
+            match self.try_send_rep(peer_id, identity, msg) {
+                Ok(()) => return Ok(()),
+                Err(TrySendError::Full(returned)) => msg = returned,
+                Err(TrySendError::Error(error)) => return Err(error),
+                Err(TrySendError::Closed) => return Err(Error::Closed),
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    pub(crate) fn try_send_rep(
+        &self,
+        peer_id: u64,
+        identity: &Bytes,
+        msg: Message,
+    ) -> core::result::Result<(), TrySendError> {
+        let mut g = self.inner.lock().expect("identity inner poisoned");
+        let Some(peer) = g.peers.get_mut(&peer_id) else {
+            return Err(TrySendError::Error(Error::Unroutable));
+        };
+        peer.target
+            .try_send_rep(identity, msg)
+            .map_err(|e| match e {
+                SendPipeError::Full(m) => TrySendError::Full(m),
+                SendPipeError::Closed(_) => TrySendError::Closed,
+            })
+    }
+
     fn try_send_to(
         &self,
         identity: &Bytes,
@@ -169,6 +256,8 @@ impl Submitter {
 pub(crate) struct IdentitySend {
     inner: Arc<Mutex<IdentityInner>>,
     router_mandatory: bool,
+    latency_profile: bool,
+    rep_latency: bool,
 }
 
 #[derive(Debug)]
@@ -184,13 +273,24 @@ struct IdentityPeer {
 }
 
 impl IdentitySend {
-    pub(crate) fn new(options: &Options) -> Self {
+    pub(crate) fn new(socket_type: SocketType, options: &Options) -> Self {
+        let latency_profile =
+            options
+                .workload_profile
+                .unwrap_or(if socket_type == SocketType::Rep {
+                    omq_proto::WorkloadProfile::Latency
+                } else {
+                    omq_proto::WorkloadProfile::Throughput
+                })
+                == omq_proto::WorkloadProfile::Latency;
         Self {
             inner: Arc::new(Mutex::new(IdentityInner {
                 peers: FxHashMap::default(),
                 identity_to_peer: FxHashMap::default(),
             })),
             router_mandatory: options.router_mandatory,
+            latency_profile,
+            rep_latency: socket_type == SocketType::Rep && latency_profile,
         }
     }
 
@@ -207,10 +307,17 @@ impl IdentitySend {
         peer_id: u64,
         handle: PeerDriverHandle,
         identity: Bytes,
+        is_inproc: bool,
     ) {
-        let target = if let Some(ref pipe_handle) = handle.send_pipe {
+        let target = if self.latency_profile {
+            PeerTarget::Direct(PeerOutbound::from_handle(&handle))
+        } else if let Some(ref pipe_handle) = handle.send_pipe {
             if let Some(pipe) = pipe_handle.lock().expect("identity send pipe").take() {
-                PeerTarget::Pipe(pipe)
+                if self.rep_latency && is_inproc {
+                    PeerTarget::RepInproc(pipe)
+                } else {
+                    PeerTarget::Pipe(pipe)
+                }
             } else {
                 PeerTarget::Inbox(handle.inbox.clone())
             }
@@ -303,7 +410,8 @@ mod tests {
 
     #[test]
     fn try_send_reports_full_and_preserves_routing_frame() {
-        let mut send = IdentitySend::new(&Options::default());
+        let options = Options::default().workload_profile(omq_proto::WorkloadProfile::Throughput);
+        let mut send = IdentitySend::new(SocketType::Rep, &options);
         let submitter = send.submitter();
 
         let (pipe_tx, _pipe_rx) = send_pipe(1);
@@ -311,9 +419,10 @@ mod tests {
             inbox: tokio::sync::mpsc::channel(1).0,
             cancel: tokio_util::sync::CancellationToken::new(),
             transmit_slot: None,
+            direct_tcp_writer: None,
             send_pipe: Some(std::sync::Arc::new(std::sync::Mutex::new(Some(pipe_tx)))),
         };
-        send.connection_added(1, handle, Bytes::from_static(b"id"));
+        send.connection_added(1, handle, Bytes::from_static(b"id"), false);
 
         submitter
             .try_send(Message::multipart([

--- a/omq-tokio/src/routing/latency.rs
+++ b/omq-tokio/src/routing/latency.rs
@@ -1,0 +1,187 @@
+//! Low-latency send routing for request/reply ping-pong.
+//!
+//! This route encodes directly into each peer's transmit slot. It avoids the
+//! generic yring send pipe, which is the right tradeoff for one-message-at-a-
+//! time REQ/REP but not for throughput-oriented routing.
+
+use std::sync::{Arc, Mutex};
+
+use crate::engine::PeerDriverHandle;
+use crate::engine::transmit_slot::TryFrameResult;
+use crate::routing::fallback_queue::{FallbackQueue, FallbackReceiver};
+use crate::routing::peer_outbound::PeerOutbound;
+use omq_proto::error::{Error, Result, TrySendError};
+use omq_proto::message::Message;
+use omq_proto::options::Options;
+
+#[derive(Debug)]
+struct Peer {
+    id: u64,
+    target: PeerOutbound,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    peers: Vec<Peer>,
+    cursor: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct LatencySend {
+    queue: FallbackQueue,
+    shared_rx: FallbackReceiver,
+    state: Arc<Mutex<State>>,
+    peer_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Submitter {
+    queue: FallbackQueue,
+    state: Arc<Mutex<State>>,
+}
+
+impl LatencySend {
+    pub(crate) fn new(options: &Options) -> Self {
+        let (cap, policy) = super::effective_queue_params(options);
+        let (queue, shared_rx) = FallbackQueue::new(cap, policy);
+        Self {
+            queue,
+            shared_rx,
+            state: Arc::new(Mutex::new(State::default())),
+            peer_count: 0,
+        }
+    }
+
+    pub(crate) fn submitter(&self) -> Submitter {
+        Submitter {
+            queue: self.queue.clone(),
+            state: self.state.clone(),
+        }
+    }
+
+    pub(crate) fn shared_rx(&self) -> FallbackReceiver {
+        self.shared_rx.clone()
+    }
+
+    pub(crate) fn connection_added(&mut self, peer_id: u64, handle: &PeerDriverHandle) {
+        self.peer_count += 1;
+        self.shared_rx.set_peer_count(self.peer_count);
+        let mut state = self.state.lock().expect("latency send state");
+        state.peers.retain(|peer| peer.id != peer_id);
+        state.peers.push(Peer {
+            id: peer_id,
+            target: PeerOutbound::from_handle(handle),
+        });
+        state.cursor %= state.peers.len();
+    }
+
+    pub(crate) fn connection_removed(&mut self, peer_id: u64) {
+        self.peer_count = self.peer_count.saturating_sub(1);
+        self.shared_rx.set_peer_count(self.peer_count);
+        let mut state = self.state.lock().expect("latency send state");
+        state.peers.retain(|peer| peer.id != peer_id);
+        if state.peers.is_empty() {
+            state.cursor = 0;
+        } else {
+            state.cursor %= state.peers.len();
+        }
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.queue.shutdown();
+        self.state.lock().expect("latency send state").peers.clear();
+    }
+
+    pub(crate) fn is_drained(&self) -> bool {
+        self.queue.len() == 0
+            && self
+                .state
+                .lock()
+                .expect("latency send state")
+                .peers
+                .iter()
+                .all(|peer| peer.target.is_empty())
+    }
+}
+
+impl Submitter {
+    pub(crate) fn shutdown(&self) {
+        self.queue.shutdown();
+        self.state.lock().expect("latency send state").peers.clear();
+    }
+
+    pub(crate) async fn send(&self, mut msg: Message) -> Result<()> {
+        loop {
+            match self.try_send(msg) {
+                Ok(()) => return Ok(()),
+                Err(TrySendError::Full(returned)) => msg = returned,
+                Err(TrySendError::Error(error)) => return Err(error),
+                Err(TrySendError::Closed) => return Err(Error::Closed),
+            }
+
+            let notified = {
+                let state = self.state.lock().expect("latency send state");
+                if state
+                    .peers
+                    .iter()
+                    .any(|peer| peer.target.has_direct_writer())
+                {
+                    None
+                } else {
+                    state
+                        .peers
+                        .iter()
+                        .find_map(|peer| peer.target.space_available())
+                }
+            };
+            let Some(notified) = notified else {
+                tokio::task::yield_now().await;
+                match self.try_send(msg) {
+                    Ok(()) => return Ok(()),
+                    Err(TrySendError::Full(msg)) => return self.queue.send(msg).await,
+                    Err(TrySendError::Error(error)) => return Err(error),
+                    Err(TrySendError::Closed) => return Err(Error::Closed),
+                }
+            };
+            let notified = notified.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            match self.try_send(msg) {
+                Ok(()) => return Ok(()),
+                Err(TrySendError::Full(returned)) => msg = returned,
+                Err(TrySendError::Error(error)) => return Err(error),
+                Err(TrySendError::Closed) => return Err(Error::Closed),
+            }
+            notified.await;
+        }
+    }
+
+    pub(crate) fn try_send(&self, msg: Message) -> core::result::Result<(), TrySendError> {
+        if self.queue.len() != 0 {
+            return self.queue.try_send(msg).map_err(TrySendError::Full);
+        }
+
+        let mut state = self.state.lock().expect("latency send state");
+        if state.peers.is_empty() {
+            return self.queue.try_send(msg).map_err(TrySendError::Full);
+        }
+
+        let mut full = false;
+        let count = state.peers.len();
+        for _ in 0..count {
+            let index = state.cursor % count;
+            state.cursor = (index + 1) % count;
+            match state.peers[index].target.try_encode(&msg) {
+                TryFrameResult::Ok => return Ok(()),
+                TryFrameResult::Full => full = true,
+                TryFrameResult::Dead => return Err(TrySendError::Closed),
+                TryFrameResult::Ineligible => unreachable!("inbox fallback handles ineligible"),
+            }
+        }
+        if full {
+            Err(TrySendError::Full(msg))
+        } else {
+            Err(TrySendError::Closed)
+        }
+    }
+}

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod fair_queue;
 pub(crate) mod fallback_queue;
 pub(crate) mod fan_out;
 pub(crate) mod identity;
+pub(crate) mod latency;
 pub(crate) mod peer_outbound;
 pub(crate) mod round_robin;
 // subscription matcher lives in omq-proto now.
@@ -45,6 +46,7 @@ pub(crate) use exclusive::{ExclusiveSend, Submitter as ExclusiveSubmitter};
 pub(crate) use fair_queue::FairQueueRecv;
 pub(crate) use fan_out::{FanOutMode, FanOutSend, Submitter as FanOutSubmitter};
 pub(crate) use identity::{IdentityRecv, IdentitySend, Submitter as IdentitySubmitter};
+pub(crate) use latency::{LatencySend, Submitter as LatencySubmitter};
 pub(crate) use round_robin::{RoundRobinSend, Submitter as RoundRobinSubmitter};
 
 /// Send-side policy.
@@ -52,6 +54,7 @@ pub(crate) use round_robin::{RoundRobinSend, Submitter as RoundRobinSubmitter};
 pub(crate) enum SendStrategy {
     None,
     RoundRobin(RoundRobinSend),
+    Latency(LatencySend),
     Exclusive(ExclusiveSend),
     FanOut(FanOutSend),
     Identity(IdentitySend),
@@ -61,6 +64,7 @@ pub(crate) enum SendStrategy {
 pub(crate) enum SendSubmitter {
     None,
     RoundRobin(RoundRobinSubmitter),
+    Latency(LatencySubmitter),
     Exclusive(ExclusiveSubmitter),
     FanOut(FanOutSubmitter),
     Identity(IdentitySubmitter),
@@ -71,6 +75,7 @@ impl SendSubmitter {
         match self {
             Self::None => {}
             Self::RoundRobin(s) => s.shutdown(),
+            Self::Latency(s) => s.shutdown(),
             Self::Exclusive(s) => s.shutdown(),
             Self::FanOut(s) => s.shutdown(),
             Self::Identity(s) => s.shutdown(),
@@ -81,9 +86,36 @@ impl SendSubmitter {
         match self {
             Self::None => Err(Error::Protocol("socket type does not support send".into())),
             Self::RoundRobin(s) => s.send(msg).await,
+            Self::Latency(s) => s.send(msg).await,
             Self::Exclusive(s) => s.send(msg).await,
             Self::FanOut(s) => s.send(msg).await,
             Self::Identity(s) => s.send(msg).await,
+        }
+    }
+
+    pub(crate) async fn send_rep_to_peer(
+        &self,
+        peer_id: u64,
+        identity: &Bytes,
+        msg: Message,
+    ) -> Result<()> {
+        match self {
+            Self::Identity(s) => s.send_rep(peer_id, identity, msg).await,
+            _ => Err(Error::Protocol("REP latency route unavailable".into())),
+        }
+    }
+
+    pub(crate) fn send_rep_try_to_peer(
+        &self,
+        peer_id: u64,
+        identity: &Bytes,
+        msg: Message,
+    ) -> core::result::Result<(), omq_proto::error::TrySendError> {
+        match self {
+            Self::Identity(s) => s.try_send_rep(peer_id, identity, msg),
+            _ => Err(omq_proto::error::TrySendError::Error(Error::Protocol(
+                "REP latency route unavailable".into(),
+            ))),
         }
     }
 
@@ -96,6 +128,7 @@ impl SendSubmitter {
                 "socket type does not support send".into(),
             ))),
             Self::RoundRobin(s) => s.try_send(msg),
+            Self::Latency(s) => s.try_send(msg),
             Self::Exclusive(s) => s.try_send(msg),
             Self::FanOut(s) => s.try_send(msg),
             Self::Identity(s) => s.try_send(msg),
@@ -104,16 +137,36 @@ impl SendSubmitter {
 }
 
 impl SendStrategy {
-    pub(crate) fn for_socket_type(t: SocketType, options: &Options) -> Self {
+    pub(crate) fn for_socket_type(
+        t: SocketType,
+        options: &Options,
+        io_pool: &crate::context::IoPoolHandle,
+    ) -> Self {
         match send_category(t) {
             SendCategory::None => Self::None,
-            SendCategory::FanOut(FanOutKind::SubscriptionPrefix) => {
-                Self::FanOut(FanOutSend::new(options, FanOutMode::SubscriptionPrefix))
-            }
+            SendCategory::FanOut(FanOutKind::SubscriptionPrefix) => Self::FanOut(FanOutSend::new(
+                options,
+                FanOutMode::SubscriptionPrefix,
+                io_pool,
+            )),
             SendCategory::FanOut(FanOutKind::Group) => {
-                Self::FanOut(FanOutSend::new(options, FanOutMode::Group))
+                Self::FanOut(FanOutSend::new(options, FanOutMode::Group, io_pool))
             }
-            SendCategory::IdentityRouted => Self::Identity(IdentitySend::new(options)),
+            SendCategory::IdentityRouted => Self::Identity(IdentitySend::new(t, options)),
+            SendCategory::RoundRobin
+                if t == SocketType::Req
+                    && !options.mechanism.has_frame_transform()
+                    && options.workload_profile != Some(omq_proto::WorkloadProfile::Throughput) =>
+            {
+                Self::Latency(LatencySend::new(options))
+            }
+            SendCategory::RoundRobin
+                if t == SocketType::Rep
+                    && !options.mechanism.has_frame_transform()
+                    && options.workload_profile != Some(omq_proto::WorkloadProfile::Throughput) =>
+            {
+                Self::Identity(IdentitySend::new(t, options))
+            }
             SendCategory::RoundRobin => Self::RoundRobin(RoundRobinSend::new(options)),
             SendCategory::Exclusive => Self::Exclusive(ExclusiveSend::new()),
         }
@@ -123,6 +176,7 @@ impl SendStrategy {
         match self {
             Self::None => SendSubmitter::None,
             Self::RoundRobin(s) => SendSubmitter::RoundRobin(s.submitter()),
+            Self::Latency(s) => SendSubmitter::Latency(s.submitter()),
             Self::Exclusive(s) => SendSubmitter::Exclusive(s.submitter()),
             Self::FanOut(s) => SendSubmitter::FanOut(s.submitter()),
             Self::Identity(s) => SendSubmitter::Identity(s.submitter()),
@@ -139,9 +193,10 @@ impl SendStrategy {
         match self {
             Self::None => {}
             Self::RoundRobin(s) => s.connection_added(peer_id, &handle, is_inproc),
+            Self::Latency(s) => s.connection_added(peer_id, &handle),
             Self::Exclusive(s) => s.connection_added(peer_id, handle),
             Self::FanOut(s) => s.connection_added(peer_id, handle),
-            Self::Identity(s) => s.connection_added(peer_id, handle, peer_identity),
+            Self::Identity(s) => s.connection_added(peer_id, handle, peer_identity, is_inproc),
         }
     }
 
@@ -158,6 +213,7 @@ impl SendStrategy {
         match self {
             Self::None => {}
             Self::RoundRobin(s) => s.connection_removed(peer_id),
+            Self::Latency(s) => s.connection_removed(peer_id),
             Self::Exclusive(s) => s.connection_removed(peer_id),
             Self::FanOut(s) => s.connection_removed(peer_id),
             Self::Identity(s) => s.connection_removed(peer_id),
@@ -206,6 +262,7 @@ impl SendStrategy {
     pub(crate) fn shared_rx(&self) -> Option<fallback_queue::FallbackReceiver> {
         match self {
             Self::RoundRobin(s) => Some(s.shared_rx()),
+            Self::Latency(s) => Some(s.shared_rx()),
             _ => None,
         }
     }
@@ -214,6 +271,7 @@ impl SendStrategy {
         match self {
             Self::None => {}
             Self::RoundRobin(s) => s.shutdown(),
+            Self::Latency(s) => s.shutdown(),
             Self::Exclusive(s) => s.shutdown(),
             Self::FanOut(s) => s.shutdown(),
             Self::Identity(s) => s.shutdown(),
@@ -224,6 +282,7 @@ impl SendStrategy {
         match self {
             Self::None => true,
             Self::RoundRobin(s) => s.is_drained(),
+            Self::Latency(s) => s.is_drained(),
             Self::Exclusive(s) => s.is_drained(),
             Self::FanOut(s) => s.is_drained(),
             Self::Identity(s) => s.is_drained(),

--- a/omq-tokio/src/routing/peer_outbound.rs
+++ b/omq-tokio/src/routing/peer_outbound.rs
@@ -1,4 +1,6 @@
+use bytes::Bytes;
 use std::sync::Arc;
+use tokio::sync::Notify;
 
 use crate::engine::transmit_slot::{PeerTransmitSlot, TryFrameResult};
 use crate::engine::{PeerDriverCommand, PeerDriverHandle};
@@ -9,6 +11,7 @@ pub(crate) enum PeerOutbound {
     Wire {
         slot: Arc<PeerTransmitSlot>,
         inbox: tokio::sync::mpsc::Sender<PeerDriverCommand>,
+        direct: Option<Arc<crate::socket::dispatch::DirectTcpWriter>>,
     },
     Inbox(tokio::sync::mpsc::Sender<PeerDriverCommand>),
 }
@@ -19,6 +22,7 @@ impl PeerOutbound {
             Some(ref slot) => Self::Wire {
                 slot: slot.clone(),
                 inbox: handle.inbox.clone(),
+                direct: handle.direct_tcp_writer.clone(),
             },
             None => Self::Inbox(handle.inbox.clone()),
         }
@@ -26,9 +30,13 @@ impl PeerOutbound {
 
     pub(crate) fn try_encode(&self, msg: &Message) -> TryFrameResult {
         match self {
-            Self::Wire { slot, inbox } => match slot.try_encode(msg) {
-                TryFrameResult::Ineligible => {
-                    match inbox.try_send(PeerDriverCommand::SendMessage(msg.clone())) {
+            Self::Wire {
+                slot,
+                inbox,
+                direct,
+            } => {
+                if direct.is_none() {
+                    return match inbox.try_send(PeerDriverCommand::SendMessage(msg.clone())) {
                         Ok(()) => TryFrameResult::Ok,
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                             TryFrameResult::Full
@@ -36,15 +44,101 @@ impl PeerOutbound {
                         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                             TryFrameResult::Dead
                         }
-                    }
+                    };
                 }
-                other => other,
-            },
+                match slot.try_encode(msg) {
+                    TryFrameResult::Ineligible => {
+                        match inbox.try_send(PeerDriverCommand::SendMessage(msg.clone())) {
+                            Ok(()) => TryFrameResult::Ok,
+                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                                TryFrameResult::Full
+                            }
+                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                TryFrameResult::Dead
+                            }
+                        }
+                    }
+                    TryFrameResult::Ok if direct.is_some() => {
+                        let direct = direct.as_ref().unwrap();
+                        match direct
+                            .try_write_buffer(|buf| slot.try_drain_arena_only(buf).is_some())
+                        {
+                            // External frame entries remain queued for the IO
+                            // driver; false does not mean the slot was full.
+                            Ok(true | false) => TryFrameResult::Ok,
+                            Err(_) => TryFrameResult::Dead,
+                        }
+                    }
+                    other => other,
+                }
+            }
             Self::Inbox(tx) => match tx.try_send(PeerDriverCommand::SendMessage(msg.clone())) {
                 Ok(()) => TryFrameResult::Ok,
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => TryFrameResult::Full,
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => TryFrameResult::Dead,
             },
+        }
+    }
+
+    pub(crate) fn try_encode_rep(&self, identity: &Bytes, msg: &Message) -> TryFrameResult {
+        match self {
+            Self::Wire {
+                slot,
+                inbox,
+                direct,
+            } => {
+                if direct.is_none() {
+                    let wrapped = Message::with_prefix(Bytes::new(), msg.clone());
+                    return match inbox.try_send(PeerDriverCommand::SendMessage(wrapped)) {
+                        Ok(()) => TryFrameResult::Ok,
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            TryFrameResult::Full
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            TryFrameResult::Dead
+                        }
+                    };
+                }
+                match slot.try_encode_rep(identity, msg) {
+                    TryFrameResult::Ineligible => {
+                        // This target is already bound to the selected peer;
+                        // identity is routing metadata, never a wire frame.
+                        let wrapped = Message::with_prefix(Bytes::new(), msg.clone());
+                        match inbox.try_send(PeerDriverCommand::SendMessage(wrapped)) {
+                            Ok(()) => TryFrameResult::Ok,
+                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                                TryFrameResult::Full
+                            }
+                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                TryFrameResult::Dead
+                            }
+                        }
+                    }
+                    TryFrameResult::Ok if direct.is_some() => {
+                        let direct = direct.as_ref().unwrap();
+                        match direct
+                            .try_write_buffer(|buf| slot.try_drain_arena_only(buf).is_some())
+                        {
+                            // External frame entries remain queued for the IO
+                            // driver; false does not mean the slot was full.
+                            Ok(true | false) => TryFrameResult::Ok,
+                            Err(_) => TryFrameResult::Dead,
+                        }
+                    }
+                    other => other,
+                }
+            }
+            Self::Inbox(tx) => {
+                let wrapped = Message::with_prefix(
+                    identity.clone(),
+                    Message::with_prefix(Bytes::new(), msg.clone()),
+                );
+                match tx.try_send(PeerDriverCommand::SendMessage(wrapped)) {
+                    Ok(()) => TryFrameResult::Ok,
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => TryFrameResult::Full,
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => TryFrameResult::Dead,
+                }
+            }
         }
     }
 
@@ -61,5 +155,22 @@ impl PeerOutbound {
             Self::Wire { slot, .. } => slot.is_empty(),
             Self::Inbox(_) => true,
         }
+    }
+
+    pub(crate) fn space_available(&self) -> Option<Arc<Notify>> {
+        match self {
+            Self::Wire { slot, .. } => Some(slot.space_available.clone()),
+            Self::Inbox(_) => None,
+        }
+    }
+
+    pub(crate) fn has_direct_writer(&self) -> bool {
+        matches!(
+            self,
+            Self::Wire {
+                direct: Some(_),
+                ..
+            }
+        )
     }
 }

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -1,13 +1,15 @@
-//! Round-robin send with swap-to-back deactivation.
+//! Round-robin send with fair deactivation.
 //!
 //! Peers register active per-peer yring pipes. The socket submitter
 //! scans active pipes from a moving cursor and sends to the first pipe
-//! with capacity. Full pipes are swapped to an inactive list and
-//! reactivated when the consumer drains below LWM.
+//! with capacity. Full pipes move to an inactive list and are reactivated
+//! when the consumer drains below LWM. Active order stays stable so a full
+//! pipe cannot reorder and bias the cursor toward another peer.
 
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use tokio::sync::Notify;
 
@@ -24,13 +26,38 @@ struct ActivePipe {
     tx: SendPipeProducer,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct ActivePipes {
     active: Vec<ActivePipe>,
     inactive: Vec<ActivePipe>,
     pipe_peers: HashSet<u64>,
     fallback_peers: HashSet<u64>,
     cursor: usize,
+    random_state: u64,
+    inactive_cursor: usize,
+    last_reactivation_probe: Instant,
+}
+
+const REACTIVATION_PROBE_INTERVAL: Duration = Duration::from_millis(1);
+const REACTIVATION_PROBE_BATCH: usize = 8;
+
+impl Default for ActivePipes {
+    fn default() -> Self {
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(1, |d| d.as_secs() ^ u64::from(d.subsec_nanos()))
+            .max(1);
+        Self {
+            active: Vec::new(),
+            inactive: Vec::new(),
+            pipe_peers: HashSet::new(),
+            fallback_peers: HashSet::new(),
+            cursor: 0,
+            random_state: seed,
+            inactive_cursor: 0,
+            last_reactivation_probe: Instant::now(),
+        }
+    }
 }
 
 impl ActivePipes {
@@ -46,27 +73,74 @@ impl ActivePipes {
         self.pipe_peers.clear();
         self.fallback_peers.clear();
         self.cursor = 0;
+        self.inactive_cursor = 0;
+        self.last_reactivation_probe = Instant::now();
     }
 
     fn deactivate(&mut self, pos: usize) {
-        let pipe = self.active.swap_remove(pos);
+        let was_empty = self.inactive.is_empty();
+        let pipe = self.active.remove(pos);
         self.inactive.push(pipe);
-        if self.active.is_empty() || self.cursor >= self.active.len() {
+        if was_empty {
+            self.inactive_cursor = self.random_index(self.inactive.len());
+        }
+        if self.active.is_empty() {
             self.cursor = 0;
+        } else {
+            if pos < self.cursor {
+                self.cursor -= 1;
+            }
+            if self.cursor >= self.active.len() {
+                self.cursor = 0;
+            }
         }
     }
 
-    fn try_reactivate_any(&mut self) {
+    fn reactivation_probe_due(&mut self) -> bool {
         if self.inactive.is_empty() {
+            return false;
+        }
+        if self.last_reactivation_probe.elapsed() >= REACTIVATION_PROBE_INTERVAL {
+            self.last_reactivation_probe = Instant::now();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_reactivate_one(&mut self) {
+        let Some(len) = (!self.inactive.is_empty()).then_some(self.inactive.len()) else {
+            return;
+        };
+        let i = self.inactive_cursor % len;
+        self.inactive_cursor = (i + 1) % len;
+        if self.inactive[i].tx.above_lwm.load(Ordering::Acquire) {
             return;
         }
-        let mut i = 0;
-        while i < self.inactive.len() {
-            if self.inactive[i].tx.above_lwm.load(Ordering::Acquire) {
-                i += 1;
-            } else {
-                let pipe = self.inactive.swap_remove(i);
-                self.active.push(pipe);
+        let pipe = self.inactive.remove(i);
+        self.active.push(pipe);
+        if self.inactive.is_empty() {
+            self.inactive_cursor = 0;
+        } else if i < self.inactive_cursor {
+            self.inactive_cursor -= 1;
+        }
+    }
+
+    fn try_reactivate_batch(&mut self) {
+        for _ in 0..REACTIVATION_PROBE_BATCH {
+            if self.inactive.is_empty() {
+                break;
+            }
+            self.try_reactivate_one();
+        }
+    }
+
+    fn try_reactivate_when_empty(&mut self) {
+        let probes = self.inactive.len();
+        for _ in 0..probes {
+            self.try_reactivate_one();
+            if !self.active.is_empty() {
+                break;
             }
         }
     }
@@ -75,17 +149,38 @@ impl ActivePipes {
         self.pipe_peers.remove(&peer_id);
         self.fallback_peers.remove(&peer_id);
         if let Some(pos) = self.active.iter().position(|p| p.peer_id == peer_id) {
-            self.active.swap_remove(pos);
-            if self.active.is_empty() || self.cursor >= self.active.len() {
+            self.active.remove(pos);
+            if self.active.is_empty() {
                 self.cursor = 0;
+            } else {
+                if pos < self.cursor {
+                    self.cursor -= 1;
+                }
+                if self.cursor >= self.active.len() {
+                    self.cursor = 0;
+                }
             }
         } else if let Some(pos) = self.inactive.iter().position(|p| p.peer_id == peer_id) {
-            self.inactive.swap_remove(pos);
+            self.inactive.remove(pos);
+            if self.inactive.is_empty() {
+                self.inactive_cursor = 0;
+            } else {
+                self.inactive_cursor %= self.inactive.len();
+            }
         }
     }
 
     fn should_use_fallback(&self) -> bool {
         (self.active.is_empty() && self.inactive.is_empty()) || !self.fallback_peers.is_empty()
+    }
+
+    fn random_index(&mut self, len: usize) -> usize {
+        let mut x = self.random_state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.random_state = x.max(1);
+        (x as usize) % len
     }
 }
 
@@ -158,7 +253,13 @@ impl Submitter {
                 .map_err(omq_proto::error::TrySendError::Full);
         }
 
-        active.try_reactivate_any();
+        if active.active.is_empty() {
+            // No pipe can make progress until one inactive pipe crosses LWM.
+            // Probe the whole rotating list only in this stalled state.
+            active.try_reactivate_when_empty();
+        } else if active.reactivation_probe_due() {
+            active.try_reactivate_batch();
+        }
 
         let mut scanned = 0usize;
         while scanned < active.active.len() {
@@ -176,21 +277,24 @@ impl Submitter {
                     if active.active.is_empty() {
                         break;
                     }
-                    // After deactivate, position i holds a different pipe
-                    // (swapped from the end). Don't increment scanned for
-                    // the new occupant.
+                    // Position i now holds the next stable-order pipe.
                     scanned = scanned.saturating_sub(1);
                 }
                 Err(SendPipeError::Closed(returned)) => {
                     let peer_id = active.active[i].peer_id;
                     active.pipe_peers.remove(&peer_id);
-                    active.active.swap_remove(i);
+                    active.active.remove(i);
                     msg = returned;
                     if active.active.is_empty() {
                         active.cursor = 0;
                         break;
                     }
-                    active.cursor %= active.active.len();
+                    if i < active.cursor {
+                        active.cursor -= 1;
+                    }
+                    if active.cursor >= active.active.len() {
+                        active.cursor = 0;
+                    }
                     scanned = scanned.saturating_sub(1);
                 }
             }
@@ -220,11 +324,18 @@ impl ActivePipes {
             }
             let peer_id = self.active[i].peer_id;
             self.pipe_peers.remove(&peer_id);
-            self.active.swap_remove(i);
+            self.active.remove(i);
             if self.active.is_empty() {
                 self.cursor = 0;
                 return None;
             }
+            if i < self.cursor {
+                self.cursor -= 1;
+            }
+            if self.cursor >= self.active.len() {
+                self.cursor = 0;
+            }
+            scanned = scanned.saturating_sub(1);
         }
         None
     }
@@ -275,7 +386,11 @@ impl RoundRobinSend {
         if let Some(tx) = send_pipe {
             active.remove_peer(peer_id);
             active.pipe_peers.insert(peer_id);
-            active.active.push(ActivePipe { peer_id, tx });
+            let pos = {
+                let len = active.active.len() + 1;
+                active.random_index(len)
+            };
+            active.active.insert(pos, ActivePipe { peer_id, tx });
             return;
         }
         active.fallback_peers.insert(peer_id);
@@ -311,5 +426,35 @@ impl RoundRobinSend {
         let active_empty = guard.active.iter().all(|pipe| pipe.tx.is_empty());
         let inactive_empty = guard.inactive.iter().all(|pipe| pipe.tx.is_empty());
         self.queue.len() == 0 && active_empty && inactive_empty
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ActivePipe, ActivePipes};
+    use crate::engine::send_pipe::send_pipe;
+
+    #[test]
+    fn deactivation_preserves_active_peer_order() {
+        let mut pipes = ActivePipes::default();
+        for peer_id in 0..4 {
+            pipes.active.push(ActivePipe {
+                peer_id,
+                tx: send_pipe(4).0,
+            });
+        }
+        pipes.cursor = 2;
+
+        pipes.deactivate(1);
+
+        assert_eq!(
+            pipes
+                .active
+                .iter()
+                .map(|pipe| pipe.peer_id)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 3]
+        );
+        assert_eq!(pipes.cursor, 1);
     }
 }

--- a/omq-tokio/src/socket/actor/lifecycle.rs
+++ b/omq-tokio/src/socket/actor/lifecycle.rs
@@ -19,6 +19,26 @@ impl<'a> PeerLifecycle<'a> {
         self.driver.send_strategy.connection_removed(peer_id);
         self.driver.recv_strategy.connection_removed(peer_id);
         let peer = self.driver.peers.remove(&peer_id);
+        if let Some(ref p) = peer {
+            self.driver.io_pool.release_thread(p.io_thread);
+            if self.driver.socket_type == SocketType::Rep && self.driver.uses_latency_profile() {
+                if self
+                    .driver
+                    .rep_current
+                    .lock()
+                    .expect("rep current")
+                    .as_ref()
+                    .is_some_and(|(current_peer_id, _)| *current_peer_id == peer_id)
+                {
+                    self.driver.rep_current.lock().expect("rep current").take();
+                }
+                self.driver
+                    .rep_pending
+                    .lock()
+                    .expect("rep pending")
+                    .retain(|(pending_peer_id, _)| *pending_peer_id != peer_id);
+            }
+        }
         self.publish_disconnect(peer.as_ref(), reason);
         Self::invalidate_spsc(peer.as_ref());
         self.update_send_ring();
@@ -88,6 +108,7 @@ impl<'a> PeerLifecycle<'a> {
     ) {
         let entry = Arc::new(crate::socket::recv::TcpYringConsumer {
             consumer: std::sync::Mutex::new(consumer),
+            batch_remaining: std::sync::atomic::AtomicUsize::new(0),
             space,
             peer_id,
         });
@@ -157,6 +178,7 @@ impl<'a> PeerLifecycle<'a> {
                     .lock()
                     .expect("type_state")
                     .on_peer_disconnected();
+                self.driver.rep_pending.lock().expect("rep pending").clear();
             }
             _ => {}
         }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -145,6 +145,8 @@ struct PeerEntry {
     /// SPSC ring for this inproc peer (None for wire/stream peers).
     spsc: Option<Arc<crate::transport::inproc::InprocSpsc>>,
     task: Option<JoinHandle<()>>,
+    /// IO thread index this peer's driver runs on (for load tracking).
+    io_thread: usize,
 }
 
 struct ListenerEntry {
@@ -183,6 +185,9 @@ pub(crate) struct SocketDriver {
     /// REQ / REP envelope + alternation state. Shared with the socket
     /// handle so `Socket::send` can call `pre_send` without an actor hop.
     type_state: Arc<Mutex<TypeState>>,
+    /// REP latency route: identity of the request currently being served.
+    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, bytes::Bytes)>>>,
+    rep_current: Arc<Mutex<Option<(u64, bytes::Bytes)>>>,
     /// REQ alternation flag. Shared with the socket handle for lock-free
     /// send/recv on REQ. Actor resets on peer disconnect.
     req_awaiting_reply: Arc<AtomicBool>,
@@ -206,6 +211,7 @@ pub(crate) struct SocketDriver {
     compression_pool: Option<Arc<crate::engine::compression_pool::CompressionPool>>,
     recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
     subscribe_count: Arc<AtomicU64>,
+    io_pool: crate::context::IoPoolHandle,
 }
 
 impl SocketDriver {
@@ -220,9 +226,12 @@ impl SocketDriver {
         send_strategy: SendStrategy,
         spsc: super::recv::SpscHandles,
         type_state: Arc<Mutex<TypeState>>,
+        rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, bytes::Bytes)>>>,
+        rep_current: Arc<Mutex<Option<(u64, bytes::Bytes)>>>,
         req_awaiting_reply: Arc<AtomicBool>,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
         subscribe_count: Arc<AtomicU64>,
+        io_pool: crate::context::IoPoolHandle,
     ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(128);
         let (peer_out_tx, peer_out_rx) = mpsc::channel(256);
@@ -244,6 +253,8 @@ impl SocketDriver {
             send_strategy,
             recv_strategy,
             type_state,
+            rep_pending,
+            rep_current,
             req_awaiting_reply,
             monitor,
             subscriptions: Vec::new(),
@@ -257,6 +268,7 @@ impl SocketDriver {
             compression_pool: None,
             recv_sink_config,
             subscribe_count,
+            io_pool,
         }
     }
 

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -9,6 +9,7 @@ use super::{
     supports_subscribe,
 };
 use crate::socket::actor::lifecycle::PeerLifecycle;
+use omq_proto::WorkloadProfile;
 
 impl SocketDriver {
     pub(super) async fn handle_internal_event(&mut self, evt: InternalEvent) {
@@ -127,7 +128,7 @@ impl SocketDriver {
     #[expect(clippy::too_many_lines)]
     fn spawn_byte_stream_connection(
         &mut self,
-        stream: AnyStream,
+        mut stream: AnyStream,
         peer_ident: PeerIdent,
         endpoint: Endpoint,
         is_server: bool,
@@ -187,8 +188,45 @@ impl SocketDriver {
             heartbeat_ttl: self.options.heartbeat_ttl,
             large_message_threshold: self.options.large_message_threshold.unwrap_or(0),
         };
+        let workload_profile = self.options.workload_profile.unwrap_or(
+            if matches!(self.socket_type, SocketType::Req | SocketType::Rep) {
+                WorkloadProfile::Latency
+            } else {
+                WorkloadProfile::Throughput
+            },
+        );
         let has_encoder = MessageEncoder::for_endpoint(&endpoint, &self.options);
         let has_transform = has_encoder.is_some();
+        let latency_profile = workload_profile == WorkloadProfile::Latency
+            && !self.options.mechanism.has_frame_transform();
+        let direct_tcp_writer = if latency_profile
+            && matches!(self.socket_type, SocketType::Req | SocketType::Rep)
+            && matches!(endpoint, Endpoint::Tcp { .. })
+            && !has_transform
+        {
+            match stream {
+                AnyStream::Tcp(tcp) => {
+                    let Ok(std_tcp) = tcp.into_std() else {
+                        return;
+                    };
+                    let Ok(direct_tcp) = std_tcp.try_clone() else {
+                        return;
+                    };
+                    let Ok(driver_tcp) = tokio::net::TcpStream::from_std(std_tcp) else {
+                        return;
+                    };
+                    let direct =
+                        Arc::new(crate::socket::dispatch::DirectTcpWriter::new(direct_tcp));
+                    stream = AnyStream::Tcp(driver_tcp);
+                    Some(direct)
+                }
+                AnyStream::Ipc(_) => None,
+                #[cfg(feature = "ws")]
+                AnyStream::Ws(_) => None,
+            }
+        } else {
+            None
+        };
         let passthrough_info = has_encoder
             .as_ref()
             .and_then(|(enc, _)| enc.passthrough_info())
@@ -201,6 +239,12 @@ impl SocketDriver {
             peer_id,
             child_cancel.clone(),
             driver_cfg,
+        )
+        .with_receive_profile(
+            crate::engine::driver::ReceiveProfile::from_workload_for_socket(
+                workload_profile,
+                self.socket_type,
+            ),
         );
         let driver = match has_encoder {
             Some((enc, dec)) => {
@@ -223,12 +267,15 @@ impl SocketDriver {
             None => driver,
         };
 
-        let arena_threshold = self
-            .options
-            .arena_threshold
-            .unwrap_or(omq_proto::frame_buffer::ARENA_THRESHOLD);
+        let arena_threshold = self.options.arena_threshold.unwrap_or(if latency_profile {
+            usize::MAX
+        } else {
+            omq_proto::frame_buffer::ARENA_THRESHOLD
+        });
         let arena_cap = if matches!(endpoint, Endpoint::Ipc(_)) {
             omq_proto::frame_buffer::ARENA_INITIAL_CAP_IPC
+        } else if latency_profile {
+            4 * 1024
         } else {
             omq_proto::frame_buffer::ARENA_INITIAL_CAP
         };
@@ -270,34 +317,69 @@ impl SocketDriver {
         // delivery with no per-type post-processing, route messages directly
         // from the connection driver into the user-facing recv channel,
         // skipping the actor's event loop.
-        let driver = if can_bypass_actor_recv(self.socket_type) {
-            let can_use_yring = !matches!(self.socket_type, SocketType::Req);
+        let rep_latency = self.socket_type == SocketType::Rep && self.uses_latency_profile();
+        let rep_identity = Arc::new(std::sync::Mutex::new(None));
+        let driver = if can_bypass_actor_recv(self.socket_type) || rep_latency {
+            let can_use_yring =
+                can_bypass_actor_recv(self.socket_type) && self.socket_type != SocketType::Req;
             if can_use_yring {
                 let from_slot = self
                     .recv_sink_config
                     .as_ref()
                     .and_then(|cfg| cfg.take_sink());
                 if let Some(sink) = from_slot {
-                    driver.with_recv_sink(sink)
+                    if rep_latency {
+                        driver.with_recv_sink(crate::engine::RecvSink::rep(
+                            sink,
+                            rep_identity.clone(),
+                            self.rep_pending.clone(),
+                            peer_id,
+                        ))
+                    } else {
+                        driver.with_recv_sink(sink)
+                    }
                 } else {
                     let cap = self.options.recv_hwm.unwrap_or(1024).max(16) as usize;
                     let (prod, cons) = yring::spsc(cap);
                     let recv_notify = self.spsc.recv_notify.clone();
+                    let blocking_waker = self.spsc.blocking_recv_waker.clone();
                     let space = std::sync::Arc::new(tokio::sync::Notify::new());
                     let sink = crate::engine::RecvSink::Yring(crate::engine::YringSink {
                         producer: prod,
-                        signal: Box::new(move || recv_notify.notify_one()),
+                        signal: Box::new(move || {
+                            recv_notify.notify_one();
+                            blocking_waker.wake();
+                        }),
                         space: space.clone(),
                     });
                     PeerLifecycle::new(self).register_tcp_consumer(cons, space, peer_id);
-                    driver.with_recv_sink(sink)
+                    if rep_latency {
+                        driver.with_recv_sink(crate::engine::RecvSink::rep(
+                            sink,
+                            rep_identity.clone(),
+                            self.rep_pending.clone(),
+                            peer_id,
+                        ))
+                    } else {
+                        driver.with_recv_sink(sink)
+                    }
                 }
+            } else if rep_latency {
+                driver.with_recv_sink(crate::engine::RecvSink::rep(
+                    crate::engine::RecvSink::Channel(self.recv_tx.clone()),
+                    rep_identity,
+                    self.rep_pending.clone(),
+                    peer_id,
+                ))
             } else {
                 driver.with_recv_direct(self.recv_tx.clone())
             }
         } else {
             driver
         };
+
+        // Assign this connection to an IO thread.
+        let io_thread = self.io_pool.assign_thread();
 
         // Insert the peer BEFORE spawning the driver task.
         self.peers.insert(
@@ -308,6 +390,7 @@ impl SocketDriver {
                     inbox: inbox_tx,
                     cancel: child_cancel,
                     transmit_slot: slot.clone(),
+                    direct_tcp_writer: direct_tcp_writer.clone(),
                     send_pipe: Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
                 },
                 identity: bytes::Bytes::new(),
@@ -316,12 +399,22 @@ impl SocketDriver {
                 is_client: !is_server,
                 spsc: None,
                 task: None,
+                io_thread,
             },
         );
 
         PeerLifecycle::new(self).after_peer_inserted();
 
-        let task = tokio::spawn(async move {
+        let needs_migration = io_thread != 0;
+        let task = self.io_pool.spawn_on(io_thread, async move {
+            let driver = if needs_migration {
+                match driver.migrate_stream() {
+                    Ok(d) => d,
+                    Err(_) => return,
+                }
+            } else {
+                driver
+            };
             let _ = driver.run().await;
         });
         if let Some(peer) = self.peers.get_mut(&peer_id) {
@@ -358,6 +451,7 @@ impl SocketDriver {
                 is_client: !is_server,
                 spsc: None,
                 task: None,
+                io_thread: 0,
             },
         );
 
@@ -424,7 +518,8 @@ impl SocketDriver {
 
         // Extract recv_sink for poll() message detection, similar to wire path.
         // Only inproc peers with yring-backed recv bypass can use this.
-        let can_use_yring = !matches!(self.socket_type, SocketType::Req);
+        let can_use_yring =
+            can_bypass_actor_recv(self.socket_type) && self.socket_type != SocketType::Req;
         let recv_sink = if can_bypass_actor_recv(self.socket_type) && can_use_yring {
             self.recv_sink_config
                 .as_ref()
@@ -439,6 +534,8 @@ impl SocketDriver {
         // event runs through the same handle_peer_event path that
         // sets `info = Some(...)`, calls strategy.connection_added,
         // and replays subscriptions / joined groups.
+        let io_thread = self.io_pool.assign_thread();
+
         self.peers.insert(
             peer_id,
             PeerEntry {
@@ -447,6 +544,7 @@ impl SocketDriver {
                     inbox: inbox_tx,
                     cancel: child_cancel.clone(),
                     transmit_slot: None,
+                    direct_tcp_writer: None,
                     send_pipe: Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
                 },
                 identity: bytes::Bytes::new(),
@@ -455,6 +553,7 @@ impl SocketDriver {
                 is_client: !is_server,
                 spsc: spsc.clone(),
                 task: None,
+                io_thread,
             },
         );
 
@@ -463,31 +562,38 @@ impl SocketDriver {
         } else {
             None
         };
+        let recv_spsc = spsc
+            .clone()
+            .filter(|_| can_bypass_actor_recv(self.socket_type));
 
-        // Per-peer SPSC: always add to consumers Vec (recv side).
-        if let Some(ref s) = spsc {
-            let recv_bypass = can_bypass_actor_recv(self.socket_type);
-            PeerLifecycle::new(self).register_inproc_consumer(s, recv_bypass);
+        // Per-peer SPSC recv bypass only applies to plain fair-queue socket
+        // types. REP latency receives need actor bookkeeping for routing.
+        if let Some(ref s) = recv_spsc {
+            PeerLifecycle::new(self).register_inproc_consumer(s, true);
         }
         PeerLifecycle::new(self).update_send_ring();
 
-        let task = tokio::spawn(inproc_peer_driver(
-            inbox_rx,
-            in_rx,
-            out,
-            InprocDriverCtx {
-                peer_out: self.peer_out_tx.clone(),
-                peer_id,
-                cancel: child_cancel,
-                peer_props,
-                max_message_size: self.options.max_message_size,
-                recv_direct,
-                spsc,
-                recv_sink,
-                shared_rx: self.send_strategy.shared_rx(),
-                send_pipe_rx,
-            },
-        ));
+        let task = self.io_pool.spawn_on(
+            io_thread,
+            inproc_peer_driver(
+                inbox_rx,
+                in_rx,
+                out,
+                InprocDriverCtx {
+                    peer_out: self.peer_out_tx.clone(),
+                    peer_id,
+                    cancel: child_cancel,
+                    peer_props,
+                    max_message_size: self.options.max_message_size,
+                    recv_direct,
+                    spsc: recv_spsc,
+                    recv_sink,
+                    shared_rx: self.send_strategy.shared_rx(),
+                    send_pipe_rx,
+                    blocking_recv_waker: self.spsc.blocking_recv_waker.clone(),
+                },
+            ),
+        );
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             peer.task = Some(task);
         }
@@ -505,6 +611,19 @@ impl SocketDriver {
             ZmtpEvent::Message(msg) => {
                 if self.closing {
                     return;
+                }
+                if self.socket_type == SocketType::Rep
+                    && self.uses_latency_profile()
+                    && self.peers.contains_key(&peer_id)
+                {
+                    let envelope_identity = msg
+                        .part_bytes(0)
+                        .filter(|part| !part.is_empty())
+                        .unwrap_or_default();
+                    self.rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .push_back((peer_id, envelope_identity));
                 }
                 if self.handle_legacy_subscribe(peer_id, &msg) {
                     return;
@@ -714,6 +833,19 @@ fn can_bypass_actor_recv(t: SocketType) -> bool {
     )
 }
 
+impl SocketDriver {
+    pub(super) fn uses_latency_profile(&self) -> bool {
+        self.options.workload_profile.unwrap_or(
+            if matches!(self.socket_type, SocketType::Req | SocketType::Rep) {
+                WorkloadProfile::Latency
+            } else {
+                WorkloadProfile::Throughput
+            },
+        ) == WorkloadProfile::Latency
+            && !self.options.mechanism.has_frame_transform()
+    }
+}
+
 /// Inproc fast path connection driver context. Replaces the
 /// `engine::ConnectionDriver` / ZMTP codec stack for in-process peers.
 struct InprocDriverCtx {
@@ -727,6 +859,7 @@ struct InprocDriverCtx {
     recv_sink: Option<crate::engine::RecvSink>,
     shared_rx: Option<crate::routing::fallback_queue::FallbackReceiver>,
     send_pipe_rx: crate::engine::SendPipeConsumer,
+    blocking_recv_waker: std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
 }
 
 /// Synthesizes `HandshakeSucceeded` immediately (no greeting exchange),
@@ -753,6 +886,7 @@ async fn inproc_peer_driver(
         mut recv_sink,
         shared_rx,
         mut send_pipe_rx,
+        blocking_recv_waker,
     } = ctx;
     let mut shared_batch = Vec::with_capacity(crate::routing::SHARED_MAX_BATCH_MSGS);
     let mut send_pipe_batch = Vec::with_capacity(crate::routing::SHARED_MAX_BATCH_MSGS);
@@ -870,7 +1004,7 @@ async fn inproc_peer_driver(
                         {
                             return;
                         }
-                        let m = try_push_spsc(spsc.as_ref(), m);
+                        let m = try_push_spsc(spsc.as_ref(), m, &blocking_recv_waker);
                         if let Some(m) = m {
                             let m = match recv_sink.as_mut() {
                                 Some(sink) => sink.try_send(m).await,
@@ -907,6 +1041,7 @@ async fn inproc_peer_driver(
     if let Some(ref ring) = spsc {
         ring.recv_notify.notify_one();
     }
+    blocking_recv_waker.wake();
     let _ = peer_out.try_send((peer_id, PeerEvent::Closed));
 }
 
@@ -915,6 +1050,7 @@ async fn inproc_peer_driver(
 fn try_push_spsc(
     spsc: Option<&Arc<crate::transport::inproc::InprocSpsc>>,
     m: Message,
+    blocking_waker: &crate::socket::recv::BlockingRecvWaker,
 ) -> Option<Message> {
     let Some(ring) = spsc else {
         return Some(m);
@@ -927,6 +1063,7 @@ fn try_push_spsc(
     producer.flush();
     drop(producer);
     ring.recv_notify.notify_one();
+    blocking_waker.wake();
     None
 }
 
@@ -955,7 +1092,11 @@ fn xpub_notification(tag: u8, prefix: &bytes::Bytes) -> Message {
     Message::single(b.freeze())
 }
 
-/// Spawn a socket driver on the current tokio runtime.
-pub(crate) fn spawn_driver(driver: SocketDriver) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move { driver.run().await })
+/// Spawn the socket driver actor. With a multi-thread IO pool, this
+/// targets the primary IO thread; otherwise bare `tokio::spawn`.
+pub(crate) fn spawn_driver(
+    driver: SocketDriver,
+    io_pool: &crate::context::IoPoolHandle,
+) -> tokio::task::JoinHandle<()> {
+    io_pool.spawn_primary(async move { driver.run().await })
 }

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -8,11 +8,79 @@
 
 use std::io;
 use std::io::IoSlice;
+use std::io::Write;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+
+/// Caller-side TCP writer for the latency profile. It uses a duplicated
+/// nonblocking descriptor, so sends do not enter the connection driver's
+/// reactor loop.
+#[derive(Debug, Clone)]
+pub(crate) struct DirectTcpWriter {
+    stream: Arc<Mutex<std::net::TcpStream>>,
+    pending: Arc<Mutex<Vec<u8>>>,
+    scratch: Arc<Mutex<Vec<u8>>>,
+}
+
+impl DirectTcpWriter {
+    pub(crate) fn new(stream: std::net::TcpStream) -> Self {
+        Self {
+            stream: Arc::new(Mutex::new(stream)),
+            pending: Arc::new(Mutex::new(Vec::new())),
+            scratch: Arc::new(Mutex::new(Vec::with_capacity(4096))),
+        }
+    }
+
+    pub(crate) fn try_write(&self, bytes: &[u8]) -> io::Result<bool> {
+        let mut pending = self.pending.lock().expect("direct writer pending");
+        if !pending.is_empty() {
+            let n = self
+                .stream
+                .lock()
+                .expect("direct writer stream")
+                .write(&pending)?;
+            pending.drain(..n);
+            if !pending.is_empty() {
+                return Ok(false);
+            }
+        }
+        let mut offset = 0;
+        while offset < bytes.len() {
+            match self
+                .stream
+                .lock()
+                .expect("direct writer stream")
+                .write(&bytes[offset..])
+            {
+                Ok(0) => return Err(io::Error::new(io::ErrorKind::WriteZero, "tcp write")),
+                Ok(n) => offset += n,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    pending.extend_from_slice(&bytes[offset..]);
+                    return Ok(false);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(true)
+    }
+
+    pub(crate) fn try_write_buffer(
+        &self,
+        fill: impl FnOnce(&mut Vec<u8>) -> bool,
+    ) -> io::Result<bool> {
+        let mut scratch = self.scratch.lock().expect("direct writer scratch");
+        scratch.clear();
+        if !fill(&mut scratch) {
+            return Ok(true);
+        }
+        self.try_write(&scratch)
+    }
+}
 
 use omq_proto::endpoint::Endpoint;
 use omq_proto::error::{Error, Result};
@@ -22,6 +90,14 @@ use crate::transport::{
     InprocConn, InprocPeerSnapshot, IpcTransport, Listener as _, PeerIdent, TcpTransport,
     Transport as _, inproc as inproc_transport,
 };
+
+/// Re-register a stream with the current thread's I/O reactor. Each
+/// `current_thread` tokio runtime has its own reactor; a stream
+/// accepted on one thread must be migrated before a driver on another
+/// thread can poll it.
+pub(crate) trait Migratable: Sized {
+    fn migrate(self) -> io::Result<Self>;
+}
 
 /// Byte-stream dispatch across TCP-shaped transports (TCP, IPC, WS).
 /// Inproc does NOT go through this - it skips the ZMTP codec entirely
@@ -34,7 +110,49 @@ pub(crate) enum AnyStream {
     Ws(Box<crate::transport::ws::WsTransport>),
 }
 
+impl Migratable for AnyStream {
+    fn migrate(self) -> io::Result<Self> {
+        match self {
+            Self::Tcp(s) => {
+                let std = s.into_std()?;
+                Ok(Self::Tcp(TcpStream::from_std(std)?))
+            }
+            #[cfg(unix)]
+            Self::Ipc(s) => {
+                let std = s.into_std()?;
+                Ok(Self::Ipc(IpcStream::from_std(std)?))
+            }
+            #[cfg(target_os = "windows")]
+            Self::Ipc(s) => Ok(Self::Ipc(s)),
+            #[cfg(feature = "ws")]
+            Self::Ws(s) => Ok(Self::Ws(Box::new(s.migrate()?))),
+        }
+    }
+}
+
 impl AnyStream {
+    /// Split the stream while retaining a TCP write-half fast path.
+    pub(crate) fn split(self, fast_write: bool) -> (AnyReadHalf, AnyWriteHalf) {
+        match self {
+            Self::Tcp(stream) => {
+                let (reader, writer) = stream.into_split();
+                (
+                    AnyReadHalf::Tcp(reader),
+                    AnyWriteHalf::Tcp { writer, fast_write },
+                )
+            }
+            Self::Ipc(stream) => {
+                let (reader, writer) = tokio::io::split(Self::Ipc(stream));
+                (AnyReadHalf::Other(reader), AnyWriteHalf::Other(writer))
+            }
+            #[cfg(feature = "ws")]
+            Self::Ws(ws) => {
+                let (reader, writer) = tokio::io::split(Self::Ws(ws));
+                (AnyReadHalf::Other(reader), AnyWriteHalf::Other(writer))
+            }
+        }
+    }
+
     /// Apply per-socket TCP options (currently just keepalive). No-op
     /// for non-TCP variants. Called from the actor on every accepted /
     /// connected stream so the option lives for the connection's
@@ -52,6 +170,95 @@ impl AnyStream {
             Self::Ipc(_) => Ok(()),
             #[cfg(feature = "ws")]
             Self::Ws(_) => Ok(()),
+        }
+    }
+}
+
+pub(crate) enum AnyReadHalf {
+    Tcp(OwnedReadHalf),
+    Other(tokio::io::ReadHalf<AnyStream>),
+}
+
+impl AsyncRead for AnyReadHalf {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.as_mut().get_mut() {
+            Self::Tcp(reader) => Pin::new(reader).poll_read(cx, buf),
+            Self::Other(reader) => Pin::new(reader).poll_read(cx, buf),
+        }
+    }
+}
+
+pub(crate) enum AnyWriteHalf {
+    Tcp {
+        writer: OwnedWriteHalf,
+        fast_write: bool,
+    },
+    Other(tokio::io::WriteHalf<AnyStream>),
+}
+
+impl AsyncWrite for AnyWriteHalf {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.as_mut().get_mut() {
+            Self::Tcp { writer, fast_write } => {
+                if *fast_write {
+                    match writer.try_write(buf) {
+                        Ok(n) => return Poll::Ready(Ok(n)),
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                        Err(e) => return Poll::Ready(Err(e)),
+                    }
+                }
+                Pin::new(writer).poll_write(cx, buf)
+            }
+            Self::Other(writer) => Pin::new(writer).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match self.as_mut().get_mut() {
+            Self::Tcp { writer, fast_write } => {
+                if *fast_write {
+                    match writer.try_write_vectored(bufs) {
+                        Ok(n) => return Poll::Ready(Ok(n)),
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                        Err(e) => return Poll::Ready(Err(e)),
+                    }
+                }
+                Pin::new(writer).poll_write_vectored(cx, bufs)
+            }
+            Self::Other(writer) => Pin::new(writer).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            Self::Tcp { writer, .. } => writer.is_write_vectored(),
+            Self::Other(writer) => writer.is_write_vectored(),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.as_mut().get_mut() {
+            Self::Tcp { writer, .. } => Pin::new(writer).poll_flush(cx),
+            Self::Other(writer) => Pin::new(writer).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.as_mut().get_mut() {
+            Self::Tcp { writer, .. } => Pin::new(writer).poll_shutdown(cx),
+            Self::Other(writer) => Pin::new(writer).poll_shutdown(cx),
         }
     }
 }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -51,6 +51,10 @@ struct Inner {
     send_submitter: SendSubmitter,
     /// Shared with the actor for REP `pre_send` / `post_recv`.
     type_state: Arc<Mutex<TypeState>>,
+    /// Shared request identity for the latency REP path.
+    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, Bytes)>>>,
+    rep_current: Arc<Mutex<Option<(u64, Bytes)>>>,
+    rep_latency: bool,
     /// REQ alternation flag. Avoids Mutex on the REQ hot path.
     /// Shared with the actor for `on_peer_disconnected` reset.
     req_awaiting_reply: Arc<AtomicBool>,
@@ -77,7 +81,20 @@ impl Socket {
     /// bytes, heartbeat TTL overflow, etc.) or if `conflate` is set on an
     /// incompatible socket type.
     pub fn new(socket_type: SocketType, options: Options) -> Self {
-        Self::new_inner(socket_type, options, None)
+        Self::new_inner(
+            socket_type,
+            options,
+            None,
+            &crate::context::IoPoolHandle::none(),
+        )
+    }
+
+    pub(crate) fn new_with_io_pool(
+        socket_type: SocketType,
+        options: Options,
+        io_pool: &crate::context::IoPoolHandle,
+    ) -> Self {
+        Self::new_inner(socket_type, options, None, io_pool)
     }
 
     /// Like [`Socket::new`], but installs a [`RecvSinkConfig`] that the
@@ -88,17 +105,31 @@ impl Socket {
         options: Options,
         config: Arc<crate::engine::RecvSinkConfig>,
     ) -> Self {
-        Self::new_inner(socket_type, options, Some(config))
+        Self::new_inner(
+            socket_type,
+            options,
+            Some(config),
+            &crate::context::IoPoolHandle::none(),
+        )
     }
 
     fn new_inner(
         socket_type: SocketType,
         options: Options,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
+        io_pool: &crate::context::IoPoolHandle,
     ) -> Self {
         options
             .validate()
             .expect("Options::validate failed in Socket::new");
+        let latency_profile = options.workload_profile.unwrap_or(
+            if matches!(socket_type, SocketType::Req | SocketType::Rep) {
+                omq_proto::WorkloadProfile::Latency
+            } else {
+                omq_proto::WorkloadProfile::Throughput
+            },
+        ) == omq_proto::WorkloadProfile::Latency
+            && !options.mechanism.has_frame_transform();
         assert!(
             !options.conflate || crate::routing::supports_conflate(socket_type),
             "Options::conflate(true) is not valid for socket type {socket_type:?} \
@@ -108,13 +139,16 @@ impl Socket {
         let cancel = CancellationToken::new();
         let (cmd_tx, cmd_rx) = mpsc::channel(options.send_hwm.unwrap_or(1024).max(16) as usize);
         let recv_hwm = options.recv_hwm.unwrap_or(1024).max(16) as usize;
+        let blocking_recv_waker = super::recv::BlockingRecvWaker::new();
         let (recv_tx, recv_consumer, recv_pipe_notify, recv_pipe_space) =
-            super::recv::recv_pipe(recv_hwm);
+            super::recv::recv_pipe(recv_hwm, blocking_recv_waker.clone());
         let monitor = MonitorPublisher::new();
-        let send_strategy = SendStrategy::for_socket_type(socket_type, &options);
+        let send_strategy = SendStrategy::for_socket_type(socket_type, &options, io_pool);
         let send_submitter = send_strategy.submitter();
-        let spsc = SpscHandles::default();
+        let spsc = SpscHandles::new(blocking_recv_waker);
         let type_state = Arc::new(Mutex::new(TypeState::new()));
+        let rep_pending = Arc::new(Mutex::new(std::collections::VecDeque::new()));
+        let rep_current = Arc::new(Mutex::new(None));
         let req_awaiting_reply = Arc::new(AtomicBool::new(false));
         let subscribe_count = Arc::new(AtomicU64::new(0));
         let driver = SocketDriver::new(
@@ -127,20 +161,32 @@ impl Socket {
             send_strategy,
             spsc.clone(),
             type_state.clone(),
+            rep_pending.clone(),
+            rep_current.clone(),
             req_awaiting_reply.clone(),
             recv_sink_config,
             subscribe_count.clone(),
+            io_pool.clone(),
         );
-        let actor_task = spawn_driver(driver);
+        let actor_task = spawn_driver(driver, io_pool);
         Self {
             inner: Arc::new(Inner {
                 socket_type,
                 cmd_tx,
-                recv_rx: SpscAwareRecv::new(recv_consumer, recv_pipe_notify, recv_pipe_space, spsc),
+                recv_rx: SpscAwareRecv::new(
+                    recv_consumer,
+                    recv_pipe_notify,
+                    recv_pipe_space,
+                    spsc,
+                    latency_profile,
+                ),
                 monitor,
                 root_cancel: cancel,
                 send_submitter,
                 type_state,
+                rep_pending,
+                rep_current,
+                rep_latency: latency_profile && socket_type == SocketType::Rep,
                 req_awaiting_reply,
                 send_ops: AtomicU32::new(0),
                 subscribe_count,
@@ -237,6 +283,16 @@ impl Socket {
                 result
             }
             SocketType::Rep => {
+                if self.inner.rep_latency {
+                    let identity = self.inner.rep_current.lock().expect("rep identity").take();
+                    if let Some((peer_id, identity)) = identity {
+                        return self
+                            .inner
+                            .send_submitter
+                            .send_rep_to_peer(peer_id, &identity, msg)
+                            .await;
+                    }
+                }
                 let msg = self
                     .inner
                     .type_state
@@ -286,6 +342,15 @@ impl Socket {
                 result
             }
             SocketType::Rep => {
+                if self.inner.rep_latency {
+                    let identity = self.inner.rep_current.lock().expect("rep identity").take();
+                    if let Some((peer_id, identity)) = identity {
+                        return self
+                            .inner
+                            .send_submitter
+                            .send_rep_try_to_peer(peer_id, &identity, msg);
+                    }
+                }
                 let msg = self
                     .inner
                     .type_state
@@ -327,7 +392,89 @@ impl Socket {
                     .store(false, Ordering::Release);
                 return Ok(msg);
             },
+            SocketType::Rep => loop {
+                let msg = self.inner.recv_rx.recv().await?;
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(msg);
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(body);
+                }
+            },
             _ => self.inner.recv_rx.recv().await,
+        }
+    }
+
+    /// Register the calling thread for `blocking_recv()` wakeups.
+    pub(crate) fn register_blocking_recv(&self) {
+        self.inner.recv_rx.register_blocking_thread();
+    }
+
+    /// Blocking receive for sync callers. The calling thread parks
+    /// until data arrives. Call `register_blocking_recv()` first.
+    pub(crate) fn blocking_recv(&self) -> Result<Message> {
+        match self.inner.socket_type {
+            SocketType::Req => loop {
+                let mut msg = self.inner.recv_rx.blocking_recv()?;
+                match msg.pop_front() {
+                    Some(delim) if delim.is_empty() => {}
+                    _ => continue,
+                }
+                self.inner
+                    .req_awaiting_reply
+                    .store(false, Ordering::Release);
+                return Ok(msg);
+            },
+            SocketType::Rep => loop {
+                let msg = self.inner.recv_rx.blocking_recv()?;
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(msg);
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(body);
+                }
+            },
+            _ => self.inner.recv_rx.blocking_recv(),
         }
     }
 
@@ -345,6 +492,37 @@ impl Socket {
                         .req_awaiting_reply
                         .store(false, Ordering::Release);
                     return Ok(msg);
+                }
+            }
+        }
+        if self.inner.socket_type == SocketType::Rep {
+            loop {
+                let msg = self.inner.recv_rx.try_recv()?;
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(msg);
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(body);
                 }
             }
         }

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -2,7 +2,7 @@
 //! yring fast paths. Zero heap allocations per message.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use arc_swap::ArcSwapOption;
@@ -24,6 +24,37 @@ pub(crate) type SpscRecvNotify = Arc<tokio::sync::Notify>;
 /// any `recv()` that's blocked so it re-drains with the updated list.
 pub(crate) type SpscActivated = Arc<tokio::sync::Notify>;
 
+const RECV_BATCH_MESSAGES: usize = 256;
+
+/// Waker for blocking `recv()`. IO threads call `wake()` alongside
+/// `tokio::sync::Notify::notify_one()`. The blocking user thread
+/// parks via `std::thread::park()` and is woken by `unpark()`.
+pub(crate) struct BlockingRecvWaker(Mutex<Option<std::thread::Thread>>);
+
+impl BlockingRecvWaker {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self(Mutex::new(None)))
+    }
+
+    pub(crate) fn register(&self, thread: std::thread::Thread) {
+        *self.0.lock().unwrap() = Some(thread);
+    }
+
+    pub(crate) fn wake(&self) {
+        if let Ok(guard) = self.0.try_lock()
+            && let Some(ref t) = *guard
+        {
+            t.unpark();
+        }
+    }
+}
+
+impl std::fmt::Debug for BlockingRecvWaker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockingRecvWaker").finish_non_exhaustive()
+    }
+}
+
 /// Bumped by the actor whenever the consumers Vec changes. Lets
 /// `SpscAwareRecv` skip re-cloning the Vec when nothing changed.
 pub(crate) type SpscConsumerGeneration = Arc<AtomicU64>;
@@ -41,6 +72,7 @@ pub(crate) enum SpscPush {
 /// into its yring producer; the recv side drains the consumer here.
 pub(crate) struct TcpYringConsumer {
     pub consumer: Mutex<yring::Consumer<Message>>,
+    pub batch_remaining: AtomicUsize,
     pub space: Arc<tokio::sync::Notify>,
     pub peer_id: u64,
 }
@@ -72,6 +104,7 @@ pub(crate) struct SharedRecvPipe {
     notify: Arc<tokio::sync::Notify>,
     space: Arc<tokio::sync::Notify>,
     closed: AtomicBool,
+    blocking_waker: Arc<BlockingRecvWaker>,
 }
 
 impl std::fmt::Debug for SharedRecvPipe {
@@ -101,6 +134,7 @@ impl SharedRecvPipe {
                         prod.flush();
                         drop(prod);
                         self.notify.notify_one();
+                        self.blocking_waker.wake();
                         return Ok(());
                     }
                     Err(returned) => {
@@ -121,6 +155,7 @@ impl SharedRecvPipe {
         }
         self.notify.notify_waiters();
         self.space.notify_waiters();
+        self.blocking_waker.wake();
     }
 }
 
@@ -131,6 +166,7 @@ impl Drop for SharedRecvPipe {
         }
         self.notify.notify_waiters();
         self.space.notify_waiters();
+        self.blocking_waker.wake();
     }
 }
 
@@ -142,6 +178,7 @@ impl Drop for SharedRecvPipe {
 /// blocked producers await it.
 pub(crate) fn recv_pipe(
     capacity: usize,
+    blocking_waker: Arc<BlockingRecvWaker>,
 ) -> (
     Arc<SharedRecvPipe>,
     yring::Consumer<Message>,
@@ -156,6 +193,7 @@ pub(crate) fn recv_pipe(
         notify: notify.clone(),
         space: space.clone(),
         closed: AtomicBool::new(false),
+        blocking_waker,
     });
     (pipe, cons, notify, space)
 }
@@ -173,10 +211,11 @@ pub(crate) struct SpscHandles {
     pub recv_notify: SpscRecvNotify,
     pub activated: SpscActivated,
     pub tcp_consumers: TcpConsumers,
+    pub blocking_recv_waker: Arc<BlockingRecvWaker>,
 }
 
-impl Default for SpscHandles {
-    fn default() -> Self {
+impl SpscHandles {
+    pub(crate) fn new(blocking_recv_waker: Arc<BlockingRecvWaker>) -> Self {
         Self {
             consumers: Arc::new(RwLock::new(Vec::new())),
             consumer_generation: Arc::new(AtomicU64::new(0)),
@@ -185,6 +224,7 @@ impl Default for SpscHandles {
             recv_notify: Arc::new(tokio::sync::Notify::new()),
             activated: Arc::new(tokio::sync::Notify::new()),
             tcp_consumers: Arc::new(RwLock::new(Vec::new())),
+            blocking_recv_waker,
         }
     }
 }
@@ -217,6 +257,8 @@ pub(crate) struct SpscAwareRecv {
     /// Drain state: cached consumer snapshots, message batch buffer,
     /// and the shared recv pipe consumer.
     drain_state: Mutex<DrainState>,
+    /// Waker for blocking `recv()` callers.
+    blocking_recv_waker: Arc<BlockingRecvWaker>,
 }
 
 #[derive(Debug)]
@@ -226,6 +268,8 @@ struct DrainState {
     tcp: Vec<Arc<TcpYringConsumer>>,
     batch: VecDeque<Message>,
     recv_consumer: yring::Consumer<Message>,
+    recv_batch_remaining: usize,
+    latency: bool,
 }
 
 enum DrainResult {
@@ -234,16 +278,49 @@ enum DrainResult {
     Closed,
 }
 
-fn drain_yring(consumer: &mut yring::Consumer<Message>, batch: &mut VecDeque<Message>) -> bool {
-    let got = consumer.prefetch();
-    if got > 0 {
-        while let Some(msg) = consumer.pop() {
-            batch.push_back(msg);
+fn drain_yring(
+    consumer: &mut yring::Consumer<Message>,
+    batch: &mut VecDeque<Message>,
+    max_items: usize,
+) -> usize {
+    let count = consumer.prefetch_bounded(max_items);
+    if count == 0 {
+        return 0;
+    }
+    let mut drained = 0;
+    for _ in 0..count {
+        let Some(msg) = consumer.pop() else {
+            break;
+        };
+        batch.push_back(msg);
+        drained += 1;
+    }
+    consumer.release();
+    drained
+}
+
+/// Pop one message while preserving yring's prefetch/release batch boundary.
+fn drain_yring_one(
+    consumer: &mut yring::Consumer<Message>,
+    batch_remaining: &mut usize,
+) -> (Option<Message>, bool) {
+    loop {
+        if *batch_remaining == 0 {
+            *batch_remaining = consumer.prefetch();
+            if *batch_remaining == 0 {
+                return (None, false);
+            }
+        }
+        if let Some(msg) = consumer.pop() {
+            *batch_remaining -= 1;
+            if *batch_remaining == 0 {
+                consumer.release();
+                return (Some(msg), true);
+            }
+            return (Some(msg), false);
         }
         consumer.release();
-        true
-    } else {
-        false
+        *batch_remaining = 0;
     }
 }
 
@@ -253,6 +330,7 @@ impl SpscAwareRecv {
         recv_pipe_notify: Arc<tokio::sync::Notify>,
         recv_pipe_space: Arc<tokio::sync::Notify>,
         handles: SpscHandles,
+        latency: bool,
     ) -> Self {
         Self {
             consumers: handles.consumers,
@@ -264,16 +342,36 @@ impl SpscAwareRecv {
             send_ring_available: handles.send_ring_available,
             recv_pipe_notify,
             recv_pipe_space,
+            blocking_recv_waker: handles.blocking_recv_waker,
             drain_state: Mutex::new(DrainState {
                 generation: u64::MAX,
                 inproc: Vec::new(),
                 tcp: Vec::new(),
                 batch: VecDeque::new(),
                 recv_consumer,
+                recv_batch_remaining: 0,
+                latency,
             }),
         }
     }
 
+    pub(crate) fn register_blocking_thread(&self) {
+        self.blocking_recv_waker.register(std::thread::current());
+    }
+
+    pub(crate) fn blocking_recv(&self) -> Result<Message> {
+        self.blocking_recv_waker.register(std::thread::current());
+        loop {
+            match self.try_drain() {
+                DrainResult::Message(msg) => return Ok(msg),
+                DrainResult::Closed => return Err(Error::Closed),
+                DrainResult::Empty => {}
+            }
+            std::thread::park();
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
     fn try_drain(&self) -> DrainResult {
         let mut guard = self.drain_state.lock().unwrap();
 
@@ -289,33 +387,121 @@ impl SpscAwareRecv {
         }
 
         let state = &mut *guard;
+        let fast_msg = if state.latency
+            && state.inproc.is_empty()
+            && state.tcp.len() == 1
+            && state.recv_consumer.is_empty()
+        {
+            let tc = &state.tcp[0];
+            if let Ok(mut consumer) = tc.consumer.try_lock() {
+                let mut remaining = tc.batch_remaining.load(Ordering::Relaxed);
+                let (msg, released) = drain_yring_one(&mut consumer, &mut remaining);
+                tc.batch_remaining.store(remaining, Ordering::Relaxed);
+                if released {
+                    tc.space.notify_one();
+                }
+                if let Some(msg) = msg {
+                    drop(consumer);
+                    Some(msg)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Some(msg) = fast_msg {
+            drop(guard);
+            return DrainResult::Message(msg);
+        }
         let mut has_disconnected = false;
+        let mut latency_result = None;
+        let mut batch_remaining = RECV_BATCH_MESSAGES;
 
         for p in &state.inproc {
+            if batch_remaining == 0 {
+                break;
+            }
             if let Ok(mut consumer) = p.consumer.try_lock() {
-                if drain_yring(&mut consumer, &mut state.batch) {
-                    p.space_notify.notify_waiters();
-                } else if consumer.is_disconnected() {
+                if state.latency {
+                    let mut remaining = p.batch_remaining.load(Ordering::Relaxed);
+                    let (msg, released) = drain_yring_one(&mut consumer, &mut remaining);
+                    p.batch_remaining.store(remaining, Ordering::Relaxed);
+                    if released {
+                        p.space_notify.notify_waiters();
+                    }
+                    latency_result = msg;
+                    if latency_result.is_none() && consumer.is_disconnected() {
+                        has_disconnected = true;
+                    }
+                } else {
+                    let drained = drain_yring(&mut consumer, &mut state.batch, batch_remaining);
+                    batch_remaining -= drained;
+                    if drained > 0 {
+                        p.space_notify.notify_waiters();
+                    }
+                }
+                if !state.latency && consumer.is_disconnected() {
                     has_disconnected = true;
                 }
+            }
+            if latency_result.is_some() {
+                break;
             }
         }
 
         for tc in &state.tcp {
+            if batch_remaining == 0 {
+                break;
+            }
+            if latency_result.is_some() {
+                break;
+            }
             if let Ok(mut consumer) = tc.consumer.try_lock() {
-                if drain_yring(&mut consumer, &mut state.batch) {
-                    tc.space.notify_one();
-                } else if consumer.is_disconnected() {
-                    has_disconnected = true;
+                if state.latency {
+                    let mut remaining = tc.batch_remaining.load(Ordering::Relaxed);
+                    let (msg, released) = drain_yring_one(&mut consumer, &mut remaining);
+                    tc.batch_remaining.store(remaining, Ordering::Relaxed);
+                    if released {
+                        tc.space.notify_one();
+                    }
+                    latency_result = msg;
+                    if latency_result.is_none() && consumer.is_disconnected() {
+                        has_disconnected = true;
+                    }
+                } else {
+                    let drained = drain_yring(&mut consumer, &mut state.batch, batch_remaining);
+                    batch_remaining -= drained;
+                    if drained > 0 {
+                        tc.space.notify_one();
+                    }
+                    if consumer.is_disconnected() {
+                        has_disconnected = true;
+                    }
                 }
             }
         }
 
-        if drain_yring(&mut state.recv_consumer, &mut state.batch) {
-            self.recv_pipe_space.notify_waiters();
+        if latency_result.is_none() {
+            if state.latency {
+                let (msg, released) =
+                    drain_yring_one(&mut state.recv_consumer, &mut state.recv_batch_remaining);
+                if released {
+                    self.recv_pipe_space.notify_waiters();
+                }
+                latency_result = msg;
+            } else if batch_remaining > 0 {
+                let drained =
+                    drain_yring(&mut state.recv_consumer, &mut state.batch, batch_remaining);
+                if drained > 0 {
+                    self.recv_pipe_space.notify_waiters();
+                }
+            }
         }
 
-        let result = state.batch.pop_front();
+        let result = latency_result.or_else(|| state.batch.pop_front());
         let pipe_disconnected = state.recv_consumer.is_disconnected();
         let has_peers = !state.inproc.is_empty() || !state.tcp.is_empty();
         drop(guard);
@@ -450,6 +636,7 @@ impl SpscAwareRecv {
         let _ = producer.push(msg);
         producer.flush();
         pair.recv_notify.notify_one();
+        self.blocking_recv_waker.wake();
         SpscPush::Sent
     }
 
@@ -461,5 +648,36 @@ impl SpscAwareRecv {
             SpscPush::Sent => Ok(()),
             SpscPush::Unavailable(msg) | SpscPush::Full { msg, .. } => Err(msg),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drain_yring_one;
+    use omq_proto::Message;
+
+    #[test]
+    fn latency_drain_keeps_prefetched_batch_open() {
+        let (mut producer, mut consumer) = yring::spsc(8);
+        producer.push(Message::from_slice(b"a")).unwrap();
+        producer.push(Message::from_slice(b"b")).unwrap();
+        producer.flush();
+
+        let mut remaining = 0;
+        let (first, released) = drain_yring_one(&mut consumer, &mut remaining);
+        assert_eq!(first.unwrap().part_bytes(0).unwrap(), &b"a"[..]);
+        assert!(!released);
+        let (second, released) = drain_yring_one(&mut consumer, &mut remaining);
+        assert_eq!(second.unwrap().part_bytes(0).unwrap(), &b"b"[..]);
+        assert!(released);
+        let (third, released) = drain_yring_one(&mut consumer, &mut remaining);
+        assert!(third.is_none());
+        assert!(!released);
+
+        producer.push(Message::from_slice(b"c")).unwrap();
+        producer.flush();
+        let (next, released) = drain_yring_one(&mut consumer, &mut remaining);
+        assert_eq!(next.unwrap().part_bytes(0).unwrap(), &b"c"[..]);
+        assert!(released);
     }
 }

--- a/omq-tokio/src/socket/udp.rs
+++ b/omq-tokio/src/socket/udp.rs
@@ -136,6 +136,7 @@ pub(crate) fn fake_handle(
         inbox,
         cancel,
         transmit_slot: None,
+        direct_tcp_writer: None,
         send_pipe: None,
     }
 }

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -30,6 +30,7 @@ use omq_proto::proto::SocketType;
 pub struct InprocSpsc {
     pub producer: Mutex<yring::Producer<Message>>,
     pub consumer: Mutex<yring::Consumer<Message>>,
+    pub batch_remaining: std::sync::atomic::AtomicUsize,
     /// Receiver socket's shared recv notification. The driver and
     /// send fast path notify this after push so `recv()` wakes up.
     pub recv_notify: Arc<tokio::sync::Notify>,
@@ -240,6 +241,7 @@ impl InprocListener {
             Some(Arc::new(InprocSpsc {
                 producer: Mutex::new(p),
                 consumer: Mutex::new(c),
+                batch_remaining: std::sync::atomic::AtomicUsize::new(0),
                 recv_notify: notify,
                 recv_ready: std::sync::atomic::AtomicBool::new(false),
                 max_message_size: mms,

--- a/omq-tokio/src/transport/stream_raw.rs
+++ b/omq-tokio/src/transport/stream_raw.rs
@@ -84,6 +84,7 @@ pub(crate) fn spawn(
         inbox: inbox_tx,
         cancel: handle_cancel,
         transmit_slot: None,
+        direct_tcp_writer: None,
         send_pipe: None,
     }
 }

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -18,6 +18,18 @@ pub(crate) enum WsTransport {
     TlsServer(tokio_rustls::server::TlsStream<TcpStream>),
 }
 
+impl WsTransport {
+    pub(crate) fn migrate(self) -> std::io::Result<Self> {
+        match self {
+            Self::Plain(tcp) => {
+                let std = tcp.into_std()?;
+                Ok(Self::Plain(TcpStream::from_std(std)?))
+            }
+            other => Ok(other),
+        }
+    }
+}
+
 impl std::fmt::Debug for WsTransport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/omq-tokio/tests/context.rs
+++ b/omq-tokio/tests/context.rs
@@ -1,0 +1,612 @@
+//! Tests for `Context` and `ContextConfig`: owned runtime, borrowed
+//! runtime (`Context::current()`), lifecycle, and cross-context TCP.
+
+mod test_support;
+
+use std::time::Duration;
+
+use omq_proto::endpoint::Host;
+use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType};
+
+fn tcp_loopback(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        port,
+    }
+}
+
+fn inproc_ep(name: &str) -> Endpoint {
+    Endpoint::Inproc {
+        name: format!(
+            "ctx-{name}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ),
+    }
+}
+
+// ---- Owned-runtime tests (plain #[test], no tokio) ----------------------
+
+#[test]
+fn context_new_defaults() {
+    let ctx = Context::new();
+    assert_eq!(ctx.io_threads(), 1);
+}
+
+#[test]
+fn context_with_io_threads() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 4 });
+    assert_eq!(ctx.io_threads(), 4);
+}
+
+#[test]
+fn context_from_env() {
+    // Safety: env mutation is inherently racy in multi-threaded test
+    // runners, but OMQ_IO_THREADS is not used elsewhere in the suite.
+    unsafe {
+        std::env::set_var("OMQ_IO_THREADS", "3");
+    }
+    let cfg = ContextConfig::from_env();
+    unsafe {
+        std::env::remove_var("OMQ_IO_THREADS");
+    }
+    assert_eq!(cfg.io_threads, 3);
+}
+
+#[test]
+fn push_pull_via_context() {
+    let ctx = Context::new();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    ctx.block_on(async move {
+        let ep = inproc_ep("pp-ctx");
+        pull.bind(ep.clone()).await.unwrap();
+        push.connect(ep).await.unwrap();
+
+        push.send(Message::single("hello")).await.unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg, Message::single("hello"));
+    });
+}
+
+#[test]
+fn req_rep_via_context() {
+    let ctx = Context::new();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    let req = ctx.socket(SocketType::Req, Options::default());
+
+    ctx.block_on(async move {
+        let ep = inproc_ep("rr-ctx");
+        rep.bind(ep.clone()).await.unwrap();
+        req.connect(ep).await.unwrap();
+
+        req.send(Message::single("question")).await.unwrap();
+        let q = tokio::time::timeout(Duration::from_secs(2), rep.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(q, Message::single("question"));
+
+        rep.send(Message::single("answer")).await.unwrap();
+        let a = tokio::time::timeout(Duration::from_secs(2), req.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(a, Message::single("answer"));
+    });
+}
+
+#[test]
+fn pub_sub_via_context() {
+    let ctx = Context::new();
+    let pub_ = ctx.socket(SocketType::Pub, Options::default());
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+
+    ctx.block_on(async move {
+        let ep = inproc_ep("ps-ctx");
+        pub_.bind(ep.clone()).await.unwrap();
+        sub.subscribe("").await.unwrap();
+        sub.connect(ep).await.unwrap();
+
+        // Retry loop: subscription propagation is asynchronous.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let mut received = false;
+        while !received && std::time::Instant::now() < deadline {
+            let _ = pub_.send(Message::single("msg")).await;
+            if let Ok(Ok(m)) = tokio::time::timeout(Duration::from_millis(20), sub.recv()).await {
+                assert_eq!(m, Message::single("msg"));
+                received = true;
+            }
+        }
+        assert!(received, "SUB never received a message from PUB");
+    });
+}
+
+#[test]
+fn multiple_sockets_one_context() {
+    let ctx = Context::new();
+
+    let push1 = ctx.socket(SocketType::Push, Options::default());
+    let pull1 = ctx.socket(SocketType::Pull, Options::default());
+    let push2 = ctx.socket(SocketType::Push, Options::default());
+    let pull2 = ctx.socket(SocketType::Pull, Options::default());
+
+    ctx.block_on(async move {
+        let ep1 = inproc_ep("multi-1");
+        let ep2 = inproc_ep("multi-2");
+
+        pull1.bind(ep1.clone()).await.unwrap();
+        push1.connect(ep1).await.unwrap();
+        pull2.bind(ep2.clone()).await.unwrap();
+        push2.connect(ep2).await.unwrap();
+
+        push1.send(Message::single("a")).await.unwrap();
+        push2.send(Message::single("b")).await.unwrap();
+
+        let m1 = tokio::time::timeout(Duration::from_secs(2), pull1.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let m2 = tokio::time::timeout(Duration::from_secs(2), pull2.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m1, Message::single("a"));
+        assert_eq!(m2, Message::single("b"));
+    });
+}
+
+#[test]
+fn multiple_contexts() {
+    let ctx1 = Context::new();
+    let ctx2 = Context::new();
+
+    let push1 = ctx1.socket(SocketType::Push, Options::default());
+    let pull1 = ctx1.socket(SocketType::Pull, Options::default());
+    let push2 = ctx2.socket(SocketType::Push, Options::default());
+    let pull2 = ctx2.socket(SocketType::Pull, Options::default());
+
+    // Each context runs independently with its own runtime.
+    ctx1.block_on(async move {
+        let ep = inproc_ep("ctx1-pp");
+        pull1.bind(ep.clone()).await.unwrap();
+        push1.connect(ep).await.unwrap();
+
+        push1.send(Message::single("from-ctx1")).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull1.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m, Message::single("from-ctx1"));
+    });
+
+    ctx2.block_on(async move {
+        let ep = inproc_ep("ctx2-pp");
+        pull2.bind(ep.clone()).await.unwrap();
+        push2.connect(ep).await.unwrap();
+
+        push2.send(Message::single("from-ctx2")).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull2.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m, Message::single("from-ctx2"));
+    });
+}
+
+#[test]
+fn context_clone_shares_runtime() {
+    let ctx = Context::new();
+    let ctx2 = ctx.clone();
+
+    // Sockets created on different clones of the same context share the
+    // runtime and can communicate via inproc.
+    let push = ctx.socket(SocketType::Push, Options::default());
+    let pull = ctx2.socket(SocketType::Pull, Options::default());
+
+    ctx.block_on(async move {
+        let ep = inproc_ep("clone-share");
+        pull.bind(ep.clone()).await.unwrap();
+        push.connect(ep).await.unwrap();
+
+        push.send(Message::single("shared")).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m, Message::single("shared"));
+    });
+}
+
+#[test]
+#[should_panic(expected = "terminated")]
+fn context_term_socket_panics() {
+    let ctx = Context::new();
+    ctx.term();
+    let _sock = ctx.socket(SocketType::Push, Options::default());
+}
+
+#[test]
+#[should_panic(expected = "terminated")]
+fn context_term_block_on_panics() {
+    let ctx = Context::new();
+    ctx.term();
+    ctx.block_on(async {});
+}
+
+#[test]
+fn context_drop_cleanup() {
+    // Verify that dropping a context does not hang. The background thread
+    // and runtime are shut down during drop.
+    {
+        let ctx = Context::new();
+        let push = ctx.socket(SocketType::Push, Options::default());
+        ctx.block_on(async move {
+            let ep = inproc_ep("drop-cleanup");
+            push.bind(ep).await.unwrap();
+        });
+        // ctx and push drop here
+    }
+    // If we reach this line, cleanup did not deadlock.
+}
+
+// ---- Embedded-runtime tests (#[tokio::test]) ----------------------------
+
+#[tokio::test]
+async fn context_current_wraps_runtime() {
+    let ctx = Context::current();
+    assert_eq!(ctx.io_threads(), 0);
+}
+
+#[tokio::test]
+async fn context_current_socket_works() {
+    let ctx = Context::current();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    let ep = inproc_ep("current-sock");
+    pull.bind(ep.clone()).await.unwrap();
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::single("via-current")).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::single("via-current"));
+}
+
+#[tokio::test]
+#[should_panic(expected = "borrowed context")]
+async fn context_current_block_on_panics() {
+    let ctx = Context::current();
+    ctx.block_on(async {});
+}
+
+#[tokio::test]
+async fn push_pull_via_current() {
+    let ctx = Context::current();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    let ep = inproc_ep("pp-current");
+    pull.bind(ep.clone()).await.unwrap();
+    push.connect(ep).await.unwrap();
+
+    for i in 0..5 {
+        let body = format!("msg-{i}");
+        push.send(Message::single(body.clone())).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m, Message::single(body));
+    }
+}
+
+// ---- Cross-context TCP test ---------------------------------------------
+
+#[test]
+#[ignore = "cross-context TCP with block_on needs investigation"]
+fn cross_context_communication() {
+    let ctx1 = Context::with_config(ContextConfig { io_threads: 2 });
+    let ctx2 = Context::with_config(ContextConfig { io_threads: 2 });
+
+    let push = ctx1.socket(SocketType::Push, Options::default());
+    let pull = ctx2.socket(SocketType::Pull, Options::default());
+
+    // Each context gets its own block_on on a separate thread so both
+    // runtimes are driven simultaneously.
+    let (port_tx, port_rx) = std::sync::mpsc::channel();
+
+    let recv_thread = std::thread::spawn(move || {
+        ctx2.block_on(async move {
+            pull.bind(tcp_loopback(0)).await.unwrap();
+            let port = match pull.last_bound_endpoint().unwrap() {
+                Endpoint::Tcp { port, .. } => port,
+                other => panic!("expected TCP endpoint, got {other:?}"),
+            };
+            let _ = port_tx.send(port);
+            tokio::time::timeout(Duration::from_secs(5), pull.recv())
+                .await
+                .unwrap()
+                .unwrap()
+        })
+    });
+
+    let port = port_rx.recv().unwrap();
+    ctx1.block_on(async move {
+        push.connect(tcp_loopback(port)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        push.send(Message::single("cross-ctx")).await.unwrap();
+    });
+
+    let msg = recv_thread.join().unwrap();
+    assert_eq!(msg, Message::single("cross-ctx"));
+}
+
+// ---- Multi-IO-thread tests -------------------------------------------
+
+#[test]
+fn multi_io_thread_push_pull_tcp() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 2 });
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    ctx.block_on(async move {
+        let ep = pull.bind(tcp_loopback(0)).await.unwrap();
+        push.connect(ep).await.unwrap();
+
+        for i in 0..20 {
+            push.send(Message::single(format!("mt-{i}"))).await.unwrap();
+        }
+        for i in 0..20 {
+            let m = tokio::time::timeout(Duration::from_secs(3), pull.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(m, Message::single(format!("mt-{i}")));
+        }
+    });
+}
+
+#[test]
+fn multi_io_thread_push_pull_many_peers() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 4 });
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let pushes: Vec<_> = (0..8)
+        .map(|_| ctx.socket(SocketType::Push, Options::default()))
+        .collect();
+
+    ctx.block_on(async move {
+        let ep = pull.bind(tcp_loopback(0)).await.unwrap();
+
+        for p in &pushes {
+            p.connect(ep.clone()).await.unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        for (i, p) in pushes.iter().enumerate() {
+            p.send(Message::single(format!("peer-{i}"))).await.unwrap();
+        }
+
+        let mut received = Vec::new();
+        for _ in 0..8 {
+            let m = tokio::time::timeout(Duration::from_secs(3), pull.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            received.push(m.try_as_parts::<1>().unwrap()[0].clone());
+        }
+        received.sort();
+        for (i, payload) in received.iter().enumerate() {
+            assert_eq!(payload.as_ref(), format!("peer-{i}").as_bytes());
+        }
+    });
+}
+
+#[test]
+fn multi_io_thread_pub_sub_tcp() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 2 });
+    let pub_ = ctx.socket(SocketType::Pub, Options::default());
+    let subs: Vec<_> = (0..4)
+        .map(|_| ctx.socket(SocketType::Sub, Options::default()))
+        .collect();
+
+    ctx.block_on(async move {
+        let ep = pub_.bind(tcp_loopback(0)).await.unwrap();
+
+        for s in &subs {
+            s.subscribe("").await.unwrap();
+            s.connect(ep.clone()).await.unwrap();
+        }
+
+        pub_.wait_subscribed(4, Duration::from_secs(3))
+            .await
+            .unwrap();
+
+        pub_.send(Message::single("fanout")).await.unwrap();
+
+        for sub in &subs {
+            let m = tokio::time::timeout(Duration::from_secs(3), sub.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(m, Message::single("fanout"));
+        }
+    });
+}
+
+#[test]
+fn multi_io_thread_req_rep_tcp() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 2 });
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    let req = ctx.socket(SocketType::Req, Options::default());
+
+    ctx.block_on(async move {
+        let ep = rep.bind(tcp_loopback(0)).await.unwrap();
+        req.connect(ep).await.unwrap();
+
+        for i in 0..5 {
+            let q = format!("q-{i}");
+            req.send(Message::single(q.clone())).await.unwrap();
+            let got = tokio::time::timeout(Duration::from_secs(3), rep.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(got, Message::single(q));
+
+            let a = format!("a-{i}");
+            rep.send(Message::single(a.clone())).await.unwrap();
+            let got = tokio::time::timeout(Duration::from_secs(3), req.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(got, Message::single(a));
+        }
+    });
+}
+
+#[test]
+fn multi_io_thread_inproc_still_works() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 4 });
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    ctx.block_on(async move {
+        let ep = inproc_ep("mt-inproc");
+        pull.bind(ep.clone()).await.unwrap();
+        push.connect(ep).await.unwrap();
+
+        push.send(Message::single("inproc-mt")).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m, Message::single("inproc-mt"));
+    });
+}
+
+// ---- Blocking socket tests -------------------------------------------
+
+#[test]
+fn blocking_socket_push_pull_inproc() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+
+    let ep = inproc_ep("blocking-pp");
+    pull.bind(ep.clone()).unwrap();
+    push.connect(ep).unwrap();
+
+    push.send(Message::single("blocking")).unwrap();
+    let m = pull.recv().unwrap();
+    assert_eq!(m, Message::single("blocking"));
+}
+
+#[test]
+fn blocking_socket_push_pull_tcp() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+
+    let ep = pull.bind(tcp_loopback(0)).unwrap();
+    push.connect(ep).unwrap();
+
+    for i in 0..10 {
+        push.send(Message::single(format!("tcp-{i}"))).unwrap();
+    }
+    for i in 0..10 {
+        let m = pull.recv().unwrap();
+        assert_eq!(m, Message::single(format!("tcp-{i}")));
+    }
+}
+
+#[test]
+fn blocking_socket_req_rep() {
+    let ctx = Context::new();
+    let rep = ctx.blocking_socket(SocketType::Rep, Options::default());
+    let req = ctx.blocking_socket(SocketType::Req, Options::default());
+
+    let ep = inproc_ep("blocking-rr");
+    rep.bind(ep.clone()).unwrap();
+    req.connect(ep).unwrap();
+
+    req.send(Message::single("question")).unwrap();
+    let q = rep.recv().unwrap();
+    assert_eq!(q, Message::single("question"));
+
+    rep.send(Message::single("answer")).unwrap();
+    let a = req.recv().unwrap();
+    assert_eq!(a, Message::single("answer"));
+}
+
+#[test]
+fn blocking_socket_pub_sub() {
+    let ctx = Context::new();
+    let pub_ = ctx.blocking_socket(SocketType::Pub, Options::default());
+    let sub = ctx.blocking_socket(SocketType::Sub, Options::default());
+
+    let ep = inproc_ep("blocking-ps");
+    pub_.bind(ep.clone()).unwrap();
+    sub.subscribe("").unwrap();
+    sub.connect(ep).unwrap();
+
+    let recv_thread = std::thread::spawn(move || sub.recv().unwrap());
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        let _ = pub_.send(Message::single("msg"));
+        std::thread::sleep(Duration::from_millis(5));
+        if recv_thread.is_finished() {
+            break;
+        }
+    }
+    let m = recv_thread.join().unwrap();
+    assert_eq!(m, Message::single("msg"));
+}
+
+#[test]
+fn blocking_socket_into_async() {
+    let ctx = Context::new();
+    let sock = ctx.blocking_socket(SocketType::Push, Options::default());
+    assert_eq!(sock.socket_type(), SocketType::Push);
+    let async_sock = sock.into_async();
+    assert_eq!(async_sock.socket_type(), SocketType::Push);
+}
+
+#[test]
+fn blocking_socket_close() {
+    let ctx = Context::new();
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+    let ep = inproc_ep("blocking-close");
+    push.bind(ep).unwrap();
+    push.close().unwrap();
+}
+
+#[test]
+fn blocking_socket_multi_io_threads() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 2 });
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+
+    let ep = pull.bind(tcp_loopback(0)).unwrap();
+    push.connect(ep).unwrap();
+
+    std::thread::sleep(Duration::from_millis(50));
+
+    for i in 0..10 {
+        push.send(Message::single(format!("mt-bl-{i}"))).unwrap();
+    }
+    for i in 0..10 {
+        let m = pull.recv().unwrap();
+        assert_eq!(m, Message::single(format!("mt-bl-{i}")));
+    }
+}

--- a/omq-tokio/tests/interop_pyzmq_curve.rs
+++ b/omq-tokio/tests/interop_pyzmq_curve.rs
@@ -156,6 +156,66 @@ ctx.term()
 }
 
 // ---------------------------------------------------------------------
+// Rust CURVE REP <- pyzmq CURVE REQ
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn rust_curve_rep_from_pyzmq_req() {
+    if skip_if_no_pyzmq_curve() {
+        return;
+    }
+
+    let server_kp = CurveKeypair::generate();
+    let client_kp = CurveKeypair::generate();
+    let server_pub_z85 = server_kp.public.to_z85();
+    let client_pub_z85 = client_kp.public.to_z85();
+    let client_sec_z85 = client_kp.secret.to_z85();
+
+    let rep = Socket::new(SocketType::Rep, Options::default().curve_server(server_kp));
+    let port = bind_loopback(&rep).await;
+    let script = r#"
+import os, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.REQ)
+s.curve_secretkey = os.environ['CLI_SEC'].encode()
+s.curve_publickey = os.environ['CLI_PUB'].encode()
+s.curve_serverkey = os.environ['SRV_PUB'].encode()
+s.connect(f"tcp://127.0.0.1:{os.environ['PORT']}")
+s.send(b"curve-req")
+assert s.recv() == b"curve-rep"
+s.close(linger=2000)
+ctx.term()
+"#;
+    let child = Command::new("python3")
+        .args(["-c", script])
+        .env("PORT", port.to_string())
+        .env("SRV_PUB", &server_pub_z85)
+        .env("CLI_PUB", &client_pub_z85)
+        .env("CLI_SEC", &client_sec_z85)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 req");
+
+    wait_for_curve_handshake(&rep).await;
+    let request = tokio::time::timeout(Duration::from_secs(5), rep.recv())
+        .await
+        .expect("CURVE REQ timed out")
+        .unwrap();
+    assert_eq!(request.part_bytes(0).unwrap(), &b"curve-req"[..]);
+    rep.send(Message::single("curve-rep")).await.unwrap();
+
+    let out = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pyzmq req exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------
 // Rust CURVE PUSH -> pyzmq CURVE PULL
 // ---------------------------------------------------------------------
 

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -148,10 +148,9 @@ async fn rep_survives_client_disconnect_mid_cycle() {
             .expect("REP recv timed out for first client")
             .unwrap();
         assert_eq!(m, Message::single("drop-me"));
-        // req1 drops here: connection closes before REP replies.
+        req1.close().await.unwrap();
     }
 
-    // Give REP time to detect the disconnect and clear the stale envelope.
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     // Second client: full roundtrip must succeed.
@@ -248,6 +247,52 @@ async fn three_req_to_one_rep_direct_io_routing() {
             reply.part_bytes(0).unwrap(),
             format!("reply-{i}").as_bytes()
         );
+    }
+}
+
+/// Multiple REQ peers may have requests queued before REP calls `recv()`. The
+/// body queue must retain each request's routing envelope independently.
+#[tokio::test]
+async fn queued_requests_from_multiple_reqs_preserve_envelopes() {
+    const PEERS: usize = 3;
+
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let mut reqs = Vec::with_capacity(PEERS);
+    for i in 0..PEERS {
+        let req = Socket::new(SocketType::Req, Options::default());
+        req.connect(ep.clone()).await.unwrap();
+        test_support::wait_for_handshake(&req).await;
+        req.send(Message::single(format!("queued-{i}")))
+            .await
+            .unwrap();
+        reqs.push(req);
+    }
+
+    for _ in 0..PEERS {
+        let request = tokio::time::timeout(Duration::from_secs(5), rep.recv())
+            .await
+            .expect("REP recv timed out")
+            .unwrap();
+        let body = request.part_bytes(0).unwrap();
+        let index = std::str::from_utf8(&body)
+            .unwrap()
+            .strip_prefix("queued-")
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        rep.send(Message::single(format!("reply-{index}")))
+            .await
+            .unwrap();
+    }
+
+    for (i, req) in reqs.iter().enumerate() {
+        let reply = tokio::time::timeout(Duration::from_secs(5), req.recv())
+            .await
+            .expect("REQ recv timed out")
+            .unwrap();
+        assert_eq!(reply, Message::single(format!("reply-{i}")));
     }
 }
 

--- a/omq-tokio/tests/soak_cancel_safety.rs
+++ b/omq-tokio/tests/soak_cancel_safety.rs
@@ -45,8 +45,8 @@ fn soak_cancel_safety() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let mut rng = rand::make_rng::<StdRng>();
         let start = Instant::now();
         let mut iterations: u64 = 0;

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -65,15 +65,8 @@ pub fn soak_duration() -> Duration {
     Duration::from_secs(secs.max(5))
 }
 
-pub fn tokio_runtime() -> tokio::runtime::Runtime {
-    match std::env::var("OMQ_SOAK_TOKIO_RUNTIME").as_deref() {
-        Ok("current_thread") => tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("current-thread runtime"),
-        Ok("multi_thread") | Err(_) => tokio::runtime::Runtime::new().expect("runtime"),
-        Ok(other) => panic!("unsupported OMQ_SOAK_TOKIO_RUNTIME={other:?}"),
-    }
+pub fn build_context() -> omq_tokio::Context {
+    omq_tokio::Context::with_config(omq_tokio::ContextConfig::from_env())
 }
 
 // ---------------------------------------------------------------------------

--- a/omq-tokio/tests/soak_compression_lz4.rs
+++ b/omq-tokio/tests/soak_compression_lz4.rs
@@ -64,8 +64,8 @@ fn soak_compression_lz4_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let (pull, ep) = pull_on_loopback().await;
         let push = Socket::new(
             SocketType::Push,

--- a/omq-tokio/tests/soak_curve.rs
+++ b/omq-tokio/tests/soak_curve.rs
@@ -24,8 +24,8 @@ fn soak_curve_sustained() {
     let client_kp = CurveKeypair::generate();
     let server_pub = server_kp.public;
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let pull = Socket::new(
             SocketType::Pull,
             soak_common::soak_options().curve_server(server_kp),

--- a/omq-tokio/tests/soak_hwm_reconnect.rs
+++ b/omq-tokio/tests/soak_hwm_reconnect.rs
@@ -43,9 +43,11 @@ async fn rebind(ep: &omq_tokio::Endpoint) -> Option<Socket> {
 fn run_hwm_storm(name: &str, mute: OnMute) {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
+    let name = name.to_owned();
+    let report_name = name.clone();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         // Probe for a port, then close so we can rebind.
         let probe = Socket::new(SocketType::Pull, soak_common::soak_options());
         let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();
@@ -115,7 +117,7 @@ fn run_hwm_storm(name: &str, mute: OnMute) {
     });
 
     let report = monitor.stop();
-    report.assert_no_leak(name);
+    report.assert_no_leak(&report_name);
 }
 
 #[test]

--- a/omq-tokio/tests/soak_inproc_cross_thread.rs
+++ b/omq-tokio/tests/soak_inproc_cross_thread.rs
@@ -20,9 +20,11 @@ fn soak_inproc_cross_thread() {
     let sent = Arc::new(AtomicU64::new(0));
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
+    let report_sent = sent.clone();
+    let report_recvd = recvd.clone();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let pull = Socket::new(SocketType::Pull, Options::default());
         pull.bind(ep.clone()).await.unwrap();
 
@@ -81,8 +83,8 @@ fn soak_inproc_cross_thread() {
         let _ = recv_task.await;
     });
 
-    let s = sent.load(Ordering::Relaxed);
-    let r = recvd.load(Ordering::Relaxed);
+    let s = report_sent.load(Ordering::Relaxed);
+    let r = report_recvd.load(Ordering::Relaxed);
     eprintln!(
         "[inproc_xthread] done: sent {s}, recvd {r} in {:.1}s",
         duration.as_secs_f64(),

--- a/omq-tokio/tests/soak_large_throughput.rs
+++ b/omq-tokio/tests/soak_large_throughput.rs
@@ -92,11 +92,13 @@ fn soak_large_message_throughput() {
     let sent = Arc::new(AtomicU64::new(0));
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
+    let report_sent = sent.clone();
+    let report_stats = Arc::new(std::sync::Mutex::new(PayloadStats::new()));
+    let stats = report_stats.clone();
 
-    let rt = soak_common::tokio_runtime();
-    let stats = Arc::new(std::sync::Mutex::new(PayloadStats::new()));
+    let ctx = soak_common::build_context();
 
-    rt.block_on(async {
+    ctx.block_on(async move {
         let pull = Socket::new(SocketType::Pull, soak_common::soak_options().recv_hwm(4));
         let ep = pull.bind(soak_common::tcp_ep(0)).await.unwrap();
 
@@ -178,8 +180,8 @@ fn soak_large_message_throughput() {
     let report = monitor.stop();
     report.assert_no_leak("large_throughput");
 
-    let mut st = stats.lock().unwrap();
-    let total_sent = sent.load(Ordering::Relaxed);
+    let mut st = report_stats.lock().unwrap();
+    let total_sent = report_sent.load(Ordering::Relaxed);
     st.finalize(total_sent);
     eprintln!(
         "[large_throughput] reorders: {}, max distance: {}, dropped: {}/{}",

--- a/omq-tokio/tests/soak_mechanism_reconnect.rs
+++ b/omq-tokio/tests/soak_mechanism_reconnect.rs
@@ -40,14 +40,16 @@ async fn rebind(ep: &omq_tokio::Endpoint, make: impl Fn() -> Socket) -> Option<S
 
 fn run_mechanism_storm(
     name: &str,
-    make_server: impl Fn() -> Socket,
-    make_client: impl Fn(omq_tokio::Endpoint) -> Socket,
+    make_server: impl Fn() -> Socket + Send + Sync + 'static,
+    make_client: impl Fn(omq_tokio::Endpoint) -> Socket + Send + Sync + 'static,
 ) {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
+    let name = name.to_owned();
+    let report_name = name.clone();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let probe = make_server();
         let ep = probe.bind(soak_common::tcp_ep(0)).await.unwrap();
         probe.close().await.unwrap();
@@ -106,7 +108,7 @@ fn run_mechanism_storm(
     });
 
     let report = monitor.stop();
-    report.assert_no_leak(name);
+    report.assert_no_leak(&report_name);
 }
 
 #[cfg(feature = "curve")]

--- a/omq-tokio/tests/soak_multi_socket.rs
+++ b/omq-tokio/tests/soak_multi_socket.rs
@@ -68,8 +68,8 @@ fn soak_multi_socket() {
     let monitor = soak_common::ResourceMonitor::start();
     let mut tracker = soak_common::ThroughputTracker::new(Duration::from_secs(10));
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    let tracker = ctx.block_on(async move {
         let pairs = create_pairs().await;
         eprintln!("[multi_socket] created {} socket pairs", pairs.len());
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -138,10 +138,10 @@ fn soak_multi_socket() {
             "[multi_socket] done: {total_exchanged} messages across 50 pairs in {:.1}s",
             start.elapsed().as_secs_f64(),
         );
+        tracker
     });
 
     let report = monitor.stop();
     tracker.assert_stable("multi_socket");
-    drop(tracker);
     report.assert_no_leak("multi_socket");
 }

--- a/omq-tokio/tests/soak_peer_churn.rs
+++ b/omq-tokio/tests/soak_peer_churn.rs
@@ -16,8 +16,8 @@ use omq_tokio::{Message, Socket, SocketType};
 fn soak_peer_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let push = Socket::new(SocketType::Push, soak_common::soak_options().send_hwm(1024));
         let ep = push.bind(soak_common::tcp_ep(0)).await.unwrap();
 

--- a/omq-tokio/tests/soak_plain.rs
+++ b/omq-tokio/tests/soak_plain.rs
@@ -20,8 +20,8 @@ fn soak_plain_sustained() {
     let recvd = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let pull = Socket::new(
             SocketType::Pull,
             soak_common::soak_options().plain_server(|peer| {

--- a/omq-tokio/tests/soak_pub_sub_churn.rs
+++ b/omq-tokio/tests/soak_pub_sub_churn.rs
@@ -20,8 +20,8 @@ fn soak_pub_sub_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let ep = soak_common::inproc_ep("soak-pub-sub-churn");
         let publisher = Socket::new(SocketType::Pub, Options::default());
         publisher.bind(ep.clone()).await.unwrap();

--- a/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
+++ b/omq-tokio/tests/soak_pub_sub_churn_tcp.rs
@@ -53,8 +53,8 @@ fn soak_pub_sub_churn_tcp() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let publisher = Socket::new(SocketType::Pub, pub_options());
         let mut mon = publisher.monitor();
         let ep = publisher.bind(soak_common::tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_pub_sub_lz4_dict.rs
+++ b/omq-tokio/tests/soak_pub_sub_lz4_dict.rs
@@ -123,8 +123,8 @@ fn soak_pub_sub_lz4_dict_sharded_fanout() {
     let raw_probes = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let publisher = Socket::new(SocketType::Pub, lz4_options());
         let (ep, mut mon) = bind_lz4_pub(&publisher).await;
 

--- a/omq-tokio/tests/soak_pub_sub_realworld_churn_tcp.rs
+++ b/omq-tokio/tests/soak_pub_sub_realworld_churn_tcp.rs
@@ -203,8 +203,8 @@ fn soak_pub_sub_realworld_churn_tcp() {
     let phase_duration = phase_duration(duration);
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let publisher = Socket::new(SocketType::Pub, pub_options());
         let mut mon = publisher.monitor();
         let ep = publisher.bind(soak_common::tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/soak_reconnect_all_types.rs
@@ -147,8 +147,8 @@ fn soak_reconnect_all_types() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let mut pairs = create_all_pairs().await;
 
         let mut rng = rand::make_rng::<StdRng>();

--- a/omq-tokio/tests/soak_reconnect_storm.rs
+++ b/omq-tokio/tests/soak_reconnect_storm.rs
@@ -15,8 +15,8 @@ fn soak_reconnect_storm() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         // Bind port 0 to discover a free port, then use that endpoint for
         // repeated bind/close cycles so the dialer reconnects to the same address.
         let probe = Socket::new(SocketType::Pull, soak_common::soak_options());

--- a/omq-tokio/tests/soak_router_dealer_churn.rs
+++ b/omq-tokio/tests/soak_router_dealer_churn.rs
@@ -128,8 +128,8 @@ fn soak_router_dealer_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let router = Socket::new(
             SocketType::Router,
             soak_common::soak_options().router_mandatory(true),

--- a/omq-tokio/tests/soak_ws.rs
+++ b/omq-tokio/tests/soak_ws.rs
@@ -52,8 +52,8 @@ fn soak_ws_throughput() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let pull = Socket::new(SocketType::Pull, soak_common::soak_options());
         let ep = pull.bind(ws_ep(0)).await.unwrap();
         let port = get_port(&ep);
@@ -112,8 +112,8 @@ fn soak_ws_reconnect_storm() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         // Probe for a port.
         let probe = Socket::new(SocketType::Pull, soak_common::soak_options());
         let ep = probe.bind(ws_ep(0)).await.unwrap();

--- a/omq-tokio/tests/soak_xpub_xsub_churn.rs
+++ b/omq-tokio/tests/soak_xpub_xsub_churn.rs
@@ -38,8 +38,8 @@ fn soak_xpub_xsub_churn() {
     let duration = soak_common::soak_duration();
     let monitor = soak_common::ResourceMonitor::start();
 
-    let rt = soak_common::tokio_runtime();
-    rt.block_on(async {
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
         let xpub = Socket::new(SocketType::XPub, xpub_options());
         let ep = xpub.bind(soak_common::tcp_ep(0)).await.unwrap();
 

--- a/scripts/gen_comparison_chart.py
+++ b/scripts/gen_comparison_chart.py
@@ -25,24 +25,44 @@ CPU_LINE_DASH = "2,5"
 
 COLORS = {
     "libzmq": "#eab308",
+    "libzmq-2t": "#ca8a04",
     "libzmq-mt": "#a16207",
     "omq-tokio": "#f97316",
-    "omq-tokio-mt": "#dc2626",
+    "omq-tokio-2t": "#ea580c",
+    "omq-tokio-4t": "#dc2626",
     "zmq.rs": "#2563eb",
     "rzmq": "#16a34a",
     "rzmq-iouring": "#15803d",
     "omq-libzmq": "#06b6d4",
+    "omq-tokio-1t": "#f97316",
+    "omq-tokio-2t": "#ea580c",
+    "libzmq-curve-1t": "#eab308",
+    "libzmq-curve-2t": "#b45309",
+    "libzmq-curve-4t": "#92400e",
+    "omq-curve-1t": "#3b82f6",
+    "omq-curve-2t": "#2563eb",
+    "omq-curve-4t": "#1d4ed8",
 }
 
 LABELS = {
     "libzmq": "libzmq v4.3.5 (1T)",
+    "libzmq-2t": "libzmq v4.3.5 (2T)",
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
-    "omq-tokio-mt": "omq-tokio (2T)",
+    "omq-tokio-2t": "omq-tokio (2T)",
+    "omq-tokio-4t": "omq-tokio (4T)",
     "zmq.rs": "zmq.rs v0.6.0 [6T]",
     "rzmq": "rzmq v0.5.24 [6T]",
     "rzmq-iouring": "rzmq v0.5.24 (io_uring) [6T]",
     "omq-libzmq": "omq-libzmq [1T]",
+    "omq-tokio-1t": "omq-tokio (1T)",
+    "omq-tokio-2t": "omq-tokio (2T)",
+    "libzmq-curve-1t": "libzmq (1T)",
+    "libzmq-curve-2t": "libzmq (2T)",
+    "libzmq-curve-4t": "libzmq (4T)",
+    "omq-curve-1t": "omq-tokio (1T)",
+    "omq-curve-2t": "omq-tokio (2T)",
+    "omq-curve-4t": "omq-tokio (4T)",
 }
 
 
@@ -364,7 +384,7 @@ def draw_throughput_panel(
     # dashed msg/s lines
     draw_order = [name for name in
                   ["rzmq-iouring", "rzmq", "zmq.rs", "libzmq", "libzmq-mt",
-                   "omq-tokio-mt", "omq-tokio"]
+                   "omq-tokio-2t", "omq-tokio"]
                   if name in impls]
     for name in draw_order:
         pts = [
@@ -441,7 +461,7 @@ def draw_latency_panel(
     L.append(svg_text(40, mid_y, "p50 latency (µs)", weight="600", rotate=-90))
 
     draw_order = [name for name in
-                  ["rzmq-iouring", "libzmq", "libzmq-mt", "omq-tokio-mt", "omq-tokio",
+                  ["rzmq-iouring", "libzmq", "libzmq-mt", "omq-tokio-2t", "omq-tokio",
                    "rzmq", "zmq.rs"]
                   if name in impls]
     for name in draw_order:
@@ -485,10 +505,19 @@ def _throughput_draw_order(impls: list[str]) -> list[str]:
     order = [
         "rzmq-iouring",
         "libzmq",
+        "libzmq-2t",
         "libzmq-mt",
+        "libzmq-curve-1t",
+        "libzmq-curve-2t",
+        "libzmq-curve-4t",
         "omq-libzmq",
-        "omq-tokio-mt",
+        "omq-tokio-2t",
         "omq-tokio",
+        "omq-tokio-1t",
+        "omq-tokio-2t",
+        "omq-curve-1t",
+        "omq-curve-2t",
+        "omq-curve-4t",
         "rzmq",
         "zmq.rs",
     ]
@@ -840,7 +869,7 @@ def draw_throughput_cpu_panel(
 
     draw_order = [name for name in
                   ["rzmq-iouring", "libzmq", "libzmq-mt", "omq-libzmq",
-                   "omq-tokio-mt", "omq-tokio", "rzmq", "zmq.rs"]
+                   "omq-tokio-2t", "omq-tokio", "rzmq", "zmq.rs"]
                   if name in impls]
 
     # dotted CPU% lines
@@ -957,7 +986,7 @@ def draw_latency_cpu_panel(
 
     draw_order = [name for name in
                   ["rzmq-iouring", "libzmq", "libzmq-mt", "omq-libzmq",
-                   "omq-tokio-mt", "omq-tokio", "rzmq", "zmq.rs"]
+                   "omq-tokio-2t", "omq-tokio", "rzmq", "zmq.rs"]
                   if name in impls]
 
     # dotted CPU% lines (right axis)
@@ -1733,15 +1762,15 @@ def main():
         "inproc": "inproc",
     }
 
-    tcp_impls = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs", "rzmq", "rzmq-iouring"]
-    ipc_impls = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt", "zmq.rs", "rzmq", "rzmq-iouring"]
-    inproc_impls = ["libzmq", "omq-tokio", "omq-tokio-mt", "rzmq", "rzmq-iouring"]
+    omq_libzmq_tcp = ["libzmq", "libzmq-2t", "libzmq-mt", "omq-tokio", "omq-tokio-2t"]
+    omq_libzmq_ipc = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-2t"]
+    omq_libzmq_inproc = ["libzmq", "omq-tokio", "omq-tokio-2t"]
 
     # (transport, impls, log).
     cross_charts = [
-        ("tcp", tcp_impls, False),
-        ("ipc", ipc_impls, False),
-        ("inproc", inproc_impls, True),
+        ("tcp", omq_libzmq_tcp, False),
+        ("ipc", omq_libzmq_ipc, False),
+        ("inproc", omq_libzmq_inproc, True),
     ]
 
     for transport, impls, log in cross_charts:
@@ -1774,19 +1803,23 @@ def main():
             print(f"Written: {out}", file=sys.stderr)
 
     # ── PUB/SUB charts ──────────────────────────────────────────
-    pubsub_peer_counts = [1, 8, 32]
+    pubsub_peer_counts = [4, 64]
+    pubsub_impls = [
+        "libzmq", "libzmq-2t", "libzmq-mt",
+        "omq-tokio", "omq-tokio-2t",
+    ]
 
     def pubsub_title(peers, tl):
         sub_label = "1 subscriber" if peers == 1 else f"{peers} subscribers"
         return f"PUB/SUB throughput, {sub_label}: {tl}"
 
     panels = [
-        (p, load_pubsub_data("tcp", tcp_impls, p))
+        (p, load_pubsub_data("tcp", pubsub_impls, p))
         for p in pubsub_peer_counts
     ]
     if any(d["sizes"] for _, d in panels):
         svg = generate_multi_panel_cpu_chart(
-            panels, tcp_impls, "TCP loopback",
+            panels, pubsub_impls, "TCP loopback",
             hw_label=hw, title_fn=pubsub_title,
             label_overrides=label_overrides, show_st_mt=True,
         )
@@ -1795,8 +1828,40 @@ def main():
             out.write_text(svg)
             print(f"Written: {out}", file=sys.stderr)
 
+    # ── CURVE PUB/SUB chart ────────────────────────────────────
+    curve_impls = [
+        "libzmq-curve-1t", "libzmq-curve-2t", "libzmq-curve-4t",
+        "omq-curve-1t", "omq-curve-2t", "omq-curve-4t",
+    ]
+    curve_labels = {
+        "libzmq-curve-1t": "libzmq (1T)",
+        "libzmq-curve-2t": "libzmq (2T)",
+        "libzmq-curve-4t": "libzmq (4T)",
+        "omq-curve-1t": "omq-tokio (1T)",
+        "omq-curve-2t": "omq-tokio (2T)",
+        "omq-curve-4t": "omq-tokio (4T)",
+    }
+
+    def curve_title(peers, tl):
+        sub_label = "1 subscriber" if peers == 1 else f"{peers} subscribers"
+        return f"PUB/SUB CURVE throughput, {sub_label}: {tl}"
+
+    curve_data = load_pubsub_data("tcp", curve_impls, 16)
+    if curve_data["sizes"]:
+        curve_panels = [(16, curve_data)]
+        svg = generate_multi_panel_cpu_chart(
+            curve_panels, curve_impls, "TCP loopback",
+            hw_label=hw, title_fn=curve_title,
+            label_overrides=curve_labels,
+        )
+        if svg:
+            out = REPO / "doc" / "charts" / "pubsub" / "curve_tcp.svg"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(svg)
+            print(f"Written: {out}", file=sys.stderr)
+
     # ── Fan-out / fan-in charts (TCP only) ──────────────────────
-    fanio_peers = [2, 4, 8]
+    fanio_peers = [4, 64]
 
     def fanout_title(peers, tl):
         return f"PUSH fan-out (1 PUSH → {peers} PULL): {tl}"
@@ -1809,13 +1874,13 @@ def main():
         ("fan_in", fanin_title, "fanin"),
     ]:
         panels = [
-            (p, load_fanio_data("tcp", tcp_impls, p, kind))
+            (p, load_fanio_data("tcp", omq_libzmq_tcp, p, kind))
             for p in fanio_peers
         ]
         if not any(d["sizes"] for _, d in panels):
             continue
         svg = generate_multi_panel_cpu_chart(
-            panels, tcp_impls, "TCP loopback",
+            panels, omq_libzmq_tcp, "TCP loopback",
             hw_label=hw,
             title_fn=tfn,
             label_overrides=label_overrides,

--- a/scripts/gen_compression_chart.py
+++ b/scripts/gen_compression_chart.py
@@ -561,7 +561,7 @@ def main():
 
     svg = generate_svg(panels, tput_ranges, dict_size_label,
                        backend=args.backend, hw_label=detect_hardware())
-    output = repo / "doc" / "charts" / "compression" / f"{args.backend}_{ds}.svg"
+    output = repo / "doc" / "charts" / "compression" / f"{args.backend}.svg"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(svg)
     print(f"Written: {output}", file=sys.stderr)

--- a/scripts/gen_main_chart.py
+++ b/scripts/gen_main_chart.py
@@ -24,14 +24,14 @@ sys.path.insert(0, str(REPO / "scripts"))
 from chart_hw import detect_hardware
 
 # Union of all impls plotted in the main chart; used only as a load filter.
-IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt",
+IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-2t",
          "zmq.rs", "rzmq", "rzmq-iouring"]
 
 COLORS = {
     "libzmq": "#eab308",
     "libzmq-mt": "#a16207",
     "omq-tokio": "#f97316",
-    "omq-tokio-mt": "#dc2626",
+    "omq-tokio-2t": "#dc2626",
     "zmq.rs": "#2563eb",
     "rzmq": "#16a34a",
     "rzmq-iouring": "#15803d",
@@ -41,16 +41,16 @@ LABELS = {
     "libzmq": "libzmq v4.3.5 (1T)",
     "libzmq-mt": "libzmq v4.3.5 (4T)",
     "omq-tokio": "omq-tokio (1T)",
-    "omq-tokio-mt": "omq-tokio (2T)",
+    "omq-tokio-2t": "omq-tokio (2T)",
     "zmq.rs": "zmq.rs v0.6.0 [6T]",
     "rzmq": "rzmq v0.5.24 [6T]",
     "rzmq-iouring": "rzmq v0.5.24 (io_uring) [6T]",
 }
 
-MAIN_IMPLS = ["libzmq", "libzmq-mt", "omq-tokio", "omq-tokio-mt",
+MAIN_IMPLS = ["libzmq", "omq-tokio",
               "zmq.rs", "rzmq", "rzmq-iouring"]
 MAIN_DRAW_ORDER = ["rzmq-iouring", "rzmq", "zmq.rs", "libzmq",
-                   "libzmq-mt", "omq-tokio-mt", "omq-tokio"]
+                   "omq-tokio"]
 MAIN_TITLE = "PUSH/PULL throughput, TCP loopback, 2-process"
 
 
@@ -349,7 +349,7 @@ def draw_latency_panel(
     L.append(svg_line(x_left, y_top, x_left, y_bot, stroke="#9ca3af", width=1.5))
     L.append(svg_line(x_left, y_bot, x_right, y_bot, stroke="#9ca3af", width=1.5))
 
-    lat_draw_order = ["libzmq", "libzmq-mt", "omq-tokio-mt", "omq-tokio",
+    lat_draw_order = ["libzmq", "omq-tokio",
                       "rzmq", "rzmq-iouring", "zmq.rs"]
     for name in lat_draw_order:
         pts = [

--- a/scripts/libzmq_bench_peer.c
+++ b/scripts/libzmq_bench_peer.c
@@ -22,14 +22,18 @@
  *   <count> <elapsed_secs> <msg_size> <cpu_secs>
  */
 
+#define _DEFAULT_SOURCE
 #include <zmq.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 #include <ctype.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <sys/resource.h>
+#include <sys/wait.h>
 
 static double now_secs(void) {
     struct timespec ts;
@@ -69,16 +73,52 @@ static void die(const char *msg) {
     exit(1);
 }
 
-static void print_bound_port(void *sock) {
+/* Fixed CURVE keypairs for benchmarking (Z85-encoded, 40 chars each). */
+#define CURVE_SERVER_PUBLIC "c[nMZc{RbXmBJGbya&4/kW#Y.Ql4uT1wNJmp6/D@"
+#define CURVE_SERVER_SECRET "2(&.P[s%^&[zcwc3wjPJHlsb^j.F]{F4Bh{ed8S?"
+#define CURVE_CLIENT_PUBLIC "c[m^Q0-jh2zf931U<A)s8LsJaZ>KZY1#Na%Plr<s"
+#define CURVE_CLIENT_SECRET "R0/+YXMg3!(j7@pEBeg:r4hj]Nuldfd7-&jIGw+/"
+
+static int bench_curve_enabled(void) {
+    const char *s = getenv("ZMQ_BENCH_CURVE");
+    return s && *s && strcmp(s, "0") != 0;
+}
+
+static void setup_curve_server(void *sock) {
+    int as_server = 1;
+    zmq_setsockopt(sock, ZMQ_CURVE_SERVER, &as_server, sizeof(as_server));
+    zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, CURVE_SERVER_PUBLIC, 40);
+    zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, CURVE_SERVER_SECRET, 40);
+}
+
+static void setup_curve_client(void *sock) {
+    zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, CURVE_CLIENT_PUBLIC, 40);
+    zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, CURVE_CLIENT_SECRET, 40);
+    zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, CURVE_SERVER_PUBLIC, 40);
+}
+
+static void report_bound_port(void *ctx, void *sock) {
     char ep[256];
     size_t ep_len = sizeof(ep);
-    if (zmq_getsockopt(sock, ZMQ_LAST_ENDPOINT, ep, &ep_len) == 0) {
-        char *colon = strrchr(ep, ':');
-        if (colon) {
-            printf("PORT %s\n", colon + 1);
-            fflush(stdout);
-        }
-    }
+    if (zmq_getsockopt(sock, ZMQ_LAST_ENDPOINT, ep, &ep_len) != 0)
+        return;
+    char *colon = strrchr(ep, ':');
+    if (!colon)
+        return;
+    const char *port_str = colon + 1;
+
+    const char *coord = getenv("OMQ_BENCH_COORD");
+    if (!coord || !*coord)
+        return;
+
+    void *push = zmq_socket(ctx, ZMQ_PUSH);
+    if (!push) return;
+    int linger = 0;
+    zmq_setsockopt(push, ZMQ_LINGER, &linger, sizeof(linger));
+    zmq_connect(push, coord);
+    char msg[64];
+    snprintf(msg, sizeof(msg), "READY %s", port_str);
+    zmq_send(push, msg, strlen(msg), 0);
 }
 
 /* Returns a zmq address string. If s looks like a bare port number, expands
@@ -95,6 +135,7 @@ static const char *resolve_addr(const char *s, char *buf, size_t bufsz) {
     }
     return s;
 }
+
 
 typedef struct { void *ctx; const char *name; int size; } InprocPushArg;
 
@@ -136,7 +177,7 @@ int main(int argc, char **argv) {
         void *sock = zmq_socket(ctx, ZMQ_PUSH);
         if (!sock) die("zmq_socket PUSH");
         if (zmq_bind(sock, addr) != 0) die("zmq_bind");
-        print_bound_port(sock);
+        report_bound_port(ctx, sock);
         wait_for_start_barrier();
 
         char *buf = calloc(1, size);
@@ -225,7 +266,7 @@ done:;
         void *sock = zmq_socket(ctx, ZMQ_PULL);
         if (!sock) die("zmq_socket PULL");
         if (zmq_bind(sock, addr) != 0) die("zmq_bind");
-        print_bound_port(sock);
+        report_bound_port(ctx, sock);
         wait_for_start_barrier();
 
         zmq_msg_t msg;
@@ -268,9 +309,8 @@ done_pull_bind:;
         double elapsed = now_secs() - t0;
         double cpu = cpu_time_secs() - cpu_before;
         printf("%lld %.6f %d %.6f\n", count, elapsed, size, cpu);
-
-        zmq_msg_close(&msg);
-        zmq_close(sock);
+        fflush(stdout);
+        _exit(0);
 
     } else if (strcmp(role, "inproc") == 0) {
         if (argc < 5) goto usage;
@@ -337,8 +377,9 @@ done_inproc:;
         if (!sock) die("zmq_socket PUB");
         int block = 1;
         zmq_setsockopt(sock, ZMQ_XPUB_NODROP, &block, sizeof(block));
+        if (bench_curve_enabled()) setup_curve_server(sock);
         if (zmq_bind(sock, addr) != 0) die("zmq_bind");
-        print_bound_port(sock);
+        report_bound_port(ctx, sock);
         wait_for_start_barrier();
 
         char *buf = calloc(1, size);
@@ -357,6 +398,7 @@ done_inproc:;
 
         void *sock = zmq_socket(ctx, ZMQ_SUB);
         if (!sock) die("zmq_socket SUB");
+        if (bench_curve_enabled()) setup_curve_client(sock);
         zmq_setsockopt(sock, ZMQ_SUBSCRIBE, "", 0);
         if (zmq_connect(sock, addr) != 0) die("zmq_connect");
         wait_for_start_barrier();
@@ -495,11 +537,152 @@ done_inproc_pubsub:;
         for (int i = 0; i < actual_peers; i++) zmq_close(subs[i]);
         exit(0);
 
+    } else if (strcmp(role, "multi-pull") == 0 ||
+               strcmp(role, "multi-sub") == 0) {
+        if (argc < 6) goto usage;
+        double duration = atof(argv[4]);
+        int count = atoi(argv[5]);
+        if (count < 1 || count > 256) {
+            fprintf(stderr, "socket_count must be 1..256\n");
+            return 1;
+        }
+        int is_sub = (strcmp(role, "multi-sub") == 0);
+
+        typedef struct {
+            void *sock;
+            _Atomic long long counter;
+            volatile int stop;
+        } RecvWorker;
+
+        void *recv_thread(void *arg) {
+            RecvWorker *w = arg;
+            zmq_msg_t msg;
+            zmq_msg_init(&msg);
+            while (!w->stop) {
+                int rc = zmq_msg_recv(&msg, w->sock, 0);
+                if (rc < 0) {
+                    if (zmq_errno() == EAGAIN) continue;
+                    break;
+                }
+                atomic_fetch_add_explicit(&w->counter, 1,
+                                          memory_order_relaxed);
+            }
+            zmq_msg_close(&msg);
+            return NULL;
+        }
+
+        RecvWorker workers[256];
+        void *sockets[256];
+        pthread_t threads[256];
+
+        for (int i = 0; i < count; i++) {
+            if (is_sub) {
+                sockets[i] = zmq_socket(ctx, ZMQ_SUB);
+                if (!sockets[i]) die("zmq_socket SUB");
+                if (bench_curve_enabled()) setup_curve_client(sockets[i]);
+                zmq_setsockopt(sockets[i], ZMQ_SUBSCRIBE, "", 0);
+            } else {
+                sockets[i] = zmq_socket(ctx, ZMQ_PULL);
+                if (!sockets[i]) die("zmq_socket PULL");
+            }
+            if (zmq_connect(sockets[i], addr) != 0) die("zmq_connect");
+            workers[i].sock = sockets[i];
+            atomic_store(&workers[i].counter, 0);
+            workers[i].stop = 0;
+        }
+
+        wait_for_start_barrier();
+
+        /* warmup: let sockets receive for 500 ms, then zero counters */
+        for (int i = 0; i < count; i++)
+            pthread_create(&threads[i], NULL, recv_thread, &workers[i]);
+
+        struct timespec warmup_ts = {0, 500000000};
+        nanosleep(&warmup_ts, NULL);
+        for (int i = 0; i < count; i++)
+            atomic_store(&workers[i].counter, 0);
+
+        double cpu_before = cpu_time_secs();
+        double t0 = now_secs();
+        double deadline_secs = duration;
+        long sleep_secs = (long)deadline_secs;
+        long sleep_ns = (long)((deadline_secs - sleep_secs) * 1e9);
+        struct timespec dur_ts = { sleep_secs, sleep_ns };
+        nanosleep(&dur_ts, NULL);
+        double elapsed = now_secs() - t0;
+        double cpu = cpu_time_secs() - cpu_before;
+
+        for (int i = 0; i < count; i++)
+            workers[i].stop = 1;
+
+        /* unblock threads stuck in zmq_msg_recv by setting a short timeout */
+        int timeout_ms = 1;
+        for (int i = 0; i < count; i++)
+            zmq_setsockopt(sockets[i], ZMQ_RCVTIMEO, &timeout_ms,
+                           sizeof(timeout_ms));
+        for (int i = 0; i < count; i++)
+            pthread_join(threads[i], NULL);
+
+        long long total = 0;
+        double per_min = 1e18, per_max = 0;
+        for (int i = 0; i < count; i++) {
+            long long c = atomic_load(&workers[i].counter);
+            total += c;
+            double rate = (double)c / elapsed;
+            if (rate < per_min) per_min = rate;
+            if (rate > per_max) per_max = rate;
+        }
+        printf("%lld %.6f %d %.6f %d %.1f %.1f\n",
+               total, elapsed, size, cpu, count, per_min, per_max);
+
+        for (int i = 0; i < count; i++)
+            zmq_close(sockets[i]);
+
+    } else if (strcmp(role, "multi-push") == 0) {
+        if (argc < 5) goto usage;
+        int count = atoi(argv[4]);
+        if (count < 1 || count > 256) {
+            fprintf(stderr, "socket_count must be 1..256\n");
+            return 1;
+        }
+
+        void *send_thread(void *arg) {
+            void *sock = arg;
+            char *buf = calloc(1, size);
+            memset(buf, 'x', size);
+            for (;;) {
+                if (zmq_send(sock, buf, size, 0) < 0) break;
+            }
+            free(buf);
+            return NULL;
+        }
+
+        void *sockets[256];
+        pthread_t threads[256];
+
+        for (int i = 0; i < count; i++) {
+            sockets[i] = zmq_socket(ctx, ZMQ_PUSH);
+            if (!sockets[i]) die("zmq_socket PUSH");
+            if (zmq_connect(sockets[i], addr) != 0) die("zmq_connect");
+        }
+
+        wait_for_start_barrier();
+
+        for (int i = 0; i < count; i++)
+            pthread_create(&threads[i], NULL, send_thread, sockets[i]);
+
+        /* run forever; killed externally */
+        for (int i = 0; i < count; i++)
+            pthread_join(threads[i], NULL);
+
+        for (int i = 0; i < count; i++)
+            zmq_close(sockets[i]);
+
     } else if (strcmp(role, "rep") == 0) {
         void *sock = zmq_socket(ctx, ZMQ_REP);
         if (!sock) die("zmq_socket REP");
         if (zmq_bind(sock, addr) != 0) die("zmq_bind");
-        print_bound_port(sock);
+        report_bound_port(ctx, sock);
 
         zmq_msg_t msg;
         zmq_msg_init(&msg);
@@ -684,6 +867,9 @@ done_inproc_pubsub:;
 usage:
     fprintf(stderr, "usage: %s push <addr> <size>\n", argv[0]);
     fprintf(stderr, "       %s pull <addr> <size> <duration_secs>\n", argv[0]);
+    fprintf(stderr, "       %s multi-pull <addr> <size> <duration_secs> <count>\n", argv[0]);
+    fprintf(stderr, "       %s multi-sub <addr> <size> <duration_secs> <count>\n", argv[0]);
+    fprintf(stderr, "       %s multi-push <addr> <size> <count>\n", argv[0]);
     fprintf(stderr, "       %s inproc <name> <size> <duration_secs>\n", argv[0]);
     fprintf(stderr, "       %s rep <addr> <size>\n", argv[0]);
     fprintf(stderr, "       %s req <addr> <size> <iterations> <warmup>\n", argv[0]);

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -204,8 +204,9 @@ def libzmq_version() -> str:
 
 # ── process management ────────────────────────────────────────────
 
-MEASURED_CPU = "0,1,2"
+MEASURED_CPU = "0,1,2,3"
 OTHER_CPU = "3,4,5"
+SINK_IO_THREADS = "3"
 
 
 def spawn_process(binary: str, *args: str, env: dict | None = None,
@@ -394,6 +395,34 @@ def parse_throughput(output: str, size: int) -> dict | None:
     return result
 
 
+def parse_multi_throughput(output: str, size: int, peers: int) -> dict | None:
+    """Parse output from multi-pull / multi-sub.
+
+    Format: total_count elapsed size cpu_secs socket_count per_min_rate per_max_rate
+    """
+    parts = output.strip().split()
+    if len(parts) < 4:
+        return None
+    count = float(parts[0])
+    elapsed = float(parts[1])
+    if count <= 0 or elapsed <= 0:
+        return None
+    cpu = float(parts[3])
+    per_peer_msgs = count / elapsed / peers
+    result = {
+        "msgs_s": per_peer_msgs,
+        "mbps": count * size / elapsed / 1e6,
+        "elapsed": elapsed,
+        "peers_measured": peers,
+    }
+    if cpu > 0:
+        result["pull_cpu"] = cpu
+    if len(parts) >= 7:
+        result["peer_min"] = float(parts[5])
+        result["peer_max"] = float(parts[6])
+    return result
+
+
 def zero_tput_result(duration: float) -> dict:
     return {
         "msgs_s": 0.0,
@@ -463,7 +492,7 @@ def _run_throughput_once(
     dur = str(duration)
     issues: list = []
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
-    recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
+    recv_env = {**cell_env, "OMQ_IO_THREADS": "1"}
     if transport == "inproc":
         fresh_name = f"{addr}-{next_addr_id()}"
         timeout_s = max(int(duration) + 5, 8)
@@ -554,7 +583,9 @@ def _run_pubsub_once(
     else:
         addr = _fresh_addr(addr)
         cleanup_ipc_socket(addr)
-        recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
+        recv_env = {**cell_env,
+                    "OMQ_IO_THREADS": SINK_IO_THREADS,
+                    "ZMQ_IO_THREADS": SINK_IO_THREADS}
         pub_args = [binary, "pub", addr, str(size)]
         if pub_needs_peers:
             pub_args.append(str(peers))
@@ -568,64 +599,29 @@ def _run_pubsub_once(
                 kill_process(pub_)
                 return None
             connect_addr = str(port)
-        subs = []
-        outputs = []
         try:
-            for _ in range(peers):
-                subs.append(spawn_process(binary, "sub", connect_addr,
-                                          str(size), dur, env=recv_env,
-                                          cpu=OTHER_CPU))
-            time.sleep(0.05)
-            timeout_s = max(int(duration) + 5, 8)
-            for s in subs:
-                try:
-                    out, _ = s.communicate(timeout=timeout_s)
-                    _deregister_proc(s)
-                except subprocess.TimeoutExpired:
-                    print(f"WARNING: timeout: {binary} sub {connect_addr} {size} {dur}",
-                          file=sys.stderr)
-                    _hard_kill(s)
-                    out = ""
-                outputs.append(out)
+            timeout_s = max(int(duration) + 8, 10)
+            output, _ = capture_with_cpu(
+                binary, "multi-sub", connect_addr, str(size), dur,
+                str(peers), timeout=timeout_s, env=recv_env, cpu=OTHER_CPU)
             pub_cpu = read_proc_cpu(pub_.pid)
         finally:
             _hard_kill(pub_)
-            for s in subs:
-                _hard_kill(s)
             cleanup_ipc_socket(addr)
-        parsed = [r for r in (parse_throughput(o, size) for o in outputs) if r]
-        if not parsed:
-            result = zero_tput_result(duration)
-        elif len(parsed) != peers:
+        result = parse_multi_throughput(output, size, peers)
+        if not result:
             result = zero_tput_result(duration)
         else:
-            per_peer = [r["msgs_s"] for r in parsed]
-            total = sum(per_peer)
-            elapsed = max(r["elapsed"] for r in parsed)
-            pull_cpu = sum(r.get("pull_cpu", 0.0) for r in parsed)
-            n_with_cpu = sum(1 for r in parsed if "pull_cpu" in r)
-            result = {
-                "msgs_s": total / peers,
-                "mbps": total * size / 1e6,
-                "elapsed": elapsed,
-                "peer_min": min(per_peer),
-                "peer_max": max(per_peer),
-                "peers_measured": len(per_peer),
-            }
             pub_ok = _note(issues, pub_cpu > 0, impl, "pubsub", transport, size,
                            peers, "pub CPU (/proc)")
-            sub_ok = _note(issues, n_with_cpu == len(parsed), impl, "pubsub",
-                           transport, size, peers,
-                           f"CPU from {len(parsed) - n_with_cpu} of "
-                           f"{len(parsed)} subscribers (peer stdout)")
+            sub_ok = _note(issues, "pull_cpu" in result, impl, "pubsub",
+                           transport, size, peers, "subscriber CPU (multi-sub stdout)")
             if pub_ok and sub_ok:
-                result["cpu_time"] = pub_cpu + pull_cpu
+                result["cpu_time"] = pub_cpu + result["pull_cpu"]
             if pub_ok:
                 result["pub_cpu_time"] = pub_cpu
     if result:
         result["_issues"] = issues
-        if peers > 1 and "peers_measured" not in result:
-            result["mbps"] *= peers
     return result
 
 
@@ -633,15 +629,15 @@ def run_fanout_cell(
     binary: str, transport: str, addr: str, size: int, peers: int,
     duration: float = DEFAULT_DURATION,
     rounds: int = DEFAULT_ROUNDS,
-    push_subcmd: str = "push",
-    push_needs_peers: bool = False,
+    fanout_subcmd: str = "push",
+    fanout_needs_peers: bool = False,
     env: dict | None = None,
     impl: str = "?",
 ) -> dict | None:
     best = None
     for _ in range(max(1, rounds)):
         result = _run_fanout_once(binary, transport, addr, size, peers, duration,
-                                  push_subcmd, push_needs_peers, env=env, impl=impl)
+                                  fanout_subcmd, fanout_needs_peers, env=env, impl=impl)
         if result and (best is None or result["msgs_s"] > best["msgs_s"]):
             best = result
     _flush_issues(best)
@@ -651,21 +647,20 @@ def run_fanout_cell(
 def _run_fanout_once(
     binary: str, transport: str, addr: str, size: int, peers: int,
     duration: float,
-    push_subcmd: str = "push",
-    push_needs_peers: bool = False,
+    fanout_subcmd: str = "push",
+    fanout_needs_peers: bool = False,
     env: dict | None = None,
     impl: str = "?",
 ) -> dict | None:
     addr = _fresh_addr(addr)
     cleanup_ipc_socket(addr)
     issues: list = []
-    start_at = time.time() + 2.0
-    cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{start_at:.6f}"}
-    recv_env = {**cell_env, "OMQ_BENCH_TOKIO_THREADS": "1"}
-    # Some peers need the worker count up front to
-    # accept exactly N connections; pass it as a trailing arg when required.
-    push_args = [binary, push_subcmd, addr, str(size)]
-    if push_needs_peers:
+    cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
+    recv_env = {**cell_env,
+                "OMQ_IO_THREADS": SINK_IO_THREADS,
+                "ZMQ_IO_THREADS": SINK_IO_THREADS}
+    push_args = [binary, fanout_subcmd, addr, str(size)]
+    if fanout_needs_peers:
         push_args.append(str(peers))
     push = spawn_process(*push_args, env=cell_env, cpu=MEASURED_CPU)
     if transport in ("ipc", "ws"):
@@ -679,85 +674,25 @@ def _run_fanout_once(
             kill_process(push)
             return None
         connect_addr = str(port)
-    # Capture EVERY puller (not 1 + N-1 blind drains) so we can report
-    # aggregate throughput AND per-peer fairness: a starving peer (broken
-    # round-robin) shows up as a wide [peer_min, peer_max] spread.
-    pulls = []
-    outputs = []
     try:
-        for _ in range(peers):
-            pulls.append(spawn_process(binary, "pull", connect_addr,
-                                       str(size), str(duration), env=recv_env,
-                                       cpu=OTHER_CPU))
-        time.sleep(0.05)
-        time.sleep(max(0.0, start_at + PEER_WARMUP_SECS - time.time()))
-        push_cpu_before = read_proc_cpu(push.pid)
-        # A starved puller (e.g. rzmq's load-balancer skipping one of N peers)
-        # blocks in recv() past its own deadline and never prints. Keep the
-        # timeout tight so a dead round is cheap: best-of-N only needs one
-        # clean round per cell, so retries are far cheaper than a 15s hang.
-        for p in pulls:
-            try:
-                out, _ = p.communicate(timeout=max(int(duration) + 3, 5))
-                _deregister_proc(p)
-            except subprocess.TimeoutExpired:
-                _hard_kill(p)
-                out = ""
-            outputs.append(out)
-        push_cpu = max(0.0, read_proc_cpu(push.pid) - push_cpu_before)
+        timeout_s = max(int(duration) + 8, 10)
+        output, _ = capture_with_cpu(
+            binary, "multi-pull", connect_addr, str(size), str(duration),
+            str(peers), timeout=timeout_s, env=recv_env, cpu=OTHER_CPU)
+        push_cpu = read_proc_cpu(push.pid)
     finally:
         _hard_kill(push)
-        for p in pulls:
-            _hard_kill(p)
         cleanup_ipc_socket(addr)
-    if os.environ.get("OMQ_DEBUG_RAW"):
-        for i, o in enumerate(outputs):
-            print(f"   [raw] {impl} fan_out size={size} peers={peers} "
-                  f"puller#{i}: {o.strip()!r}", file=sys.stderr)
-    parsed = [r for r in (parse_throughput(o, size) for o in outputs) if r]
-    if not parsed:
+    result = parse_multi_throughput(output, size, peers)
+    if not result:
         return zero_tput_result(duration)
-    # Every puller must report, or msgs_s (total/peers) and the fairness whisker
-    # would be computed from a partial set. Treat persistent partial delivery as
-    # zero transported for this supported pattern instead of recording an
-    # undercounted point.
-    if len(parsed) != peers:
-        return zero_tput_result(duration)
-    per_peer = [r["msgs_s"] for r in parsed]
-    total = sum(per_peer)
-    # Reject physically-impossible rounds. A single TCP loopback stream tops
-    # out well under SINGLE_STREAM_MBPS, so any one peer reporting above that
-    # is a measurement glitch (a truncated/concatenated stdout line parsed
-    # into a bogus count), NOT a real result. Discard the whole round:
-    # best-of-N selects the MAX msgs_s, so without this guard an inflated
-    # glitch round wins and a 78 GB/s point lands in the chart.
-    peak_mbps = max(per_peer) * size / 1e6
-    if peak_mbps > SINGLE_STREAM_MBPS:
-        print(f"   !! discarding glitch round: {impl} fan_out size={size} "
-              f"peers={peers} peak {peak_mbps:.0f} MB/s/peer "
-              f"(> {SINGLE_STREAM_MBPS} ceiling)", file=sys.stderr)
-        return None
-    elapsed = max(r["elapsed"] for r in parsed)
-    pull_cpu = sum(r.get("pull_cpu", 0.0) for r in parsed)
-    n_with_cpu = sum(1 for r in parsed if "pull_cpu" in r)
-    # msgs_s = mean per-peer rate (outer-right axis, matches the whisker);
-    # mbps = aggregate bytes/s across all pullers (inner-right GB/s axis).
-    result = {
-        "msgs_s": total / peers,
-        "mbps": total * size / 1e6,
-        "elapsed": elapsed,
-        "peer_min": min(per_peer),
-        "peer_max": max(per_peer),
-        "peers_measured": len(per_peer),
-    }
     push_ok = _note(issues, push_cpu > 0, impl, "fan_out", transport, size, peers,
-                          "push CPU (/proc)")
+                    "push CPU (/proc)")
     if push_ok:
-        # Fan-out CPU is producer-side cost. Pullers are measurement sinks.
         result["cpu_time"] = push_cpu
         result["push_cpu_time"] = push_cpu
-    if n_with_cpu == len(parsed):
-        result["pull_cpu_time"] = pull_cpu
+    if "pull_cpu" in result:
+        result["pull_cpu_time"] = result["pull_cpu"]
     result["_issues"] = issues
     return result
 
@@ -794,7 +729,6 @@ def _run_fanin_once(
     dur = str(duration)
     issues: list = []
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
-    # Some peers need the worker count to accept exactly N pushers.
     pull_args = [binary, pull_subcmd, addr, str(size), dur]
     if pull_needs_peers:
         pull_args.append(str(peers))
@@ -808,35 +742,28 @@ def _run_fanin_once(
             kill_process(pull)
             return None
         connect_addr = str(port)
-    pushers = []
+    multi_push = spawn_process(binary, "multi-push", connect_addr,
+                               str(size), str(peers), env=cell_env,
+                               cpu=OTHER_CPU)
     try:
-        for _ in range(peers):
-            pushers.append(spawn_process(binary, "push-connect", connect_addr,
-                                         str(size), env=cell_env,
-                                         cpu=OTHER_CPU))
         stdout, _ = pull.communicate(timeout=max(int(duration) + 10, 15))
         _deregister_proc(pull)
-        pusher_cpus = [read_proc_cpu(p.pid) for p in pushers]
+        push_cpu = read_proc_cpu(multi_push.pid)
     except subprocess.TimeoutExpired:
         _hard_kill(pull)
         stdout = ""
-        pusher_cpus = []
+        push_cpu = 0.0
     finally:
-        for p in pushers:
-            _hard_kill(p)
+        _hard_kill(multi_push)
         cleanup_ipc_socket(addr)
     result = parse_throughput(stdout, size)
     if result:
-        # Pusher CPU comes from /proc, which always reads (alive or zombie), so
-        # a per-pusher 0 means genuinely idle (back-pressured), not missing.
-        # Only a whole-set zero is suspicious; the collector's stdout CPU is the
-        # field that can actually go absent.
-        push_ok = _note(issues, sum(pusher_cpus) > 0, impl, "fan_in", transport,
-                              size, peers, "pusher CPU (all /proc reads 0)")
+        push_ok = _note(issues, push_cpu > 0, impl, "fan_in", transport,
+                        size, peers, "pusher CPU (/proc multi-push)")
         pull_ok = _note(issues, "pull_cpu" in result, impl, "fan_in", transport,
-                              size, peers, "collector CPU (peer stdout)")
+                        size, peers, "collector CPU (peer stdout)")
         if push_ok and pull_ok:
-            result["cpu_time"] = sum(pusher_cpus) + result["pull_cpu"]
+            result["cpu_time"] = push_cpu + result["pull_cpu"]
         if pull_ok:
             result["pull_cpu_time"] = result["pull_cpu"]
         result["_issues"] = issues
@@ -979,9 +906,11 @@ IMPLS = {
         "inproc_lat_subcmd": "inproc-latency",
         "inproc_pubsub_subcmd": "inproc-pubsub",
         "pub_needs_peer_count": True,
+        "fanout_subcmd": "pub-fanout",
+        "fanio_needs_peer_count": True,
         "supports_pubsub": True,
     },
-    "omq-tokio-mt": {
+    "omq-tokio-2t": {
         "binary_from": "omq-tokio",
         "prefix": "u",
         "class": "classic",
@@ -990,10 +919,10 @@ IMPLS = {
         "inproc_lat_subcmd": "inproc-latency",
         "inproc_pubsub_subcmd": "inproc-pubsub",
         "pub_needs_peer_count": True,
-        "fanout_push_subcmd": "push-fanout",
-        "fanio_needs_peer_count": True,
+        "fanout_subcmd": "push",
+        "fanio_needs_peer_count": False,
         "supports_pubsub": True,
-        "env": {"OMQ_BENCH_TOKIO_THREADS": "2"},
+        "env": {"OMQ_IO_THREADS": "2"},
     },
     "libzmq": {
         "prefix": "z",
@@ -1003,6 +932,14 @@ IMPLS = {
         "inproc_lat_subcmd": "inproc-latency",
         "inproc_pubsub_subcmd": "inproc-pubsub",
         "supports_pubsub": True,
+    },
+    "libzmq-2t": {
+        "binary_from": "libzmq",
+        "prefix": "Y",
+        "class": "classic",
+        "transports": ["tcp", "ipc", "ws"],
+        "supports_pubsub": True,
+        "env": {"ZMQ_IO_THREADS": "2"},
     },
     "libzmq-mt": {
         "binary_from": "libzmq",
@@ -1038,37 +975,109 @@ IMPLS = {
         "supports_pubsub": True,
         "env": {"RZMQ_IO_URING": "1"},
     },
+    "omq-tokio-1t": {
+        "binary_from": "omq-tokio",
+        "prefix": "s1",
+        "transports": ["tcp", "ipc"],
+        "pub_needs_peer_count": True,
+        "fanout_subcmd": "pub-fanout",
+        "fanio_needs_peer_count": True,
+        "supports_pubsub": True,
+        "env": {"OMQ_IO_THREADS": "1"},
+    },
+    "omq-tokio-4t": {
+        "binary_from": "omq-tokio",
+        "prefix": "s4",
+        "transports": ["tcp", "ipc"],
+        "pub_needs_peer_count": True,
+        "fanout_subcmd": "pub-fanout",
+        "fanio_needs_peer_count": True,
+        "supports_pubsub": True,
+        "env": {"OMQ_IO_THREADS": "4"},
+    },
+    "libzmq-curve-1t": {
+        "binary_from": "libzmq",
+        "prefix": "lc1",
+        "class": "curve",
+        "transports": ["tcp"],
+        "supports_pubsub": True,
+        "env": {"ZMQ_IO_THREADS": "1", "ZMQ_BENCH_CURVE": "1"},
+    },
+    "libzmq-curve-2t": {
+        "binary_from": "libzmq",
+        "prefix": "lc2",
+        "class": "curve",
+        "transports": ["tcp"],
+        "supports_pubsub": True,
+        "env": {"ZMQ_IO_THREADS": "2", "ZMQ_BENCH_CURVE": "1"},
+    },
+    "libzmq-curve-4t": {
+        "binary_from": "libzmq",
+        "prefix": "lc4",
+        "class": "curve",
+        "transports": ["tcp"],
+        "supports_pubsub": True,
+        "env": {"ZMQ_IO_THREADS": "4", "ZMQ_BENCH_CURVE": "1"},
+    },
+    "omq-curve-1t": {
+        "binary_from": "omq-tokio",
+        "prefix": "oc1",
+        "class": "curve",
+        "transports": ["tcp"],
+        "pub_needs_peer_count": True,
+        "supports_pubsub": True,
+        "env": {"OMQ_IO_THREADS": "1", "OMQ_BENCH_MECHANISM": "curve"},
+    },
+    "omq-curve-2t": {
+        "binary_from": "omq-tokio",
+        "prefix": "oc2",
+        "class": "curve",
+        "transports": ["tcp"],
+        "pub_needs_peer_count": True,
+        "supports_pubsub": True,
+        "env": {"OMQ_IO_THREADS": "2", "OMQ_BENCH_MECHANISM": "curve"},
+    },
+    "omq-curve-4t": {
+        "binary_from": "omq-tokio",
+        "prefix": "oc4",
+        "class": "curve",
+        "transports": ["tcp"],
+        "pub_needs_peer_count": True,
+        "supports_pubsub": True,
+        "env": {"OMQ_IO_THREADS": "4", "OMQ_BENCH_MECHANISM": "curve"},
+    },
 }
 
-PUBSUB_PEER_COUNTS = [1, 8, 32]
-FANOUT_PEER_COUNTS = [2, 4, 8]
-FANIN_PEER_COUNTS = [2, 4, 8]
+PUBSUB_PEER_COUNTS = [4, 64]
+FANOUT_PEER_COUNTS = [4, 64]
+FANIN_PEER_COUNTS = [4, 64]
 
 
 def build_peers(impl_names: set[str], ws_needed: bool):
     binaries = {}
     features = ["ws"] if ws_needed else []
 
-    if impl_names & {"omq-tokio", "omq-tokio-mt"}:
+    omq_io_names = {"omq-tokio-1t", "omq-tokio-2t", "omq-tokio-4t"}
+    curve_omq_names = {"omq-curve-1t", "omq-curve-2t", "omq-curve-4t"}
+    omq_all = {"omq-tokio", "omq-tokio-2t"} | omq_io_names | curve_omq_names
+    if impl_names & omq_all:
         print("==> building omq-tokio bench_peer...", file=sys.stderr)
         tokio_features = list(features) if features else []
-        tokio_features.append("rt-multi-thread")
+        if impl_names & curve_omq_names:
+            tokio_features.append("curve")
         cargo_build("omq-tokio", "bench_peer_tokio", features=tokio_features)
         tokio_bin = str(ROOT / "target" / "release" / "bench_peer_tokio")
-        if "omq-tokio" in impl_names:
-            binaries["omq-tokio"] = tokio_bin
-        if "omq-tokio-mt" in impl_names:
-            binaries["omq-tokio-mt"] = tokio_bin
+        for name in omq_all & impl_names:
+            binaries[name] = tokio_bin
 
-    if impl_names & {"libzmq", "libzmq-mt"}:
+    curve_libzmq_names = {"libzmq-curve-1t", "libzmq-curve-2t", "libzmq-curve-4t"}
+    if impl_names & ({"libzmq", "libzmq-2t", "libzmq-mt"} | curve_libzmq_names):
         print("==> building libzmq bench_peer...", file=sys.stderr)
         src = ROOT / "scripts" / "libzmq_bench_peer.c"
         out = ROOT / "scripts" / "libzmq_bench_peer"
         gcc_build(src, out)
-        if "libzmq" in impl_names:
-            binaries["libzmq"] = str(out)
-        if "libzmq-mt" in impl_names:
-            binaries["libzmq-mt"] = str(out)
+        for ln in ({"libzmq", "libzmq-2t", "libzmq-mt"} | curve_libzmq_names) & impl_names:
+            binaries[ln] = str(out)
 
     if "zmq.rs" in impl_names:
         print("==> building zmq.rs bench_peer...", file=sys.stderr)
@@ -1115,6 +1124,8 @@ def run_benchmarks(
     fanout_peers: list[int] | None = None,
     run_fanin: bool = False,
     fanin_peers: list[int] | None = None,
+    run_curve: bool = False,
+    curve_peers: int = 16,
 ):
     _cleanup_ipc_sockets()
     atexit.register(_cleanup_ipc_sockets)
@@ -1235,6 +1246,7 @@ def run_benchmarks(
             pubsub_active = {
                 name: path for name, path in active.items()
                 if IMPLS[name].get("supports_pubsub")
+                and IMPLS[name].get("class") != "curve"
             }
         else:
             pubsub_active = {}
@@ -1313,8 +1325,8 @@ def run_benchmarks(
                         result = run_fanout_cell(
                             binary, transport, addr, size, peers,
                             duration=duration, rounds=rounds,
-                            push_subcmd=impl_def.get("fanout_push_subcmd", "push"),
-                            push_needs_peers=impl_def.get("fanio_needs_peer_count", False),
+                            fanout_subcmd=impl_def.get("fanout_subcmd", "push"),
+                            fanout_needs_peers=impl_def.get("fanio_needs_peer_count", False),
                             env=impl_def.get("env"), impl=name,
                         )
                         cells[name] = result
@@ -1419,6 +1431,66 @@ def run_benchmarks(
                             line += f"  {0:>9.0f} msg/s {0:>6.1f} MB/s ZERO"
                     print(line, file=sys.stderr)
 
+    # ── CURVE PUB/SUB ─────────────────────────────────────────────
+    if run_curve:
+        curve_active = {
+            name: path for name, path in binaries.items()
+            if IMPLS[name].get("class") == "curve"
+            and "tcp" in IMPLS[name]["transports"]
+        }
+        if curve_active:
+            peers = curve_peers
+            print(f"\n── CURVE pub/sub {peers}p: tcp ──", file=sys.stderr)
+            header = "".join(f"  {name:>22s}" for name in curve_active)
+            print(f"{'size':>10s}{header}", file=sys.stderr)
+            for idx, size in enumerate(sizes):
+                cells = {}
+                for name, binary in curve_active.items():
+                    impl_def = IMPLS[name]
+                    prefix = impl_def["prefix"]
+                    port_offset = 500 + idx
+                    addr = addr_for("tcp", prefix, port_offset, base_port)
+                    result = run_pubsub_cell(
+                        binary, "tcp", addr, size, peers,
+                        pub_needs_peers=impl_def.get("pub_needs_peer_count", False),
+                        duration=duration, rounds=rounds,
+                        env=impl_def.get("env"), impl=name,
+                    )
+                    cells[name] = result
+                    if result:
+                        row = {
+                            "run_id": run_id,
+                            "impl": name,
+                            "kind": "pub_sub",
+                            "transport": "tcp",
+                            "peers": peers,
+                            "msg_size": size,
+                            "msgs_s": round(result["msgs_s"], 1),
+                            "mbps": round(result["mbps"], 1),
+                        }
+                        if "elapsed" in result:
+                            row["elapsed"] = round(result["elapsed"], 6)
+                        if "cpu_time" in result:
+                            row["cpu_time"] = round(result["cpu_time"], 6)
+                        if "pub_cpu_time" in result:
+                            row["pub_cpu_time"] = round(result["pub_cpu_time"], 6)
+                        if result.get("zero_transport"):
+                            row["zero_transport"] = True
+                        append_jsonl(row)
+                    else:
+                        append_zero_tput_row(run_id, name, "pub_sub",
+                                             "tcp", size, peers)
+
+                line = f"{size_label(size):>10s}"
+                for name in curve_active:
+                    r = cells.get(name)
+                    if r and not r.get("zero_transport"):
+                        line += (f"  {r['msgs_s']:>9.0f} msg/s"
+                                 f" {r['mbps']:>6.1f} MB/s")
+                    else:
+                        line += f"  {0:>9.0f} msg/s {0:>6.1f} MB/s ZERO"
+                print(line, file=sys.stderr)
+
     print(file=sys.stderr)
 
 
@@ -1432,7 +1504,7 @@ def main():
     )
     parser.add_argument(
         "--omq", action="store_true",
-        help="rebench only this project's backends (omq-tokio, omq-tokio-mt). "
+        help="rebench only this project's backends (omq-tokio, omq-tokio-2t). "
              "Competitor data is external and stable, so it is "
              "reused from the JSONL cache. The fast iteration path.",
     )
@@ -1507,6 +1579,14 @@ def main():
         help=f"comma-separated peer counts for fan-in (default: {','.join(str(p) for p in FANIN_PEER_COUNTS)})",
     )
     parser.add_argument(
+        "--curve", action="store_true",
+        help="run CURVE PUB/SUB benchmarks (libzmq + omq, 1T/2T/4T, 16 subscribers)",
+    )
+    parser.add_argument(
+        "--curve-peers", type=int, default=16,
+        help="subscriber count for CURVE benchmarks (default: 16)",
+    )
+    parser.add_argument(
         "--base-port", type=int, default=0,
         help="base TCP port (default: random ephemeral)",
     )
@@ -1545,14 +1625,18 @@ def main():
 
     impl_names = set(args.impls) if args.impls else set()
     if args.omq:
-        impl_names |= {"omq-tokio", "omq-tokio-mt"}
+        impl_names |= {"omq-tokio", "omq-tokio-2t"}
+    curve_impl_names = {"libzmq-curve-1t", "libzmq-curve-2t", "libzmq-curve-4t",
+                        "omq-curve-1t", "omq-curve-2t", "omq-curve-4t"}
+    if args.curve and not impl_names & curve_impl_names:
+        impl_names |= curve_impl_names
     if not impl_names:
         impl_names = set(IMPLS.keys())
 
     binaries = build_peers(impl_names, ws_needed)
 
     versions = []
-    if impl_names & {"omq-tokio", "omq-tokio-mt"}:
+    if impl_names & {"omq-tokio", "omq-tokio-2t"}:
         versions.append(f"omq {cargo_version('omq-tokio')}")
     if "libzmq" in impl_names:
         versions.append(f"libzmq {libzmq_version()}")
@@ -1581,7 +1665,9 @@ def main():
                    run_fanout=args.fanout,
                    fanout_peers=fanout_peers,
                    run_fanin=args.fanin,
-                   fanin_peers=fanin_peers)
+                   fanin_peers=fanin_peers,
+                   run_curve=args.curve,
+                   curve_peers=args.curve_peers)
 
     # A run that quietly undercounted CPU is worse than a failed one: it ships a
     # plausible chart that lies. Abort loudly so the operator fixes the peer

--- a/scripts/rzmq_bench_peer/src/main.rs
+++ b/scripts/rzmq_bench_peer/src/main.rs
@@ -74,16 +74,29 @@ fn resolve_addr(s: &str) -> String {
     }
 }
 
-fn resolve_bind_addr(s: &str) -> String {
-    if s == "0" {
+fn resolve_bind_addr(s: &str) -> (String, Option<u16>) {
+    if s == "0" || s == "tcp://127.0.0.1:0" || s == "tcp://0.0.0.0:0" {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
-        println!("PORT {port}");
-        format!("tcp://127.0.0.1:{port}")
+        (format!("tcp://127.0.0.1:{port}"), Some(port))
     } else {
-        resolve_addr(s)
+        (resolve_addr(s), None)
     }
+}
+
+async fn report_bound_port(ctx: &Context, port: u16) {
+    let Ok(coord_ep) = std::env::var("OMQ_BENCH_COORD") else {
+        return;
+    };
+    let push = ctx.socket(SocketType::Push).expect("coord push");
+    push.connect(&coord_ep).await.expect("coord connect");
+    let msg = format!("READY {port}");
+    push.send(Msg::from_vec(msg.into_bytes()))
+        .await
+        .expect("coord send");
+    // Keep socket alive so rzmq flushes the message.
+    std::mem::forget(push);
 }
 
 fn leaked_payload(size: usize) -> &'static [u8] {
@@ -93,6 +106,7 @@ fn leaked_payload(size: usize) -> &'static [u8] {
 fn use_io_uring() -> bool {
     std::env::var_os("RZMQ_IO_URING").is_some_and(|v| v != "0")
 }
+
 
 async fn configure_socket(socket: &Socket) {
     if !use_io_uring() {
@@ -128,14 +142,15 @@ async fn wait_for_start_barrier() {
     }
 }
 
+// current_thread is broken: rzmq's internal tasks deadlock without multi_thread.
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(String::as_str) {
         Some("push") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_push(&addr, size).await;
+            run_push(&addr, port, size).await;
         }
         Some("pull") => {
             let addr = resolve_addr(&args[2]);
@@ -144,8 +159,8 @@ async fn main() {
             run_pull(&addr, size, Duration::from_secs_f64(duration)).await;
         }
         Some("rep") => {
-            let addr = resolve_bind_addr(&args[2]);
-            run_rep(&addr).await;
+            let (addr, port) = resolve_bind_addr(&args[2]);
+            run_rep(&addr, port).await;
         }
         Some("req") => {
             let addr = resolve_addr(&args[2]);
@@ -155,9 +170,9 @@ async fn main() {
             run_req(&addr, size, iterations, warmup).await;
         }
         Some("pub") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_pub(&addr, size).await;
+            run_pub(&addr, port, size).await;
         }
         Some("sub") => {
             let addr = resolve_addr(&args[2]);
@@ -171,10 +186,10 @@ async fn main() {
             run_push_connect(&addr, size).await;
         }
         Some("pull-bind") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
-            run_pull_bind(&addr, size, Duration::from_secs_f64(duration)).await;
+            run_pull_bind(&addr, port, size, Duration::from_secs_f64(duration)).await;
         }
         Some("inproc") => {
             let addr = format!("inproc://{}", &args[2]);
@@ -189,6 +204,26 @@ async fn main() {
             let warmup: usize = args[5].parse().expect("warmup");
             run_inproc_latency(&addr, size, iterations, warmup).await;
         }
+        Some("multi-pull") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_pull(&addr, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-sub") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_sub(&addr, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-push") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let count: usize = args[4].parse().expect("socket_count");
+            run_multi_push(&addr, size, count).await;
+        }
         _ => {
             eprintln!("usage: rzmq_bench_peer push <addr> <size>");
             eprintln!("       rzmq_bench_peer pull <addr> <size> <duration_secs>");
@@ -201,11 +236,14 @@ async fn main() {
     }
 }
 
-async fn run_push(addr: &str, size: usize) {
+async fn run_push(addr: &str, coord_port: Option<u16>, size: usize) {
     let ctx = Context::new().expect("context");
     let push = ctx.socket(SocketType::Push).expect("push socket");
     configure_socket(&push).await;
     push.bind(addr).await.expect("push bind");
+    if let Some(port) = coord_port {
+        report_bound_port(&ctx, port).await;
+    }
     wait_for_start_barrier().await;
     let payload = leaked_payload(size);
     loop {
@@ -215,11 +253,14 @@ async fn run_push(addr: &str, size: usize) {
     }
 }
 
-async fn run_rep(addr: &str) {
+async fn run_rep(addr: &str, coord_port: Option<u16>) {
     let ctx = Context::new().expect("context");
     let rep = ctx.socket(SocketType::Rep).expect("rep socket");
     configure_socket(&rep).await;
     rep.bind(addr).await.expect("rep bind");
+    if let Some(port) = coord_port {
+        report_bound_port(&ctx, port).await;
+    }
     while let Ok(msg) = rep.recv().await {
         if rep.send(msg).await.is_err() {
             break;
@@ -272,11 +313,14 @@ async fn run_push_connect(addr: &str, size: usize) {
     }
 }
 
-async fn run_pull_bind(addr: &str, size: usize, duration: Duration) {
+async fn run_pull_bind(addr: &str, coord_port: Option<u16>, size: usize, duration: Duration) {
     let ctx = Context::new().expect("context");
     let pull = ctx.socket(SocketType::Pull).expect("pull socket");
     configure_socket(&pull).await;
     pull.bind(addr).await.expect("pull bind");
+    if let Some(port) = coord_port {
+        report_bound_port(&ctx, port).await;
+    }
 
     wait_for_start_barrier().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -304,11 +348,14 @@ async fn run_pull_bind(addr: &str, size: usize, duration: Duration) {
     std::process::exit(0);
 }
 
-async fn run_pub(addr: &str, size: usize) {
+async fn run_pub(addr: &str, coord_port: Option<u16>, size: usize) {
     let ctx = Context::new().expect("context");
     let pub_ = ctx.socket(SocketType::Pub).expect("pub socket");
     configure_socket(&pub_).await;
     pub_.bind(addr).await.expect("pub bind");
+    if let Some(port) = coord_port {
+        report_bound_port(&ctx, port).await;
+    }
     wait_for_start_barrier().await;
     let payload = leaked_payload(size);
     loop {
@@ -468,4 +515,127 @@ async fn run_inproc_latency(addr: &str, size: usize, iterations: usize, warmup: 
     rep_handle.abort();
     print_latency_cpu(&rtts, iterations, 0.0, elapsed);
     std::process::exit(0);
+}
+
+async fn run_multi_pull(addr: &str, size: usize, duration: Duration, socket_count: usize) {
+    let ctx = Context::new().expect("context");
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Pull).expect("pull socket");
+        configure_socket(&s).await;
+        s.connect(addr).await.expect("pull connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let counters: Vec<Arc<AtomicU64>> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            loop {
+                if sock.recv().await.is_err() {
+                    break;
+                }
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    tokio::time::sleep(duration).await;
+    for h in &handles {
+        h.abort();
+    }
+
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!("{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}");
+    std::process::exit(0);
+}
+
+async fn run_multi_sub(addr: &str, size: usize, duration: Duration, socket_count: usize) {
+    let ctx = Context::new().expect("context");
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Sub).expect("sub socket");
+        configure_socket(&s).await;
+        s.set_option(6, b"").await.expect("subscribe");
+        s.connect(addr).await.expect("sub connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let counters: Vec<Arc<AtomicU64>> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            loop {
+                if sock.recv().await.is_err() {
+                    break;
+                }
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    tokio::time::sleep(duration).await;
+    for h in &handles {
+        h.abort();
+    }
+
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!("{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}");
+    std::process::exit(0);
+}
+
+async fn run_multi_push(addr: &str, size: usize, socket_count: usize) {
+    let ctx = Context::new().expect("context");
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let s = ctx.socket(SocketType::Push).expect("push socket");
+        configure_socket(&s).await;
+        s.connect(addr).await.expect("push connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    let payload = leaked_payload(size);
+
+    for sock in sockets {
+        tokio::spawn(async move {
+            loop {
+                if sock.send(Msg::from_static(payload)).await.is_err() {
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+    }
+
+    std::future::pending::<()>().await;
 }

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -6,7 +6,7 @@
 # Knobs:
 #   OMQ_FUZZ=1          opt in to the ~1 M-iter hand-rolled fuzz suites
 #   OMQ_SKIP_PYOMQ=1    skip the pyomq build + pytest pass
-#   OMQ_TEST_RETRIES=N  retry each step up to N times (default 1) -
+#   OMQ_TEST_RETRIES=N  retry each step up to N times (default 2) -
 #                       a few timing-sensitive tests may need one
 #                       retry on heavily loaded runners.
 #   OMQ_TEST_JOBS=N     max parallel test steps (default 2)
@@ -15,8 +15,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-retries="${OMQ_TEST_RETRIES:-1}"
-jobs="${OMQ_TEST_JOBS:-4}"
+retries="${OMQ_TEST_RETRIES:-2}"
+jobs="${OMQ_TEST_JOBS:-2}"
 
 run() {
     echo "::: $*"
@@ -102,8 +102,11 @@ par_wait() {
 run cargo clippy --all-targets --no-deps -- -D warnings
 run cargo test
 
-
-
+if [[ "${OMQ_PERF:-}" == "1" && -f .perf_hw ]]; then
+    run cargo run --release -q -p omq-tokio --bin perf_verify
+else
+    echo "skip: .perf_hw not set up; see doc/perf-verification.md"
+fi
 
 # ---------------------------------------------------------------- #
 # 2) Feature-gated tests only. Step 1 already ran the full suite
@@ -151,7 +154,9 @@ elif [[ -d bindings/pyomq/.venv ]]; then
     # shellcheck disable=SC1091
     source .venv/bin/activate
     run maturin develop --release
-    run pytest -v
+    # The checked-in venv may have been copied from another worktree; invoke
+    # pytest through the active interpreter so its path cannot escape here.
+    run python -m pytest -v
     deactivate
     popd >/dev/null
 else

--- a/scripts/zmqrs_bench_peer/src/main.rs
+++ b/scripts/zmqrs_bench_peer/src/main.rs
@@ -29,8 +29,14 @@ use zeromq::{
 
 fn cpu_time_secs() -> f64 {
     let mut usage = libc::rusage {
-        ru_utime: libc::timeval { tv_sec: 0, tv_usec: 0 },
-        ru_stime: libc::timeval { tv_sec: 0, tv_usec: 0 },
+        ru_utime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_stime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
         ..unsafe { std::mem::zeroed() }
     };
     // SAFETY: passing a valid pointer to a zeroed rusage struct.
@@ -48,26 +54,36 @@ fn resolve_addr(s: &str) -> String {
     }
 }
 
-fn resolve_bind_addr(s: &str) -> String {
-    if s == "0" {
+fn resolve_bind_addr(s: &str) -> (String, Option<u16>) {
+    if s == "0" || s == "tcp://127.0.0.1:0" || s == "tcp://0.0.0.0:0" {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
-        println!("PORT {port}");
-        format!("tcp://127.0.0.1:{port}")
+        (format!("tcp://127.0.0.1:{port}"), Some(port))
     } else {
-        resolve_addr(s)
+        (resolve_addr(s), None)
     }
 }
 
-#[tokio::main]
+async fn report_bound_port(port: u16) {
+    let Ok(coord_ep) = std::env::var("OMQ_BENCH_COORD") else {
+        return;
+    };
+    let mut push = PushSocket::new();
+    push.connect(&coord_ep).await.expect("coord connect");
+    let msg = format!("READY {port}");
+    push.send(ZmqMessage::from(msg)).await.expect("coord send");
+    std::mem::forget(push);
+}
+
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(String::as_str) {
         Some("push") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_push(&addr, size).await;
+            run_push(&addr, port, size).await;
         }
         Some("pull") => {
             let addr = resolve_addr(&args[2]);
@@ -76,8 +92,8 @@ async fn main() {
             run_pull(&addr, size, Duration::from_secs_f64(duration)).await;
         }
         Some("rep") => {
-            let addr = resolve_bind_addr(&args[2]);
-            run_rep(&addr).await;
+            let (addr, port) = resolve_bind_addr(&args[2]);
+            run_rep(&addr, port).await;
         }
         Some("req") => {
             let addr = resolve_addr(&args[2]);
@@ -92,21 +108,41 @@ async fn main() {
             run_push_connect(&addr, size).await;
         }
         Some("pull-bind") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
-            run_pull_bind(&addr, size, Duration::from_secs_f64(duration)).await;
+            run_pull_bind(&addr, port, size, Duration::from_secs_f64(duration)).await;
         }
         Some("pub") => {
-            let addr = resolve_bind_addr(&args[2]);
+            let (addr, port) = resolve_bind_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
-            run_pub(&addr, size).await;
+            run_pub(&addr, port, size).await;
         }
         Some("sub") => {
             let addr = resolve_addr(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let duration: f64 = args[4].parse().expect("duration_secs");
             run_sub(&addr, size, Duration::from_secs_f64(duration)).await;
+        }
+        Some("multi-pull") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_pull(&addr, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-sub") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let duration: f64 = args[4].parse().expect("duration_secs");
+            let count: usize = args[5].parse().expect("socket_count");
+            run_multi_sub(&addr, size, Duration::from_secs_f64(duration), count).await;
+        }
+        Some("multi-push") => {
+            let addr = resolve_addr(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let count: usize = args[4].parse().expect("socket_count");
+            run_multi_push(&addr, size, count).await;
         }
         _ => {
             eprintln!("usage: zmqrs_bench_peer push <addr> <size>");
@@ -121,9 +157,12 @@ async fn main() {
     }
 }
 
-async fn run_push(addr: &str, size: usize) {
+async fn run_push(addr: &str, coord_port: Option<u16>, size: usize) {
     let mut socket = PushSocket::new();
     socket.bind(addr).await.expect("push bind");
+    if let Some(port) = coord_port {
+        report_bound_port(port).await;
+    }
     wait_for_start_barrier().await;
     let payload = Bytes::from(vec![b'x'; size]);
     loop {
@@ -152,9 +191,12 @@ async fn wait_for_start_barrier() {
     }
 }
 
-async fn run_rep(addr: &str) {
+async fn run_rep(addr: &str, coord_port: Option<u16>) {
     let mut rep = RepSocket::new();
     rep.bind(addr).await.expect("rep bind");
+    if let Some(port) = coord_port {
+        report_bound_port(port).await;
+    }
     loop {
         match rep.recv().await {
             Ok(msg) => {
@@ -222,9 +264,12 @@ async fn run_push_connect(addr: &str, size: usize) {
     }
 }
 
-async fn run_pull_bind(addr: &str, size: usize, duration: Duration) {
+async fn run_pull_bind(addr: &str, coord_port: Option<u16>, size: usize, duration: Duration) {
     let mut socket = PullSocket::new();
     socket.bind(addr).await.expect("pull bind");
+    if let Some(port) = coord_port {
+        report_bound_port(port).await;
+    }
 
     wait_for_start_barrier().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -252,9 +297,12 @@ async fn run_pull_bind(addr: &str, size: usize, duration: Duration) {
     std::process::exit(0);
 }
 
-async fn run_pub(addr: &str, size: usize) {
+async fn run_pub(addr: &str, coord_port: Option<u16>, size: usize) {
     let mut socket = PubSocket::new();
     socket.bind(addr).await.expect("pub bind");
+    if let Some(port) = coord_port {
+        report_bound_port(port).await;
+    }
     wait_for_start_barrier().await;
     let payload = Bytes::from(vec![b'x'; size]);
     loop {
@@ -334,4 +382,131 @@ async fn run_pull(addr: &str, size: usize, duration: Duration) {
     // socket drop; without this the runtime blocks in sigsuspend indefinitely,
     // keeping the pipe open and stalling the caller's command substitution.
     std::process::exit(0);
+}
+
+async fn run_multi_pull(addr: &str, size: usize, duration: Duration, socket_count: usize) {
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let mut s = PullSocket::new();
+        s.connect(addr).await.expect("pull connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let counters: Vec<_> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (mut sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            loop {
+                if sock.recv().await.is_err() {
+                    break;
+                }
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    tokio::time::sleep(duration).await;
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+
+    for h in &handles {
+        h.abort();
+    }
+
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}"
+    );
+    std::process::exit(0);
+}
+
+async fn run_multi_sub(addr: &str, size: usize, duration: Duration, socket_count: usize) {
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let mut s = SubSocket::new();
+        s.connect(addr).await.expect("sub connect");
+        s.subscribe("").await.expect("subscribe");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let counters: Vec<_> = (0..socket_count)
+        .map(|_| Arc::new(AtomicU64::new(0)))
+        .collect();
+
+    let cpu_before = cpu_time_secs();
+    let t0 = Instant::now();
+
+    let mut handles = Vec::with_capacity(socket_count);
+    for (mut sock, counter) in sockets.into_iter().zip(counters.iter().cloned()) {
+        handles.push(tokio::spawn(async move {
+            loop {
+                if sock.recv().await.is_err() {
+                    break;
+                }
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    tokio::time::sleep(duration).await;
+    let elapsed = t0.elapsed().as_secs_f64();
+    let cpu = cpu_time_secs() - cpu_before;
+
+    for h in &handles {
+        h.abort();
+    }
+
+    let per_socket: Vec<u64> = counters.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+    let total: u64 = per_socket.iter().sum();
+    let per_min = per_socket.iter().copied().min().unwrap_or(0);
+    let per_max = per_socket.iter().copied().max().unwrap_or(0);
+    let per_min_rate = per_min as f64 / elapsed;
+    let per_max_rate = per_max as f64 / elapsed;
+    println!(
+        "{total} {elapsed:.6} {size} {cpu:.6} {socket_count} {per_min_rate:.1} {per_max_rate:.1}"
+    );
+    std::process::exit(0);
+}
+
+async fn run_multi_push(addr: &str, size: usize, socket_count: usize) {
+    let mut sockets = Vec::with_capacity(socket_count);
+    for _ in 0..socket_count {
+        let mut s = PushSocket::new();
+        s.connect(addr).await.expect("push connect");
+        sockets.push(s);
+    }
+
+    wait_for_start_barrier().await;
+
+    let payload = Bytes::from(vec![b'x'; size]);
+    for sock in sockets {
+        let p = payload.clone();
+        tokio::spawn(async move {
+            let mut sock = sock;
+            loop {
+                if sock.send(ZmqMessage::from(p.clone())).await.is_err() {
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+    }
+
+    std::future::pending::<()>().await;
 }

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -161,6 +161,14 @@ impl<T> Ring<T> {
         count
     }
 
+    pub(crate) fn prefetch_bounded(&self, cached_tail: &mut usize, max_items: usize) -> usize {
+        let new_tail = self.tail.0.load(Ordering::Acquire);
+        let available = new_tail.wrapping_sub(*cached_tail);
+        let count = available.min(max_items);
+        *cached_tail = cached_tail.wrapping_add(count);
+        count
+    }
+
     #[inline]
     pub(crate) fn consumer_is_empty(&self, head: usize, cached_tail: usize) -> bool {
         head == cached_tail && self.tail.0.load(Ordering::Acquire) == head
@@ -378,6 +386,16 @@ impl<T> Consumer<T> {
         self.ring.prefetch(&mut self.cached_tail)
     }
 
+    /// Load at most `max_items` flushed items with one Acquire load.
+    ///
+    /// Unlike [`prefetch`](Self::prefetch), this leaves later flushed items
+    /// for a subsequent prefetch. Call [`release`](Self::release) only after
+    /// all items returned by this prefetch have been popped.
+    #[inline]
+    pub fn prefetch_bounded(&mut self, max_items: usize) -> usize {
+        self.ring.prefetch_bounded(&mut self.cached_tail, max_items)
+    }
+
     /// Convenience: prefetch + pop + release. For callers that don't
     /// need batching.
     #[inline]
@@ -503,6 +521,30 @@ mod tests {
             assert_eq!(c.pop(), Some(i));
         }
         assert!(c.pop().is_none());
+    }
+
+    #[test]
+    fn bounded_batch_prefetch() {
+        let (mut p, mut c) = spsc::<u32>(8);
+        for i in 0..5 {
+            p.push(i).unwrap();
+        }
+        p.flush();
+
+        assert_eq!(c.prefetch_bounded(2), 2);
+        assert_eq!(c.pop(), Some(0));
+        assert_eq!(c.pop(), Some(1));
+        c.release();
+
+        assert_eq!(c.prefetch_bounded(2), 2);
+        assert_eq!(c.pop(), Some(2));
+        assert_eq!(c.pop(), Some(3));
+        c.release();
+
+        assert_eq!(c.prefetch_bounded(2), 1);
+        assert_eq!(c.pop(), Some(4));
+        c.release();
+        assert_eq!(c.prefetch_bounded(2), 0);
     }
 
     #[test]


### PR DESCRIPTION
- `Context` API: `Context::new()`, `Context::with_config()`,
  `Context::current()`; owns one or more `current_thread` tokio
  runtimes on dedicated OS threads
- `Context::socket()` / `Context::blocking_socket()` for sync callers
  with background IO thread
- `Socket::dispatch()` for recv-loop multiplexing
- `omq-bench` crate: comparison benchmarks, mechanism benchmarks,
  compression benchmarks, chart generation (replaces Python scripts)
- `bench_peer_blocking` binary for blocking API benchmarks
- `perf_verify` binary and `.perf_hw` config for CI perf regression
  gates
- Port all zguide examples to Context API
- `omq-libzmq` context management via `zmq_ctx_new()` /
  `zmq_ctx_term()`
- Latency tracking in routing layer
- Fix CURVE REP replies (nonce ordering after envelope strip/restore)
- Port pyomq to sync sockets with `Context` and `dispatch()`
- `interop_pyzmq_curve` test