### PR TITLE
Fix REP broker envelopes on byte streams

### DIFF
--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures::FutureExt;
 use omq_tokio::Socket as InnerSocket;
 use pyo3::prelude::*;
@@ -491,7 +490,6 @@ pub fn proxy_handles(
     let cap = cap.map(|s| Arc::new(s.into_async()));
     let ctrl = ctrl.map(|s| Arc::new(s.into_async()));
     ctx.spawn_blocking(async move {
-        let mut route_id: Option<Bytes> = None;
         loop {
             tokio::select! {
                 biased;
@@ -515,25 +513,11 @@ pub fn proxy_handles(
                 }
                 msg = fe.recv() => {
                     let Ok(msg) = msg else { return; };
-                    let parts: Vec<Bytes> = msg.iter().collect();
-                    let msg = if parts.len() >= 3 && parts[1].is_empty() {
-                        route_id = Some(parts[0].clone());
-                        omq_tokio::Message::multipart(parts[2..].to_vec())
-                    } else { msg };
                     if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
                     if be.send(msg).await.is_err() { return; }
                 }
                 msg = be.recv() => {
                     let Ok(msg) = msg else { return; };
-                    let msg = if let Some(id) = &route_id {
-                        let mut parts: Vec<Bytes> = msg.iter().collect();
-                        if parts.first().is_some_and(Bytes::is_empty) {
-                            parts.remove(0);
-                        }
-                        let mut routed = vec![id.clone(), Bytes::new()];
-                        routed.extend(parts);
-                        omq_tokio::Message::multipart(routed)
-                    } else { msg };
                     if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
                     if fe.send(msg).await.is_err() { return; }
                 }

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -607,6 +607,8 @@ def test_proxy_req_rep(tcp_endpoint):
     backend = ctx.socket(zmq.DEALER)
     worker = ctx.socket(zmq.REP)
     client = ctx.socket(zmq.REQ)
+    worker.rcvtimeo = 2000
+    client.rcvtimeo = 2000
 
     fe_port = _free_tcp_port()
     be_port = _free_tcp_port()
@@ -629,6 +631,66 @@ def test_proxy_req_rep(tcp_endpoint):
         assert client.recv() == b"pong"
     finally:
         client.close()
+        worker.close()
+        frontend.close()
+        backend.close()
+        ctx.term()
+
+
+def test_proxy_req_rep_two_clients_preserves_routes(tcp_endpoint):
+    import socket
+    import threading
+    import time
+
+    def _free_tcp_port():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+        finally:
+            s.close()
+
+    ctx = zmq.Context()
+    frontend = ctx.socket(zmq.ROUTER)
+    backend = ctx.socket(zmq.DEALER)
+    worker = ctx.socket(zmq.REP)
+    client_a = ctx.socket(zmq.REQ)
+    client_b = ctx.socket(zmq.REQ)
+    worker.rcvtimeo = 2000
+    client_a.rcvtimeo = 2000
+    client_b.rcvtimeo = 2000
+
+    fe_port = _free_tcp_port()
+    be_port = _free_tcp_port()
+
+    try:
+        frontend.bind(f"tcp://127.0.0.1:{fe_port}")
+        backend.bind(f"tcp://127.0.0.1:{be_port}")
+        worker.connect(f"tcp://127.0.0.1:{be_port}")
+        client_a.connect(f"tcp://127.0.0.1:{fe_port}")
+        client_b.connect(f"tcp://127.0.0.1:{fe_port}")
+
+        proxy_thread = threading.Thread(
+            target=zmq.proxy, args=(frontend, backend), daemon=True,
+        )
+        proxy_thread.start()
+
+        time.sleep(0.05)
+        client_a.send(b"from-a")
+        client_b.send(b"from-b")
+
+        first = worker.recv()
+        worker.send(b"ack-" + first)
+        second = worker.recv()
+        worker.send(b"ack-" + second)
+
+        assert {client_a.recv(), client_b.recv()} == {
+            b"ack-from-a",
+            b"ack-from-b",
+        }
+    finally:
+        client_a.close()
+        client_b.close()
         worker.close()
         frontend.close()
         backend.close()

--- a/examples/zguide-pyomq/01_req_rep/run.sh
+++ b/examples/zguide-pyomq/01_req_rep/run.sh
@@ -2,11 +2,13 @@
 set -e
 cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+PYTHON=${PYTHON:-python3}
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}../../../bindings/pyomq/python"
 
-python broker.py &
+"$PYTHON" broker.py &
 sleep 0.3
-python worker.py ipc://@omq-zguide-01-backend 0 &
-python worker.py ipc://@omq-zguide-01-backend 1 &
-python worker.py ipc://@omq-zguide-01-backend 2 &
+"$PYTHON" worker.py ipc://@omq-zguide-01-backend 0 &
+"$PYTHON" worker.py ipc://@omq-zguide-01-backend 1 &
+"$PYTHON" worker.py ipc://@omq-zguide-01-backend 2 &
 sleep 0.3
-python client.py
+"$PYTHON" client.py

--- a/examples/zguide-pyomq/02_pub_sub/run.sh
+++ b/examples/zguide-pyomq/02_pub_sub/run.sh
@@ -2,9 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+PYTHON=${PYTHON:-python3}
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}../../../bindings/pyomq/python"
 
-python publisher.py ipc://@omq-zguide-02-pubsub 20 &
+"$PYTHON" publisher.py ipc://@omq-zguide-02-pubsub 20 &
 sleep 0.3
-python subscriber.py ipc://@omq-zguide-02-pubsub weather.nyc 10 &
-python subscriber.py ipc://@omq-zguide-02-pubsub weather.sfo 10 &
+"$PYTHON" subscriber.py ipc://@omq-zguide-02-pubsub weather.nyc 10 &
+"$PYTHON" subscriber.py ipc://@omq-zguide-02-pubsub weather.sfo 10 &
 wait

--- a/examples/zguide-pyomq/03_pipeline/run.sh
+++ b/examples/zguide-pyomq/03_pipeline/run.sh
@@ -2,12 +2,14 @@
 set -e
 cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+PYTHON=${PYTHON:-python3}
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}../../../bindings/pyomq/python"
 
-python sink.py &
+"$PYTHON" sink.py &
 sleep 0.3
-python worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 0 &
-python worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 1 &
-python worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 2 &
+"$PYTHON" worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 0 &
+"$PYTHON" worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 1 &
+"$PYTHON" worker.py ipc://@omq-zguide-03-ventilator ipc://@omq-zguide-03-sink 2 &
 sleep 0.3
-python ventilator.py
+"$PYTHON" ventilator.py
 wait

--- a/examples/zguide-tokio/01_req_rep/run.sh
+++ b/examples/zguide-tokio/01_req_rep/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg01_broker &

--- a/examples/zguide-tokio/02_pub_sub/run.sh
+++ b/examples/zguide-tokio/02_pub_sub/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg02_publisher -- ipc://@omq-zguide-02-pubsub 20 &

--- a/examples/zguide-tokio/03_pipeline/run.sh
+++ b/examples/zguide-tokio/03_pipeline/run.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo build --bins 2>&1
-BIN="$(dirname "$0")/../target/debug"
+BIN="../target/debug"
 
 "$BIN/zg03_sink" &
 SINK_PID=$!

--- a/examples/zguide-tokio/04_lazy_pirate/run.sh
+++ b/examples/zguide-tokio/04_lazy_pirate/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg04_server &

--- a/examples/zguide-tokio/05_heartbeat/run.sh
+++ b/examples/zguide-tokio/05_heartbeat/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg05_publisher &

--- a/examples/zguide-tokio/06_last_value_cache/run.sh
+++ b/examples/zguide-tokio/06_last_value_cache/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg06_cache &

--- a/examples/zguide-tokio/07_clone/run.sh
+++ b/examples/zguide-tokio/07_clone/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg07_server &

--- a/examples/zguide-tokio/08_majordomo/run.sh
+++ b/examples/zguide-tokio/08_majordomo/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg08_broker -- ipc://@omq-zguide-08-frontend ipc://@omq-zguide-08-backend 3 &

--- a/examples/zguide-tokio/09_titanic/run.sh
+++ b/examples/zguide-tokio/09_titanic/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 STORE=$(mktemp -d)
 trap 'kill $(jobs -p) 2>/dev/null || true; rm -rf "$STORE"' EXIT
 

--- a/examples/zguide-tokio/10_binary_star/run.sh
+++ b/examples/zguide-tokio/10_binary_star/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 cargo run --bin zg10_primary &

--- a/examples/zguide-tokio/11_freelance/run.sh
+++ b/examples/zguide-tokio/11_freelance/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 echo "=== Model 1: Sequential Failover ==="

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -22,7 +22,7 @@ use omq_proto::proto::{Command, Connection, Event};
 use super::compression_pool::CompressionPool;
 use super::send_pipe::{SendPipeConsumer, SendPipeProducerHandle};
 use super::transmit_slot::PeerTransmitSlot;
-use crate::routing::fallback_queue::FallbackReceiver;
+use crate::routing::{RepEnvelope, fallback_queue::FallbackReceiver};
 use crate::socket::dispatch::{AnyReadHalf, AnyStream, AnyWriteHalf};
 use crate::socket::recv::RecvItem;
 use omq_proto::flow::{DrainBudget, max_batch_bytes};
@@ -126,8 +126,7 @@ pub enum RecvSink {
 #[derive(Debug)]
 pub struct RepRecvSink {
     sink: Box<RecvSink>,
-    identity: std::sync::Arc<std::sync::Mutex<Option<bytes::Bytes>>>,
-    pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, bytes::Bytes)>>>,
+    pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, RepEnvelope)>>>,
     peer_id: u64,
 }
 
@@ -242,21 +241,13 @@ impl YringSink {
 }
 
 impl RecvSink {
-    pub(crate) fn set_rep_identity(&mut self, identity: bytes::Bytes) {
-        if let Self::Rep(rep) = self {
-            *rep.identity.lock().expect("rep identity") = Some(identity);
-        }
-    }
-
     pub(crate) fn rep(
         sink: RecvSink,
-        identity: std::sync::Arc<std::sync::Mutex<Option<bytes::Bytes>>>,
-        pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, bytes::Bytes)>>>,
+        pending: std::sync::Arc<std::sync::Mutex<VecDeque<(u64, RepEnvelope)>>>,
         peer_id: u64,
     ) -> Self {
         Self::Rep(RepRecvSink {
             sink: Box::new(sink),
-            identity,
             pending,
             peer_id,
         })
@@ -325,29 +316,14 @@ impl RecvSink {
 
     async fn send(&mut self, m: Message) -> bool {
         if let Self::Rep(rep) = self {
-            let mut m = m;
-            let identity =
-                if let Some(identity) = rep.identity.lock().expect("rep identity").clone() {
-                    if m.part_bytes(0).is_some_and(|part| part.is_empty()) {
-                        m.pop_front();
-                    }
-                    identity
-                } else if m.part_bytes(1).is_some_and(|part| part.is_empty()) {
-                    let Some(identity) = m.pop_front() else {
-                        return false;
-                    };
-                    m.pop_front();
-                    identity
-                } else {
-                    bytes::Bytes::new()
-                };
+            let Some((envelope, body)) = crate::routing::split_rep_request(&m) else {
+                return true;
+            };
             rep.pending
                 .lock()
                 .expect("rep pending")
-                .push_back((rep.peer_id, identity.clone()));
-            let wrapped =
-                Message::with_prefix(identity, Message::with_prefix(bytes::Bytes::new(), m));
-            return rep.sink.send_plain(wrapped).await;
+                .push_back((rep.peer_id, envelope));
+            return rep.sink.send_plain(body).await;
         }
         self.send_plain(m).await
     }
@@ -752,18 +728,6 @@ where
             }
 
             while let Some(ev) = codec.poll_event() {
-                if let Event::HandshakeSucceeded {
-                    peer_properties, ..
-                } = &ev
-                {
-                    let identity = peer_properties
-                        .identity
-                        .clone()
-                        .unwrap_or_else(|| omq_proto::message::generated_identity(peer_id));
-                    if let Some(sink) = recv_direct.as_mut() {
-                        sink.set_rep_identity(identity);
-                    }
-                }
                 if peer_out
                     .send((peer_id, PeerEvent::Event(ev)))
                     .await

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -165,28 +165,6 @@ impl PeerTransmitSlot {
         TryFrameResult::Ok
     }
 
-    /// Encode a REP reply directly with its routing identity. Avoids building
-    /// a temporary multipart `Message` on the latency path.
-    pub(crate) fn try_encode_rep(&self, identity: &Bytes, msg: &Message) -> TryFrameResult {
-        if self.dead.load(Ordering::Acquire) {
-            return TryFrameResult::Dead;
-        }
-        if !self.handshake_done.load(Ordering::Acquire) {
-            return TryFrameResult::Ineligible;
-        }
-        let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
-        if self.is_full(&eq) {
-            self.above_lwm.store(true, Ordering::Relaxed);
-            return TryFrameResult::Full;
-        }
-        eq.frame_rep(identity, msg);
-        self.queued_msgs.fetch_add(1, Ordering::Relaxed);
-        self.mark_above_lwm_if_needed(eq.total_bytes(), self.queued_msgs.load(Ordering::Relaxed));
-        drop(eq);
-        self.signal_encoded();
-        TryFrameResult::Ok
-    }
-
     pub(crate) fn try_push_encoded(&self, chunks: &[Bytes]) -> TryFrameResult {
         if self.dead.load(Ordering::Acquire) {
             return TryFrameResult::Dead;

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -23,6 +23,7 @@ use bytes::Bytes;
 use crate::engine::transmit_slot::TryFrameResult;
 use crate::engine::{PeerDriverCommand, PeerDriverHandle, SendPipeError, SendPipeProducer};
 use crate::routing::peer_outbound::PeerOutbound;
+use crate::routing::{RepEnvelope, rep_reply_with_envelope};
 use omq_proto::error::{Error, Result, TrySendError};
 use omq_proto::message::Message;
 use omq_proto::options::Options;
@@ -67,45 +68,6 @@ impl PeerTarget {
             Self::Pipe(p) | Self::RepInproc(p) => Some(p.space_available()),
             Self::Direct(target) => target.space_available(),
             Self::Inbox(_) => None,
-        }
-    }
-
-    pub(crate) fn try_send_rep(
-        &mut self,
-        identity: &Bytes,
-        msg: Message,
-    ) -> core::result::Result<(), SendPipeError> {
-        match self {
-            Self::Direct(target) => match target.try_encode_rep(identity, &msg) {
-                TryFrameResult::Ok => Ok(()),
-                TryFrameResult::Full => Err(SendPipeError::Full(msg)),
-                TryFrameResult::Dead => Err(SendPipeError::Closed(msg)),
-                TryFrameResult::Ineligible => unreachable!(),
-            },
-            Self::Pipe(p) => {
-                let wrapped =
-                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg));
-                p.try_send(wrapped)
-            }
-            Self::RepInproc(p) => {
-                let msg = if identity.is_empty() {
-                    Message::with_prefix(Bytes::new(), msg)
-                } else {
-                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg))
-                };
-                p.try_send(msg)
-            }
-            Self::Inbox(tx) => {
-                let wrapped =
-                    Message::with_prefix(identity.clone(), Message::with_prefix(Bytes::new(), msg));
-                match tx.try_send(PeerDriverCommand::SendMessage(wrapped)) {
-                    Ok(()) => Ok(()),
-                    Err(tokio::sync::mpsc::error::TrySendError::Full(
-                        PeerDriverCommand::SendMessage(m),
-                    )) => Err(SendPipeError::Full(m)),
-                    Err(_) => Err(SendPipeError::Closed(Message::default())),
-                }
-            }
         }
     }
 
@@ -188,11 +150,12 @@ impl Submitter {
     pub(crate) async fn send_rep(
         &self,
         peer_id: u64,
-        identity: &Bytes,
+        envelope: &RepEnvelope,
         mut msg: Message,
     ) -> Result<()> {
+        msg = rep_reply_with_envelope(envelope, &msg);
         loop {
-            match self.try_send_rep(peer_id, identity, msg) {
+            match self.try_send_rep_wire(peer_id, msg) {
                 Ok(()) => return Ok(()),
                 Err(TrySendError::Full(returned)) => msg = returned,
                 Err(TrySendError::Error(error)) => return Err(error),
@@ -205,19 +168,30 @@ impl Submitter {
     pub(crate) fn try_send_rep(
         &self,
         peer_id: u64,
-        identity: &Bytes,
+        envelope: &RepEnvelope,
+        msg: Message,
+    ) -> core::result::Result<(), TrySendError> {
+        let wire = rep_reply_with_envelope(envelope, &msg);
+        match self.try_send_rep_wire(peer_id, wire) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(TrySendError::Full(msg)),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn try_send_rep_wire(
+        &self,
+        peer_id: u64,
         msg: Message,
     ) -> core::result::Result<(), TrySendError> {
         let mut g = self.inner.lock().expect("identity inner poisoned");
         let Some(peer) = g.peers.get_mut(&peer_id) else {
             return Err(TrySendError::Error(Error::Unroutable));
         };
-        peer.target
-            .try_send_rep(identity, msg)
-            .map_err(|e| match e {
-                SendPipeError::Full(m) => TrySendError::Full(m),
-                SendPipeError::Closed(_) => TrySendError::Closed,
-            })
+        peer.target.try_send(msg).map_err(|e| match e {
+            SendPipeError::Full(m) => TrySendError::Full(m),
+            SendPipeError::Closed(_) => TrySendError::Closed,
+        })
     }
 
     fn try_send_to(

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use omq_proto::subscription;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use smallvec::SmallVec;
 
 use crate::engine::PeerDriverHandle;
 use omq_proto::error::{Error, Result};
@@ -48,6 +49,34 @@ pub(crate) use fan_out::{FanOutMode, FanOutSend, Submitter as FanOutSubmitter};
 pub(crate) use identity::{IdentityRecv, IdentitySend, Submitter as IdentitySubmitter};
 pub(crate) use latency::{LatencySend, Submitter as LatencySubmitter};
 pub(crate) use round_robin::{RoundRobinSend, Submitter as RoundRobinSubmitter};
+
+pub(crate) type RepEnvelope = SmallVec<[Bytes; 2]>;
+
+pub(crate) fn split_rep_request(msg: &Message) -> Option<(RepEnvelope, Message)> {
+    let mut envelope = RepEnvelope::new();
+    let mut body = Vec::new();
+    let mut seen_delimiter = false;
+
+    for part in msg {
+        if seen_delimiter {
+            body.push(part);
+        } else if part.is_empty() {
+            seen_delimiter = true;
+        } else {
+            envelope.push(part);
+        }
+    }
+
+    seen_delimiter.then(|| (envelope, Message::multipart(body)))
+}
+
+pub(crate) fn rep_reply_with_envelope(envelope: &RepEnvelope, body: &Message) -> Message {
+    let mut parts = Vec::with_capacity(envelope.len() + 1 + body.len());
+    parts.extend(envelope.iter().cloned());
+    parts.push(Bytes::new());
+    parts.extend(body.iter());
+    Message::multipart(parts)
+}
 
 /// Send-side policy.
 #[derive(Debug)]
@@ -96,11 +125,11 @@ impl SendSubmitter {
     pub(crate) async fn send_rep_to_peer(
         &self,
         peer_id: u64,
-        identity: &Bytes,
+        envelope: &RepEnvelope,
         msg: Message,
     ) -> Result<()> {
         match self {
-            Self::Identity(s) => s.send_rep(peer_id, identity, msg).await,
+            Self::Identity(s) => s.send_rep(peer_id, envelope, msg).await,
             _ => Err(Error::Protocol("REP latency route unavailable".into())),
         }
     }
@@ -108,11 +137,11 @@ impl SendSubmitter {
     pub(crate) fn send_rep_try_to_peer(
         &self,
         peer_id: u64,
-        identity: &Bytes,
+        envelope: &RepEnvelope,
         msg: Message,
     ) -> core::result::Result<(), omq_proto::error::TrySendError> {
         match self {
-            Self::Identity(s) => s.try_send_rep(peer_id, identity, msg),
+            Self::Identity(s) => s.try_send_rep(peer_id, envelope, msg),
             _ => Err(omq_proto::error::TrySendError::Error(Error::Protocol(
                 "REP latency route unavailable".into(),
             ))),

--- a/omq-tokio/src/routing/peer_outbound.rs
+++ b/omq-tokio/src/routing/peer_outbound.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use std::sync::Arc;
 use tokio::sync::Notify;
 
@@ -77,68 +76,6 @@ impl PeerOutbound {
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => TryFrameResult::Full,
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => TryFrameResult::Dead,
             },
-        }
-    }
-
-    pub(crate) fn try_encode_rep(&self, identity: &Bytes, msg: &Message) -> TryFrameResult {
-        match self {
-            Self::Wire {
-                slot,
-                inbox,
-                direct,
-            } => {
-                if direct.is_none() {
-                    let wrapped = Message::with_prefix(Bytes::new(), msg.clone());
-                    return match inbox.try_send(PeerDriverCommand::SendMessage(wrapped)) {
-                        Ok(()) => TryFrameResult::Ok,
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                            TryFrameResult::Full
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                            TryFrameResult::Dead
-                        }
-                    };
-                }
-                match slot.try_encode_rep(identity, msg) {
-                    TryFrameResult::Ineligible => {
-                        // This target is already bound to the selected peer;
-                        // identity is routing metadata, never a wire frame.
-                        let wrapped = Message::with_prefix(Bytes::new(), msg.clone());
-                        match inbox.try_send(PeerDriverCommand::SendMessage(wrapped)) {
-                            Ok(()) => TryFrameResult::Ok,
-                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                TryFrameResult::Full
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                TryFrameResult::Dead
-                            }
-                        }
-                    }
-                    TryFrameResult::Ok if direct.is_some() => {
-                        let direct = direct.as_ref().unwrap();
-                        match direct
-                            .try_write_buffer(|buf| slot.try_drain_arena_only(buf).is_some())
-                        {
-                            // External frame entries remain queued for the IO
-                            // driver; false does not mean the slot was full.
-                            Ok(true | false) => TryFrameResult::Ok,
-                            Err(_) => TryFrameResult::Dead,
-                        }
-                    }
-                    other => other,
-                }
-            }
-            Self::Inbox(tx) => {
-                let wrapped = Message::with_prefix(
-                    identity.clone(),
-                    Message::with_prefix(Bytes::new(), msg.clone()),
-                );
-                match tx.try_send(PeerDriverCommand::SendMessage(wrapped)) {
-                    Ok(()) => TryFrameResult::Ok,
-                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => TryFrameResult::Full,
-                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => TryFrameResult::Dead,
-                }
-            }
         }
     }
 

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -31,7 +31,7 @@ use super::udp::{
     spawn_dish_listener, spawn_radio_sender,
 };
 use crate::routing::{
-    RecvStrategy, SendStrategy, max_peer_count, supports_groups, supports_subscribe,
+    RecvStrategy, RepEnvelope, SendStrategy, max_peer_count, supports_groups, supports_subscribe,
 };
 use crate::transport::{
     Canceled, InboundFrame, InprocConn, InprocPeerSnapshot, PeerIdent, dial_with_backoff,
@@ -185,9 +185,9 @@ pub(crate) struct SocketDriver {
     /// REQ / REP envelope + alternation state. Shared with the socket
     /// handle so `Socket::send` can call `pre_send` without an actor hop.
     type_state: Arc<Mutex<TypeState>>,
-    /// REP latency route: identity of the request currently being served.
-    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, bytes::Bytes)>>>,
-    rep_current: Arc<Mutex<Option<(u64, bytes::Bytes)>>>,
+    /// REP latency route: envelope of the request currently being served.
+    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, RepEnvelope)>>>,
+    rep_current: Arc<Mutex<Option<(u64, RepEnvelope)>>>,
     /// REQ alternation flag. Shared with the socket handle for lock-free
     /// send/recv on REQ. Actor resets on peer disconnect.
     req_awaiting_reply: Arc<AtomicBool>,
@@ -226,8 +226,8 @@ impl SocketDriver {
         send_strategy: SendStrategy,
         spsc: super::recv::SpscHandles,
         type_state: Arc<Mutex<TypeState>>,
-        rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, bytes::Bytes)>>>,
-        rep_current: Arc<Mutex<Option<(u64, bytes::Bytes)>>>,
+        rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, RepEnvelope)>>>,
+        rep_current: Arc<Mutex<Option<(u64, RepEnvelope)>>>,
         req_awaiting_reply: Arc<AtomicBool>,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
         subscribe_count: Arc<AtomicU64>,

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -318,7 +318,6 @@ impl SocketDriver {
         // from the connection driver into the user-facing recv channel,
         // skipping the actor's event loop.
         let rep_latency = self.socket_type == SocketType::Rep && self.uses_latency_profile();
-        let rep_identity = Arc::new(std::sync::Mutex::new(None));
         let driver = if can_bypass_actor_recv(self.socket_type) || rep_latency {
             let can_use_yring =
                 can_bypass_actor_recv(self.socket_type) && self.socket_type != SocketType::Req;
@@ -331,7 +330,6 @@ impl SocketDriver {
                     if rep_latency {
                         driver.with_recv_sink(crate::engine::RecvSink::rep(
                             sink,
-                            rep_identity.clone(),
                             self.rep_pending.clone(),
                             peer_id,
                         ))
@@ -356,7 +354,6 @@ impl SocketDriver {
                     if rep_latency {
                         driver.with_recv_sink(crate::engine::RecvSink::rep(
                             sink,
-                            rep_identity.clone(),
                             self.rep_pending.clone(),
                             peer_id,
                         ))
@@ -367,7 +364,6 @@ impl SocketDriver {
             } else if rep_latency {
                 driver.with_recv_sink(crate::engine::RecvSink::rep(
                     crate::engine::RecvSink::Channel(self.recv_tx.clone()),
-                    rep_identity,
                     self.rep_pending.clone(),
                     peer_id,
                 ))
@@ -616,15 +612,12 @@ impl SocketDriver {
                 if self.socket_type == SocketType::Rep
                     && self.uses_latency_profile()
                     && self.peers.contains_key(&peer_id)
+                    && let Some((envelope, _)) = crate::routing::split_rep_request(&msg)
                 {
-                    let envelope_identity = msg
-                        .part_bytes(0)
-                        .filter(|part| !part.is_empty())
-                        .unwrap_or_default();
                     self.rep_pending
                         .lock()
                         .expect("rep pending")
-                        .push_back((peer_id, envelope_identity));
+                        .push_back((peer_id, envelope));
                 }
                 if self.handle_legacy_subscribe(peer_id, &msg) {
                     return;

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -18,7 +18,7 @@ use omq_proto::type_state::TypeState;
 use super::actor::{SocketCommand, SocketDriver, spawn_driver};
 use super::monitor::{ConnectionStatus, MonitorPublisher, MonitorStream};
 use super::recv::{SpscAwareRecv, SpscHandles, SpscPush};
-use crate::routing::{SendStrategy, SendSubmitter};
+use crate::routing::{RepEnvelope, SendStrategy, SendSubmitter};
 
 pub use omq_proto::error::TrySendError;
 
@@ -51,9 +51,9 @@ struct Inner {
     send_submitter: SendSubmitter,
     /// Shared with the actor for REP `pre_send` / `post_recv`.
     type_state: Arc<Mutex<TypeState>>,
-    /// Shared request identity for the latency REP path.
-    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, Bytes)>>>,
-    rep_current: Arc<Mutex<Option<(u64, Bytes)>>>,
+    /// Shared request envelope for the latency REP path.
+    rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, RepEnvelope)>>>,
+    rep_current: Arc<Mutex<Option<(u64, RepEnvelope)>>>,
     rep_latency: bool,
     /// REQ alternation flag. Avoids Mutex on the REQ hot path.
     /// Shared with the actor for `on_peer_disconnected` reset.

--- a/omq-tokio/tests/broker.rs
+++ b/omq-tokio/tests/broker.rs
@@ -8,12 +8,47 @@
 //! Message envelope at the DEALER/REP level: [`client_id` | "" | body]
 //! REP delivers [body] to the application and re-wraps on reply.
 
+use std::net::{Ipv4Addr, TcpListener};
 use std::time::Duration;
 
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
 fn inproc(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
+}
+
+fn free_tcp_port() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn tcp(port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+#[cfg(feature = "lz4")]
+fn lz4_tcp(port: u16) -> Endpoint {
+    Endpoint::Lz4Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+#[cfg(unix)]
+fn ipc(name: &str) -> Endpoint {
+    Endpoint::Ipc(omq_proto::endpoint::IpcPath::Abstract(format!(
+        "omq-broker-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )))
 }
 
 #[tokio::test]
@@ -21,6 +56,53 @@ async fn router_dealer_rep_single_cycle() {
     let frontend = inproc("broker-fe-tok");
     let backend = inproc("broker-be-tok");
 
+    router_dealer_rep_single_cycle_with(frontend, backend).await;
+}
+
+#[tokio::test]
+async fn router_dealer_rep_single_cycle_tcp() {
+    let frontend = tcp(free_tcp_port());
+    let backend = tcp(free_tcp_port());
+
+    router_dealer_rep_single_cycle_with(frontend, backend).await;
+}
+
+#[tokio::test]
+async fn router_dealer_rep_multi_hop_envelope_tcp() {
+    let frontend = tcp(free_tcp_port());
+    let backend = tcp(free_tcp_port());
+
+    router_dealer_rep_multi_hop_envelope_with(frontend, backend).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "lz4")]
+async fn router_dealer_rep_single_cycle_lz4_tcp() {
+    let frontend = lz4_tcp(free_tcp_port());
+    let backend = lz4_tcp(free_tcp_port());
+
+    router_dealer_rep_single_cycle_with(frontend, backend).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "lz4")]
+async fn router_dealer_rep_multi_hop_envelope_lz4_tcp() {
+    let frontend = lz4_tcp(free_tcp_port());
+    let backend = lz4_tcp(free_tcp_port());
+
+    router_dealer_rep_multi_hop_envelope_with(frontend, backend).await;
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn router_dealer_rep_single_cycle_ipc() {
+    let frontend = ipc("fe");
+    let backend = ipc("be");
+
+    router_dealer_rep_single_cycle_with(frontend, backend).await;
+}
+
+async fn router_dealer_rep_single_cycle_with(frontend: Endpoint, backend: Endpoint) {
     let router = Socket::new(SocketType::Router, Options::default());
     router.bind(frontend.clone()).await.unwrap();
 
@@ -64,6 +146,62 @@ async fn router_dealer_rep_single_cycle() {
         .unwrap()
         .unwrap();
     assert_eq!(reply, Message::single("done"));
+
+    broker.await.unwrap();
+}
+
+async fn router_dealer_rep_multi_hop_envelope_with(frontend: Endpoint, backend: Endpoint) {
+    let router = Socket::new(SocketType::Router, Options::default());
+    router.bind(frontend.clone()).await.unwrap();
+
+    let dealer = Socket::new(SocketType::Dealer, Options::default());
+    dealer.bind(backend.clone()).await.unwrap();
+
+    let client = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(Bytes::from_static(b"hop-a")),
+    );
+    client.connect(frontend).await.unwrap();
+
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    rep.connect(backend).await.unwrap();
+
+    let router_c = router.clone();
+    let dealer_c = dealer.clone();
+    let broker = tokio::spawn(async move {
+        let request = tokio::time::timeout(Duration::from_secs(2), router_c.recv())
+            .await
+            .expect("router recv timed out")
+            .unwrap();
+        dealer_c.send(request).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(2), dealer_c.recv())
+            .await
+            .expect("dealer recv timed out")
+            .unwrap();
+        router_c.send(reply).await.unwrap();
+    });
+
+    client
+        .send(Message::multipart(["hop-b", "", "work"]))
+        .await
+        .unwrap();
+
+    let work = tokio::time::timeout(Duration::from_secs(2), rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(work, Message::single("work"));
+    rep.send(Message::single("done")).await.unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reply.len(), 3);
+    assert_eq!(reply.part_bytes(0).unwrap(), &b"hop-b"[..]);
+    assert!(reply.part_bytes(1).unwrap().is_empty());
+    assert_eq!(reply.part_bytes(2).unwrap(), &b"done"[..]);
 
     broker.await.unwrap();
 }


### PR DESCRIPTION
- Preserve full REP request envelopes on byte-stream paths before delivering bodies to user code.
- Forward pyomq proxy frames unchanged so ROUTER/DEALER proxies keep multi-client routes.
- Cover brokered REP over IPC, TCP, and lz4+tcp, including multi-hop identities.
- Make zguide run scripts cwd-safe/runnable.