### PR TITLE
Expose CURVE peer identity to authenticator

### DIFF
--- a/omq-proto/src/proto/mechanism/curve.rs
+++ b/omq-proto/src/proto/mechanism/curve.rs
@@ -838,10 +838,13 @@ impl CurveServer {
             &cp,
         )?;
 
+        let props = decode_metadata(metadata)?;
+
         if let Some(auth) = &self.authenticator {
             let peer = super::MechanismPeerInfo {
                 mechanism: crate::proto::greeting::MechanismName::CURVE,
                 public_key: *cl.as_bytes(),
+                identity: props.identity.clone(),
                 username: None,
                 password: None,
             };
@@ -851,8 +854,6 @@ impl CurveServer {
                 ));
             }
         }
-
-        let props = decode_metadata(metadata)?;
 
         self.state = CurveServerState::Done {
             our_eph_secret: sn_secret,

--- a/omq-proto/src/proto/mechanism/mod.rs
+++ b/omq-proto/src/proto/mechanism/mod.rs
@@ -145,6 +145,8 @@ impl MechanismSetup {
 
 use std::sync::Arc;
 
+use bytes::Bytes;
+
 use super::command::{Command, PeerProperties};
 use super::greeting::MechanismName;
 use crate::error::{Error, Result};
@@ -181,6 +183,8 @@ pub struct MechanismPeerInfo {
     pub mechanism: MechanismName,
     /// Peer's long-term 32-byte public key (CURVE). Zeroed for PLAIN.
     pub public_key: [u8; 32],
+    /// Peer's routing identity from the READY metadata.
+    pub identity: Option<Bytes>,
     /// PLAIN username. `None` for encrypting mechanisms.
     pub username: Option<String>,
     /// PLAIN password. `None` for encrypting mechanisms.

--- a/omq-proto/src/proto/mechanism/plain.rs
+++ b/omq-proto/src/proto/mechanism/plain.rs
@@ -153,6 +153,7 @@ impl PlainServer {
                 let peer = MechanismPeerInfo {
                     mechanism: MechanismName::PLAIN,
                     public_key: [0; 32],
+                    identity: None,
                     username: Some(username),
                     password: Some(password),
                 };

--- a/omq-tokio/tests/curve.rs
+++ b/omq-tokio/tests/curve.rs
@@ -6,6 +6,7 @@
 use std::time::Duration;
 
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use omq_tokio::endpoint::Host;
@@ -176,7 +177,9 @@ async fn curve_authenticator_admits_known_client() {
 
     let client = Socket::new(
         SocketType::Push,
-        Options::default().curve_client(client_kp, server_pub),
+        Options::default()
+            .identity(bytes::Bytes::from_static(b"client-id"))
+            .curve_client(client_kp, server_pub),
     );
     client.connect(ep).await.unwrap();
 
@@ -189,6 +192,76 @@ async fn curve_authenticator_admits_known_client() {
     assert!(
         saw_callback.load(Ordering::SeqCst),
         "authenticator must run"
+    );
+}
+
+#[tokio::test]
+async fn curve_authenticator_identity_matches_router_message() {
+    let server_kp = CurveKeypair::generate();
+    let server_pub = server_kp.public;
+    let auth_identities = Arc::new(Mutex::new(Vec::new()));
+    let auth_identities_cb = auth_identities.clone();
+
+    let router = Socket::new(
+        SocketType::Router,
+        Options::default()
+            .curve_server(server_kp)
+            .authenticator(move |peer| {
+                if let Some(identity) = &peer.identity {
+                    auth_identities_cb.lock().unwrap().push(identity.clone());
+                }
+                true
+            }),
+    );
+    let ep = router.bind(auth_ep("auth-router-identity")).await.unwrap();
+
+    let dealer_one = Socket::new(
+        SocketType::Dealer,
+        Options::default()
+            .identity(bytes::Bytes::from_static(b"client-one"))
+            .curve_client(CurveKeypair::generate(), server_pub),
+    );
+    dealer_one.connect(ep.clone()).await.unwrap();
+
+    let dealer_two = Socket::new(
+        SocketType::Dealer,
+        Options::default()
+            .identity(bytes::Bytes::from_static(b"client-two"))
+            .curve_client(CurveKeypair::generate(), server_pub),
+    );
+    dealer_two.connect(ep).await.unwrap();
+
+    dealer_one.send(Message::single("from-one")).await.unwrap();
+    dealer_two.send(Message::single("from-two")).await.unwrap();
+
+    let mut identities_by_message = Vec::new();
+    for _ in 0..2 {
+        let message = tokio::time::timeout(Duration::from_secs(1), router.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        identities_by_message.push((
+            message.part_bytes(1).unwrap().to_vec(),
+            message.part_bytes(0).unwrap().to_vec(),
+        ));
+    }
+    identities_by_message.sort_unstable();
+    assert_eq!(
+        identities_by_message,
+        vec![
+            (b"from-one".to_vec(), b"client-one".to_vec()),
+            (b"from-two".to_vec(), b"client-two".to_vec()),
+        ]
+    );
+
+    let mut stored_identities = auth_identities.lock().unwrap().clone();
+    stored_identities.sort_unstable();
+    assert_eq!(
+        stored_identities,
+        vec![
+            bytes::Bytes::from_static(b"client-one"),
+            bytes::Bytes::from_static(b"client-two"),
+        ]
     );
 }
 


### PR DESCRIPTION
- Add `identity: Option<Bytes>` to `MechanismPeerInfo`.
- Decode CURVE READY metadata before authenticator admission.
- Add two-DEALER ROUTER regression test matching message content to identity.

Closes #157