### PR TITLE
Add proxy helper and binding integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ scripts/omq_libzmq_bench_peer
 perf.data*
 /TODO
 .chart_hw
+!bindings/pyomq/.chart_hw
 .perf_hw

--- a/bindings/pyomq/.chart_hw
+++ b/bindings/pyomq/.chart_hw
@@ -1,0 +1,2 @@
+prefix=Linux VM on a 2018 Mac Mini
+postfix=performance governor, turbo off

--- a/bindings/pyomq/CLAUDE.md
+++ b/bindings/pyomq/CLAUDE.md
@@ -30,18 +30,17 @@ workspace root lock file.
 
 ## Benchmarks
 
-**Always set `OMQ_HW_EXTRAS` before running.** It appends to the chart
-subtitle alongside any auto-detected governor/turbo info. On the bench
-machine (i7-8700B, performance governor, turbo off):
+Chart subtitle reads `bindings/pyomq/.chart_hw` plus detected CPU info.
+Use `OMQ_HW_PREFIX`/`OMQ_HW_POSTFIX` to override it for one run, or
+`OMQ_HW_EXTRAS` to append one-off details.
 
-```sh
-export OMQ_HW_EXTRAS="performance governor,turbo off"
-```
+Bench machine: i7-8700B, performance governor, turbo off.
 
 ```sh
 maturin develop --release
 python scripts/update_perf.py                # full (pyomq + pyzmq)
 python scripts/update_perf.py --impl pyomq   # reuse latest pyzmq baseline
+python scripts/update_perf.py --proxy-only --impl pyomq
 python scripts/update_perf.py --chart-only   # regenerate SVG from JSONL
 ```
 
@@ -49,11 +48,11 @@ Results in `~/.cache/omq/bindings.jsonl` (latest `run_id` per impl wins).
 Regenerates `doc/charts/bindings.svg` and the proxy table in `README.md`.
 
 The proxy PUSH/PULL benchmark uses a native omq-tokio client
-(`bench_proxy_client`) to saturate the proxy without Python
+(`omq_bench_proxy_client`) to saturate the proxy without Python
 sender/receiver overhead. Build it before running benchmarks:
 
 ```sh
-cargo build --release -p omq-tokio --bin bench_proxy_client
+cargo build --release -p omq-tokio --bin omq_bench_proxy_client
 ```
 
 If the binary is missing, the proxy PUSH/PULL bench falls back to

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -37,13 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "blume"
-version = "0.4.5"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,17 +192,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -514,7 +496,6 @@ name = "omq-tokio"
 version = "0.19.1"
 dependencies = [
  "arc-swap",
- "blume",
  "bytes",
  "concurrent-queue",
  "futures",
@@ -541,12 +522,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "patricia_tree"

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -78,8 +78,8 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.08 M/s |  1.60 M/s | **1.30×** |
-| REQ/REP rt/s       |   8,140/s |   4,543/s | **1.79×** |
+| PUSH/PULL msg/s    |  2.81 M/s |  1.53 M/s | **1.83×** |
+| REQ/REP rt/s       |   8,411/s |   4,511/s | **1.86×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -1,31 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
   <rect width="850" height="684" fill="white"/>
   <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 6 cores</text>
-  <line x1="90" y1="342.1" x2="760" y2="342.1" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="342.1" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
-  <text x="768" y="342.1" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="300.2" x2="760" y2="300.2" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="300.2" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="300.2" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.0 GB/s</text>
-  <line x1="90" y1="258.4" x2="760" y2="258.4" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="258.4" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
-  <text x="768" y="258.4" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
   <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.0 GB/s</text>
-  <line x1="90" y1="174.6" x2="760" y2="174.6" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="174.6" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
-  <text x="768" y="174.6" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="132.8" x2="760" y2="132.8" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="132.8" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
-  <text x="768" y="132.8" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.0 GB/s</text>
-  <line x1="90" y1="90.9" x2="760" y2="90.9" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="90.9" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3.5M</text>
-  <text x="768" y="90.9" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3.5M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4.5M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
   <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.0 GB/s</text>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
   <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
@@ -43,66 +49,66 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,197.9 145.8,197.5 201.7,192.8 257.5,238.0 313.3,231.8 369.2,230.7 425.0,228.9 480.8,235.7 536.7,261.8 592.5,311.2 648.3,344.8 704.2,363.4 760.0,373.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,302.8 145.8,301.4 201.7,299.7 257.5,302.4 313.3,303.8 369.2,305.8 425.0,309.7 480.8,325.6 536.7,326.5 592.5,339.5 648.3,353.2 704.2,366.1 760.0,374.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,285.2 145.8,285.7 201.7,285.4 257.5,296.6 313.3,314.5 369.2,322.4 425.0,319.4 480.8,336.4 536.7,350.0 592.5,363.9 648.3,366.8 704.2,378.2 760.0,379.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,379.6 145.8,379.6 201.7,379.6 257.5,379.8 313.3,379.7 369.2,379.6 425.0,379.7 480.8,379.7 536.7,379.9 592.5,379.8 648.3,380.1 704.2,380.3 760.0,380.5" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.5 145.8,381.0 201.7,377.9 257.5,374.7 313.3,364.5 369.2,344.8 425.0,304.6 480.8,232.1 536.7,133.6 592.5,85.7 648.3,63.3 704.2,46.9 760.0,40.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="381.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="374.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="364.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="344.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="304.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="232.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="133.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="85.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="63.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="46.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="40.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.4 145.8,382.7 201.7,381.3 257.5,378.8 313.3,373.7 369.2,364.0 425.0,346.0 480.8,324.2 536.7,266.3 592.5,201.6 648.3,131.3 704.2,91.4 760.0,55.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="381.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="378.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="373.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="364.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="346.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="324.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="266.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="201.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="131.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="91.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="55.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.2 145.8,382.4 201.7,380.8 257.5,378.4 313.3,375.1 369.2,368.2 425.0,350.9 480.8,335.2 536.7,314.4 592.5,301.5 648.3,243.1 704.2,289.7 760.0,227.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="380.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="378.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="375.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="368.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="350.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="335.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="314.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="301.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="243.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="289.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="227.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.7 313.3,383.4 369.2,382.9 425.0,381.8 480.8,379.6 536.7,375.6 592.5,366.9 648.3,351.8 704.2,323.3 760.0,269.6" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,236.2 145.8,232.0 201.7,234.2 257.5,261.5 313.3,260.1 369.2,262.6 425.0,258.8 480.8,268.5 536.7,281.0 592.5,324.5 648.3,352.4 704.2,366.9 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,320.1 145.8,318.9 201.7,319.4 257.5,319.8 313.3,320.9 369.2,322.1 425.0,324.4 480.8,329.1 536.7,335.2 592.5,344.5 648.3,355.9 704.2,368.1 760.0,376.4" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,305.5 145.8,306.4 201.7,303.5 257.5,314.7 313.3,326.6 369.2,336.9 425.0,333.7 480.8,343.9 536.7,356.1 592.5,367.6 648.3,375.3 704.2,379.4 760.0,380.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.6 145.8,380.5 201.7,380.6 257.5,380.6 313.3,380.6 369.2,380.5 425.0,380.6 480.8,380.6 536.7,380.7 592.5,380.9 648.3,380.9 704.2,381.0 760.0,381.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,382.8 145.8,381.6 201.7,379.2 257.5,376.2 313.3,368.1 369.2,352.9 425.0,319.9 480.8,265.7 536.7,173.1 592.5,140.3 648.3,125.1 704.2,103.7 760.0,101.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="381.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="379.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="376.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="368.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="352.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="319.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="265.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="173.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="140.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="125.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="103.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="101.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.1 425.0,353.5 480.8,327.8 536.7,284.1 592.5,222.4 648.3,153.9 704.2,123.8 760.0,135.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="383.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="381.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="379.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="375.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="368.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="353.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="327.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="284.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="222.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="153.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="123.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="135.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.4 145.8,382.8 201.7,381.4 257.5,379.6 313.3,376.7 369.2,371.9 425.0,358.3 480.8,342.9 536.7,326.9 592.5,316.6 648.3,313.1 704.2,309.2 760.0,261.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="382.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="381.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="379.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="376.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="371.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="358.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="342.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="326.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="316.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="313.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="309.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="261.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.8 313.3,383.6 369.2,383.1 425.0,382.3 480.8,380.5 536.7,377.2 592.5,371.2 648.3,358.7 704.2,334.9 760.0,291.6" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="384.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="383.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="383.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="382.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="381.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="379.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="375.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="366.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="351.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="323.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="269.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="383.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="383.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="383.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="382.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="380.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="377.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="371.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="358.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="334.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="291.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -153,62 +159,62 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,544.8 145.8,546.2 201.7,545.7 257.5,545.5 313.3,545.7 369.2,546.0 425.0,544.4 480.8,546.1 536.7,544.0 592.5,543.2 648.3,542.5 704.2,536.7 760.0,526.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="544.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="546.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="545.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="545.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="545.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="546.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="544.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="546.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="544.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="543.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="542.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="536.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="526.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,517.2 145.8,516.3 201.7,517.0 257.5,516.8 313.3,516.7 369.2,516.7 425.0,516.2 480.8,516.4 536.7,514.6 592.5,515.3 648.3,513.4 704.2,508.6 760.0,501.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="517.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="516.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="517.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="516.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="516.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="516.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="516.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="514.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="515.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="513.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="508.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="501.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,528.9 145.8,528.3 201.7,527.7 257.5,525.1 313.3,526.8 369.2,526.4 425.0,527.5 480.8,526.3 536.7,525.4 592.5,524.3 648.3,511.0 704.2,508.8 760.0,501.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="528.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="528.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="527.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="525.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="526.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="526.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="527.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="526.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="525.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="524.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="508.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="501.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,488.5 145.8,489.3 201.7,488.7 257.5,487.4 313.3,487.9 369.2,488.3 425.0,488.7 480.8,488.0 536.7,485.6 592.5,482.6 648.3,452.5 704.2,450.5 760.0,444.3" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="488.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="489.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="488.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="487.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="487.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="488.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="488.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="488.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="485.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="482.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="452.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="450.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="444.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,552.0 145.8,551.1 201.7,550.9 257.5,551.4 313.3,550.6 369.2,551.4 425.0,551.4 480.8,551.3 536.7,550.4 592.5,547.9 648.3,541.0 704.2,531.2 760.0,521.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="552.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="551.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="550.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="550.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="550.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="547.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="541.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="531.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="521.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,518.9 145.8,518.8 201.7,518.8 257.5,518.7 313.3,517.8 369.2,517.6 425.0,518.3 480.8,517.0 536.7,516.8 592.5,512.9 648.3,508.3 704.2,503.7 760.0,496.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="518.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="518.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="518.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="518.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="517.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="518.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="517.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="512.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="508.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="503.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="496.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,527.6 145.8,527.1 201.7,527.8 257.5,527.3 313.3,525.3 369.2,527.4 425.0,526.1 480.8,526.4 536.7,524.4 592.5,524.0 648.3,509.9 704.2,508.3 760.0,499.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="527.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="527.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="527.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="525.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="527.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="526.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="526.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="524.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="524.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="509.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="508.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="499.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,487.8 145.8,489.4 201.7,487.8 257.5,487.1 313.3,488.3 369.2,486.7 425.0,487.1 480.8,486.5 536.7,487.0 592.5,483.9 648.3,453.7 704.2,450.8 760.0,443.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="487.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="489.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="487.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="487.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="488.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="486.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="487.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="486.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="487.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="483.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="453.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="450.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="443.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>

--- a/bindings/pyomq/doc/performance.md
+++ b/bindings/pyomq/doc/performance.md
@@ -152,9 +152,9 @@ on PUSH/PULL proxy (TCP-bound, not async-loop-bound).
 The proxy benchmark previously used Python sender/receiver in one
 subprocess. Python's per-message send/recv overhead (~1.5M msg/s)
 bottlenecked the measurement. Switching to a native omq-compio
-sender/receiver (`bench_proxy_client`) reveals the true proxy throughput:
-~2.4M msg/s for pyomq vs ~1.85M for pyzmq (1.3x). REQ/REP: ~9.5k vs
-~5.3k (1.8x).
+sender/receiver (`omq_bench_proxy_client`) reveals the true proxy
+throughput: ~2.81M msg/s for pyomq vs ~1.53M for pyzmq (1.83x).
+REQ/REP: ~8.4k vs ~4.5k (1.86x).
 
 ### Materialized slot: Mutex -> RwLock
 

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -74,6 +74,17 @@ def save_results(run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, 
     print(f"  appended {len(rows)} rows to {JSONL_FILE}")
 
 
+def save_proxy_results(run_id, impl, proxy_pp, proxy_rr):
+    rows = [
+        {"run_id": run_id, "impl": impl, "kind": "proxy",
+         "pattern": "pushpull", "msgs_s": proxy_pp},
+        {"run_id": run_id, "impl": impl, "kind": "proxy",
+         "pattern": "reqrep", "msgs_s": proxy_rr},
+    ]
+    append_jsonl(rows)
+    print(f"  appended {len(rows)} rows to {JSONL_FILE}")
+
+
 def chart_data_from_jsonl():
     rows = load_jsonl()
 
@@ -689,13 +700,22 @@ sys.stdout.flush(); os._exit(0)
         proxy_proc.wait(timeout=5)
 
 
-BENCH_PROXY_CLIENT = os.path.join(
-    os.path.dirname(__file__), "..", "target", "release",
-    "bench_proxy_client",
-)
+_SCRIPT_DIR = os.path.dirname(__file__)
+_REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
+BENCH_PROXY_CLIENTS = [
+    os.path.join(_REPO_ROOT, "target", "release", "omq_bench_proxy_client"),
+    os.path.join(_SCRIPT_DIR, "..", "target", "release", "bench_proxy_client"),
+]
 
 
-def _measure_proxy_native(lib_name, duration=2.0):
+def _bench_proxy_client():
+    for path in BENCH_PROXY_CLIENTS:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _measure_proxy_native(lib_name, client, duration=2.0):
     if lib_name == "pyzmq":
         lib_import = "import zmq as lib"
     else:
@@ -738,7 +758,7 @@ except Exception:
 
     try:
         r = subprocess.run(
-            [BENCH_PROXY_CLIENT, str(fe_port), str(be_port), "128",
+            [client, str(fe_port), str(be_port), "128",
              str(duration)],
             capture_output=True, text=True,
             timeout=duration + 10,
@@ -756,13 +776,14 @@ except Exception:
 
 
 def run_proxy(lib_name):
-    use_native = os.path.isfile(BENCH_PROXY_CLIENT)
+    client = _bench_proxy_client()
 
     sys.stdout.write("  PUSH/PULL ...")
     sys.stdout.flush()
-    if use_native:
-        _measure_proxy_native(lib_name, 1.0)
-        pp = max(_measure_proxy_native(lib_name) for _ in range(N_ROUNDS))
+    if client is not None:
+        _measure_proxy_native(lib_name, client, 1.0)
+        pp = max(_measure_proxy_native(lib_name, client)
+                 for _ in range(N_ROUNDS))
     else:
         _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
         pp = max(_measure_proxy_subprocess(lib_name, "pushpull", 200_000)
@@ -815,13 +836,31 @@ def _fmt_y_us(val):
 
 def _fmt_mbps(val):
     if val >= 1000:
-        return f"{val / 1000:.1f} GB/s"
+        return f"{val / 1000:g} GB/s"
     if val >= 10:
         return f"{val:.0f} MB/s"
     return f"{val:.1f} MB/s"
 
 
+def _read_chart_hw():
+    config = {}
+    path = os.path.join(os.path.dirname(__file__), "..", ".chart_hw")
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, sep, value = line.partition("=")
+                if sep:
+                    config[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return config
+
+
 def _detect_hardware():
+    hw_conf = _read_chart_hw()
     try:
         cpu = None
         for line in open("/proc/cpuinfo"):
@@ -832,28 +871,17 @@ def _detect_hardware():
         cores = os.cpu_count()
         if cpu and cores:
             label = f"{cpu}, {cores} cores"
-            extras = []
-            try:
-                gov = open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor").read().strip()
-                if gov == "performance":
-                    extras.append("performance governor")
-            except OSError:
-                pass
-            for path, off_val in [
-                ("/sys/devices/system/cpu/intel_pstate/no_turbo", "1"),
-                ("/sys/devices/system/cpu/cpufreq/boost", "0"),
-            ]:
-                try:
-                    if open(path).read().strip() == off_val:
-                        extras.append("turbo off")
-                    break
-                except OSError:
-                    continue
+            prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
+            postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
+            extras = [e.strip() for e in postfix.split(",")] if postfix else []
             hw_extras = os.environ.get("OMQ_HW_EXTRAS")
             if hw_extras:
                 extras.extend(hw_extras.split(","))
+            extras = [e.strip() for e in extras if e.strip()]
             if extras:
                 label += ", " + ", ".join(extras)
+            if prefix:
+                label = f"{prefix}, {label}"
             return label
     except OSError:
         pass
@@ -884,8 +912,8 @@ def gen_combined_chart(data, path):
     async_omq_tp = data["async_omq_tp"]
     async_pz_tp = data["async_pz_tp"]
 
-    msg_max = 4_000_000
-    mbps_max = 4_000
+    msg_max = 5_000_000
+    mbps_max = 5_000
 
     def y_msg(v):
         frac = v / msg_max if msg_max > 0 else 0
@@ -921,10 +949,12 @@ def gen_combined_chart(data, path):
             f' fill="#9ca3af" font-size="10">{hw_label}</text>'
         )
 
-    msg_tick = 500_000
-    mbps_tick = 500
-    for val in range(msg_tick, msg_max + 1, msg_tick):
-        yy = y_msg(val)
+    tick_count = 10
+    for i in range(1, tick_count + 1):
+        frac = i / tick_count
+        msg_val = int(msg_max * frac)
+        mbps_val = mbps_max * frac
+        yy = t1_bot - frac * t1_h
         L.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
             f' stroke="#e5e7eb" stroke-width="1"/>'
@@ -932,9 +962,8 @@ def gen_combined_chart(data, path):
         L.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
             f' dominant-baseline="middle" fill="#374151"'
-            f' font-size="10">{_fmt_y_rate(val)}</text>'
+            f' font-size="10">{_fmt_y_rate(msg_val)}</text>'
         )
-        mbps_val = (val // msg_tick) * mbps_tick
         L.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
             f' dominant-baseline="middle" fill="#6b7280"'
@@ -1158,6 +1187,16 @@ def update_marker(content, marker, table):
     return new_content
 
 
+def update_readme_proxy_table():
+    proxy_table = build_proxy_table()
+    with open(README) as f:
+        content = f.read()
+    content = update_marker(content, "PROXY_PERF", proxy_table)
+    with open(README, "w") as f:
+        f.write(content)
+    print(f"\nUpdated {README}")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--impl", action="append", dest="impls",
@@ -1165,7 +1204,12 @@ def main():
                         help="implementation(s) to benchmark (default: both)")
     parser.add_argument("--chart-only", action="store_true",
                         help="regenerate SVG from existing JSONL, no benchmarking")
+    parser.add_argument("--proxy-only", action="store_true",
+                        help="benchmark proxy only and update README proxy table")
     args = parser.parse_args()
+
+    if args.chart_only and args.proxy_only:
+        parser.error("--chart-only and --proxy-only are mutually exclusive")
 
     if args.chart_only:
         print("Generating chart from existing JSONL...")
@@ -1180,6 +1224,13 @@ def main():
         print(f"\n{'=' * 40}")
         print(f"Benchmarking {impl}")
         print(f"{'=' * 40}")
+
+        if args.proxy_only:
+            print(f"\n{impl} zmq.proxy() forwarding...")
+            proxy_pp, proxy_rr = run_proxy(impl)
+            print("\nSaving proxy results...")
+            save_proxy_results(run_id, impl, proxy_pp, proxy_rr)
+            continue
 
         print(f"\n{impl} sync PUSH/PULL throughput...")
         tp_inproc, tp_tcp = run_throughput(impl)
@@ -1200,13 +1251,10 @@ def main():
         save_results(run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat,
                      proxy_pp, proxy_rr)
 
-    proxy_table = build_proxy_table()
-    with open(README) as f:
-        content = f.read()
-    content = update_marker(content, "PROXY_PERF", proxy_table)
-    with open(README, "w") as f:
-        f.write(content)
-    print(f"\nUpdated {README}")
+    update_readme_proxy_table()
+
+    if args.proxy_only:
+        return
 
     print("\nGenerating chart...")
     data = chart_data_from_jsonl()

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -503,44 +503,15 @@ pub fn proxy_handles(
     cap: Option<omq_tokio::blocking::Socket>,
     ctrl: Option<omq_tokio::blocking::Socket>,
 ) {
-    let fe = Arc::new(fe.into_async());
-    let be = Arc::new(be.into_async());
-    let cap = cap.map(|s| Arc::new(s.into_async()));
-    let ctrl = ctrl.map(|s| Arc::new(s.into_async()));
+    let mut proxy = omq_tokio::Proxy::new(fe.into_async(), be.into_async());
+    if let Some(cap) = cap {
+        proxy = proxy.capture(cap.into_async());
+    }
+    if let Some(ctrl) = ctrl {
+        proxy = proxy.control(ctrl.into_async());
+    }
     ctx.spawn_blocking(async move {
-        loop {
-            tokio::select! {
-                biased;
-                command = async {
-                    let Some(ctrl) = &ctrl else { futures::future::pending().await };
-                    ctrl.recv().await
-                } => {
-                    let Ok(msg) = command else { return; };
-                    let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
-                    match command.as_slice() {
-                        b"TERMINATE" | b"KILL" => return,
-                        b"PAUSE" => loop {
-                            let Some(ctrl) = &ctrl else { return; };
-                            let Ok(msg) = ctrl.recv().await else { return; };
-                            let command: Vec<u8> = msg.iter().next().unwrap_or_default().to_vec();
-                            if command == b"RESUME" { break; }
-                            if command == b"TERMINATE" || command == b"KILL" { return; }
-                        },
-                        _ => {}
-                    }
-                }
-                msg = fe.recv() => {
-                    let Ok(msg) = msg else { return; };
-                    if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
-                    if be.send(msg).await.is_err() { return; }
-                }
-                msg = be.recv() => {
-                    let Ok(msg) = msg else { return; };
-                    if let Some(cap) = &cap { let _ = cap.send(msg.clone()).await; }
-                    if fe.send(msg).await.is_err() { return; }
-                }
-            }
-        }
+        let _ = proxy.run().await;
     });
 }
 

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -781,3 +781,59 @@ def test_proxy_steerable(tcp_endpoint):
         backend.close()
         control.close()
         ctx.term()
+
+
+def test_proxy_xsub_xpub_forwards_subscriptions():
+    import threading
+    import time
+
+    ctx = zmq.Context()
+    frontend = ctx.socket(zmq.XSUB)
+    backend = ctx.socket(zmq.XPUB)
+    control = ctx.socket(zmq.REP)
+    publisher = ctx.socket(zmq.PUB)
+    subscriber = ctx.socket(zmq.SUB)
+    controller = ctx.socket(zmq.REQ)
+
+    base = f"inproc://proxy-xsub-xpub-{time.time_ns()}"
+    try:
+        frontend.bind(base + "-fe")
+        backend.bind(base + "-be")
+        control.bind(base + "-ctrl")
+        publisher.connect(base + "-fe")
+        subscriber.connect(base + "-be")
+        controller.connect(base + "-ctrl")
+
+        proxy_thread = threading.Thread(
+            target=zmq.proxy_steerable,
+            args=(frontend, backend, None, control),
+            daemon=True,
+        )
+        proxy_thread.start()
+
+        subscriber.subscribe(b"news.")
+        subscriber.rcvtimeo = 200
+        deadline = time.time() + 3
+        while time.time() < deadline:
+            publisher.send(b"news.alpha")
+            publisher.send(b"sports.beta")
+            try:
+                assert subscriber.recv() == b"news.alpha"
+                break
+            except zmq.Again:
+                pass
+        else:
+            raise AssertionError("subscriber never received proxied topic")
+
+        controller.send(b"TERMINATE")
+        assert controller.recv() == b""
+        proxy_thread.join(timeout=2)
+        assert not proxy_thread.is_alive()
+    finally:
+        publisher.close()
+        subscriber.close()
+        controller.close()
+        frontend.close()
+        backend.close()
+        control.close()
+        ctx.term()

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -219,6 +219,24 @@ Identity-routed sockets (`ROUTER`, `REP`, `SERVER`, `PEER`) route by peer
 identity. Exclusive sockets (`PAIR`, `CHANNEL`) target one peer. Fair-queue
 recv preserves per-peer ordering while rotating across peers.
 
+## Proxy
+
+`omq-tokio::Proxy` composes two existing sockets. It has no socket type of
+its own and no forwarding yring; local buffering is limited to one pending
+message per direction when a target reports HWM backpressure. Socket HWMs,
+routing policies, and drop/block behavior remain the source of truth.
+
+The loop drains at most `burst_size` complete messages from one direction
+before rechecking control and the opposite direction. Default burst is 64:
+large enough to avoid one `select!` per message under load, bounded enough
+that a hot frontend cannot indefinitely starve backend-to-frontend traffic.
+When a target is full, the proxy retries the pending message before reading
+more from that source.
+
+Steerable control supports `PAUSE`, `RESUME`, `TERMINATE`, and `KILL`.
+`STATISTICS` is omitted. Capture sockets receive best-effort copies via
+nonblocking send and never backpressure data forwarding.
+
 ## Inproc
 
 Inproc bypasses ZMTP framing and kernel I/O. Cross-thread peers use `yring`

--- a/omq-libzmq/src/proxy.rs
+++ b/omq-libzmq/src/proxy.rs
@@ -1,53 +1,442 @@
 //! `zmq_proxy` / `zmq_proxy_steerable`.
+//!
+//! The C binding cannot run `omq_tokio::Proxy` directly. libzmq sockets
+//! install a yring recv sink and an optional inproc byte bypass, so the
+//! async `Socket::recv` pipe is not the authoritative inbound queue. This
+//! proxy uses the same message-level policy as the tokio proxy, but its I/O
+//! adapters read and write through libzmq's queues.
 
 use std::ffi::c_void;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use crate::consts;
-use crate::msg::{
-    OmqMsgRepr, zmq_msg_close, zmq_msg_init, zmq_msg_more, zmq_msg_recv, zmq_msg_send,
-};
 use crate::poll::{ZmqPollItem, zmq_poll};
-use crate::send_recv::zmq_recv;
-use crate::socket::OmqSocket;
+use crate::send_recv::{SendMessageAttempt, try_recv_message, try_send_message, zmq_recv};
+use crate::socket::{OmqSocket, ensure_materialized};
 
 const ZMQ_POLLIN: libc::c_short = consts::ZMQ_POLLIN as libc::c_short;
-const ZMQ_SNDMORE: i32 = consts::ZMQ_SNDMORE;
 const ZMQ_DONTWAIT: i32 = consts::ZMQ_DONTWAIT;
+const DEFAULT_PROXY_BURST_SIZE: usize = omq_tokio::proxy::DEFAULT_PROXY_BURST_SIZE;
 
-fn forward(from: *mut c_void, to: *mut c_void, capture: *mut c_void) -> libc::c_int {
-    let mut msg = std::mem::MaybeUninit::<OmqMsgRepr>::uninit();
-    loop {
-        zmq_msg_init(msg.as_mut_ptr());
-        let rc = zmq_msg_recv(msg.as_mut_ptr(), from, 0);
-        if rc < 0 {
-            zmq_msg_close(msg.as_mut_ptr());
-            return -1;
-        }
-        let more = zmq_msg_more(msg.as_ptr()) != 0;
-        let flags = if more { ZMQ_SNDMORE } else { 0 };
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Direction {
+    FrontendToBackend,
+    BackendToFrontend,
+}
 
-        if !capture.is_null() {
-            let mut copy = std::mem::MaybeUninit::<OmqMsgRepr>::uninit();
-            zmq_msg_init(copy.as_mut_ptr());
-            crate::msg::zmq_msg_copy(copy.as_mut_ptr(), msg.as_ptr());
-            // zmq_msg_send closes the msg on success; close on failure.
-            if zmq_msg_send(copy.as_mut_ptr(), capture, flags) < 0 {
-                zmq_msg_close(copy.as_mut_ptr());
-            }
-        }
-
-        // zmq_msg_send closes the msg on success.
-        let rc = zmq_msg_send(msg.as_mut_ptr(), to, flags);
-        if rc < 0 {
-            zmq_msg_close(msg.as_mut_ptr());
-            return -1;
-        }
-        if !more {
-            break;
+impl Direction {
+    fn opposite(self) -> Self {
+        match self {
+            Self::FrontendToBackend => Self::BackendToFrontend,
+            Self::BackendToFrontend => Self::FrontendToBackend,
         }
     }
-    0
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProxyState {
+    Active,
+    Paused,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ControlAction {
+    Continue,
+    Terminate,
+}
+
+#[derive(Debug)]
+struct Pending {
+    msg: omq_tokio::Message,
+}
+
+struct ProxyCtx {
+    frontend_ptr: *mut c_void,
+    backend_ptr: *mut c_void,
+    control_ptr: *mut c_void,
+    frontend: Arc<OmqSocket>,
+    backend: Arc<OmqSocket>,
+    capture: Option<Arc<OmqSocket>>,
+    control: Option<Arc<OmqSocket>>,
+    fe_to_be_enabled: bool,
+    be_to_fe_enabled: bool,
+    burst_size: usize,
+}
+
+impl ProxyCtx {
+    fn new(
+        frontend_ptr: *mut c_void,
+        backend_ptr: *mut c_void,
+        capture_ptr: *mut c_void,
+        control_ptr: *mut c_void,
+    ) -> Result<Self, libc::c_int> {
+        if frontend_ptr.is_null() || backend_ptr.is_null() {
+            return Err(libc::EFAULT);
+        }
+
+        let frontend = socket_arc(frontend_ptr)?;
+        let backend = socket_arc(backend_ptr)?;
+        let capture = optional_socket_arc(capture_ptr)?;
+        let control = optional_socket_arc(control_ptr)?;
+
+        let sockets = [
+            Some(frontend.clone()),
+            Some(backend.clone()),
+            capture.clone(),
+            control.clone(),
+        ];
+        for sock in sockets.into_iter().flatten() {
+            let _ = ensure_materialized(&sock);
+        }
+
+        let same_socket = Arc::ptr_eq(&frontend, &backend);
+        let fe_to_be_enabled =
+            socket_can_recv(frontend.socket_type) && socket_can_send(backend.socket_type);
+        let be_to_fe_enabled = !same_socket
+            && socket_can_recv(backend.socket_type)
+            && socket_can_send(frontend.socket_type);
+
+        Ok(Self {
+            frontend_ptr,
+            backend_ptr,
+            control_ptr,
+            frontend,
+            backend,
+            capture,
+            control,
+            fe_to_be_enabled,
+            be_to_fe_enabled,
+            burst_size: DEFAULT_PROXY_BURST_SIZE,
+        })
+    }
+
+    fn run(&self) -> libc::c_int {
+        let mut state = ProxyState::Active;
+        let mut fe_pending: Option<Pending> = None;
+        let mut be_pending: Option<Pending> = None;
+        let mut preferred = Direction::FrontendToBackend;
+
+        'main: loop {
+            match self.try_handle_control(&mut state) {
+                Ok(Some(ControlAction::Terminate)) => return 0,
+                Ok(Some(ControlAction::Continue) | None) => {}
+                Err(e) => return crate::error::fail(e),
+            }
+
+            if state == ProxyState::Active {
+                for direction in [preferred, preferred.opposite()] {
+                    match self.flush_pending_direction(direction, &mut fe_pending, &mut be_pending)
+                    {
+                        Ok(true) => {
+                            preferred = direction.opposite();
+                            continue 'main;
+                        }
+                        Ok(false) => {}
+                        Err(e) => return crate::error::fail(e),
+                    }
+                    match self.try_forward_available(direction, &mut fe_pending, &mut be_pending) {
+                        Ok(true) => {
+                            preferred = direction.opposite();
+                            continue 'main;
+                        }
+                        Ok(false) => {}
+                        Err(e) => return crate::error::fail(e),
+                    }
+                }
+            }
+
+            if self.frontend.ctx.terminated.load(Ordering::Acquire) {
+                return crate::error::fail(crate::error::ETERM);
+            }
+
+            if let Some(pending) = fe_pending.as_ref() {
+                Self::wait_send_progress(&self.backend, &pending.msg);
+            } else if let Some(pending) = be_pending.as_ref() {
+                Self::wait_send_progress(&self.frontend, &pending.msg);
+            }
+
+            let timeout_ms = if fe_pending.is_some() || be_pending.is_some() {
+                1
+            } else {
+                100
+            };
+            if self.poll_for_input(
+                state,
+                fe_pending.is_none(),
+                be_pending.is_none(),
+                timeout_ms,
+            ) < 0
+            {
+                return -1;
+            }
+        }
+    }
+
+    fn flush_pending_direction(
+        &self,
+        direction: Direction,
+        fe_pending: &mut Option<Pending>,
+        be_pending: &mut Option<Pending>,
+    ) -> Result<bool, libc::c_int> {
+        if !self.direction_enabled(direction) {
+            return Ok(false);
+        }
+        let pending = match direction {
+            Direction::FrontendToBackend => fe_pending,
+            Direction::BackendToFrontend => be_pending,
+        };
+        let Some(pending_msg) = pending.take() else {
+            return Ok(false);
+        };
+        match self.try_forward(direction, pending_msg.msg)? {
+            SendMessageAttempt::Sent => Ok(true),
+            SendMessageAttempt::Full(msg) => {
+                *pending = Some(Pending { msg });
+                Ok(false)
+            }
+        }
+    }
+
+    fn try_forward_available(
+        &self,
+        direction: Direction,
+        fe_pending: &mut Option<Pending>,
+        be_pending: &mut Option<Pending>,
+    ) -> Result<bool, libc::c_int> {
+        if !self.direction_enabled(direction) {
+            return Ok(false);
+        }
+        match direction {
+            Direction::FrontendToBackend if fe_pending.is_some() => return Ok(false),
+            Direction::BackendToFrontend if be_pending.is_some() => return Ok(false),
+            _ => {}
+        }
+
+        let Some(first) = self.try_recv(direction)? else {
+            return Ok(false);
+        };
+        let pending = match direction {
+            Direction::FrontendToBackend => fe_pending,
+            Direction::BackendToFrontend => be_pending,
+        };
+        self.forward_burst(direction, first, pending)?;
+        Ok(true)
+    }
+
+    fn forward_burst(
+        &self,
+        direction: Direction,
+        first: omq_tokio::Message,
+        pending: &mut Option<Pending>,
+    ) -> Result<(), libc::c_int> {
+        let mut msg = first;
+        for n in 0..self.burst_size {
+            match self.try_forward(direction, msg)? {
+                SendMessageAttempt::Sent => {}
+                SendMessageAttempt::Full(returned) => {
+                    *pending = Some(Pending { msg: returned });
+                    return Ok(());
+                }
+            }
+
+            if n + 1 == self.burst_size {
+                return Ok(());
+            }
+            let Some(next) = self.try_recv(direction)? else {
+                return Ok(());
+            };
+            msg = next;
+        }
+        Ok(())
+    }
+
+    fn try_forward(
+        &self,
+        direction: Direction,
+        msg: omq_tokio::Message,
+    ) -> Result<SendMessageAttempt, libc::c_int> {
+        let copy = msg.clone();
+        let attempt = try_send_message(self.target(direction), msg)?;
+        if matches!(attempt, SendMessageAttempt::Sent)
+            && let Some(capture) = &self.capture
+        {
+            let _ = try_send_message(capture, copy);
+        }
+        Ok(attempt)
+    }
+
+    fn try_recv(&self, direction: Direction) -> Result<Option<omq_tokio::Message>, libc::c_int> {
+        try_recv_message(self.source(direction))
+    }
+
+    fn try_handle_control(
+        &self,
+        state: &mut ProxyState,
+    ) -> Result<Option<ControlAction>, libc::c_int> {
+        let Some(control) = &self.control else {
+            return Ok(None);
+        };
+        let mut cmd = [0u8; 64];
+        let rc = zmq_recv(
+            self.control_ptr,
+            cmd.as_mut_ptr().cast(),
+            cmd.len(),
+            ZMQ_DONTWAIT,
+        );
+        if rc < 0 {
+            let errno = crate::error::zmq_errno();
+            return if errno == libc::EAGAIN {
+                Ok(None)
+            } else {
+                Err(errno)
+            };
+        }
+        if rc == 0 {
+            self.send_control_ack(control);
+            return Ok(Some(ControlAction::Continue));
+        }
+
+        let msg = std::str::from_utf8(&cmd[..(rc as usize).min(cmd.len())]).unwrap_or("");
+        let action = match msg {
+            "PAUSE" => {
+                *state = ProxyState::Paused;
+                ControlAction::Continue
+            }
+            "RESUME" => {
+                *state = ProxyState::Active;
+                ControlAction::Continue
+            }
+            "TERMINATE" | "KILL" => ControlAction::Terminate,
+            _ => ControlAction::Continue,
+        };
+        self.send_control_ack(control);
+        Ok(Some(action))
+    }
+
+    fn send_control_ack(&self, control: &Arc<OmqSocket>) {
+        if control.socket_type == omq_tokio::SocketType::Rep {
+            let _ = crate::send_recv::zmq_send(self.control_ptr, std::ptr::null(), 0, 0);
+        }
+    }
+
+    fn wait_send_progress(target: &OmqSocket, msg: &omq_tokio::Message) {
+        let wait_on = target.inner.get().map(|socket| socket.as_ref().clone());
+        let Some(socket) = wait_on else {
+            std::thread::sleep(Duration::from_millis(1));
+            return;
+        };
+        let Some(handle) = target.ctx.handle() else {
+            std::thread::sleep(Duration::from_millis(1));
+            return;
+        };
+        let msg = msg.clone();
+        handle.block_on(async move {
+            tokio::select! {
+                () = socket.wait_send_progress_for(&msg) => {}
+                () = tokio::time::sleep(Duration::from_millis(1)) => {}
+            }
+        });
+    }
+
+    fn poll_for_input(
+        &self,
+        state: ProxyState,
+        fe_can_read: bool,
+        be_can_read: bool,
+        timeout_ms: libc::c_long,
+    ) -> libc::c_int {
+        let mut items = Vec::with_capacity(3);
+        if state == ProxyState::Active && self.fe_to_be_enabled && fe_can_read {
+            items.push(ZmqPollItem {
+                socket: self.frontend_ptr,
+                fd: -1,
+                events: ZMQ_POLLIN,
+                revents: 0,
+            });
+        }
+        if state == ProxyState::Active && self.be_to_fe_enabled && be_can_read {
+            items.push(ZmqPollItem {
+                socket: self.backend_ptr,
+                fd: -1,
+                events: ZMQ_POLLIN,
+                revents: 0,
+            });
+        }
+        if self.control.is_some() {
+            items.push(ZmqPollItem {
+                socket: self.control_ptr,
+                fd: -1,
+                events: ZMQ_POLLIN,
+                revents: 0,
+            });
+        }
+        if items.is_empty() {
+            std::thread::sleep(Duration::from_millis(timeout_ms as u64));
+            return 0;
+        }
+        let nitems = libc::c_int::try_from(items.len()).expect("proxy poll item count fits c_int");
+        zmq_poll(items.as_mut_ptr(), nitems, timeout_ms)
+    }
+
+    fn direction_enabled(&self, direction: Direction) -> bool {
+        match direction {
+            Direction::FrontendToBackend => self.fe_to_be_enabled,
+            Direction::BackendToFrontend => self.be_to_fe_enabled,
+        }
+    }
+
+    fn source(&self, direction: Direction) -> &OmqSocket {
+        match direction {
+            Direction::FrontendToBackend => &self.frontend,
+            Direction::BackendToFrontend => &self.backend,
+        }
+    }
+
+    fn target(&self, direction: Direction) -> &Arc<OmqSocket> {
+        match direction {
+            Direction::FrontendToBackend => &self.backend,
+            Direction::BackendToFrontend => &self.frontend,
+        }
+    }
+}
+
+fn socket_arc(ptr: *mut c_void) -> Result<Arc<OmqSocket>, libc::c_int> {
+    if ptr.is_null() {
+        return Err(libc::EFAULT);
+    }
+    // SAFETY: public entry points receive pointers returned by `zmq_socket`.
+    let sock = unsafe { &*(ptr.cast::<Arc<OmqSocket>>()) };
+    Ok(sock.clone())
+}
+
+fn optional_socket_arc(ptr: *mut c_void) -> Result<Option<Arc<OmqSocket>>, libc::c_int> {
+    if ptr.is_null() {
+        Ok(None)
+    } else {
+        socket_arc(ptr).map(Some)
+    }
+}
+
+fn socket_can_recv(socket_type: omq_tokio::SocketType) -> bool {
+    !matches!(
+        socket_type,
+        omq_tokio::SocketType::Pub
+            | omq_tokio::SocketType::Push
+            | omq_tokio::SocketType::Radio
+            | omq_tokio::SocketType::Scatter
+    )
+}
+
+fn socket_can_send(socket_type: omq_tokio::SocketType) -> bool {
+    !matches!(
+        socket_type,
+        omq_tokio::SocketType::Pull
+            | omq_tokio::SocketType::Sub
+            | omq_tokio::SocketType::Dish
+            | omq_tokio::SocketType::Gather
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -66,97 +455,9 @@ pub extern "C" fn zmq_proxy_steerable(
     capture: *mut c_void,
     control: *mut c_void,
 ) -> libc::c_int {
-    if frontend.is_null() || backend.is_null() {
-        return crate::error::fail(libc::EFAULT);
-    }
-
-    let has_control = !control.is_null();
-    let npoll = if has_control { 3 } else { 2 };
-
-    let mut poll_items = vec![
-        ZmqPollItem {
-            socket: frontend,
-            fd: -1,
-            events: ZMQ_POLLIN,
-            revents: 0,
-        },
-        ZmqPollItem {
-            socket: backend,
-            fd: -1,
-            events: ZMQ_POLLIN,
-            revents: 0,
-        },
-    ];
-    if has_control {
-        poll_items.push(ZmqPollItem {
-            socket: control,
-            fd: -1,
-            events: ZMQ_POLLIN,
-            revents: 0,
-        });
-    }
-
-    loop {
-        for item in &mut poll_items {
-            item.revents = 0;
-        }
-
-        let rc = zmq_poll(poll_items.as_mut_ptr(), npoll, 100);
-        if rc < 0 {
-            return -1;
-        }
-
-        if has_control && (poll_items[2].revents & ZMQ_POLLIN) != 0 {
-            let mut cmd = [0u8; 64];
-            let rc = zmq_recv(control, cmd.as_mut_ptr().cast(), cmd.len(), ZMQ_DONTWAIT);
-            if rc > 0 {
-                let msg = std::str::from_utf8(&cmd[..(rc as usize).min(cmd.len())]).unwrap_or("");
-                if msg == "TERMINATE" || msg == "KILL" {
-                    return 0;
-                }
-                if msg == "PAUSE" {
-                    loop {
-                        let mut pause_items = [ZmqPollItem {
-                            socket: control,
-                            fd: -1,
-                            events: ZMQ_POLLIN,
-                            revents: 0,
-                        }];
-                        zmq_poll(pause_items.as_mut_ptr(), 1, 100);
-                        if (pause_items[0].revents & ZMQ_POLLIN) != 0 {
-                            let rc =
-                                zmq_recv(control, cmd.as_mut_ptr().cast(), cmd.len(), ZMQ_DONTWAIT);
-                            if rc > 0 {
-                                let m = std::str::from_utf8(&cmd[..(rc as usize).min(cmd.len())])
-                                    .unwrap_or("");
-                                if m == "RESUME" {
-                                    break;
-                                }
-                                if m == "TERMINATE" || m == "KILL" {
-                                    return 0;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (poll_items[0].revents & ZMQ_POLLIN) != 0 && forward(frontend, backend, capture) < 0 {
-            return -1;
-        }
-        if (poll_items[1].revents & ZMQ_POLLIN) != 0 && forward(backend, frontend, capture) < 0 {
-            return -1;
-        }
-
-        // SAFETY: frontend is non-null (checked at function entry).
-        let fe_sock = unsafe { &*(frontend.cast::<Arc<OmqSocket>>()) };
-        if fe_sock
-            .ctx
-            .terminated
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
-            return crate::error::fail(crate::error::ETERM);
-        }
-    }
+    let proxy = match ProxyCtx::new(frontend, backend, capture, control) {
+        Ok(proxy) => proxy,
+        Err(e) => return crate::error::fail(e),
+    };
+    proxy.run()
 }

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use bytes::Bytes;
 
 use crate::consts::{ZMQ_DONTWAIT, ZMQ_SNDMORE};
-use crate::error::{ETERM, fail};
+use crate::error::{ETERM, fail, map_omq_err};
 use crate::notify::NotifyHandle;
 use crate::socket::OmqSocket;
 
@@ -42,6 +42,97 @@ impl HasPipeClosed for crate::inproc_bypass::BypassSend {
 impl HasPipeClosed for crate::inproc_bypass::BypassRecv {
     fn pipe_closed(&self) -> &std::sync::atomic::AtomicBool {
         &self.pipe.closed
+    }
+}
+
+pub(crate) enum SendMessageAttempt {
+    Sent,
+    Full(omq_tokio::Message),
+}
+
+/// Non-blocking full-message receive used by `zmq_proxy`.
+///
+/// This reads the same libzmq-facing queues as `zmq_recv`: the direct yring
+/// consumers, plus the inproc byte bypass where applicable. It must not call
+/// `omq_tokio::Socket::try_recv`, because libzmq sockets install a custom
+/// recv sink and the async socket recv pipe is not the owner of that hot path.
+pub(crate) fn try_recv_message(sock: &OmqSocket) -> Result<Option<omq_tokio::Message>, c_int> {
+    use std::sync::atomic::Ordering;
+
+    if sock.drain_nonempty.load(Ordering::Relaxed) {
+        let Ok(mut drain) = sock.recv_drain.lock() else {
+            return Err(ETERM);
+        };
+        if !drain.is_empty() {
+            let parts: Vec<Bytes> = drain.drain(..).collect();
+            sock.drain_nonempty.store(false, Ordering::Relaxed);
+            return Ok(Some(omq_tokio::Message::multipart(parts)));
+        }
+        sock.drain_nonempty.store(false, Ordering::Relaxed);
+    }
+
+    clear_stale_bypass(&sock.bypass_recv);
+    if let Some(bypass) = sock.bypass_recv.get() {
+        if let Some(cons) = sock.recv_cons.get()
+            && let Some(m) = try_pop_dual(cons, sock)
+        {
+            signal_recv_space(sock);
+            return Ok(Some(m));
+        }
+        if let Some((ptr, len)) = bypass.peek() {
+            let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+            let msg = omq_tokio::Message::single(Bytes::copy_from_slice(slice));
+            bypass.advance(len);
+            return Ok(Some(msg));
+        }
+        if bypass.pipe.closed.load(Ordering::Acquire) {
+            return Err(ETERM);
+        }
+        return Ok(None);
+    }
+
+    let Some(cons) = sock.recv_cons.get() else {
+        return Err(ETERM);
+    };
+    if let Some(m) = try_pop_dual(cons, sock) {
+        signal_recv_space(sock);
+        return Ok(Some(m));
+    }
+    Ok(None)
+}
+
+/// Non-blocking full-message send used by `zmq_proxy`.
+///
+/// Single-frame PUSH/PULL inproc messages take the byte bypass. Other
+/// messages go through the materialized omq-tokio socket so type-specific
+/// send behavior, including XSUB raw subscribe commands, stays in one place.
+pub(crate) fn try_send_message(
+    sock: &Arc<OmqSocket>,
+    msg: omq_tokio::Message,
+) -> Result<SendMessageAttempt, c_int> {
+    if msg.len() == 1 {
+        clear_stale_bypass(&sock.bypass_send);
+        if let Some(bypass) = sock.bypass_send.get() {
+            let result = {
+                let data = msg.get(0).unwrap_or(&[]);
+                bypass.push(data)
+            };
+            return match result {
+                Ok(()) => Ok(SendMessageAttempt::Sent),
+                Err(libc::EAGAIN) => Ok(SendMessageAttempt::Full(msg)),
+                Err(e) => Err(e),
+            };
+        }
+    }
+
+    let Some(inner) = sock.inner.get() else {
+        return Err(ETERM);
+    };
+    match inner.try_send(msg) {
+        Ok(()) => Ok(SendMessageAttempt::Sent),
+        Err(omq_tokio::TrySendError::Full(msg)) => Ok(SendMessageAttempt::Full(msg)),
+        Err(omq_tokio::TrySendError::Closed) => Err(ETERM),
+        Err(omq_tokio::TrySendError::Error(e)) => Err(map_omq_err(&e)),
     }
 }
 

--- a/omq-libzmq/tests/proxy.rs
+++ b/omq-libzmq/tests/proxy.rs
@@ -8,19 +8,36 @@ use std::mem::size_of;
 use std::time::Duration;
 
 use omq_zmq::{
-    zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_msg_close, zmq_msg_data,
-    zmq_msg_init, zmq_msg_recv, zmq_msg_send, zmq_msg_size, zmq_proxy_steerable, zmq_recv,
-    zmq_send, zmq_setsockopt, zmq_socket,
+    zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_getsockopt, zmq_msg_close,
+    zmq_msg_data, zmq_msg_init, zmq_msg_recv, zmq_msg_send, zmq_msg_size, zmq_proxy_steerable,
+    zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
 };
 
 const ZMQ_PAIR: i32 = 0;
+const ZMQ_PUB: i32 = 1;
+const ZMQ_SUB: i32 = 2;
+const ZMQ_DONTWAIT: i32 = 1;
 const ZMQ_PUSH: i32 = 8;
 const ZMQ_PULL: i32 = 7;
+const ZMQ_XPUB: i32 = 9;
+const ZMQ_XSUB: i32 = 10;
+const ZMQ_SNDMORE: i32 = 2;
+const ZMQ_SUBSCRIBE: i32 = 6;
+const ZMQ_RCVMORE: i32 = 13;
+const ZMQ_SNDHWM: i32 = 23;
+const ZMQ_RCVHWM: i32 = 24;
 const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_SNDTIMEO: i32 = 28;
 
 fn set_timeo(sock: *mut c_void, opt: i32, ms: i32) {
     zmq_setsockopt(sock, opt, (&ms as *const i32).cast(), size_of::<i32>());
+}
+
+fn rcvmore(sock: *mut c_void) -> bool {
+    let mut v: i32 = 0;
+    let mut sz = size_of::<i32>();
+    zmq_getsockopt(sock, ZMQ_RCVMORE, (&mut v as *mut i32).cast(), &mut sz);
+    v != 0
 }
 
 const ZMQ_MSG_WORDS: usize = 64 / size_of::<usize>();
@@ -43,11 +60,23 @@ impl ZmqMsg {
 struct ProxyArgs {
     fe: *mut c_void,
     be: *mut c_void,
+    cap: *mut c_void,
     ctrl: *mut c_void,
 }
 
 // SAFETY: ZMQ sockets are thread-safe when used by one thread at a time.
 unsafe impl Send for ProxyArgs {}
+
+struct SocketArg(*mut c_void);
+
+// SAFETY: tests move each socket to exactly one thread.
+unsafe impl Send for SocketArg {}
+
+impl SocketArg {
+    fn into_ptr(self) -> *mut c_void {
+        self.0
+    }
+}
 
 /// Proxy forwards a small message (well under 64 KB).
 #[test]
@@ -78,11 +107,12 @@ fn proxy_small_message() {
     let args = ProxyArgs {
         fe,
         be,
+        cap: std::ptr::null_mut(),
         ctrl: ctrl_a,
     };
     let proxy = std::thread::spawn(move || {
         let a = args;
-        zmq_proxy_steerable(a.fe, a.be, std::ptr::null_mut(), a.ctrl)
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
     });
 
     let payload = b"small proxy test";
@@ -95,6 +125,365 @@ fn proxy_small_message() {
 
     zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
     proxy.join().ok();
+
+    zmq_close(src);
+    zmq_close(dst);
+    zmq_close(ctrl_b);
+    zmq_close(fe);
+    zmq_close(be);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_retries_pending_after_bypass_backpressure() {
+    const N: usize = 64;
+
+    let ctx = zmq_ctx_new();
+    let fe = zmq_socket(ctx, ZMQ_PULL);
+    let be = zmq_socket(ctx, ZMQ_PUSH);
+    let src = zmq_socket(ctx, ZMQ_PUSH);
+    let dst = zmq_socket(ctx, ZMQ_PULL);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let hwm = 16i32;
+    zmq_setsockopt(
+        be,
+        ZMQ_SNDHWM,
+        (&hwm as *const i32).cast(),
+        size_of::<i32>(),
+    );
+    zmq_setsockopt(
+        dst,
+        ZMQ_RCVHWM,
+        (&hwm as *const i32).cast(),
+        size_of::<i32>(),
+    );
+
+    let addr_fe = CString::new("inproc://proxy-fe-backpressure").unwrap();
+    let addr_be = CString::new("inproc://proxy-be-backpressure").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-ctrl-backpressure").unwrap();
+
+    zmq_bind(fe, addr_fe.as_ptr());
+    zmq_bind(be, addr_be.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(src, addr_fe.as_ptr());
+    zmq_connect(dst, addr_be.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    std::thread::sleep(Duration::from_millis(50));
+
+    set_timeo(dst, ZMQ_RCVTIMEO, 5000);
+
+    let args = ProxyArgs {
+        fe,
+        be,
+        cap: std::ptr::null_mut(),
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    let src_arg = SocketArg(src);
+    let sender = std::thread::spawn(move || {
+        let src = src_arg.into_ptr();
+        let mut sent = 0usize;
+        while sent < N {
+            let data = (sent as u32).to_le_bytes();
+            let rc = zmq_send(src, data.as_ptr().cast(), data.len(), ZMQ_DONTWAIT);
+            if rc == i32::try_from(data.len()).expect("test payload len fits i32") {
+                sent += 1;
+            } else {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+        SocketArg(src)
+    });
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let mut got = Vec::with_capacity(N);
+    let mut buf = [0u8; 4];
+    for _ in 0..N {
+        let rc = zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+        assert_eq!(rc, 4, "dst recv failed (errno={})", omq_zmq::zmq_errno());
+        got.push(u32::from_le_bytes(buf));
+    }
+    assert_eq!(got, (0..N as u32).collect::<Vec<_>>());
+
+    let src = sender.join().unwrap().0;
+    zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
+
+    zmq_close(src);
+    zmq_close(dst);
+    zmq_close(ctrl_b);
+    zmq_close(fe);
+    zmq_close(be);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_does_not_starve_reverse_direction_when_frontend_is_hot() {
+    let ctx = zmq_ctx_new();
+    let fe = zmq_socket(ctx, ZMQ_PAIR);
+    let be = zmq_socket(ctx, ZMQ_PAIR);
+    let left = zmq_socket(ctx, ZMQ_PAIR);
+    let right = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let hwm = 16i32;
+    zmq_setsockopt(
+        be,
+        ZMQ_SNDHWM,
+        (&hwm as *const i32).cast(),
+        size_of::<i32>(),
+    );
+    zmq_setsockopt(
+        right,
+        ZMQ_RCVHWM,
+        (&hwm as *const i32).cast(),
+        size_of::<i32>(),
+    );
+
+    let addr_fe = CString::new("inproc://proxy-fe-starve").unwrap();
+    let addr_be = CString::new("inproc://proxy-be-starve").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-ctrl-starve").unwrap();
+
+    zmq_bind(fe, addr_fe.as_ptr());
+    zmq_bind(be, addr_be.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(left, addr_fe.as_ptr());
+    zmq_connect(right, addr_be.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    std::thread::sleep(Duration::from_millis(50));
+
+    set_timeo(left, ZMQ_RCVTIMEO, 5000);
+    set_timeo(right, ZMQ_SNDTIMEO, 5000);
+
+    let args = ProxyArgs {
+        fe,
+        be,
+        cap: std::ptr::null_mut(),
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    for i in 0..512u32 {
+        let data = i.to_le_bytes();
+        let _ = zmq_send(left, data.as_ptr().cast(), data.len(), ZMQ_DONTWAIT);
+    }
+
+    let payload = b"right-to-left";
+    zmq_send(right, payload.as_ptr().cast(), payload.len(), 0);
+
+    let mut buf = [0u8; 64];
+    let rc = zmq_recv(left, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(
+        rc as usize,
+        payload.len(),
+        "left recv failed (errno={})",
+        omq_zmq::zmq_errno()
+    );
+    assert_eq!(&buf[..payload.len()], payload);
+
+    zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
+
+    zmq_close(left);
+    zmq_close(right);
+    zmq_close(ctrl_b);
+    zmq_close(fe);
+    zmq_close(be);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_multipart_message() {
+    let ctx = zmq_ctx_new();
+    let fe = zmq_socket(ctx, ZMQ_PULL);
+    let be = zmq_socket(ctx, ZMQ_PUSH);
+    let src = zmq_socket(ctx, ZMQ_PUSH);
+    let dst = zmq_socket(ctx, ZMQ_PULL);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let addr_fe = CString::new("inproc://proxy-fe-multipart").unwrap();
+    let addr_be = CString::new("inproc://proxy-be-multipart").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-ctrl-multipart").unwrap();
+
+    zmq_bind(fe, addr_fe.as_ptr());
+    zmq_bind(be, addr_be.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(src, addr_fe.as_ptr());
+    zmq_connect(dst, addr_be.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    std::thread::sleep(Duration::from_millis(50));
+
+    set_timeo(dst, ZMQ_RCVTIMEO, 5000);
+    set_timeo(src, ZMQ_SNDTIMEO, 5000);
+
+    let args = ProxyArgs {
+        fe,
+        be,
+        cap: std::ptr::null_mut(),
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    zmq_send(src, b"part-a".as_ptr().cast(), 6, ZMQ_SNDMORE);
+    zmq_send(src, b"part-b".as_ptr().cast(), 6, 0);
+
+    let mut buf = [0u8; 64];
+    let rc = zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(rc, 6);
+    assert_eq!(&buf[..6], b"part-a");
+    assert!(rcvmore(dst));
+    let rc = zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(rc, 6);
+    assert_eq!(&buf[..6], b"part-b");
+    assert!(!rcvmore(dst));
+
+    zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
+
+    zmq_close(src);
+    zmq_close(dst);
+    zmq_close(ctrl_b);
+    zmq_close(fe);
+    zmq_close(be);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_capture_gets_copy() {
+    let ctx = zmq_ctx_new();
+    let fe = zmq_socket(ctx, ZMQ_PULL);
+    let be = zmq_socket(ctx, ZMQ_PUSH);
+    let cap = zmq_socket(ctx, ZMQ_PUSH);
+    let src = zmq_socket(ctx, ZMQ_PUSH);
+    let dst = zmq_socket(ctx, ZMQ_PULL);
+    let cap_dst = zmq_socket(ctx, ZMQ_PULL);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let addr_fe = CString::new("inproc://proxy-fe-capture").unwrap();
+    let addr_be = CString::new("inproc://proxy-be-capture").unwrap();
+    let addr_cap = CString::new("inproc://proxy-cap-capture").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-ctrl-capture").unwrap();
+
+    zmq_bind(fe, addr_fe.as_ptr());
+    zmq_bind(be, addr_be.as_ptr());
+    zmq_bind(cap, addr_cap.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(src, addr_fe.as_ptr());
+    zmq_connect(dst, addr_be.as_ptr());
+    zmq_connect(cap_dst, addr_cap.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    std::thread::sleep(Duration::from_millis(50));
+
+    set_timeo(dst, ZMQ_RCVTIMEO, 5000);
+    set_timeo(cap_dst, ZMQ_RCVTIMEO, 5000);
+
+    let args = ProxyArgs {
+        fe,
+        be,
+        cap,
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    let payload = b"capture copy";
+    zmq_send(src, payload.as_ptr().cast(), payload.len(), 0);
+
+    let mut buf = [0u8; 64];
+    let rc = zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(rc as usize, payload.len());
+    assert_eq!(&buf[..payload.len()], payload);
+    let rc = zmq_recv(cap_dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(rc as usize, payload.len());
+    assert_eq!(&buf[..payload.len()], payload);
+
+    zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
+
+    zmq_close(src);
+    zmq_close(dst);
+    zmq_close(cap_dst);
+    zmq_close(ctrl_b);
+    zmq_close(fe);
+    zmq_close(be);
+    zmq_close(cap);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_pause_resume() {
+    let ctx = zmq_ctx_new();
+    let fe = zmq_socket(ctx, ZMQ_PULL);
+    let be = zmq_socket(ctx, ZMQ_PUSH);
+    let src = zmq_socket(ctx, ZMQ_PUSH);
+    let dst = zmq_socket(ctx, ZMQ_PULL);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let addr_fe = CString::new("inproc://proxy-fe-pause").unwrap();
+    let addr_be = CString::new("inproc://proxy-be-pause").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-ctrl-pause").unwrap();
+
+    zmq_bind(fe, addr_fe.as_ptr());
+    zmq_bind(be, addr_be.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(src, addr_fe.as_ptr());
+    zmq_connect(dst, addr_be.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    std::thread::sleep(Duration::from_millis(50));
+
+    set_timeo(dst, ZMQ_RCVTIMEO, 100);
+
+    let args = ProxyArgs {
+        fe,
+        be,
+        cap: std::ptr::null_mut(),
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    zmq_send(ctrl_b, b"PAUSE".as_ptr().cast(), 5, 0);
+    std::thread::sleep(Duration::from_millis(100));
+
+    let payload = b"paused payload";
+    zmq_send(src, payload.as_ptr().cast(), payload.len(), 0);
+    let mut buf = [0u8; 64];
+    assert!(zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0) < 0);
+
+    set_timeo(dst, ZMQ_RCVTIMEO, 5000);
+    zmq_send(ctrl_b, b"RESUME".as_ptr().cast(), 6, 0);
+    let rc = zmq_recv(dst, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(rc as usize, payload.len());
+    assert_eq!(&buf[..payload.len()], payload);
+
+    zmq_send(ctrl_b, b"KILL".as_ptr().cast(), 4, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
 
     zmq_close(src);
     zmq_close(dst);
@@ -140,11 +529,12 @@ fn proxy_large_message() {
     let args = ProxyArgs {
         fe,
         be,
+        cap: std::ptr::null_mut(),
         ctrl: ctrl_a,
     };
     let proxy = std::thread::spawn(move || {
         let a = args;
-        zmq_proxy_steerable(a.fe, a.be, std::ptr::null_mut(), a.ctrl)
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
     });
 
     // 128 KB payload: well above the old 64 KB stack buffer limit.
@@ -179,6 +569,68 @@ fn proxy_large_message() {
     zmq_close(ctrl_b);
     zmq_close(fe);
     zmq_close(be);
+    zmq_close(ctrl_a);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn proxy_forwards_xpub_subscriptions_to_xsub() {
+    let ctx = zmq_ctx_new();
+    let xsub = zmq_socket(ctx, ZMQ_XSUB);
+    let xpub = zmq_socket(ctx, ZMQ_XPUB);
+    let publisher = zmq_socket(ctx, ZMQ_PUB);
+    let subscriber = zmq_socket(ctx, ZMQ_SUB);
+    let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
+    let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    let addr_xsub = CString::new("inproc://proxy-xsub-side").unwrap();
+    let addr_xpub = CString::new("inproc://proxy-xpub-side").unwrap();
+    let addr_ctrl = CString::new("inproc://proxy-xpub-ctrl").unwrap();
+
+    zmq_bind(xsub, addr_xsub.as_ptr());
+    zmq_bind(xpub, addr_xpub.as_ptr());
+    zmq_bind(ctrl_a, addr_ctrl.as_ptr());
+    zmq_connect(publisher, addr_xsub.as_ptr());
+    zmq_connect(subscriber, addr_xpub.as_ptr());
+    zmq_connect(ctrl_b, addr_ctrl.as_ptr());
+    set_timeo(subscriber, ZMQ_RCVTIMEO, 5000);
+
+    let args = ProxyArgs {
+        fe: xsub,
+        be: xpub,
+        cap: std::ptr::null_mut(),
+        ctrl: ctrl_a,
+    };
+    let proxy = std::thread::spawn(move || {
+        let a = args;
+        zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
+    });
+
+    std::thread::sleep(Duration::from_millis(100));
+    zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, b"news.".as_ptr().cast(), 5);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let payload = b"news.hello";
+    zmq_send(publisher, payload.as_ptr().cast(), payload.len(), 0);
+
+    let mut buf = [0u8; 64];
+    let rc = zmq_recv(subscriber, buf.as_mut_ptr().cast(), buf.len(), 0);
+    assert_eq!(
+        rc as usize,
+        payload.len(),
+        "subscriber recv failed (errno={})",
+        omq_zmq::zmq_errno()
+    );
+    assert_eq!(&buf[..payload.len()], payload);
+
+    zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
+    assert_eq!(proxy.join().unwrap(), 0);
+
+    zmq_close(publisher);
+    zmq_close(subscriber);
+    zmq_close(ctrl_b);
+    zmq_close(xsub);
+    zmq_close(xpub);
     zmq_close(ctrl_a);
     zmq_ctx_term(ctx);
 }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -330,6 +330,10 @@ name = "omq_plain"
 path = "tests/plain.rs"
 
 [[test]]
+name = "omq_proxy"
+path = "tests/proxy.rs"
+
+[[test]]
 name = "omq_pub_sub"
 path = "tests/pub_sub.rs"
 

--- a/omq-tokio/src/bin/bench_proxy_client.rs
+++ b/omq-tokio/src/bin/bench_proxy_client.rs
@@ -1,7 +1,7 @@
 //! Proxy benchmark client: connects PUSH to a proxy frontend and PULL
 //! to its backend, runs a warmup exchange, then measures throughput.
 //!
-//! Usage: `bench_proxy_client` `fe_port` `be_port` `msg_size` `duration_secs`
+//! Usage: `omq_bench_proxy_client` `fe_port` `be_port` `msg_size` `duration_secs`
 //!
 //! Output (stdout): `count` `elapsed_secs` `msg_size`
 

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -16,6 +16,7 @@ compile_error!("omq-tokio requires target_has_atomic = \"64\"");
 pub mod blocking;
 pub mod context;
 pub mod engine;
+pub mod proxy;
 pub(crate) mod routing;
 pub mod socket;
 pub mod transport;
@@ -44,6 +45,7 @@ pub use omq_proto::options;
 pub use omq_proto::proto;
 
 pub use context::{Context, ContextConfig};
+pub use proxy::{Proxy, ProxyExit};
 pub use socket::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorStream,
     MonitorTryRecvError, PeerCommandKind, PeerIdent, PeerInfo, Socket,

--- a/omq-tokio/src/proxy.rs
+++ b/omq-tokio/src/proxy.rs
@@ -1,0 +1,459 @@
+//! Socket proxy helper.
+//!
+//! A proxy composes two normal sockets. It adds no socket type and no
+//! yring of its own. Existing socket HWM and routing rules remain in
+//! force.
+//!
+//! The loop keeps at most one unsent message per direction when a target
+//! reports HWM backpressure. It retries that pending message before taking
+//! more input from the same side. The configured burst size bounds how many
+//! complete messages one hot side may forward before the other side and the
+//! control socket get another chance to run.
+//!
+//! Steerable control accepts `PAUSE`, `RESUME`, `TERMINATE`, and `KILL`.
+//! `KILL` is kept as an alias for callers that already use it. `STATISTICS`
+//! is intentionally not implemented.
+
+use omq_proto::error::{Error, Result, TrySendError};
+use omq_proto::message::Message;
+use omq_proto::proto::SocketType;
+
+use crate::Socket;
+
+/// Default max complete messages forwarded from one side per wake.
+///
+/// Larger bursts reduce select-loop overhead under load. Smaller bursts
+/// reduce worst-case delay for the opposite direction and control socket.
+pub const DEFAULT_PROXY_BURST_SIZE: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProxyExit {
+    /// A control message requested termination.
+    Terminated,
+    /// A proxied socket closed.
+    Closed,
+}
+
+/// Forward messages between two sockets.
+///
+/// `Proxy` owns only socket handles plus optional capture/control sockets.
+/// It does not allocate a forwarding queue. Capture is best-effort: a full
+/// capture socket drops the copied message and never backpressures the data
+/// path.
+#[derive(Debug)]
+pub struct Proxy {
+    frontend: Socket,
+    backend: Socket,
+    capture: Option<Socket>,
+    control: Option<Socket>,
+    burst_size: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Direction {
+    FrontendToBackend,
+    BackendToFrontend,
+}
+
+impl Direction {
+    fn opposite(self) -> Self {
+        match self {
+            Self::FrontendToBackend => Self::BackendToFrontend,
+            Self::BackendToFrontend => Self::FrontendToBackend,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Pending {
+    msg: Message,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProxyState {
+    Active,
+    Paused,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ControlAction {
+    Continue,
+    Terminate,
+}
+
+enum ForwardAttempt {
+    Sent,
+    Full(Message),
+    Closed,
+}
+
+impl Proxy {
+    pub fn new(frontend: Socket, backend: Socket) -> Self {
+        Self {
+            frontend,
+            backend,
+            capture: None,
+            control: None,
+            burst_size: DEFAULT_PROXY_BURST_SIZE,
+        }
+    }
+
+    #[must_use]
+    pub fn capture(mut self, socket: Socket) -> Self {
+        self.capture = Some(socket);
+        self
+    }
+
+    /// Set steerable control socket.
+    ///
+    /// A REP control socket receives an empty reply after each command,
+    /// matching the pyzmq/libzmq request-reply control shape.
+    #[must_use]
+    pub fn control(mut self, socket: Socket) -> Self {
+        self.control = Some(socket);
+        self
+    }
+
+    /// Set max messages drained from one direction before rechecking peer
+    /// direction and control.
+    #[must_use]
+    pub fn burst_size(mut self, burst_size: usize) -> Self {
+        self.burst_size = burst_size.max(1);
+        self
+    }
+
+    pub async fn run(self) -> Result<ProxyExit> {
+        match self.run_loop().await {
+            Err(Error::Closed) => Ok(ProxyExit::Closed),
+            result => result,
+        }
+    }
+
+    async fn run_loop(self) -> Result<ProxyExit> {
+        let same_socket = self.frontend.same_socket(&self.backend);
+        let fe_to_be_enabled = self.can_forward_direction(Direction::FrontendToBackend, false);
+        let be_to_fe_enabled =
+            self.can_forward_direction(Direction::BackendToFrontend, same_socket);
+        let mut state = ProxyState::Active;
+        let mut fe_pending: Option<Pending> = None;
+        let mut be_pending: Option<Pending> = None;
+        let mut preferred = Direction::FrontendToBackend;
+
+        'main: loop {
+            if let Some(action) = self.try_handle_control(&mut state).await?
+                && action == ControlAction::Terminate
+            {
+                return Ok(ProxyExit::Terminated);
+            }
+
+            if state == ProxyState::Active {
+                for direction in [preferred, preferred.opposite()] {
+                    if self.flush_pending_direction(
+                        direction,
+                        &mut fe_pending,
+                        &mut be_pending,
+                        fe_to_be_enabled,
+                        be_to_fe_enabled,
+                    )? {
+                        preferred = direction.opposite();
+                        continue 'main;
+                    }
+                    if self.try_forward_available(
+                        direction,
+                        &mut fe_pending,
+                        &mut be_pending,
+                        fe_to_be_enabled,
+                        be_to_fe_enabled,
+                    )? {
+                        preferred = direction.opposite();
+                        continue 'main;
+                    }
+                }
+            }
+
+            let fe_wait_msg = fe_pending.as_ref().map(|pending| pending.msg.clone());
+            let be_wait_msg = be_pending.as_ref().map(|pending| pending.msg.clone());
+            let frontend = self.frontend.clone();
+            let backend = self.backend.clone();
+            let control = self.control.clone();
+
+            tokio::select! {
+                biased;
+                command = recv_optional(control), if self.control.is_some() => {
+                    match command? {
+                        Some(command) => {
+                            if self.handle_control(command, &mut state).await?
+                                == ControlAction::Terminate
+                            {
+                                return Ok(ProxyExit::Terminated);
+                            }
+                        }
+                        None => return Ok(ProxyExit::Closed),
+                    }
+                }
+                () = wait_for_send_progress(backend.clone(), fe_wait_msg),
+                    if state == ProxyState::Active && fe_to_be_enabled && fe_pending.is_some() => {}
+                () = wait_for_send_progress(frontend.clone(), be_wait_msg),
+                    if state == ProxyState::Active && be_to_fe_enabled && be_pending.is_some() => {}
+                msg = frontend.recv(),
+                    if state == ProxyState::Active && fe_to_be_enabled && fe_pending.is_none() => {
+                    let msg = msg?;
+                    self.forward_burst(Direction::FrontendToBackend, msg, &mut fe_pending)?;
+                    preferred = Direction::BackendToFrontend;
+                }
+                msg = backend.recv(),
+                    if state == ProxyState::Active && be_to_fe_enabled && be_pending.is_none() => {
+                    let msg = msg?;
+                    self.forward_burst(Direction::BackendToFrontend, msg, &mut be_pending)?;
+                    preferred = Direction::FrontendToBackend;
+                }
+            }
+        }
+    }
+
+    fn flush_pending_direction(
+        &self,
+        direction: Direction,
+        fe_pending: &mut Option<Pending>,
+        be_pending: &mut Option<Pending>,
+        fe_to_be_enabled: bool,
+        be_to_fe_enabled: bool,
+    ) -> Result<bool> {
+        if !direction_enabled(direction, fe_to_be_enabled, be_to_fe_enabled) {
+            return Ok(false);
+        }
+        match direction {
+            Direction::FrontendToBackend => self.flush_pending(direction, fe_pending),
+            Direction::BackendToFrontend => self.flush_pending(direction, be_pending),
+        }
+    }
+
+    fn try_forward_available(
+        &self,
+        direction: Direction,
+        fe_pending: &mut Option<Pending>,
+        be_pending: &mut Option<Pending>,
+        fe_to_be_enabled: bool,
+        be_to_fe_enabled: bool,
+    ) -> Result<bool> {
+        if !direction_enabled(direction, fe_to_be_enabled, be_to_fe_enabled) {
+            return Ok(false);
+        }
+        match direction {
+            Direction::FrontendToBackend if fe_pending.is_some() => return Ok(false),
+            Direction::BackendToFrontend if be_pending.is_some() => return Ok(false),
+            _ => {}
+        }
+
+        let pending = match direction {
+            Direction::FrontendToBackend => fe_pending,
+            Direction::BackendToFrontend => be_pending,
+        };
+
+        match self.source(direction).try_recv() {
+            Ok(msg) => {
+                self.forward_burst(direction, msg, pending)?;
+                Ok(true)
+            }
+            Err(Error::WouldBlock) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn can_forward_direction(&self, direction: Direction, same_socket: bool) -> bool {
+        if same_socket && direction == Direction::BackendToFrontend {
+            return false;
+        }
+        socket_can_recv(self.source(direction).socket_type())
+            && socket_can_send(self.target(direction).socket_type())
+    }
+
+    fn flush_pending(&self, direction: Direction, pending: &mut Option<Pending>) -> Result<bool> {
+        let Some(p) = pending.take() else {
+            return Ok(false);
+        };
+        match self.try_forward(direction, p.msg)? {
+            ForwardAttempt::Sent => Ok(true),
+            ForwardAttempt::Full(msg) => {
+                *pending = Some(Pending { msg });
+                Ok(false)
+            }
+            ForwardAttempt::Closed => Err(Error::Closed),
+        }
+    }
+
+    fn forward_burst(
+        &self,
+        direction: Direction,
+        first: Message,
+        pending: &mut Option<Pending>,
+    ) -> Result<()> {
+        let mut msg = first;
+        for n in 0..self.burst_size {
+            match self.try_forward(direction, msg)? {
+                ForwardAttempt::Sent => {}
+                ForwardAttempt::Full(returned) => {
+                    *pending = Some(Pending { msg: returned });
+                    return Ok(());
+                }
+                ForwardAttempt::Closed => return Err(Error::Closed),
+            }
+
+            if n + 1 == self.burst_size {
+                return Ok(());
+            }
+            msg = match self.source(direction).try_recv() {
+                Ok(next) => next,
+                Err(Error::WouldBlock) => return Ok(()),
+                Err(Error::Closed) => return Err(Error::Closed),
+                Err(error) => return Err(error),
+            };
+        }
+        Ok(())
+    }
+
+    fn try_forward(&self, direction: Direction, msg: Message) -> Result<ForwardAttempt> {
+        let copy = msg.clone();
+        let attempt = match self.target(direction).try_send(msg) {
+            Ok(()) => {
+                if let Some(capture) = &self.capture {
+                    let _ = capture.try_send(copy);
+                }
+                ForwardAttempt::Sent
+            }
+            Err(TrySendError::Full(msg)) => ForwardAttempt::Full(msg),
+            Err(TrySendError::Closed) => ForwardAttempt::Closed,
+            Err(TrySendError::Error(error)) => return Err(error),
+        };
+        Ok(attempt)
+    }
+
+    fn source(&self, direction: Direction) -> &Socket {
+        match direction {
+            Direction::FrontendToBackend => &self.frontend,
+            Direction::BackendToFrontend => &self.backend,
+        }
+    }
+
+    fn target(&self, direction: Direction) -> &Socket {
+        match direction {
+            Direction::FrontendToBackend => &self.backend,
+            Direction::BackendToFrontend => &self.frontend,
+        }
+    }
+
+    async fn try_handle_control(&self, state: &mut ProxyState) -> Result<Option<ControlAction>> {
+        let Some(control) = &self.control else {
+            return Ok(None);
+        };
+        // REP try_recv would mutate REP state and then handle_control() would
+        // send the ack through the wrong path. Let the normal recv branch own
+        // REP control sockets.
+        if control.socket_type() == SocketType::Rep {
+            return Ok(None);
+        }
+        match control.try_recv() {
+            Ok(msg) => self.handle_control(msg, state).await.map(Some),
+            Err(Error::WouldBlock) => Ok(None),
+            Err(Error::Closed) => Ok(Some(ControlAction::Terminate)),
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn handle_control(&self, msg: Message, state: &mut ProxyState) -> Result<ControlAction> {
+        let command = msg.part_bytes(0).unwrap_or_default();
+        let action = match command.as_ref() {
+            b"PAUSE" => {
+                *state = ProxyState::Paused;
+                ControlAction::Continue
+            }
+            b"RESUME" => {
+                *state = ProxyState::Active;
+                ControlAction::Continue
+            }
+            b"TERMINATE" | b"KILL" => ControlAction::Terminate,
+            _ => ControlAction::Continue,
+        };
+
+        if let Some(control) = &self.control
+            && control.socket_type() == SocketType::Rep
+        {
+            let _ = control.send(Message::single(bytes::Bytes::new())).await;
+        }
+        if action == ControlAction::Terminate {
+            tokio::task::yield_now().await;
+        }
+
+        Ok(action)
+    }
+}
+
+pub async fn proxy(
+    frontend: Socket,
+    backend: Socket,
+    capture: Option<Socket>,
+) -> Result<ProxyExit> {
+    let mut proxy = Proxy::new(frontend, backend);
+    if let Some(capture) = capture {
+        proxy = proxy.capture(capture);
+    }
+    proxy.run().await
+}
+
+pub async fn proxy_steerable(
+    frontend: Socket,
+    backend: Socket,
+    capture: Option<Socket>,
+    control: Option<Socket>,
+) -> Result<ProxyExit> {
+    let mut proxy = Proxy::new(frontend, backend);
+    if let Some(capture) = capture {
+        proxy = proxy.capture(capture);
+    }
+    if let Some(control) = control {
+        proxy = proxy.control(control);
+    }
+    proxy.run().await
+}
+
+async fn recv_optional(socket: Option<Socket>) -> Result<Option<Message>> {
+    let Some(socket) = socket else {
+        std::future::pending::<()>().await;
+        return Ok(None);
+    };
+    socket.recv().await.map(Some)
+}
+
+async fn wait_for_send_progress(socket: Socket, msg: Option<Message>) {
+    let Some(msg) = msg else {
+        std::future::pending::<()>().await;
+        return;
+    };
+    // Space notifications are best-effort across multiple send strategies.
+    // The short timer prevents a lost notify from pinning a pending message.
+    tokio::select! {
+        () = socket.wait_send_progress_for(&msg) => {}
+        () = tokio::time::sleep(std::time::Duration::from_millis(1)) => {}
+    }
+}
+
+fn direction_enabled(direction: Direction, fe_to_be_enabled: bool, be_to_fe_enabled: bool) -> bool {
+    match direction {
+        Direction::FrontendToBackend => fe_to_be_enabled,
+        Direction::BackendToFrontend => be_to_fe_enabled,
+    }
+}
+
+fn socket_can_recv(socket_type: SocketType) -> bool {
+    !matches!(
+        socket_type,
+        SocketType::Pub | SocketType::Push | SocketType::Radio | SocketType::Scatter
+    )
+}
+
+fn socket_can_send(socket_type: SocketType) -> bool {
+    !matches!(
+        socket_type,
+        SocketType::Pull | SocketType::Sub | SocketType::Dish | SocketType::Gather
+    )
+}

--- a/omq-tokio/src/routing/exclusive.rs
+++ b/omq-tokio/src/routing/exclusive.rs
@@ -62,6 +62,19 @@ impl Submitter {
         }
     }
 
+    pub(crate) async fn wait_send_progress(&self) {
+        let space = {
+            let guard = self.pipe.lock().expect("exclusive pipe");
+            guard.as_ref().map(SendPipeProducer::space_available)
+        };
+
+        if let Some(space) = space {
+            space.notified().await;
+        } else {
+            self.peer_ready.notified().await;
+        }
+    }
+
     pub(crate) fn try_send(
         &self,
         msg: Message,

--- a/omq-tokio/src/routing/fallback_queue.rs
+++ b/omq-tokio/src/routing/fallback_queue.rs
@@ -161,6 +161,10 @@ impl FallbackQueue {
         self.inner.space_available.notified()
     }
 
+    pub(crate) async fn wait_space_available(&self) {
+        self.inner.space_available.notified().await;
+    }
+
     pub(crate) fn shutdown(&self) {
         self.inner.queue.close();
         let mut drained = 0usize;

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -147,6 +147,26 @@ impl Submitter {
         }
     }
 
+    pub(crate) async fn wait_send_progress(&self, msg: &Message) {
+        let Some(identity) = msg.part_bytes(0) else {
+            tokio::task::yield_now().await;
+            return;
+        };
+        let identity = Bytes::copy_from_slice(identity.as_ref());
+        let notified = {
+            let g = self.inner.lock().expect("identity inner poisoned");
+            g.identity_to_peer
+                .get(&identity)
+                .and_then(|id| g.peers.get(id))
+                .and_then(|peer| peer.target.space_available())
+        };
+        if let Some(notified) = notified {
+            notified.notified().await;
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+
     pub(crate) async fn send_rep(
         &self,
         peer_id: u64,

--- a/omq-tokio/src/routing/latency.rs
+++ b/omq-tokio/src/routing/latency.rs
@@ -156,6 +156,31 @@ impl Submitter {
         }
     }
 
+    pub(crate) async fn wait_send_progress(&self) {
+        let notified = {
+            let state = self.state.lock().expect("latency send state");
+            if state
+                .peers
+                .iter()
+                .any(|peer| peer.target.has_direct_writer())
+            {
+                None
+            } else {
+                state
+                    .peers
+                    .iter()
+                    .find_map(|peer| peer.target.space_available())
+            }
+        };
+        if let Some(notified) = notified {
+            notified.notified().await;
+        } else if self.queue.len() != 0 {
+            self.queue.wait_space_available().await;
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+
     pub(crate) fn try_send(&self, msg: Message) -> core::result::Result<(), TrySendError> {
         if self.queue.len() != 0 {
             return self.queue.try_send(msg).map_err(TrySendError::Full);

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -163,6 +163,16 @@ impl SendSubmitter {
             Self::Identity(s) => s.try_send(msg),
         }
     }
+
+    pub(crate) async fn wait_send_progress(&self, msg: &Message) {
+        match self {
+            Self::None | Self::FanOut(_) => tokio::task::yield_now().await,
+            Self::RoundRobin(s) => s.wait_send_progress().await,
+            Self::Latency(s) => s.wait_send_progress().await,
+            Self::Exclusive(s) => s.wait_send_progress().await,
+            Self::Identity(s) => s.wait_send_progress(msg).await,
+        }
+    }
 }
 
 impl SendStrategy {

--- a/omq-tokio/src/routing/round_robin.rs
+++ b/omq-tokio/src/routing/round_robin.rs
@@ -240,6 +240,36 @@ impl Submitter {
         }
     }
 
+    pub(crate) async fn wait_send_progress(&self) {
+        let space_available = {
+            let mut active = self.active.lock().expect("round_robin active");
+            if active.should_use_fallback() {
+                None
+            } else {
+                active.next_space_notify_any()
+            }
+        };
+
+        let Some(space_available) = space_available else {
+            if self.queue.is_closed() {
+                return;
+            }
+            let queue_space = self.queue.space_notified();
+            let active_changed = self.active_changed.notified();
+            tokio::pin!(queue_space);
+            tokio::pin!(active_changed);
+            queue_space.as_mut().enable();
+            active_changed.as_mut().enable();
+            tokio::select! {
+                () = queue_space => {}
+                () = active_changed => {}
+            }
+            return;
+        };
+
+        space_available.notified().await;
+    }
+
     pub(crate) fn try_send(
         &self,
         mut msg: Message,

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -380,7 +380,8 @@ impl Socket {
         self.inner.recv_rx.wait_for_spsc_space(msg)
     }
 
-    pub(crate) async fn wait_send_progress_for(&self, msg: &Message) {
+    #[doc(hidden)]
+    pub async fn wait_send_progress_for(&self, msg: &Message) {
         if self.inner.socket_type == SocketType::XSub && xsub_raw_command(msg).is_ok() {
             let _ = self.inner.cmd_tx.reserve().await;
             return;

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -305,6 +305,7 @@ impl Socket {
                 check_pre_send_frame_count(self.inner.socket_type, &msg)?;
                 self.inner.send_submitter.send(msg).await
             }
+            SocketType::XSub => self.send_xsub_raw_command(&msg).await,
             _ => {
                 check_pre_send_frame_count(self.inner.socket_type, &msg)?;
                 self.send_spsc_or_submit(msg).await
@@ -362,6 +363,7 @@ impl Socket {
                     .map_err(TrySendError::Error)?;
                 self.inner.send_submitter.try_send(msg)
             }
+            SocketType::XSub => self.try_send_xsub_raw_command(msg),
             _ => {
                 check_pre_send_frame_count(self.inner.socket_type, &msg)
                     .map_err(TrySendError::Error)?;
@@ -376,6 +378,21 @@ impl Socket {
 
     pub(crate) fn wait_for_spsc_space(&self, msg: &Message) -> bool {
         self.inner.recv_rx.wait_for_spsc_space(msg)
+    }
+
+    pub(crate) async fn wait_send_progress_for(&self, msg: &Message) {
+        if self.inner.socket_type == SocketType::XSub && xsub_raw_command(msg).is_ok() {
+            let _ = self.inner.cmd_tx.reserve().await;
+            return;
+        }
+        if self.inner.recv_rx.wait_for_spsc_space_async(msg).await {
+            return;
+        }
+        self.inner.send_submitter.wait_send_progress(msg).await;
+    }
+
+    pub(crate) fn same_socket(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 
     /// Receive the next message. Blocks until one is available or the socket
@@ -797,6 +814,34 @@ impl omq_proto::socket_api::SocketApi for Socket {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum XSubRawCommand {
+    Subscribe,
+    Unsubscribe,
+}
+
+fn xsub_raw_command(msg: &Message) -> Result<(XSubRawCommand, Bytes)> {
+    if msg.len() != 1 {
+        return Err(Error::Protocol(
+            "XSUB raw command must be a single frame".into(),
+        ));
+    }
+    let part = msg.part_bytes(0).unwrap_or_default();
+    let Some((&tag, prefix)) = part.split_first() else {
+        return Err(Error::Protocol("XSUB raw command cannot be empty".into()));
+    };
+    let command = match tag {
+        0x01 => XSubRawCommand::Subscribe,
+        0x00 => XSubRawCommand::Unsubscribe,
+        _ => {
+            return Err(Error::Protocol(
+                "XSUB raw command must start with 0x01 or 0x00".into(),
+            ));
+        }
+    };
+    Ok((command, Bytes::copy_from_slice(prefix)))
+}
+
 /// Validate frame count for socket types that enforce a fixed count but whose
 /// `TypeState::pre_send` has no mutable side effects. This mirrors the check
 /// inside `TypeState::pre_send` for the relevant types so the actor-bypass
@@ -819,6 +864,28 @@ fn check_pre_send_frame_count(t: SocketType, msg: &Message) -> Result<()> {
 }
 
 impl Socket {
+    async fn send_xsub_raw_command(&self, msg: &Message) -> Result<()> {
+        let (command, prefix) = xsub_raw_command(msg)?;
+        match command {
+            XSubRawCommand::Subscribe => self.subscribe(prefix).await,
+            XSubRawCommand::Unsubscribe => self.unsubscribe(prefix).await,
+        }
+    }
+
+    fn try_send_xsub_raw_command(&self, msg: Message) -> core::result::Result<(), TrySendError> {
+        let (command, prefix) = xsub_raw_command(&msg).map_err(TrySendError::Error)?;
+        let (ack, _rx) = oneshot::channel();
+        let command = match command {
+            XSubRawCommand::Subscribe => SocketCommand::Subscribe { prefix, ack },
+            XSubRawCommand::Unsubscribe => SocketCommand::Unsubscribe { prefix, ack },
+        };
+        match self.inner.cmd_tx.try_send(command) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(TrySendError::Full(msg)),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(TrySendError::Closed),
+        }
+    }
+
     async fn send_spsc_or_submit(&self, mut msg: Message) -> Result<()> {
         loop {
             match self.inner.recv_rx.try_push_spsc_or_full(msg) {

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -828,6 +828,43 @@ impl SpscAwareRecv {
         pair.wait_for_space();
         true
     }
+
+    pub(crate) async fn wait_for_spsc_space_async(&self, msg: &Message) -> bool {
+        if !self.send_ring_available.load(Ordering::Acquire) {
+            return false;
+        }
+        let pair = self.send_ring.load_full();
+        let Some(pair) = pair.as_ref() else {
+            return false;
+        };
+        if !pair.recv_ready.load(Ordering::Acquire)
+            || pair
+                .max_message_size
+                .is_some_and(|max| msg.byte_len() > max)
+            || pair.producer.is_consumer_dropped()
+        {
+            return false;
+        }
+        if !pair.producer.is_full() {
+            return true;
+        }
+
+        let notified = pair.space_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if !pair.recv_ready.load(Ordering::Acquire)
+            || pair
+                .max_message_size
+                .is_some_and(|max| msg.byte_len() > max)
+            || pair.producer.is_consumer_dropped()
+        {
+            return false;
+        }
+        if pair.producer.is_full() {
+            notified.await;
+        }
+        true
+    }
 }
 
 #[cfg(test)]

--- a/omq-tokio/tests/proxy.rs
+++ b/omq-tokio/tests/proxy.rs
@@ -1,0 +1,331 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use omq_tokio::{Message, Options, Proxy, ProxyExit, Socket, SocketType};
+
+fn endpoint(name: &str) -> omq_tokio::Endpoint {
+    format!("inproc://proxy-{name}").parse().unwrap()
+}
+
+async fn send_control(control: &Socket, command: &'static [u8]) {
+    control.send(Message::single(command)).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), control.recv())
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+async fn control_pair(id: &str) -> (Socket, Socket) {
+    let control = Socket::new(SocketType::Rep, Options::default());
+    let controller = Socket::new(SocketType::Req, Options::default());
+    control.bind(endpoint(id)).await.unwrap();
+    controller.connect(endpoint(id)).await.unwrap();
+    controller
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    (control, controller)
+}
+
+#[tokio::test]
+async fn steerable_proxy_pause_resume_terminate() {
+    let frontend = Socket::new(SocketType::Pull, Options::default());
+    let backend = Socket::new(SocketType::Push, Options::default());
+    let control = Socket::new(SocketType::Rep, Options::default());
+    let sender = Socket::new(SocketType::Push, Options::default());
+    let receiver = Socket::new(SocketType::Pull, Options::default());
+    let controller = Socket::new(SocketType::Req, Options::default());
+
+    frontend.bind(endpoint("steer-fe")).await.unwrap();
+    backend.bind(endpoint("steer-be")).await.unwrap();
+    control.bind(endpoint("steer-ctrl")).await.unwrap();
+    sender.connect(endpoint("steer-fe")).await.unwrap();
+    receiver.connect(endpoint("steer-be")).await.unwrap();
+    controller.connect(endpoint("steer-ctrl")).await.unwrap();
+
+    let task = tokio::spawn(
+        Proxy::new(frontend.clone(), backend.clone())
+            .control(control.clone())
+            .run(),
+    );
+
+    sender.send(Message::single("hello")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"hello");
+
+    send_control(&controller, b"PAUSE").await;
+    sender.send(Message::single("paused")).await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), receiver.recv())
+            .await
+            .is_err()
+    );
+
+    send_control(&controller, b"RESUME").await;
+    let msg = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"paused");
+
+    send_control(&controller, b"TERMINATE").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}
+
+#[tokio::test]
+async fn steerable_proxy_kill_terminates() {
+    let frontend = Socket::new(SocketType::Pull, Options::default());
+    let backend = Socket::new(SocketType::Push, Options::default());
+    let (control, controller) = control_pair("kill-ctrl").await;
+
+    frontend.bind(endpoint("kill-fe")).await.unwrap();
+    backend.bind(endpoint("kill-be")).await.unwrap();
+    let task = tokio::spawn(Proxy::new(frontend, backend).control(control).run());
+
+    send_control(&controller, b"KILL").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}
+
+#[tokio::test]
+async fn proxy_exits_closed_when_socket_closes() {
+    let frontend = Socket::new(SocketType::Pull, Options::default());
+    let backend = Socket::new(SocketType::Push, Options::default());
+    let task = tokio::spawn(Proxy::new(frontend.clone(), backend).run());
+
+    frontend.close().await.unwrap();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap(),
+        ProxyExit::Closed
+    );
+}
+
+#[tokio::test]
+async fn proxy_capture_gets_forwarded_copy() {
+    let frontend = Socket::new(SocketType::Pull, Options::default());
+    let backend = Socket::new(SocketType::Push, Options::default());
+    let capture = Socket::new(SocketType::Push, Options::default());
+    let sender = Socket::new(SocketType::Push, Options::default());
+    let receiver = Socket::new(SocketType::Pull, Options::default());
+    let capture_recv = Socket::new(SocketType::Pull, Options::default());
+    let control = Socket::new(SocketType::Rep, Options::default());
+    let controller = Socket::new(SocketType::Req, Options::default());
+
+    frontend.bind(endpoint("capture-fe")).await.unwrap();
+    backend.bind(endpoint("capture-be")).await.unwrap();
+    capture.bind(endpoint("capture-copy")).await.unwrap();
+    control.bind(endpoint("capture-ctrl")).await.unwrap();
+    sender.connect(endpoint("capture-fe")).await.unwrap();
+    receiver.connect(endpoint("capture-be")).await.unwrap();
+    capture_recv
+        .connect(endpoint("capture-copy"))
+        .await
+        .unwrap();
+    controller.connect(endpoint("capture-ctrl")).await.unwrap();
+    controller
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    capture
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    let task = tokio::spawn(
+        Proxy::new(frontend, backend)
+            .capture(capture)
+            .control(control.clone())
+            .run(),
+    );
+
+    sender.send(Message::single("trace")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"trace");
+    let captured = tokio::time::timeout(Duration::from_secs(2), capture_recv.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&captured.part_bytes(0).unwrap()[..], b"trace");
+
+    send_control(&controller, b"TERMINATE").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}
+
+#[tokio::test]
+async fn proxy_flushes_pending_after_backend_backpressure() {
+    let opts = Options::default().send_hwm(16).recv_hwm(16);
+    let frontend = Socket::new(SocketType::Pull, opts.clone());
+    let backend = Socket::new(SocketType::Push, opts.clone());
+    let sender = Socket::new(SocketType::Push, opts.clone());
+    let receiver = Socket::new(SocketType::Pull, opts);
+    let (control, controller) = control_pair("backpressure-ctrl").await;
+
+    frontend.bind(endpoint("backpressure-fe")).await.unwrap();
+    backend.bind(endpoint("backpressure-be")).await.unwrap();
+    sender.connect(endpoint("backpressure-fe")).await.unwrap();
+    receiver.connect(endpoint("backpressure-be")).await.unwrap();
+    let task = tokio::spawn(Proxy::new(frontend, backend).control(control.clone()).run());
+
+    let send_task = tokio::spawn(async move {
+        for i in 0..96usize {
+            sender.send(Message::single(i.to_string())).await.unwrap();
+        }
+    });
+
+    let mut got = Vec::new();
+    for _ in 0..96 {
+        let msg = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        got.push(String::from_utf8(msg.part_bytes(0).unwrap().to_vec()).unwrap());
+    }
+    send_task.await.unwrap();
+    assert_eq!(got.len(), 96);
+
+    send_control(&controller, b"TERMINATE").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}
+
+#[tokio::test]
+async fn proxy_does_not_starve_backend_when_frontend_is_hot() {
+    let opts = Options::default().send_hwm(16).recv_hwm(16);
+    let frontend = Socket::new(SocketType::Pair, opts.clone());
+    let backend = Socket::new(SocketType::Pair, opts.clone());
+    let client = Socket::new(SocketType::Pair, opts.clone());
+    let server = Socket::new(SocketType::Pair, opts);
+    let (control, controller) = control_pair("fair-ctrl").await;
+
+    frontend.bind(endpoint("fair-fe")).await.unwrap();
+    backend.bind(endpoint("fair-be")).await.unwrap();
+    client.connect(endpoint("fair-fe")).await.unwrap();
+    server.connect(endpoint("fair-be")).await.unwrap();
+    let task = tokio::spawn(
+        Proxy::new(frontend, backend)
+            .control(control.clone())
+            .burst_size(4)
+            .run(),
+    );
+    client
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    server
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let drained = Arc::new(AtomicUsize::new(0));
+    let spam_stop = stop.clone();
+    let spam_client = client.clone();
+    let spam = tokio::spawn(async move {
+        while !spam_stop.load(Ordering::Relaxed) {
+            if spam_client.send(Message::single("load")).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let drain_stop = stop.clone();
+    let drain_count = drained.clone();
+    let drain_server = server.clone();
+    let drain = tokio::spawn(async move {
+        while !drain_stop.load(Ordering::Relaxed) {
+            if let Ok(Ok(_)) =
+                tokio::time::timeout(Duration::from_millis(20), drain_server.recv()).await
+            {
+                drain_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while drained.load(Ordering::Relaxed) < 64 {
+        assert!(std::time::Instant::now() < deadline);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    server.send(Message::single("probe")).await.unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"probe");
+
+    stop.store(true, Ordering::Relaxed);
+    spam.abort();
+    drain.abort();
+    send_control(&controller, b"TERMINATE").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}
+
+#[tokio::test]
+async fn proxy_forwards_xpub_subscriptions_to_xsub() {
+    let frontend = Socket::new(SocketType::XSub, Options::default());
+    let backend = Socket::new(SocketType::XPub, Options::default());
+    let control = Socket::new(SocketType::Rep, Options::default());
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let subscriber = Socket::new(SocketType::Sub, Options::default());
+    let controller = Socket::new(SocketType::Req, Options::default());
+
+    frontend.bind(endpoint("xsub-xpub-fe")).await.unwrap();
+    backend.bind(endpoint("xsub-xpub-be")).await.unwrap();
+    control.bind(endpoint("xsub-xpub-ctrl")).await.unwrap();
+    publisher.connect(endpoint("xsub-xpub-fe")).await.unwrap();
+    subscriber.connect(endpoint("xsub-xpub-be")).await.unwrap();
+    controller
+        .connect(endpoint("xsub-xpub-ctrl"))
+        .await
+        .unwrap();
+
+    let task = tokio::spawn(
+        Proxy::new(frontend.clone(), backend.clone())
+            .control(control.clone())
+            .run(),
+    );
+
+    publisher
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    subscriber
+        .wait_connected(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    subscriber.subscribe("news.").await.unwrap();
+    publisher
+        .wait_subscribed(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        publisher.send(Message::single("news.alpha")).await.unwrap();
+        publisher
+            .send(Message::single("sports.beta"))
+            .await
+            .unwrap();
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::from_millis(20), subscriber.recv()).await
+        {
+            assert_eq!(&msg.part_bytes(0).unwrap()[..], b"news.alpha");
+            break;
+        }
+        assert!(std::time::Instant::now() < deadline);
+    }
+
+    send_control(&controller, b"TERMINATE").await;
+    assert_eq!(task.await.unwrap().unwrap(), ProxyExit::Terminated);
+}

--- a/omq-tokio/tests/xpub_xsub.rs
+++ b/omq-tokio/tests/xpub_xsub.rs
@@ -154,18 +154,36 @@ async fn xsub_subscribe_filters_messages_from_xpub() {
 }
 
 #[tokio::test]
-async fn xsub_send_returns_protocol_error() {
-    // XSUB has no send strategy for normal messages; send() should error.
-    // This documents the current limitation: the XSUB-as-proxy pattern
-    // (forwarding \x01<topic> messages via xsub.send()) is not yet supported.
-    let xsub = omq_tokio::Socket::new(omq_tokio::SocketType::XSub, omq_tokio::Options::default());
-    let r = xsub
-        .send(omq_tokio::Message::single(b"\x01topic".as_ref()))
-        .await;
-    assert!(
-        matches!(r, Err(omq_tokio::Error::Protocol(_))),
-        "XSUB send should return Protocol error; got {r:?}"
-    );
+async fn xsub_send_raw_subscribe_commands() {
+    let publisher_side = Socket::new(SocketType::XPub, Options::default());
+    let subscriber_side = Socket::new(SocketType::XSub, Options::default());
+    let endpoint = "inproc://xsub-send-raw-subscribe".parse().unwrap();
+
+    publisher_side.bind(endpoint).await.unwrap();
+    subscriber_side
+        .connect("inproc://xsub-send-raw-subscribe".parse().unwrap())
+        .await
+        .unwrap();
+
+    subscriber_side
+        .send(Message::single(b"\x01topic".as_ref()))
+        .await
+        .unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), publisher_side.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"\x01topic");
+
+    subscriber_side
+        .send(Message::single(b"\x00topic".as_ref()))
+        .await
+        .unwrap();
+    let msg = tokio::time::timeout(Duration::from_secs(2), publisher_side.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&msg.part_bytes(0).unwrap()[..], b"\x00topic");
 }
 
 // Raw ZMTP bytes for a ZMTP 3.0 SUB greeting and READY command.


### PR DESCRIPTION
- Add omq-tokio Proxy with steerable control, capture, bounded bursts, and pending retry.
- Use the tokio proxy in pyomq and refresh pyomq benchmark docs/charts.
- Port omq-libzmq proxy to message-level forwarding through libzmq queues.
- Cover proxy control, backpressure, fairness, capture, multipart, and XPUB/XSUB behavior.