### PR TITLE
Expand libzmq coverage and full test gate

### DIFF
--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -35,7 +35,7 @@ impl OmqContext {
         let n = n_io_threads;
         Arc::new(Self {
             ctx: OnceLock::new(),
-            configured_io_threads: AtomicI32::new(n as i32),
+            configured_io_threads: AtomicI32::new(i32::try_from(n).unwrap_or(i32::MAX)),
             terminated: Arc::new(AtomicBool::new(false)),
             socket_count: AtomicI32::new(0),
             socket_notify: (Mutex::new(()), Condvar::new()),
@@ -188,7 +188,6 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
         ZMQ_MAX_MSGSZ => {
             ctx.max_msg_size.store(i64::from(value), Ordering::Relaxed);
         }
-        #[expect(clippy::match_same_arms)]
         ZMQ_SOCKET_LIMIT | ZMQ_IPV6_CTX => {}
         _ => return crate::error::fail(libc::EINVAL),
     }

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -4,13 +4,14 @@ use std::ffi::c_int;
 
 use rustc_hash::FxHashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use tokio::runtime::Handle;
 
-/// Per-context: a single `omq_tokio::Context` managing the tokio runtime.
+/// Per-context: lazily-created `omq_tokio::Context` and ZMQ state.
 pub(crate) struct OmqContext {
-    pub(crate) ctx: omq_tokio::Context,
+    pub(crate) ctx: OnceLock<omq_tokio::Context>,
+    pub(crate) configured_io_threads: AtomicI32,
     pub terminated: Arc<AtomicBool>,
     pub socket_count: AtomicI32,
     socket_notify: (Mutex<()>, Condvar),
@@ -31,10 +32,10 @@ pub(crate) fn next_socket_id() -> u64 {
 
 impl OmqContext {
     fn new(n_io_threads: usize) -> Arc<Self> {
-        let n = n_io_threads.max(1);
-        let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig { io_threads: n });
+        let n = n_io_threads;
         Arc::new(Self {
-            ctx,
+            ctx: OnceLock::new(),
+            configured_io_threads: AtomicI32::new(n as i32),
             terminated: Arc::new(AtomicBool::new(false)),
             socket_count: AtomicI32::new(0),
             socket_notify: (Mutex::new(()), Condvar::new()),
@@ -45,8 +46,23 @@ impl OmqContext {
         })
     }
 
-    pub(crate) fn handle(&self) -> &Handle {
-        self.ctx.handle()
+    pub(crate) fn handle(&self) -> Option<&Handle> {
+        self.ctx.get().map(omq_tokio::Context::handle)
+    }
+
+    pub(crate) fn io_context(&self) -> Option<&omq_tokio::Context> {
+        let n = self.configured_io_threads.load(Ordering::Acquire);
+        (n > 0).then(|| {
+            self.ctx.get_or_init(|| {
+                omq_tokio::Context::with_config(omq_tokio::ContextConfig {
+                    io_threads: n as usize,
+                })
+            })
+        })
+    }
+
+    pub(crate) fn zero_io_threads(&self) -> bool {
+        self.configured_io_threads.load(Ordering::Acquire) == 0
     }
 
     pub(crate) fn socket_opened(&self) {
@@ -84,7 +100,7 @@ pub extern "C" fn zmq_ctx_new() -> *mut libc::c_void {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_init(io_threads: c_int) -> *mut libc::c_void {
-    let n = (io_threads as usize).max(1);
+    let n = io_threads.max(0) as usize;
     let arc = OmqContext::new(n);
     Box::into_raw(Box::new(arc)).cast()
 }
@@ -125,6 +141,9 @@ pub extern "C" fn zmq_ctx_term(ctx_ptr: *mut libc::c_void) -> c_int {
         }
     }
 
+    if let Some(ctx) = arc.ctx.get() {
+        ctx.term();
+    }
     drop(arc);
     0
 }
@@ -154,7 +173,11 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
     let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
     match option {
         ZMQ_IO_THREADS => {
-            // io threads already running; setting this is a no-op
+            if value < 0 || ctx.socket_count.load(Ordering::Acquire) != 0 || ctx.ctx.get().is_some()
+            {
+                return crate::error::fail(libc::EINVAL);
+            }
+            ctx.configured_io_threads.store(value, Ordering::Release);
         }
         ZMQ_MAX_SOCKETS => {
             if value < 0 {
@@ -180,7 +203,7 @@ pub extern "C" fn zmq_ctx_get(ctx_ptr: *mut libc::c_void, option: c_int) -> c_in
     // SAFETY: caller guarantees ctx_ptr is a valid context from zmq_ctx_new.
     let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
     match option {
-        ZMQ_IO_THREADS => c_int::try_from(ctx.ctx.io_threads()).unwrap_or(c_int::MAX),
+        ZMQ_IO_THREADS => ctx.configured_io_threads.load(Ordering::Acquire),
         ZMQ_MAX_SOCKETS | ZMQ_SOCKET_LIMIT => ctx.max_sockets.load(Ordering::Relaxed),
         ZMQ_MAX_MSGSZ => ctx.max_msg_size.load(Ordering::Relaxed) as c_int,
         ZMQ_IPV6_CTX => 0,

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -217,7 +217,9 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
                     Err(omq_tokio::TrySendError::Full(returned)) => msg = returned,
                 }
             }
-            let handle = sock.ctx.handle();
+            let Some(handle) = sock.ctx.handle() else {
+                return fail(ETERM);
+            };
             let s = inner.clone();
             if sndtimeo > 0 {
                 let timeout = Duration::from_millis(sndtimeo as u64);

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -128,7 +128,10 @@ where
 {
     let (otx, orx) = flume::bounded::<T>(1);
     let s = inner.clone();
-    ctx.handle().spawn(async move {
+    let Some(handle) = ctx.handle() else {
+        return Err(());
+    };
+    handle.spawn(async move {
         let out = op(s).await;
         let _ = otx.send(out);
     });
@@ -140,6 +143,12 @@ fn is_bypass_eligible(a: SocketType, b: SocketType) -> bool {
         (a, b),
         (SocketType::Push, SocketType::Pull) | (SocketType::Pull, SocketType::Push)
     )
+}
+
+fn zero_io_inproc_supported(sock: &OmqSocket, endpoint: &Endpoint) -> bool {
+    sock.ctx.zero_io_threads()
+        && matches!(endpoint, Endpoint::Inproc { .. })
+        && matches!(sock.socket_type, SocketType::Push | SocketType::Pull)
 }
 
 fn try_install_bypass(sender: &Arc<OmqSocket>, receiver: &Arc<OmqSocket>) {
@@ -279,7 +288,10 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
 /// options, then start the recv pump. Called once on first bind/connect
 /// so that options set between `zmq_socket` and first bind/connect take
 /// effect.
-pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
+pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) -> bool {
+    if sock.ctx.io_context().is_none() {
+        return false;
+    }
     // CAS guarantees exactly one thread wins the materialization race.
     if sock
         .bound_or_connected
@@ -290,10 +302,10 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
         while sock.inner.get().is_none() {
             std::hint::spin_loop();
         }
-        return;
+        return true;
     }
     let Ok(overlay) = sock.overlay.lock() else {
-        return;
+        return false;
     };
     let opts = overlay
         .to_options()
@@ -336,7 +348,10 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
     // Enter the tokio runtime context so that Socket::new (which calls
     // tokio::spawn internally for its driver task) and the recv pump
     // spawn below are scheduled on the context's runtime.
-    let _guard = sock.ctx.handle().enter();
+    let Some(handle) = sock.ctx.handle() else {
+        return false;
+    };
+    let _guard = handle.enter();
 
     let inner = Arc::new(omq_tokio::Socket::new_with_recv_sink_config(
         socket_type,
@@ -357,6 +372,7 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) {
 
     let _ = sock.inner.set(inner);
     let _ = sock.recv_pump.set(recv_pump);
+    true
 }
 
 #[unsafe(no_mangle)]
@@ -374,7 +390,13 @@ pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
     // Enter the tokio runtime context so that dropping OmqSocket (and
     // the Arc<omq_tokio::Socket> it holds) doesn't panic from missing
     // reactor.
-    let _guard = arc.ctx.handle().enter();
+    let Some(handle) = arc.ctx.handle() else {
+        arc.notify.close();
+        arc.ctx.socket_closed();
+        drop(arc);
+        return 0;
+    };
+    let _guard = handle.enter();
 
     arc.notify.close();
     arc.ctx.socket_closed();
@@ -464,7 +486,22 @@ pub extern "C" fn zmq_bind(sock_ptr: *mut c_void, addr: *const libc::c_char) -> 
     }
     drop(ov);
 
-    ensure_materialized(sock);
+    if sock.ctx.zero_io_threads() {
+        if !zero_io_inproc_supported(sock, &endpoint) {
+            return fail(libc::ENOTSUP);
+        }
+        if let Endpoint::Inproc { .. } = endpoint {
+            register_inproc_bind(sock, &addr_str);
+            if let Ok(mut ep) = sock.last_endpoint.lock() {
+                *ep = Some(addr_str);
+            }
+            return 0;
+        }
+    }
+
+    if !ensure_materialized(sock) {
+        return fail(ETERM);
+    }
 
     let Some(inner) = sock.inner.get() else {
         return fail(ETERM);
@@ -498,7 +535,22 @@ pub extern "C" fn zmq_connect(sock_ptr: *mut c_void, addr: *const libc::c_char) 
         Err(e) => return fail(e),
     };
 
-    ensure_materialized(sock);
+    if sock.ctx.zero_io_threads() {
+        if !zero_io_inproc_supported(sock, &endpoint) {
+            return fail(libc::ENOTSUP);
+        }
+        if let Endpoint::Inproc { .. } = endpoint {
+            register_inproc_connect(sock, &addr_str);
+            if let Ok(mut ep) = sock.last_endpoint.lock() {
+                *ep = Some(addr_str);
+            }
+            return 0;
+        }
+    }
+
+    if !ensure_materialized(sock) {
+        return fail(ETERM);
+    }
 
     let Some(inner) = sock.inner.get() else {
         return fail(ETERM);

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -58,6 +58,28 @@ fn ctx_set_zero_io_threads() {
 }
 
 #[test]
+fn ctx_set_io_threads_before_socket_creation() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, 3), 0);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_IO_THREADS), 3);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_set_io_threads_rejects_negative_and_late_changes() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, -1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    let sock = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!sock.is_null());
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, 2), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    zmq_close(sock);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn zero_io_threads_support_inproc_push_pull() {
     let ctx = zmq_init(0);
     let push = zmq_socket(ctx, ZMQ_PUSH);
@@ -74,6 +96,24 @@ fn zero_io_threads_support_inproc_push_pull() {
 
     zmq_close(push);
     zmq_close(pull);
+    assert_eq!(zmq_ctx_term(ctx), 0);
+}
+
+#[test]
+fn zero_io_threads_reject_unsupported_transports() {
+    let ctx = zmq_init(0);
+    let pair = zmq_socket(ctx, 0);
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+    let tcp = CString::new("tcp://127.0.0.1:*").unwrap();
+    let inproc = CString::new("inproc://zero-io-unsupported").unwrap();
+
+    assert_eq!(zmq_bind(pair, inproc.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::ENOTSUP);
+    assert_eq!(zmq_bind(push, tcp.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::ENOTSUP);
+
+    zmq_close(pair);
+    zmq_close(push);
     assert_eq!(zmq_ctx_term(ctx), 0);
 }
 

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -1,8 +1,10 @@
 //! Context lifecycle tests.
 
 use omq_zmq::{
-    zmq_close, zmq_ctx_get, zmq_ctx_new, zmq_ctx_set, zmq_ctx_shutdown, zmq_ctx_term, zmq_socket,
+    zmq_bind, zmq_close, zmq_connect, zmq_ctx_get, zmq_ctx_new, zmq_ctx_set, zmq_ctx_shutdown,
+    zmq_ctx_term, zmq_init, zmq_recv, zmq_send, zmq_socket,
 };
+use std::ffi::CString;
 use std::ffi::c_void;
 
 const ZMQ_PUSH: i32 = 8;
@@ -45,6 +47,34 @@ fn ctx_get_io_threads_default() {
     let n = zmq_ctx_get(ctx, ZMQ_IO_THREADS);
     assert_eq!(n, 1);
     zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_set_zero_io_threads() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, 0), 0);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_IO_THREADS), 0);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn zero_io_threads_support_inproc_push_pull() {
+    let ctx = zmq_init(0);
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+    let pull = zmq_socket(ctx, ZMQ_PULL);
+    let addr = CString::new("inproc://zero-io-threads").unwrap();
+
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
+    assert_eq!(zmq_send(push, b"hello".as_ptr().cast(), 5, 0), 5);
+
+    let mut buf = [0u8; 8];
+    assert_eq!(zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0), 5);
+    assert_eq!(&buf[..5], b"hello");
+
+    zmq_close(push);
+    zmq_close(pull);
+    assert_eq!(zmq_ctx_term(ctx), 0);
 }
 
 #[test]

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -30,7 +30,8 @@ type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 #[derive(Clone, Copy, Debug)]
 pub struct ContextConfig {
     /// Number of IO threads. Each IO thread runs an independent
-    /// `current_thread` tokio runtime on its own OS thread.
+    /// `current_thread` tokio runtime on its own OS thread. Zero disables
+    /// owned IO threads and uses the caller's active runtime instead.
     /// Default: 1.
     pub io_threads: usize,
 }
@@ -49,7 +50,6 @@ impl ContextConfig {
         let io_threads = std::env::var("OMQ_IO_THREADS")
             .ok()
             .and_then(|v| v.parse().ok())
-            .filter(|&v: &usize| v > 0)
             .unwrap_or(1);
         Self { io_threads }
     }
@@ -336,9 +336,13 @@ impl Context {
     /// Each IO thread runs an independent `current_thread` tokio
     /// runtime on its own OS thread. Connections are pinned to an
     /// IO thread for life (least-loaded assignment at connect/accept
-    /// time).
+    /// time). With zero IO threads, this is equivalent to
+    /// [`Context::current`] and requires an active tokio runtime.
     pub fn with_config(config: ContextConfig) -> Self {
-        let io_threads = config.io_threads.max(1);
+        if config.io_threads == 0 {
+            return Self::current();
+        }
+        let io_threads = config.io_threads;
         let pool = IoThreadPool::new(io_threads);
         Self {
             inner: Arc::new(ContextInner {
@@ -383,6 +387,10 @@ impl Context {
         socket_type: SocketType,
         options: Options,
     ) -> crate::blocking::Socket {
+        assert!(
+            self.io_threads() > 0,
+            "blocking_socket() requires at least one owned IO thread"
+        );
         crate::blocking::Socket::new(self.socket(socket_type, options), self.clone())
     }
 

--- a/omq-tokio/tests/context.rs
+++ b/omq-tokio/tests/context.rs
@@ -265,6 +265,25 @@ async fn context_current_wraps_runtime() {
 }
 
 #[tokio::test]
+async fn context_zero_io_threads_uses_caller_runtime() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 0 });
+    assert_eq!(ctx.io_threads(), 0);
+
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+    let ep = inproc_ep("zero-io-threads");
+    pull.bind(ep.clone()).await.unwrap();
+    push.connect(ep).await.unwrap();
+    push.send(Message::single("zero")).await.unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg, Message::single("zero"));
+}
+
+#[tokio::test]
 async fn context_current_socket_works() {
     let ctx = Context::current();
     let pull = ctx.socket(SocketType::Pull, Options::default());

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -132,7 +132,9 @@ par_wait() {
 # Clippy compiles all targets; a separate all-target build only duplicates
 # that work before the test suite.
 run cargo clippy --all-targets --no-deps -- -D warnings
+run cargo clippy -p omq-libzmq --all-targets --no-deps -- -D warnings
 run cargo test
+run cargo test -p omq-libzmq
 
 if [[ "${OMQ_PERF:-}" == "1" && -f .perf_hw ]]; then
     run cargo run --release -q -p omq-tokio --bin omq_perf_verify


### PR DESCRIPTION
## Summary

- add libzmq context coverage for IO-thread configuration and zero-thread rejection paths
- run libzmq clippy and tests from scripts/test-all.sh

## Validation

- ./scripts/test-all.sh
- 326 Python tests passed, 1 skipped
- Rust tests and clippy passed