### PR TITLE
Fix bounded inproc backpressure and producer overhead

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,6 +98,7 @@ cargo test -p omq-tokio --test stress_connect_before_bind -- --test-threads=1
 
 ```sh
 cargo bench -p omq-tokio --bench push_pull
+cargo bench -p omq-tokio --bench inproc_threads
 ```
 
 Env knobs: `OMQ_BENCH_TRANSPORTS`, `OMQ_BENCH_SIZES`,

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -120,8 +120,8 @@ impl Overlay {
     pub fn to_options(&self) -> PyResult<backend::Options> {
         #[allow(unused_mut)]
         let mut opts = backend::Options {
-            send_hwm: self.send_hwm,
-            recv_hwm: self.recv_hwm,
+            send_hwm: self.send_hwm.unwrap_or(1000),
+            recv_hwm: self.recv_hwm.unwrap_or(1000),
             linger: self.linger,
             identity: self.identity.clone(),
             max_message_size: self.max_message_size,
@@ -205,8 +205,8 @@ impl Overlay {
             rcvtimeo: None,
             sndtimeo: None,
             linger: o.linger,
-            send_hwm: o.send_hwm,
-            recv_hwm: o.recv_hwm,
+            send_hwm: Some(o.send_hwm),
+            recv_hwm: Some(o.recv_hwm),
             identity: o.identity.clone(),
             keepalive: o.tcp_keepalive,
             keepalive_idle: None,

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -239,8 +239,8 @@ impl SocketInner {
         }
         *slot = None;
         let opts = self.overlay.lock().unwrap().to_options()?;
-        let send_cap = opts.send_hwm.map(|n| n.max(1) as usize).unwrap_or(1000);
-        let recv_cap = opts.recv_hwm.map(|n| n.max(1) as usize).unwrap_or(1000);
+        let send_cap = opts.send_hwm.max(1) as usize;
+        let recv_cap = opts.recv_hwm.max(1) as usize;
         let (send_prod, send_cons) = yring::async_spsc(send_cap);
         let (recv_prod, recv_cons) = yring::spsc(recv_cap);
         let recv_notify = Arc::new(RecvNotify::new());

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -133,8 +133,8 @@ impl SocketOverlay {
             },
         };
         omq_tokio::Options {
-            send_hwm: self.send_hwm.or(Some(DEFAULT_HWM as u32)),
-            recv_hwm: self.recv_hwm.or(Some(DEFAULT_HWM as u32)),
+            send_hwm: self.send_hwm.unwrap_or(DEFAULT_HWM as u32),
+            recv_hwm: self.recv_hwm.unwrap_or(DEFAULT_HWM as u32),
             linger: self.linger,
             identity: self.identity.clone(),
             max_message_size: self.max_message_size,
@@ -321,13 +321,19 @@ pub extern "C" fn zmq_setsockopt(
             let Some(v) = read_i32(optval, optvallen) else {
                 return fail(libc::EINVAL);
             };
-            lock_overlay!(sock_arc).send_hwm = if v <= 0 { None } else { Some(v as u32) };
+            if v <= 0 {
+                return fail(libc::EINVAL);
+            }
+            lock_overlay!(sock_arc).send_hwm = Some(v as u32);
         }
         ZMQ_RCVHWM => {
             let Some(v) = read_i32(optval, optvallen) else {
                 return fail(libc::EINVAL);
             };
-            lock_overlay!(sock_arc).recv_hwm = if v <= 0 { None } else { Some(v as u32) };
+            if v <= 0 {
+                return fail(libc::EINVAL);
+            }
+            lock_overlay!(sock_arc).recv_hwm = Some(v as u32);
         }
         ZMQ_LINGER => {
             let Some(v) = read_i32(optval, optvallen) else {

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -99,8 +99,13 @@ fn hwm_roundtrip() {
     set_i32(s, ZMQ_RCVHWM, 2000);
     assert_eq!(get_i32(s, ZMQ_RCVHWM), 2000);
 
-    set_i32(s, ZMQ_SNDHWM, 0);
-    assert_eq!(get_i32(s, ZMQ_SNDHWM), 0);
+    assert_eq!(set_i32(s, ZMQ_SNDHWM, 0), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, ZMQ_SNDHWM), 500);
+
+    assert_eq!(set_i32(s, ZMQ_RCVHWM, 0), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, ZMQ_RCVHWM), 2000);
 
     zmq_close(s);
     zmq_ctx_term(ctx);

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -33,11 +33,11 @@ pub struct Options {
     /// explicitly on both endpoints.
     pub workload_profile: Option<WorkloadProfile>,
 
-    /// Send-side high-water mark, total for the socket. `None` = unbounded.
-    pub send_hwm: Option<u32>,
+    /// Send-side high-water mark, total for the socket.
+    pub send_hwm: u32,
 
-    /// Receive-side high-water mark, total for the socket. `None` = unbounded.
-    pub recv_hwm: Option<u32>,
+    /// Receive-side high-water mark, total for the socket.
+    pub recv_hwm: u32,
 
     /// Time to wait on close for the send queue to drain.
     /// `None` = wait forever. `Some(Duration::ZERO)` = drop immediately.
@@ -200,8 +200,8 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             workload_profile: None,
-            send_hwm: Some(1000),
-            recv_hwm: Some(1000),
+            send_hwm: 1000,
+            recv_hwm: 1000,
             linger: Some(Duration::ZERO),
             identity: Bytes::new(),
             reconnect: ReconnectPolicy::default(),
@@ -298,25 +298,13 @@ impl Options {
 
     #[must_use]
     pub fn send_hwm(mut self, hwm: u32) -> Self {
-        self.send_hwm = Some(hwm);
+        self.send_hwm = hwm;
         self
     }
 
     #[must_use]
     pub fn recv_hwm(mut self, hwm: u32) -> Self {
-        self.recv_hwm = Some(hwm);
-        self
-    }
-
-    #[must_use]
-    pub fn unbounded_send(mut self) -> Self {
-        self.send_hwm = None;
-        self
-    }
-
-    #[must_use]
-    pub fn unbounded_recv(mut self) -> Self {
-        self.recv_hwm = None;
+        self.recv_hwm = hwm;
         self
     }
 
@@ -715,8 +703,8 @@ mod tests {
     #[test]
     fn defaults_are_per_socket_hwm_block() {
         let o = Options::default();
-        assert_eq!(o.send_hwm, Some(1000));
-        assert_eq!(o.recv_hwm, Some(1000));
+        assert_eq!(o.send_hwm, 1000);
+        assert_eq!(o.recv_hwm, 1000);
         assert_eq!(o.linger, Some(Duration::ZERO));
         assert_eq!(o.handshake_timeout, Some(Duration::from_secs(30)));
         assert_eq!(o.heartbeat_interval, None);
@@ -790,9 +778,9 @@ mod tests {
             .conflate(true)
             .router_mandatory(true)
             .on_mute(OnMute::DropNewest);
-        assert_eq!(o.send_hwm, Some(42));
+        assert_eq!(o.send_hwm, 42);
         assert_eq!(o.workload_profile, Some(WorkloadProfile::Latency));
-        assert_eq!(o.recv_hwm, Some(99));
+        assert_eq!(o.recv_hwm, 99);
         assert_eq!(o.linger, Some(Duration::from_secs(5)));
         assert_eq!(o.identity, &b"router-id"[..]);
         assert_eq!(o.heartbeat_interval, Some(Duration::from_secs(1)));
@@ -814,13 +802,6 @@ mod tests {
     }
 
     #[test]
-    fn unbounded_queues() {
-        let o = Options::new().unbounded_send().unbounded_recv();
-        assert_eq!(o.send_hwm, None);
-        assert_eq!(o.recv_hwm, None);
-    }
-
-    #[test]
     fn linger_forever() {
         let o = Options::new().linger_forever();
         assert_eq!(o.linger, None);
@@ -830,6 +811,6 @@ mod tests {
     fn from_bytes_sets_identity() {
         let o: Options = Bytes::from_static(b"id").into();
         assert_eq!(o.identity, &b"id"[..]);
-        assert_eq!(o.send_hwm, Some(1000));
+        assert_eq!(o.send_hwm, 1000);
     }
 }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -81,6 +81,10 @@ name = "push_pull"
 harness = false
 
 [[bench]]
+name = "inproc_threads"
+harness = false
+
+[[bench]]
 name = "pub_sub"
 harness = false
 

--- a/omq-tokio/benches/inproc_threads.rs
+++ b/omq-tokio/benches/inproc_threads.rs
@@ -1,0 +1,123 @@
+//! Inproc PUSH/PULL with one application thread per socket and one IO thread.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType};
+
+#[path = "common/mod.rs"]
+mod common;
+
+const PATTERN: &str = "inproc_threads";
+const TIMER_CHECK_INTERVAL: usize = 10_000;
+
+fn endpoint(seq: usize) -> Endpoint {
+    Endpoint::Inproc {
+        name: format!("bench-inproc-threads-{seq}"),
+    }
+}
+
+fn round(ctx: &Context, size: usize, seq: usize, duration: Duration) -> common::Cell {
+    let ep = endpoint(seq);
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+    pull.bind(ep.clone()).expect("bind PULL");
+    push.connect(ep).expect("connect PUSH");
+    push.wait_connected(1, Duration::from_secs(5))
+        .expect("wait for PUSH/PULL connection");
+
+    let payload = vec![b'x'; size];
+    let template = Message::from_slice(&payload);
+    let barrier = Arc::new(Barrier::new(2));
+    let stop = Arc::new(AtomicBool::new(false));
+    let cpu_before = common::process_cpu_time();
+
+    let sender_barrier = barrier.clone();
+    let sender_stop = stop.clone();
+    let sender_push = push.clone();
+    let sender = thread::spawn(move || {
+        sender_barrier.wait();
+        while !sender_stop.load(Ordering::Acquire) {
+            let mut msg = template.clone();
+            loop {
+                match sender_push.try_send(msg) {
+                    Ok(()) => break,
+                    Err(omq_proto::TrySendError::Full(returned)) => {
+                        msg = returned;
+                        if sender_stop.load(Ordering::Acquire) {
+                            return;
+                        }
+                        std::hint::spin_loop();
+                    }
+                    Err(_) => return,
+                }
+            }
+        }
+    });
+
+    let receiver_barrier = barrier;
+    let receiver_stop = stop.clone();
+    let receiver_pull = pull.clone();
+    let receiver = thread::spawn(move || {
+        receiver_barrier.wait();
+        let start = Instant::now();
+        let deadline = start + duration;
+        let mut count = 0usize;
+        let mut until_timer_check = TIMER_CHECK_INTERVAL;
+        loop {
+            match receiver_pull.try_recv() {
+                Ok(_) => count += 1,
+                Err(omq_proto::error::Error::WouldBlock) => std::hint::spin_loop(),
+                Err(_) => break,
+            }
+            until_timer_check -= 1;
+            if until_timer_check == 0 {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                until_timer_check = TIMER_CHECK_INTERVAL;
+            }
+        }
+        receiver_stop.store(true, Ordering::Release);
+        (count, start.elapsed())
+    });
+
+    let (count, elapsed) = receiver.join().expect("receiver thread");
+    sender.join().expect("sender thread");
+    let cpu_time = common::process_cpu_time().saturating_sub(cpu_before);
+    let _ = pull.close();
+    let _ = push.close();
+    let elapsed_secs = elapsed.as_secs_f64();
+    common::Cell {
+        n: count,
+        elapsed,
+        mbps: count as f64 * size as f64 / elapsed_secs / 1e6,
+        msgs_s: count as f64 / elapsed_secs,
+        cpu_time,
+    }
+}
+
+fn main() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 1 });
+    println!("runtime: 1 dedicated background IO thread\n");
+    common::print_header("INPROC PUSH/PULL: TWO APPLICATION THREADS");
+
+    let rounds = common::rounds();
+    let duration = common::round_duration();
+    let mut seq = 0usize;
+    for size in common::sizes() {
+        let mut best = None;
+        for _ in 0..rounds {
+            seq += 1;
+            let cell = round(&ctx, size, seq, duration);
+            if best.is_none_or(|current: common::Cell| cell.elapsed < current.elapsed) {
+                best = Some(cell);
+            }
+        }
+        let cell = best.expect("at least one benchmark round");
+        common::print_cell(size, cell);
+        common::append_jsonl(PATTERN, "inproc-threads", 1, size, cell);
+    }
+}

--- a/omq-tokio/src/bin/perf_verify.rs
+++ b/omq-tokio/src/bin/perf_verify.rs
@@ -35,6 +35,10 @@ fn tcp_zero() -> Endpoint {
     "tcp://127.0.0.1:0".parse().expect("valid TCP endpoint")
 }
 
+fn inproc_endpoint() -> Endpoint {
+    "inproc://perf-gate".parse().expect("valid inproc endpoint")
+}
+
 fn read_thresholds() -> HashMap<String, f64> {
     let Ok(contents) = std::fs::read_to_string(".perf_hw") else {
         return HashMap::new();
@@ -129,13 +133,13 @@ async fn count_messages(sock: omq_tokio::Socket, deadline: Instant) -> u64 {
     count
 }
 
-async fn pushpull(size: usize, io_threads: usize) -> f64 {
+async fn pushpull(size: usize, io_threads: usize, endpoint: Endpoint) -> f64 {
     tokio::task::spawn_blocking(move || {
         let pull_ctx = Context::with_config(ContextConfig { io_threads });
         let push_ctx = Context::with_config(ContextConfig { io_threads });
         let pull = pull_ctx.blocking_socket(SocketType::Pull, Options::default());
         let push = push_ctx.blocking_socket(SocketType::Push, Options::default());
-        let endpoint = pull.bind(tcp_zero()).expect("PULL bind");
+        let endpoint = pull.bind(endpoint).expect("PULL bind");
         push.connect(endpoint).expect("PUSH connect");
         pull.wait_connected(1, Duration::from_secs(1))
             .expect("PULL connect timeout");
@@ -298,7 +302,7 @@ async fn main() {
     );
     for io_threads in [1, 2] {
         for (size, suffix) in [(16, "16b"), (1024, "1k"), (16 * 1024, "16k")] {
-            let value = pushpull(size, io_threads).await;
+            let value = pushpull(size, io_threads, tcp_zero()).await;
             ok &= verify(
                 &Sample {
                     name: format!("pushpull_{io_threads}io.{suffix}_msgs_s"),
@@ -320,6 +324,15 @@ async fn main() {
             );
         }
     }
+    let value = pushpull(16, 1, inproc_endpoint()).await;
+    ok &= verify(
+        &Sample {
+            name: "inproc_pushpull_1io.16b_msgs_s".to_string(),
+            value,
+            unit: "msg/s",
+        },
+        &thresholds,
+    );
     if thresholds.is_empty() {
         eprintln!("warning: .perf_hw missing; measurements not threshold-checked");
     }

--- a/omq-tokio/src/engine/signal.rs
+++ b/omq-tokio/src/engine/signal.rs
@@ -77,8 +77,8 @@ impl DataSignal {
         self.notify.notify_waiters();
     }
 
-    pub(crate) async fn notified(&self) {
-        self.notify.notified().await;
+    pub(crate) fn notified(&self) -> tokio::sync::futures::Notified<'_> {
+        self.notify.notified()
     }
 }
 

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -266,7 +266,7 @@ impl FanOutShards {
         mode: FanOutMode,
         io_pool: &crate::context::IoPoolHandle,
     ) -> Arc<Self> {
-        let pipe_cap = options.send_hwm.unwrap_or(1000).max(16) as usize;
+        let pipe_cap = options.send_hwm.max(16) as usize;
         let worker_shards = Self::worker_shard_count(io_pool.thread_count());
         let lossy = fan_out_is_lossy(options);
         let active_mask = Arc::new(AtomicU8::new(0));

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -379,9 +379,6 @@ pub(crate) fn effective_queue_params(
     if options.conflate {
         (1, omq_proto::options::OnMute::DropOldest)
     } else {
-        (
-            options.send_hwm.map_or(usize::MAX, |n| n as usize),
-            options.on_mute,
-        )
+        (options.send_hwm as usize, options.on_mute)
     }
 }

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -298,6 +298,7 @@ impl SocketDriver {
             &endpoint,
             &snapshot,
             &self.spsc.recv_notify,
+            &self.spsc.blocking_recv_waker,
             self.options.max_message_size,
             #[cfg(feature = "ws")]
             &self.options.wss_tls,
@@ -382,6 +383,7 @@ impl SocketDriver {
         let tx_for_delay = tx.clone();
         let snapshot = self.inproc_snapshot();
         let recv_notify = self.spsc.recv_notify.clone();
+        let blocking_recv_waker = self.spsc.blocking_recv_waker.clone();
         let max_message_size = self.options.max_message_size;
         #[cfg(feature = "ws")]
         let accept_invalid_certs = self.options.wss_tls.accept_invalid_certs;
@@ -395,6 +397,7 @@ impl SocketDriver {
                         &ep_for_dial,
                         &snapshot,
                         &recv_notify,
+                        &blocking_recv_waker,
                         max_message_size,
                         #[cfg(feature = "ws")]
                         accept_invalid_certs,

--- a/omq-tokio/src/socket/actor/lifecycle.rs
+++ b/omq-tokio/src/socket/actor/lifecycle.rs
@@ -55,7 +55,7 @@ impl<'a> PeerLifecycle<'a> {
     }
 
     pub(super) fn update_send_ring(&mut self) {
-        let mut sole_spsc: Option<&Arc<crate::transport::inproc::InprocSpsc>> = None;
+        let mut sole_spsc: Option<&Arc<crate::transport::inproc::InprocTx>> = None;
         let mut count = 0;
         for p in self.driver.peers.values() {
             if let Some(ref s) = p.spsc {
@@ -84,7 +84,7 @@ impl<'a> PeerLifecycle<'a> {
 
     pub(super) fn register_inproc_consumer(
         &mut self,
-        spsc: &Arc<crate::transport::inproc::InprocSpsc>,
+        spsc: &Arc<crate::transport::inproc::InprocRx>,
         recv_bypass: bool,
     ) {
         self.driver

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -143,7 +143,7 @@ struct PeerEntry {
     /// Used to decide whether to restart the dial after a mid-session drop.
     is_client: bool,
     /// SPSC ring for this inproc peer (None for wire/stream peers).
-    spsc: Option<Arc<crate::transport::inproc::InprocSpsc>>,
+    spsc: Option<Arc<crate::transport::inproc::InprocTx>>,
     task: Option<JoinHandle<()>>,
     /// IO thread index this peer's driver runs on (for load tracking).
     io_thread: usize,

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -287,7 +287,7 @@ impl SocketDriver {
                 .options
                 .transmit_slot_cap
                 .unwrap_or(crate::engine::transmit_slot::TRANSMIT_SLOT_CAP_DEFAULT);
-            let transmit_slot_msg_cap = self.options.send_hwm.unwrap_or(1000).max(1) as usize;
+            let transmit_slot_msg_cap = self.options.send_hwm.max(1) as usize;
             Some(crate::engine::transmit_slot::PeerTransmitSlot::new(
                 peer_id,
                 has_transform,
@@ -309,7 +309,7 @@ impl SocketDriver {
             Some(ref s) => driver.with_transmit_slot(s.clone()),
             None => driver,
         };
-        let pipe_cap = self.options.send_hwm.unwrap_or(1024).max(16) as usize;
+        let pipe_cap = self.options.send_hwm.max(16) as usize;
         let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
         let driver = driver.with_send_pipe(send_pipe_rx);
 
@@ -339,7 +339,7 @@ impl SocketDriver {
                         driver.with_recv_sink(sink)
                     }
                 } else {
-                    let cap = self.options.recv_hwm.unwrap_or(1024).max(16) as usize;
+                    let cap = self.options.recv_hwm.max(16) as usize;
                     let (prod, cons) = yring::spsc(cap);
                     let recv_notify = self.spsc.recv_notify.clone();
                     let blocking_waker = self.spsc.blocking_recv_waker.clone();
@@ -499,7 +499,7 @@ impl SocketDriver {
         let inbox_cap = 64usize;
         let (inbox_tx, inbox_rx) = mpsc::channel(inbox_cap);
         let child_cancel = self.cancel.child_token();
-        let pipe_cap = self.options.send_hwm.unwrap_or(1024).max(16) as usize;
+        let pipe_cap = self.options.send_hwm.max(16) as usize;
         let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
 
         // Pre-build the synthesised PeerProperties from the
@@ -1004,23 +1004,20 @@ async fn inproc_peer_driver(
                         {
                             return;
                         }
-                        let m = try_push_spsc(spsc.as_ref(), m, &blocking_recv_waker);
-                        if let Some(m) = m {
-                            let m = match recv_sink.as_mut() {
-                                Some(sink) => sink.try_send(m).await,
-                                None => Some(m),
-                            };
-                            if let Some(m) = m
-                                && !route_inproc_message(
-                                    m,
-                                    recv_direct.as_ref(),
-                                    &peer_out,
-                                    peer_id,
-                                )
-                                .await
-                            {
-                                return;
-                            }
+                        let m = match recv_sink.as_mut() {
+                            Some(sink) => sink.try_send(m).await,
+                            None => Some(m),
+                        };
+                        if let Some(m) = m
+                            && !route_inproc_message(
+                                m,
+                                recv_direct.as_ref(),
+                                &peer_out,
+                                peer_id,
+                            )
+                            .await
+                        {
+                            return;
                         }
                     }
                     Some(InboundFrame::Command(c)) => {
@@ -1043,28 +1040,6 @@ async fn inproc_peer_driver(
     }
     blocking_recv_waker.wake();
     let _ = peer_out.try_send((peer_id, PeerEvent::Closed));
-}
-
-/// Try to push a message into the SPSC ring. Returns `None` if pushed
-/// (consumed), or `Some(m)` if the ring is full or absent.
-fn try_push_spsc(
-    spsc: Option<&Arc<crate::transport::inproc::InprocSpsc>>,
-    m: Message,
-    blocking_waker: &crate::socket::recv::BlockingRecvWaker,
-) -> Option<Message> {
-    let Some(ring) = spsc else {
-        return Some(m);
-    };
-    let mut producer = ring.producer.lock().unwrap();
-    if producer.is_full() {
-        return Some(m);
-    }
-    let _ = producer.push(m);
-    producer.flush();
-    drop(producer);
-    ring.recv_notify.notify_one();
-    blocking_waker.wake();
-    None
 }
 
 /// Route a message to `recv_direct` or through the actor via `emit_event`.

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -347,7 +347,7 @@ impl SocketDriver {
                     let sink = crate::engine::RecvSink::Yring(crate::engine::YringSink {
                         producer: prod,
                         signal: Box::new(move || {
-                            recv_notify.notify_one();
+                            recv_notify.mark();
                             blocking_waker.wake();
                         }),
                         space: space.clone(),
@@ -1037,7 +1037,7 @@ async fn inproc_peer_driver(
     .await;
     let () = result;
     if let Some(ref ring) = spsc {
-        ring.recv_notify.notify_one();
+        ring.recv_notify.wake_all();
     }
     blocking_recv_waker.wake();
     let _ = peer_out.try_send((peer_id, PeerEvent::Closed));

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -513,7 +513,8 @@ impl SocketDriver {
             out,
             in_rx,
             peer: _peer,
-            spsc,
+            tx,
+            rx,
         } = conn;
 
         // Extract recv_sink for poll() message detection, similar to wire path.
@@ -551,7 +552,7 @@ impl SocketDriver {
                 info: None,
                 endpoint,
                 is_client: !is_server,
-                spsc: spsc.clone(),
+                spsc: tx.clone(),
                 task: None,
                 io_thread,
             },
@@ -562,7 +563,7 @@ impl SocketDriver {
         } else {
             None
         };
-        let recv_spsc = spsc
+        let recv_spsc = rx
             .clone()
             .filter(|_| can_bypass_actor_recv(self.socket_type));
 
@@ -855,7 +856,7 @@ struct InprocDriverCtx {
     peer_props: omq_proto::proto::command::PeerProperties,
     max_message_size: Option<usize>,
     recv_direct: Option<std::sync::Arc<crate::socket::recv::SharedRecvPipe>>,
-    spsc: Option<std::sync::Arc<crate::transport::inproc::InprocSpsc>>,
+    spsc: Option<std::sync::Arc<crate::transport::inproc::InprocRx>>,
     recv_sink: Option<crate::engine::RecvSink>,
     shared_rx: Option<crate::routing::fallback_queue::FallbackReceiver>,
     send_pipe_rx: crate::engine::SendPipeConsumer,

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -437,6 +437,7 @@ pub(super) async fn bind_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] wss_tls: &omq_proto::options::WssTls,
 ) -> Result<AnyListener> {
@@ -471,6 +472,7 @@ pub(super) async fn bind_any(
             name,
             snapshot.clone(),
             recv_notify.clone(),
+            blocking_recv_waker.clone(),
             max_message_size,
         )?)),
         Endpoint::Ipc(_) => Ok(AnyListener::Ipc(IpcTransport::bind(endpoint).await?)),
@@ -483,6 +485,7 @@ pub(super) async fn connect_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] accept_invalid_certs: bool,
     #[cfg(feature = "ws")] mechanism: &omq_proto::MechanismSetup,
@@ -530,6 +533,7 @@ pub(super) async fn connect_any(
                 name,
                 snapshot.clone(),
                 recv_notify.clone(),
+                blocking_recv_waker.clone(),
                 max_message_size,
             )
             .await?;

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -17,6 +17,8 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 
+use crate::engine::signal::DataSignal;
+
 /// Caller-side TCP writer for the latency profile. It uses a duplicated
 /// nonblocking descriptor, so sends do not enter the connection driver's
 /// reactor loop.
@@ -436,7 +438,7 @@ impl AnyListener {
 pub(super) async fn bind_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
-    recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    recv_notify: &std::sync::Arc<DataSignal>,
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] wss_tls: &omq_proto::options::WssTls,
@@ -484,7 +486,7 @@ pub(super) async fn bind_any(
 pub(super) async fn connect_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
-    recv_notify: &std::sync::Arc<tokio::sync::Notify>,
+    recv_notify: &std::sync::Arc<DataSignal>,
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] accept_invalid_certs: bool,

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -137,8 +137,8 @@ impl Socket {
              carry queueable single-message-state semantics"
         );
         let cancel = CancellationToken::new();
-        let (cmd_tx, cmd_rx) = mpsc::channel(options.send_hwm.unwrap_or(1024).max(16) as usize);
-        let recv_hwm = options.recv_hwm.unwrap_or(1024).max(16) as usize;
+        let (cmd_tx, cmd_rx) = mpsc::channel(options.send_hwm.max(16) as usize);
+        let recv_hwm = options.recv_hwm.max(16) as usize;
         let blocking_recv_waker = super::recv::BlockingRecvWaker::new();
         let (recv_tx, recv_consumer, recv_pipe_notify, recv_pipe_space) =
             super::recv::recv_pipe(recv_hwm, blocking_recv_waker.clone());
@@ -307,10 +307,7 @@ impl Socket {
             }
             _ => {
                 check_pre_send_frame_count(self.inner.socket_type, &msg)?;
-                let Some(msg) = self.send_spsc_or_return(msg).await? else {
-                    return Ok(());
-                };
-                self.inner.send_submitter.send(msg).await
+                self.send_spsc_or_submit(msg).await
             }
         }
     }
@@ -368,11 +365,11 @@ impl Socket {
             _ => {
                 check_pre_send_frame_count(self.inner.socket_type, &msg)
                     .map_err(TrySendError::Error)?;
-                let msg = match self.try_push_spsc(msg) {
-                    Ok(()) => return Ok(()),
-                    Err(msg) => msg,
-                };
-                self.inner.send_submitter.try_send(msg)
+                match self.inner.recv_rx.try_push_spsc_or_full(msg) {
+                    SpscPush::Sent => Ok(()),
+                    SpscPush::Full { msg, .. } => Err(TrySendError::Full(msg)),
+                    SpscPush::Unavailable(msg) => self.inner.send_submitter.try_send(msg),
+                }
             }
         }
     }
@@ -802,11 +799,13 @@ fn check_pre_send_frame_count(t: SocketType, msg: &Message) -> Result<()> {
 }
 
 impl Socket {
-    async fn send_spsc_or_return(&self, mut msg: Message) -> Result<Option<Message>> {
+    async fn send_spsc_or_submit(&self, mut msg: Message) -> Result<()> {
         loop {
             match self.inner.recv_rx.try_push_spsc_or_full(msg) {
-                SpscPush::Sent => return Ok(None),
-                SpscPush::Unavailable(returned) => return Ok(Some(returned)),
+                SpscPush::Sent => return Ok(()),
+                SpscPush::Unavailable(returned) => {
+                    return self.inner.send_submitter.send(returned).await;
+                }
                 SpscPush::Full {
                     msg: returned,
                     space,
@@ -816,28 +815,18 @@ impl Socket {
                     tokio::pin!(notified);
                     notified.as_mut().enable();
                     match self.inner.recv_rx.try_push_spsc_or_full(msg) {
-                        SpscPush::Sent => return Ok(None),
-                        SpscPush::Unavailable(returned) => return Ok(Some(returned)),
+                        SpscPush::Sent => return Ok(()),
+                        SpscPush::Unavailable(returned) => {
+                            return self.inner.send_submitter.send(returned).await;
+                        }
                         SpscPush::Full { msg: returned, .. } => {
-                            tokio::select! {
-                                biased;
-                                () = notified => {
-                                    msg = returned;
-                                }
-                                () = tokio::task::yield_now() => return Ok(Some(returned)),
-                            }
+                            notified.await;
+                            msg = returned;
                         }
                     }
                 }
             }
         }
-    }
-
-    /// SPSC send fast path: push directly into the peer's yring.
-    /// Returns `Ok(())` if sent, `Err(msg)` if the fast path is
-    /// unavailable or the ring is full.
-    fn try_push_spsc(&self, msg: Message) -> core::result::Result<(), Message> {
-        self.inner.recv_rx.try_push_spsc(msg)
     }
 }
 

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -9,13 +9,13 @@ use arc_swap::ArcSwapOption;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 
-use crate::transport::inproc::InprocSpsc;
+use crate::transport::inproc::{InprocRx, InprocTx};
 
 /// Per-peer SPSC consumers Vec. Actor appends; recv fair-queues.
-pub(crate) type SpscConsumers = Arc<RwLock<Vec<Arc<InprocSpsc>>>>;
+pub(crate) type SpscConsumers = Arc<RwLock<Vec<Arc<InprocRx>>>>;
 
 /// Single-peer send fast path ring. Actor sets/clears.
-pub(crate) type SpscSendRing = Arc<ArcSwapOption<InprocSpsc>>;
+pub(crate) type SpscSendRing = Arc<ArcSwapOption<InprocTx>>;
 
 /// Shared recv notification. All inproc producers notify this.
 pub(crate) type SpscRecvNotify = Arc<tokio::sync::Notify>;
@@ -272,7 +272,7 @@ pub(crate) struct SpscAwareRecv {
 #[derive(Debug)]
 struct DrainState {
     generation: u64,
-    inproc: Vec<Arc<InprocSpsc>>,
+    inproc: Vec<Arc<InprocRx>>,
     tcp: Vec<Arc<TcpYringConsumer>>,
     batch: VecDeque<Message>,
     recv_consumer: yring::Consumer<Message>,
@@ -630,18 +630,17 @@ impl SpscAwareRecv {
         {
             return SpscPush::Unavailable(msg);
         }
-        let mut producer = pair.producer.lock().unwrap();
-        if producer.is_consumer_dropped() || !pair.recv_ready.load(Ordering::Acquire) {
+        if pair.producer.is_consumer_dropped() || !pair.recv_ready.load(Ordering::Acquire) {
             return SpscPush::Unavailable(msg);
         }
-        if producer.is_full() {
+        if pair.producer.is_full() {
             return SpscPush::Full {
                 msg,
                 space: pair.space_notify.clone(),
             };
         }
-        let _ = producer.push(msg);
-        producer.flush();
+        let _ = pair.producer.push(msg);
+        pair.producer.flush();
         pair.recv_notify.notify_one();
         self.blocking_recv_waker.wake();
         SpscPush::Sent

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -31,6 +31,7 @@ const RECV_BATCH_MESSAGES: usize = 256;
 /// parks via `std::thread::park()` and is woken by `unpark()`.
 pub(crate) struct BlockingRecvWaker {
     registered: AtomicBool,
+    sleeping: AtomicBool,
     thread: Mutex<Option<std::thread::Thread>>,
 }
 
@@ -38,6 +39,7 @@ impl BlockingRecvWaker {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             registered: AtomicBool::new(false),
+            sleeping: AtomicBool::new(false),
             thread: Mutex::new(None),
         })
     }
@@ -47,12 +49,21 @@ impl BlockingRecvWaker {
         self.registered.store(true, Ordering::Release);
     }
 
+    pub(crate) fn prepare_sleep(&self) {
+        self.sleeping.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn cancel_sleep(&self) {
+        self.sleeping.store(false, Ordering::Release);
+    }
+
     pub(crate) fn wake(&self) {
-        if self.registered.load(Ordering::Acquire)
-            && let Ok(guard) = self.thread.try_lock()
-            && let Some(ref t) = *guard
+        if !self.sleeping.swap(false, Ordering::AcqRel) || !self.registered.load(Ordering::Acquire)
         {
-            t.unpark();
+            return;
+        }
+        if let Some(thread) = self.thread.lock().unwrap().clone() {
+            thread.unpark();
         }
     }
 }
@@ -375,7 +386,18 @@ impl SpscAwareRecv {
                 DrainResult::Closed => return Err(Error::Closed),
                 DrainResult::Empty => {}
             }
-            std::thread::park();
+            self.blocking_recv_waker.prepare_sleep();
+            match self.try_drain() {
+                DrainResult::Message(msg) => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Ok(msg);
+                }
+                DrainResult::Closed => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Err(Error::Closed);
+                }
+                DrainResult::Empty => std::thread::park(),
+            }
         }
     }
 

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -29,19 +29,27 @@ const RECV_BATCH_MESSAGES: usize = 256;
 /// Waker for blocking `recv()`. IO threads call `wake()` alongside
 /// `tokio::sync::Notify::notify_one()`. The blocking user thread
 /// parks via `std::thread::park()` and is woken by `unpark()`.
-pub(crate) struct BlockingRecvWaker(Mutex<Option<std::thread::Thread>>);
+pub(crate) struct BlockingRecvWaker {
+    registered: AtomicBool,
+    thread: Mutex<Option<std::thread::Thread>>,
+}
 
 impl BlockingRecvWaker {
     pub(crate) fn new() -> Arc<Self> {
-        Arc::new(Self(Mutex::new(None)))
+        Arc::new(Self {
+            registered: AtomicBool::new(false),
+            thread: Mutex::new(None),
+        })
     }
 
     pub(crate) fn register(&self, thread: std::thread::Thread) {
-        *self.0.lock().unwrap() = Some(thread);
+        *self.thread.lock().unwrap() = Some(thread);
+        self.registered.store(true, Ordering::Release);
     }
 
     pub(crate) fn wake(&self) {
-        if let Ok(guard) = self.0.try_lock()
+        if self.registered.load(Ordering::Acquire)
+            && let Ok(guard) = self.thread.try_lock()
             && let Some(ref t) = *guard
         {
             t.unpark();
@@ -611,7 +619,8 @@ impl SpscAwareRecv {
         if !self.send_ring_available.load(Ordering::Acquire) {
             return SpscPush::Unavailable(msg);
         }
-        let Some(pair) = self.send_ring.load_full() else {
+        let pair = self.send_ring.load();
+        let Some(pair) = pair.as_ref() else {
             return SpscPush::Unavailable(msg);
         };
         if !pair.recv_ready.load(Ordering::Acquire)
@@ -621,9 +630,7 @@ impl SpscAwareRecv {
         {
             return SpscPush::Unavailable(msg);
         }
-        let Ok(mut producer) = pair.producer.try_lock() else {
-            return SpscPush::Unavailable(msg);
-        };
+        let mut producer = pair.producer.lock().unwrap();
         if producer.is_consumer_dropped() || !pair.recv_ready.load(Ordering::Acquire) {
             return SpscPush::Unavailable(msg);
         }
@@ -638,16 +645,6 @@ impl SpscAwareRecv {
         pair.recv_notify.notify_one();
         self.blocking_recv_waker.wake();
         SpscPush::Sent
-    }
-
-    /// SPSC send fast path: push directly into the peer's yring.
-    /// Returns `Ok(())` if sent, `Err(msg)` if the fast path is
-    /// unavailable or the ring is full.
-    pub(crate) fn try_push_spsc(&self, msg: Message) -> core::result::Result<(), Message> {
-        match self.try_push_spsc_or_full(msg) {
-            SpscPush::Sent => Ok(()),
-            SpscPush::Unavailable(msg) | SpscPush::Full { msg, .. } => Err(msg),
-        }
     }
 }
 

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -9,6 +9,7 @@ use arc_swap::ArcSwapOption;
 use omq_proto::error::{Error, Result};
 use omq_proto::message::Message;
 
+use crate::engine::signal::DataSignal;
 use crate::transport::inproc::{InprocRx, InprocTx};
 
 /// Per-peer SPSC consumers Vec. Actor appends; recv fair-queues.
@@ -18,7 +19,7 @@ pub(crate) type SpscConsumers = Arc<RwLock<Vec<Arc<InprocRx>>>>;
 pub(crate) type SpscSendRing = Arc<ArcSwapOption<InprocTx>>;
 
 /// Shared recv notification. All inproc producers notify this.
-pub(crate) type SpscRecvNotify = Arc<tokio::sync::Notify>;
+pub(crate) type SpscRecvNotify = Arc<DataSignal>;
 
 /// Notified by the actor when the consumers Vec changes. Wakes
 /// any `recv()` that's blocked so it re-drains with the updated list.
@@ -240,7 +241,7 @@ impl SpscHandles {
             consumer_generation: Arc::new(AtomicU64::new(0)),
             send_ring: Arc::new(ArcSwapOption::empty()),
             send_ring_available: Arc::new(AtomicBool::new(false)),
-            recv_notify: Arc::new(tokio::sync::Notify::new()),
+            recv_notify: Arc::new(DataSignal::new()),
             activated: Arc::new(tokio::sync::Notify::new()),
             tcp_consumers: Arc::new(RwLock::new(Vec::new())),
             blocking_recv_waker,
@@ -534,6 +535,35 @@ impl SpscAwareRecv {
         let result = latency_result.or_else(|| state.batch.pop_front());
         let pipe_disconnected = state.recv_consumer.is_disconnected();
         let has_peers = !state.inproc.is_empty() || !state.tcp.is_empty();
+        let recv_empty = result.is_none()
+            && state.batch.is_empty()
+            && state.recv_consumer.is_empty()
+            && state.inproc.iter().all(|p| {
+                p.consumer
+                    .try_lock()
+                    .is_ok_and(|consumer| consumer.is_empty())
+            })
+            && state.tcp.iter().all(|tc| {
+                tc.consumer
+                    .try_lock()
+                    .is_ok_and(|consumer| consumer.is_empty())
+            });
+        if recv_empty {
+            self.recv_notify.clear();
+            let still_empty = state.batch.is_empty()
+                && state.recv_consumer.is_empty()
+                && state.inproc.iter().all(|p| {
+                    p.consumer
+                        .try_lock()
+                        .is_ok_and(|consumer| consumer.is_empty())
+                })
+                && state.tcp.iter().all(|tc| {
+                    tc.consumer
+                        .try_lock()
+                        .is_ok_and(|consumer| consumer.is_empty())
+                });
+            self.recv_notify.rearm_if_nonempty(still_empty);
+        }
         drop(guard);
 
         if has_disconnected {
@@ -663,7 +693,7 @@ impl SpscAwareRecv {
         }
         let _ = pair.producer.push(msg);
         pair.producer.flush();
-        pair.recv_notify.notify_one();
+        pair.recv_notify.mark();
         pair.blocking_recv_waker.wake();
         SpscPush::Sent
     }

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -642,7 +642,7 @@ impl SpscAwareRecv {
         let _ = pair.producer.push(msg);
         pair.producer.flush();
         pair.recv_notify.notify_one();
-        self.blocking_recv_waker.wake();
+        pair.blocking_recv_waker.wake();
         SpscPush::Sent
     }
 }

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -25,23 +25,23 @@ use omq_proto::inproc::{InboundFrame, InprocPeerSnapshot};
 use omq_proto::message::Message;
 use omq_proto::proto::SocketType;
 
-/// Per-peer SPSC state for inproc fast path.
+/// Sender-side SPSC state for inproc fast path.
 #[derive(Debug)]
-pub struct InprocSpsc {
-    pub producer: Mutex<yring::Producer<Message>>,
+pub struct InprocTx {
+    pub producer: yring::ProducerOwner<Message>,
+    pub recv_notify: Arc<tokio::sync::Notify>,
+    pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
+    pub max_message_size: Option<usize>,
+    pub space_notify: Arc<tokio::sync::Notify>,
+}
+
+/// Receiver-side SPSC state for inproc fast path.
+#[derive(Debug)]
+pub struct InprocRx {
     pub consumer: Mutex<yring::Consumer<Message>>,
     pub batch_remaining: std::sync::atomic::AtomicUsize,
-    /// Receiver socket's shared recv notification. The driver and
-    /// send fast path notify this after push so `recv()` wakes up.
     pub recv_notify: Arc<tokio::sync::Notify>,
-    /// Gates the send fast path (`Socket::send` bypassing the actor).
-    /// Set by the actor after installing the ring. The per-peer
-    /// driver does NOT check this; it always tries the ring first.
-    pub recv_ready: std::sync::atomic::AtomicBool,
-    /// Receiver's max message size. The send fast path checks this
-    /// before pushing (the driver checks separately). `None` = no limit.
-    pub max_message_size: Option<usize>,
-    /// Wakes async senders waiting for the receiver to drain this ring.
+    pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub space_notify: Arc<tokio::sync::Notify>,
 }
 
@@ -79,7 +79,8 @@ pub struct InprocConn {
     pub out: mpsc::Sender<InboundFrame>,
     pub in_rx: mpsc::Receiver<InboundFrame>,
     pub peer: InprocPeerSnapshot,
-    pub spsc: Option<Arc<InprocSpsc>>,
+    pub tx: Option<Arc<InprocTx>>,
+    pub rx: Option<Arc<InprocRx>>,
 }
 
 /// Default per-direction inflight-message capacity. Holds whole
@@ -97,8 +98,14 @@ struct InprocConnectRequest {
     listener_to_connector_tx: mpsc::Sender<InboundFrame>,
     connector_recv_notify: Arc<tokio::sync::Notify>,
     connector_max_message_size: Option<usize>,
-    accept_ack: oneshot::Sender<(InprocPeerSnapshot, Option<Arc<InprocSpsc>>)>,
+    accept_ack: oneshot::Sender<InprocAck>,
 }
+
+type InprocAck = (
+    InprocPeerSnapshot,
+    Option<Arc<InprocTx>>,
+    Option<Arc<InprocRx>>,
+);
 
 /// Global registry of bound inproc names → request channel.
 static REGISTRY: LazyLock<Mutex<FxHashMap<String, mpsc::Sender<InprocConnectRequest>>>> =
@@ -108,7 +115,7 @@ static REGISTRY: LazyLock<Mutex<FxHashMap<String, mpsc::Sender<InprocConnectRequ
 /// `InprocConn` per accepted connector. `snapshot` is captured
 /// here so we can hand it back to each connector synchronously
 /// during `accept`.
-pub fn bind(
+pub(crate) fn bind(
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_notify: Arc<tokio::sync::Notify>,
@@ -136,17 +143,6 @@ pub fn bind(
         max_message_size,
         incoming: rx,
     })
-}
-
-/// Connect to a previously-bound `name`. Creates two channels
-/// (one per direction), sends the listener-side halves through
-/// the registry, awaits the listener's snapshot reply.
-pub async fn connect(
-    name: &str,
-    snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<tokio::sync::Notify>,
-) -> Result<InprocConn> {
-    connect_with_max_message_size(name, snapshot, recv_notify, None).await
 }
 
 pub(crate) async fn connect_with_max_message_size(
@@ -179,7 +175,7 @@ pub(crate) async fn connect_with_max_message_size(
         .send(request)
         .await
         .map_err(|_| Error::InvalidEndpoint(format!("inproc binding closed: {name}")))?;
-    let (listener_snapshot, spsc) = ack_rx
+    let (listener_snapshot, tx, rx) = ack_rx
         .await
         .map_err(|_| Error::InvalidEndpoint(format!("inproc accept dropped: {name}")))?;
 
@@ -187,7 +183,8 @@ pub(crate) async fn connect_with_max_message_size(
         out: c2l_tx,
         in_rx: l2c_rx,
         peer: listener_snapshot,
-        spsc,
+        tx,
+        rx,
     })
 }
 
@@ -215,6 +212,7 @@ impl InprocListener {
 
     /// Accept the next incoming connector. Returns the connector's
     /// snapshot via the `InprocConn`. Acks back our own snapshot.
+    #[expect(clippy::needless_return)]
     pub async fn accept(&mut self) -> Result<InprocConn> {
         let req = self.incoming.recv().await.ok_or(Error::Closed)?;
         let InprocConnectRequest {
@@ -225,7 +223,17 @@ impl InprocListener {
             connector_max_message_size,
             accept_ack,
         } = req;
-        let spsc = if is_spsc_eligible(self.snapshot.socket_type, connector.socket_type) {
+        if !is_spsc_eligible(self.snapshot.socket_type, connector.socket_type) {
+            let _ = accept_ack.send((self.snapshot.clone(), None, None));
+            return Ok(InprocConn {
+                out: listener_to_connector_tx,
+                in_rx: connector_to_listener_rx,
+                peer: connector,
+                tx: None,
+                rx: None,
+            });
+        }
+        {
             let (p, c) = yring::spsc(DEFAULT_INPROC_HWM);
             let listener_is_recv = is_recv_side(self.snapshot.socket_type);
             let notify = if listener_is_recv {
@@ -238,25 +246,35 @@ impl InprocListener {
             } else {
                 connector_max_message_size
             };
-            Some(Arc::new(InprocSpsc {
-                producer: Mutex::new(p),
-                consumer: Mutex::new(c),
-                batch_remaining: std::sync::atomic::AtomicUsize::new(0),
+            let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let tx = Arc::new(InprocTx {
+                producer: yring::ProducerOwner::new(p),
                 recv_notify: notify,
-                recv_ready: std::sync::atomic::AtomicBool::new(false),
+                recv_ready: ready.clone(),
                 max_message_size: mms,
                 space_notify: Arc::new(tokio::sync::Notify::new()),
-            }))
-        } else {
-            None
-        };
-        let _ = accept_ack.send((self.snapshot.clone(), spsc.clone()));
-        Ok(InprocConn {
-            out: listener_to_connector_tx,
-            in_rx: connector_to_listener_rx,
-            peer: connector,
-            spsc,
-        })
+            });
+            let rx = Arc::new(InprocRx {
+                consumer: Mutex::new(c),
+                batch_remaining: std::sync::atomic::AtomicUsize::new(0),
+                recv_notify: tx.recv_notify.clone(),
+                recv_ready: ready,
+                space_notify: tx.space_notify.clone(),
+            });
+            let (listener_tx, listener_rx, connector_tx, connector_rx) = if listener_is_recv {
+                (None, Some(rx.clone()), Some(tx.clone()), None)
+            } else {
+                (Some(tx.clone()), None, None, Some(rx.clone()))
+            };
+            let _ = accept_ack.send((self.snapshot.clone(), connector_tx, connector_rx));
+            return Ok(InprocConn {
+                out: listener_to_connector_tx,
+                in_rx: connector_to_listener_rx,
+                peer: connector,
+                tx: listener_tx,
+                rx: listener_rx,
+            });
+        }
     }
 }
 
@@ -289,8 +307,9 @@ mod tests {
     async fn bind_connect_accept_exchange() {
         let mut l = bind("test-bca", snap(SocketType::Pull), notify(), None).unwrap();
         let n = notify();
-        let connector =
-            tokio::spawn(async move { connect("test-bca", snap(SocketType::Push), n).await });
+        let connector = tokio::spawn(async move {
+            connect_with_max_message_size("test-bca", snap(SocketType::Push), n, None).await
+        });
         let server_side = l.accept().await.unwrap();
         let client_side = connector.await.unwrap().unwrap();
 
@@ -329,7 +348,8 @@ mod tests {
     #[tokio::test]
     async fn connect_without_bind_fails() {
         assert!(matches!(
-            connect("test-unbound", snap(SocketType::Push), notify()).await,
+            connect_with_max_message_size("test-unbound", snap(SocketType::Push), notify(), None,)
+                .await,
             Err(Error::InvalidEndpoint(_))
         ));
     }

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -33,6 +33,7 @@ pub struct InprocTx {
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub max_message_size: Option<usize>,
     pub space_notify: Arc<tokio::sync::Notify>,
+    pub(crate) blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
 }
 
 /// Receiver-side SPSC state for inproc fast path.
@@ -97,6 +98,7 @@ struct InprocConnectRequest {
     connector_to_listener_rx: mpsc::Receiver<InboundFrame>,
     listener_to_connector_tx: mpsc::Sender<InboundFrame>,
     connector_recv_notify: Arc<tokio::sync::Notify>,
+    connector_blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     connector_max_message_size: Option<usize>,
     accept_ack: oneshot::Sender<InprocAck>,
 }
@@ -119,6 +121,7 @@ pub(crate) fn bind(
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_notify: Arc<tokio::sync::Notify>,
+    blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocListener> {
     let (tx, rx) = mpsc::channel(32);
@@ -140,6 +143,7 @@ pub(crate) fn bind(
         },
         snapshot,
         recv_notify,
+        blocking_recv_waker,
         max_message_size,
         incoming: rx,
     })
@@ -149,6 +153,7 @@ pub(crate) async fn connect_with_max_message_size(
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_notify: Arc<tokio::sync::Notify>,
+    blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocConn> {
     let req_tx = {
@@ -167,6 +172,7 @@ pub(crate) async fn connect_with_max_message_size(
         connector_to_listener_rx: c2l_rx,
         listener_to_connector_tx: l2c_tx,
         connector_recv_notify: recv_notify,
+        connector_blocking_recv_waker: blocking_recv_waker,
         connector_max_message_size: max_message_size,
         accept_ack: ack_tx,
     };
@@ -195,6 +201,7 @@ pub struct InprocListener {
     endpoint: omq_proto::endpoint::Endpoint,
     snapshot: InprocPeerSnapshot,
     recv_notify: Arc<tokio::sync::Notify>,
+    blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     incoming: mpsc::Receiver<InprocConnectRequest>,
 }
@@ -220,6 +227,7 @@ impl InprocListener {
             connector_to_listener_rx,
             listener_to_connector_tx,
             connector_recv_notify,
+            connector_blocking_recv_waker,
             connector_max_message_size,
             accept_ack,
         } = req;
@@ -253,6 +261,11 @@ impl InprocListener {
                 recv_ready: ready.clone(),
                 max_message_size: mms,
                 space_notify: Arc::new(tokio::sync::Notify::new()),
+                blocking_recv_waker: if listener_is_recv {
+                    Arc::clone(&self.blocking_recv_waker)
+                } else {
+                    Arc::clone(&connector_blocking_recv_waker)
+                },
             });
             let rx = Arc::new(InprocRx {
                 consumer: Mutex::new(c),

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -316,12 +316,17 @@ mod tests {
         Arc::new(tokio::sync::Notify::new())
     }
 
+    fn waker() -> Arc<crate::socket::recv::BlockingRecvWaker> {
+        crate::socket::recv::BlockingRecvWaker::new()
+    }
+
     #[tokio::test]
     async fn bind_connect_accept_exchange() {
-        let mut l = bind("test-bca", snap(SocketType::Pull), notify(), None).unwrap();
+        let mut l = bind("test-bca", snap(SocketType::Pull), notify(), waker(), None).unwrap();
         let n = notify();
         let connector = tokio::spawn(async move {
-            connect_with_max_message_size("test-bca", snap(SocketType::Push), n, None).await
+            connect_with_max_message_size("test-bca", snap(SocketType::Push), n, waker(), None)
+                .await
         });
         let server_side = l.accept().await.unwrap();
         let client_side = connector.await.unwrap().unwrap();
@@ -351,9 +356,9 @@ mod tests {
 
     #[tokio::test]
     async fn double_bind_rejected() {
-        let _l = bind("test-dup", snap(SocketType::Pair), notify(), None).unwrap();
+        let _l = bind("test-dup", snap(SocketType::Pair), notify(), waker(), None).unwrap();
         assert!(matches!(
-            bind("test-dup", snap(SocketType::Pair), notify(), None),
+            bind("test-dup", snap(SocketType::Pair), notify(), waker(), None),
             Err(Error::InvalidEndpoint(_))
         ));
     }
@@ -361,8 +366,14 @@ mod tests {
     #[tokio::test]
     async fn connect_without_bind_fails() {
         assert!(matches!(
-            connect_with_max_message_size("test-unbound", snap(SocketType::Push), notify(), None,)
-                .await,
+            connect_with_max_message_size(
+                "test-unbound",
+                snap(SocketType::Push),
+                notify(),
+                waker(),
+                None,
+            )
+            .await,
             Err(Error::InvalidEndpoint(_))
         ));
     }
@@ -370,8 +381,8 @@ mod tests {
     #[tokio::test]
     async fn listener_drop_releases_name() {
         {
-            let _l = bind("test-drop", snap(SocketType::Pair), notify(), None).unwrap();
+            let _l = bind("test-drop", snap(SocketType::Pair), notify(), waker(), None).unwrap();
         }
-        let _l2 = bind("test-drop", snap(SocketType::Pair), notify(), None).unwrap();
+        let _l2 = bind("test-drop", snap(SocketType::Pair), notify(), waker(), None).unwrap();
     }
 }

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -25,11 +25,13 @@ use omq_proto::inproc::{InboundFrame, InprocPeerSnapshot};
 use omq_proto::message::Message;
 use omq_proto::proto::SocketType;
 
+use crate::engine::signal::DataSignal;
+
 /// Sender-side SPSC state for inproc fast path.
 #[derive(Debug)]
 pub struct InprocTx {
     pub producer: yring::ProducerOwner<Message>,
-    pub recv_notify: Arc<tokio::sync::Notify>,
+    pub(crate) recv_notify: Arc<DataSignal>,
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub max_message_size: Option<usize>,
     pub space_notify: Arc<tokio::sync::Notify>,
@@ -41,7 +43,7 @@ pub struct InprocTx {
 pub struct InprocRx {
     pub consumer: Mutex<yring::Consumer<Message>>,
     pub batch_remaining: std::sync::atomic::AtomicUsize,
-    pub recv_notify: Arc<tokio::sync::Notify>,
+    pub(crate) recv_notify: Arc<DataSignal>,
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub space_notify: Arc<tokio::sync::Notify>,
 }
@@ -97,7 +99,7 @@ struct InprocConnectRequest {
     connector: InprocPeerSnapshot,
     connector_to_listener_rx: mpsc::Receiver<InboundFrame>,
     listener_to_connector_tx: mpsc::Sender<InboundFrame>,
-    connector_recv_notify: Arc<tokio::sync::Notify>,
+    connector_recv_notify: Arc<DataSignal>,
     connector_blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     connector_max_message_size: Option<usize>,
     accept_ack: oneshot::Sender<InprocAck>,
@@ -120,7 +122,7 @@ static REGISTRY: LazyLock<Mutex<FxHashMap<String, mpsc::Sender<InprocConnectRequ
 pub(crate) fn bind(
     name: &str,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<tokio::sync::Notify>,
+    recv_notify: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocListener> {
@@ -152,7 +154,7 @@ pub(crate) fn bind(
 pub(crate) async fn connect_with_max_message_size(
     name: &str,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<tokio::sync::Notify>,
+    recv_notify: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocConn> {
@@ -200,7 +202,7 @@ pub struct InprocListener {
     name: String,
     endpoint: omq_proto::endpoint::Endpoint,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<tokio::sync::Notify>,
+    recv_notify: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     incoming: mpsc::Receiver<InprocConnectRequest>,
@@ -312,8 +314,8 @@ mod tests {
         }
     }
 
-    fn notify() -> Arc<tokio::sync::Notify> {
-        Arc::new(tokio::sync::Notify::new())
+    fn notify() -> Arc<DataSignal> {
+        Arc::new(DataSignal::new())
     }
 
     fn waker() -> Arc<crate::socket::recv::BlockingRecvWaker> {

--- a/omq-tokio/tests/handshake_timeout.rs
+++ b/omq-tokio/tests/handshake_timeout.rs
@@ -27,7 +27,7 @@ async fn connect_to_silent_peer_times_out_then_backpressures() {
     let opts = Options {
         handshake_timeout: Some(Duration::from_millis(100)),
         reconnect: ReconnectPolicy::Disabled,
-        send_hwm: Some(hwm),
+        send_hwm: hwm,
         ..Default::default()
     };
     let push = Socket::new(SocketType::Push, opts);

--- a/omq-tokio/tests/options_polish.rs
+++ b/omq-tokio/tests/options_polish.rs
@@ -212,58 +212,6 @@ async fn identity_propagates_on_handshake() {
 }
 
 #[tokio::test]
-async fn unbounded_send_hwm_accepts_large_burst() {
-    const N: usize = 2_000;
-
-    let ep = inproc_ep("opt-unbounded-send");
-    let pull = Socket::new(SocketType::Pull, Options::default().recv_hwm(4096));
-    pull.bind(ep.clone()).await.unwrap();
-
-    let push = Socket::new(SocketType::Push, Options::default().unbounded_send());
-    push.connect(ep).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(30)).await;
-
-    for i in 0..N {
-        push.send(Message::single(format!("m{i}"))).await.unwrap();
-    }
-
-    let mut received = 0usize;
-    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_millis(500), pull.recv()).await {
-        received += 1;
-    }
-    assert!(
-        received >= N / 2,
-        "unbounded HWM should not throttle sender; got {received}/{N}"
-    );
-}
-
-#[tokio::test]
-async fn unbounded_recv_hwm_accepts_large_burst() {
-    const N: usize = 2_000;
-
-    let ep = inproc_ep("opt-unbounded-recv");
-    let pull = Socket::new(SocketType::Pull, Options::default().unbounded_recv());
-    pull.bind(ep.clone()).await.unwrap();
-
-    let push = Socket::new(SocketType::Push, Options::default());
-    push.connect(ep).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(30)).await;
-
-    for i in 0..N {
-        push.send(Message::single(format!("m{i}"))).await.unwrap();
-    }
-
-    let mut received = 0usize;
-    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_millis(500), pull.recv()).await {
-        received += 1;
-    }
-    assert!(
-        received >= N / 2,
-        "unbounded recv HWM should not drop messages; got {received}/{N}"
-    );
-}
-
-#[tokio::test]
 async fn drop_oldest_keeps_newest_messages() {
     // HWM=1, DropOldest: when the queue is full, the oldest queued
     // message is evicted and the new message takes its place.

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -248,6 +248,64 @@ impl<T> Drop for Producer<T> {
 // underlying Ring is Send+Sync. Moving the producer to another thread is safe.
 unsafe impl<T: Send> Send for Producer<T> {}
 
+/// Single-thread owner handle for a producer shared through an `Arc`.
+///
+/// The caller must use this value from exactly one producer thread. This
+/// preserves the SPSC producer cursor without a mutex. It is intended for
+/// transports that already guarantee one socket thread, such as inproc.
+pub struct ProducerOwner<T> {
+    producer: UnsafeCell<Producer<T>>,
+}
+
+// SAFETY: callers uphold the single-producer-thread contract documented
+// above. The underlying ring is already Send + Sync.
+unsafe impl<T: Send> Send for ProducerOwner<T> {}
+unsafe impl<T: Send> Sync for ProducerOwner<T> {}
+
+impl<T> ProducerOwner<T> {
+    /// Wrap a producer for single-thread shared ownership.
+    pub fn new(producer: Producer<T>) -> Self {
+        Self {
+            producer: UnsafeCell::new(producer),
+        }
+    }
+
+    /// Push one value without producer locking.
+    #[inline]
+    pub fn push(&self, value: T) -> Result<(), T> {
+        // SAFETY: the single-producer-thread contract guarantees exclusive
+        // access to the producer cursor.
+        unsafe { (&mut *self.producer.get()).push(value) }
+    }
+
+    /// Publish pending values.
+    #[inline]
+    pub fn flush(&self) {
+        // SAFETY: see `push`.
+        unsafe { (&mut *self.producer.get()).flush() }
+    }
+
+    /// Test whether the ring is full.
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        // SAFETY: see `push`.
+        unsafe { (&mut *self.producer.get()).is_full() }
+    }
+
+    /// Test whether the consumer has gone away.
+    #[inline]
+    pub fn is_consumer_dropped(&self) -> bool {
+        // SAFETY: see `push`.
+        unsafe { (&*self.producer.get()).is_consumer_dropped() }
+    }
+}
+
+impl<T> std::fmt::Debug for ProducerOwner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProducerOwner").finish_non_exhaustive()
+    }
+}
+
 /// Receiving half. `Send` but not `Sync`.
 pub struct Consumer<T> {
     ring: Arc<Ring<T>>,


### PR DESCRIPTION
- Reject unbounded HWM settings and enforce bounded inproc backpressure.
- Split inproc TX/RX state and remove the producer mutex with `ProducerOwner`.
- Wake blocking receivers from direct inproc delivery.