### PR TITLE
Add kanal sync to yring SPSC chart

### DIFF
--- a/yring/Cargo.toml
+++ b/yring/Cargo.toml
@@ -26,7 +26,7 @@ loom = "0.7"
 futures-lite = "2"
 rtrb = "0.3"
 crossbeam-channel = "0.5"
-flume = "0.12"
+kanal = { version = "0.1.1", default-features = false }
 
 [target.'cfg(all(loom, target_pointer_width = "64"))'.dev-dependencies]
 loom = "0.7"

--- a/yring/README.md
+++ b/yring/README.md
@@ -95,12 +95,12 @@ cap=1024, batch=64:
 
 | Channel | API | u64 (8 B) | [u8; 32] | [u8; 64] | [u8; 128] |
 |---------|-----|----------:|----------:|----------:|----------:|
-| **yring** | per-item, batch=1 | 427 | 208 | 99 | 48 |
-| **yring** | per-item, batch=64 | 569 | 394 | 210 | 109 |
-| rtrb | per-item | 32 | 32 | 32 | 32 |
-| rtrb | chunk, batch=64 | **1937** | **603** | **313** | **171** |
-| crossbeam | bounded | 15 | 15 | 14 | 13 |
-| flume | bounded | 4 | 5 | 5 | 5 |
+| **yring** | per-item, batch=1 | 426 | 268 | 98 | 62 |
+| **yring** | per-item, batch=64 | 585 | 366 | **243** | 138 |
+| rtrb | per-item | 32 | 31 | 32 | 32 |
+| rtrb | chunk, batch=64 | **1567** | **625** | 240 | **172** |
+| crossbeam | bounded | 14 | 14 | 15 | 14 |
+| kanal | bounded sync | 7 | 6 | 3 | 1 |
 
 yring vs rtrb per-item (the natural API comparison): **3x** at 64
 bytes, **6x** at 32 bytes. rtrb's chunk API is faster in raw

--- a/yring/benches/comparison.rs
+++ b/yring/benches/comparison.rs
@@ -134,15 +134,17 @@ fn crossbeam_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     received as f64 / start.elapsed().as_secs_f64()
 }
 
-fn flume_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
+fn kanal_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     let stop = Arc::new(AtomicBool::new(false));
-    let (tx, rx) = flume::bounded::<T>(cap);
+    let (tx, rx) = kanal::bounded::<T>(cap);
 
     let stop2 = stop.clone();
     let sender = thread::spawn(move || {
         while !stop2.load(Ordering::Relaxed) {
-            if tx.try_send(val).is_err() {
-                thread::yield_now();
+            match tx.try_send(val) {
+                Ok(true) => {}
+                Ok(false) => thread::yield_now(),
+                Err(_) => break,
             }
         }
     });
@@ -151,8 +153,9 @@ fn flume_bounded<T: Copy + Send + 'static>(cap: usize, val: T) -> f64 {
     let mut received = 0u64;
     while start.elapsed() < DURATION {
         match rx.try_recv() {
-            Ok(_) => received += 1,
-            Err(_) => thread::yield_now(),
+            Ok(Some(_)) => received += 1,
+            Ok(None) => thread::yield_now(),
+            Err(_) => break,
         }
     }
     stop.store(true, Ordering::Relaxed);
@@ -187,8 +190,8 @@ fn run_suite<T: Copy + Send + 'static>(label: &str, cap: usize, batch: usize, va
     let r = crossbeam_bounded(cap, val);
     println!("  crossbeam bounded          {:>7.1}M items/s", m(r));
 
-    let r = flume_bounded(cap, val);
-    println!("  flume bounded              {:>7.1}M items/s", m(r));
+    let r = kanal_bounded(cap, val);
+    println!("  kanal bounded sync         {:>7.1}M items/s", m(r));
 
     println!();
 }

--- a/yring/doc/spsc_comparison.svg
+++ b/yring/doc/spsc_comparison.svg
@@ -3,57 +3,51 @@
   <text x="350.0" y="22" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="700">SPSC channel throughput (M items/s, higher is better)</text>
   <text x="350.0" y="38" text-anchor="middle" fill="#7d8590" font-size="10">cap=1024, 2s per config. Linux VM, i7-8700B @ 3.20 GHz, 6 cores, performance governor, turbo off</text>
   <text x="22" y="180.0" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" transform="rotate(-90,22,180.0)">M items/s</text>
-  <line x1="70" y1="268.9" x2="680" y2="268.9" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="268.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">100</text>
-  <line x1="70" y1="232.8" x2="680" y2="232.8" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="232.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
-  <line x1="70" y1="196.8" x2="680" y2="196.8" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="196.8" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">300</text>
-  <line x1="70" y1="160.7" x2="680" y2="160.7" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="160.7" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
-  <line x1="70" y1="124.6" x2="680" y2="124.6" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="124.6" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">500</text>
-  <line x1="70" y1="88.5" x2="680" y2="88.5" stroke="#21262d" stroke-width="1"/>
-  <text x="62" y="88.5" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">600</text>
+  <line x1="70" y1="235.4" x2="680" y2="235.4" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="235.4" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">200</text>
+  <line x1="70" y1="165.9" x2="680" y2="165.9" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="165.9" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">400</text>
+  <line x1="70" y1="96.3" x2="680" y2="96.3" stroke="#21262d" stroke-width="1"/>
+  <text x="62" y="96.3" text-anchor="end" dominant-baseline="middle" fill="#7d8590" font-size="10">600</text>
   <line x1="70" y1="305" x2="680" y2="305" stroke="#30363d" stroke-width="1.5"/>
-  <rect x="91.6" y="230.1" width="23.7" height="74.9" fill="#e85d04" rx="1"/>
-  <text x="103.5" y="225.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">208</text>
-  <rect x="118.9" y="163.0" width="23.7" height="142.0" fill="#dc2626" rx="1"/>
-  <text x="130.7" y="158.0" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">394</text>
-  <rect x="146.2" y="293.3" width="23.7" height="11.7" fill="#2563eb" rx="1"/>
-  <text x="158.0" y="288.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.3</text>
+  <rect x="91.6" y="211.9" width="23.7" height="93.1" fill="#e85d04" rx="1"/>
+  <text x="103.5" y="206.9" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">268</text>
+  <rect x="118.9" y="177.8" width="23.7" height="127.2" fill="#dc2626" rx="1"/>
+  <text x="130.7" y="172.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">366</text>
+  <rect x="146.2" y="294.1" width="23.7" height="10.9" fill="#2563eb" rx="1"/>
+  <text x="158.0" y="289.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.4</text>
   <rect x="173.4" y="87.6" width="23.7" height="217.4" fill="#7c3aed" rx="1"/>
-  <text x="185.3" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">602</text>
-  <rect x="200.7" y="299.7" width="23.7" height="5.3" fill="#525c68" rx="1"/>
-  <text x="212.6" y="294.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.8</text>
-  <rect x="228.0" y="303.3" width="23.7" height="1.7" fill="#16a34a" rx="1"/>
-  <text x="239.9" y="298.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">4.8</text>
+  <text x="185.3" y="82.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">625</text>
+  <rect x="200.7" y="300.1" width="23.7" height="4.9" fill="#525c68" rx="1"/>
+  <text x="212.6" y="295.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.0</text>
+  <rect x="228.0" y="303.0" width="23.7" height="2.0" fill="#0891b2" rx="1"/>
+  <text x="239.9" y="298.0" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">5.8</text>
   <text x="171.7" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 32]</text>
-  <rect x="294.9" y="269.2" width="23.7" height="35.8" fill="#e85d04" rx="1"/>
-  <text x="306.8" y="264.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">99.2</text>
-  <rect x="322.2" y="229.3" width="23.7" height="75.7" fill="#dc2626" rx="1"/>
-  <text x="334.1" y="224.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">210</text>
-  <rect x="349.5" y="293.4" width="23.7" height="11.6" fill="#2563eb" rx="1"/>
-  <text x="361.4" y="288.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.1</text>
-  <rect x="376.8" y="192.1" width="23.7" height="112.9" fill="#7c3aed" rx="1"/>
-  <text x="388.6" y="187.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">313</text>
-  <rect x="404.1" y="299.9" width="23.7" height="5.1" fill="#525c68" rx="1"/>
-  <text x="415.9" y="294.9" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.2</text>
-  <rect x="431.3" y="303.2" width="23.7" height="1.8" fill="#16a34a" rx="1"/>
-  <text x="443.2" y="298.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">5.0</text>
+  <rect x="294.9" y="270.8" width="23.7" height="34.2" fill="#e85d04" rx="1"/>
+  <text x="306.8" y="265.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">98.4</text>
+  <rect x="322.2" y="220.4" width="23.7" height="84.6" fill="#dc2626" rx="1"/>
+  <text x="334.1" y="215.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">243</text>
+  <rect x="349.5" y="293.8" width="23.7" height="11.2" fill="#2563eb" rx="1"/>
+  <text x="361.4" y="288.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.2</text>
+  <rect x="376.8" y="221.4" width="23.7" height="83.6" fill="#7c3aed" rx="1"/>
+  <text x="388.6" y="216.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">240</text>
+  <rect x="404.1" y="299.7" width="23.7" height="5.3" fill="#525c68" rx="1"/>
+  <text x="415.9" y="294.7" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">15.3</text>
+  <rect x="431.3" y="304.1" width="23.7" height="0.9" fill="#0891b2" rx="1"/>
+  <text x="443.2" y="299.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">2.7</text>
   <text x="375.0" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 64]</text>
-  <rect x="498.3" y="287.8" width="23.7" height="17.2" fill="#e85d04" rx="1"/>
-  <text x="510.1" y="282.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">47.7</text>
-  <rect x="525.6" y="265.6" width="23.7" height="39.4" fill="#dc2626" rx="1"/>
-  <text x="537.4" y="260.6" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">109</text>
-  <rect x="552.8" y="293.5" width="23.7" height="11.5" fill="#2563eb" rx="1"/>
-  <text x="564.7" y="288.5" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">31.9</text>
-  <rect x="580.1" y="243.2" width="23.7" height="61.8" fill="#7c3aed" rx="1"/>
-  <text x="592.0" y="238.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">171</text>
-  <rect x="607.4" y="300.2" width="23.7" height="4.8" fill="#525c68" rx="1"/>
-  <text x="619.3" y="295.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">13.3</text>
-  <rect x="634.7" y="303.4" width="23.7" height="1.6" fill="#16a34a" rx="1"/>
-  <text x="646.5" y="298.4" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">4.5</text>
+  <rect x="498.3" y="283.3" width="23.7" height="21.7" fill="#e85d04" rx="1"/>
+  <text x="510.1" y="278.3" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">62.3</text>
+  <rect x="525.6" y="257.1" width="23.7" height="47.9" fill="#dc2626" rx="1"/>
+  <text x="537.4" y="252.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">138</text>
+  <rect x="552.8" y="293.8" width="23.7" height="11.2" fill="#2563eb" rx="1"/>
+  <text x="564.7" y="288.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">32.3</text>
+  <rect x="580.1" y="245.2" width="23.7" height="59.8" fill="#7c3aed" rx="1"/>
+  <text x="592.0" y="240.2" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">172</text>
+  <rect x="607.4" y="300.1" width="23.7" height="4.9" fill="#525c68" rx="1"/>
+  <text x="619.3" y="295.1" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">14.0</text>
+  <rect x="634.7" y="304.8" width="23.7" height="0.2" fill="#0891b2" rx="1"/>
+  <text x="646.5" y="299.8" text-anchor="middle" fill="#e6edf3" font-size="8" font-weight="600">0.7</text>
   <text x="578.3" y="321" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600">[u8; 128]</text>
   <rect x="130" y="338" width="12" height="12" fill="#e85d04" rx="2"/>
   <text x="148" y="348" fill="#e6edf3" font-size="10" font-weight="500">yring (per-item, no batching)</text>
@@ -65,6 +59,6 @@
   <text x="398" y="348" fill="#e6edf3" font-size="10" font-weight="500">rtrb v0.3 (chunk API, batch=64)</text>
   <rect x="380" y="356" width="12" height="12" fill="#525c68" rx="2"/>
   <text x="398" y="366" fill="#e6edf3" font-size="10" font-weight="500">crossbeam-channel v0.5 (bounded MPMC)</text>
-  <rect x="380" y="374" width="12" height="12" fill="#16a34a" rx="2"/>
-  <text x="398" y="384" fill="#e6edf3" font-size="10" font-weight="500">flume v0.11 (bounded MPMC)</text>
+  <rect x="380" y="374" width="12" height="12" fill="#0891b2" rx="2"/>
+  <text x="398" y="384" fill="#e6edf3" font-size="10" font-weight="500">kanal v0.1 (bounded sync MPMC)</text>
 </svg>

--- a/yring/scripts/gen_chart.py
+++ b/yring/scripts/gen_chart.py
@@ -14,7 +14,7 @@ CHANNEL_ORDER = [
     "rtrb per-item",
     "rtrb chunked",
     "crossbeam bounded",
-    "flume bounded",
+    "kanal bounded sync",
 ]
 
 COLORS = {
@@ -23,7 +23,7 @@ COLORS = {
     "rtrb per-item":      ("#2563eb", "#1d4ed8"),
     "rtrb chunked":       ("#7c3aed", "#6d28d9"),
     "crossbeam bounded":  ("#525c68", "#3d454f"),
-    "flume bounded":      ("#16a34a", "#15803d"),
+    "kanal bounded sync": ("#0891b2", "#0e7490"),
 }
 
 LABELS = {
@@ -32,33 +32,33 @@ LABELS = {
     "rtrb per-item":      "rtrb v0.3 (per-item)",
     "rtrb chunked":       "rtrb v0.3 (chunk API, batch=64)",
     "crossbeam bounded":  "crossbeam-channel v0.5 (bounded MPMC)",
-    "flume bounded":      "flume v0.11 (bounded MPMC)",
+    "kanal bounded sync": "kanal v0.1 (bounded sync MPMC)",
 }
 
 RESULTS = {
     "[u8; 32]": {
-        "yring (batch=1)": 207.6,
-        "yring (batch=64)": 393.6,
-        "rtrb per-item": 32.3,
-        "rtrb chunked": 602.5,
-        "crossbeam bounded": 14.8,
-        "flume bounded": 4.8,
+        "yring (batch=1)": 267.7,
+        "yring (batch=64)": 365.7,
+        "rtrb per-item": 31.4,
+        "rtrb chunked": 625.0,
+        "crossbeam bounded": 14.0,
+        "kanal bounded sync": 5.8,
     },
     "[u8; 64]": {
-        "yring (batch=1)": 99.2,
-        "yring (batch=64)": 209.7,
-        "rtrb per-item": 32.1,
-        "rtrb chunked": 312.8,
-        "crossbeam bounded": 14.2,
-        "flume bounded": 5.0,
+        "yring (batch=1)": 98.4,
+        "yring (batch=64)": 243.2,
+        "rtrb per-item": 32.2,
+        "rtrb chunked": 240.4,
+        "crossbeam bounded": 15.3,
+        "kanal bounded sync": 2.7,
     },
     "[u8; 128]": {
-        "yring (batch=1)": 47.7,
-        "yring (batch=64)": 109.3,
-        "rtrb per-item": 31.9,
-        "rtrb chunked": 171.2,
-        "crossbeam bounded": 13.3,
-        "flume bounded": 4.5,
+        "yring (batch=1)": 62.3,
+        "yring (batch=64)": 137.6,
+        "rtrb per-item": 32.3,
+        "rtrb chunked": 172.0,
+        "crossbeam bounded": 14.0,
+        "kanal bounded sync": 0.7,
     },
 }
 


### PR DESCRIPTION
- Adds `kanal` bounded sync channel to the yring SPSC comparison benchmark.
- Replaces the `flume` chart row with the measured `kanal` sync row.
- Regenerates `yring/doc/spsc_comparison.svg` from the updated chart data.