### PR TITLE
Fix pyomq wheel CPU portability

### DIFF
--- a/.github/workflows/release-pyomq.yml
+++ b/.github/workflows/release-pyomq.yml
@@ -18,6 +18,8 @@ jobs:
         manylinux: [auto, musllinux_1_2]
     steps:
       - uses: actions/checkout@v4
+      - name: Disable local CPU rustflags
+        run: rm -f .cargo/config.toml
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Disable local CPU rustflags
+        run: rm -f .cargo/config.toml
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-19
+
+### Fixed
+
+- Build PyPI wheels without inheriting the repo-local `target-cpu=native`
+  rustflags, so release artifacts stay portable across Linux CPUs.
+
 ## [0.16.0] - 2026-07-19
 
 ### Fixed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.16.0"
+version = "0.16.1"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- Bump pyomq package metadata and lockfile to 0.16.1.
- Remove `.cargo/config.toml` in the pyomq release workflow before maturin builds wheels/sdist so release artifacts do not inherit `target-cpu=native`.
- Keep `pyomq-v0.16.0` untouched; follow-up release should tag `pyomq-v0.16.1`.

Tests:
- `cargo check --manifest-path bindings/pyomq/Cargo.toml`
- `git diff --check`