### PR TITLE
Fix pubsub fast path and matched 2IO benches

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,8 +126,8 @@ when a measured cell looks bad, don't hand-wave it as noise.
 
 | binary | source | impls |
 |--------|--------|-------|
-| `omq_bench_peer_tokio` | `omq-tokio/src/bin/bench_peer_tokio.rs` | omq-tokio-ct, omq-tokio-2t |
-| `omq_bench_peer_blocking` | `omq-tokio/src/bin/bench_peer_blocking.rs` | omq-tokio-1t |
+| `omq_bench_peer_tokio` | `omq-tokio/src/bin/bench_peer_tokio.rs` | omq-tokio-ct |
+| `omq_bench_peer_blocking` | `omq-tokio/src/bin/bench_peer_blocking.rs` | omq-tokio-1t, omq-tokio-2t |
 | `libzmq_bench_peer` | `scripts/libzmq_bench_peer.c` | libzmq, libzmq-2t |
 | `zmqrs_bench_peer` | `scripts/zmqrs_bench_peer/` | zmq.rs |
 | `rzmq_bench_peer` | `scripts/rzmq_bench_peer/` | rzmq, rzmq-iouring |

--- a/doc/charts/main_pubsub_tcp.svg
+++ b/doc/charts/main_pubsub_tcp.svg
@@ -192,105 +192,104 @@ small messages (higher is better)
 <circle cx="201" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="309" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="80,92 86,94 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="88,95 94,97 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="97,98 103,100 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="105,101 111,103 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="114,104 119,106 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="122,107 128,109 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="131,110 136,113 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="139,114 145,116 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="148,117 153,119 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="156,120 162,122 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="165,123 170,125 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="173,126 179,128 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="181,129 187,131 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="190,132 196,134 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="198,135 201,136 204,136 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="207,137 213,138 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="216,138 222,139 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="225,139 231,140 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="234,140 240,141 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="243,141 249,142 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="252,142 258,143 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="261,143 267,144 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="270,145 276,145 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="279,146 285,146 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="288,147 294,147 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="297,148 302,149 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="305,149 311,150 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="314,150 320,151 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="323,152 328,156 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="330,158 335,161 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="337,163 342,167 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="344,169 348,173 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="351,175 355,179 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="358,181 362,184 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="365,186 369,190 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="372,192 376,196 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="378,198 383,202 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="385,203 390,207 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="392,209 397,213 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="399,215 404,219 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="406,221 411,225 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="413,226 418,230 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="420,232 425,236 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="427,238 432,242 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="434,244 439,247 "/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="441,249 444,252 "/>
-<circle cx="80" cy="92" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="136" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="151" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="80,93 85,95 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="88,97 94,99 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="96,100 102,103 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="105,104 110,107 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="113,108 118,110 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="121,112 126,114 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="129,115 135,118 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="137,119 143,122 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="146,123 151,125 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="154,127 159,129 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="162,130 167,133 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="170,134 176,136 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="178,138 184,140 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="187,141 192,144 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="195,145 200,148 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="203,148 209,149 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="212,149 218,149 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="221,150 227,150 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="230,150 236,151 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="239,151 245,152 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="248,152 254,152 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="257,153 263,153 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="266,153 272,154 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="275,154 281,155 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="284,155 290,155 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="293,156 299,156 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="302,156 308,157 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="311,157 317,158 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="320,158 322,158 325,160 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="327,162 332,166 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="334,168 339,171 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="342,173 346,177 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="349,179 353,182 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="356,184 361,188 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="363,190 368,193 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="370,195 375,199 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="377,201 382,204 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="384,206 389,210 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="391,212 396,215 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="399,217 403,221 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="406,222 410,226 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="413,228 418,232 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="420,233 425,237 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="427,239 432,243 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="434,244 439,248 "/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="441,250 444,252 "/>
+<circle cx="80" cy="93" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="148" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="158" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="252" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,143 86,145 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="88,146 94,148 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="97,149 103,151 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="105,152 111,154 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="114,155 120,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="122,158 128,160 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="131,161 137,163 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="139,164 145,166 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="148,167 153,169 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,170 162,172 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="165,173 170,175 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="173,176 179,178 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="182,179 187,181 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="190,182 196,184 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="199,185 201,186 204,188 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="206,190 211,193 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="214,195 219,198 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="221,200 226,203 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="229,205 234,208 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="236,210 241,213 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="244,215 249,218 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="251,220 256,223 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="259,225 264,228 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="266,230 271,233 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="274,235 279,238 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="281,240 286,243 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="289,245 294,248 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="296,250 301,253 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="304,255 309,258 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="311,260 316,263 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="319,265 322,267 324,267 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="327,267 333,268 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="336,268 342,268 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="345,269 351,269 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="354,269 360,270 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="363,270 369,270 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="372,271 378,271 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="381,271 387,272 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="390,272 396,272 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="399,273 405,273 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="408,273 414,274 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="417,274 423,274 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="426,275 432,275 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="435,275 441,276 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="444,276 444,276 "/>
-<circle cx="80" cy="143" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="186" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="267" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="276" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,145 86,147 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="89,148 94,150 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="97,151 103,153 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="106,154 111,156 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="114,157 120,159 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="123,160 128,162 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="131,163 137,165 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="140,166 145,168 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="148,169 154,171 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="157,172 162,174 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="165,175 171,176 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="174,177 179,179 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="182,180 188,182 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="191,183 196,185 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="199,186 201,187 204,189 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="207,191 212,194 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="214,196 219,199 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="222,201 227,204 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="229,206 234,209 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="237,210 242,214 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="244,215 249,219 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="252,220 257,224 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="260,225 265,229 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="267,230 272,233 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="275,235 280,238 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="282,240 287,243 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="290,245 295,248 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="297,250 302,253 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="305,255 310,258 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="312,260 317,263 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="320,265 322,266 325,266 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="328,267 334,267 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="337,267 343,268 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="346,268 352,269 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="355,269 361,270 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="364,270 370,270 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="373,271 379,271 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="382,271 388,272 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="391,272 397,273 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="400,273 406,274 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="409,274 415,274 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="418,275 424,275 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="427,275 433,276 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="436,276 442,277 "/>
+<circle cx="80" cy="145" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="187" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="266" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="277" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="80,157 86,159 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="88,160 94,162 "/>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="97,163 103,165 "/>
@@ -395,10 +394,9 @@ medium/large messages (higher is better)
 <line opacity="1" stroke="#374151" stroke-width="1" x1="746" y1="311" x2="746" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="877" y1="311" x2="877" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="311" x2="877" y2="311"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="260" x2="877" y2="260"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="209" x2="877" y2="209"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="158" x2="877" y2="158"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="107" x2="877" y2="107"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="248" x2="877" y2="248"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="184" x2="877" y2="184"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="120" x2="877" y2="120"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="485" y1="56" x2="877" y2="56"/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="485,312 877,312 "/>
 <text x="485" y="322" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
@@ -422,61 +420,57 @@ medium/large messages (higher is better)
 
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,311 883,311 "/>
-<text x="888" y="260" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<text x="888" y="248" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2 GB/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,260 883,260 "/>
-<text x="888" y="209" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,248 883,248 "/>
+<text x="888" y="184" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4 GB/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,209 883,209 "/>
-<text x="888" y="158" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,184 883,184 "/>
+<text x="888" y="120" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6 GB/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,158 883,158 "/>
-<text x="888" y="107" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,120 883,120 "/>
+<text x="888" y="56" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8 GB/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,107 883,107 "/>
-<text x="888" y="56" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10 GB/s
-</text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,56 883,56 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="485,285 615,242 746,179 877,157 "/>
-<circle cx="485" cy="285" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="242" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="179" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="157" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="485,295 615,261 746,213 877,172 "/>
-<circle cx="485" cy="295" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="261" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="213" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="172" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="485,310 615,307 746,296 877,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="485,279 615,225 746,146 877,118 "/>
+<circle cx="485" cy="279" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="225" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="146" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="118" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="485,291 615,249 746,189 877,137 "/>
+<circle cx="485" cy="291" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="249" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="189" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="137" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="485,310 615,306 746,293 877,255 "/>
 <circle cx="485" cy="310" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="296" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="266" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="485,246 615,214 746,122 877,91 "/>
-<circle cx="485" cy="246" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="214" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="122" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="91" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,293 615,254 746,201 877,174 "/>
-<circle cx="485" cy="293" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="254" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="201" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="174" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="485,286 615,286 746,284 877,270 "/>
-<circle cx="485" cy="286" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="286" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="284" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="270" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,291 615,287 746,285 877,274 "/>
-<circle cx="485" cy="291" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="287" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="285" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="274" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="293" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="255" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="485,233 615,190 746,65 877,58 "/>
+<circle cx="485" cy="233" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="190" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="65" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="58" r="2.5" opacity="1" fill="#B91C1C" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,288 615,240 746,172 877,134 "/>
+<circle cx="485" cy="288" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="240" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="172" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="134" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="485,280 615,280 746,277 877,259 "/>
+<circle cx="485" cy="280" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="280" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="277" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="259" r="2.5" opacity="1" fill="#F59E0B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,286 615,280 746,278 877,264 "/>
+<circle cx="485" cy="286" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="280" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="278" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="264" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
@@ -511,7 +505,7 @@ omq
 1 IO
 </text>
 <text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-191%
+189%
 </text>
 <polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -521,7 +515,7 @@ omq
 2 IO
 </text>
 <text x="340" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-254%
+235%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,430 92,430 "/>
 <text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">

--- a/omq-bench/src/bench/comparisons.rs
+++ b/omq-bench/src/bench/comparisons.rs
@@ -99,7 +99,7 @@ static IMPLS: &[ImplDef] = &[
     },
     ImplDef {
         name: "omq-tokio-2t",
-        binary_from: Some("omq-tokio-ct"),
+        binary_from: Some("omq-tokio-1t"),
         prefix: "u",
         class: Some(ImplClass::Classic),
         main: false,
@@ -259,7 +259,7 @@ static IMPLS: &[ImplDef] = &[
     },
     ImplDef {
         name: "omq-curve-2t",
-        binary_from: Some("omq-tokio-ct"),
+        binary_from: Some("omq-tokio-1t"),
         prefix: "oc2",
         class: Some(ImplClass::Curve),
         main: false,
@@ -279,50 +279,12 @@ fn find_impl(name: &str) -> Option<&'static ImplDef> {
     IMPLS.iter().find(|i| i.name == name)
 }
 
-fn canonical_peer_binary<'a>(
-    binary: &'a Path,
-    def: &ImplDef,
-    binaries: &'a HashMap<String, PathBuf>,
-) -> &'a Path {
-    if def.binary_from.unwrap_or(def.name) == "omq-tokio-ct" {
-        &binaries["omq-tokio-1t"]
-    } else {
-        binary
-    }
-}
-
-fn io_bench_binary<'a>(impl_name: &str, binaries: &'a HashMap<String, PathBuf>) -> &'a Path {
-    if matches!(impl_name, "omq-tokio-2t" | "omq-curve-2t") {
-        &binaries["omq-tokio-1t"]
-    } else {
-        &binaries[impl_name]
-    }
-}
-
+#[cfg(test)]
 fn impl_io_threads(def: &ImplDef) -> &'static str {
     def.env
         .iter()
         .find_map(|&(k, v)| matches!(k, "OMQ_IO_THREADS" | "ZMQ_IO_THREADS").then_some(v))
         .unwrap_or("1")
-}
-
-fn non_io_env(def: &ImplDef) -> Vec<(&'static str, &'static str)> {
-    def.env
-        .iter()
-        .copied()
-        .filter(|(k, _)| *k != "OMQ_IO_THREADS" && *k != "ZMQ_IO_THREADS")
-        .collect()
-}
-
-fn latency_client_io_threads(def: &ImplDef, override_threads: Option<&str>) -> Option<String> {
-    if let Some(threads) = override_threads {
-        return Some(threads.to_string());
-    }
-    if def.name == "omq-tokio-ct" {
-        None
-    } else {
-        Some(impl_io_threads(def).to_string())
-    }
 }
 
 fn all_chart_sizes() -> Vec<u64> {
@@ -398,17 +360,13 @@ fn addr_for(
 fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMap<String, PathBuf> {
     let mut binaries: HashMap<String, PathBuf> = HashMap::new();
     let mut built: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    let mut sources: Vec<&str> = impl_names
+    let sources: Vec<&str> = impl_names
         .iter()
         .map(|&name| {
             let def = find_impl(name).unwrap();
             def.binary_from.unwrap_or(def.name)
         })
         .collect();
-    if sources.contains(&"omq-tokio-ct") && !sources.contains(&"omq-tokio-1t") {
-        sources.push("omq-tokio-1t");
-    }
-
     for source in sources {
         if built.contains(source) {
             continue;
@@ -447,6 +405,13 @@ fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMa
                 );
             }
             "omq-tokio-1t" => {
+                let mut features = Vec::new();
+                if needs_ws {
+                    features.push("ws");
+                }
+                if needs_curve {
+                    features.push("curve");
+                }
                 let mut cmd = vec![
                     "cargo",
                     "build",
@@ -457,9 +422,11 @@ fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMa
                     "omq_bench_peer_blocking",
                     "-q",
                 ];
-                if needs_curve {
+                let feat_str;
+                if !features.is_empty() {
+                    feat_str = features.join(",");
                     cmd.push("--features");
-                    cmd.push("curve");
+                    cmd.push(&feat_str);
                 }
                 run_build(&cmd);
                 binaries.insert(
@@ -708,11 +675,7 @@ fn run_throughput_once(
     let connect_addr;
 
     let push_env: Vec<(&str, &str)> = def.env.to_vec();
-    let mut pull_env: Vec<(&str, &str)> = non_io_env(def);
-    let pull_io_threads = std::env::var("OMQ_BENCH_RECEIVER_IO_THREADS")
-        .unwrap_or_else(|_| impl_io_threads(def).to_string());
-    pull_env.push(("OMQ_IO_THREADS", &pull_io_threads));
-    pull_env.push(("ZMQ_IO_THREADS", &pull_io_threads));
+    let pull_env: Vec<(&str, &str)> = def.env.to_vec();
 
     let push_cmd: Vec<&str>;
     let mut push_proc;
@@ -865,11 +828,7 @@ fn run_pubsub_once(
     let connect_addr;
 
     let mut pub_env: Vec<(&str, &str)> = def.env.to_vec();
-    let mut sub_env: Vec<(&str, &str)> = non_io_env(def);
-    let receiver_io_threads = std::env::var("OMQ_BENCH_RECEIVER_IO_THREADS")
-        .unwrap_or_else(|_| impl_io_threads(def).to_string());
-    sub_env.push(("OMQ_IO_THREADS", &receiver_io_threads));
-    sub_env.push(("ZMQ_IO_THREADS", &receiver_io_threads));
+    let mut sub_env: Vec<(&str, &str)> = def.env.to_vec();
     let start_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before Unix epoch")
@@ -1002,11 +961,7 @@ fn run_fanout_once(
     let connect_addr;
 
     let mut push_env: Vec<(&str, &str)> = def.env.to_vec();
-    let mut pull_env: Vec<(&str, &str)> = non_io_env(def);
-    let pull_io_threads = std::env::var("OMQ_BENCH_RECEIVER_IO_THREADS")
-        .unwrap_or_else(|_| impl_io_threads(def).to_string());
-    pull_env.push(("OMQ_IO_THREADS", &pull_io_threads));
-    pull_env.push(("ZMQ_IO_THREADS", &pull_io_threads));
+    let mut pull_env: Vec<(&str, &str)> = def.env.to_vec();
     let start_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before Unix epoch")
@@ -1172,11 +1127,7 @@ fn run_fanin_once(
     let connect_addr;
 
     let mut pull_env: Vec<(&str, &str)> = def.env.to_vec();
-    let mut push_env: Vec<(&str, &str)> = non_io_env(def);
-    let push_io_threads = std::env::var("OMQ_BENCH_SENDER_IO_THREADS")
-        .unwrap_or_else(|_| impl_io_threads(def).to_string());
-    push_env.push(("OMQ_IO_THREADS", &push_io_threads));
-    push_env.push(("ZMQ_IO_THREADS", &push_io_threads));
+    let mut push_env: Vec<(&str, &str)> = def.env.to_vec();
     let start_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before Unix epoch")
@@ -1333,13 +1284,7 @@ fn run_latency_cell(
     let connect_addr;
 
     let rep_env: Vec<(&str, &str)> = def.env.to_vec();
-    let mut req_env: Vec<(&str, &str)> = non_io_env(def);
-    let req_io_threads_override = std::env::var("OMQ_BENCH_CLIENT_IO_THREADS").ok();
-    let req_io_threads = latency_client_io_threads(def, req_io_threads_override.as_deref());
-    if let Some(req_io_threads) = req_io_threads.as_deref() {
-        req_env.push(("OMQ_IO_THREADS", req_io_threads));
-        req_env.push(("ZMQ_IO_THREADS", req_io_threads));
-    }
+    let req_env: Vec<(&str, &str)> = def.env.to_vec();
 
     let mut rep_cmd = vec![peer_binary_str, "rep"];
     if transport == TransportKind::Tcp {
@@ -1580,8 +1525,8 @@ pub(crate) fn run(args: ComparisonsArgs) {
                 let mut cells = Vec::with_capacity(active_impls.len());
                 for &impl_name in &active_impls {
                     let def = find_impl(impl_name).unwrap();
-                    let binary = io_bench_binary(impl_name, &binaries);
-                    let peer_binary = canonical_peer_binary(binary, def, &binaries);
+                    let binary = binaries[impl_name].as_path();
+                    let peer_binary = binary;
 
                     let result = run_throughput_cell(
                         binary,
@@ -1655,7 +1600,7 @@ pub(crate) fn run(args: ComparisonsArgs) {
                 let mut cells = Vec::with_capacity(active_impls.len());
                 for &impl_name in &active_impls {
                     let def = find_impl(impl_name).unwrap();
-                    let binary = io_bench_binary(impl_name, &binaries);
+                    let binary = binaries[impl_name].as_path();
 
                     let result = run_latency_cell(
                         binary,
@@ -1737,8 +1682,8 @@ pub(crate) fn run(args: ComparisonsArgs) {
                     let mut cells = Vec::with_capacity(pubsub_impls.len());
                     for &impl_name in &pubsub_impls {
                         let def = find_impl(impl_name).unwrap();
-                        let binary = io_bench_binary(impl_name, &binaries);
-                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+                        let binary = binaries[impl_name].as_path();
+                        let peer_binary = binary;
 
                         let result = run_pubsub_cell(
                             binary,
@@ -1829,8 +1774,8 @@ pub(crate) fn run(args: ComparisonsArgs) {
                     let mut cells = Vec::with_capacity(fanout_impls.len());
                     for &impl_name in &fanout_impls {
                         let def = find_impl(impl_name).unwrap();
-                        let binary = io_bench_binary(impl_name, &binaries);
-                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+                        let binary = binaries[impl_name].as_path();
+                        let peer_binary = binary;
 
                         let result = run_fanout_cell(
                             binary,
@@ -1915,8 +1860,8 @@ pub(crate) fn run(args: ComparisonsArgs) {
                     let mut cells = Vec::with_capacity(fanin_impls.len());
                     for &impl_name in &fanin_impls {
                         let def = find_impl(impl_name).unwrap();
-                        let binary = io_bench_binary(impl_name, &binaries);
-                        let peer_binary = canonical_peer_binary(binary, def, &binaries);
+                        let binary = binaries[impl_name].as_path();
+                        let peer_binary = binary;
 
                         let result = run_fanin_cell(
                             binary,
@@ -2007,8 +1952,8 @@ pub(crate) fn run(args: ComparisonsArgs) {
                 let mut cells = Vec::with_capacity(curve_impls.len());
                 for &impl_name in &curve_impls {
                     let def = find_impl(impl_name).unwrap();
-                    let binary = io_bench_binary(impl_name, &binaries);
-                    let peer_binary = canonical_peer_binary(binary, def, &binaries);
+                    let binary = binaries[impl_name].as_path();
+                    let peer_binary = binary;
 
                     let result = run_pubsub_cell(
                         binary,
@@ -2127,20 +2072,47 @@ fn fmt_gbps(val: f64) -> String {
 mod tests {
     use super::*;
 
+    fn io_threads_from_env<'a>(env: &'a [(&'a str, &'a str)]) -> &'a str {
+        env.iter()
+            .find_map(|&(k, v)| matches!(k, "OMQ_IO_THREADS" | "ZMQ_IO_THREADS").then_some(v))
+            .unwrap_or("1")
+    }
+
     #[test]
-    fn latency_client_keeps_ct_embedded_by_default() {
+    fn two_io_omq_impls_use_blocking_binary_source() {
         let ct = find_impl("omq-tokio-ct").unwrap();
         let two_thread = find_impl("omq-tokio-2t").unwrap();
+        let curve_two_thread = find_impl("omq-curve-2t").unwrap();
 
-        assert_eq!(latency_client_io_threads(ct, None), None);
-        assert_eq!(
-            latency_client_io_threads(ct, Some("2")).as_deref(),
-            Some("2")
-        );
-        assert_eq!(
-            latency_client_io_threads(two_thread, None).as_deref(),
-            Some("2")
-        );
+        assert_eq!(ct.binary_from, None);
+        assert_eq!(two_thread.binary_from, Some("omq-tokio-1t"));
+        assert_eq!(curve_two_thread.binary_from, Some("omq-tokio-1t"));
+    }
+
+    #[test]
+    fn paired_benchmark_envs_match_exactly() {
+        for def in IMPLS {
+            let sender_env = def.env.to_vec();
+            let receiver_env = def.env.to_vec();
+            let sender_io = io_threads_from_env(&sender_env);
+            let receiver_io = io_threads_from_env(&receiver_env);
+
+            assert_eq!(sender_env, receiver_env, "{}", def.name);
+            assert_eq!(sender_io, receiver_io, "{}", def.name);
+        }
+    }
+
+    #[test]
+    fn two_io_impls_configure_two_io_threads() {
+        for name in [
+            "omq-tokio-2t",
+            "libzmq-2t",
+            "omq-curve-2t",
+            "libzmq-curve-2t",
+        ] {
+            let def = find_impl(name).unwrap();
+            assert_eq!(impl_io_threads(def), "2", "{name}");
+        }
     }
 
     #[test]

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -137,20 +137,23 @@ impl Submitter {
 
         // Slow path: fallback peers exist, acquire inner mutex.
         let g = self.inner.lock().expect("fanout inner poisoned");
+        let all_subscribe_all =
+            filter::all_peers_subscribe_all(self.mode, g.subscribe_all_count, g.peers.len());
         let fallback_targets: SmallVec<[PeerOutbound; 8]> = g
             .peers
             .values()
             .filter(|p| p.lane.is_none())
             .filter(|p| p.fanout_active)
             .filter(|p| {
-                filter::peer_matches(
-                    self.mode,
-                    &p.subscriptions,
-                    &p.groups,
-                    p.any_groups,
-                    &topic,
-                    group.as_deref(),
-                )
+                all_subscribe_all
+                    || filter::peer_matches(
+                        self.mode,
+                        &p.subscriptions,
+                        &p.groups,
+                        p.any_groups,
+                        &topic,
+                        group.as_deref(),
+                    )
             })
             .map(|p| p.target.clone())
             .collect();
@@ -223,6 +226,7 @@ pub(crate) struct FanOutSend {
 
 struct FanOutInner {
     peers: FxHashMap<u64, FanOutPeer>,
+    subscribe_all_count: usize,
     has_compression: bool,
     compression_dict: Option<Bytes>,
     options: Options,
@@ -280,6 +284,7 @@ impl FanOutSend {
         let lanes = FanOutLanes::spawn(options, mode, lossy, io_pool);
         let inner = Arc::new(Mutex::new(FanOutInner {
             peers: FxHashMap::default(),
+            subscribe_all_count: 0,
             has_compression: false,
             compression_dict: options.compression_dict.clone(),
             options: options.clone(),
@@ -428,6 +433,9 @@ impl FanOutSend {
     pub(crate) fn connection_removed(&mut self, peer_id: u64) {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if let Some(peer) = g.peers.remove(&peer_id) {
+            if peer.subscriptions.is_subscribe_all() {
+                g.subscribe_all_count = g.subscribe_all_count.saturating_sub(1);
+            }
             if peer.lane.is_some() {
                 self.lane_peer_count.fetch_sub(1, Ordering::Release);
             } else {
@@ -445,8 +453,11 @@ impl FanOutSend {
     pub(crate) fn peer_subscribe(&self, peer_id: u64, prefix: Bytes) {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if let Some(p) = g.peers.get_mut(&peer_id) {
-            p.subscriptions.add(&prefix);
+            let became_subscribe_all = filter::add_subscription(&mut p.subscriptions, &prefix);
             let lane = p.lane;
+            if became_subscribe_all {
+                g.subscribe_all_count += 1;
+            }
             drop(g);
             if let Some(lane) = lane {
                 self.lanes.send_subscribe(lane, peer_id, prefix.clone());
@@ -458,8 +469,11 @@ impl FanOutSend {
     pub(crate) fn peer_cancel(&self, peer_id: u64, prefix: &[u8]) {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if let Some(p) = g.peers.get_mut(&peer_id) {
-            p.subscriptions.remove(prefix);
+            let stopped_subscribe_all = filter::remove_subscription(&mut p.subscriptions, prefix);
             let lane = p.lane;
+            if stopped_subscribe_all {
+                g.subscribe_all_count = g.subscribe_all_count.saturating_sub(1);
+            }
             drop(g);
             if let Some(lane) = lane {
                 self.lanes
@@ -505,6 +519,7 @@ impl FanOutSend {
         self.lanes.shutdown();
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         g.peers.clear();
+        g.subscribe_all_count = 0;
         drop(g);
         self.lane_peer_count.store(0, Ordering::Release);
         self.fallback_peer_count.store(0, Ordering::Release);

--- a/omq-tokio/src/routing/fan_out/filter.rs
+++ b/omq-tokio/src/routing/fan_out/filter.rs
@@ -59,3 +59,66 @@ pub(super) fn peer_matches(
         (FanOutMode::Group, None) => false,
     }
 }
+
+pub(super) fn add_subscription(subscriptions: &mut SubscriptionSet, prefix: &[u8]) -> bool {
+    let was_all = subscriptions.is_subscribe_all();
+    subscriptions.add(prefix);
+    !was_all && subscriptions.is_subscribe_all()
+}
+
+pub(super) fn remove_subscription(subscriptions: &mut SubscriptionSet, prefix: &[u8]) -> bool {
+    let was_all = subscriptions.is_subscribe_all();
+    subscriptions.remove(prefix);
+    was_all && !subscriptions.is_subscribe_all()
+}
+
+pub(super) fn all_peers_subscribe_all(
+    mode: FanOutMode,
+    subscribe_all_count: usize,
+    peer_count: usize,
+) -> bool {
+    matches!(mode, FanOutMode::SubscriptionPrefix)
+        && peer_count != 0
+        && subscribe_all_count == peer_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_all_counter_changes_only_on_empty_prefix_edges() {
+        let mut subscriptions = SubscriptionSet::new();
+
+        assert!(!add_subscription(&mut subscriptions, b"abc"));
+        assert!(!subscriptions.is_subscribe_all());
+        assert!(add_subscription(&mut subscriptions, b""));
+        assert!(subscriptions.is_subscribe_all());
+        assert!(!add_subscription(&mut subscriptions, b""));
+        assert!(!remove_subscription(&mut subscriptions, b"abc"));
+        assert!(subscriptions.is_subscribe_all());
+        assert!(remove_subscription(&mut subscriptions, b""));
+        assert!(!subscriptions.is_subscribe_all());
+        assert!(!remove_subscription(&mut subscriptions, b""));
+    }
+
+    #[test]
+    fn all_peers_subscribe_all_requires_subscription_mode_and_peers() {
+        assert!(all_peers_subscribe_all(
+            FanOutMode::SubscriptionPrefix,
+            2,
+            2
+        ));
+        assert!(!all_peers_subscribe_all(
+            FanOutMode::SubscriptionPrefix,
+            0,
+            0
+        ));
+        assert!(!all_peers_subscribe_all(
+            FanOutMode::SubscriptionPrefix,
+            1,
+            2
+        ));
+        assert!(!all_peers_subscribe_all(FanOutMode::Group, 2, 2));
+    }
+}

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -150,6 +150,7 @@ struct LaneWorker {
     mode: FanOutMode,
     lossy: bool,
     peers: FxHashMap<u64, LanePeer>,
+    subscribe_all_count: usize,
     eq: FrameBuffer,
     chunks: Vec<Bytes>,
     #[cfg(feature = "lz4")]
@@ -250,6 +251,7 @@ impl FanOutLanes {
                     mode,
                     lossy,
                     peers: FxHashMap::default(),
+                    subscribe_all_count: 0,
                     eq: FrameBuffer::one_shot(),
                     chunks: Vec::new(),
                     #[cfg(feature = "lz4")]
@@ -431,6 +433,7 @@ impl LaneWorker {
             if shutdown {
                 self.flush_touched(&mut touched);
                 self.peers.clear();
+                self.subscribe_all_count = 0;
                 return;
             }
 
@@ -518,16 +521,24 @@ impl LaneWorker {
                 );
             }
             LaneControl::RemovePeer { peer_id } => {
-                self.peers.remove(&peer_id);
+                if let Some(peer) = self.peers.remove(&peer_id)
+                    && peer.subscriptions.is_subscribe_all()
+                {
+                    self.subscribe_all_count = self.subscribe_all_count.saturating_sub(1);
+                }
             }
             LaneControl::Subscribe { peer_id, prefix } => {
-                if let Some(peer) = self.peers.get_mut(&peer_id) {
-                    peer.subscriptions.add(&prefix);
+                if let Some(peer) = self.peers.get_mut(&peer_id)
+                    && filter::add_subscription(&mut peer.subscriptions, &prefix)
+                {
+                    self.subscribe_all_count += 1;
                 }
             }
             LaneControl::Cancel { peer_id, prefix } => {
-                if let Some(peer) = self.peers.get_mut(&peer_id) {
-                    peer.subscriptions.remove(&prefix);
+                if let Some(peer) = self.peers.get_mut(&peer_id)
+                    && filter::remove_subscription(&mut peer.subscriptions, &prefix)
+                {
+                    self.subscribe_all_count = self.subscribe_all_count.saturating_sub(1);
                 }
             }
             LaneControl::Join { peer_id, group } => {
@@ -577,16 +588,19 @@ impl LaneWorker {
 
     async fn dispatch(&mut self, dispatch: &LaneDispatch, touched: &mut SmallVec<[u64; 32]>) {
         let mut peer_ids = SmallVec::<[u64; 32]>::new();
+        let all_subscribe_all =
+            filter::all_peers_subscribe_all(self.mode, self.subscribe_all_count, self.peers.len());
         for (&peer_id, peer) in &self.peers {
             if peer.slot.fanout_active()
-                && filter::peer_matches(
-                    self.mode,
-                    &peer.subscriptions,
-                    &peer.groups,
-                    peer.any_groups,
-                    &dispatch.topic,
-                    dispatch.group.as_deref(),
-                )
+                && (all_subscribe_all
+                    || filter::peer_matches(
+                        self.mode,
+                        &peer.subscriptions,
+                        &peer.groups,
+                        peer.any_groups,
+                        &dispatch.topic,
+                        dispatch.group.as_deref(),
+                    ))
             {
                 peer_ids.push(peer_id);
             }

--- a/scripts/run_comparisons.py
+++ b/scripts/run_comparisons.py
@@ -207,7 +207,6 @@ def libzmq_version() -> str:
 
 MEASURED_CPU = "0,1,2,3"
 OTHER_CPU = "3,4,5"
-SINK_IO_THREADS = "3"
 
 
 def spawn_process(binary: str, *args: str, env: dict | None = None,
@@ -495,7 +494,7 @@ def _run_throughput_once(
     dur = str(duration)
     issues: list = []
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
-    recv_env = {**cell_env, "OMQ_IO_THREADS": "1"}
+    recv_env = cell_env
     if transport == "inproc":
         fresh_name = f"{addr}-{next_addr_id()}"
         timeout_s = max(int(duration) + 5, 8)
@@ -586,9 +585,7 @@ def _run_pubsub_once(
     else:
         addr = _fresh_addr(addr)
         cleanup_ipc_socket(addr)
-        recv_env = {**cell_env,
-                    "OMQ_IO_THREADS": SINK_IO_THREADS,
-                    "ZMQ_IO_THREADS": SINK_IO_THREADS}
+        recv_env = cell_env
         pub_args = [binary, "pub", addr, str(size)]
         if pub_needs_peers:
             pub_args.append(str(peers))
@@ -659,9 +656,7 @@ def _run_fanout_once(
     cleanup_ipc_socket(addr)
     issues: list = []
     cell_env = {**(env or {}), "OMQ_BENCH_START_AT": f"{time.time() + 2.0:.6f}"}
-    recv_env = {**cell_env,
-                "OMQ_IO_THREADS": SINK_IO_THREADS,
-                "ZMQ_IO_THREADS": SINK_IO_THREADS}
+    recv_env = cell_env
     push_args = [binary, fanout_subcmd, addr, str(size)]
     if fanout_needs_peers:
         push_args.append(str(peers))
@@ -914,7 +909,7 @@ IMPLS = {
         "supports_pubsub": True,
     },
     "omq-tokio-2t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "u",
         "class": "classic",
         "transports": ["tcp", "inproc", "ipc", "ws"],
@@ -979,7 +974,7 @@ IMPLS = {
         "env": {"RZMQ_IO_URING": "1"},
     },
     "omq-tokio-1t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "s1",
         "transports": ["tcp", "ipc"],
         "pub_needs_peer_count": True,
@@ -989,7 +984,7 @@ IMPLS = {
         "env": {"OMQ_IO_THREADS": "1"},
     },
     "omq-tokio-4t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "s4",
         "transports": ["tcp", "ipc"],
         "pub_needs_peer_count": True,
@@ -1023,7 +1018,7 @@ IMPLS = {
         "env": {"ZMQ_IO_THREADS": "4", "ZMQ_BENCH_CURVE": "1"},
     },
     "omq-curve-1t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "oc1",
         "class": "curve",
         "transports": ["tcp"],
@@ -1032,7 +1027,7 @@ IMPLS = {
         "env": {"OMQ_IO_THREADS": "1", "OMQ_BENCH_MECHANISM": "curve"},
     },
     "omq-curve-2t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "oc2",
         "class": "curve",
         "transports": ["tcp"],
@@ -1041,7 +1036,7 @@ IMPLS = {
         "env": {"OMQ_IO_THREADS": "2", "OMQ_BENCH_MECHANISM": "curve"},
     },
     "omq-curve-4t": {
-        "binary_from": "omq-tokio",
+        "binary_from": "omq-tokio-1t",
         "prefix": "oc4",
         "class": "curve",
         "transports": ["tcp"],
@@ -1062,16 +1057,22 @@ def build_peers(impl_names: set[str], ws_needed: bool):
 
     omq_io_names = {"omq-tokio-1t", "omq-tokio-2t", "omq-tokio-4t"}
     curve_omq_names = {"omq-curve-1t", "omq-curve-2t", "omq-curve-4t"}
-    omq_all = {"omq-tokio", "omq-tokio-2t"} | omq_io_names | curve_omq_names
-    if impl_names & omq_all:
-        print("==> building omq-tokio omq_bench_peer...", file=sys.stderr)
+    if "omq-tokio" in impl_names:
+        print("==> building omq-tokio omq_bench_peer_tokio...", file=sys.stderr)
         tokio_features = list(features) if features else []
-        if impl_names & curve_omq_names:
-            tokio_features.append("curve")
         cargo_build("omq-tokio", "omq_bench_peer_tokio", features=tokio_features)
-        tokio_bin = str(ROOT / "target" / "release" / "omq_bench_peer_tokio")
-        for name in omq_all & impl_names:
-            binaries[name] = tokio_bin
+        binaries["omq-tokio"] = str(ROOT / "target" / "release" / "omq_bench_peer_tokio")
+
+    blocking_omq_names = omq_io_names | curve_omq_names
+    if impl_names & blocking_omq_names:
+        print("==> building omq-tokio omq_bench_peer_blocking...", file=sys.stderr)
+        blocking_features = list(features) if features else []
+        if impl_names & curve_omq_names:
+            blocking_features.append("curve")
+        cargo_build("omq-tokio", "omq_bench_peer_blocking", features=blocking_features)
+        blocking_bin = str(ROOT / "target" / "release" / "omq_bench_peer_blocking")
+        for name in blocking_omq_names & impl_names:
+            binaries[name] = blocking_bin
 
     curve_libzmq_names = {"libzmq-curve-1t", "libzmq-curve-2t", "libzmq-curve-4t"}
     if impl_names & ({"libzmq", "libzmq-2t", "libzmq-mt"} | curve_libzmq_names):


### PR DESCRIPTION
- Restore subscribe-all fast path by tracking empty-prefix subscription counts in fan-out routing and lane workers.
- Use same comparison-bench binary and IO-thread env on both benchmark roles for each impl.
- Refresh main PUB/SUB TCP chart from matched 2IO benchmark data.