### PR TITLE
docs: add benchmark link alias

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,7 @@
+# Benchmarks
+
+General cross-implementation benchmark charts live in
+[COMPARISONS.md](COMPARISONS.md).
+
+Compression transport benchmarks live in
+[BENCHMARKS_COMPRESSION.md](BENCHMARKS_COMPRESSION.md).

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -64,7 +64,7 @@ across the runtime trip.
 
 ## Performance
 
-See [BENCHMARKS.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS.md) for full tables.
+See [COMPARISONS.md](https://github.com/paddor/omq.rs/blob/main/COMPARISONS.md) for full tables.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/pyomq/doc/charts/bindings.svg" alt="pyomq vs pyzmq performance" width="850">


### PR DESCRIPTION
- Adds root `BENCHMARKS.md` as a stable pointer to `COMPARISONS.md` and `BENCHMARKS_COMPRESSION.md`.
- Updates the pyomq README general benchmark link to target `COMPARISONS.md` directly.