### PR TITLE
Document context APIs and remove bounded prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,6 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 ### Changed
 
 - Deny `unsafe_op_in_unsafe_fn` lint.
-- Rename `prefetch_upto` to `prefetch_up_to`.
 
 ## [omq-libzmq 0.5.3] - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ OMQ is designed for real ZMQ behavior, not just happy-path PUSH/PULL throughput.
 > The API is still evolving and may change between minor versions. Bug reports and testing in real workloads are welcome.
 
 The Rust backend is [`omq-tokio`](omq-tokio/): tokio + mio on Linux,
-macOS, and Windows. It works on single-thread and multi-thread tokio
-runtimes.
+macOS, and Windows. It can run socket IO on OMQ-owned runtime threads or
+inside an existing tokio runtime.
+
+| API | Runtime placement | Scaling model |
+|-----|-------------------|---------------|
+| `Context::new().socket(...)` | Async socket, OMQ-owned IO threads | Linear IO-lane scaling; PUB peers are sharded across lanes |
+| `Context::current().socket(...)` | Async socket, caller's active tokio runtime | Tokio scheduler/work stealing; PUB fan-out stays on one OMQ lane |
+| `Context::new().blocking_socket(...)` | Sync socket, OMQ-owned IO threads | Linear IO-lane scaling; caller thread stays out of IO |
 
 Supported 32-bit Linux targets are `i686-unknown-linux-gnu` and
 `armv7-unknown-linux-gnueabihf`. They require native 64-bit atomics. ZMTP wire
@@ -68,13 +74,15 @@ platform allocation limits (below 4 GiB on 32-bit).
 If you know ZeroMQ, you know OMQ. Same socket types, same connect/bind/send/recv:
 
 ```rust
-use omq_tokio::{Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Message, Options, SocketType};
 
-let push = Socket::new(SocketType::Push, Options::default());
+let ctx = Context::new();
+
+let push = ctx.socket(SocketType::Push, Options::default());
 push.connect("tcp://127.0.0.1:5555".parse()?).await?;
 push.send(Message::single("hello")).await?;
 
-let pull = Socket::new(SocketType::Pull, Options::default());
+let pull = ctx.socket(SocketType::Pull, Options::default());
 pull.bind("tcp://127.0.0.1:5555".parse()?).await?;
 let msg = pull.recv().await?;
 assert_eq!(&msg[0], b"hello");

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -36,9 +36,12 @@ thread run with zero contention from connections on other threads.
   where a `multi_thread` runtime can push a single TCP pipe to its
   limit. It does not scale fan-out across threads.
 
-`Context::socket()` creates sockets whose driver tasks run on the
-context's runtime. `Context::block_on()` runs a future on the owned
-runtime and blocks the caller (not available on `Context::current()`).
+`Context::socket()` creates async sockets whose driver tasks run on the
+context's runtime. With an owned context, callers await socket futures
+from their own async runtime while OMQ IO stays on the context's runtime
+threads. `Context::block_on()` is a plain-`fn main()` helper that runs a
+future on the owned runtime and blocks the caller (not available on
+`Context::current()`).
 
 ## Blocking API (background IO)
 

--- a/examples/zguide-tokio/01_req_rep/broker.rs
+++ b/examples/zguide-tokio/01_req_rep/broker.rs
@@ -5,45 +5,47 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin broker [frontend] [backend]
 
-use omq_tokio::{Context, Endpoint, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
-        let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-01-backend");
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
+    let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-01-backend");
 
-        let frontend = Socket::new(SocketType::Router, Options::default());
-        frontend.bind(frontend_ep.clone()).await.unwrap();
+    let frontend = ctx.socket(SocketType::Router, Options::default());
+    frontend.bind(frontend_ep.clone()).await.unwrap();
 
-        let backend = Socket::new(SocketType::Dealer, Options::default());
-        backend.bind(backend_ep.clone()).await.unwrap();
+    let backend = ctx.socket(SocketType::Dealer, Options::default());
+    backend.bind(backend_ep.clone()).await.unwrap();
 
-        println!("broker: frontend={frontend_ep} backend={backend_ep}");
+    println!("broker: frontend={frontend_ep} backend={backend_ep}");
 
-        let fe = frontend.clone();
-        let be = backend.clone();
-        let fwd = tokio::spawn(async move {
-            loop {
-                let msg = fe.recv().await.unwrap();
-                be.send(msg).await.unwrap();
-            }
-        });
-
-        let fe = frontend;
-        let be = backend;
-        let ret = tokio::spawn(async move {
-            loop {
-                let msg = be.recv().await.unwrap();
-                fe.send(msg).await.unwrap();
-            }
-        });
-
-        let _ = tokio::join!(fwd, ret);
+    let fe = frontend.clone();
+    let be = backend.clone();
+    let fwd = tokio::spawn(async move {
+        loop {
+            let msg = fe.recv().await.unwrap();
+            be.send(msg).await.unwrap();
+        }
     });
+
+    let fe = frontend;
+    let be = backend;
+    let ret = tokio::spawn(async move {
+        loop {
+            let msg = be.recv().await.unwrap();
+            fe.send(msg).await.unwrap();
+        }
+    });
+
+    let _ = tokio::join!(fwd, ret);
 }

--- a/examples/zguide-tokio/01_req_rep/client.rs
+++ b/examples/zguide-tokio/01_req_rep/client.rs
@@ -5,34 +5,36 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin client [frontend] [n_requests]
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
-        let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(9);
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-frontend");
+    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(9);
 
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(frontend_ep).await.unwrap();
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(frontend_ep).await.unwrap();
 
-        for i in 0..n {
-            let request = format!("request-{i}");
-            req.send(Message::single(request.clone())).await.unwrap();
-            let reply = req.recv().await.unwrap();
-            let body = msg_str(&reply, 0);
-            println!("client: {request} -> {body}");
-        }
+    for i in 0..n {
+        let request = format!("request-{i}");
+        req.send(Message::single(request.clone())).await.unwrap();
+        let reply = req.recv().await.unwrap();
+        let body = msg_str(&reply, 0);
+        println!("client: {request} -> {body}");
+    }
 
-        println!("done: {n} replies");
-    });
+    println!("done: {n} replies");
 }

--- a/examples/zguide-tokio/01_req_rep/echo.rs
+++ b/examples/zguide-tokio/01_req_rep/echo.rs
@@ -6,49 +6,51 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-echo");
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-echo");
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(ep.clone()).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(ep.clone()).await.unwrap();
 
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(ep).await.unwrap();
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(ep).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let server = tokio::spawn(async move {
-            for _ in 0..3 {
-                let msg = rep.recv().await.unwrap();
-                let body = msg_str(&msg, 0);
-                rep.send(Message::single(format!("echo:{body}")))
-                    .await
-                    .unwrap();
-            }
-        });
-
-        for i in 0..3 {
-            let request = format!("hello-{i}");
-            req.send(Message::single(request.clone())).await.unwrap();
-            let reply = req.recv().await.unwrap();
-            let body = msg_str(&reply, 0);
-            println!("client: {request} -> {body}");
+    let server = tokio::spawn(async move {
+        for _ in 0..3 {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            rep.send(Message::single(format!("echo:{body}")))
+                .await
+                .unwrap();
         }
-
-        server.await.unwrap();
-        println!("done: 3 request-reply cycles");
     });
+
+    for i in 0..3 {
+        let request = format!("hello-{i}");
+        req.send(Message::single(request.clone())).await.unwrap();
+        let reply = req.recv().await.unwrap();
+        let body = msg_str(&reply, 0);
+        println!("client: {request} -> {body}");
+    }
+
+    server.await.unwrap();
+    println!("done: 3 request-reply cycles");
 }

--- a/examples/zguide-tokio/01_req_rep/worker.rs
+++ b/examples/zguide-tokio/01_req_rep/worker.rs
@@ -5,34 +5,36 @@
 //!
 //!     cargo run -p zguide-tokio-01-req-rep --bin worker [backend] [id]
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-backend");
-        let id = args.get(2).map_or("0", |s| s.as_str());
+    let args: Vec<String> = std::env::args().collect();
+    let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-01-backend");
+    let id = args.get(2).map_or("0", |s| s.as_str());
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.connect(backend_ep).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.connect(backend_ep).await.unwrap();
 
-        println!("worker-{id}: ready");
+    println!("worker-{id}: ready");
 
-        loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            let reply = format!("worker-{id}:{body}");
-            println!("worker-{id}: {body} -> {reply}");
-            rep.send(Message::single(reply)).await.unwrap();
-        }
-    });
+    loop {
+        let msg = rep.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        let reply = format!("worker-{id}:{body}");
+        println!("worker-{id}: {body} -> {reply}");
+        rep.send(Message::single(reply)).await.unwrap();
+    }
 }

--- a/examples/zguide-tokio/02_pub_sub/Cargo.toml
+++ b/examples/zguide-tokio/02_pub_sub/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/02_pub_sub/proxy.rs
+++ b/examples/zguide-tokio/02_pub_sub/proxy.rs
@@ -11,33 +11,35 @@
 //! NOTE: This uses SUB/PUB relay instead of the canonical XSUB/XPUB
 //! proxy because `XSUB.send()` is not yet supported.
 
-use omq_tokio::{Context, Endpoint, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let upstream_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-upstream");
-        let downstream_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-02-downstream");
+    let args: Vec<String> = std::env::args().collect();
+    let upstream_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-upstream");
+    let downstream_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-02-downstream");
 
-        // Upstream: SUB connects to the publisher and subscribes to everything.
-        let upstream = Socket::new(SocketType::Sub, Options::default());
-        upstream.connect(upstream_ep.clone()).await.unwrap();
-        upstream.subscribe("").await.unwrap();
+    // Upstream: SUB connects to the publisher and subscribes to everything.
+    let upstream = ctx.socket(SocketType::Sub, Options::default());
+    upstream.connect(upstream_ep.clone()).await.unwrap();
+    upstream.subscribe("").await.unwrap();
 
-        // Downstream: PUB binds so downstream subscribers can connect.
-        let downstream = Socket::new(SocketType::Pub, Options::default());
-        downstream.bind(downstream_ep.clone()).await.unwrap();
+    // Downstream: PUB binds so downstream subscribers can connect.
+    let downstream = ctx.socket(SocketType::Pub, Options::default());
+    downstream.bind(downstream_ep.clone()).await.unwrap();
 
-        println!("proxy: upstream={upstream_ep} downstream={downstream_ep}");
+    println!("proxy: upstream={upstream_ep} downstream={downstream_ep}");
 
-        loop {
-            let msg = upstream.recv().await.unwrap();
-            downstream.send(msg).await.unwrap();
-        }
-    });
+    loop {
+        let msg = upstream.recv().await.unwrap();
+        downstream.send(msg).await.unwrap();
+    }
 }

--- a/examples/zguide-tokio/02_pub_sub/publisher.rs
+++ b/examples/zguide-tokio/02_pub_sub/publisher.rs
@@ -9,49 +9,51 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
-        let count: Option<usize> = args.get(2).and_then(|s| s.parse().ok());
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
+    let count: Option<usize> = args.get(2).and_then(|s| s.parse().ok());
 
-        let pub_ = Socket::new(SocketType::Pub, Options::default());
-        pub_.bind(ep.clone()).await.unwrap();
+    let pub_ = ctx.socket(SocketType::Pub, Options::default());
+    pub_.bind(ep.clone()).await.unwrap();
 
-        println!("publisher: bound to {ep}");
+    println!("publisher: bound to {ep}");
 
-        // Give subscribers time to connect and send SUBSCRIBE commands.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+    // Give subscribers time to connect and send SUBSCRIBE commands.
+    tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let rounds = count.unwrap_or(usize::MAX);
-        for i in 0..rounds {
-            let nyc_temp = 55 + (i % 30);
-            let sfo_temp = 60 + (i % 20);
-            let chi_temp = 40 + (i % 35);
+    let rounds = count.unwrap_or(usize::MAX);
+    for i in 0..rounds {
+        let nyc_temp = 55 + (i % 30);
+        let sfo_temp = 60 + (i % 20);
+        let chi_temp = 40 + (i % 35);
 
-            pub_.send(Message::single(format!("weather.nyc {nyc_temp}F")))
-                .await
-                .unwrap();
-            pub_.send(Message::single(format!("weather.sfo {sfo_temp}F")))
-                .await
-                .unwrap();
-            pub_.send(Message::single(format!("weather.chi {chi_temp}F")))
-                .await
-                .unwrap();
-            pub_.send(Message::single(format!("sports.nba score-{i}")))
-                .await
-                .unwrap();
+        pub_.send(Message::single(format!("weather.nyc {nyc_temp}F")))
+            .await
+            .unwrap();
+        pub_.send(Message::single(format!("weather.sfo {sfo_temp}F")))
+            .await
+            .unwrap();
+        pub_.send(Message::single(format!("weather.chi {chi_temp}F")))
+            .await
+            .unwrap();
+        pub_.send(Message::single(format!("sports.nba score-{i}")))
+            .await
+            .unwrap();
 
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
-        println!("publisher: done ({rounds} rounds)");
-    });
+    println!("publisher: done ({rounds} rounds)");
 }

--- a/examples/zguide-tokio/02_pub_sub/subscriber.rs
+++ b/examples/zguide-tokio/02_pub_sub/subscriber.rs
@@ -8,40 +8,42 @@
 //! If `count` is given, receives that many messages then exits.
 //! Otherwise runs indefinitely (Ctrl-C to stop).
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
-        let topic: String = args
-            .get(2)
-            .cloned()
-            .unwrap_or_else(|| "weather.nyc".to_string());
-        let count: Option<usize> = args.get(3).and_then(|s| s.parse().ok());
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-02-pubsub");
+    let topic: String = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "weather.nyc".to_string());
+    let count: Option<usize> = args.get(3).and_then(|s| s.parse().ok());
 
-        let sub = Socket::new(SocketType::Sub, Options::default());
-        sub.connect(ep.clone()).await.unwrap();
-        sub.subscribe(topic.clone()).await.unwrap();
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+    sub.connect(ep.clone()).await.unwrap();
+    sub.subscribe(topic.clone()).await.unwrap();
 
-        println!("subscriber: connected to {ep}, topic={topic:?}");
+    println!("subscriber: connected to {ep}, topic={topic:?}");
 
-        let limit = count.unwrap_or(usize::MAX);
-        for i in 0..limit {
-            let msg = sub.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            println!("subscriber[{topic}]: [{i}] {body}");
-        }
+    let limit = count.unwrap_or(usize::MAX);
+    for i in 0..limit {
+        let msg = sub.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        println!("subscriber[{topic}]: [{i}] {body}");
+    }
 
-        println!("subscriber: done ({limit} messages)");
-    });
+    println!("subscriber: done ({limit} messages)");
 }

--- a/examples/zguide-tokio/03_pipeline/Cargo.toml
+++ b/examples/zguide-tokio/03_pipeline/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/03_pipeline/sink.rs
+++ b/examples/zguide-tokio/03_pipeline/sink.rs
@@ -8,48 +8,50 @@
 
 use std::collections::HashMap;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let sink_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-sink");
-        let expected: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+    let args: Vec<String> = std::env::args().collect();
+    let sink_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-sink");
+    let expected: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
 
-        let pull = Socket::new(SocketType::Pull, Options::default());
-        pull.bind(sink_ep.clone()).await.unwrap();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    pull.bind(sink_ep.clone()).await.unwrap();
 
-        println!("sink: listening on {sink_ep}, expecting {expected} results");
+    println!("sink: listening on {sink_ep}, expecting {expected} results");
 
-        let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut counts: HashMap<String, usize> = HashMap::new();
 
-        for i in 0..expected {
-            let msg = pull.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            let worker_id = body.split(':').next().unwrap_or("unknown").to_string();
-            *counts.entry(worker_id).or_default() += 1;
-            if (i + 1) % 25 == 0 || i + 1 == expected {
-                println!("sink: received {}/{expected}", i + 1);
-            }
+    for i in 0..expected {
+        let msg = pull.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        let worker_id = body.split(':').next().unwrap_or("unknown").to_string();
+        *counts.entry(worker_id).or_default() += 1;
+        if (i + 1) % 25 == 0 || i + 1 == expected {
+            println!("sink: received {}/{expected}", i + 1);
         }
+    }
 
-        println!(
-            "sink: done — {expected} results from {} workers",
-            counts.len()
-        );
-        let mut sorted: Vec<_> = counts.into_iter().collect();
-        sorted.sort();
-        for (worker, count) in &sorted {
-            println!("  {worker}: {count} items");
-        }
-    });
+    println!(
+        "sink: done — {expected} results from {} workers",
+        counts.len()
+    );
+    let mut sorted: Vec<_> = counts.into_iter().collect();
+    sorted.sort();
+    for (worker, count) in &sorted {
+        println!("  {worker}: {count} items");
+    }
 }

--- a/examples/zguide-tokio/03_pipeline/ventilator.rs
+++ b/examples/zguide-tokio/03_pipeline/ventilator.rs
@@ -7,34 +7,36 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
-        let n_tasks: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+    let args: Vec<String> = std::env::args().collect();
+    let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
+    let n_tasks: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
 
-        let push = Socket::new(
-            SocketType::Push,
-            Options::default().linger(Duration::from_secs(2)),
-        );
-        push.bind(vent_ep.clone()).await.unwrap();
+    let push = ctx.socket(
+        SocketType::Push,
+        Options::default().linger(Duration::from_secs(2)),
+    );
+    push.bind(vent_ep.clone()).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
-        for i in 0..n_tasks {
-            push.send(Message::single(format!("task-{i}")))
-                .await
-                .unwrap();
-        }
+    for i in 0..n_tasks {
+        push.send(Message::single(format!("task-{i}")))
+            .await
+            .unwrap();
+    }
 
-        println!("ventilator: sent {n_tasks} tasks on {vent_ep}");
-        push.close().await.unwrap();
-    });
+    println!("ventilator: sent {n_tasks} tasks on {vent_ep}");
+    push.close().await.unwrap();
 }

--- a/examples/zguide-tokio/03_pipeline/worker.rs
+++ b/examples/zguide-tokio/03_pipeline/worker.rs
@@ -5,37 +5,39 @@
 //!
 //!     cargo run -p zguide-tokio-03-pipeline --bin worker [vent_ep] [sink_ep] [worker_id]
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
-        let sink_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-03-sink");
-        let id = args.get(3).map_or("0", |s| s.as_str());
+    let args: Vec<String> = std::env::args().collect();
+    let vent_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-03-ventilator");
+    let sink_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-03-sink");
+    let id = args.get(3).map_or("0", |s| s.as_str());
 
-        let pull = Socket::new(SocketType::Pull, Options::default());
-        pull.connect(vent_ep).await.unwrap();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    pull.connect(vent_ep).await.unwrap();
 
-        let push = Socket::new(SocketType::Push, Options::default());
-        push.connect(sink_ep).await.unwrap();
+    let push = ctx.socket(SocketType::Push, Options::default());
+    push.connect(sink_ep).await.unwrap();
 
-        println!("worker-{id}: ready");
+    println!("worker-{id}: ready");
 
-        loop {
-            let msg = pull.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            let result = format!("worker-{id}:{body}");
-            push.send(Message::single(result)).await.unwrap();
-        }
-    });
+    loop {
+        let msg = pull.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        let result = format!("worker-{id}:{body}");
+        push.send(Message::single(result)).await.unwrap();
+    }
 }

--- a/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
+++ b/examples/zguide-tokio/04_lazy_pirate/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/04_lazy_pirate/client.rs
+++ b/examples/zguide-tokio/04_lazy_pirate/client.rs
@@ -9,70 +9,72 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-async fn new_req(ep: &Endpoint) -> Socket {
-    let req = Socket::new(SocketType::Req, Options::default());
+async fn new_req(ctx: &Context, ep: &Endpoint) -> omq_tokio::Socket {
+    let req = ctx.socket(SocketType::Req, Options::default());
     req.connect(ep.clone()).await.unwrap();
     // Brief pause so the connection can establish.
     tokio::time::sleep(Duration::from_millis(20)).await;
     req
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
 
-        let max_retries = 3;
-        let mut total_retries: u32 = 0;
-        let mut replies: Vec<String> = Vec::new();
+    let max_retries = 3;
+    let mut total_retries: u32 = 0;
+    let mut replies: Vec<String> = Vec::new();
 
-        let mut req = new_req(&ep).await;
+    let mut req = new_req(&ctx, &ep).await;
 
-        for seq in 0..5 {
-            let request = format!("request-{seq}");
-            let mut attempts = 0;
+    for seq in 0..5 {
+        let request = format!("request-{seq}");
+        let mut attempts = 0;
 
-            loop {
-                req.send(Message::single(request.clone())).await.unwrap();
+        loop {
+            req.send(Message::single(request.clone())).await.unwrap();
 
-                match tokio::time::timeout(Duration::from_millis(400), req.recv()).await {
-                    Ok(Ok(reply)) => {
-                        let body = msg_str(&reply, 0);
-                        println!("client: {request} -> {body}");
-                        replies.push(body);
+            match tokio::time::timeout(Duration::from_millis(400), req.recv()).await {
+                Ok(Ok(reply)) => {
+                    let body = msg_str(&reply, 0);
+                    println!("client: {request} -> {body}");
+                    replies.push(body);
+                    break;
+                }
+                Ok(Err(e)) => {
+                    eprintln!("client: recv error on {request}: {e}");
+                    break;
+                }
+                Err(_) => {
+                    attempts += 1;
+                    total_retries += 1;
+                    println!("client: timeout on {request}, retry {attempts}");
+                    // Destroy and recreate the socket (Lazy Pirate pattern).
+                    let _ = req.close().await;
+                    req = new_req(&ctx, &ep).await;
+                    if attempts >= max_retries {
+                        println!("client: giving up on {request}");
                         break;
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("client: recv error on {request}: {e}");
-                        break;
-                    }
-                    Err(_) => {
-                        attempts += 1;
-                        total_retries += 1;
-                        println!("client: timeout on {request}, retry {attempts}");
-                        // Destroy and recreate the socket (Lazy Pirate pattern).
-                        let _ = req.close().await;
-                        req = new_req(&ep).await;
-                        if attempts >= max_retries {
-                            println!("client: giving up on {request}");
-                            break;
-                        }
                     }
                 }
             }
         }
+    }
 
-        println!("done: {} replies, {total_retries} retries", replies.len());
-    });
+    println!("done: {} replies, {total_retries} retries", replies.len());
 }

--- a/examples/zguide-tokio/04_lazy_pirate/server.rs
+++ b/examples/zguide-tokio/04_lazy_pirate/server.rs
@@ -8,57 +8,59 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-04-server");
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(ep).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(ep).await.unwrap();
 
-        let mut handled: u32 = 0;
-        loop {
-            let msg = match tokio::time::timeout(Duration::from_secs(3), rep.recv()).await {
-                Ok(Ok(msg)) => msg,
-                Ok(Err(e)) => {
-                    eprintln!("server: recv error: {e}");
-                    continue;
-                }
-                Err(_) => {
-                    println!("server: no request for 3s, exiting");
-                    break;
-                }
-            };
-
-            handled += 1;
-            let body = msg_str(&msg, 0);
-
-            if handled == 3 {
-                println!("server: simulating crash on '{body}'");
-                tokio::time::sleep(Duration::from_millis(500)).await;
+    let mut handled: u32 = 0;
+    loop {
+        let msg = match tokio::time::timeout(Duration::from_secs(3), rep.recv()).await {
+            Ok(Ok(msg)) => msg,
+            Ok(Err(e)) => {
+                eprintln!("server: recv error: {e}");
+                continue;
             }
-
-            let reply = format!("reply:{body}");
-            match rep.send(Message::single(reply)).await {
-                Ok(()) => println!("server: replied to {body}"),
-                Err(e) => {
-                    // Stale retry from client that already reconnected; skip it.
-                    eprintln!("server: send error for {body}: {e}");
-                }
+            Err(_) => {
+                println!("server: no request for 3s, exiting");
+                break;
             }
+        };
+
+        handled += 1;
+        let body = msg_str(&msg, 0);
+
+        if handled == 3 {
+            println!("server: simulating crash on '{body}'");
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
-        println!("server: handled {handled} requests");
-    });
+        let reply = format!("reply:{body}");
+        match rep.send(Message::single(reply)).await {
+            Ok(()) => println!("server: replied to {body}"),
+            Err(e) => {
+                // Stale retry from client that already reconnected; skip it.
+                eprintln!("server: send error for {body}: {e}");
+            }
+        }
+    }
+
+    println!("server: handled {handled} requests");
 }

--- a/examples/zguide-tokio/05_heartbeat/Cargo.toml
+++ b/examples/zguide-tokio/05_heartbeat/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/05_heartbeat/monitor.rs
+++ b/examples/zguide-tokio/05_heartbeat/monitor.rs
@@ -7,54 +7,56 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
 
-        let sub = Socket::new(SocketType::Sub, Options::default());
-        sub.connect(ep).await.unwrap();
-        sub.subscribe("HEARTBEAT").await.unwrap();
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+    sub.connect(ep).await.unwrap();
+    sub.subscribe("HEARTBEAT").await.unwrap();
 
-        let timeout = Duration::from_millis(150);
-        let mut alive = false;
-        let mut events: Vec<String> = Vec::new();
+    let timeout = Duration::from_millis(150);
+    let mut alive = false;
+    let mut events: Vec<String> = Vec::new();
 
-        for _ in 0..20 {
-            match tokio::time::timeout(timeout, sub.recv()).await {
-                Ok(Ok(msg)) => {
-                    let body = msg_str(&msg, 0);
-                    if !alive {
-                        events.push("alive".to_string());
-                        alive = true;
-                        println!("monitor: ALIVE ({body})");
-                    }
+    for _ in 0..20 {
+        match tokio::time::timeout(timeout, sub.recv()).await {
+            Ok(Ok(msg)) => {
+                let body = msg_str(&msg, 0);
+                if !alive {
+                    events.push("alive".to_string());
+                    alive = true;
+                    println!("monitor: ALIVE ({body})");
                 }
-                Ok(Err(e)) => {
-                    eprintln!("monitor: recv error: {e}");
-                    break;
-                }
-                Err(_) => {
-                    if alive {
-                        events.push("dead".to_string());
-                        alive = false;
-                        println!("monitor: DEAD (timeout)");
-                    }
+            }
+            Ok(Err(e)) => {
+                eprintln!("monitor: recv error: {e}");
+                break;
+            }
+            Err(_) => {
+                if alive {
+                    events.push("dead".to_string());
+                    alive = false;
+                    println!("monitor: DEAD (timeout)");
                 }
             }
         }
+    }
 
-        println!("monitor: events: {events:?}");
-    });
+    println!("monitor: events: {events:?}");
 }

--- a/examples/zguide-tokio/05_heartbeat/publisher.rs
+++ b/examples/zguide-tokio/05_heartbeat/publisher.rs
@@ -10,42 +10,44 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-05-heartbeat");
 
-        let pub_socket = Socket::new(SocketType::Pub, Options::default());
-        pub_socket.bind(ep).await.unwrap();
+    let pub_socket = ctx.socket(SocketType::Pub, Options::default());
+    pub_socket.bind(ep).await.unwrap();
 
-        // Brief pause for subscribers to connect.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+    // Brief pause for subscribers to connect.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Phase 1: alive
-        for i in 0..8 {
-            pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
-            println!("publisher: heartbeat {i}");
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+    // Phase 1: alive
+    for i in 0..8 {
+        pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
+        println!("publisher: heartbeat {i}");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
-        // Phase 2: simulate failure
-        println!("publisher: simulating failure (300ms pause)");
-        tokio::time::sleep(Duration::from_millis(300)).await;
+    // Phase 2: simulate failure
+    println!("publisher: simulating failure (300ms pause)");
+    tokio::time::sleep(Duration::from_millis(300)).await;
 
-        // Phase 3: recover
-        for i in 8..16 {
-            pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
-            println!("publisher: heartbeat {i}");
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+    // Phase 3: recover
+    for i in 8..16 {
+        pub_socket.send(Message::single("HEARTBEAT")).await.unwrap();
+        println!("publisher: heartbeat {i}");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
-        println!("publisher: done");
-    });
+    println!("publisher: done");
 }

--- a/examples/zguide-tokio/06_last_value_cache/cache.rs
+++ b/examples/zguide-tokio/06_last_value_cache/cache.rs
@@ -9,81 +9,83 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
-        let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
-        let snapshot_ep = endpoint_or(&args, 3, "ipc://@omq-zguide-06-snapshot");
+    let args: Vec<String> = std::env::args().collect();
+    let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
+    let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
+    let snapshot_ep = endpoint_or(&args, 3, "ipc://@omq-zguide-06-snapshot");
 
-        let pull = Socket::new(SocketType::Pull, Options::default());
-        pull.bind(pub_ep.clone()).await.unwrap();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    pull.bind(pub_ep.clone()).await.unwrap();
 
-        let pub_ = Socket::new(SocketType::Pub, Options::default());
-        pub_.bind(sub_ep.clone()).await.unwrap();
+    let pub_ = ctx.socket(SocketType::Pub, Options::default());
+    pub_.bind(sub_ep.clone()).await.unwrap();
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(snapshot_ep.clone()).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(snapshot_ep.clone()).await.unwrap();
 
-        println!("cache: PULL bound to {pub_ep}");
-        println!("cache: PUB  bound to {sub_ep}");
-        println!("cache: REP  bound to {snapshot_ep}");
+    println!("cache: PULL bound to {pub_ep}");
+    println!("cache: PUB  bound to {sub_ep}");
+    println!("cache: REP  bound to {snapshot_ep}");
 
-        let cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+    let cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
 
-        // Forward task: recv from PULL, cache, forward via PUB.
-        let cache_fwd = Arc::clone(&cache);
-        let forward = tokio::spawn(async move {
-            loop {
-                let msg = pull.recv().await.unwrap();
-                let body = msg_str(&msg, 0);
-                if let Some((topic, value)) = body.split_once(' ') {
-                    cache_fwd
-                        .lock()
-                        .unwrap()
-                        .insert(topic.to_owned(), value.to_owned());
-                    println!("cache: cached {topic}={value}");
-                }
-                pub_.send(Message::single(body)).await.unwrap();
+    // Forward task: recv from PULL, cache, forward via PUB.
+    let cache_fwd = Arc::clone(&cache);
+    let forward = tokio::spawn(async move {
+        loop {
+            let msg = pull.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            if let Some((topic, value)) = body.split_once(' ') {
+                cache_fwd
+                    .lock()
+                    .unwrap()
+                    .insert(topic.to_owned(), value.to_owned());
+                println!("cache: cached {topic}={value}");
             }
-        });
-
-        // Snapshot task: serve cached state on REQ/REP.
-        let cache_snap = Arc::clone(&cache);
-        let snapshot = tokio::spawn(async move {
-            loop {
-                let msg = rep.recv().await.unwrap();
-                let body = msg_str(&msg, 0);
-                if body == "SNAPSHOT" {
-                    let payload = {
-                        let locked = cache_snap.lock().unwrap();
-                        let p: String = locked
-                            .iter()
-                            .map(|(k, v)| format!("{k} {v}"))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        println!("cache: snapshot served ({} entries)", locked.len());
-                        p
-                    };
-                    rep.send(Message::single(payload)).await.unwrap();
-                }
-            }
-        });
-
-        tokio::select! {
-            r = forward => r.unwrap(),
-            r = snapshot => r.unwrap(),
+            pub_.send(Message::single(body)).await.unwrap();
         }
     });
+
+    // Snapshot task: serve cached state on REQ/REP.
+    let cache_snap = Arc::clone(&cache);
+    let snapshot = tokio::spawn(async move {
+        loop {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            if body == "SNAPSHOT" {
+                let payload = {
+                    let locked = cache_snap.lock().unwrap();
+                    let p: String = locked
+                        .iter()
+                        .map(|(k, v)| format!("{k} {v}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    println!("cache: snapshot served ({} entries)", locked.len());
+                    p
+                };
+                rep.send(Message::single(payload)).await.unwrap();
+            }
+        }
+    });
+
+    tokio::select! {
+        r = forward => r.unwrap(),
+        r = snapshot => r.unwrap(),
+    }
 }

--- a/examples/zguide-tokio/06_last_value_cache/publisher.rs
+++ b/examples/zguide-tokio/06_last_value_cache/publisher.rs
@@ -7,38 +7,40 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
-        let count: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+    let args: Vec<String> = std::env::args().collect();
+    let pub_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-publisher");
+    let count: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
 
-        let push = Socket::new(SocketType::Push, Options::default());
-        push.connect(pub_ep.clone()).await.unwrap();
+    let push = ctx.socket(SocketType::Push, Options::default());
+    push.connect(pub_ep.clone()).await.unwrap();
 
-        println!("publisher: connected to {pub_ep}, sending {count} rounds");
+    println!("publisher: connected to {pub_ep}, sending {count} rounds");
 
-        // Let the connection establish.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+    // Let the connection establish.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
-        for i in 0..count {
-            let nyc = format!("weather.nyc {}F", 70 + i);
-            let sfo = format!("weather.sfo {}F", 60 + i);
+    for i in 0..count {
+        let nyc = format!("weather.nyc {}F", 70 + i);
+        let sfo = format!("weather.sfo {}F", 60 + i);
 
-            push.send(Message::single(nyc.clone())).await.unwrap();
-            push.send(Message::single(sfo.clone())).await.unwrap();
-            println!("publisher: {nyc}, {sfo}");
+        push.send(Message::single(nyc.clone())).await.unwrap();
+        push.send(Message::single(sfo.clone())).await.unwrap();
+        println!("publisher: {nyc}, {sfo}");
 
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
-        println!("publisher: done ({count} rounds)");
-    });
+    println!("publisher: done ({count} rounds)");
 }

--- a/examples/zguide-tokio/06_last_value_cache/subscriber.rs
+++ b/examples/zguide-tokio/06_last_value_cache/subscriber.rs
@@ -8,62 +8,64 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let snapshot_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-snapshot");
-        let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
+    let args: Vec<String> = std::env::args().collect();
+    let snapshot_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-06-snapshot");
+    let sub_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-06-subscriber");
 
-        // Request snapshot from cache.
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(snapshot_ep.clone()).await.unwrap();
+    // Request snapshot from cache.
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(snapshot_ep.clone()).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
-        req.send(Message::single("SNAPSHOT")).await.unwrap();
-        let reply = req.recv().await.unwrap();
-        let body = msg_str(&reply, 0);
+    req.send(Message::single("SNAPSHOT")).await.unwrap();
+    let reply = req.recv().await.unwrap();
+    let body = msg_str(&reply, 0);
 
-        println!("subscriber: snapshot from cache:");
-        if body.is_empty() {
-            println!("  (empty)");
-        } else {
-            for line in body.lines() {
-                println!("  {line}");
+    println!("subscriber: snapshot from cache:");
+    if body.is_empty() {
+        println!("  (empty)");
+    } else {
+        for line in body.lines() {
+            println!("  {line}");
+        }
+    }
+
+    // Subscribe for live updates.
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+    sub.connect(sub_ep.clone()).await.unwrap();
+    sub.subscribe("").await.unwrap();
+
+    println!("subscriber: listening for live updates (2s) ...");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        tokio::select! {
+            msg = sub.recv() => {
+                let body = msg_str(&msg.unwrap(), 0);
+                println!("  live: {body}");
+            }
+            () = tokio::time::sleep_until(deadline) => {
+                break;
             }
         }
+    }
 
-        // Subscribe for live updates.
-        let sub = Socket::new(SocketType::Sub, Options::default());
-        sub.connect(sub_ep.clone()).await.unwrap();
-        sub.subscribe("").await.unwrap();
-
-        println!("subscriber: listening for live updates (2s) ...");
-
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-        loop {
-            tokio::select! {
-                msg = sub.recv() => {
-                    let body = msg_str(&msg.unwrap(), 0);
-                    println!("  live: {body}");
-                }
-                () = tokio::time::sleep_until(deadline) => {
-                    break;
-                }
-            }
-        }
-
-        println!("subscriber: done");
-    });
+    println!("subscriber: done");
 }

--- a/examples/zguide-tokio/07_clone/client.rs
+++ b/examples/zguide-tokio/07_clone/client.rs
@@ -10,107 +10,109 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
-        let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
+    let args: Vec<String> = std::env::args().collect();
+    let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
+    let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
 
-        // Subscribe for live updates first (before snapshot) so we don't
-        // miss anything published between snapshot reply and SUB connect.
-        let sub = Socket::new(SocketType::Sub, Options::default());
-        sub.connect(updates_ep.clone()).await.unwrap();
-        sub.subscribe("").await.unwrap();
-        println!("client: SUB connected to {updates_ep}");
+    // Subscribe for live updates first (before snapshot) so we don't
+    // miss anything published between snapshot reply and SUB connect.
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+    sub.connect(updates_ep.clone()).await.unwrap();
+    sub.subscribe("").await.unwrap();
+    println!("client: SUB connected to {updates_ep}");
 
-        // Buffer live updates in a background task.
-        let buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let buffer_tx = Arc::clone(&buffer);
-        let buffer_task = tokio::spawn(async move {
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-            loop {
-                tokio::select! {
-                    msg = sub.recv() => {
-                        let body = msg_str(&msg.unwrap(), 0);
-                        buffer_tx.lock().unwrap().push(body);
-                    }
-                    () = tokio::time::sleep_until(deadline) => {
-                        break;
-                    }
+    // Buffer live updates in a background task.
+    let buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer_tx = Arc::clone(&buffer);
+    let buffer_task = tokio::spawn(async move {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            tokio::select! {
+                msg = sub.recv() => {
+                    let body = msg_str(&msg.unwrap(), 0);
+                    buffer_tx.lock().unwrap().push(body);
                 }
-            }
-        });
-
-        // Give SUB time to connect and subscribe.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Request snapshot.
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(snapshot_ep.clone()).await.unwrap();
-
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        req.send(Message::single("SNAPSHOT")).await.unwrap();
-        let reply = req.recv().await.unwrap();
-        let snapshot_body = msg_str(&reply, 0);
-
-        let mut store: HashMap<String, String> = HashMap::new();
-        let mut snapshot_seq: u64 = 0;
-
-        for line in snapshot_body.lines() {
-            if let Some((seq_str, rest)) = line.split_once('|')
-                && let Some((key, val)) = rest.split_once('|')
-            {
-                let s: u64 = seq_str.parse().unwrap_or(0);
-                store.insert(key.to_owned(), val.to_owned());
-                if s > snapshot_seq {
-                    snapshot_seq = s;
-                }
-                println!("client (snapshot): {key}={val} seq={s}");
-            }
-        }
-        println!(
-            "client: snapshot has {} entries (up to seq={snapshot_seq})",
-            store.len()
-        );
-
-        // Wait for buffered updates to finish arriving.
-        buffer_task.await.unwrap();
-
-        // Apply buffered updates where seq > snapshot_seq.
-        let buffered = buffer.lock().unwrap();
-        for line in buffered.iter() {
-            if let Some((seq_str, rest)) = line.split_once('|')
-                && let Some((key, val)) = rest.split_once('|')
-            {
-                let s: u64 = seq_str.parse().unwrap_or(0);
-                if s > snapshot_seq {
-                    store.insert(key.to_owned(), val.to_owned());
-                    println!("client (live): {key}={val} seq={s}");
-                } else {
-                    println!("client (skip): {key}={val} seq={s} (already in snapshot)");
+                () = tokio::time::sleep_until(deadline) => {
+                    break;
                 }
             }
         }
-
-        println!("client: final store ({} entries):", store.len());
-        let mut keys: Vec<_> = store.keys().collect();
-        keys.sort();
-        for k in keys {
-            println!("  {k} = {}", store[k]);
-        }
-
-        println!("client: done");
     });
+
+    // Give SUB time to connect and subscribe.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Request snapshot.
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(snapshot_ep.clone()).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    req.send(Message::single("SNAPSHOT")).await.unwrap();
+    let reply = req.recv().await.unwrap();
+    let snapshot_body = msg_str(&reply, 0);
+
+    let mut store: HashMap<String, String> = HashMap::new();
+    let mut snapshot_seq: u64 = 0;
+
+    for line in snapshot_body.lines() {
+        if let Some((seq_str, rest)) = line.split_once('|')
+            && let Some((key, val)) = rest.split_once('|')
+        {
+            let s: u64 = seq_str.parse().unwrap_or(0);
+            store.insert(key.to_owned(), val.to_owned());
+            if s > snapshot_seq {
+                snapshot_seq = s;
+            }
+            println!("client (snapshot): {key}={val} seq={s}");
+        }
+    }
+    println!(
+        "client: snapshot has {} entries (up to seq={snapshot_seq})",
+        store.len()
+    );
+
+    // Wait for buffered updates to finish arriving.
+    buffer_task.await.unwrap();
+
+    // Apply buffered updates where seq > snapshot_seq.
+    let buffered = buffer.lock().unwrap();
+    for line in buffered.iter() {
+        if let Some((seq_str, rest)) = line.split_once('|')
+            && let Some((key, val)) = rest.split_once('|')
+        {
+            let s: u64 = seq_str.parse().unwrap_or(0);
+            if s > snapshot_seq {
+                store.insert(key.to_owned(), val.to_owned());
+                println!("client (live): {key}={val} seq={s}");
+            } else {
+                println!("client (skip): {key}={val} seq={s} (already in snapshot)");
+            }
+        }
+    }
+
+    println!("client: final store ({} entries):", store.len());
+    let mut keys: Vec<_> = store.keys().collect();
+    keys.sort();
+    for k in keys {
+        println!("  {k} = {}", store[k]);
+    }
+
+    println!("client: done");
 }

--- a/examples/zguide-tokio/07_clone/server.rs
+++ b/examples/zguide-tokio/07_clone/server.rs
@@ -11,10 +11,13 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
@@ -26,101 +29,100 @@ struct Entry {
     seq: u64,
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
-        let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
+    let args: Vec<String> = std::env::args().collect();
+    let updates_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-07-updates");
+    let snapshot_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-07-snapshot");
 
-        let pub_ = Socket::new(SocketType::Pub, Options::default());
-        pub_.bind(updates_ep.clone()).await.unwrap();
+    let pub_ = ctx.socket(SocketType::Pub, Options::default());
+    pub_.bind(updates_ep.clone()).await.unwrap();
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(snapshot_ep.clone()).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(snapshot_ep.clone()).await.unwrap();
 
-        println!("server: PUB bound to {updates_ep}");
-        println!("server: REP bound to {snapshot_ep}");
+    println!("server: PUB bound to {updates_ep}");
+    println!("server: REP bound to {snapshot_ep}");
 
-        let store: Arc<Mutex<HashMap<String, Entry>>> = Arc::new(Mutex::new(HashMap::new()));
-        let mut seq: u64 = 0;
+    let store: Arc<Mutex<HashMap<String, Entry>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mut seq: u64 = 0;
 
-        // Snapshot task: serve snapshot requests.
-        let store_snap = Arc::clone(&store);
-        let snapshot_task = tokio::spawn(async move {
-            loop {
-                let msg = rep.recv().await.unwrap();
-                let body = msg_str(&msg, 0);
-                if body == "SNAPSHOT" {
-                    let payload = {
-                        let locked = store_snap.lock().unwrap();
-                        let p: String = locked
-                            .iter()
-                            .map(|(k, e)| format!("{}|{k}|{}", e.seq, e.value))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        println!("server: snapshot served ({} entries)", locked.len());
-                        p
-                    };
-                    rep.send(Message::single(payload)).await.unwrap();
-                }
-            }
-        });
-
-        // Give subscribers time to connect.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Publish initial updates.
-        for i in 0..5 {
-            seq += 1;
-            let cur = seq;
-
-            let key = format!("key-{i}");
-            let val = format!("val-{i}");
-            store.lock().unwrap().insert(
-                key.clone(),
-                Entry {
-                    value: val.clone(),
-                    seq: cur,
-                },
-            );
-
-            let msg = format!("{cur}|{key}|{val}");
-            pub_.send(Message::single(msg)).await.unwrap();
-            println!("server: published {key}={val} (seq={cur})");
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-
-        // Pause so client can request snapshot.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        // Publish post-snapshot updates.
-        for i in 0..3 {
-            seq += 1;
-            let cur = seq;
-
-            let key = format!("key-{i}");
-            let val = format!("updated-{i}");
-            store.lock().unwrap().insert(
-                key.clone(),
-                Entry {
-                    value: val.clone(),
-                    seq: cur,
-                },
-            );
-
-            let msg = format!("{cur}|{key}|{val}");
-            pub_.send(Message::single(msg)).await.unwrap();
-            println!("server: published {key}={val} (seq={cur})");
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-
-        // Keep serving snapshots briefly, then exit.
-        tokio::select! {
-            r = snapshot_task => r.unwrap(),
-            () = tokio::time::sleep(Duration::from_secs(3)) => {
-                println!("server: done");
+    // Snapshot task: serve snapshot requests.
+    let store_snap = Arc::clone(&store);
+    let snapshot_task = tokio::spawn(async move {
+        loop {
+            let msg = rep.recv().await.unwrap();
+            let body = msg_str(&msg, 0);
+            if body == "SNAPSHOT" {
+                let payload = {
+                    let locked = store_snap.lock().unwrap();
+                    let p: String = locked
+                        .iter()
+                        .map(|(k, e)| format!("{}|{k}|{}", e.seq, e.value))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    println!("server: snapshot served ({} entries)", locked.len());
+                    p
+                };
+                rep.send(Message::single(payload)).await.unwrap();
             }
         }
     });
+
+    // Give subscribers time to connect.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Publish initial updates.
+    for i in 0..5 {
+        seq += 1;
+        let cur = seq;
+
+        let key = format!("key-{i}");
+        let val = format!("val-{i}");
+        store.lock().unwrap().insert(
+            key.clone(),
+            Entry {
+                value: val.clone(),
+                seq: cur,
+            },
+        );
+
+        let msg = format!("{cur}|{key}|{val}");
+        pub_.send(Message::single(msg)).await.unwrap();
+        println!("server: published {key}={val} (seq={cur})");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Pause so client can request snapshot.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Publish post-snapshot updates.
+    for i in 0..3 {
+        seq += 1;
+        let cur = seq;
+
+        let key = format!("key-{i}");
+        let val = format!("updated-{i}");
+        store.lock().unwrap().insert(
+            key.clone(),
+            Entry {
+                value: val.clone(),
+                seq: cur,
+            },
+        );
+
+        let msg = format!("{cur}|{key}|{val}");
+        pub_.send(Message::single(msg)).await.unwrap();
+        println!("server: published {key}={val} (seq={cur})");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Keep serving snapshots briefly, then exit.
+    tokio::select! {
+        r = snapshot_task => r.unwrap(),
+        () = tokio::time::sleep(Duration::from_secs(3)) => {
+            println!("server: done");
+        }
+    }
 }

--- a/examples/zguide-tokio/08_majordomo/Cargo.toml
+++ b/examples/zguide-tokio/08_majordomo/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/08_majordomo/broker.rs
+++ b/examples/zguide-tokio/08_majordomo/broker.rs
@@ -10,104 +10,106 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
-        let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-08-backend");
-        let n_workers: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
+    let backend_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-08-backend");
+    let n_workers: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
 
-        let frontend = Socket::new(SocketType::Router, Options::default());
-        frontend.bind(frontend_ep.clone()).await.unwrap();
+    let frontend = ctx.socket(SocketType::Router, Options::default());
+    frontend.bind(frontend_ep.clone()).await.unwrap();
 
-        let backend = Socket::new(SocketType::Router, Options::default());
-        backend.bind(backend_ep.clone()).await.unwrap();
+    let backend = ctx.socket(SocketType::Router, Options::default());
+    backend.bind(backend_ep.clone()).await.unwrap();
 
-        println!("broker: frontend={frontend_ep} backend={backend_ep} n_workers={n_workers}");
+    println!("broker: frontend={frontend_ep} backend={backend_ep} n_workers={n_workers}");
 
-        // Worker registration: service_name -> [worker_identity, ...]
-        let mut services: HashMap<String, Vec<Bytes>> = HashMap::new();
+    // Worker registration: service_name -> [worker_identity, ...]
+    let mut services: HashMap<String, Vec<Bytes>> = HashMap::new();
 
-        for _ in 0..n_workers {
-            let msg = backend.recv().await.unwrap();
-            let worker_id = msg.part_bytes(0).unwrap();
-            let command = msg_str(&msg, 1);
-            let service = msg_str(&msg, 2);
-            if command == "READY" {
-                println!(
-                    "broker: worker '{}' registered for '{service}'",
-                    String::from_utf8_lossy(&worker_id)
-                );
-                services.entry(service).or_default().push(worker_id);
-            }
-        }
-
-        // Route requests: recv from frontend, dispatch to worker, relay reply.
-        loop {
-            let msg = frontend.recv().await.unwrap();
-            // REQ client -> ROUTER: [client_id, "", service, body]
-            let client_id = msg.part_bytes(0).unwrap();
-            // frame 1 is empty delimiter from REQ
-            let service = msg_str(&msg, 2);
-            let body = msg.part_bytes(3).unwrap();
-
-            let Some(worker_id) = services.get_mut(&service).and_then(|pool| {
-                if pool.is_empty() {
-                    None
-                } else {
-                    Some(pool.remove(0))
-                }
-            }) else {
-                println!("broker: no worker for service '{service}'");
-                continue;
-            };
-
+    for _ in 0..n_workers {
+        let msg = backend.recv().await.unwrap();
+        let worker_id = msg.part_bytes(0).unwrap();
+        let command = msg_str(&msg, 1);
+        let service = msg_str(&msg, 2);
+        if command == "READY" {
             println!(
-                "broker: routing '{service}' request to {}",
+                "broker: worker '{}' registered for '{service}'",
                 String::from_utf8_lossy(&worker_id)
             );
-
-            // Send to backend ROUTER: [worker_id, client_id, "", body]
-            backend
-                .send(Message::multipart([
-                    worker_id.clone(),
-                    client_id.clone(),
-                    Bytes::from_static(b""),
-                    body,
-                ]))
-                .await
-                .unwrap();
-
-            // Recv reply from backend: [worker_id, client_id, "", reply]
-            let reply_msg = backend.recv().await.unwrap();
-            let reply_worker_id = reply_msg.part_bytes(0).unwrap();
-            let reply_client_id = reply_msg.part_bytes(1).unwrap();
-            // frame 2 is empty delimiter
-            let reply_body = reply_msg.part_bytes(3).unwrap();
-
-            // Return worker to pool
-            services.entry(service).or_default().push(reply_worker_id);
-
-            // Forward to frontend ROUTER: [client_id, "", reply]
-            frontend
-                .send(Message::multipart([
-                    reply_client_id,
-                    Bytes::from_static(b""),
-                    reply_body,
-                ]))
-                .await
-                .unwrap();
+            services.entry(service).or_default().push(worker_id);
         }
-    });
+    }
+
+    // Route requests: recv from frontend, dispatch to worker, relay reply.
+    loop {
+        let msg = frontend.recv().await.unwrap();
+        // REQ client -> ROUTER: [client_id, "", service, body]
+        let client_id = msg.part_bytes(0).unwrap();
+        // frame 1 is empty delimiter from REQ
+        let service = msg_str(&msg, 2);
+        let body = msg.part_bytes(3).unwrap();
+
+        let Some(worker_id) = services.get_mut(&service).and_then(|pool| {
+            if pool.is_empty() {
+                None
+            } else {
+                Some(pool.remove(0))
+            }
+        }) else {
+            println!("broker: no worker for service '{service}'");
+            continue;
+        };
+
+        println!(
+            "broker: routing '{service}' request to {}",
+            String::from_utf8_lossy(&worker_id)
+        );
+
+        // Send to backend ROUTER: [worker_id, client_id, "", body]
+        backend
+            .send(Message::multipart([
+                worker_id.clone(),
+                client_id.clone(),
+                Bytes::from_static(b""),
+                body,
+            ]))
+            .await
+            .unwrap();
+
+        // Recv reply from backend: [worker_id, client_id, "", reply]
+        let reply_msg = backend.recv().await.unwrap();
+        let reply_worker_id = reply_msg.part_bytes(0).unwrap();
+        let reply_client_id = reply_msg.part_bytes(1).unwrap();
+        // frame 2 is empty delimiter
+        let reply_body = reply_msg.part_bytes(3).unwrap();
+
+        // Return worker to pool
+        services.entry(service).or_default().push(reply_worker_id);
+
+        // Forward to frontend ROUTER: [client_id, "", reply]
+        frontend
+            .send(Message::multipart([
+                reply_client_id,
+                Bytes::from_static(b""),
+                reply_body,
+            ]))
+            .await
+            .unwrap();
+    }
 }

--- a/examples/zguide-tokio/08_majordomo/client.rs
+++ b/examples/zguide-tokio/08_majordomo/client.rs
@@ -5,41 +5,43 @@
 //!
 //!     cargo run -p zguide-tokio-08-majordomo --bin client [frontend_ep]
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-frontend");
 
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(frontend_ep).await.unwrap();
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(frontend_ep).await.unwrap();
 
-        let requests = [
-            ("echo", "hello"),
-            ("echo", "world"),
-            ("upper", "foo"),
-            ("echo", "test"),
-            ("upper", "bar"),
-            ("upper", "baz"),
-        ];
+    let requests = [
+        ("echo", "hello"),
+        ("echo", "world"),
+        ("upper", "foo"),
+        ("echo", "test"),
+        ("upper", "bar"),
+        ("upper", "baz"),
+    ];
 
-        for (service, body) in requests {
-            req.send(Message::multipart([service, body])).await.unwrap();
-            let reply = req.recv().await.unwrap();
-            let reply_body = msg_str(&reply, 0);
-            println!("client: {service}({body}) -> {reply_body}");
-        }
+    for (service, body) in requests {
+        req.send(Message::multipart([service, body])).await.unwrap();
+        let reply = req.recv().await.unwrap();
+        let reply_body = msg_str(&reply, 0);
+        println!("client: {service}({body}) -> {reply_body}");
+    }
 
-        println!("done: {} requests", requests.len());
-    });
+    println!("done: {} requests", requests.len());
 }

--- a/examples/zguide-tokio/08_majordomo/worker.rs
+++ b/examples/zguide-tokio/08_majordomo/worker.rs
@@ -7,58 +7,60 @@
 //!         [backend_ep] [service_name] [worker_id]
 
 use bytes::Bytes;
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-backend");
-        let service: String = args.get(2).map_or_else(|| "echo".into(), Clone::clone);
-        let id: String = args.get(3).map_or_else(|| "0".into(), Clone::clone);
+    let args: Vec<String> = std::env::args().collect();
+    let backend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-08-backend");
+    let service: String = args.get(2).map_or_else(|| "echo".into(), Clone::clone);
+    let id: String = args.get(3).map_or_else(|| "0".into(), Clone::clone);
 
-        let identity = Bytes::from(format!("{service}-{id}"));
-        let dealer = Socket::new(SocketType::Dealer, Options::default().identity(identity));
-        dealer.connect(backend_ep).await.unwrap();
+    let identity = Bytes::from(format!("{service}-{id}"));
+    let dealer = ctx.socket(SocketType::Dealer, Options::default().identity(identity));
+    dealer.connect(backend_ep).await.unwrap();
 
-        // Register with broker
+    // Register with broker
+    dealer
+        .send(Message::multipart(["READY".to_string(), service.clone()]))
+        .await
+        .unwrap();
+    println!("worker({service}-{id}): ready");
+
+    // Process requests
+    loop {
+        let msg = dealer.recv().await.unwrap();
+        // DEALER sees: [client_id, "", body]
+        let client_id = msg.part_bytes(0).unwrap();
+        let body = msg_str(&msg, 2);
+
+        let reply = match service.as_str() {
+            "echo" => format!("echo:{body}"),
+            "upper" => body.to_uppercase(),
+            _ => body.clone(),
+        };
+
+        println!("worker({service}-{id}): {body} -> {reply}");
+
         dealer
-            .send(Message::multipart(["READY".to_string(), service.clone()]))
+            .send(Message::multipart([
+                client_id,
+                Bytes::from_static(b""),
+                Bytes::from(reply),
+            ]))
             .await
             .unwrap();
-        println!("worker({service}-{id}): ready");
-
-        // Process requests
-        loop {
-            let msg = dealer.recv().await.unwrap();
-            // DEALER sees: [client_id, "", body]
-            let client_id = msg.part_bytes(0).unwrap();
-            let body = msg_str(&msg, 2);
-
-            let reply = match service.as_str() {
-                "echo" => format!("echo:{body}"),
-                "upper" => body.to_uppercase(),
-                _ => body.clone(),
-            };
-
-            println!("worker({service}-{id}): {body} -> {reply}");
-
-            dealer
-                .send(Message::multipart([
-                    client_id,
-                    Bytes::from_static(b""),
-                    Bytes::from(reply),
-                ]))
-                .await
-                .unwrap();
-        }
-    });
+    }
 }

--- a/examples/zguide-tokio/09_titanic/Cargo.toml
+++ b/examples/zguide-tokio/09_titanic/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/09_titanic/client.rs
+++ b/examples/zguide-tokio/09_titanic/client.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(
@@ -20,49 +20,48 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
 
-        let req = Socket::new(SocketType::Req, Options::default());
-        req.connect(frontend_ep).await.unwrap();
+    let req = ctx.socket(SocketType::Req, Options::default());
+    req.connect(frontend_ep).await.unwrap();
 
-        let requests = [("echo", "hello"), ("upper", "world"), ("echo", "foo")];
+    let requests = [("echo", "hello"), ("upper", "world"), ("echo", "foo")];
 
-        // Submit requests, collect tickets.
-        let mut tickets = Vec::new();
-        for (service, body) in &requests {
-            req.send(Message::single(format!("SUBMIT|{service}|{body}")))
-                .await
-                .unwrap();
-            let reply = req.recv().await.unwrap();
-            let reply = msg_str(&reply, 0);
-            let (status, ticket) = reply.split_once('|').expect("bad reply");
-            assert_eq!(status, "TICKET");
-            println!("client: submitted {service}({body}) -> ticket {ticket}");
-            tickets.push(ticket.to_owned());
-        }
+    // Submit requests, collect tickets.
+    let mut tickets = Vec::new();
+    for (service, body) in &requests {
+        req.send(Message::single(format!("SUBMIT|{service}|{body}")))
+            .await
+            .unwrap();
+        let reply = req.recv().await.unwrap();
+        let reply = msg_str(&reply, 0);
+        let (status, ticket) = reply.split_once('|').expect("bad reply");
+        assert_eq!(status, "TICKET");
+        println!("client: submitted {service}({body}) -> ticket {ticket}");
+        tickets.push(ticket.to_owned());
+    }
 
-        // Give the dispatcher time to process.
-        tokio::time::sleep(Duration::from_millis(500)).await;
+    // Give the dispatcher time to process.
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
-        // Poll for results.
-        for ticket in &tickets {
-            req.send(Message::single(format!("RESULT|{ticket}")))
-                .await
-                .unwrap();
-            let reply = req.recv().await.unwrap();
-            let reply = msg_str(&reply, 0);
-            let (status, result) = reply.split_once('|').expect("bad reply");
-            assert_eq!(status, "OK", "expected result for {ticket}");
-            println!("client: result for {ticket} -> {result}");
-        }
+    // Poll for results.
+    for ticket in &tickets {
+        req.send(Message::single(format!("RESULT|{ticket}")))
+            .await
+            .unwrap();
+        let reply = req.recv().await.unwrap();
+        let reply = msg_str(&reply, 0);
+        let (status, result) = reply.split_once('|').expect("bad reply");
+        assert_eq!(status, "OK", "expected result for {ticket}");
+        println!("client: result for {ticket} -> {result}");
+    }
 
-        println!(
-            "done: {} requests persisted, dispatched, and retrieved",
-            tickets.len()
-        );
-    });
+    println!(
+        "done: {} requests persisted, dispatched, and retrieved",
+        tickets.len()
+    );
 }

--- a/examples/zguide-tokio/09_titanic/dispatcher.rs
+++ b/examples/zguide-tokio/09_titanic/dispatcher.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
     args.get(index).map_or_else(
@@ -22,44 +22,42 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let dispatch_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-dispatch");
-        let store_dir = args.get(2).map_or("/tmp/omq-titanic", String::as_str);
+    let args: Vec<String> = std::env::args().collect();
+    let dispatch_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-dispatch");
+    let store_dir = args.get(2).map_or("/tmp/omq-titanic", String::as_str);
 
-        let pull = Socket::new(SocketType::Pull, Options::default());
-        pull.connect(dispatch_ep.clone()).await.unwrap();
+    let pull = ctx.socket(SocketType::Pull, Options::default());
+    pull.connect(dispatch_ep.clone()).await.unwrap();
 
-        println!("dispatcher: {dispatch_ep} store={store_dir}");
+    println!("dispatcher: {dispatch_ep} store={store_dir}");
 
-        loop {
-            let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), pull.recv()).await
-            else {
-                break;
-            };
-            let ticket = msg_str(&msg, 0);
-            let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
+    loop {
+        let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), pull.recv()).await else {
+            break;
+        };
+        let ticket = msg_str(&msg, 0);
+        let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
 
-            let Ok(contents) = std::fs::read_to_string(&req_path) else {
-                continue;
-            };
+        let Ok(contents) = std::fs::read_to_string(&req_path) else {
+            continue;
+        };
 
-            let (service, body) = contents.split_once('|').unwrap_or(("", &contents));
+        let (service, body) = contents.split_once('|').unwrap_or(("", &contents));
 
-            let result = match service {
-                "echo" => format!("echo:{body}"),
-                "upper" => body.to_uppercase(),
-                _ => format!("unknown service: {service}"),
-            };
+        let result = match service {
+            "echo" => format!("echo:{body}"),
+            "upper" => body.to_uppercase(),
+            _ => format!("unknown service: {service}"),
+        };
 
-            let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
-            std::fs::write(&res_path, &result).expect("write .res failed");
+        let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
+        std::fs::write(&res_path, &result).expect("write .res failed");
 
-            println!("dispatcher: processed {ticket} -> {result}");
-        }
+        println!("dispatcher: processed {ticket} -> {result}");
+    }
 
-        println!("dispatcher: done (recv timeout)");
-    });
+    println!("dispatcher: done (recv timeout)");
 }

--- a/examples/zguide-tokio/09_titanic/frontend.rs
+++ b/examples/zguide-tokio/09_titanic/frontend.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 static NEXT: AtomicU64 = AtomicU64::new(1);
 
@@ -25,73 +25,70 @@ fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
-        let dispatch_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-09-dispatch");
-        let store_dir = args.get(3).map_or("/tmp/omq-titanic", String::as_str);
+    let args: Vec<String> = std::env::args().collect();
+    let frontend_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-09-frontend");
+    let dispatch_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-09-dispatch");
+    let store_dir = args.get(3).map_or("/tmp/omq-titanic", String::as_str);
 
-        std::fs::create_dir_all(store_dir).expect("cannot create store dir");
+    std::fs::create_dir_all(store_dir).expect("cannot create store dir");
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(frontend_ep.clone()).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(frontend_ep.clone()).await.unwrap();
 
-        let push = Socket::new(SocketType::Push, Options::default());
-        push.bind(dispatch_ep.clone()).await.unwrap();
+    let push = ctx.socket(SocketType::Push, Options::default());
+    push.bind(dispatch_ep.clone()).await.unwrap();
 
-        println!("frontend: {frontend_ep} dispatch={dispatch_ep} store={store_dir}");
+    println!("frontend: {frontend_ep} dispatch={dispatch_ep} store={store_dir}");
 
-        loop {
-            let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), rep.recv()).await
-            else {
-                break;
-            };
-            let body = msg_str(&msg, 0);
-            let parts: Vec<&str> = body.splitn(3, '|').collect();
+    loop {
+        let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(3), rep.recv()).await else {
+            break;
+        };
+        let body = msg_str(&msg, 0);
+        let parts: Vec<&str> = body.splitn(3, '|').collect();
 
-            match parts[0] {
-                "SUBMIT" if parts.len() == 3 => {
-                    let service = parts[1];
-                    let payload = parts[2];
-                    let ticket = NEXT.fetch_add(1, Ordering::Relaxed);
-                    let ticket = format!("{ticket:016x}");
+        match parts[0] {
+            "SUBMIT" if parts.len() == 3 => {
+                let service = parts[1];
+                let payload = parts[2];
+                let ticket = NEXT.fetch_add(1, Ordering::Relaxed);
+                let ticket = format!("{ticket:016x}");
 
-                    let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
-                    std::fs::write(&req_path, format!("{service}|{payload}"))
-                        .expect("write .req failed");
+                let req_path = Path::new(store_dir).join(format!("{ticket}.req"));
+                std::fs::write(&req_path, format!("{service}|{payload}"))
+                    .expect("write .req failed");
 
-                    rep.send(Message::single(format!("TICKET|{ticket}")))
+                rep.send(Message::single(format!("TICKET|{ticket}")))
+                    .await
+                    .unwrap();
+                push.send(Message::single(ticket.clone())).await.unwrap();
+
+                println!("frontend: accepted {ticket} for '{service}'");
+            }
+            "RESULT" if parts.len() >= 2 => {
+                let ticket = parts[1];
+                let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
+
+                if res_path.exists() {
+                    let contents = std::fs::read_to_string(&res_path).expect("read .res failed");
+                    rep.send(Message::single(format!("OK|{contents}")))
                         .await
                         .unwrap();
-                    push.send(Message::single(ticket.clone())).await.unwrap();
-
-                    println!("frontend: accepted {ticket} for '{service}'");
-                }
-                "RESULT" if parts.len() >= 2 => {
-                    let ticket = parts[1];
-                    let res_path = Path::new(store_dir).join(format!("{ticket}.res"));
-
-                    if res_path.exists() {
-                        let contents =
-                            std::fs::read_to_string(&res_path).expect("read .res failed");
-                        rep.send(Message::single(format!("OK|{contents}")))
-                            .await
-                            .unwrap();
-                        println!("frontend: served result for {ticket}");
-                    } else {
-                        rep.send(Message::single("PENDING")).await.unwrap();
-                    }
-                }
-                _ => {
-                    rep.send(Message::single("ERROR|unknown command"))
-                        .await
-                        .unwrap();
+                    println!("frontend: served result for {ticket}");
+                } else {
+                    rep.send(Message::single("PENDING")).await.unwrap();
                 }
             }
+            _ => {
+                rep.send(Message::single("ERROR|unknown command"))
+                    .await
+                    .unwrap();
+            }
         }
+    }
 
-        println!("frontend: done (recv timeout)");
-    });
+    println!("frontend: done (recv timeout)");
 }

--- a/examples/zguide-tokio/10_binary_star/Cargo.toml
+++ b/examples/zguide-tokio/10_binary_star/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["rt", "time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/10_binary_star/backup.rs
+++ b/examples/zguide-tokio/10_binary_star/backup.rs
@@ -8,54 +8,56 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let heartbeat_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-heartbeat");
-        let service_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
+    let args: Vec<String> = std::env::args().collect();
+    let heartbeat_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-heartbeat");
+    let service_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
 
-        let sub = Socket::new(SocketType::Sub, Options::default());
-        sub.connect(heartbeat_ep).await.unwrap();
-        sub.subscribe("HB").await.unwrap();
+    let sub = ctx.socket(SocketType::Sub, Options::default());
+    sub.connect(heartbeat_ep).await.unwrap();
+    sub.subscribe("HB").await.unwrap();
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(service_ep).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(service_ep).await.unwrap();
 
-        // Phase 1: monitor heartbeats.
-        let timeout = Duration::from_millis(300);
-        loop {
-            match tokio::time::timeout(timeout, sub.recv()).await {
-                Ok(Ok(_)) => {} // heartbeat received, primary is alive
-                Ok(Err(e)) => {
-                    eprintln!("backup: recv error: {e}");
-                    return;
-                }
-                Err(_) => {
-                    println!("backup: primary heartbeat lost -- taking over!");
-                    break;
-                }
+    // Phase 1: monitor heartbeats.
+    let timeout = Duration::from_millis(300);
+    loop {
+        match tokio::time::timeout(timeout, sub.recv()).await {
+            Ok(Ok(_)) => {} // heartbeat received, primary is alive
+            Ok(Err(e)) => {
+                eprintln!("backup: recv error: {e}");
+                return;
+            }
+            Err(_) => {
+                println!("backup: primary heartbeat lost -- taking over!");
+                break;
             }
         }
+    }
 
-        // Phase 2: serve requests.
-        loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            println!("backup: served {body}");
-            rep.send(Message::single(format!("backup:{body}")))
-                .await
-                .unwrap();
-        }
-    });
+    // Phase 2: serve requests.
+    loop {
+        let msg = rep.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        println!("backup: served {body}");
+        rep.send(Message::single(format!("backup:{body}")))
+            .await
+            .unwrap();
+    }
 }

--- a/examples/zguide-tokio/10_binary_star/client.rs
+++ b/examples/zguide-tokio/10_binary_star/client.rs
@@ -8,68 +8,70 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let primary_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
-        let backup_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
-        let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(4);
+    let args: Vec<String> = std::env::args().collect();
+    let primary_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
+    let backup_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-backup");
+    let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(4);
 
-        for i in 0..n {
-            let body = format!("req-{i}");
+    for i in 0..n {
+        let body = format!("req-{i}");
 
-            // Try primary first.
-            let req = Socket::new(SocketType::Req, Options::default());
-            req.connect(primary_ep.clone()).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(20)).await;
+        // Try primary first.
+        let req = ctx.socket(SocketType::Req, Options::default());
+        req.connect(primary_ep.clone()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
 
-            req.send(Message::single(body.clone())).await.unwrap();
+        req.send(Message::single(body.clone())).await.unwrap();
 
-            match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
-                Ok(Ok(reply)) => {
-                    println!("client: {body} -> {}", msg_str(&reply, 0));
-                    continue;
-                }
-                Ok(Err(e)) => {
-                    eprintln!("client: recv error from primary: {e}");
-                }
-                Err(_) => {
-                    println!("client: primary timeout for {body}, trying backup");
-                }
+        match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
+            Ok(Ok(reply)) => {
+                println!("client: {body} -> {}", msg_str(&reply, 0));
+                continue;
             }
-            drop(req);
-
-            // Fallback to backup.
-            let req = Socket::new(SocketType::Req, Options::default());
-            req.connect(backup_ep.clone()).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(20)).await;
-
-            req.send(Message::single(body.clone())).await.unwrap();
-
-            match tokio::time::timeout(Duration::from_secs(1), req.recv()).await {
-                Ok(Ok(reply)) => {
-                    println!("client: {body} -> {}", msg_str(&reply, 0));
-                }
-                Ok(Err(e)) => {
-                    eprintln!("client: recv error from backup: {e}");
-                }
-                Err(_) => {
-                    eprintln!("client: backup also timed out for {body}");
-                }
+            Ok(Err(e)) => {
+                eprintln!("client: recv error from primary: {e}");
+            }
+            Err(_) => {
+                println!("client: primary timeout for {body}, trying backup");
             }
         }
+        drop(req);
 
-        println!("client: done ({n} requests)");
-    });
+        // Fallback to backup.
+        let req = ctx.socket(SocketType::Req, Options::default());
+        req.connect(backup_ep.clone()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        req.send(Message::single(body.clone())).await.unwrap();
+
+        match tokio::time::timeout(Duration::from_secs(1), req.recv()).await {
+            Ok(Ok(reply)) => {
+                println!("client: {body} -> {}", msg_str(&reply, 0));
+            }
+            Ok(Err(e)) => {
+                eprintln!("client: recv error from backup: {e}");
+            }
+            Err(_) => {
+                eprintln!("client: backup also timed out for {body}");
+            }
+        }
+    }
+
+    println!("client: done ({n} requests)");
 }

--- a/examples/zguide-tokio/10_binary_star/primary.rs
+++ b/examples/zguide-tokio/10_binary_star/primary.rs
@@ -8,45 +8,47 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let service_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
-        let heartbeat_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-heartbeat");
+    let args: Vec<String> = std::env::args().collect();
+    let service_ep = endpoint_or(&args, 1, "ipc://@omq-zguide-10-primary");
+    let heartbeat_ep = endpoint_or(&args, 2, "ipc://@omq-zguide-10-heartbeat");
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(service_ep).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(service_ep).await.unwrap();
 
-        let pub_socket = Socket::new(SocketType::Pub, Options::default());
-        pub_socket.bind(heartbeat_ep).await.unwrap();
+    let pub_socket = ctx.socket(SocketType::Pub, Options::default());
+    pub_socket.bind(heartbeat_ep).await.unwrap();
 
-        // Heartbeat task: send "HB" every 50ms.
-        tokio::spawn(async move {
-            loop {
-                pub_socket.send(Message::single("HB")).await.unwrap();
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            }
-        });
-
-        // Server task: recv on REP, reply with "primary:{body}".
+    // Heartbeat task: send "HB" every 50ms.
+    tokio::spawn(async move {
         loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            println!("primary: served {body}");
-            rep.send(Message::single(format!("primary:{body}")))
-                .await
-                .unwrap();
+            pub_socket.send(Message::single("HB")).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     });
+
+    // Server task: recv on REP, reply with "primary:{body}".
+    loop {
+        let msg = rep.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        println!("primary: served {body}");
+        rep.send(Message::single(format!("primary:{body}")))
+            .await
+            .unwrap();
+    }
 }

--- a/examples/zguide-tokio/11_freelance/Cargo.toml
+++ b/examples/zguide-tokio/11_freelance/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 omq-tokio = { version = "0.19.1", path = "../../../omq-tokio" }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/zguide-tokio/11_freelance/client_sequential.rs
+++ b/examples/zguide-tokio/11_freelance/client_sequential.rs
@@ -8,60 +8,59 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let endpoints: Vec<Endpoint> = if args.len() > 1 {
-            args[1..]
-                .iter()
-                .map(|s| s.parse().expect("invalid endpoint"))
-                .collect()
-        } else {
-            vec![
-                "ipc://@omq-zguide-11-server1".parse().unwrap(),
-                "ipc://@omq-zguide-11-server2".parse().unwrap(),
-                "ipc://@omq-zguide-11-server3".parse().unwrap(),
-            ]
-        };
+    let args: Vec<String> = std::env::args().collect();
+    let endpoints: Vec<Endpoint> = if args.len() > 1 {
+        args[1..]
+            .iter()
+            .map(|s| s.parse().expect("invalid endpoint"))
+            .collect()
+    } else {
+        vec![
+            "ipc://@omq-zguide-11-server1".parse().unwrap(),
+            "ipc://@omq-zguide-11-server2".parse().unwrap(),
+            "ipc://@omq-zguide-11-server3".parse().unwrap(),
+        ]
+    };
 
-        for i in 0..3 {
-            let body = format!("request-{i}");
-            let mut served = false;
+    for i in 0..3 {
+        let body = format!("request-{i}");
+        let mut served = false;
 
-            for ep in &endpoints {
-                let req = Socket::new(SocketType::Req, Options::default());
-                req.connect(ep.clone()).await.unwrap();
-                tokio::time::sleep(Duration::from_millis(20)).await;
+        for ep in &endpoints {
+            let req = ctx.socket(SocketType::Req, Options::default());
+            req.connect(ep.clone()).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
 
-                req.send(Message::single(body.clone())).await.unwrap();
+            req.send(Message::single(body.clone())).await.unwrap();
 
-                match tokio::time::timeout(Duration::from_millis(150), req.recv()).await {
-                    Ok(Ok(reply)) => {
-                        println!("client: {body} -> {}", msg_str(&reply, 0));
-                        served = true;
-                        break;
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("client: recv error on {ep}: {e}");
-                    }
-                    Err(_) => {
-                        println!("client: timeout on {ep}, trying next");
-                    }
+            match tokio::time::timeout(Duration::from_millis(150), req.recv()).await {
+                Ok(Ok(reply)) => {
+                    println!("client: {body} -> {}", msg_str(&reply, 0));
+                    served = true;
+                    break;
                 }
-            }
-
-            if !served {
-                eprintln!("client: all endpoints failed for {body}");
+                Ok(Err(e)) => {
+                    eprintln!("client: recv error on {ep}: {e}");
+                }
+                Err(_) => {
+                    println!("client: timeout on {ep}, trying next");
+                }
             }
         }
 
-        println!("client: done (3 requests)");
-    });
+        if !served {
+            eprintln!("client: all endpoints failed for {body}");
+        }
+    }
+
+    println!("client: done (3 requests)");
 }

--- a/examples/zguide-tokio/11_freelance/client_shotgun.rs
+++ b/examples/zguide-tokio/11_freelance/client_shotgun.rs
@@ -7,58 +7,57 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let endpoints: Vec<Endpoint> = if args.len() > 1 {
-            args[1..]
-                .iter()
-                .map(|s| s.parse().expect("invalid endpoint"))
-                .collect()
-        } else {
-            vec![
-                "ipc://@omq-zguide-11-server1".parse().unwrap(),
-                "ipc://@omq-zguide-11-server2".parse().unwrap(),
-            ]
-        };
+    let args: Vec<String> = std::env::args().collect();
+    let endpoints: Vec<Endpoint> = if args.len() > 1 {
+        args[1..]
+            .iter()
+            .map(|s| s.parse().expect("invalid endpoint"))
+            .collect()
+    } else {
+        vec![
+            "ipc://@omq-zguide-11-server1".parse().unwrap(),
+            "ipc://@omq-zguide-11-server2".parse().unwrap(),
+        ]
+    };
 
-        let dealer = Socket::new(SocketType::Dealer, Options::default());
-        for ep in &endpoints {
-            dealer.connect(ep.clone()).await.unwrap();
+    let dealer = ctx.socket(SocketType::Dealer, Options::default());
+    for ep in &endpoints {
+        dealer.connect(ep.clone()).await.unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Send one request per endpoint (empty delimiter + body).
+    for _ in &endpoints {
+        dealer
+            .send(Message::multipart(["", "shotgun-req"]))
+            .await
+            .unwrap();
+    }
+
+    // Take the first reply.
+    match tokio::time::timeout(Duration::from_secs(1), dealer.recv()).await {
+        Ok(Ok(reply)) => {
+            // Reply from REP via DEALER: [delimiter, body].
+            let n = reply.len();
+            let body = msg_str(&reply, n - 1);
+            println!("client: first reply = {body}");
         }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Send one request per endpoint (empty delimiter + body).
-        for _ in &endpoints {
-            dealer
-                .send(Message::multipart(["", "shotgun-req"]))
-                .await
-                .unwrap();
+        Ok(Err(e)) => {
+            eprintln!("client: recv error: {e}");
         }
-
-        // Take the first reply.
-        match tokio::time::timeout(Duration::from_secs(1), dealer.recv()).await {
-            Ok(Ok(reply)) => {
-                // Reply from REP via DEALER: [delimiter, body].
-                let n = reply.len();
-                let body = msg_str(&reply, n - 1);
-                println!("client: first reply = {body}");
-            }
-            Ok(Err(e)) => {
-                eprintln!("client: recv error: {e}");
-            }
-            Err(_) => {
-                eprintln!("client: timeout waiting for reply");
-            }
+        Err(_) => {
+            eprintln!("client: timeout waiting for reply");
         }
+    }
 
-        println!("client: done");
-    });
+    println!("client: done");
 }

--- a/examples/zguide-tokio/11_freelance/client_tracked.rs
+++ b/examples/zguide-tokio/11_freelance/client_tracked.rs
@@ -11,83 +11,82 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let endpoints: Vec<Endpoint> = if args.len() > 1 {
-            args[1..]
-                .iter()
-                .map(|s| s.parse().expect("invalid endpoint"))
-                .collect()
+    let args: Vec<String> = std::env::args().collect();
+    let endpoints: Vec<Endpoint> = if args.len() > 1 {
+        args[1..]
+            .iter()
+            .map(|s| s.parse().expect("invalid endpoint"))
+            .collect()
+    } else {
+        vec![
+            "ipc://@omq-zguide-11-server1".parse().unwrap(),
+            "ipc://@omq-zguide-11-server2".parse().unwrap(),
+        ]
+    };
+
+    let mut known_good: Option<usize> = None;
+
+    for i in 0..6 {
+        let body = format!("request-{i}");
+
+        // Build try order: known_good first, then the rest.
+        let try_order: Vec<usize> = if let Some(kg) = known_good {
+            let mut order = vec![kg];
+            for idx in 0..endpoints.len() {
+                if idx != kg {
+                    order.push(idx);
+                }
+            }
+            order
         } else {
-            vec![
-                "ipc://@omq-zguide-11-server1".parse().unwrap(),
-                "ipc://@omq-zguide-11-server2".parse().unwrap(),
-            ]
+            (0..endpoints.len()).collect()
         };
 
-        let mut known_good: Option<usize> = None;
+        let mut served = false;
+        for &idx in &try_order {
+            let ep = &endpoints[idx];
+            let req = ctx.socket(SocketType::Req, Options::default());
+            req.connect(ep.clone()).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
 
-        for i in 0..6 {
-            let body = format!("request-{i}");
+            req.send(Message::single(body.clone())).await.unwrap();
 
-            // Build try order: known_good first, then the rest.
-            let try_order: Vec<usize> = if let Some(kg) = known_good {
-                let mut order = vec![kg];
-                for idx in 0..endpoints.len() {
-                    if idx != kg {
-                        order.push(idx);
-                    }
+            match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
+                Ok(Ok(reply)) => {
+                    let reply_str = msg_str(&reply, 0);
+                    println!("client: {body} -> {reply_str} (via {ep})");
+                    known_good = Some(idx);
+                    served = true;
+                    break;
                 }
-                order
-            } else {
-                (0..endpoints.len()).collect()
-            };
-
-            let mut served = false;
-            for &idx in &try_order {
-                let ep = &endpoints[idx];
-                let req = Socket::new(SocketType::Req, Options::default());
-                req.connect(ep.clone()).await.unwrap();
-                tokio::time::sleep(Duration::from_millis(20)).await;
-
-                req.send(Message::single(body.clone())).await.unwrap();
-
-                match tokio::time::timeout(Duration::from_millis(200), req.recv()).await {
-                    Ok(Ok(reply)) => {
-                        let reply_str = msg_str(&reply, 0);
-                        println!("client: {body} -> {reply_str} (via {ep})");
-                        known_good = Some(idx);
-                        served = true;
-                        break;
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("client: recv error on {ep}: {e}");
-                    }
-                    Err(_) => {
-                        println!("client: {ep} timed out, rotating");
-                        if known_good == Some(idx) {
-                            known_good = None;
-                        }
+                Ok(Err(e)) => {
+                    eprintln!("client: recv error on {ep}: {e}");
+                }
+                Err(_) => {
+                    println!("client: {ep} timed out, rotating");
+                    if known_good == Some(idx) {
+                        known_good = None;
                     }
                 }
             }
-
-            if !served {
-                eprintln!("client: all endpoints failed for {body}");
-            }
-
-            // Pace requests so run.sh can kill a server mid-run.
-            tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        println!("client: done (6 requests)");
-    });
+        if !served {
+            eprintln!("client: all endpoints failed for {body}");
+        }
+
+        // Pace requests so run.sh can kill a server mid-run.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    println!("client: done (6 requests)");
 }

--- a/examples/zguide-tokio/11_freelance/server.rs
+++ b/examples/zguide-tokio/11_freelance/server.rs
@@ -7,37 +7,39 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 fn endpoint_or(args: &[String], index: usize, default: &str) -> Endpoint {
-    args.get(index).map_or_else(|| default.parse().unwrap(), |s| s.parse().expect("invalid endpoint"))
+    args.get(index).map_or_else(
+        || default.parse().unwrap(),
+        |s| s.parse().expect("invalid endpoint"),
+    )
 }
 
 fn msg_str(msg: &Message, idx: usize) -> String {
     String::from_utf8_lossy(&msg.part_bytes(idx).unwrap()).to_string()
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let args: Vec<String> = std::env::args().collect();
-        let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-11-server1");
-        let name = args.get(2).cloned().unwrap_or_else(|| "server".to_string());
-        let delay_secs: f64 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    let args: Vec<String> = std::env::args().collect();
+    let ep = endpoint_or(&args, 1, "ipc://@omq-zguide-11-server1");
+    let name = args.get(2).cloned().unwrap_or_else(|| "server".to_string());
+    let delay_secs: f64 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0.0);
 
-        let rep = Socket::new(SocketType::Rep, Options::default());
-        rep.bind(ep).await.unwrap();
+    let rep = ctx.socket(SocketType::Rep, Options::default());
+    rep.bind(ep).await.unwrap();
 
-        loop {
-            let msg = rep.recv().await.unwrap();
-            let body = msg_str(&msg, 0);
-            if delay_secs > 0.0 {
-                tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
-            }
-            println!("{name}: served {body}");
-            rep.send(Message::single(format!("{name}:{body}")))
-                .await
-                .unwrap();
+    loop {
+        let msg = rep.recv().await.unwrap();
+        let body = msg_str(&msg, 0);
+        if delay_secs > 0.0 {
+            tokio::time::sleep(Duration::from_secs_f64(delay_secs)).await;
         }
-    });
+        println!("{name}: served {body}");
+        rep.send(Message::single(format!("{name}:{body}")))
+            .await
+            .unwrap();
+    }
 }

--- a/examples/zguide-tokio/Cargo.lock
+++ b/examples/zguide-tokio/Cargo.lock
@@ -662,6 +662,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "omq-tokio",
+ "tokio",
 ]
 
 [[package]]

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -96,7 +96,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `RecvSink` gains `Rep` variant.
 - **Breaking:** `Socket` no longer implements `UnwindSafe`/
   `RefUnwindSafe`.
-- Rename `prefetch_upto` to `prefetch_up_to`.
 - *(deps)* Bump `omq-proto` to 0.23.0, `yring` to 0.3.8.
 
 ## [0.17.0] - 2026-07-10

--- a/omq-tokio/README.md
+++ b/omq-tokio/README.md
@@ -22,17 +22,23 @@ Built on [omq-proto](https://crates.io/crates/omq-proto) and
 ## Usage
 
 ```rust
-use omq_tokio::{Socket, SocketType, Options, Message};
+use omq_tokio::{Context, SocketType, Options, Message};
 
-let push = Socket::new(SocketType::Push, Options::default());
+let ctx = Context::new();
+
+let push = ctx.socket(SocketType::Push, Options::default());
 push.bind("tcp://127.0.0.1:5555".parse()?).await?;
 
-let pull = Socket::new(SocketType::Pull, Options::default());
+let pull = ctx.socket(SocketType::Pull, Options::default());
 pull.connect("tcp://127.0.0.1:5555".parse()?).await?;
 
 push.send(Message::single("hello")).await?;
 let msg = pull.recv().await?;
 ```
+
+Use `Socket::new(...)` when you want the socket driver on the caller's
+active tokio runtime. Use `ctx.socket(...)` when OMQ should own IO runtime
+threads.
 
 `cargo add omq` picks this backend by default.
 

--- a/omq-tokio/examples/bench_1push_8pull.rs
+++ b/omq-tokio/examples/bench_1push_8pull.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Context, Endpoint, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
 
 const PEERS: usize = 8;
 const SIZE: usize = 128;
@@ -14,87 +14,86 @@ const WARMUP_MSGS: usize = 50_000;
 const ROUNDS: usize = 5;
 const ROUND_MSGS: usize = 500_000;
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let port = {
-            let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
-            l.local_addr().unwrap().port()
-        };
-        let ep = Endpoint::Tcp {
-            host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
-            port,
-        };
+    let port = {
+        let l = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+        l.local_addr().unwrap().port()
+    };
+    let ep = Endpoint::Tcp {
+        host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
+        port,
+    };
 
-        let push = Socket::new(SocketType::Push, Options::default());
-        push.bind(ep.clone()).await.unwrap();
+    let push = ctx.socket(SocketType::Push, Options::default());
+    push.bind(ep.clone()).await.unwrap();
 
-        let pulls: Vec<Arc<Socket>> = (0..PEERS)
-            .map(|_| {
-                let s = Socket::new(SocketType::Pull, Options::default());
-                Arc::new(s)
-            })
-            .collect();
+    let pulls: Vec<Arc<omq_tokio::Socket>> = (0..PEERS)
+        .map(|_| {
+            let s = ctx.socket(SocketType::Pull, Options::default());
+            Arc::new(s)
+        })
+        .collect();
 
-        for p in &pulls {
-            p.connect(ep.clone()).await.unwrap();
+    for p in &pulls {
+        p.connect(ep.clone()).await.unwrap();
+    }
+
+    // Wait for all connections to complete ZMTP handshake.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let conns = push.connections().await.unwrap_or_default();
+        if conns.iter().filter(|c| c.peer_info.is_some()).count() == PEERS {
+            break;
         }
+        assert!(Instant::now() < deadline, "peers never connected");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 
-        // Wait for all connections to complete ZMTP handshake.
-        let deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            let conns = push.connections().await.unwrap_or_default();
-            if conns.iter().filter(|c| c.peer_info.is_some()).count() == PEERS {
-                break;
-            }
-            assert!(Instant::now() < deadline, "peers never connected");
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
+    let payload = Bytes::from(vec![0u8; SIZE]);
 
-        let payload = Bytes::from(vec![0u8; SIZE]);
+    // Spawn one recv task per PULL.
+    let recv_handles: Vec<_> = pulls
+        .iter()
+        .map(|p| {
+            let p = p.clone();
+            tokio::spawn(async move { while p.recv().await.is_ok() {} })
+        })
+        .collect();
 
-        // Spawn one recv task per PULL.
-        let recv_handles: Vec<_> = pulls
-            .iter()
-            .map(|p| {
-                let p = p.clone();
-                tokio::spawn(async move { while p.recv().await.is_ok() {} })
-            })
-            .collect();
+    let push = Arc::new(push);
 
-        let push = Arc::new(push);
+    // Warmup.
+    for _ in 0..WARMUP_MSGS {
+        push.send(Message::single(payload.clone())).await.unwrap();
+    }
+    // Give receivers a moment to drain.
+    tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // Warmup.
-        for _ in 0..WARMUP_MSGS {
+    // Timed rounds.
+    let mut best_mbps = 0.0f64;
+    for _ in 0..ROUNDS {
+        let n = ROUND_MSGS;
+        let t = Instant::now();
+        for _ in 0..n {
             push.send(Message::single(payload.clone())).await.unwrap();
         }
-        // Give receivers a moment to drain.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Timed rounds.
-        let mut best_mbps = 0.0f64;
-        for _ in 0..ROUNDS {
-            let n = ROUND_MSGS;
-            let t = Instant::now();
-            for _ in 0..n {
-                push.send(Message::single(payload.clone())).await.unwrap();
-            }
-            let elapsed = t.elapsed();
-            let mbps = (n * SIZE) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
-            let msgs_s = n as f64 / elapsed.as_secs_f64();
-            println!(
-                "  {SIZE}B  {mbps:.1} MB/s  {msgs_s:.0} msg/s  ({:.3}s, n={n})",
-                elapsed.as_secs_f64()
-            );
-            if mbps > best_mbps {
-                best_mbps = mbps;
-            }
+        let elapsed = t.elapsed();
+        let mbps = (n * SIZE) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+        let msgs_s = n as f64 / elapsed.as_secs_f64();
+        println!(
+            "  {SIZE}B  {mbps:.1} MB/s  {msgs_s:.0} msg/s  ({:.3}s, n={n})",
+            elapsed.as_secs_f64()
+        );
+        if mbps > best_mbps {
+            best_mbps = mbps;
         }
-        println!("best: {best_mbps:.1} MB/s");
+    }
+    println!("best: {best_mbps:.1} MB/s");
 
-        // Cleanup.
-        for h in recv_handles {
-            h.abort();
-        }
-    });
+    // Cleanup.
+    for h in recv_handles {
+        h.abort();
+    }
 }

--- a/omq-tokio/examples/pub_sub_lz4.rs
+++ b/omq-tokio/examples/pub_sub_lz4.rs
@@ -5,46 +5,45 @@
 
 use std::time::Duration;
 
-use omq_tokio::{Context, Message, Options, Socket, SocketType};
+use omq_tokio::{Context, Message, Options, SocketType};
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let ctx = Context::new();
-    ctx.block_on(async move {
-        let publisher = Socket::new(SocketType::Pub, Options::default());
-        publisher
-            .bind("lz4+tcp://127.0.0.1:5556".parse().unwrap())
-            .await
-            .unwrap();
+    let publisher = ctx.socket(SocketType::Pub, Options::default());
+    publisher
+        .bind("lz4+tcp://127.0.0.1:5556".parse().unwrap())
+        .await
+        .unwrap();
 
-        let subscriber = Socket::new(SocketType::Sub, Options::default());
-        subscriber
-            .connect("lz4+tcp://127.0.0.1:5556".parse().unwrap())
-            .await
-            .unwrap();
-        subscriber.subscribe("news.").await.unwrap(); // prefix match
+    let subscriber = ctx.socket(SocketType::Sub, Options::default());
+    subscriber
+        .connect("lz4+tcp://127.0.0.1:5556".parse().unwrap())
+        .await
+        .unwrap();
+    subscriber.subscribe("news.").await.unwrap(); // prefix match
 
-        // SUBSCRIBE travels from sub to pub over the wire; give it a moment.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    // SUBSCRIBE travels from sub to pub over the wire; give it a moment.
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
-        publisher
-            .send(Message::multipart(["news.sports", "ball scores"]))
-            .await
-            .unwrap();
-        publisher
-            .send(Message::multipart(["weather", "sunny"]))
-            .await
-            .unwrap(); // filtered out
+    publisher
+        .send(Message::multipart(["news.sports", "ball scores"]))
+        .await
+        .unwrap();
+    publisher
+        .send(Message::multipart(["weather", "sunny"]))
+        .await
+        .unwrap(); // filtered out
 
-        let m = subscriber.recv().await.unwrap(); // only "news.sports" arrives
-        let topic = m.part_bytes(0).unwrap();
-        let body = m.part_bytes(1).unwrap();
-        assert_eq!(&*topic, b"news.sports");
-        assert_eq!(&*body, b"ball scores");
+    let m = subscriber.recv().await.unwrap(); // only "news.sports" arrives
+    let topic = m.part_bytes(0).unwrap();
+    let body = m.part_bytes(1).unwrap();
+    assert_eq!(&*topic, b"news.sports");
+    assert_eq!(&*body, b"ball scores");
 
-        println!(
-            "{}: {}",
-            String::from_utf8_lossy(&topic),
-            String::from_utf8_lossy(&body),
-        );
-    });
+    println!(
+        "{}: {}",
+        String::from_utf8_lossy(&topic),
+        String::from_utf8_lossy(&body),
+    );
 }

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -247,18 +247,21 @@ impl IoPoolHandle {
 /// threads, each running an independent `current_thread` tokio runtime.
 /// Sockets created via [`Context::socket()`] have their driver tasks on
 /// those runtimes. The user does not need tokio in their own
-/// `Cargo.toml`.
+/// `Cargo.toml` for OMQ IO work.
 ///
 /// ```no_run
 /// use omq_tokio::{Context, SocketType, Options, Message};
 ///
+/// # async fn example() {
 /// let ctx = Context::new();
 /// let sock = ctx.socket(SocketType::Push, Options::default());
-/// ctx.block_on(async move {
-///     sock.bind("tcp://*:5555".parse().unwrap()).await.unwrap();
-///     sock.send(Message::from("hello")).await.unwrap();
-/// });
+/// sock.bind("tcp://*:5555".parse().unwrap()).await.unwrap();
+/// sock.send(Message::from("hello")).await.unwrap();
+/// # }
 /// ```
+///
+/// In a plain `fn main()`, either use [`blocking_socket`](Self::blocking_socket)
+/// or [`block_on`](Self::block_on) as a small executor helper.
 ///
 /// # Embedded in an existing runtime
 ///
@@ -405,6 +408,8 @@ impl Context {
     /// Run a future on this context's runtime, blocking the calling
     /// thread until it completes. The future runs inline on the
     /// primary IO thread with the same priority as spawned driver tasks.
+    /// If the caller already has an async runtime, await socket futures
+    /// directly instead.
     ///
     /// # Panics
     ///

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -445,7 +445,7 @@ fn drain_yring(
 ) -> usize {
     let mut drained = 0;
     while !budget.exhausted() {
-        let (item, _) = drain_yring_one_up_to(consumer, batch_remaining, budget.remaining_msgs());
+        let (item, _) = drain_yring_one(consumer, batch_remaining);
         let Some(item) = item else {
             break;
         };
@@ -465,32 +465,6 @@ fn drain_yring_one(
     loop {
         if *batch_remaining == 0 {
             *batch_remaining = consumer.prefetch();
-            if *batch_remaining == 0 {
-                return (None, false);
-            }
-        }
-        if let Some(item) = consumer.pop() {
-            *batch_remaining -= 1;
-            if *batch_remaining == 0 {
-                consumer.release();
-                return (Some(item), true);
-            }
-            return (Some(item), false);
-        }
-        consumer.release();
-        *batch_remaining = 0;
-    }
-}
-
-/// Pop one message from a prefetched window capped by caller budget.
-fn drain_yring_one_up_to(
-    consumer: &mut yring::Consumer<RecvItem>,
-    batch_remaining: &mut usize,
-    prefetch_limit: usize,
-) -> (Option<RecvItem>, bool) {
-    loop {
-        if *batch_remaining == 0 {
-            *batch_remaining = consumer.prefetch_up_to(prefetch_limit);
             if *batch_remaining == 0 {
                 return (None, false);
             }
@@ -999,7 +973,7 @@ mod tests {
     }
 
     #[test]
-    fn throughput_drain_prefetches_only_message_budget() {
+    fn throughput_drain_tracks_prefetched_remainder() {
         let (mut producer, mut consumer) = yring::spsc(RECV_BATCH_MESSAGES + 1);
         for _ in 0..RECV_BATCH_MESSAGES {
             producer
@@ -1019,7 +993,7 @@ mod tests {
             RECV_BATCH_MESSAGES
         );
         assert_eq!(batch.len(), RECV_BATCH_MESSAGES);
-        assert_eq!(remaining, 0);
+        assert_eq!(remaining, 1);
         assert!(!consumer.is_empty());
 
         let next = consumer.prefetch_and_pop().unwrap();

--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `Consumer::prefetch_up_to()` and `AsyncConsumer::prefetch_up_to()` for
-  bounded local prefetch without releasing unpopped items.
-
 ### Changed
 
 - Replace the unreleased 64-bit cursor change with pointer-width cursors
@@ -39,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deny `unsafe_op_in_unsafe_fn` lint. All unsafe function bodies now
   require explicit `unsafe` blocks.
-- Rename `prefetch_upto` to `prefetch_up_to`.
 - Remove bounded prefetch API (replaced by size-class draining in
   `omq-tokio`).
 

--- a/yring/README.md
+++ b/yring/README.md
@@ -17,9 +17,11 @@ Three pointers instead of two:
 - `tail`: last flushed position (AtomicUsize, producer writes / consumer reads)
 
 `push()` writes to the ring with zero atomics. `flush()` makes all
-pending writes visible with a single Release store. `pop()` reads with
-zero atomics. `prefetch()` loads all available items with a single
-Acquire load. Result: 2 atomic ops per batch, not per item.
+pending writes visible with a single Release store. `prefetch()` loads
+all available items with a single Acquire load. `pop()` reads with zero
+atomics. `release()` publishes consumed slots back to the producer with
+a single Release store. Result: atomic synchronization happens per
+batch, not per item.
 
 This is the core ypipe innovation from ZeroMQ, applied to a fixed-capacity
 ring buffer instead of a linked list.

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -234,16 +234,6 @@ impl<T> AsyncConsumer<T> {
         self.ring.ring.prefetch(&mut self.cached_tail)
     }
 
-    /// Load up to `limit` items flushed since the last prefetch. One
-    /// Acquire load. Returns the count of newly prefetched items.
-    ///
-    /// This only extends the local visible window. It does not consume
-    /// items and does not release slots to the producer.
-    #[inline]
-    pub fn prefetch_up_to(&mut self, limit: usize) -> usize {
-        self.ring.ring.prefetch_up_to(&mut self.cached_tail, limit)
-    }
-
     /// Prefetch + pop + release in one call.
     #[inline]
     pub fn prefetch_and_pop(&mut self) -> Option<T> {
@@ -366,14 +356,14 @@ mod tests {
     }
 
     #[test]
-    fn async_prefetch_up_to_releases_only_popped_items() {
+    fn async_release_after_prefetch_releases_only_popped_items() {
         let (mut p, mut c) = async_spsc::<u32>(2);
 
         p.push(10).unwrap();
         p.push(20).unwrap();
         p.flush();
 
-        assert_eq!(c.prefetch_up_to(2), 2);
+        assert_eq!(c.prefetch(), 2);
         assert_eq!(c.pop(), Some(10));
         c.release();
 
@@ -386,7 +376,7 @@ mod tests {
         p.push(40).unwrap();
         p.flush();
 
-        assert_eq!(c.prefetch_up_to(2), 2);
+        assert_eq!(c.prefetch(), 2);
         assert_eq!(c.pop(), Some(30));
         assert_eq!(c.pop(), Some(40));
         assert_eq!(c.pop(), None);

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -183,18 +183,6 @@ impl<T> Ring<T> {
     }
 
     #[inline]
-    pub(crate) fn prefetch_up_to(&self, cached_tail: &mut Cursor, limit: usize) -> usize {
-        if limit == 0 {
-            return 0;
-        }
-        let new_tail = self.tail.0.load(Ordering::Acquire);
-        let available = new_tail.wrapping_sub(*cached_tail);
-        let count = available.min(limit);
-        *cached_tail = cached_tail.wrapping_add(count);
-        Self::count(count)
-    }
-
-    #[inline]
     pub(crate) fn consumer_is_empty(&self, head: Cursor, cached_tail: Cursor) -> bool {
         head == cached_tail && self.tail.0.load(Ordering::Acquire) == head
     }
@@ -512,16 +500,6 @@ impl<T> Consumer<T> {
         self.ring.prefetch(&mut self.cached_tail)
     }
 
-    /// Load up to `limit` items flushed since the last prefetch. One
-    /// Acquire load. Returns the count of newly prefetched items.
-    ///
-    /// This only extends the local visible window. It does not consume
-    /// items and does not release slots to the producer.
-    #[inline]
-    pub fn prefetch_up_to(&mut self, limit: usize) -> usize {
-        self.ring.prefetch_up_to(&mut self.cached_tail, limit)
-    }
-
     /// Convenience: prefetch + pop + release. For callers that don't
     /// need batching.
     #[inline]
@@ -678,42 +656,14 @@ mod tests {
     }
 
     #[test]
-    fn prefetch_up_to_limits_visible_window() {
-        let (mut p, mut c) = spsc::<u32>(8);
-        for i in 0..5 {
-            p.push(i).unwrap();
-        }
-
-        assert_eq!(c.prefetch_up_to(0), 0);
-        assert!(c.pop().is_none());
-
-        p.flush();
-        assert_eq!(c.prefetch_up_to(2), 2);
-        assert_eq!(c.pop(), Some(0));
-        assert_eq!(c.pop(), Some(1));
-        assert!(c.pop().is_none());
-        c.release();
-
-        assert_eq!(c.prefetch_up_to(2), 2);
-        assert_eq!(c.pop(), Some(2));
-        assert_eq!(c.pop(), Some(3));
-        c.release();
-
-        assert_eq!(c.prefetch_up_to(2), 1);
-        assert_eq!(c.pop(), Some(4));
-        c.release();
-        assert_eq!(c.prefetch_up_to(2), 0);
-    }
-
-    #[test]
-    fn release_after_prefetch_up_to_releases_only_popped_items() {
+    fn release_after_prefetch_releases_only_popped_items() {
         let (mut p, mut c) = spsc::<u32>(2);
 
         p.push(10).unwrap();
         p.push(20).unwrap();
         p.flush();
 
-        assert_eq!(c.prefetch_up_to(2), 2);
+        assert_eq!(c.prefetch(), 2);
         assert_eq!(c.pop(), Some(10));
         c.release();
 
@@ -726,30 +676,9 @@ mod tests {
         p.push(40).unwrap();
         p.flush();
 
-        assert_eq!(c.prefetch_up_to(2), 2);
+        assert_eq!(c.prefetch(), 2);
         assert_eq!(c.pop(), Some(30));
         assert_eq!(c.pop(), Some(40));
-        assert_eq!(c.pop(), None);
-        c.release();
-    }
-
-    #[test]
-    fn prefetch_up_to_extends_existing_visible_window() {
-        let (mut p, mut c) = spsc::<u32>(8);
-        for i in 0..5 {
-            p.push(i).unwrap();
-        }
-        p.flush();
-
-        assert_eq!(c.prefetch_up_to(2), 2);
-        assert_eq!(c.prefetch_up_to(2), 2);
-        for i in 0..4 {
-            assert_eq!(c.pop(), Some(i));
-        }
-        assert_eq!(c.pop(), None);
-
-        assert_eq!(c.prefetch_up_to(2), 1);
-        assert_eq!(c.pop(), Some(4));
         assert_eq!(c.pop(), None);
         c.release();
     }
@@ -864,33 +793,6 @@ mod tests {
         assert_eq!(c.pop(), None);
         c.release();
         assert!(p.is_empty());
-    }
-
-    #[test]
-    fn prefetch_up_to_handles_wrapped_counters() {
-        let (mut p, mut c) = spsc::<u32>(4);
-        let base: Cursor = usize::MAX - 1;
-        p.cursor = base;
-        p.cached_head = base;
-        c.head = base;
-        c.cached_tail = base;
-        p.ring.head.0.store(base, Ordering::Relaxed);
-        p.ring.tail.0.store(base, Ordering::Relaxed);
-
-        p.push(1).unwrap();
-        p.push(2).unwrap();
-        p.push(3).unwrap();
-        p.flush();
-
-        assert_eq!(c.prefetch_up_to(2), 2);
-        assert_eq!(c.pop(), Some(1));
-        assert_eq!(c.pop(), Some(2));
-        c.release();
-
-        assert_eq!(c.prefetch_up_to(2), 1);
-        assert_eq!(c.pop(), Some(3));
-        assert_eq!(c.pop(), None);
-        c.release();
     }
 
     #[test]

--- a/yring/tests/loom.rs
+++ b/yring/tests/loom.rs
@@ -56,36 +56,7 @@ fn push_full_release_retry() {
 }
 
 #[test]
-fn prefetch_up_to_drains_in_bounded_windows() {
-    loom::model(|| {
-        let (mut p, mut c) = yring::spsc::<u32>(2);
-
-        let h = thread::spawn(move || {
-            p.push(10).unwrap();
-            p.push(20).unwrap();
-            p.flush();
-        });
-
-        let mut received = Vec::new();
-        while received.len() < 2 {
-            if c.prefetch_up_to(1) > 0 {
-                if let Some(v) = c.pop() {
-                    received.push(v);
-                }
-                assert_eq!(c.pop(), None);
-                c.release();
-            } else {
-                thread::yield_now();
-            }
-        }
-
-        h.join().unwrap();
-        assert_eq!(received, [10, 20]);
-    });
-}
-
-#[test]
-fn release_after_prefetch_up_to_releases_only_popped_items() {
+fn release_after_prefetch_releases_only_popped_items() {
     use loom::sync::Arc;
     use loom::sync::atomic::{AtomicBool, Ordering};
 
@@ -121,7 +92,7 @@ fn release_after_prefetch_up_to_releases_only_popped_items() {
             p.flush();
         });
 
-        assert_eq!(c.prefetch_up_to(2), 2);
+        assert_eq!(c.prefetch(), 2);
         assert_eq!(c.pop(), Some(10));
         c.release();
         released_one.store(true, Ordering::Release);
@@ -134,7 +105,7 @@ fn release_after_prefetch_up_to_releases_only_popped_items() {
         c.release();
 
         loop {
-            if c.prefetch_up_to(2) > 0 {
+            if c.prefetch() > 0 {
                 assert_eq!(c.pop(), Some(30));
                 assert_eq!(c.pop(), Some(40));
                 assert_eq!(c.pop(), None);
@@ -213,42 +184,6 @@ fn pointer_width_cursor_wrap_boundary() {
         loop {
             if c.prefetch() > 0 {
                 assert_eq!(c.pop(), Some(10));
-                assert_eq!(c.pop(), Some(20));
-                assert_eq!(c.pop(), None);
-                c.release();
-                break;
-            }
-            thread::yield_now();
-        }
-
-        h.join().unwrap();
-    });
-}
-
-#[test]
-fn prefetch_up_to_pointer_width_cursor_wrap_boundary() {
-    loom::model(|| {
-        let base = usize::MAX - 1;
-        let (mut p, mut c) = yring::loom_spsc_with_cursors::<u32>(2, base);
-
-        let h = thread::spawn(move || {
-            p.push(10).unwrap();
-            p.push(20).unwrap();
-            p.flush();
-        });
-
-        loop {
-            if c.prefetch_up_to(1) > 0 {
-                assert_eq!(c.pop(), Some(10));
-                assert_eq!(c.pop(), None);
-                c.release();
-                break;
-            }
-            thread::yield_now();
-        }
-
-        loop {
-            if c.prefetch_up_to(1) > 0 {
                 assert_eq!(c.pop(), Some(20));
                 assert_eq!(c.pop(), None);
                 c.release();


### PR DESCRIPTION
Summary:
- Update docs/examples toward `ctx.socket()` owned-context async use.
- Remove unpublished `prefetch_up_to()` from yring sync/async APIs.
- Use normal yring `prefetch()` batching in OMQ recv drains.

Validation:
- `OMQ_STRESS=1 scripts/test-all.sh`
- Perf gate passed on script retry; first attempt missed one noisy PUB/SUB metric.