### PR TITLE
Reduce idle TCP peer memory

### DIFF
--- a/omq-proto/src/frame_buffer.rs
+++ b/omq-proto/src/frame_buffer.rs
@@ -63,6 +63,17 @@ impl FrameBuffer {
         }
     }
 
+    pub fn with_config_lazy(arena_threshold: usize, arena_cap: usize) -> Self {
+        Self {
+            entries: VecDeque::new(),
+            total_bytes: 0,
+            arena: BytesMut::new(),
+            arena_threshold,
+            arena_mark: 0,
+            arena_peak_cap: arena_cap,
+        }
+    }
+
     pub fn one_shot() -> Self {
         Self {
             entries: VecDeque::new(),
@@ -131,8 +142,15 @@ impl FrameBuffer {
     }
 
     pub fn push_pre_framed(&mut self, data: &[u8]) {
+        self.reserve_arena(data.len());
         self.arena.extend_from_slice(data);
         self.total_bytes += data.len();
+    }
+
+    fn reserve_arena(&mut self, additional: usize) {
+        if self.arena.capacity() == 0 && self.arena_peak_cap > 0 {
+            self.arena.reserve(self.arena_peak_cap.max(additional));
+        }
     }
 
     /// Commits the pending arena range (`arena_mark..arena.len()`) as an
@@ -152,6 +170,7 @@ impl FrameBuffer {
 
     #[inline]
     pub fn frame_inline(&mut self, msg: &Message) {
+        self.reserve_arena(msg.byte_len() + msg.len() * 9);
         let before = self.arena.len();
         frame::encode_message_flat(msg, &mut self.arena);
         self.total_bytes += self.arena.len() - before;
@@ -160,6 +179,7 @@ impl FrameBuffer {
     pub fn frame_gather(&mut self, msg: &Message) {
         let parts = msg.parts_payload();
         let n = parts.len();
+        self.reserve_arena(n * 9);
         for (i, part) in parts.iter().enumerate() {
             let before = self.arena.len();
             frame::write_frame_header(&mut self.arena, i + 1 < n, part.len());
@@ -175,6 +195,7 @@ impl FrameBuffer {
 
     #[cfg(feature = "ws")]
     pub fn frame_ws(&mut self, msg: &Message, masked: bool) {
+        self.reserve_arena(msg.byte_len() + msg.len() * 14);
         let before = self.arena.len();
         if masked {
             frame::encode_message_flat_ws_masked(msg, &mut self.arena);
@@ -185,6 +206,7 @@ impl FrameBuffer {
     }
 
     pub fn frame_prefixed_inline(&mut self, prefix: &Bytes, msg: &Message) {
+        self.reserve_arena(msg.byte_len() + prefix.len() * msg.len() + msg.len() * 9);
         let before = self.arena.len();
         frame::encode_message_prefixed_flat(prefix, msg, &mut self.arena);
         self.total_bytes += self.arena.len() - before;
@@ -207,6 +229,7 @@ impl FrameBuffer {
     }
 
     fn frame_rep_gather(&mut self, msg: &Message) {
+        self.reserve_arena((msg.len() + 1) * 9);
         let before = self.arena.len();
         frame::write_frame_header(&mut self.arena, !msg.is_empty(), 0);
         self.total_bytes += self.arena.len() - before;
@@ -238,6 +261,7 @@ impl FrameBuffer {
     pub fn frame_prefixed_gather(&mut self, prefix: &Bytes, msg: &Message) {
         let parts = msg.parts_payload();
         let n = parts.len();
+        self.reserve_arena(n * 9);
         for (i, part) in parts.iter().enumerate() {
             let payload_len = prefix.len() + part.len();
             let before = self.arena.len();
@@ -353,6 +377,17 @@ impl Default for FrameBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lazy_config_defers_arena_allocation_until_encode() {
+        let mut eq = FrameBuffer::with_config_lazy(ARENA_THRESHOLD, ARENA_INITIAL_CAP);
+        assert_eq!(eq.arena.capacity(), 0);
+
+        eq.frame(&Message::single("abc"));
+
+        assert!(eq.arena.capacity() >= ARENA_INITIAL_CAP);
+        assert!(!eq.arena_bytes().is_empty());
+    }
 
     #[test]
     fn put_back_partial_write() {

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -395,7 +395,10 @@ async fn batch_encode(
     Ok(count)
 }
 
-const READ_BUF_SIZE: usize = 128 * 1024;
+const READ_BUF_INITIAL_LATENCY: usize = 1024;
+const READ_BUF_INITIAL_THROUGHPUT: usize = 1024;
+const READ_BUF_MAX: usize = 128 * 1024;
+const READ_BUF_GROW_FULL_READS: usize = 2;
 
 use crate::routing::SHARED_MAX_BATCH_MSGS;
 
@@ -701,12 +704,18 @@ where
         let mut offload_pipeline: OffloadPipeline = FuturesOrdered::new();
         let latency_profile = !matches!(receive_profile, ReceiveProfile::Throughput);
         let (mut reader, mut writer) = stream.split(latency_profile);
-        let mut read_buf = BytesMut::with_capacity(READ_BUF_SIZE);
+        let mut read_buf_target = if latency_profile {
+            READ_BUF_INITIAL_LATENCY
+        } else {
+            READ_BUF_INITIAL_THROUGHPUT
+        };
+        let mut read_buf_full_reads = 0usize;
+        let mut read_buf = BytesMut::with_capacity(read_buf_target);
         let recv_pool = RecvBufPool::new();
-        let mut eq = FrameBuffer::with_config(arena_threshold, arena_cap);
-        let mut drain_buf: Vec<Bytes> = Vec::with_capacity(64);
-        let mut arena_buf: Vec<u8> = Vec::with_capacity(4096);
-        let mut pipe_batch: Vec<Message> = Vec::with_capacity(SHARED_MAX_BATCH_MSGS);
+        let mut eq = FrameBuffer::with_config_lazy(arena_threshold, arena_cap);
+        let mut drain_buf: Vec<Bytes> = Vec::new();
+        let mut arena_buf: Vec<u8> = Vec::new();
+        let mut pipe_batch: Vec<Message> = Vec::new();
         let mut last_input = Instant::now();
         let mut handshake_deadline: Option<Instant> =
             config.handshake_timeout.map(|d| last_input + d);
@@ -841,7 +850,17 @@ where
                         inbox.close();
                         return Ok(());
                     }
+                    if n >= read_buf_target && read_buf_target < READ_BUF_MAX {
+                        read_buf_full_reads += 1;
+                        if read_buf_full_reads >= READ_BUF_GROW_FULL_READS {
+                            read_buf_target = (read_buf_target * 2).min(READ_BUF_MAX);
+                            read_buf_full_reads = 0;
+                        }
+                    } else {
+                        read_buf_full_reads = 0;
+                    }
                     let chunk = read_buf.split().freeze();
+                    read_buf.reserve(read_buf_target.saturating_sub(read_buf.capacity()));
                     if let Err(e) = codec.handle_input(chunk) {
                         while let Some(ev) = codec.poll_event() {
                             let _ = peer_out

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -88,7 +88,7 @@ impl PeerTransmitSlot {
         #[cfg(feature = "ws")] ws_masked: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
-            eq: Mutex::new(FrameBuffer::with_config(arena_threshold, arena_cap)),
+            eq: Mutex::new(FrameBuffer::with_config_lazy(arena_threshold, arena_cap)),
             cap,
             msg_cap: msg_cap.max(1),
             data_signal: DataSignal::new(),

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -275,6 +275,14 @@ impl IdentitySend {
         }
     }
 
+    pub(crate) fn needs_peer_send_pipe(&self) -> bool {
+        !self.latency_profile
+    }
+
+    pub(crate) fn needs_transmit_slot(&self) -> bool {
+        self.latency_profile
+    }
+
     #[expect(clippy::needless_pass_by_value)]
     pub(crate) fn connection_added(
         &mut self,
@@ -381,6 +389,24 @@ mod tests {
 
     use super::*;
     use crate::engine::send_pipe;
+
+    #[test]
+    fn throughput_identity_uses_peer_pipe_not_transmit_slot() {
+        let options = Options::default().workload_profile(omq_proto::WorkloadProfile::Throughput);
+        let send = IdentitySend::new(SocketType::Router, &options);
+
+        assert!(send.needs_peer_send_pipe());
+        assert!(!send.needs_transmit_slot());
+    }
+
+    #[test]
+    fn latency_identity_uses_transmit_slot_not_peer_pipe() {
+        let options = Options::default().workload_profile(omq_proto::WorkloadProfile::Latency);
+        let send = IdentitySend::new(SocketType::Rep, &options);
+
+        assert!(!send.needs_peer_send_pipe());
+        assert!(send.needs_transmit_slot());
+    }
 
     #[test]
     fn try_send_reports_full_and_preserves_routing_frame() {

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -296,6 +296,22 @@ impl SendStrategy {
         }
     }
 
+    pub(crate) fn needs_peer_send_pipe(&self) -> bool {
+        match self {
+            Self::RoundRobin(_) | Self::Exclusive(_) => true,
+            Self::Identity(s) => s.needs_peer_send_pipe(),
+            Self::None | Self::Latency(_) | Self::FanOut(_) => false,
+        }
+    }
+
+    pub(crate) fn needs_transmit_slot(&self) -> bool {
+        match self {
+            Self::Latency(_) | Self::FanOut(_) => true,
+            Self::Identity(s) => s.needs_transmit_slot(),
+            Self::None | Self::RoundRobin(_) | Self::Exclusive(_) => false,
+        }
+    }
+
     pub(crate) fn shutdown(&self) {
         match self {
             Self::None => {}

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -283,9 +283,7 @@ impl SocketDriver {
             omq_proto::frame_buffer::ARENA_INITIAL_CAP
         };
         let uses_crypto = self.options.mechanism.has_frame_transform();
-        let slot = if uses_crypto {
-            None
-        } else {
+        let slot = if !uses_crypto && self.send_strategy.needs_transmit_slot() {
             let transmit_slot_cap = self
                 .options
                 .transmit_slot_cap
@@ -304,6 +302,8 @@ impl SocketDriver {
                 #[cfg(feature = "ws")]
                 ws_masked,
             ))
+        } else {
+            None
         };
         let driver = driver
             .with_arena_threshold(arena_threshold)
@@ -312,9 +312,16 @@ impl SocketDriver {
             Some(ref s) => driver.with_transmit_slot(s.clone()),
             None => driver,
         };
-        let pipe_cap = self.options.send_hwm.max(16) as usize;
-        let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
-        let driver = driver.with_send_pipe(send_pipe_rx);
+        let (send_pipe, driver) = if self.send_strategy.needs_peer_send_pipe() {
+            let pipe_cap = self.options.send_hwm.max(16) as usize;
+            let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
+            (
+                Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
+                driver.with_send_pipe(send_pipe_rx),
+            )
+        } else {
+            (None, driver)
+        };
 
         // Recv bypass: for socket types whose recv path is a plain fair-queue
         // delivery with no per-type post-processing, route messages directly
@@ -390,7 +397,7 @@ impl SocketDriver {
                     cancel: child_cancel,
                     transmit_slot: slot.clone(),
                     direct_tcp_writer: direct_tcp_writer.clone(),
-                    send_pipe: Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
+                    send_pipe,
                 },
                 identity: bytes::Bytes::new(),
                 info: None,
@@ -498,8 +505,16 @@ impl SocketDriver {
         let inbox_cap = 64usize;
         let (inbox_tx, inbox_rx) = mpsc::channel(inbox_cap);
         let child_cancel = self.cancel.child_token();
-        let pipe_cap = self.options.send_hwm.max(16) as usize;
-        let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
+        let (send_pipe, send_pipe_rx) = if self.send_strategy.needs_peer_send_pipe() {
+            let pipe_cap = self.options.send_hwm.max(16) as usize;
+            let (send_pipe, send_pipe_rx) = crate::engine::send_pipe(pipe_cap);
+            (
+                Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
+                Some(send_pipe_rx),
+            )
+        } else {
+            (None, None)
+        };
 
         // Pre-build the synthesised PeerProperties from the
         // connect-time snapshot. The handshake-replay code in
@@ -545,7 +560,7 @@ impl SocketDriver {
                     cancel: child_cancel.clone(),
                     transmit_slot: None,
                     direct_tcp_writer: None,
-                    send_pipe: Some(std::sync::Arc::new(std::sync::Mutex::new(Some(send_pipe)))),
+                    send_pipe,
                 },
                 identity: bytes::Bytes::new(),
                 info: None,
@@ -855,7 +870,7 @@ struct InprocDriverCtx {
     spsc: Option<std::sync::Arc<crate::transport::inproc::InprocRx>>,
     recv_sink: Option<crate::engine::RecvSink>,
     shared_rx: Option<crate::routing::fallback_queue::FallbackReceiver>,
-    send_pipe_rx: crate::engine::SendPipeConsumer,
+    send_pipe_rx: Option<crate::engine::SendPipeConsumer>,
     blocking_recv_waker: std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
 }
 
@@ -885,8 +900,8 @@ async fn inproc_peer_driver(
         mut send_pipe_rx,
         blocking_recv_waker,
     } = ctx;
-    let mut shared_batch = Vec::with_capacity(crate::routing::SHARED_MAX_BATCH_MSGS);
-    let mut send_pipe_batch = Vec::with_capacity(crate::routing::SHARED_MAX_BATCH_MSGS);
+    let mut shared_batch = Vec::new();
+    let mut send_pipe_batch = Vec::new();
 
     #[expect(clippy::items_after_statements)]
     async fn emit_event(
@@ -973,7 +988,10 @@ async fn inproc_peer_driver(
                         rx.release_permits(popped);
                     }
                 },
-                () = send_pipe_rx.notified() => {
+                () = async {
+                    send_pipe_rx.as_ref().unwrap().notified().await;
+                }, if send_pipe_rx.is_some() => {
+                    let send_pipe_rx = send_pipe_rx.as_mut().unwrap();
                     let drained = send_pipe_rx.drain_into(
                         &mut send_pipe_batch,
                         crate::routing::SHARED_MAX_BATCH_MSGS,

--- a/omq-tokio/src/socket/monitor.rs
+++ b/omq-tokio/src/socket/monitor.rs
@@ -12,6 +12,8 @@
 
 use tokio::sync::broadcast;
 
+use std::sync::{Arc, Mutex};
+
 pub use omq_proto::monitor::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorTryRecvError,
     PeerCommandKind, PeerIdent, PeerInfo,
@@ -62,23 +64,31 @@ impl MonitorStream {
 /// Internal publisher used by the socket driver.
 #[derive(Debug, Clone)]
 pub(crate) struct MonitorPublisher {
-    tx: broadcast::Sender<MonitorEvent>,
+    tx: Arc<Mutex<Option<broadcast::Sender<MonitorEvent>>>>,
 }
 
 impl MonitorPublisher {
     pub(crate) fn new() -> Self {
-        let (tx, _) = broadcast::channel(MONITOR_CAPACITY);
-        Self { tx }
+        Self {
+            tx: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub(crate) fn publish(&self, event: MonitorEvent) {
         // `broadcast::Sender::send` only errors if there are no
         // subscribers, which is the common case when no one called
         // `Socket::monitor()`. Silently ignore.
-        let _ = self.tx.send(event);
+        if let Some(tx) = self.tx.lock().expect("monitor publisher").as_ref() {
+            let _ = tx.send(event);
+        }
     }
 
     pub(crate) fn subscribe(&self) -> MonitorStream {
-        MonitorStream::new(self.tx.subscribe())
+        let mut tx = self.tx.lock().expect("monitor publisher");
+        let tx = tx.get_or_insert_with(|| {
+            let (tx, _) = broadcast::channel(MONITOR_CAPACITY);
+            tx
+        });
+        MonitorStream::new(tx.subscribe())
     }
 }


### PR DESCRIPTION
- Allocate peer send pipes and transmit slots only for routing modes that use them.
- Start TCP read buffers and frame arenas small, then grow under load.
- Allocate monitor broadcast channels lazily on first subscription.
- Measured HWM16 TCP PUSH/PULL at ~44.8 KiB/socket idle and ~50.1 KiB/socket after one 4 KiB message.