### PR TITLE
Add 32-bit Linux target support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         run: cross check --target ${{ matrix.target }} --workspace --all-targets --all-features
       - name: yring tests
         run: cross test --target ${{ matrix.target }} -p yring --all-features
+      - name: tokio tcp smoke tests
+        run: cross test --target ${{ matrix.target }} -p omq-tokio --test tcp_smoke
       - name: proto lz4 tests
         run: cross test --target ${{ matrix.target }} -p omq-proto --features lz4 --lib
       - name: libzmq ABI and inproc tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,39 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo test -p omq-tokio --features lz4 -- --test-threads=1
 
+  linux-32bit:
+    name: 32-bit linux (${{ matrix.target }})
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - uses: Swatinem/rust-cache@v2
+      - name: compile workspace
+        run: cross check --target ${{ matrix.target }} --workspace --all-targets --all-features
+      - name: yring tests
+        run: cross test --target ${{ matrix.target }} -p yring --all-features
+      - name: proto lz4 tests
+        run: cross test --target ${{ matrix.target }} -p omq-proto --features lz4 --lib
+      - name: libzmq ABI and inproc tests
+        run: |
+          cross test --target ${{ matrix.target }} -p omq-libzmq --test ctx
+          cross test --target ${{ matrix.target }} -p omq-libzmq --test multipart
+          cross test --target ${{ matrix.target }} -p omq-libzmq --test proxy
+          cross test --target ${{ matrix.target }} -p omq-libzmq --test draft
+
   lint:
     name: fmt + clippy
     needs: [changes]
@@ -148,7 +181,7 @@ jobs:
 
   ci-success:
     name: CI success
-    needs: [changes, test, encryption, compression, lint, pyomq]
+    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- CI coverage for `i686-unknown-linux-gnu` and
+  `armv7-unknown-linux-gnueabihf`.
+
+### Changed
+
+- `yring` cursors and libzmq inproc bypass cursors now use 64-bit atomics
+  on 32-bit targets.
+- 32-bit builds are supported on targets with native 64-bit atomics. Per-frame
+  and per-message payloads remain bounded by platform allocation limits
+  (below 4 GiB on 32-bit Linux).
+
 ## [omq-proto 0.23.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ The Rust backend is [`omq-tokio`](omq-tokio/): tokio + mio on Linux,
 macOS, and Windows. It works on single-thread and multi-thread tokio
 runtimes.
 
+Supported 32-bit Linux targets are `i686-unknown-linux-gnu` and
+`armv7-unknown-linux-gnueabihf`. They require native 64-bit atomics. ZMTP wire
+length fields stay 64-bit, but practical frame/message size is bounded by
+platform allocation limits (below 4 GiB on 32-bit).
+
 If you know ZeroMQ, you know OMQ. Same socket types, same connect/bind/send/recv:
 
 ```rust

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -424,8 +424,7 @@ dependencies = [
 [[package]]
 name = "lz4rip"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f98b1380e382ff43bbeab40323ddbcd90eaba9293e166f8f21d5d458998375"
+source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
 dependencies = [
  "lz4rip-core",
  "lz4rip-decode",
@@ -435,14 +434,12 @@ dependencies = [
 [[package]]
 name = "lz4rip-core"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d5114cd4d615ffb90b111dc7eac57191eba2004a49830e577b8daab4610b75"
+source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
 
 [[package]]
 name = "lz4rip-decode"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e82397fe986267ef8a26640c8265e776344e6606e9debc69a3fb1643fad01d3"
+source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
 dependencies = [
  "lz4rip-core",
 ]
@@ -450,8 +447,7 @@ dependencies = [
 [[package]]
 name = "lz4rip-encode"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002ccf86457fc2e44ee2e246ae05e7792097a1fa07b2bb79c63b9e9d6c0e04ba"
+source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
 dependencies = [
  "lz4rip-core",
 ]

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -423,8 +423,9 @@ dependencies = [
 
 [[package]]
 name = "lz4rip"
-version = "0.11.1"
-source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb69a12f600139f42d2c63d929b60733582f8bb706da4d2cd951e5beb6c649c"
 dependencies = [
  "lz4rip-core",
  "lz4rip-decode",
@@ -433,21 +434,24 @@ dependencies = [
 
 [[package]]
 name = "lz4rip-core"
-version = "0.5.4"
-source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc4edb61fcaf1cdad24ac2982eff7af4417ef463c33bcf5c42ba549abd8b96"
 
 [[package]]
 name = "lz4rip-decode"
-version = "0.10.2"
-source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d65bfd4c032fefcf8c18fb5f8d9958f4925146845db16dbc9d416f1566b9bf"
 dependencies = [
  "lz4rip-core",
 ]
 
 [[package]]
 name = "lz4rip-encode"
-version = "0.10.4"
-source = "git+https://github.com/paddor/lz4rip?rev=2e02fe810c6b809ff8f7cd16102058a1b59d4b47#2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e92b7345788ec0d32b5e31051dc6a86730e17b01267e502e9ec2744b689d34"
 dependencies = [
  "lz4rip-core",
 ]

--- a/omq-libzmq/CHANGELOG.md
+++ b/omq-libzmq/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ZMQ_MSG_T_SIZE` support through `zmq_ctx_get`.
+
+### Changed
+
+- `zmq_msg_t` storage now matches libzmq's 64-byte, pointer-aligned ABI on
+  both 64-bit and 32-bit targets.
+- Inproc bypass cursors now use 64-bit atomics so 32-bit targets do not alias
+  at the 4 GiB cursor boundary.
+
 ## [0.5.4] - 2026-07-19
 
 ### Fixed

--- a/omq-libzmq/README.md
+++ b/omq-libzmq/README.md
@@ -15,6 +15,10 @@ in other languages) to link against omq instead of libzmq.
 - **Cross-Platform:** Linux, macOS, Windows, BSD
 - **API Compatibility:** Drop-in libzmq replacement with identical ABI
 
+32-bit Linux support covers `i686-unknown-linux-gnu` and
+`armv7-unknown-linux-gnueabihf`. `zmq_msg_t` is 64 bytes and pointer-aligned,
+matching libzmq; `zmq_ctx_get(ctx, ZMQ_MSG_T_SIZE)` returns 64.
+
 ## Build
 
 Produces `libomq_zmq.so` / `libomq_zmq.a` / `libomq_zmq.dylib`.

--- a/omq-libzmq/examples/bench_zero_copy.rs
+++ b/omq-libzmq/examples/bench_zero_copy.rs
@@ -21,13 +21,14 @@ use omq_zmq::{
 const ZMQ_PUSH: i32 = 8;
 const ZMQ_PULL: i32 = 7;
 const ZMQ_RCVTIMEO: i32 = 27;
+const ZMQ_MSG_WORDS: usize = 64 / std::mem::size_of::<usize>();
 
-#[repr(C, align(8))]
-struct Msg([u8; 64]);
+#[repr(C)]
+struct Msg([usize; ZMQ_MSG_WORDS]);
 
 impl Msg {
     fn new() -> Self {
-        let mut m = Self([0u8; 64]);
+        let mut m = Self([0; ZMQ_MSG_WORDS]);
         zmq_msg_init(m.0.as_mut_ptr().cast());
         m
     }

--- a/omq-libzmq/include/zmq.h
+++ b/omq-libzmq/include/zmq.h
@@ -232,7 +232,21 @@ extern "C" {
 
 /*  Handle to a message. Opaque 64-byte struct matching the layout used      */
 /*  by omq-libzmq internally.                                                */
-typedef struct zmq_msg_t { unsigned char _[64]; } zmq_msg_t;
+typedef struct zmq_msg_t
+{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+    __declspec(align(8)) unsigned char _[64];
+#elif defined(_MSC_VER) && \
+    (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
+    __declspec(align(4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || \
+    (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
+    (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _[64] __attribute__((aligned(sizeof(void *))));
+#else
+    unsigned char _[64];
+#endif
+} zmq_msg_t;
 
 /*  Free function for zmq_msg_init_data.                                     */
 typedef void (zmq_free_fn) (void *data_, void *hint_);

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -162,6 +162,7 @@ const ZMQ_IO_THREADS: c_int = 1;
 const ZMQ_MAX_SOCKETS: c_int = 2;
 const ZMQ_SOCKET_LIMIT: c_int = 3;
 const ZMQ_MAX_MSGSZ: c_int = 5;
+const ZMQ_MSG_T_SIZE: c_int = 6;
 const ZMQ_IPV6_CTX: c_int = 42;
 
 #[unsafe(no_mangle)]
@@ -205,6 +206,7 @@ pub extern "C" fn zmq_ctx_get(ctx_ptr: *mut libc::c_void, option: c_int) -> c_in
         ZMQ_IO_THREADS => ctx.configured_io_threads.load(Ordering::Acquire),
         ZMQ_MAX_SOCKETS | ZMQ_SOCKET_LIMIT => ctx.max_sockets.load(Ordering::Relaxed),
         ZMQ_MAX_MSGSZ => ctx.max_msg_size.load(Ordering::Relaxed) as c_int,
+        ZMQ_MSG_T_SIZE => c_int::try_from(crate::msg::ZMQ_MSG_T_SIZE).unwrap_or(c_int::MAX),
         ZMQ_IPV6_CTX => 0,
         _ => crate::error::fail(libc::EINVAL),
     }

--- a/omq-libzmq/src/inproc_bypass.rs
+++ b/omq-libzmq/src/inproc_bypass.rs
@@ -10,7 +10,7 @@
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Shared state between the sender and receiver halves of an inproc bypass.
 pub(crate) struct InprocPipe {
@@ -53,13 +53,24 @@ const fn aligned_entry_size(payload_len: usize) -> usize {
     (HEADER_SIZE + payload_len + ALIGN_MASK) & !ALIGN_MASK
 }
 
+#[inline]
+fn checked_aligned_entry_size(payload_len: usize) -> Option<usize> {
+    if payload_len >= WRAP_SENTINEL as usize {
+        return None;
+    }
+    HEADER_SIZE
+        .checked_add(payload_len)?
+        .checked_add(ALIGN_MASK)
+        .map(|n| n & !ALIGN_MASK)
+}
+
 struct RingBuf {
     buf: Box<[UnsafeCell<u8>]>,
     capacity: usize,
     /// Producer write position (mod capacity).
-    tail: AtomicUsize,
+    tail: AtomicU64,
     /// Consumer read position (mod capacity).
-    head: AtomicUsize,
+    head: AtomicU64,
 }
 
 impl std::fmt::Debug for RingBuf {
@@ -79,27 +90,32 @@ impl RingBuf {
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
             capacity: cap,
-            tail: AtomicUsize::new(0),
-            head: AtomicUsize::new(0),
+            tail: AtomicU64::new(0),
+            head: AtomicU64::new(0),
         }
     }
 
     #[inline]
-    fn free_space(&self, tail: usize, head: usize) -> usize {
-        self.capacity - (tail - head)
+    fn free_space(&self, tail: u64, head: u64) -> usize {
+        let used = tail.wrapping_sub(head);
+        if used >= self.capacity as u64 {
+            0
+        } else {
+            (self.capacity as u64 - used) as usize
+        }
     }
 }
 
 pub(crate) struct RingProducer {
     ring: Arc<RingBuf>,
-    tail: usize,
-    cached_head: usize,
+    tail: u64,
+    cached_head: u64,
 }
 
 pub(crate) struct RingConsumer {
     ring: Arc<RingBuf>,
-    head: usize,
-    cached_tail: usize,
+    head: u64,
+    cached_tail: u64,
 }
 
 impl std::fmt::Debug for RingProducer {
@@ -142,11 +158,13 @@ impl RingProducer {
     /// Returns false if not enough space.
     #[inline]
     fn try_push(&mut self, data: &[u8]) -> bool {
-        let entry_size = aligned_entry_size(data.len());
+        let Some(entry_size) = checked_aligned_entry_size(data.len()) else {
+            return false;
+        };
         let cap = self.ring.capacity;
         let mask = cap - 1;
         let tail = self.tail;
-        let tail_offset = tail & mask;
+        let tail_offset = (tail as usize) & mask;
 
         // Check if we have enough total free space.
         let mut free = self.ring.free_space(tail, self.cached_head);
@@ -180,7 +198,7 @@ impl RingProducer {
                     HEADER_SIZE,
                 );
             }
-            self.tail = tail + contiguous;
+            self.tail = tail.wrapping_add(contiguous as u64);
             self.write_entry(data);
         } else {
             self.write_entry(data);
@@ -192,7 +210,7 @@ impl RingProducer {
     fn write_entry(&mut self, data: &[u8]) {
         let cap = self.ring.capacity;
         let mask = cap - 1;
-        let offset = self.tail & mask;
+        let offset = (self.tail as usize) & mask;
         let len = data.len() as u32;
         // SAFETY: caller guaranteed sufficient contiguous space.
         unsafe {
@@ -200,7 +218,9 @@ impl RingProducer {
             std::ptr::copy_nonoverlapping(len.to_ne_bytes().as_ptr(), base, HEADER_SIZE);
             std::ptr::copy_nonoverlapping(data.as_ptr(), base.add(HEADER_SIZE), data.len());
         }
-        self.tail += aligned_entry_size(data.len());
+        self.tail = self
+            .tail
+            .wrapping_add(aligned_entry_size(data.len()) as u64);
     }
 
     /// Publish all written entries to the consumer. Returns true if
@@ -228,7 +248,7 @@ impl RingConsumer {
         }
         let cap = self.ring.capacity;
         let mask = cap - 1;
-        let offset = self.head & mask;
+        let offset = (self.head as usize) & mask;
         // SAFETY: head..head+4 is within published region.
         let len = unsafe {
             let mut bytes = [0u8; HEADER_SIZE];
@@ -241,8 +261,8 @@ impl RingConsumer {
         };
         if len == WRAP_SENTINEL {
             let contiguous = cap - offset;
-            self.head += contiguous;
-            let new_offset = self.head & mask;
+            self.head = self.head.wrapping_add(contiguous as u64);
+            let new_offset = (self.head as usize) & mask;
             debug_assert_eq!(new_offset, 0);
             if self.head == self.cached_tail {
                 self.cached_tail = self.ring.tail.load(Ordering::Acquire);
@@ -275,7 +295,7 @@ impl RingConsumer {
     /// Advance past the last peeked entry and publish the new head.
     #[inline]
     fn advance_and_release(&mut self, len: usize) {
-        self.head += aligned_entry_size(len);
+        self.head = self.head.wrapping_add(aligned_entry_size(len) as u64);
         self.ring.head.store(self.head, Ordering::Release);
     }
 
@@ -408,5 +428,37 @@ impl BypassRecv {
     /// Check if the ring is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.consumer.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_size_rejects_wrap_sentinel_length() {
+        assert_eq!(checked_aligned_entry_size(0), Some(HEADER_SIZE));
+        assert!(checked_aligned_entry_size(WRAP_SENTINEL as usize).is_none());
+    }
+
+    #[test]
+    fn byte_ring_crosses_u32_boundary_without_aliasing() {
+        let (mut producer, mut consumer) = ring_pair(64);
+        let base = u64::from(u32::MAX) - 3;
+        producer.tail = base;
+        producer.cached_head = base;
+        consumer.head = base;
+        consumer.cached_tail = base;
+        producer.ring.head.store(base, Ordering::Relaxed);
+        producer.ring.tail.store(base, Ordering::Relaxed);
+
+        assert!(producer.try_push(b"abcd"));
+        assert!(producer.flush());
+
+        let (ptr, len) = consumer.try_peek().expect("entry visible");
+        let got = unsafe { std::slice::from_raw_parts(ptr, len) };
+        assert_eq!(got, b"abcd");
+        consumer.advance_and_release(len);
+        assert!(consumer.is_empty());
     }
 }

--- a/omq-libzmq/src/lib.rs
+++ b/omq-libzmq/src/lib.rs
@@ -13,6 +13,9 @@
 // #[expect] would be pure noise for a C API crate.
 #![expect(clippy::not_unsafe_ptr_arg_deref)]
 
+#[cfg(not(target_has_atomic = "64"))]
+compile_error!("omq-libzmq requires target_has_atomic = \"64\"");
+
 mod consts;
 mod context;
 pub mod curve;
@@ -57,3 +60,4 @@ pub use util::{
 pub use opts::{zmq_getsockopt, zmq_setsockopt};
 
 const _: () = assert!(std::mem::size_of::<msg::OmqMsgRepr>() == 64);
+const _: () = assert!(std::mem::align_of::<msg::OmqMsgRepr>() == std::mem::align_of::<usize>());

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -1,6 +1,7 @@
 //! `zmq_msg_t` implementation.
 //!
 //! The repr must be exactly 64 bytes to match libzmq's ABI.
+//! Public alignment follows `zmq_msg_t`: pointer-sized, not always 8 bytes.
 //! kind values: 0=empty, 1=heap-alloc, 2=external-ptr, 3=bytes-arc (from recv).
 
 use std::ffi::{CStr, c_int};
@@ -16,23 +17,12 @@ const KIND_BYTES: u8 = 3;
 
 /// `zmq_msg_t` compatible repr: 64 bytes, C layout.
 ///
-/// Field layout:
-/// - kind, more: discriminant and multipart flag
-/// - size, ptr: message data length and pointer
-/// - `free_fn`, hint: external-buffer free callback
-/// - boxed: `Box<Bytes>` for zero-copy recv path
-/// - reserved: `routing_id` (first 4 bytes) and group name (next 12 bytes)
+/// libzmq exposes `zmq_msg_t` as an opaque 64-byte blob aligned to pointer
+/// size. Keep the Rust type equally opaque: typed `u64` fields would raise
+/// alignment to 8 on armv7, which is ABI-incompatible with C callers.
 #[repr(C)]
 pub struct OmqMsgRepr {
-    kind: u8,
-    more: u8,
-    pad: [u8; 6],
-    size: u64,
-    ptr: *mut u8,
-    free_fn: *mut libc::c_void,
-    hint: *mut libc::c_void,
-    boxed: *mut libc::c_void,
-    reserved: [u8; 16],
+    storage: [usize; MSG_WORDS],
 }
 
 // SAFETY: pointer fields are owned by exactly one OmqMsgRepr instance.
@@ -44,14 +34,174 @@ unsafe impl Send for OmqMsgRepr {}
 impl std::fmt::Debug for OmqMsgRepr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OmqMsgRepr")
-            .field("kind", &self.kind)
-            .field("more", &self.more)
-            .field("size", &self.size)
+            .field("kind", &self.kind())
+            .field("more", &self.more())
+            .field("size", &self.size())
             .finish_non_exhaustive()
     }
 }
 
-const _SIZE_ASSERT: () = assert!(std::mem::size_of::<OmqMsgRepr>() == 64);
+pub(crate) const ZMQ_MSG_T_SIZE: usize = 64;
+const PTR_SIZE: usize = std::mem::size_of::<usize>();
+const MSG_WORDS: usize = ZMQ_MSG_T_SIZE / PTR_SIZE;
+const OFF_KIND: usize = 0;
+const OFF_MORE: usize = 1;
+const OFF_SIZE: usize = 8;
+const OFF_PTR: usize = 16;
+const OFF_FREE_FN: usize = OFF_PTR + PTR_SIZE;
+const OFF_HINT: usize = OFF_FREE_FN + PTR_SIZE;
+const OFF_BOXED: usize = OFF_HINT + PTR_SIZE;
+const OFF_RESERVED: usize = OFF_BOXED + PTR_SIZE;
+const RESERVED_LEN: usize = 16;
+
+type FreeFn = unsafe extern "C" fn(*mut libc::c_void, *mut libc::c_void);
+
+impl OmqMsgRepr {
+    #[inline]
+    fn clear(&mut self) {
+        self.storage = [0; MSG_WORDS];
+    }
+
+    #[inline]
+    fn bytes(&self) -> &[u8; ZMQ_MSG_T_SIZE] {
+        // SAFETY: storage is exactly 64 bytes; `[u8; 64]` has alignment 1.
+        unsafe {
+            &*(self
+                .storage
+                .as_ptr()
+                .cast::<u8>()
+                .cast::<[u8; ZMQ_MSG_T_SIZE]>())
+        }
+    }
+
+    #[inline]
+    fn bytes_mut(&mut self) -> &mut [u8; ZMQ_MSG_T_SIZE] {
+        // SAFETY: storage is exactly 64 bytes; `[u8; 64]` has alignment 1.
+        unsafe {
+            &mut *(self
+                .storage
+                .as_mut_ptr()
+                .cast::<u8>()
+                .cast::<[u8; ZMQ_MSG_T_SIZE]>())
+        }
+    }
+
+    #[inline]
+    fn kind(&self) -> u8 {
+        self.bytes()[OFF_KIND]
+    }
+
+    #[inline]
+    fn more(&self) -> u8 {
+        self.bytes()[OFF_MORE]
+    }
+
+    #[inline]
+    fn set_more(&mut self, more: u8) {
+        self.bytes_mut()[OFF_MORE] = more;
+    }
+
+    #[inline]
+    fn size(&self) -> usize {
+        usize::try_from(self.read_u64(OFF_SIZE)).unwrap_or(usize::MAX)
+    }
+
+    #[inline]
+    fn ptr(&self) -> *mut u8 {
+        self.read_usize(OFF_PTR) as *mut u8
+    }
+
+    #[inline]
+    fn boxed(&self) -> *mut libc::c_void {
+        self.read_usize(OFF_BOXED) as *mut libc::c_void
+    }
+
+    #[inline]
+    fn hint(&self) -> *mut libc::c_void {
+        self.read_usize(OFF_HINT) as *mut libc::c_void
+    }
+
+    #[inline]
+    fn free_fn(&self) -> Option<FreeFn> {
+        let raw = self.read_usize(OFF_FREE_FN);
+        if raw == 0 {
+            None
+        } else {
+            // SAFETY: raw was written from a `FreeFn` in `init_fields`.
+            Some(unsafe { std::mem::transmute::<usize, FreeFn>(raw) })
+        }
+    }
+
+    #[inline]
+    fn reserved(&self) -> &[u8] {
+        &self.bytes()[OFF_RESERVED..OFF_RESERVED + RESERVED_LEN]
+    }
+
+    #[inline]
+    fn reserved_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes_mut()[OFF_RESERVED..OFF_RESERVED + RESERVED_LEN]
+    }
+
+    #[inline]
+    fn reserved_array(&self) -> [u8; RESERVED_LEN] {
+        let mut reserved = [0; RESERVED_LEN];
+        reserved.copy_from_slice(self.reserved());
+        reserved
+    }
+
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn init_fields(
+        &mut self,
+        kind: u8,
+        more: u8,
+        size: usize,
+        ptr: *mut u8,
+        free_fn: Option<FreeFn>,
+        hint: *mut libc::c_void,
+        boxed: *mut libc::c_void,
+        reserved: [u8; RESERVED_LEN],
+    ) {
+        self.clear();
+        self.bytes_mut()[OFF_KIND] = kind;
+        self.bytes_mut()[OFF_MORE] = more;
+        self.write_u64(OFF_SIZE, size as u64);
+        self.write_usize(OFF_PTR, ptr as usize);
+        self.write_usize(OFF_FREE_FN, free_fn.map_or(0, |f| f as usize));
+        self.write_usize(OFF_HINT, hint as usize);
+        self.write_usize(OFF_BOXED, boxed as usize);
+        self.reserved_mut().copy_from_slice(&reserved);
+    }
+
+    #[inline]
+    fn read_u64(&self, off: usize) -> u64 {
+        let mut bytes = [0; 8];
+        bytes.copy_from_slice(&self.bytes()[off..off + 8]);
+        u64::from_ne_bytes(bytes)
+    }
+
+    #[inline]
+    fn write_u64(&mut self, off: usize, value: u64) {
+        self.bytes_mut()[off..off + 8].copy_from_slice(&value.to_ne_bytes());
+    }
+
+    #[inline]
+    fn read_usize(&self, off: usize) -> usize {
+        let mut bytes = [0; PTR_SIZE];
+        bytes.copy_from_slice(&self.bytes()[off..off + PTR_SIZE]);
+        usize::from_ne_bytes(bytes)
+    }
+
+    #[inline]
+    fn write_usize(&mut self, off: usize, value: usize) {
+        self.bytes_mut()[off..off + PTR_SIZE].copy_from_slice(&value.to_ne_bytes());
+    }
+}
+
+const _SIZE_ASSERT: () = assert!(std::mem::size_of::<OmqMsgRepr>() == ZMQ_MSG_T_SIZE);
+const _ALIGN_ASSERT: () =
+    assert!(std::mem::align_of::<OmqMsgRepr>() == std::mem::align_of::<usize>());
+const _RESERVED_ASSERT: () = assert!(OFF_RESERVED + RESERVED_LEN <= ZMQ_MSG_T_SIZE);
 
 #[inline]
 /// # Safety
@@ -61,15 +211,21 @@ unsafe fn repr<'a>(msg: *mut OmqMsgRepr) -> &'a mut OmqMsgRepr {
     unsafe { &mut *msg }
 }
 
+#[inline]
+/// # Safety
+///
+/// `msg` must be non-null and point to a valid, initialized `OmqMsgRepr`.
+unsafe fn repr_ref<'a>(msg: *const OmqMsgRepr) -> &'a OmqMsgRepr {
+    unsafe { &*msg }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_msg_init(msg: *mut OmqMsgRepr) -> c_int {
     if msg.is_null() {
         return crate::error::fail(libc::EFAULT);
     }
-    // SAFETY: msg is non-null (checked above); zeroing the 64-byte repr.
-    unsafe {
-        std::ptr::write_bytes(msg, 0, 1);
-    }
+    // SAFETY: msg is non-null (checked above).
+    unsafe { repr(msg).clear() };
     0
 }
 
@@ -85,15 +241,16 @@ pub extern "C" fn zmq_msg_init_size(msg: *mut OmqMsgRepr, size: usize) -> c_int 
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    r.kind = KIND_HEAP;
-    r.more = 0;
-    r.pad = [0; 6];
-    r.size = size as u64;
-    r.ptr = ptr;
-    r.free_fn = std::ptr::null_mut();
-    r.hint = std::ptr::null_mut();
-    r.boxed = std::ptr::null_mut();
-    r.reserved = [0; 16];
+    r.init_fields(
+        KIND_HEAP,
+        0,
+        size,
+        ptr,
+        None,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        [0; RESERVED_LEN],
+    );
     0
 }
 
@@ -113,17 +270,16 @@ pub extern "C" fn zmq_msg_init_data(
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    r.kind = KIND_EXTERNAL;
-    r.more = 0;
-    r.pad = [0; 6];
-    r.size = size as u64;
-    r.ptr = data.cast();
-    r.free_fn = ffn.map_or(std::ptr::null_mut(), |f| {
-        (f as unsafe extern "C" fn(*mut libc::c_void, *mut libc::c_void)) as *mut libc::c_void
-    });
-    r.hint = hint;
-    r.boxed = std::ptr::null_mut();
-    r.reserved = [0; 16];
+    r.init_fields(
+        KIND_EXTERNAL,
+        0,
+        size,
+        data.cast(),
+        ffn,
+        hint,
+        std::ptr::null_mut(),
+        [0; RESERVED_LEN],
+    );
     0
 }
 
@@ -143,7 +299,7 @@ pub extern "C" fn zmq_msg_init_buffer(
         // SAFETY: msg was just initialized by zmq_msg_init_size; buf is non-null.
         let r = unsafe { repr(msg) };
         unsafe {
-            std::ptr::copy_nonoverlapping(buf.cast::<u8>(), r.ptr, size);
+            std::ptr::copy_nonoverlapping(buf.cast::<u8>(), r.ptr(), size);
         }
     }
     0
@@ -156,7 +312,7 @@ pub extern "C" fn zmq_msg_data(msg: *mut OmqMsgRepr) -> *mut libc::c_void {
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    r.ptr.cast()
+    r.ptr().cast()
 }
 
 #[unsafe(no_mangle)]
@@ -165,7 +321,8 @@ pub extern "C" fn zmq_msg_size(msg: *const OmqMsgRepr) -> usize {
         return 0;
     }
     // SAFETY: msg is non-null (checked above).
-    unsafe { (*msg).size as usize }
+    // SAFETY: msg is non-null (checked above).
+    unsafe { repr_ref(msg).size() }
 }
 
 #[unsafe(no_mangle)]
@@ -174,7 +331,7 @@ pub extern "C" fn zmq_msg_more(msg: *const OmqMsgRepr) -> c_int {
         return 0;
     }
     // SAFETY: msg is non-null (checked above).
-    c_int::from(unsafe { (*msg).more })
+    c_int::from(unsafe { repr_ref(msg).more() })
 }
 
 #[unsafe(no_mangle)]
@@ -184,35 +341,32 @@ pub extern "C" fn zmq_msg_close(msg: *mut OmqMsgRepr) -> c_int {
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    #[expect(clippy::collapsible_match)]
-    match r.kind {
+    match r.kind() {
         KIND_HEAP => {
-            if !r.ptr.is_null() {
+            let ptr = r.ptr();
+            if !ptr.is_null() {
                 // SAFETY: ptr was allocated by libc::malloc in zmq_msg_init_size.
-                unsafe { libc::free(r.ptr.cast()) };
+                unsafe { libc::free(ptr.cast()) };
             }
         }
         KIND_EXTERNAL => {
-            if !r.free_fn.is_null() && !r.ptr.is_null() {
-                // SAFETY: free_fn was stored as a fn(*mut c_void, *mut c_void) in
-                // zmq_msg_init_data; transmuting back to the original type.
-                let ffn: unsafe extern "C" fn(*mut libc::c_void, *mut libc::c_void) =
-                    unsafe { std::mem::transmute(r.free_fn) };
-                unsafe { ffn(r.ptr.cast(), r.hint) };
+            let ptr = r.ptr();
+            if let Some(ffn) = r.free_fn()
+                && !ptr.is_null()
+            {
+                unsafe { ffn(ptr.cast(), r.hint()) };
             }
         }
         KIND_BYTES => {
-            if !r.boxed.is_null() {
+            let boxed = r.boxed();
+            if !boxed.is_null() {
                 // SAFETY: boxed was created by Box::into_raw in zmq_msg_recv.
-                drop(unsafe { Box::from_raw(r.boxed.cast::<Bytes>()) });
+                drop(unsafe { Box::from_raw(boxed.cast::<Bytes>()) });
             }
         }
         _ => {}
     }
-    // SAFETY: msg is non-null; zeroing the repr marks it as empty.
-    unsafe {
-        std::ptr::write_bytes(msg, 0, 1);
-    }
+    r.clear();
     0
 }
 
@@ -230,7 +384,7 @@ pub extern "C" fn zmq_msg_move(dst: *mut OmqMsgRepr, src: *mut OmqMsgRepr) -> c_
     // (ZMQ API contract). Move the repr then zero src to prevent double-free.
     unsafe {
         std::ptr::copy_nonoverlapping(src, dst, 1);
-        std::ptr::write_bytes(src, 0, 1);
+        repr(src).clear();
     }
     0
 }
@@ -245,29 +399,35 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
     }
     zmq_msg_close(dst);
     // SAFETY: src is non-null (checked above).
-    let s = unsafe { &*src };
-    match s.kind {
+    let s = unsafe { repr_ref(src) };
+    match s.kind() {
         KIND_BYTES => {
             // Clone the Bytes (increments the Arc refcount).
             // SAFETY: boxed was created by Box::into_raw in zmq_msg_recv.
-            let original = unsafe { &*(s.boxed.cast::<Bytes>()) };
+            let boxed = s.boxed();
+            if boxed.is_null() {
+                return crate::error::fail(libc::EFAULT);
+            }
+            let original = unsafe { &*(boxed.cast::<Bytes>()) };
             let cloned = Box::new(original.clone());
             // SAFETY: dst was closed above and is ready for reinitialization.
             let d = unsafe { repr(dst) };
-            d.kind = KIND_BYTES;
-            d.more = s.more;
-            d.pad = [0; 6];
-            d.size = s.size;
-            d.ptr = cloned.as_ptr().cast_mut();
-            d.free_fn = std::ptr::null_mut();
-            d.hint = std::ptr::null_mut();
-            d.boxed = Box::into_raw(cloned).cast::<libc::c_void>();
-            d.reserved = s.reserved;
+            d.init_fields(
+                KIND_BYTES,
+                s.more(),
+                s.size(),
+                cloned.as_ptr().cast_mut(),
+                None,
+                std::ptr::null_mut(),
+                Box::into_raw(cloned).cast::<libc::c_void>(),
+                s.reserved_array(),
+            );
         }
         KIND_HEAP | KIND_EXTERNAL => {
             // Deep copy into a new heap allocation.
-            let size = s.size as usize;
-            if size > 0 && s.ptr.is_null() {
+            let size = s.size();
+            let src_ptr = s.ptr();
+            if size > 0 && src_ptr.is_null() {
                 return crate::error::fail(libc::EFAULT);
             }
             let new_ptr = if size > 0 {
@@ -277,27 +437,28 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
                     return crate::error::fail(libc::ENOMEM);
                 }
                 // SAFETY: s.ptr is valid for size bytes; p was just allocated.
-                unsafe { std::ptr::copy_nonoverlapping(s.ptr, p, size) };
+                unsafe { std::ptr::copy_nonoverlapping(src_ptr, p, size) };
                 p
             } else {
                 std::ptr::null_mut()
             };
             // SAFETY: dst was closed above and is ready for reinitialization.
             let d = unsafe { repr(dst) };
-            d.kind = KIND_HEAP;
-            d.more = s.more;
-            d.pad = [0; 6];
-            d.size = s.size;
-            d.ptr = new_ptr;
-            d.free_fn = std::ptr::null_mut();
-            d.hint = std::ptr::null_mut();
-            d.boxed = std::ptr::null_mut();
-            d.reserved = s.reserved;
+            d.init_fields(
+                KIND_HEAP,
+                s.more(),
+                size,
+                new_ptr,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                s.reserved_array(),
+            );
         }
         _ => {
             // Empty: just zero dst.
             // SAFETY: dst is non-null (checked above).
-            unsafe { std::ptr::write_bytes(dst, 0, 1) };
+            unsafe { repr(dst).clear() };
         }
     }
     0
@@ -328,11 +489,11 @@ pub extern "C" fn zmq_msg_set(msg: *mut OmqMsgRepr, property: c_int, val: c_int)
     let r = unsafe { repr(msg) };
     match property {
         1 => {
-            r.more = u8::from(val != 0);
+            r.set_more(u8::from(val != 0));
             0
         }
         5 => {
-            r.reserved[0..4].copy_from_slice(&(val as u32).to_le_bytes());
+            r.reserved_mut()[0..4].copy_from_slice(&(val as u32).to_le_bytes());
             0
         }
         _ => crate::error::fail(libc::EINVAL),
@@ -367,7 +528,7 @@ pub extern "C" fn zmq_msg_set_routing_id(msg: *mut OmqMsgRepr, routing_id: u32) 
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    r.reserved[0..4].copy_from_slice(&routing_id.to_le_bytes());
+    r.reserved_mut()[0..4].copy_from_slice(&routing_id.to_le_bytes());
     0
 }
 
@@ -377,7 +538,7 @@ pub extern "C" fn zmq_msg_routing_id(msg: *const OmqMsgRepr) -> u32 {
         return 0;
     }
     // SAFETY: msg is non-null (checked above).
-    let bytes = unsafe { &(&(*msg).reserved)[0..4] };
+    let bytes = unsafe { &repr_ref(msg).reserved()[0..4] };
     u32::from_le_bytes(bytes.try_into().unwrap_or([0; 4]))
 }
 
@@ -394,8 +555,9 @@ pub extern "C" fn zmq_msg_set_group(msg: *mut OmqMsgRepr, group: *const libc::c_
     }
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
-    r.reserved[4..4 + s.len()].copy_from_slice(s);
-    r.reserved[4 + s.len()] = 0;
+    let reserved = r.reserved_mut();
+    reserved[4..4 + s.len()].copy_from_slice(s);
+    reserved[4 + s.len()] = 0;
     0
 }
 
@@ -405,7 +567,7 @@ pub extern "C" fn zmq_msg_group(msg: *const OmqMsgRepr) -> *const libc::c_char {
         return c"".as_ptr();
     }
     // SAFETY: msg is non-null (checked above); reserved area is always valid.
-    unsafe { (&(*msg).reserved)[4..].as_ptr().cast() }
+    unsafe { repr_ref(msg).reserved()[4..].as_ptr().cast() }
 }
 
 /// Send the data held in `msg` on `sock`. The msg is zeroed on success.
@@ -438,11 +600,12 @@ pub extern "C" fn zmq_msg_send(
     // zmq_msg_copy dereference a null pointer. On success the Box is dropped
     // by zmq_msg_close below.
     // SAFETY: msg is non-null (checked above).
-    let r = unsafe { &*msg };
-    let bytes = if r.kind == KIND_BYTES && !r.boxed.is_null() {
+    let r = unsafe { repr_ref(msg) };
+    let boxed = r.boxed();
+    let bytes = if r.kind() == KIND_BYTES && !boxed.is_null() {
         // SAFETY: boxed was created by Box::into_raw in zmq_msg_recv; non-null.
-        unsafe { &*(r.boxed.cast::<Bytes>()) }.clone()
-    } else if r.ptr.is_null() && r.size > 0 {
+        unsafe { &*(boxed.cast::<Bytes>()) }.clone()
+    } else if r.ptr().is_null() && r.size() > 0 {
         return crate::error::fail(libc::EFAULT);
     } else {
         extract_bytes(msg)
@@ -484,8 +647,8 @@ pub extern "C" fn zmq_recvmsg(
 
 fn msg_group_bytes(msg: *mut OmqMsgRepr) -> bytes::Bytes {
     // SAFETY: caller guarantees msg is non-null.
-    let r = unsafe { &*msg };
-    let group_area = &r.reserved[4..];
+    let r = unsafe { repr_ref(msg) };
+    let group_area = &r.reserved()[4..];
     let nul = group_area
         .iter()
         .position(|&b| b == 0)
@@ -524,7 +687,6 @@ pub extern "C" fn zmq_msg_recv(
             zmq_msg_close(msg);
             let sz = frame.len();
             // SAFETY: msg was just closed above and is ready for reinitialization.
-            let r = unsafe { repr(msg) };
             if sz <= 128 {
                 // Small frame: malloc + memcpy (1 alloc) instead of
                 // Box<Bytes> (2 allocs: Bytes::copy_from_slice + Box::new).
@@ -542,27 +704,31 @@ pub extern "C" fn zmq_msg_recv(
                 } else {
                     std::ptr::null_mut()
                 };
-                r.kind = KIND_HEAP;
-                r.more = u8::from(more);
-                r.pad = [0; 6];
-                r.size = sz as u64;
-                r.ptr = ptr;
-                r.free_fn = std::ptr::null_mut();
-                r.hint = std::ptr::null_mut();
-                r.boxed = std::ptr::null_mut();
-                r.reserved = [0; 16];
+                let r = unsafe { repr(msg) };
+                r.init_fields(
+                    KIND_HEAP,
+                    u8::from(more),
+                    sz,
+                    ptr,
+                    None,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    [0; RESERVED_LEN],
+                );
             } else {
                 let boxed = Box::new(frame);
                 let data_ptr = boxed.as_ptr().cast_mut();
-                r.kind = KIND_BYTES;
-                r.more = u8::from(more);
-                r.pad = [0; 6];
-                r.size = sz as u64;
-                r.ptr = data_ptr;
-                r.free_fn = std::ptr::null_mut();
-                r.hint = std::ptr::null_mut();
-                r.boxed = Box::into_raw(boxed).cast::<libc::c_void>();
-                r.reserved = [0; 16];
+                let r = unsafe { repr(msg) };
+                r.init_fields(
+                    KIND_BYTES,
+                    u8::from(more),
+                    sz,
+                    data_ptr,
+                    None,
+                    std::ptr::null_mut(),
+                    Box::into_raw(boxed).cast::<libc::c_void>(),
+                    [0; RESERVED_LEN],
+                );
             }
             match c_int::try_from(sz) {
                 Ok(n) => n,
@@ -576,10 +742,12 @@ pub extern "C" fn zmq_msg_recv(
 /// Extract a Bytes copy out of a msg without consuming ownership.
 fn extract_bytes(msg: *const OmqMsgRepr) -> Bytes {
     // SAFETY: caller guarantees msg is non-null and initialized.
-    let r = unsafe { &*msg };
-    if r.ptr.is_null() || r.size == 0 {
+    let r = unsafe { repr_ref(msg) };
+    let ptr = r.ptr();
+    let size = r.size();
+    if ptr.is_null() || size == 0 {
         return Bytes::new();
     }
-    // SAFETY: r.ptr is non-null with r.size readable bytes (message invariant).
-    Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(r.ptr, r.size as usize) })
+    // SAFETY: ptr is non-null with size readable bytes (message invariant).
+    Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(ptr, size) })
 }

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -12,6 +12,7 @@ const ZMQ_PULL: i32 = 7;
 const ZMQ_IO_THREADS: i32 = 1;
 const ZMQ_MAX_SOCKETS: i32 = 2;
 const ZMQ_MAX_MSGSZ: i32 = 5;
+const ZMQ_MSG_T_SIZE: i32 = 6;
 
 #[test]
 fn ctx_new_term() {
@@ -46,6 +47,13 @@ fn ctx_get_io_threads_default() {
     let ctx = zmq_ctx_new();
     let n = zmq_ctx_get(ctx, ZMQ_IO_THREADS);
     assert_eq!(n, 1);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_get_msg_t_size() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_MSG_T_SIZE), 64);
     zmq_ctx_term(ctx);
 }
 

--- a/omq-libzmq/tests/draft.rs
+++ b/omq-libzmq/tests/draft.rs
@@ -28,11 +28,19 @@ const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_TYPE: i32 = 16;
 const ZMQ_IDENTITY: i32 = 5;
 
-#[repr(C, align(8))]
-struct ZmqMsg([u8; 64]);
+const ZMQ_MSG_WORDS: usize = 64 / size_of::<usize>();
+
+#[repr(C)]
+struct ZmqMsg([usize; ZMQ_MSG_WORDS]);
+
+impl ZmqMsg {
+    fn zeroed() -> Self {
+        Self([0; ZMQ_MSG_WORDS])
+    }
+}
 
 fn radio_send(sock: *mut c_void, group: &std::ffi::CStr, data: &[u8]) -> i32 {
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     zmq_msg_init_buffer(m.0.as_mut_ptr().cast(), data.as_ptr().cast(), data.len());
     zmq_msg_set_group(m.0.as_mut_ptr().cast(), group.as_ptr());
     let rc = zmq_msg_send(m.0.as_mut_ptr().cast(), sock, 0);

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -23,13 +23,19 @@ const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_MORE: i32 = 1;
 const ZMQ_ROUTING_ID: i32 = 5;
 
-// 64-byte opaque zmq_msg_t, aligned to pointer size (OmqMsgRepr has *mut u8 fields).
-#[repr(C, align(8))]
-struct ZmqMsg([u8; 64]);
+const ZMQ_MSG_WORDS: usize = 64 / size_of::<usize>();
+
+// 64-byte opaque zmq_msg_t, aligned to pointer size.
+#[repr(C)]
+struct ZmqMsg([usize; ZMQ_MSG_WORDS]);
 
 impl ZmqMsg {
+    fn zeroed() -> Self {
+        Self([0; ZMQ_MSG_WORDS])
+    }
+
     fn new() -> Self {
-        let mut m = Self([0u8; 64]);
+        let mut m = Self::zeroed();
         zmq_msg_init(m.0.as_mut_ptr().cast());
         m
     }
@@ -58,7 +64,7 @@ fn msg_init_close() {
 /// `zmq_msg_init_size` allocates writable memory
 #[test]
 fn msg_init_size() {
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     assert_eq!(zmq_msg_init_size(m.0.as_mut_ptr().cast(), 16), 0);
     assert_eq!(zmq_msg_size(m.0.as_ptr().cast()), 16);
 
@@ -72,7 +78,7 @@ fn msg_init_size() {
 
 #[test]
 fn msg_init_data_and_buffer_reject_null_nonzero_payload() {
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     assert_eq!(
         zmq_msg_init_data(
             m.0.as_mut_ptr().cast(),
@@ -95,7 +101,7 @@ fn msg_init_data_and_buffer_reject_null_nonzero_payload() {
 #[test]
 fn msg_move_and_copy_self_alias_are_noops() {
     let payload = b"alias";
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     assert_eq!(
         zmq_msg_init_buffer(
             m.0.as_mut_ptr().cast(),
@@ -152,7 +158,7 @@ fn msg_set_handles_supported_and_invalid_properties() {
 #[test]
 fn msg_init_buffer() {
     let payload = b"hello buffer";
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     assert_eq!(
         zmq_msg_init_buffer(
             m.0.as_mut_ptr().cast(),
@@ -184,7 +190,7 @@ fn msg_init_data_with_free_fn() {
     assert!(!buf.is_null());
     unsafe { std::ptr::write_bytes(buf.cast::<u8>(), 0x55, 8) };
 
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     assert_eq!(
         zmq_msg_init_data(
             m.0.as_mut_ptr().cast(),
@@ -204,7 +210,7 @@ fn msg_init_data_with_free_fn() {
 /// `zmq_msg_move` transfers ownership; src becomes empty
 #[test]
 fn msg_move() {
-    let mut src = ZmqMsg([0u8; 64]);
+    let mut src = ZmqMsg::zeroed();
     zmq_msg_init_buffer(src.0.as_mut_ptr().cast(), b"move-me".as_ptr().cast(), 7);
 
     let mut dst = ZmqMsg::new();
@@ -223,7 +229,7 @@ fn msg_move() {
 /// `zmq_msg_copy` makes an independent copy
 #[test]
 fn msg_copy() {
-    let mut src = ZmqMsg([0u8; 64]);
+    let mut src = ZmqMsg::zeroed();
     zmq_msg_init_buffer(src.0.as_mut_ptr().cast(), b"copy-me".as_ptr().cast(), 7);
 
     let mut dst = ZmqMsg::new();
@@ -253,7 +259,7 @@ fn msg_send_recv_roundtrip() {
     set_timeo(pull, ZMQ_RCVTIMEO, 1000);
 
     let payload = b"msg api roundtrip";
-    let mut out_m = ZmqMsg([0u8; 64]);
+    let mut out_m = ZmqMsg::zeroed();
     zmq_msg_init_buffer(
         out_m.0.as_mut_ptr().cast(),
         payload.as_ptr().cast(),
@@ -345,7 +351,7 @@ fn msg_send_then_raw_recv() {
     std::thread::sleep(Duration::from_millis(20));
     set_timeo(pull, ZMQ_RCVTIMEO, 1000);
 
-    let mut m = ZmqMsg([0u8; 64]);
+    let mut m = ZmqMsg::zeroed();
     zmq_msg_init_buffer(m.0.as_mut_ptr().cast(), b"raw recv".as_ptr().cast(), 8);
     zmq_msg_send(m.0.as_mut_ptr().cast(), push, 0);
 
@@ -398,7 +404,11 @@ fn kind_bytes_arc_stolen_on_zmq_msg_send() {
         assert_eq!(rc as usize, payload.len());
 
         // zmq_msg_send zeros the msg on success.
-        assert_eq!(msg.0, [0u8; 64], "msg must be zeroed after zmq_msg_send");
+        assert_eq!(
+            msg.0,
+            ZmqMsg::zeroed().0,
+            "msg must be zeroed after zmq_msg_send"
+        );
 
         // Verify forwarded data arrived intact.
         let mut out = ZmqMsg::new();

--- a/omq-libzmq/tests/proxy.rs
+++ b/omq-libzmq/tests/proxy.rs
@@ -23,12 +23,18 @@ fn set_timeo(sock: *mut c_void, opt: i32, ms: i32) {
     zmq_setsockopt(sock, opt, (&ms as *const i32).cast(), size_of::<i32>());
 }
 
-#[repr(C, align(8))]
-struct ZmqMsg([u8; 64]);
+const ZMQ_MSG_WORDS: usize = 64 / size_of::<usize>();
+
+#[repr(C)]
+struct ZmqMsg([usize; ZMQ_MSG_WORDS]);
 
 impl ZmqMsg {
+    fn zeroed() -> Self {
+        Self([0; ZMQ_MSG_WORDS])
+    }
+
     fn new() -> Self {
-        let mut m = Self([0u8; 64]);
+        let mut m = Self::zeroed();
         zmq_msg_init(m.0.as_mut_ptr().cast());
         m
     }
@@ -145,7 +151,7 @@ fn proxy_large_message() {
     let size = 128 * 1024;
     let payload: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
 
-    let mut msg = ZmqMsg([0u8; 64]);
+    let mut msg = ZmqMsg::zeroed();
     omq_zmq::zmq_msg_init_size(msg.0.as_mut_ptr().cast(), size);
     let data = zmq_msg_data(msg.0.as_mut_ptr().cast());
     unsafe { std::ptr::copy_nonoverlapping(payload.as_ptr(), data.cast::<u8>(), size) };

--- a/omq-proto/CHANGELOG.md
+++ b/omq-proto/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the blanket 32-bit target rejection. 32-bit Linux targets with
+  native 64-bit atomics are supported.
+- Document and enforce platform allocation bounds for 64-bit ZMTP, WebSocket,
+  and LZ4 declared lengths.
+
 ## [0.23.0] - 2026-07-19
 
 ### Added

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -40,8 +40,7 @@ thiserror = "2.0.18"
 zeroize = { version = "1.8.0", features = ["zeroize_derive"], optional = true }
 
 [dependencies.lz4rip]
-git = "https://github.com/paddor/lz4rip"
-rev = "2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+version = "0.11.2"
 default-features = false
 features = ["std"]
 optional = true

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -32,13 +32,19 @@ crypto_box = { version = "0.9", optional = true }
 crypto_secretbox = { version = "0.1", optional = true }
 subtle = { version = "2.6", optional = true }
 x25519-dalek = { version = "3", features = ["static_secrets", "getrandom"], optional = true }
-lz4rip = { version = "0.11.1", default-features = false, features = ["std"], optional = true }
 rand = "0.10"
 patricia_tree = "0.10"
 smallvec = { version = "1", features = ["const_generics", "union"] }
 socket2 = { version = "0.6", features = ["all"] }
 thiserror = "2.0.18"
 zeroize = { version = "1.8.0", features = ["zeroize_derive"], optional = true }
+
+[dependencies.lz4rip]
+git = "https://github.com/paddor/lz4rip"
+rev = "2e02fe810c6b809ff8f7cd16102058a1b59d4b47"
+default-features = false
+features = ["std"]
+optional = true
 
 [[bench]]
 name = "mechanism_frame"

--- a/omq-proto/README.md
+++ b/omq-proto/README.md
@@ -6,6 +6,10 @@ Backend-agnostic foundation for `omq-tokio`. Use this crate directly
 only when building a custom backend or embedding the ZMTP codec into a
 non-standard transport.
 
+On 32-bit targets, 64-bit ZMTP/WebSocket/LZ4 wire lengths are accepted only
+when they fit platform allocation limits. Practical per-frame/per-message
+payloads are below 4 GiB.
+
 ## What's inside
 
 | Module | What it does |

--- a/omq-proto/src/lib.rs
+++ b/omq-proto/src/lib.rs
@@ -6,9 +6,6 @@
 //! subscription matcher. None of this depends on a runtime.
 #![forbid(unsafe_code)]
 
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("omq requires a 64-bit target");
-
 pub mod backoff;
 pub mod endpoint;
 pub mod error;

--- a/omq-proto/src/proto/connection/inbound.rs
+++ b/omq-proto/src/proto/connection/inbound.rs
@@ -565,6 +565,11 @@ impl Connection {
                     ws_hdr.payload_len
                 ))
             })?;
+            if payload_len > isize::MAX as usize {
+                return Err(Error::Protocol(format!(
+                    "WS payload length {payload_len} exceeds maximum allocation"
+                )));
+            }
             let total_frame = ws_hdr
                 .header_len
                 .checked_add(payload_len)

--- a/omq-proto/src/proto/connection/outbound.rs
+++ b/omq-proto/src/proto/connection/outbound.rs
@@ -334,17 +334,8 @@ impl Connection {
             let more = i + 1 < n;
             let payload_len = p.len();
             if payload_len > frame::MAX_SHORT_FRAME_SIZE {
-                flat_buf.extend_from_slice(&[
-                    frame::FLAG_LONG | u8::from(more),
-                    (payload_len >> 56) as u8,
-                    (payload_len >> 48) as u8,
-                    (payload_len >> 40) as u8,
-                    (payload_len >> 32) as u8,
-                    (payload_len >> 24) as u8,
-                    (payload_len >> 16) as u8,
-                    (payload_len >> 8) as u8,
-                    payload_len as u8,
-                ]);
+                flat_buf.extend_from_slice(&[frame::FLAG_LONG | u8::from(more)]);
+                flat_buf.extend_from_slice(&(payload_len as u64).to_be_bytes());
             } else {
                 flat_buf.extend_from_slice(&[u8::from(more), payload_len as u8]);
             }

--- a/omq-proto/src/proto/frame.rs
+++ b/omq-proto/src/proto/frame.rs
@@ -4,6 +4,10 @@
 //! Short frames (payload <= 255 bytes) use a single-byte size; long frames use
 //! 8-byte big-endian. The flags byte carries MORE (0x01), LONG (0x02), and
 //! COMMAND (0x04). The remaining bits are reserved and must be zero.
+//!
+//! On 32-bit targets, 64-bit wire lengths are accepted only when they fit
+//! platform allocation limits. Practical per-frame/per-message payload size
+//! is therefore below 4 GiB, and usually bounded further by `isize::MAX`.
 
 use std::collections::VecDeque;
 
@@ -94,17 +98,8 @@ pub fn encode_frame_into(frame: &Frame, out: &mut VecDeque<Bytes>, scratch: &mut
 pub(crate) fn write_frame_header(buf: &mut BytesMut, more: bool, payload_len: usize) {
     let flags = u8::from(more);
     if payload_len > MAX_SHORT_FRAME_SIZE {
-        buf.extend_from_slice(&[
-            flags | FLAG_LONG,
-            (payload_len >> 56) as u8,
-            (payload_len >> 48) as u8,
-            (payload_len >> 40) as u8,
-            (payload_len >> 32) as u8,
-            (payload_len >> 24) as u8,
-            (payload_len >> 16) as u8,
-            (payload_len >> 8) as u8,
-            payload_len as u8,
-        ]);
+        buf.put_u8(flags | FLAG_LONG);
+        buf.extend_from_slice(&(payload_len as u64).to_be_bytes());
     } else {
         buf.extend_from_slice(&[flags, payload_len as u8]);
     }

--- a/omq-proto/src/proto/transform/lz4.rs
+++ b/omq-proto/src/proto/transform/lz4.rs
@@ -17,6 +17,10 @@
 //! silently and uses the installed dict on its receive side. Per RFC §6.2,
 //! dicts are 1..=8192 bytes and shipped at most once per direction per
 //! connection.
+//!
+//! 32-bit targets can parse the 64-bit wire length fields, but decoded
+//! plaintext is bounded by platform allocation size (`isize::MAX`) and
+//! by configured message limits.
 
 use bytes::Bytes;
 pub use lz4rip::block::DictTrainer;
@@ -65,6 +69,17 @@ pub const MAX_DICT_BYTES: usize = 8192;
 
 /// Default auto-train dictionary capacity in bytes.
 const DEFAULT_DICT_CAPACITY: usize = 2048;
+
+fn decode_len(declared: u64, label: &str) -> Result<usize> {
+    let size = usize::try_from(declared)
+        .map_err(|_| Error::Protocol(format!("{label} declared size exceeds usize")))?;
+    if size > isize::MAX as usize {
+        return Err(Error::Protocol(format!(
+            "{label} declared size exceeds maximum allocation"
+        )));
+    }
+    Ok(size)
+}
 
 pub fn is_dict_shipment(msg: &Message) -> bool {
     msg.len() == 1
@@ -508,8 +523,7 @@ fn decode_lz4b(
     }
     let declared = u64::from_le_bytes(body[..8].try_into().unwrap());
     let block = &body[8..];
-    let decompressed_size = usize::try_from(declared)
-        .map_err(|_| Error::Protocol("LZ4B declared size exceeds usize".into()))?;
+    let decompressed_size = decode_len(declared, "LZ4B")?;
     if decompressed_size > block_size {
         return Err(Error::Protocol(
             "LZ4B declared size exceeds block limit; use LZ4M for large parts".into(),
@@ -544,8 +558,7 @@ fn decode_lz4m(
         ));
     }
     let declared = u64::from_le_bytes(body[..8].try_into().unwrap());
-    let decompressed_size = usize::try_from(declared)
-        .map_err(|_| Error::Protocol("LZ4M declared size exceeds usize".into()))?;
+    let decompressed_size = decode_len(declared, "LZ4M")?;
     take_budget(budget, decompressed_size)?;
 
     // Decompression-bomb guard. `decompressed_size` is an attacker-controlled

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- 32-bit Linux targets with native 64-bit atomics are supported. Per-frame and
+  per-message payloads remain bounded by platform allocation limits.
+
 ## [0.19.1] - 2026-07-19
 
 ### Fixed

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -10,6 +10,9 @@
 //! transport implementations, and the public `Socket` actor.
 #![forbid(unsafe_code)]
 
+#[cfg(not(target_has_atomic = "64"))]
+compile_error!("omq-tokio requires target_has_atomic = \"64\"");
+
 pub mod blocking;
 pub mod context;
 pub mod engine;

--- a/omq-tokio/tests/multi_peer.rs
+++ b/omq-tokio/tests/multi_peer.rs
@@ -95,15 +95,18 @@ async fn push_distributes_fairly_over_tcp() {
 
     // Spawn concurrent drainers BEFORE sending so the push side stays hot.
     let counts: Vec<Arc<AtomicUsize>> = (0..N).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+    let total_received = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::new();
     for (p, c) in pulls.into_iter().zip(counts.iter().cloned()) {
+        let total_received = total_received.clone();
         handles.push(tokio::spawn(async move {
             loop {
-                match tokio::time::timeout(Duration::from_millis(500), p.recv()).await {
-                    Ok(Ok(_)) => {
+                match p.recv().await {
+                    Ok(_) => {
                         c.fetch_add(1, Ordering::SeqCst);
+                        total_received.fetch_add(1, Ordering::SeqCst);
                     }
-                    _ => return,
+                    Err(e) => panic!("pull receiver failed before test finished: {e:?}"),
                 }
             }
         }));
@@ -112,11 +115,22 @@ async fn push_distributes_fairly_over_tcp() {
     for i in 0..M {
         push.send(Message::single(format!("m{i}"))).await.unwrap();
     }
-    for h in handles {
-        let _ = h.await;
-    }
+    let all_arrived = tokio::time::timeout(Duration::from_secs(10), async {
+        while total_received.load(Ordering::SeqCst) < M {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
 
     let total: usize = counts.iter().map(|c| c.load(Ordering::SeqCst)).sum();
+    for h in handles {
+        h.abort();
+        let _ = h.await;
+    }
+    assert!(
+        all_arrived.is_ok(),
+        "every message must reach exactly one pull; got {total} / {M}"
+    );
     assert_eq!(total, M, "every message must reach exactly one pull");
     // No peer may be starved. With direct round-robin the split is even
     // (~M/N each); the shared-queue regression let one connection driver

--- a/omq-tokio/tests/tcp_smoke.rs
+++ b/omq-tokio/tests/tcp_smoke.rs
@@ -1,0 +1,51 @@
+mod test_support;
+
+use std::time::Duration;
+
+use omq_tokio::{Message, Options, Socket, SocketType};
+
+#[tokio::test]
+async fn push_pull_tcp_smoke() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let port = test_support::bind_loopback(&pull).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&push).await;
+
+    push.send(Message::single("tcp-push-pull")).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(1), pull.recv())
+        .await
+        .expect("pull did not receive TCP message")
+        .unwrap();
+    assert_eq!(got, Message::single("tcp-push-pull"));
+}
+
+#[tokio::test]
+async fn req_rep_tcp_smoke() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let port = test_support::bind_loopback(&rep).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&req).await;
+
+    req.send(Message::single("tcp-request")).await.unwrap();
+
+    let request = tokio::time::timeout(Duration::from_secs(1), rep.recv())
+        .await
+        .expect("rep did not receive TCP request")
+        .unwrap();
+    assert_eq!(request, Message::single("tcp-request"));
+
+    rep.send(Message::single("tcp-reply")).await.unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(1), req.recv())
+        .await
+        .expect("req did not receive TCP reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("tcp-reply"));
+}

--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use 64-bit cursors (`AtomicU64` + `u64`) instead of pointer-width cursors,
+  allowing 32-bit targets with native 64-bit atomics to run without aliasing at
+  the 4 GiB cursor boundary.
+
 ## [0.3.8] - 2026-07-19
 
 ### Added

--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace the unreleased 64-bit cursor change with pointer-width cursors
+  (`AtomicUsize` + `usize`) and a half-range capacity guard so 32-bit targets
+  with pointer atomics can run safely.
 - Use 64-bit cursors (`AtomicU64` + `u64`) instead of pointer-width cursors,
   allowing 32-bit targets with native 64-bit atomics to run without aliasing at
   the 4 GiB cursor boundary.

--- a/yring/Cargo.toml
+++ b/yring/Cargo.toml
@@ -19,7 +19,7 @@ async = ["dep:atomic-waker", "dep:futures-core"]
 atomic-waker = { version = "1.1.0", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 
-[target.'cfg(loom)'.dependencies]
+[target.'cfg(all(loom, target_pointer_width = "64"))'.dependencies]
 loom = "0.7"
 
 [dev-dependencies]
@@ -28,7 +28,7 @@ rtrb = "0.3"
 crossbeam-channel = "0.5"
 flume = "0.12"
 
-[target.'cfg(target_pointer_width = "64")'.dev-dependencies]
+[target.'cfg(all(loom, target_pointer_width = "64"))'.dev-dependencies]
 loom = "0.7"
 
 [[bench]]

--- a/yring/Cargo.toml
+++ b/yring/Cargo.toml
@@ -24,10 +24,12 @@ loom = "0.7"
 
 [dev-dependencies]
 futures-lite = "2"
-loom = "0.7"
 rtrb = "0.3"
 crossbeam-channel = "0.5"
 flume = "0.12"
+
+[target.'cfg(target_pointer_width = "64")'.dev-dependencies]
+loom = "0.7"
 
 [[bench]]
 name = "throughput"

--- a/yring/README.md
+++ b/yring/README.md
@@ -12,9 +12,9 @@ atomics become the bottleneck.
 
 Three pointers instead of two:
 
-- `head`: consumer read position (AtomicUsize, consumer-owned)
-- `cursor`: producer write position (plain usize, producer-private, no atomic)
-- `tail`: last flushed position (AtomicUsize, producer writes / consumer reads)
+- `head`: consumer read position (AtomicU64, consumer-owned)
+- `cursor`: producer write position (plain u64, producer-private, no atomic)
+- `tail`: last flushed position (AtomicU64, producer writes / consumer reads)
 
 `push()` writes to the ring with zero atomics. `flush()` makes all
 pending writes visible with a single Release store. `pop()` reads with

--- a/yring/README.md
+++ b/yring/README.md
@@ -12,9 +12,9 @@ atomics become the bottleneck.
 
 Three pointers instead of two:
 
-- `head`: consumer read position (AtomicU64, consumer-owned)
-- `cursor`: producer write position (plain u64, producer-private, no atomic)
-- `tail`: last flushed position (AtomicU64, producer writes / consumer reads)
+- `head`: consumer read position (AtomicUsize, consumer-owned)
+- `cursor`: producer write position (plain usize, producer-private, no atomic)
+- `tail`: last flushed position (AtomicUsize, producer writes / consumer reads)
 
 `push()` writes to the ring with zero atomics. `flush()` makes all
 pending writes visible with a single Release store. `pop()` reads with

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -14,7 +14,7 @@ use std::task::{Context, Poll};
 use atomic_waker::AtomicWaker;
 use futures_core::Stream;
 
-use crate::{Padded, Ring};
+use crate::{Cursor, Padded, Ring};
 
 struct AsyncRing<T> {
     ring: Ring<T>,
@@ -41,8 +41,8 @@ impl<T> Drop for AsyncRing<T> {
 /// Async sending half. Wakes the consumer on flush when the ring was empty.
 pub struct AsyncProducer<T> {
     ring: Arc<AsyncRing<T>>,
-    cursor: usize,
-    cached_head: usize,
+    cursor: Cursor,
+    cached_head: Cursor,
 }
 
 // SAFETY: AsyncProducer<T> is Send because it is single-owner (not Sync) and
@@ -52,8 +52,8 @@ unsafe impl<T: Send> Send for AsyncProducer<T> {}
 /// Async receiving half. Implements [`Stream`].
 pub struct AsyncConsumer<T> {
     ring: Arc<AsyncRing<T>>,
-    head: usize,
-    cached_tail: usize,
+    head: Cursor,
+    cached_tail: Cursor,
 }
 
 // SAFETY: AsyncConsumer<T> is Send because it is single-owner (not Sync) and

--- a/yring/src/compat.rs
+++ b/yring/src/compat.rs
@@ -11,9 +11,9 @@ pub(crate) use loom::sync::Arc;
 pub(crate) use std::sync::Arc;
 
 #[cfg(loom)]
-pub(crate) use loom::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+pub(crate) use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(not(loom))]
-pub(crate) use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 #[cfg(not(loom))]
 pub(crate) trait UnsafeCellExt<T> {

--- a/yring/src/compat.rs
+++ b/yring/src/compat.rs
@@ -11,9 +11,9 @@ pub(crate) use loom::sync::Arc;
 pub(crate) use std::sync::Arc;
 
 #[cfg(loom)]
-pub(crate) use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+pub(crate) use loom::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(not(loom))]
-pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+pub(crate) use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[cfg(not(loom))]
 pub(crate) trait UnsafeCellExt<T> {

--- a/yring/src/compat.rs
+++ b/yring/src/compat.rs
@@ -1,26 +1,26 @@
-//! Compatibility shim: swap std types for loom types under `cfg(loom)`.
+//! Compatibility shim: swap std types for loom types in supported loom builds.
 
-#[cfg(loom)]
+#[cfg(all(loom, target_pointer_width = "64"))]
 pub(crate) use loom::cell::UnsafeCell;
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 pub(crate) use std::cell::UnsafeCell;
 
-#[cfg(loom)]
+#[cfg(all(loom, target_pointer_width = "64"))]
 pub(crate) use loom::sync::Arc;
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 pub(crate) use std::sync::Arc;
 
-#[cfg(loom)]
+#[cfg(all(loom, target_pointer_width = "64"))]
 pub(crate) use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 pub(crate) trait UnsafeCellExt<T> {
     fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R;
 }
 
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 impl<T> UnsafeCellExt<T> for std::cell::UnsafeCell<T> {
     #[inline]
     fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -2,9 +2,9 @@
 //! Bounded SPSC ring with ypipe-style batched flush/prefetch.
 //!
 //! Three pointers:
-//! - `head`: consumer read position (`AtomicUsize`, consumer-owned)
-//! - `cursor`: writer position (plain usize, producer-only, no atomic)
-//! - `tail`: last flushed position (`AtomicUsize`, producer writes, consumer reads)
+//! - `head`: consumer read position (`AtomicU64`, consumer-owned)
+//! - `cursor`: writer position (plain u64, producer-only, no atomic)
+//! - `tail`: last flushed position (`AtomicU64`, producer writes, consumer reads)
 //!
 //! `push` writes to the ring with zero atomics. `flush` makes all
 //! pending writes visible with one Release store. `pop` reads with
@@ -16,8 +16,8 @@ mod r#async;
 #[cfg(feature = "async")]
 pub use r#async::{AsyncConsumer, AsyncProducer, async_spsc};
 
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("yring requires a 64-bit target (AtomicUsize must not wrap in practice)");
+#[cfg(not(target_has_atomic = "64"))]
+compile_error!("yring requires target_has_atomic = \"64\"");
 
 mod compat;
 
@@ -26,7 +26,9 @@ use std::sync::OnceLock;
 
 #[cfg(not(loom))]
 use compat::UnsafeCellExt;
-use compat::{Arc, AtomicBool, AtomicUsize, Ordering, UnsafeCell};
+use compat::{Arc, AtomicBool, AtomicU64, Ordering, UnsafeCell};
+
+type Cursor = u64;
 
 #[repr(align(128))]
 pub(crate) struct Padded<T>(pub(crate) T);
@@ -35,9 +37,9 @@ pub(crate) struct Ring<T> {
     pub(crate) buf: Box<[UnsafeCell<MaybeUninit<T>>]>,
     pub(crate) mask: usize,
     /// Consumer read position. Written by consumer, read by producer.
-    pub(crate) head: Padded<AtomicUsize>,
+    pub(crate) head: Padded<AtomicU64>,
     /// Last flushed position. Written by producer, read by consumer.
-    pub(crate) tail: Padded<AtomicUsize>,
+    pub(crate) tail: Padded<AtomicU64>,
     /// Set by `Producer::drop`. Lets the consumer detect that no more
     /// data will ever arrive.
     pub(crate) producer_dropped: AtomicBool,
@@ -66,8 +68,8 @@ impl<T> Ring<T> {
         Self {
             buf: buf.into_boxed_slice(),
             mask: cap - 1,
-            head: Padded(AtomicUsize::new(0)),
-            tail: Padded(AtomicUsize::new(0)),
+            head: Padded(AtomicU64::new(0)),
+            tail: Padded(AtomicU64::new(0)),
             producer_dropped: AtomicBool::new(false),
             consumer_dropped: AtomicBool::new(false),
         }
@@ -78,26 +80,37 @@ impl<T> Ring<T> {
     }
 
     #[inline]
-    fn distance(from: usize, to: usize) -> usize {
+    fn distance(from: Cursor, to: Cursor) -> Cursor {
         from.wrapping_sub(to)
+    }
+
+    #[inline]
+    fn count(n: Cursor) -> usize {
+        debug_assert!(n <= usize::MAX as Cursor);
+        n as usize
+    }
+
+    #[inline]
+    fn index(&self, cursor: Cursor) -> usize {
+        (cursor as usize) & self.mask
     }
 
     #[inline]
     pub(crate) fn push(
         &self,
-        cursor: &mut usize,
-        cached_head: &mut usize,
+        cursor: &mut Cursor,
+        cached_head: &mut Cursor,
         val: T,
     ) -> Result<(), T> {
-        if Self::distance(*cursor, *cached_head) >= self.capacity() {
+        if Self::distance(*cursor, *cached_head) >= self.capacity() as Cursor {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            if Self::distance(*cursor, *cached_head) >= self.capacity() {
+            if Self::distance(*cursor, *cached_head) >= self.capacity() as Cursor {
                 return Err(val);
             }
         }
         // SAFETY: capacity check above guarantees this slot is not
         // visible to the consumer (cursor < head + capacity).
-        self.buf[*cursor & self.mask].with_mut(|ptr| unsafe {
+        self.buf[self.index(*cursor)].with_mut(|ptr| unsafe {
             (*ptr).write(val);
         });
         *cursor = cursor.wrapping_add(1);
@@ -105,7 +118,7 @@ impl<T> Ring<T> {
     }
 
     #[inline]
-    pub(crate) fn flush_to(&self, cursor: usize, cached_head: &mut usize) -> FlushResult {
+    pub(crate) fn flush_to(&self, cursor: Cursor, cached_head: &mut Cursor) -> FlushResult {
         let prev_tail = self.tail.0.load(Ordering::Relaxed);
         if cursor == prev_tail {
             return FlushResult::NothingToFlush;
@@ -114,62 +127,65 @@ impl<T> Ring<T> {
         *cached_head = self.head.0.load(Ordering::Acquire);
         let was_empty = prev_tail == *cached_head;
         self.tail.0.store(cursor, Ordering::Release);
-        FlushResult::Flushed { count, was_empty }
+        FlushResult::Flushed {
+            count: Self::count(count),
+            was_empty,
+        }
     }
 
     #[inline]
-    pub(crate) fn is_full(&self, cursor: usize, cached_head: &mut usize) -> bool {
-        if Self::distance(cursor, *cached_head) >= self.capacity() {
+    pub(crate) fn is_full(&self, cursor: Cursor, cached_head: &mut Cursor) -> bool {
+        if Self::distance(cursor, *cached_head) >= self.capacity() as Cursor {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            Self::distance(cursor, *cached_head) >= self.capacity()
+            Self::distance(cursor, *cached_head) >= self.capacity() as Cursor
         } else {
             false
         }
     }
 
     #[inline]
-    pub(crate) fn producer_len(&self, cursor: usize) -> usize {
-        cursor.wrapping_sub(self.head.0.load(Ordering::Acquire))
+    pub(crate) fn producer_len(&self, cursor: Cursor) -> usize {
+        Self::count(cursor.wrapping_sub(self.head.0.load(Ordering::Acquire)))
     }
 
     #[inline]
-    pub(crate) fn producer_is_empty(&self, cursor: usize) -> bool {
+    pub(crate) fn producer_is_empty(&self, cursor: Cursor) -> bool {
         cursor == self.head.0.load(Ordering::Acquire)
     }
 
     #[inline]
-    pub(crate) fn pop(&self, head: &mut usize, cached_tail: usize) -> Option<T> {
+    pub(crate) fn pop(&self, head: &mut Cursor, cached_tail: Cursor) -> Option<T> {
         if *head == cached_tail {
             return None;
         }
         // SAFETY: head < cached_tail, so this slot was written by the
         // producer and made visible via flush (Release store).
-        let val = self.buf[*head & self.mask].with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
+        let val = self.buf[self.index(*head)].with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
         *head = head.wrapping_add(1);
         Some(val)
     }
 
     #[inline]
-    pub(crate) fn release(&self, head: usize) {
+    pub(crate) fn release(&self, head: Cursor) {
         self.head.0.store(head, Ordering::Release);
     }
 
     #[inline]
-    pub(crate) fn prefetch(&self, cached_tail: &mut usize) -> usize {
+    pub(crate) fn prefetch(&self, cached_tail: &mut Cursor) -> usize {
         let new_tail = self.tail.0.load(Ordering::Acquire);
         let count = new_tail.wrapping_sub(*cached_tail);
         *cached_tail = new_tail;
-        count
+        Self::count(count)
     }
 
     #[inline]
-    pub(crate) fn consumer_is_empty(&self, head: usize, cached_tail: usize) -> bool {
+    pub(crate) fn consumer_is_empty(&self, head: Cursor, cached_tail: Cursor) -> bool {
         head == cached_tail && self.tail.0.load(Ordering::Acquire) == head
     }
 
     #[inline]
-    pub(crate) fn consumer_len(&self, head: usize) -> usize {
-        self.tail.0.load(Ordering::Acquire).wrapping_sub(head)
+    pub(crate) fn consumer_len(&self, head: Cursor) -> usize {
+        Self::count(self.tail.0.load(Ordering::Acquire).wrapping_sub(head))
     }
 
     /// Drop all items between head and tail. Must only be called with
@@ -191,7 +207,7 @@ impl<T> Ring<T> {
         while i != tail {
             // SAFETY: &mut self guarantees exclusive access. Slots
             // [head..tail] were written by the producer and flushed.
-            self.buf[i & self.mask].with_mut(|ptr| unsafe {
+            self.buf[self.index(i)].with_mut(|ptr| unsafe {
                 (*ptr).assume_init_drop();
             });
             i = i.wrapping_add(1);
@@ -223,9 +239,9 @@ pub enum FlushResult {
 pub struct Producer<T> {
     ring: Arc<Ring<T>>,
     /// Private write position. No atomic; only the producer touches it.
-    cursor: usize,
+    cursor: Cursor,
     /// Cached copy of the consumer's `head` to avoid Acquire loads.
-    cached_head: usize,
+    cached_head: Cursor,
 }
 
 impl<T> Producer<T> {
@@ -319,9 +335,9 @@ impl<T> std::fmt::Debug for ProducerOwner<T> {
 pub struct Consumer<T> {
     ring: Arc<Ring<T>>,
     /// Private read position. Only the consumer touches it.
-    head: usize,
+    head: Cursor,
     /// Cached copy of `tail`. Updated by `prefetch()`.
-    cached_tail: usize,
+    cached_tail: Cursor,
 }
 
 impl<T> Consumer<T> {
@@ -690,12 +706,13 @@ mod tests {
     #[test]
     fn counters_wrap_without_panicking() {
         let (mut p, mut c) = spsc::<u32>(4);
-        p.cursor = usize::MAX - 1;
-        p.cached_head = usize::MAX - 1;
-        c.head = usize::MAX - 1;
-        c.cached_tail = usize::MAX - 1;
-        p.ring.head.0.store(usize::MAX - 1, Ordering::Relaxed);
-        p.ring.tail.0.store(usize::MAX - 1, Ordering::Relaxed);
+        let base: Cursor = u64::MAX - 1;
+        p.cursor = base;
+        p.cached_head = base;
+        c.head = base;
+        c.cached_tail = base;
+        p.ring.head.0.store(base, Ordering::Relaxed);
+        p.ring.tail.0.store(base, Ordering::Relaxed);
 
         p.push(1).unwrap();
         p.push(2).unwrap();
@@ -712,6 +729,38 @@ mod tests {
         assert_eq!(c.pop(), Some(1));
         assert_eq!(c.pop(), Some(2));
         assert_eq!(c.pop(), Some(3));
+        assert_eq!(c.pop(), None);
+        c.release();
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn counters_cross_u32_boundary_without_aliasing() {
+        let (mut p, mut c) = spsc::<u32>(4);
+        let base: Cursor = u64::from(u32::MAX) - 1;
+        p.cursor = base;
+        p.cached_head = base;
+        c.head = base;
+        c.cached_tail = base;
+        p.ring.head.0.store(base, Ordering::Relaxed);
+        p.ring.tail.0.store(base, Ordering::Relaxed);
+
+        for i in 0..4 {
+            p.push(i).unwrap();
+        }
+        assert_eq!(p.push(99), Err(99));
+        assert_eq!(
+            p.flush_and_check(),
+            FlushResult::Flushed {
+                count: 4,
+                was_empty: true
+            }
+        );
+
+        assert_eq!(c.prefetch(), 4);
+        for i in 0..4 {
+            assert_eq!(c.pop(), Some(i));
+        }
         assert_eq!(c.pop(), None);
         c.release();
         assert!(p.is_empty());
@@ -753,12 +802,13 @@ mod tests {
 
         DROPS.store(0, Ordering::Relaxed);
         let (mut p, mut c) = spsc::<Counted>(4);
-        p.cursor = usize::MAX - 1;
-        p.cached_head = usize::MAX - 1;
-        c.head = usize::MAX - 1;
-        c.cached_tail = usize::MAX - 1;
-        p.ring.head.0.store(usize::MAX - 1, Ordering::Relaxed);
-        p.ring.tail.0.store(usize::MAX - 1, Ordering::Relaxed);
+        let base: Cursor = u64::MAX - 1;
+        p.cursor = base;
+        p.cached_head = base;
+        c.head = base;
+        c.cached_tail = base;
+        p.ring.head.0.store(base, Ordering::Relaxed);
+        p.ring.tail.0.store(base, Ordering::Relaxed);
 
         p.push(Counted).unwrap();
         p.push(Counted).unwrap();

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -24,7 +24,7 @@ mod compat;
 use std::mem::MaybeUninit;
 use std::sync::OnceLock;
 
-#[cfg(not(loom))]
+#[cfg(not(all(loom, target_pointer_width = "64")))]
 use compat::UnsafeCellExt;
 use compat::{Arc, AtomicBool, AtomicUsize, Ordering, UnsafeCell};
 
@@ -374,7 +374,7 @@ pub fn spsc<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
     )
 }
 
-#[cfg(loom)]
+#[cfg(all(loom, target_pointer_width = "64"))]
 #[doc(hidden)]
 pub fn loom_spsc_with_cursors<T>(capacity: usize, cursor: usize) -> (Producer<T>, Consumer<T>) {
     let ring = Arc::new(Ring::new(capacity));

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -2,9 +2,9 @@
 //! Bounded SPSC ring with ypipe-style batched flush/prefetch.
 //!
 //! Three pointers:
-//! - `head`: consumer read position (`AtomicU64`, consumer-owned)
-//! - `cursor`: writer position (plain u64, producer-only, no atomic)
-//! - `tail`: last flushed position (`AtomicU64`, producer writes, consumer reads)
+//! - `head`: consumer read position (`AtomicUsize`, consumer-owned)
+//! - `cursor`: writer position (plain usize, producer-only, no atomic)
+//! - `tail`: last flushed position (`AtomicUsize`, producer writes, consumer reads)
 //!
 //! `push` writes to the ring with zero atomics. `flush` makes all
 //! pending writes visible with one Release store. `pop` reads with
@@ -16,8 +16,8 @@ mod r#async;
 #[cfg(feature = "async")]
 pub use r#async::{AsyncConsumer, AsyncProducer, async_spsc};
 
-#[cfg(not(target_has_atomic = "64"))]
-compile_error!("yring requires target_has_atomic = \"64\"");
+#[cfg(not(target_has_atomic = "ptr"))]
+compile_error!("yring requires target_has_atomic = \"ptr\"");
 
 mod compat;
 
@@ -26,9 +26,10 @@ use std::sync::OnceLock;
 
 #[cfg(not(loom))]
 use compat::UnsafeCellExt;
-use compat::{Arc, AtomicBool, AtomicU64, Ordering, UnsafeCell};
+use compat::{Arc, AtomicBool, AtomicUsize, Ordering, UnsafeCell};
 
-type Cursor = u64;
+type AtomicCursor = AtomicUsize;
+type Cursor = usize;
 
 #[repr(align(128))]
 pub(crate) struct Padded<T>(pub(crate) T);
@@ -37,9 +38,9 @@ pub(crate) struct Ring<T> {
     pub(crate) buf: Box<[UnsafeCell<MaybeUninit<T>>]>,
     pub(crate) mask: usize,
     /// Consumer read position. Written by consumer, read by producer.
-    pub(crate) head: Padded<AtomicU64>,
+    pub(crate) head: Padded<AtomicCursor>,
     /// Last flushed position. Written by producer, read by consumer.
-    pub(crate) tail: Padded<AtomicU64>,
+    pub(crate) tail: Padded<AtomicCursor>,
     /// Set by `Producer::drop`. Lets the consumer detect that no more
     /// data will ever arrive.
     pub(crate) producer_dropped: AtomicBool,
@@ -62,14 +63,18 @@ impl<T> Ring<T> {
         let cap = capacity
             .checked_next_power_of_two()
             .expect("capacity must fit in the next power of two");
+        assert!(
+            cap <= usize::MAX / 2,
+            "capacity must be <= half the cursor range"
+        );
         let buf: Vec<UnsafeCell<MaybeUninit<T>>> = (0..cap)
             .map(|_| UnsafeCell::new(MaybeUninit::uninit()))
             .collect();
         Self {
             buf: buf.into_boxed_slice(),
             mask: cap - 1,
-            head: Padded(AtomicU64::new(0)),
-            tail: Padded(AtomicU64::new(0)),
+            head: Padded(AtomicCursor::new(0)),
+            tail: Padded(AtomicCursor::new(0)),
             producer_dropped: AtomicBool::new(false),
             consumer_dropped: AtomicBool::new(false),
         }
@@ -86,13 +91,12 @@ impl<T> Ring<T> {
 
     #[inline]
     fn count(n: Cursor) -> usize {
-        debug_assert!(n <= usize::MAX as Cursor);
-        n as usize
+        n
     }
 
     #[inline]
     fn index(&self, cursor: Cursor) -> usize {
-        (cursor as usize) & self.mask
+        cursor & self.mask
     }
 
     #[inline]
@@ -102,9 +106,9 @@ impl<T> Ring<T> {
         cached_head: &mut Cursor,
         val: T,
     ) -> Result<(), T> {
-        if Self::distance(*cursor, *cached_head) >= self.capacity() as Cursor {
+        if Self::distance(*cursor, *cached_head) >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            if Self::distance(*cursor, *cached_head) >= self.capacity() as Cursor {
+            if Self::distance(*cursor, *cached_head) >= self.capacity() {
                 return Err(val);
             }
         }
@@ -135,9 +139,9 @@ impl<T> Ring<T> {
 
     #[inline]
     pub(crate) fn is_full(&self, cursor: Cursor, cached_head: &mut Cursor) -> bool {
-        if Self::distance(cursor, *cached_head) >= self.capacity() as Cursor {
+        if Self::distance(cursor, *cached_head) >= self.capacity() {
             *cached_head = self.head.0.load(Ordering::Acquire);
-            Self::distance(cursor, *cached_head) >= self.capacity() as Cursor
+            Self::distance(cursor, *cached_head) >= self.capacity()
         } else {
             false
         }
@@ -366,6 +370,26 @@ pub fn spsc<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
             ring,
             head: 0,
             cached_tail: 0,
+        },
+    )
+}
+
+#[cfg(loom)]
+#[doc(hidden)]
+pub fn loom_spsc_with_cursors<T>(capacity: usize, cursor: usize) -> (Producer<T>, Consumer<T>) {
+    let ring = Arc::new(Ring::new(capacity));
+    ring.head.0.store(cursor, Ordering::Relaxed);
+    ring.tail.0.store(cursor, Ordering::Relaxed);
+    (
+        Producer {
+            ring: ring.clone(),
+            cursor,
+            cached_head: cursor,
+        },
+        Consumer {
+            ring,
+            head: cursor,
+            cached_tail: cursor,
         },
     )
 }
@@ -704,9 +728,15 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "capacity must be <= half the cursor range")]
+    fn capacity_half_range_panics_with_message() {
+        let _ = spsc::<u8>((usize::MAX / 2) + 1);
+    }
+
+    #[test]
     fn counters_wrap_without_panicking() {
         let (mut p, mut c) = spsc::<u32>(4);
-        let base: Cursor = u64::MAX - 1;
+        let base: Cursor = usize::MAX - 1;
         p.cursor = base;
         p.cached_head = base;
         c.head = base;
@@ -737,7 +767,7 @@ mod tests {
     #[test]
     fn counters_cross_u32_boundary_without_aliasing() {
         let (mut p, mut c) = spsc::<u32>(4);
-        let base: Cursor = u64::from(u32::MAX) - 1;
+        let base: Cursor = u32::MAX as usize - 1;
         p.cursor = base;
         p.cached_head = base;
         c.head = base;
@@ -802,7 +832,7 @@ mod tests {
 
         DROPS.store(0, Ordering::Relaxed);
         let (mut p, mut c) = spsc::<Counted>(4);
-        let base: Cursor = u64::MAX - 1;
+        let base: Cursor = usize::MAX - 1;
         p.cursor = base;
         p.cached_head = base;
         c.head = base;

--- a/yring/tests/loom.rs
+++ b/yring/tests/loom.rs
@@ -1,4 +1,4 @@
-#![cfg(loom)]
+#![cfg(all(loom, target_pointer_width = "64"))]
 
 use loom::thread;
 

--- a/yring/tests/loom.rs
+++ b/yring/tests/loom.rs
@@ -106,6 +106,33 @@ fn wraparound_correctness() {
 }
 
 #[test]
+fn pointer_width_cursor_wrap_boundary() {
+    loom::model(|| {
+        let base = usize::MAX - 1;
+        let (mut p, mut c) = yring::loom_spsc_with_cursors::<u32>(2, base);
+
+        let h = thread::spawn(move || {
+            p.push(10).unwrap();
+            p.push(20).unwrap();
+            p.flush();
+        });
+
+        loop {
+            if c.prefetch() > 0 {
+                assert_eq!(c.pop(), Some(10));
+                assert_eq!(c.pop(), Some(20));
+                assert_eq!(c.pop(), None);
+                c.release();
+                break;
+            }
+            thread::yield_now();
+        }
+
+        h.join().unwrap();
+    });
+}
+
+#[test]
 fn is_disconnected_after_producer_drop() {
     loom::model(|| {
         let (mut p, mut c) = yring::spsc::<u32>(4);


### PR DESCRIPTION
- Supports `i686-unknown-linux-gnu` and `armv7-unknown-linux-gnueabihf` on targets with native 64-bit atomics.
- Uses `u64` cursors for `yring` and `omq-libzmq` inproc bypass.
- Matches libzmq `zmq_msg_t` as 64-byte pointer-aligned opaque storage.
- Pins `lz4rip` to `2e02fe81` so 32-bit CI exercises the verified LZ4 path before the crates.io release.
- Adds `cross`-based 32-bit Linux CI jobs.
- Closes https://github.com/paddor/omq.rs/issues/175