### PR TITLE
pyomq: expose CURVE peer identity

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-07-22
+
+### Added
+
+- CURVE authentication callbacks now receive `PeerInfo.identity`, exposing
+  the peer routing identity from READY metadata.
+
+### Fixed
+
+- Python CURVE authenticators can now bind an authenticated client public key
+  to the ROUTER identity frame seen by application code.
+- The `compression_auto_train` overlay default now matches the documented
+  off-by-default behavior.
+
 ## [0.16.2] - 2026-07-22
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -112,6 +112,13 @@ to the peer once. After that the compression threshold drops from 512 B to
 128 B, so small structured messages start compressing too. Pure Rust (lz4rip),
 no C compiler required.
 
+Enable it on sockets that send compressible traffic before `bind()`/`connect()`:
+
+```python
+push.compression_auto_train = 1
+# or: push.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 1)
+```
+
 See [BENCHMARKS_COMPRESSION.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS_COMPRESSION.md) for throughput charts and benchmark details.
 Wire format: [LZ4 transport RFC](https://github.com/paddor/omq.rs/blob/main/doc/lz4-rfc.md).
 
@@ -133,7 +140,8 @@ pull.curve_secretkey = server_sec
 # Option 1: allow specific client keys (checked in Rust, no GIL overhead)
 pull.set_curve_auth([client_pub])
 
-# Option 2: custom callback receiving a PeerInfo with a .public_key (Z85 bytes)
+# Option 2: custom callback. PeerInfo has .public_key (Z85) and
+# .identity (bytes or None).
 pull.set_curve_auth(lambda peer: peer.public_key in allowed_keys)
 
 # Option 3: accept any valid CURVE client (the default)

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.16.2"
+version = "0.16.3"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/pyomq/src/auth.rs
+++ b/bindings/pyomq/src/auth.rs
@@ -50,7 +50,10 @@ pub(crate) fn build_authenticator(
             let cb = Python::attach(|py| cb.clone_ref(py));
             omq_proto::proto::mechanism::Authenticator::new(move |peer| {
                 Python::attach(|py| {
-                    let info = Py::new(py, PeerInfo::from_raw(py, &peer.public_key));
+                    let info = Py::new(
+                        py,
+                        PeerInfo::from_raw(py, &peer.public_key, peer.identity.as_ref()),
+                    );
                     let info = match info {
                         Ok(i) => i,
                         Err(_) => return false,

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -108,7 +108,7 @@ impl Default for Overlay {
             curve_authenticator: None,
             on_mute: OnMute::Block,
             compression_dict: None,
-            compression_auto_train: true,
+            compression_auto_train: false,
             reconnect_stop: 0,
         }
     }

--- a/bindings/pyomq/src/peer_info.rs
+++ b/bindings/pyomq/src/peer_info.rs
@@ -5,6 +5,7 @@ use pyo3::types::PyBytes;
 #[pyclass(frozen, module = "pyomq._native")]
 pub struct PeerInfo {
     public_key: Py<PyBytes>,
+    identity: Option<Py<PyBytes>>,
 }
 
 #[pymethods]
@@ -13,15 +14,25 @@ impl PeerInfo {
     fn public_key(&self, py: Python<'_>) -> Py<PyBytes> {
         self.public_key.clone_ref(py)
     }
+
+    #[getter]
+    fn identity(&self, py: Python<'_>) -> Option<Py<PyBytes>> {
+        self.identity.as_ref().map(|id| id.clone_ref(py))
+    }
 }
 
 impl PeerInfo {
     #[cfg(feature = "curve")]
-    pub(crate) fn from_raw(py: Python<'_>, raw: &[u8; 32]) -> Self {
+    pub(crate) fn from_raw(
+        py: Python<'_>,
+        raw: &[u8; 32],
+        identity: Option<&bytes::Bytes>,
+    ) -> Self {
         let pk = omq_proto::CurvePublicKey::from_bytes(*raw);
         let z85 = pk.to_z85();
         Self {
             public_key: PyBytes::new(py, z85.as_bytes()).unbind(),
+            identity: identity.map(|id| PyBytes::new(py, id).unbind()),
         }
     }
 }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -792,7 +792,9 @@ impl Socket {
         }
         if let Some(m) = self.inner.take_materialized() {
             let ctx = self.inner.ctx.clone();
-            py.detach(|| ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump, linger));
+            py.detach(|| {
+                ctx.destroy_socket(m.socket, m.send_prod, m.send_pump, m.recv_pump, linger)
+            });
         }
         Ok(())
     }

--- a/bindings/pyomq/tests/test_async_auth.py
+++ b/bindings/pyomq/tests/test_async_auth.py
@@ -1,5 +1,7 @@
 """Async API authentication tests for CURVE."""
 
+import asyncio
+
 import pytest
 
 import pyomq
@@ -65,3 +67,39 @@ async def test_async_curve_auth_callback(tcp_endpoint):
     finally:
         push.close()
         pull.close()
+
+
+@pytest.mark.skipif(not pyomq.has("curve"), reason="curve feature not compiled")
+@pytest.mark.asyncio
+async def test_async_curve_auth_callback_receives_identity(tcp_endpoint):
+    server_pub, server_sec = pyomq.curve_keypair()
+    client_pub, client_sec = pyomq.curve_keypair()
+    captured = []
+
+    ctx = zmq_async.Context()
+    router = ctx.socket(pyomq.ROUTER)
+    dealer = ctx.socket(pyomq.DEALER)
+    try:
+        router.curve_server = 1
+        router.curve_publickey = server_pub
+        router.curve_secretkey = server_sec
+        router.set_curve_auth(
+            lambda peer: captured.append(peer.identity) is None
+            and peer.public_key == client_pub
+            and peer.identity == b"async-client"
+        )
+
+        dealer.identity = b"async-client"
+        dealer.curve_serverkey = server_pub
+        dealer.curve_publickey = client_pub
+        dealer.curve_secretkey = client_sec
+
+        ep = router.bind(tcp_endpoint)
+        dealer.connect(ep)
+        dealer.send(b"async-probe")
+        msg = await asyncio.wait_for(router.recv_multipart(), timeout=5.0)
+        assert msg == [b"async-client", b"async-probe"]
+        assert captured == [b"async-client"]
+    finally:
+        dealer.close()
+        router.close()

--- a/bindings/pyomq/tests/test_curve_auth.py
+++ b/bindings/pyomq/tests/test_curve_auth.py
@@ -147,3 +147,30 @@ def test_curve_auth_callback_receives_z85_key(tcp_endpoint):
         push.close()
         pull.close()
         ctx.term()
+
+
+def test_curve_auth_callback_receives_identity(tcp_endpoint):
+    captured = []
+    ctx = zmq.Context()
+    router = ctx.socket(zmq.ROUTER)
+    dealer = ctx.socket(zmq.DEALER)
+    try:
+        client_pub = _setup_curve(router, dealer)
+        dealer.identity = b"client-one"
+
+        def auth(peer):
+            captured.append(peer.identity)
+            return peer.public_key == client_pub and peer.identity == b"client-one"
+
+        router.set_curve_auth(auth)
+        ep = router.bind(tcp_endpoint)
+        dealer.connect(ep)
+        dealer.send(b"probe")
+        router.setsockopt(zmq.RCVTIMEO, 5000)
+        assert router.recv_multipart() == [b"client-one", b"probe"]
+
+        assert captured == [b"client-one"]
+    finally:
+        dealer.close()
+        router.close()
+        ctx.term()


### PR DESCRIPTION
- Exposes `PeerInfo.identity` to pyomq CURVE auth callbacks.
- Adds sync and `asyncio` regression coverage for binding auth keys to `ROUTER` identities.
- Restores `compression_auto_train` to the documented off-by-default behavior and documents opt-in before `bind()`/`connect()`.
- Prepares `pyomq` `0.16.3` release metadata.