### PR TITLE
Fix pyomq proxy blocking semantics

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -78,15 +78,15 @@ See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) fo
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.81 M/s |  1.53 M/s | **1.83×** |
-| REQ/REP rt/s       |   8,411/s |   4,511/s | **1.86×** |
+| PUSH/PULL msg/s    |  2.75 M/s |  1.53 M/s | **1.79×** |
+| REQ/REP rt/s       |   8,441/s |   4,511/s | **1.87×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,
 no Python per-message overhead. pyzmq's `zmq.proxy()` calls libzmq's
 C-level `zmq_proxy`. PUSH/PULL forwarding is throughput-bound and pyomq is
-~1.3x faster. REQ/REP proxy is latency-bound (4 TCP hops per round-trip);
-pyomq is ~1.8x faster thanks to direct socket forwarding.
+~1.8x faster. REQ/REP proxy is latency-bound (4 TCP hops per round-trip);
+pyomq is ~1.9x faster thanks to direct socket forwarding.
 
 Run `scripts/update_perf.py` (after `maturin develop --release`) to re-measure, regenerate the chart, and update the proxy table.
 

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -49,38 +49,38 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,236.2 145.8,232.0 201.7,234.2 257.5,261.5 313.3,260.1 369.2,262.6 425.0,258.8 480.8,268.5 536.7,281.0 592.5,324.5 648.3,352.4 704.2,366.9 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,320.1 145.8,318.9 201.7,319.4 257.5,319.8 313.3,320.9 369.2,322.1 425.0,324.4 480.8,329.1 536.7,335.2 592.5,344.5 648.3,355.9 704.2,368.1 760.0,376.4" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,231.9 145.8,240.3 201.7,236.5 257.5,263.3 313.3,259.3 369.2,255.4 425.0,253.0 480.8,265.3 536.7,283.5 592.5,326.2 648.3,352.2 704.2,366.6 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,319.4 145.8,319.1 201.7,318.8 257.5,319.8 313.3,320.4 369.2,321.6 425.0,324.3 480.8,328.7 536.7,338.8 592.5,344.5 648.3,356.2 704.2,366.2 760.0,376.0" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,305.5 145.8,306.4 201.7,303.5 257.5,314.7 313.3,326.6 369.2,336.9 425.0,333.7 480.8,343.9 536.7,356.1 592.5,367.6 648.3,375.3 704.2,379.4 760.0,380.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="90.0,380.6 145.8,380.5 201.7,380.6 257.5,380.6 313.3,380.6 369.2,380.5 425.0,380.6 480.8,380.6 536.7,380.7 592.5,380.9 648.3,380.9 704.2,381.0 760.0,381.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.8 145.8,381.6 201.7,379.2 257.5,376.2 313.3,368.1 369.2,352.9 425.0,319.9 480.8,265.7 536.7,173.1 592.5,140.3 648.3,125.1 704.2,103.7 760.0,101.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,382.8 145.8,381.7 201.7,379.3 257.5,376.3 313.3,368.0 369.2,351.1 425.0,316.9 480.8,262.4 536.7,178.3 592.5,147.3 648.3,123.8 704.2,98.8 760.0,103.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="381.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="379.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="376.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="368.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="352.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="319.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="265.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="173.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="140.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="125.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="103.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="101.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.1 425.0,353.5 480.8,327.8 536.7,284.1 592.5,222.4 648.3,153.9 704.2,123.8 760.0,135.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="145.8" cy="381.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="379.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="376.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="368.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="351.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="316.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="262.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="178.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="147.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="123.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="98.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="103.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.0 425.0,353.4 480.8,327.4 536.7,291.5 592.5,222.0 648.3,156.1 704.2,92.0 760.0,122.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="383.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="381.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="257.5" cy="379.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="313.3" cy="375.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="368.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="353.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="327.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="284.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="222.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="153.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="123.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="135.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="368.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="353.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="327.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="291.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="222.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="156.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="92.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="122.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,383.4 145.8,382.8 201.7,381.4 257.5,379.6 313.3,376.7 369.2,371.9 425.0,358.3 480.8,342.9 536.7,326.9 592.5,316.6 648.3,313.1 704.2,309.2 760.0,261.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="383.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="382.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
@@ -159,34 +159,34 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,552.0 145.8,551.1 201.7,550.9 257.5,551.4 313.3,550.6 369.2,551.4 425.0,551.4 480.8,551.3 536.7,550.4 592.5,547.9 648.3,541.0 704.2,531.2 760.0,521.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="552.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="551.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="550.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="550.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="551.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="550.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="547.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="541.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="531.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="521.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,518.9 145.8,518.8 201.7,518.8 257.5,518.7 313.3,517.8 369.2,517.6 425.0,518.3 480.8,517.0 536.7,516.8 592.5,512.9 648.3,508.3 704.2,503.7 760.0,496.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="518.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="518.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="518.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="518.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="517.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="518.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="517.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="512.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="508.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="503.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="496.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,551.3 145.8,551.2 201.7,550.3 257.5,551.0 313.3,550.5 369.2,550.5 425.0,550.9 480.8,549.9 536.7,548.9 592.5,544.6 648.3,545.3 704.2,529.4 760.0,522.6" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="551.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="550.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="551.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="550.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="549.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="548.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="544.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="545.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="529.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="522.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,516.9 145.8,517.8 201.7,517.9 257.5,520.0 313.3,517.3 369.2,518.1 425.0,517.3 480.8,518.7 536.7,515.1 592.5,512.6 648.3,510.0 704.2,505.3 760.0,497.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="516.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="520.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="517.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="518.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="517.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="518.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="515.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="512.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="510.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="505.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="497.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <polyline points="90.0,527.6 145.8,527.1 201.7,527.8 257.5,527.3 313.3,525.3 369.2,527.4 425.0,526.1 480.8,526.4 536.7,524.4 592.5,524.0 648.3,509.9 704.2,508.3 760.0,499.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="527.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -120,7 +120,8 @@ fn native_proxy(
         .map(|inner| inner.ensure_blocking_socket())
         .transpose()?;
     let ctx = fe.ctx.clone();
-    py.detach(|| runtime::proxy_handles(&ctx, fe_sock, be_sock, cap_sock, ctrl_sock));
+    py.detach(|| runtime::proxy_handles(&ctx, fe_sock, be_sock, cap_sock, ctrl_sock))
+        .map_err(error::map_err)?;
     Ok(())
 }
 

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -502,7 +502,7 @@ pub fn proxy_handles(
     be: omq_tokio::blocking::Socket,
     cap: Option<omq_tokio::blocking::Socket>,
     ctrl: Option<omq_tokio::blocking::Socket>,
-) {
+) -> omq_proto::error::Result<omq_tokio::proxy::ProxyExit> {
     let mut proxy = omq_tokio::Proxy::new(fe.into_async(), be.into_async());
     if let Some(cap) = cap {
         proxy = proxy.capture(cap.into_async());
@@ -510,9 +510,7 @@ pub fn proxy_handles(
     if let Some(ctrl) = ctrl {
         proxy = proxy.control(ctrl.into_async());
     }
-    ctx.spawn_blocking(async move {
-        let _ = proxy.run().await;
-    });
+    ctx.spawn_blocking(async move { proxy.run().await })
 }
 
 #[allow(dead_code)]

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -746,6 +746,7 @@ def test_proxy_steerable(tcp_endpoint):
         )
         proxy_thread.start()
         time.sleep(0.05)
+        assert proxy_thread.is_alive()
 
         # Basic forwarding
         sender.send(b"hello")

--- a/omq-tokio/tests/curve.rs
+++ b/omq-tokio/tests/curve.rs
@@ -405,8 +405,9 @@ async fn curve_reconnects_after_server_restart() {
             ..Options::default().curve_client(client_kp, server_pub)
         },
     );
+    let mut client_mon = client.monitor();
     client.connect(ep.clone()).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    test_support::wait_for_handshake_on(&mut client_mon).await;
 
     client.send(Message::single("before")).await.unwrap();
     let m = tokio::time::timeout(Duration::from_secs(2), server1.recv())
@@ -429,8 +430,9 @@ async fn curve_reconnects_after_server_restart() {
     }
     assert!(bound, "server2 failed to bind after server1 closed");
 
+    test_support::wait_for_handshake_on(&mut client_mon).await;
     client.send(Message::single("after")).await.unwrap();
-    let m = tokio::time::timeout(Duration::from_secs(3), server2.recv())
+    let m = tokio::time::timeout(Duration::from_secs(5), server2.recv())
         .await
         .expect("second recv timed out — CURVE reconnect failed")
         .unwrap();

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -59,17 +59,13 @@ async fn push_duplicate_tcp_connect_weights_round_robin() {
         .await
         .expect("push did not keep three pipes");
 
-    let drain_a = tokio::spawn(async move { drain_until_idle(pull_a).await });
-    let drain_b = tokio::spawn(async move { drain_until_idle(pull_b).await });
-
     for i in 0..N {
         push.send(Message::single(format!("weighted-{i}")))
             .await
             .unwrap();
     }
 
-    let count_a = drain_a.await.unwrap();
-    let count_b = drain_b.await.unwrap();
+    let (count_a, count_b) = drain_pair_until_total(pull_a, pull_b, N).await;
 
     assert_eq!(count_a + count_b, N, "every message must arrive");
     assert_eq!(
@@ -82,12 +78,34 @@ async fn push_duplicate_tcp_connect_weights_round_robin() {
     );
 }
 
-async fn drain_until_idle(socket: Socket) -> usize {
-    let mut count = 0;
-    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_millis(500), socket.recv()).await {
-        count += 1;
+async fn drain_pair_until_total(a: Socket, b: Socket, total: usize) -> (usize, usize) {
+    let mut count_a = 0;
+    let mut count_b = 0;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let timeout = tokio::time::sleep_until(deadline);
+    tokio::pin!(timeout);
+
+    while count_a + count_b < total {
+        tokio::select! {
+            biased;
+            () = &mut timeout => {
+                panic!(
+                    "timed out draining duplicate connect distribution: \
+                     count_a={count_a}, count_b={count_b}, total={total}"
+                );
+            }
+            msg = a.recv() => {
+                msg.unwrap();
+                count_a += 1;
+            }
+            msg = b.recv() => {
+                msg.unwrap();
+                count_b += 1;
+            }
+        }
     }
-    count
+
+    (count_a, count_b)
 }
 
 #[tokio::test]

--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -9,12 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace the unreleased 64-bit cursor change with pointer-width cursors
+- Replace the 64-bit target rejection with pointer-width cursors
   (`AtomicUsize` + `usize`) and a half-range capacity guard so 32-bit targets
   with pointer atomics can run safely.
-- Use 64-bit cursors (`AtomicU64` + `u64`) instead of pointer-width cursors,
-  allowing 32-bit targets with native 64-bit atomics to run without aliasing at
-  the 4 GiB cursor boundary.
 
 ## [0.3.8] - 2026-07-19
 


### PR DESCRIPTION
- Make pyomq native proxy helpers block until the tokio proxy exits, matching pyzmq behavior.
- Return proxy errors to Python instead of swallowing the result.
- Add coverage that a steerable proxy thread stays alive before TERMINATE.
- Correct the yring Unreleased note and refresh pyomq proxy perf docs/chart.