### PR TITLE
Fix duplicate connect semantics

### DIFF
--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -10,6 +10,24 @@ use super::{
 use crate::socket::actor::lifecycle::PeerLifecycle;
 
 impl SocketDriver {
+    pub(super) fn socket_type_ignores_duplicate_connect(&self) -> bool {
+        matches!(
+            self.socket_type,
+            SocketType::Dealer | SocketType::Sub | SocketType::Pub | SocketType::Req
+        )
+    }
+
+    pub(super) fn should_ignore_duplicate_connect(&self, endpoint: &Endpoint) -> bool {
+        if !self.socket_type_ignores_duplicate_connect() {
+            return false;
+        }
+        self.dialers.iter().any(|d| &d.endpoint == endpoint)
+            || self
+                .peers
+                .values()
+                .any(|peer| peer.is_client && &peer.endpoint == endpoint)
+    }
+
     pub(super) fn unbind(&mut self, endpoint: &Endpoint) -> Result<()> {
         let before = self.listeners.len() + self.udp_listeners.len();
         self.listeners.retain(|l| {
@@ -433,7 +451,11 @@ impl SocketDriver {
                         .await;
                 }
                 Err(Canceled::Token | Canceled::PolicyDisabled | Canceled::StoppedConnRefused) => {
-                    let _ = tx.send(InternalEvent::ConnectGaveUp).await;
+                    let _ = tx
+                        .send(InternalEvent::ConnectGaveUp {
+                            endpoint: dialer_ep,
+                        })
+                        .await;
                 }
             }
         });

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -111,7 +111,9 @@ enum InternalEvent {
         conn: AnyConn,
         endpoint: Endpoint,
     },
-    ConnectGaveUp,
+    ConnectGaveUp {
+        endpoint: Endpoint,
+    },
     ConnectDelayed {
         endpoint: Endpoint,
         retry_in: Duration,
@@ -343,6 +345,8 @@ impl SocketDriver {
                     let _ = ack.send(res);
                 } else if let Err(e) = reject_encrypted_inproc(&endpoint, &self.options.mechanism) {
                     let _ = ack.send(Err(e));
+                } else if self.should_ignore_duplicate_connect(&endpoint) {
+                    let _ = ack.send(Ok(()));
                 } else {
                     self.start_dial(endpoint);
                     let _ = ack.send(Ok(()));

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -20,9 +20,12 @@ impl SocketDriver {
             InternalEvent::Connected { conn, endpoint } => {
                 self.spawn_on_handshake(conn, endpoint, false);
             }
-            InternalEvent::ConnectGaveUp => {
-                // Dial task exited. Leave the entry alone; the Socket remains
-                // usable; a follow-up connect would re-arm.
+            InternalEvent::ConnectGaveUp { endpoint } => {
+                if self.socket_type_ignores_duplicate_connect() {
+                    self.dialers.retain(|d| d.endpoint != endpoint);
+                }
+                // Non-deduped socket types leave the entry alone; follow-up
+                // connect calls can still add another dialer.
             }
             InternalEvent::ConnectDelayed {
                 endpoint,

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -43,6 +43,50 @@ async fn bind_lz4_loopback(sock: &Socket) -> Endpoint {
     }
 }
 
+#[tokio::test]
+async fn sub_duplicate_lz4_tcp_connect_is_ignored() {
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let ep = bind_lz4_loopback(&publisher).await;
+
+    let subscriber = Socket::new(SocketType::Sub, Options::default());
+    subscriber.connect(ep.clone()).await.unwrap();
+    subscriber.connect(ep).await.unwrap();
+
+    publisher
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("publisher did not see subscriber");
+    subscriber
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("subscriber did not connect");
+    test_support::assert_no_second_connection(&publisher, "publisher").await;
+    test_support::assert_no_second_connection(&subscriber, "subscriber").await;
+
+    subscriber.subscribe(bytes::Bytes::new()).await.unwrap();
+    publisher
+        .wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
+    let second_subscribe = publisher
+        .wait_subscribed(2, Duration::from_millis(250))
+        .await;
+    assert!(
+        second_subscribe.is_err(),
+        "duplicate lz4+tcp connect replayed subscription twice"
+    );
+
+    publisher.send(Message::single("hello")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(1), subscriber.recv())
+        .await
+        .expect("subscriber did not receive message")
+        .unwrap();
+    assert_eq!(msg, Message::single("hello"));
+
+    let duplicate = tokio::time::timeout(Duration::from_millis(250), subscriber.recv()).await;
+    assert!(duplicate.is_err(), "subscriber received duplicate message");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pub_sub_lz4_sharded_fan_out_ships_dict_to_late_subscriber() {
     use omq_proto::proto::transform::lz4::DictTrainer;

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -2,12 +2,21 @@
 
 mod test_support;
 
+use std::net::TcpListener as StdTcpListener;
 use std::time::Duration;
 
+use omq_tokio::options::ReconnectPolicy;
 use omq_tokio::{Endpoint, Message, OnMute, Options, Socket, SocketType};
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
+}
+
+fn free_tcp_port() -> u16 {
+    let listener = StdTcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
 }
 
 #[tokio::test]
@@ -50,6 +59,147 @@ async fn pub_sub_simple_prefix_match() {
     // No third message -- 'weather' was filtered.
     let third = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(third.is_err(), "non-matching message must not be delivered");
+}
+
+#[tokio::test]
+async fn sub_duplicate_tcp_connect_is_ignored() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let port = test_support::bind_loopback(&pub_).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.connect(ep.clone()).await.unwrap();
+    sub.connect(ep).await.unwrap();
+
+    pub_.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("publisher did not see subscriber");
+    sub.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("subscriber did not connect");
+    test_support::assert_no_second_connection(&pub_, "publisher").await;
+    test_support::assert_no_second_connection(&sub, "subscriber").await;
+
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
+    let second_subscribe = pub_.wait_subscribed(2, Duration::from_millis(250)).await;
+    assert!(
+        second_subscribe.is_err(),
+        "duplicate connect replayed subscription twice"
+    );
+
+    pub_.send(Message::single("hello")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(1), sub.recv())
+        .await
+        .expect("subscriber did not receive message")
+        .unwrap();
+    assert_eq!(msg, Message::single("hello"));
+
+    let duplicate = tokio::time::timeout(Duration::from_millis(250), sub.recv()).await;
+    assert!(duplicate.is_err(), "subscriber received duplicate message");
+}
+
+#[tokio::test]
+async fn sub_duplicate_tcp_connect_before_bind_is_ignored() {
+    let ep = test_support::tcp_loopback(free_tcp_port());
+    let reconnect = Options::default().reconnect(ReconnectPolicy::Fixed(Duration::from_millis(20)));
+
+    let sub = Socket::new(SocketType::Sub, reconnect);
+    sub.connect(ep.clone()).await.unwrap();
+    sub.connect(ep.clone()).await.unwrap();
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep).await.unwrap();
+
+    pub_.wait_connected(1, Duration::from_secs(5))
+        .await
+        .expect("publisher did not see subscriber");
+    sub.wait_connected(1, Duration::from_secs(5))
+        .await
+        .expect("subscriber did not connect");
+    pub_.wait_subscribed(1, Duration::from_secs(5))
+        .await
+        .expect("subscription did not arrive");
+
+    test_support::assert_no_second_connection(&pub_, "publisher").await;
+    test_support::assert_no_second_connection(&sub, "subscriber").await;
+    let second_subscribe = pub_.wait_subscribed(2, Duration::from_millis(250)).await;
+    assert!(
+        second_subscribe.is_err(),
+        "duplicate dialer replayed subscription twice"
+    );
+}
+
+#[tokio::test]
+async fn sub_duplicate_inproc_connect_is_ignored() {
+    let ep = inproc_ep("ps-duplicate-inproc");
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep.clone()).await.unwrap();
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.connect(ep.clone()).await.unwrap();
+    sub.connect(ep).await.unwrap();
+
+    pub_.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("publisher did not see subscriber");
+    sub.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("subscriber did not connect");
+    test_support::assert_no_second_connection(&pub_, "publisher").await;
+    test_support::assert_no_second_connection(&sub, "subscriber").await;
+
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
+
+    pub_.send(Message::single("hello")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(1), sub.recv())
+        .await
+        .expect("subscriber did not receive message")
+        .unwrap();
+    assert_eq!(msg, Message::single("hello"));
+
+    let duplicate = tokio::time::timeout(Duration::from_millis(250), sub.recv()).await;
+    assert!(duplicate.is_err(), "subscriber received duplicate message");
+}
+
+#[tokio::test]
+async fn pub_duplicate_tcp_connect_is_ignored() {
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    let port = test_support::bind_loopback(&sub).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.connect(ep.clone()).await.unwrap();
+    pub_.connect(ep).await.unwrap();
+
+    sub.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("subscriber did not see publisher");
+    pub_.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("publisher did not connect");
+    test_support::assert_no_second_connection(&sub, "subscriber").await;
+    test_support::assert_no_second_connection(&pub_, "publisher").await;
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
+
+    pub_.send(Message::single("hello")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(1), sub.recv())
+        .await
+        .expect("subscriber did not receive message")
+        .unwrap();
+    assert_eq!(msg, Message::single("hello"));
+
+    let duplicate = tokio::time::timeout(Duration::from_millis(250), sub.recv()).await;
+    assert!(duplicate.is_err(), "subscriber received duplicate message");
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -13,6 +13,24 @@ fn inproc_ep(name: &str) -> Endpoint {
 }
 
 #[tokio::test]
+async fn push_duplicate_tcp_connect_keeps_separate_pipes() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let port = test_support::bind_loopback(&pull).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep.clone()).await.unwrap();
+    push.connect(ep).await.unwrap();
+
+    pull.wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("pull did not see both push pipes");
+    push.wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("push did not keep both pipes");
+}
+
+#[tokio::test]
 async fn push_pull_single_peer() {
     let ep = inproc_ep("pp-single");
     let pull = Socket::new(SocketType::Pull, Options::default());

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -31,6 +31,66 @@ async fn push_duplicate_tcp_connect_keeps_separate_pipes() {
 }
 
 #[tokio::test]
+async fn push_duplicate_tcp_connect_weights_round_robin() {
+    const N: usize = 90;
+
+    let pull_a = Socket::new(SocketType::Pull, Options::default());
+    let port_a = test_support::bind_loopback(&pull_a).await;
+    let ep_a = test_support::tcp_loopback(port_a);
+
+    let pull_b = Socket::new(SocketType::Pull, Options::default());
+    let port_b = test_support::bind_loopback(&pull_b).await;
+    let ep_b = test_support::tcp_loopback(port_b);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep_a.clone()).await.unwrap();
+    push.connect(ep_a).await.unwrap();
+    push.connect(ep_b).await.unwrap();
+
+    pull_a
+        .wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("first pull did not get duplicate pipes");
+    pull_b
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("second pull did not connect");
+    push.wait_connected(3, Duration::from_secs(1))
+        .await
+        .expect("push did not keep three pipes");
+
+    let drain_a = tokio::spawn(async move { drain_until_idle(pull_a).await });
+    let drain_b = tokio::spawn(async move { drain_until_idle(pull_b).await });
+
+    for i in 0..N {
+        push.send(Message::single(format!("weighted-{i}")))
+            .await
+            .unwrap();
+    }
+
+    let count_a = drain_a.await.unwrap();
+    let count_b = drain_b.await.unwrap();
+
+    assert_eq!(count_a + count_b, N, "every message must arrive");
+    assert_eq!(
+        count_a, 60,
+        "first pull should receive two thirds via two pipes"
+    );
+    assert_eq!(
+        count_b, 30,
+        "second pull should receive one third via one pipe"
+    );
+}
+
+async fn drain_until_idle(socket: Socket) -> usize {
+    let mut count = 0;
+    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_millis(500), socket.recv()).await {
+        count += 1;
+    }
+    count
+}
+
+#[tokio::test]
 async fn push_pull_single_peer() {
     let ep = inproc_ep("pp-single");
     let pull = Socket::new(SocketType::Pull, Options::default());

--- a/omq-tokio/tests/reconnect_stop.rs
+++ b/omq-tokio/tests/reconnect_stop.rs
@@ -115,3 +115,31 @@ async fn reconnect_stop_after_established_session() {
         "expected no ConnectDelayed after ECONNREFUSED stop"
     );
 }
+
+#[tokio::test]
+async fn reconnect_stop_sub_can_rearm_same_endpoint() {
+    let ep = grab_and_release_port();
+
+    let opts = Options::default()
+        .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(50)))
+        .reconnect_stop_conn_refused(true);
+    let sub = Socket::new(SocketType::Sub, opts);
+    sub.connect(ep.clone()).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep.clone()).await.unwrap();
+    sub.connect(ep).await.unwrap();
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+
+    pub_.wait_subscribed(1, Duration::from_secs(2))
+        .await
+        .expect("subscription did not arrive after reconnect was rearmed");
+    pub_.send(Message::single("again")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+        .await
+        .expect("subscriber did not receive after reconnect was rearmed")
+        .unwrap();
+    assert_eq!(msg, Message::single("again"));
+}

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -28,6 +28,32 @@ fn inproc_ep(name: &str) -> Endpoint {
 }
 
 #[tokio::test]
+async fn req_duplicate_tcp_connect_is_ignored() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(ep.clone()).await.unwrap();
+    req.connect(ep).await.unwrap();
+
+    rep.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("rep did not see req");
+    req.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("req did not connect");
+    test_support::assert_no_second_connection(&rep, "rep").await;
+    test_support::assert_no_second_connection(&req, "req").await;
+
+    req.send(Message::single("hello")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), rep.recv())
+        .await
+        .expect("rep did not receive request")
+        .unwrap();
+    assert_eq!(got, Message::single("hello"));
+}
+
+#[tokio::test]
 async fn req_rep_basic_roundtrip() {
     let ep = inproc_ep("rr-basic");
     let rep = Socket::new(SocketType::Rep, Options::default());

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -5,6 +5,8 @@
 //! round-robin over peers (same as Phase 5's PUSH/PULL) and fair-queued
 //! on recv.
 
+mod test_support;
+
 use std::time::Duration;
 
 use omq_tokio::{
@@ -13,6 +15,35 @@ use omq_tokio::{
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
+}
+
+#[tokio::test]
+async fn dealer_duplicate_tcp_connect_is_ignored() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = test_support::bind_loopback(&router).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let dealer = Socket::new(SocketType::Dealer, Options::default());
+    dealer.connect(ep.clone()).await.unwrap();
+    dealer.connect(ep).await.unwrap();
+
+    router
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router did not see dealer");
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
+    test_support::assert_no_second_connection(&router, "router").await;
+    test_support::assert_no_second_connection(&dealer, "dealer").await;
+
+    dealer.send(Message::single("hello")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), router.recv())
+        .await
+        .expect("router did not receive")
+        .unwrap();
+    assert_eq!(got.part_bytes(1).unwrap(), &b"hello"[..]);
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/test_support/mod.rs
+++ b/omq-tokio/tests/test_support/mod.rs
@@ -61,3 +61,8 @@ pub async fn wait_for_join(sock: &Socket) {
         .await
         .expect("join did not propagate within 5s");
 }
+
+pub async fn assert_no_second_connection(sock: &Socket, context: &str) {
+    let second = sock.wait_connected(2, Duration::from_millis(250)).await;
+    assert!(second.is_err(), "{context}: duplicate connection appeared");
+}

--- a/omq-tokio/tests/unbind_disconnect.rs
+++ b/omq-tokio/tests/unbind_disconnect.rs
@@ -92,3 +92,45 @@ async fn disconnect_after_connect_succeeds() {
         .unwrap();
     assert_eq!(m.part_bytes(0).unwrap(), &b"again"[..]);
 }
+
+#[tokio::test]
+async fn disconnect_after_duplicate_connect_closes_all_pipes() {
+    let push = Socket::new(SocketType::Push, Options::default());
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let ep = pull.bind(tcp_loopback(0)).await.unwrap();
+
+    push.connect(ep.clone()).await.unwrap();
+    push.connect(ep.clone()).await.unwrap();
+
+    push.wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("push did not keep both pipes");
+    pull.wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("pull did not see both pipes");
+
+    push.disconnect(ep.clone()).await.unwrap();
+    wait_no_connections(&push).await;
+    wait_no_connections(&pull).await;
+
+    let r = push.disconnect(ep.clone()).await;
+    assert!(matches!(r, Err(Error::Unroutable)), "got {r:?}");
+
+    push.connect(ep).await.unwrap();
+    push.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("push did not reconnect one pipe");
+    pull.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("pull did not see reconnected pipe");
+
+    let extra = push.wait_connected(2, Duration::from_millis(250)).await;
+    assert!(extra.is_err(), "duplicate pipe survived disconnect");
+
+    push.send(Message::single("again")).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap(), &b"again"[..]);
+}


### PR DESCRIPTION
- Match libzmq duplicate-connect behavior for `DEALER`, `SUB`, `PUB`, and `REQ`.
- Return success for ignored duplicate connects without spawning extra dialers.
- Preserve `PUSH` duplicate connects as separate weighted round-robin pipes.
- Verify one `disconnect(endpoint)` removes all duplicate `PUSH` pipes.
- Cover `tcp://`, `inproc://`, and `lz4+tcp://` duplicate-connect cases.
- Inspired by https://github.com/zeromq/zmq.rs/issues/291
