### PR TITLE
Fix Rust audit findings

### DIFF
--- a/omq-libzmq/src/local_cell.rs
+++ b/omq-libzmq/src/local_cell.rs
@@ -1,32 +1,87 @@
 use std::cell::UnsafeCell;
+use std::sync::OnceLock;
 
 /// Single-threaded interior mutability without runtime overhead.
 ///
-/// Wraps `UnsafeCell<T>` behind a safe `get(&self) -> &mut T` accessor.
-/// Sound because the ZMQ C API contract requires that each socket is
-/// accessed from at most one thread at a time.
-pub(crate) struct LocalCell<T>(UnsafeCell<T>);
+/// Wraps `UnsafeCell<T>` behind an owner-thread check. The first `get`
+/// call binds the cell to the current thread; later calls from another
+/// thread panic before touching the cell.
+pub(crate) struct LocalCell<T> {
+    value: UnsafeCell<T>,
+    owner: OnceLock<std::thread::ThreadId>,
+}
 
-// SAFETY: ZMQ's C API contract guarantees single-threaded socket
-// access. No concurrent mutation is possible under correct usage.
+// SAFETY: `get` binds access to one thread before touching the UnsafeCell.
+// Calls from other threads panic without accessing the cell.
 unsafe impl<T: Send> Sync for LocalCell<T> {}
 
 impl<T> LocalCell<T> {
     pub(crate) fn new(val: T) -> Self {
-        Self(UnsafeCell::new(val))
+        Self {
+            value: UnsafeCell::new(val),
+            owner: OnceLock::new(),
+        }
     }
 
     #[inline]
     #[expect(clippy::mut_from_ref)]
-    pub(crate) fn get(&self) -> &mut T {
-        // SAFETY: ZMQ's single-threaded socket contract guarantees
-        // no concurrent access to these fields.
-        unsafe { &mut *self.0.get() }
+    pub(crate) unsafe fn get(&self) -> &mut T {
+        let current = std::thread::current().id();
+        let owner = self.owner.get_or_init(|| current);
+        assert_eq!(
+            *owner, current,
+            "LocalCell accessed from multiple socket threads"
+        );
+        // SAFETY: caller upholds the socket single-thread access invariant.
+        unsafe { &mut *self.value.get() }
+    }
+
+    #[inline]
+    #[expect(clippy::mut_from_ref)]
+    pub(crate) unsafe fn get_unchecked(&self) -> &mut T {
+        // SAFETY: caller guarantees setup or teardown has exclusive access and
+        // must not bind the runtime owner thread for later app-facing access.
+        unsafe { &mut *self.value.get() }
     }
 }
 
 impl<T> std::fmt::Debug for LocalCell<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LocalCell").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::LocalCell;
+
+    #[test]
+    fn permits_repeated_access_from_owner_thread() {
+        let cell = LocalCell::new(1usize);
+
+        // SAFETY: test accesses the cell from one thread.
+        *unsafe { cell.get() } += 1;
+        // SAFETY: same owner thread as above.
+        assert_eq!(*unsafe { cell.get() }, 2);
+    }
+
+    #[test]
+    fn rejects_access_from_second_thread() {
+        let cell = Arc::new(LocalCell::new(1usize));
+
+        // SAFETY: this binds the owner to the current test thread.
+        assert_eq!(*unsafe { cell.get() }, 1);
+
+        let other = Arc::clone(&cell);
+        let result = std::thread::spawn(move || {
+            // SAFETY: this intentionally violates the owner-thread contract
+            // to verify the guard panics before returning a mutable reference.
+            let _ = unsafe { other.get() };
+        })
+        .join();
+
+        assert!(result.is_err());
     }
 }

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -612,7 +612,8 @@ pub extern "C" fn zmq_msg_send(
     };
 
     if !group.is_empty() {
-        let accum = sock_arc.send_accum.get();
+        // SAFETY: libzmq sockets are accessed by at most one application thread.
+        let accum = unsafe { sock_arc.send_accum.get() };
         accum.push(group);
     }
 

--- a/omq-libzmq/src/notify.rs
+++ b/omq-libzmq/src/notify.rs
@@ -760,7 +760,7 @@ pub(crate) use unix::UnixNotifyHandle as PlatformNotifyHandle;
 pub(crate) use windows::WindowsNotifyHandle as PlatformNotifyHandle;
 
 pub(crate) fn has_bypass_data(sock: &crate::socket::OmqSocket) -> bool {
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    let bypass_ptr = &*sock.bypass_recv.get();
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let bypass_ptr = &*unsafe { sock.bypass_recv.get() };
     bypass_ptr.as_ref().is_some_and(|br| !br.is_empty())
 }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -880,19 +880,18 @@ pub extern "C" fn zmq_getsockopt(
         }
         ZMQ_EVENTS => {
             let mut events = ZMQ_POLLOUT; // optimistic: always writable
-            let has_data = sock_arc
+            let drain_nonempty = sock_arc
                 .drain_nonempty
-                .load(std::sync::atomic::Ordering::Relaxed)
-                || sock_arc
-                    .recv_cons
-                    .get()
-                    .as_ref()
-                    .is_some_and(|c| !c.fast.is_empty() || !c.pump.is_empty())
-                || sock_arc
-                    .bypass_recv
-                    .get()
-                    .as_ref()
-                    .is_some_and(|br| !br.is_empty());
+                .load(std::sync::atomic::Ordering::Relaxed);
+            // SAFETY: libzmq sockets are accessed by at most one application thread.
+            let recv_cons_has_data = unsafe { sock_arc.recv_cons.get() }
+                .as_ref()
+                .is_some_and(|c| !c.fast.is_empty() || !c.pump.is_empty());
+            // SAFETY: same socket-thread invariant as above.
+            let bypass_recv_has_data = unsafe { sock_arc.bypass_recv.get() }
+                .as_ref()
+                .is_some_and(|br| !br.is_empty());
+            let has_data = drain_nonempty || recv_cons_has_data || bypass_recv_has_data;
             if has_data {
                 events |= ZMQ_POLLIN;
             }

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -32,7 +32,7 @@ macro_rules! lock_overlay {
 pub(crate) struct SocketOverlay {
     pub send_hwm: Option<u32>,
     pub recv_hwm: Option<u32>,
-    pub linger: Option<Duration>,
+    pub linger: LingerSetting,
     pub identity: Bytes,
     pub router_mandatory: bool,
     pub reconnect_ivl: Option<Duration>,
@@ -81,7 +81,29 @@ pub(crate) enum MechanismOverlay {
     },
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum LingerSetting {
+    #[default]
+    Unset,
+    Forever,
+    Finite(Duration),
+}
+
 impl SocketOverlay {
+    pub(crate) fn effective_linger(&self) -> Option<Duration> {
+        match self.linger {
+            LingerSetting::Unset | LingerSetting::Forever => None,
+            LingerSetting::Finite(d) => Some(d),
+        }
+    }
+
+    fn linger_ms(&self) -> i32 {
+        match self.linger {
+            LingerSetting::Unset | LingerSetting::Forever => -1,
+            LingerSetting::Finite(d) => d.as_millis() as i32,
+        }
+    }
+
     pub(crate) fn to_options(&self) -> omq_tokio::Options {
         let keepalive = match self.tcp_keepalive {
             1 => KeepAlive::Enabled {
@@ -135,7 +157,7 @@ impl SocketOverlay {
         omq_tokio::Options {
             send_hwm: self.send_hwm.unwrap_or(DEFAULT_HWM as u32),
             recv_hwm: self.recv_hwm.unwrap_or(DEFAULT_HWM as u32),
-            linger: self.linger,
+            linger: self.effective_linger(),
             identity: self.identity.clone(),
             max_message_size: self.max_message_size,
             router_mandatory: self.router_mandatory,
@@ -340,9 +362,9 @@ pub extern "C" fn zmq_setsockopt(
                 return fail(libc::EINVAL);
             };
             lock_overlay!(sock_arc).linger = if v < 0 {
-                None
+                LingerSetting::Forever
             } else {
-                Some(Duration::from_millis(v as u64))
+                LingerSetting::Finite(Duration::from_millis(v as u64))
             };
         }
         ZMQ_IDENTITY => {
@@ -807,9 +829,7 @@ pub extern "C" fn zmq_getsockopt(
             write_i32(optval, optvallen, v)
         }
         ZMQ_LINGER => {
-            let v = lock_overlay!(sock_arc)
-                .linger
-                .map_or(-1, |d| d.as_millis() as i32);
+            let v = lock_overlay!(sock_arc).linger_ms();
             write_i32(optval, optvallen, v)
         }
         ZMQ_IDENTITY => {
@@ -1304,6 +1324,27 @@ mod tests {
             overlay.to_options().handshake_timeout,
             Some(Duration::from_millis(10))
         );
+    }
+
+    #[test]
+    fn default_linger_matches_libzmq_forever() {
+        let overlay = SocketOverlay::default();
+
+        assert_eq!(overlay.linger_ms(), -1);
+        assert_eq!(overlay.effective_linger(), None);
+        assert_eq!(overlay.to_options().linger, None);
+    }
+
+    #[test]
+    fn explicit_linger_zero_maps_to_native_zero() {
+        let overlay = SocketOverlay {
+            linger: LingerSetting::Finite(Duration::ZERO),
+            ..Default::default()
+        };
+
+        assert_eq!(overlay.linger_ms(), 0);
+        assert_eq!(overlay.effective_linger(), Some(Duration::ZERO));
+        assert_eq!(overlay.to_options().linger, Some(Duration::ZERO));
     }
 
     #[test]

--- a/omq-libzmq/src/poll.rs
+++ b/omq-libzmq/src/poll.rs
@@ -39,19 +39,18 @@ fn check_immediate(items: &mut [ZmqPollItem]) -> i32 {
         let sock = unsafe { &*(item.socket.cast::<Arc<OmqSocket>>()) };
 
         if (item.events & ZMQ_POLLIN) != 0 {
-            let has_buffered = sock
+            let drain_nonempty = sock
                 .drain_nonempty
-                .load(std::sync::atomic::Ordering::Relaxed)
-                || sock
-                    .recv_cons
-                    .get()
-                    .as_ref()
-                    .is_some_and(|c| !c.fast.is_empty() || !c.pump.is_empty())
-                || sock
-                    .bypass_recv
-                    .get()
-                    .as_ref()
-                    .is_some_and(|br| !br.is_empty());
+                .load(std::sync::atomic::Ordering::Relaxed);
+            // SAFETY: libzmq sockets are accessed by at most one application thread.
+            let recv_cons_has_data = unsafe { sock.recv_cons.get() }
+                .as_ref()
+                .is_some_and(|c| !c.fast.is_empty() || !c.pump.is_empty());
+            // SAFETY: same socket-thread invariant as above.
+            let bypass_recv_has_data = unsafe { sock.bypass_recv.get() }
+                .as_ref()
+                .is_some_and(|br| !br.is_empty());
+            let has_buffered = drain_nonempty || recv_cons_has_data || bypass_recv_has_data;
             if has_buffered {
                 item.revents |= ZMQ_POLLIN;
             }
@@ -80,7 +79,8 @@ fn accumulate_buffered(items: &mut [ZmqPollItem]) -> i32 {
                 .drain_nonempty
                 .load(std::sync::atomic::Ordering::Relaxed);
 
-            let cons_ptr = &*sock.recv_cons.get();
+            // SAFETY: libzmq sockets are accessed by at most one application thread.
+            let cons_ptr = &*unsafe { sock.recv_cons.get() };
             let recv_cons_has_data = cons_ptr
                 .as_ref()
                 .is_some_and(|c| !c.fast.is_empty() || !c.pump.is_empty());

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -20,7 +20,8 @@ fn checked_c_int_len(n: usize) -> Result<c_int, c_int> {
 /// Clear a bypass option if the peer has closed the pipe.
 ///
 fn clear_stale_bypass<B: HasPipeClosed>(bypass_cell: &crate::local_cell::LocalCell<Option<B>>) {
-    let opt = bypass_cell.get();
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let opt = unsafe { bypass_cell.get() };
     if opt
         .as_ref()
         .is_some_and(|b| b.pipe_closed().load(std::sync::atomic::Ordering::Acquire))
@@ -72,8 +73,10 @@ pub(crate) fn try_recv_message(sock: &OmqSocket) -> Result<Option<omq_tokio::Mes
     }
 
     clear_stale_bypass(&sock.bypass_recv);
-    if let Some(bypass) = sock.bypass_recv.get() {
-        if let Some(cons) = sock.recv_cons.get()
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    if let Some(bypass) = unsafe { sock.bypass_recv.get() } {
+        // SAFETY: same socket-thread invariant as above.
+        if let Some(cons) = unsafe { sock.recv_cons.get() }
             && let Some(m) = try_pop_dual(cons, sock)
         {
             signal_recv_space(sock);
@@ -91,7 +94,8 @@ pub(crate) fn try_recv_message(sock: &OmqSocket) -> Result<Option<omq_tokio::Mes
         return Ok(None);
     }
 
-    let Some(cons) = sock.recv_cons.get() else {
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let Some(cons) = (unsafe { sock.recv_cons.get() }) else {
         return Err(ETERM);
     };
     if let Some(m) = try_pop_dual(cons, sock) {
@@ -112,7 +116,8 @@ pub(crate) fn try_send_message(
 ) -> Result<SendMessageAttempt, c_int> {
     if msg.len() == 1 {
         clear_stale_bypass(&sock.bypass_send);
-        if let Some(bypass) = sock.bypass_send.get() {
+        // SAFETY: libzmq sockets are accessed by at most one application thread.
+        if let Some(bypass) = unsafe { sock.bypass_send.get() } {
             let result = {
                 let data = msg.get(0).unwrap_or(&[]);
                 bypass.push(data)
@@ -297,15 +302,15 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
 
     // Inproc bypass: write raw bytes into the byte ring.
     // Checked BEFORE Message construction to avoid heap allocation.
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
     if flags & ZMQ_SNDMORE == 0 {
-        // SAFETY: zmq contract guarantees single-threaded access per socket.
-        let accum = sock.send_accum.get();
+        // SAFETY: libzmq sockets are accessed by at most one application thread.
+        let accum = unsafe { sock.send_accum.get() };
         if accum.is_empty() {
             clear_stale_bypass(&sock.bypass_send);
         }
         if accum.is_empty()
-            && let Some(bypass) = sock.bypass_send.get()
+            // SAFETY: same socket-thread invariant as `send_accum`.
+            && let Some(bypass) = unsafe { sock.bypass_send.get() }
         {
             let sndtimeo = sock.sndtimeo_ms.load(std::sync::atomic::Ordering::Relaxed);
             let dontwait = (flags & ZMQ_DONTWAIT) != 0 || sndtimeo == 0;
@@ -322,8 +327,8 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
         }
     }
 
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    let accum = sock.send_accum.get();
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let accum = unsafe { sock.send_accum.get() };
 
     // If SNDMORE: buffer and return immediately.
     if flags & ZMQ_SNDMORE != 0 {
@@ -460,9 +465,9 @@ fn zmq_recv_impl(sock: &OmqSocket, buf: *mut libc::c_void, buf_len: usize, flags
 
     // Inproc bypass fast path: copy from byte ring directly into user
     // buffer. Zero intermediate Bytes allocation.
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
     clear_stale_bypass(&sock.bypass_recv);
-    if let Some(bypass) = sock.bypass_recv.get() {
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    if let Some(bypass) = unsafe { sock.bypass_recv.get() } {
         match recv_bypass_direct(sock, bypass, buf, buf_len, flags) {
             Ok(n) => return n,
             Err(e) => return fail(e),
@@ -477,8 +482,8 @@ fn zmq_recv_impl(sock: &OmqSocket, buf: *mut libc::c_void, buf_len: usize, flags
     // Fast path: pop Message from yring, borrow first frame directly.
     // Avoids the Bytes::copy_from_slice that pop_recv_frame/decompose_message
     // would do for inline messages.
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    let Some(cons) = sock.recv_cons.get() else {
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let Some(cons) = (unsafe { sock.recv_cons.get() }) else {
         return fail(ETERM);
     };
 
@@ -575,13 +580,14 @@ pub(crate) fn pop_recv_frame(sock: &OmqSocket, flags: c_int) -> Result<(Bytes, b
     // Inproc bypass path: peek from byte ring, wrap in Bytes.
     // Used by zmq_msg_recv (which needs an owned Bytes).
     // zmq_recv uses recv_bypass_direct instead (zero alloc).
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
     clear_stale_bypass(&sock.bypass_recv);
-    if let Some(bypass) = sock.bypass_recv.get() {
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    if let Some(bypass) = unsafe { sock.bypass_recv.get() } {
         // Drain yring first (messages from before bypass was installed,
         // or multipart messages that went through the regular tokio path
         // because the send-side bypass was skipped for SNDMORE batches).
-        if let Some(cons) = sock.recv_cons.get()
+        // SAFETY: same socket-thread invariant as above.
+        if let Some(cons) = unsafe { sock.recv_cons.get() }
             && let Some(m) = try_pop_dual(cons, sock)
         {
             signal_recv_space(sock);
@@ -602,8 +608,8 @@ pub(crate) fn pop_recv_frame(sock: &OmqSocket, flags: c_int) -> Result<(Bytes, b
         // rather than the bypass ring.
     }
 
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    let Some(cons) = sock.recv_cons.get() else {
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    let Some(cons) = (unsafe { sock.recv_cons.get() }) else {
         return Err(ETERM);
     };
 
@@ -653,8 +659,8 @@ fn recv_bypass_direct(
     }
 
     // Drain yring first (multipart messages that went through omq-tokio).
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    if let Some(cons) = sock.recv_cons.get()
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    if let Some(cons) = unsafe { sock.recv_cons.get() }
         && let Some(m) = try_pop_dual(cons, sock)
     {
         signal_recv_space(sock);
@@ -700,8 +706,8 @@ fn try_recv_bypass_or_yring(
         bypass.advance(len);
         return checked_c_int_len(len).map(Some);
     }
-    // SAFETY: zmq contract guarantees single-threaded access per socket.
-    if let Some(cons) = sock.recv_cons.get()
+    // SAFETY: libzmq sockets are accessed by at most one application thread.
+    if let Some(cons) = unsafe { sock.recv_cons.get() }
         && let Some(m) = try_pop_dual(cons, sock)
     {
         signal_recv_space(sock);

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -390,7 +390,9 @@ pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
     let linger = arc
         .overlay
         .lock()
-        .map_or(Some(std::time::Duration::ZERO), |overlay| overlay.linger);
+        .map_or(Some(std::time::Duration::ZERO), |overlay| {
+            overlay.effective_linger()
+        });
     let close_socket = arc.inner.get().map(|inner| inner.as_ref().clone());
 
     // Enter the tokio runtime context so that dropping OmqSocket (and

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -170,8 +170,11 @@ fn try_install_bypass(sender: &Arc<OmqSocket>, receiver: &Arc<OmqSocket>) {
     // average size. Rounded up to a power of two internally.
     let byte_ring_cap = capacity * 1024;
     let (bsend, brecv) = crate::inproc_bypass::create_bypass(byte_ring_cap, recv_notify);
-    *sender.bypass_send.get() = Some(bsend);
-    *receiver.bypass_recv.get() = Some(brecv);
+    // SAFETY: bypass setup happens from bind/connect plumbing and must not
+    // bind either socket's later app-facing owner thread.
+    *unsafe { sender.bypass_send.get_unchecked() } = Some(bsend);
+    // SAFETY: same setup phase as above.
+    *unsafe { receiver.bypass_recv.get_unchecked() } = Some(brecv);
 }
 
 /// Register an inproc bind. If there are pending connectors, install
@@ -318,7 +321,9 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) -> bool {
     let cap = recv_hwm.max(16);
     let (fast_prod, fast_cons) = yring::spsc(cap);
     let (mut pump_prod, pump_cons) = yring::spsc(cap);
-    *sock.recv_cons.get() = Some(RecvConsumers {
+    // SAFETY: materialization happens before user recv access and must not
+    // bind the later app-facing owner thread.
+    *unsafe { sock.recv_cons.get_unchecked() } = Some(RecvConsumers {
         fast: fast_cons,
         pump: pump_cons,
     });
@@ -385,8 +390,11 @@ pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
     if let Some(h) = arc.recv_pump.get() {
         h.abort();
     }
-    *arc.bypass_send.get() = None;
-    *arc.bypass_recv.get() = None;
+    // SAFETY: `zmq_close` reclaims the socket pointer, so no later user access
+    // can legally race this cleanup.
+    *unsafe { arc.bypass_send.get_unchecked() } = None;
+    // SAFETY: same close-time exclusive ownership as above.
+    *unsafe { arc.bypass_recv.get_unchecked() } = None;
     let linger = arc
         .overlay
         .lock()

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -136,6 +136,8 @@ fn linger_roundtrip() {
     let ctx = zmq_ctx_new();
     let s = zmq_socket(ctx, ZMQ_PUSH);
 
+    assert_eq!(get_i32(s, ZMQ_LINGER), -1);
+
     set_i32(s, ZMQ_LINGER, 100);
     assert_eq!(get_i32(s, ZMQ_LINGER), 100);
 
@@ -147,6 +149,40 @@ fn linger_roundtrip() {
 
     zmq_close(s);
     zmq_ctx_term(ctx);
+}
+
+#[test]
+fn explicit_linger_zero_close_after_connect_without_peer_does_not_hang() {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let ctx = zmq_ctx_new();
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+
+    assert_eq!(get_i32(push, ZMQ_LINGER), -1);
+    assert_eq!(set_i32(push, ZMQ_LINGER, 0), 0);
+    assert_eq!(get_i32(push, ZMQ_LINGER), 0);
+
+    let endpoint = std::ffi::CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
+    assert_eq!(zmq_connect(push, endpoint.as_ptr()), 0);
+    assert_eq!(zmq_send(push, std::ptr::null(), 0, 0), 0);
+
+    // Regression for rust-zmq #382: a queued send to an unconnected peer
+    // must not make close/term hang when the user explicitly disables linger.
+    let close_start = Instant::now();
+    assert_eq!(zmq_close(push), 0);
+    assert!(
+        close_start.elapsed() < Duration::from_millis(100),
+        "zmq_close blocked with explicit linger=0"
+    );
+
+    let term_start = Instant::now();
+    assert_eq!(zmq_ctx_term(ctx), 0);
+    assert!(
+        term_start.elapsed() < Duration::from_millis(500),
+        "zmq_ctx_term blocked with explicit linger=0"
+    );
 }
 
 #[test]

--- a/omq-proto/src/message.rs
+++ b/omq-proto/src/message.rs
@@ -406,6 +406,16 @@ impl Message {
         }
     }
 
+    /// Size charged against [`Options::max_message_size`](crate::Options::max_message_size).
+    ///
+    /// This includes payload bytes plus one internal payload slot per part.
+    /// Counting the slot keeps multi-part and zero-length frame floods bounded
+    /// consistently across ZMTP and inproc transports.
+    pub fn max_message_size_len(&self) -> usize {
+        self.byte_len()
+            .saturating_add(self.len().saturating_mul(std::mem::size_of::<Payload>()))
+    }
+
     /// Whether this is a multi-part message (more than one frame).
     pub fn is_multipart(&self) -> bool {
         matches!(

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -717,6 +717,13 @@ mod tests {
     }
 
     #[test]
+    fn native_default_linger_is_zero() {
+        // Native OMQ intentionally differs from libzmq here: async socket
+        // close should not wait forever unless the user asks for it.
+        assert_eq!(Options::default().linger, Some(Duration::ZERO));
+    }
+
+    #[test]
     fn large_message_threshold_setters() {
         assert_eq!(
             Options::new()

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -62,7 +62,8 @@ pub struct Options {
     /// Max time allowed to complete the ZMTP handshake.
     pub handshake_timeout: Option<Duration>,
 
-    /// Reject incoming messages larger than this. `None` = no limit.
+    /// Reject incoming messages larger than this. Accounting includes payload
+    /// bytes plus one internal payload slot per part. `None` = no limit.
     pub max_message_size: Option<usize>,
 
     /// Conflate: keep only the latest message per subscriber. Applies to

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -902,8 +902,6 @@ where
                         transmit_slot.as_ref().unwrap(), &mut drain_buf,
                         &mut arena_buf, &mut writer,
                     ).await?;
-                    if latency_profile {
-                    }
                 }
 
                 // Handshake deadline; disabled once handshake completes.

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -590,7 +590,7 @@ pub(super) async fn inproc_peer_driver(
                 frame = in_rx.recv() => match frame {
                     Some(InboundFrame::Message(m)) => {
                         if let Some(max) = max_message_size
-                            && m.byte_len() > max
+                            && m.max_message_size_len() > max
                         {
                             return;
                         }

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -39,16 +39,16 @@ pub(super) fn spawn_byte_stream_connection(
     let child_cancel = socket.cancel.child_token();
     let driver_cfg = peer_driver_config(socket);
     let workload_profile = workload_profile(socket);
-    let has_encoder = MessageEncoder::for_endpoint(&endpoint, &socket.options);
-    let has_transform = has_encoder.is_some();
+    let transforms = MessageEncoder::for_endpoint(&endpoint, &socket.options);
+    let has_transforms = transforms.is_some();
     let latency_profile = workload_profile == WorkloadProfile::Latency
         && !socket.options.mechanism.has_frame_transform();
     let Ok((stream, direct_tcp_writer)) =
-        split_direct_tcp_writer(socket, stream, &endpoint, latency_profile, has_transform)
+        split_direct_tcp_writer(socket, stream, &endpoint, latency_profile, has_transforms)
     else {
         return;
     };
-    let passthrough_info = has_encoder
+    let passthrough_info = transforms
         .as_ref()
         .and_then(|(enc, _)| enc.passthrough_info())
         .map(|(s, t)| (s.clone(), t));
@@ -68,7 +68,7 @@ pub(super) fn spawn_byte_stream_connection(
             socket.socket_type,
         ),
     );
-    let peer_driver = attach_transforms(socket, peer_driver, has_encoder);
+    let peer_driver = attach_transforms(socket, peer_driver, transforms);
     let peer_driver = match socket.send_strategy.shared_rx() {
         Some(rx) => peer_driver.with_shared_rx(rx),
         None => peer_driver,
@@ -78,7 +78,7 @@ pub(super) fn spawn_byte_stream_connection(
     let transmit_slot = build_transmit_slot(
         socket,
         peer_id,
-        has_transform,
+        has_transforms,
         passthrough_info,
         arena,
         #[cfg(feature = "ws")]
@@ -303,7 +303,7 @@ fn split_direct_tcp_writer(
     stream: AnyStream,
     endpoint: &Endpoint,
     latency_profile: bool,
-    has_transform: bool,
+    has_transforms: bool,
 ) -> Result<
     (
         AnyStream,
@@ -314,7 +314,7 @@ fn split_direct_tcp_writer(
     if !latency_profile
         || !matches!(socket.socket_type, SocketType::Req | SocketType::Rep)
         || !matches!(endpoint, Endpoint::Tcp { .. })
-        || has_transform
+        || has_transforms
     {
         return Ok((stream, None));
     }
@@ -336,12 +336,12 @@ fn split_direct_tcp_writer(
 fn attach_transforms(
     socket: &mut SocketDriver,
     peer_driver: ConnectionDriver<AnyStream>,
-    encoder: Option<(
+    transforms: Option<(
         omq_proto::proto::transform::MessageEncoder,
         omq_proto::proto::transform::MessageDecoder,
     )>,
 ) -> ConnectionDriver<AnyStream> {
-    let Some((enc, dec)) = encoder else {
+    let Some((enc, dec)) = transforms else {
         return peer_driver;
     };
     let mut peer_driver = peer_driver.with_encoder(enc).with_decoder(dec);
@@ -385,7 +385,7 @@ fn arena_config(endpoint: &Endpoint, latency_profile: bool, socket: &SocketDrive
 fn build_transmit_slot(
     socket: &SocketDriver,
     peer_id: u64,
-    has_transform: bool,
+    has_transforms: bool,
     passthrough_info: Option<(bytes::Bytes, usize)>,
     arena: ArenaConfig,
     #[cfg(feature = "ws")] is_ws: bool,
@@ -402,7 +402,7 @@ fn build_transmit_slot(
     let transmit_slot_msg_cap = socket.options.send_hwm.max(1) as usize;
     Some(crate::engine::transmit_slot::PeerTransmitSlot::new(
         peer_id,
-        has_transform,
+        has_transforms,
         passthrough_info,
         arena.threshold,
         arena.cap,

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -804,7 +804,7 @@ impl SpscAwareRecv {
         if !pair.recv_ready.load(Ordering::Acquire)
             || pair
                 .max_message_size
-                .is_some_and(|max| msg.byte_len() > max)
+                .is_some_and(|max| msg.max_message_size_len() > max)
         {
             return SpscPush::Unavailable(msg);
         }
@@ -835,7 +835,7 @@ impl SpscAwareRecv {
         if !pair.recv_ready.load(Ordering::Acquire)
             || pair
                 .max_message_size
-                .is_some_and(|max| msg.byte_len() > max)
+                .is_some_and(|max| msg.max_message_size_len() > max)
             || pair.producer.is_consumer_dropped()
         {
             return false;
@@ -855,7 +855,7 @@ impl SpscAwareRecv {
         if !pair.recv_ready.load(Ordering::Acquire)
             || pair
                 .max_message_size
-                .is_some_and(|max| msg.byte_len() > max)
+                .is_some_and(|max| msg.max_message_size_len() > max)
             || pair.producer.is_consumer_dropped()
         {
             return false;
@@ -870,7 +870,7 @@ impl SpscAwareRecv {
         if !pair.recv_ready.load(Ordering::Acquire)
             || pair
                 .max_message_size
-                .is_some_and(|max| msg.byte_len() > max)
+                .is_some_and(|max| msg.max_message_size_len() > max)
             || pair.producer.is_consumer_dropped()
         {
             return false;

--- a/omq-tokio/tests/options_polish.rs
+++ b/omq-tokio/tests/options_polish.rs
@@ -7,6 +7,10 @@ use std::time::Duration;
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Error, Message, OnMute, Options, Socket, SocketType, TrySendError};
 
+fn max_message_size_for_payload(payload_len: usize) -> usize {
+    payload_len + std::mem::size_of::<omq_tokio::message::Payload>()
+}
+
 fn tcp_ep(port: u16) -> Endpoint {
     Endpoint::Tcp {
         host: Host::Ip(Ipv4Addr::LOCALHOST.into()),
@@ -67,7 +71,10 @@ async fn router_mandatory_true_errors_on_unknown() {
 #[tokio::test]
 async fn max_message_size_rejects_oversize() {
     let ep = inproc_ep("opt-mms");
-    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(8));
+    let pull = Socket::new(
+        SocketType::Pull,
+        Options::default().max_message_size(max_message_size_for_payload(8)),
+    );
     pull.bind(ep.clone()).await.unwrap();
 
     let push = Socket::new(SocketType::Push, Options::default());
@@ -96,7 +103,10 @@ async fn max_message_size_rejects_oversize_when_receiver_connects_inproc() {
     let push = Socket::new(SocketType::Push, Options::default());
     push.bind(ep.clone()).await.unwrap();
 
-    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(8));
+    let pull = Socket::new(
+        SocketType::Pull,
+        Options::default().max_message_size(max_message_size_for_payload(8)),
+    );
     pull.connect(ep).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -244,7 +254,10 @@ async fn drop_oldest_keeps_newest_messages() {
 #[tokio::test]
 async fn max_message_size_exactly_at_limit_is_accepted() {
     let ep = inproc_ep("opt-mms-exact");
-    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(8));
+    let pull = Socket::new(
+        SocketType::Pull,
+        Options::default().max_message_size(max_message_size_for_payload(8)),
+    );
     pull.bind(ep.clone()).await.unwrap();
 
     let push = Socket::new(SocketType::Push, Options::default());
@@ -261,7 +274,10 @@ async fn max_message_size_exactly_at_limit_is_accepted() {
 
 #[tokio::test]
 async fn max_message_size_one_byte_over_drops_connection() {
-    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(8));
+    let pull = Socket::new(
+        SocketType::Pull,
+        Options::default().max_message_size(max_message_size_for_payload(8)),
+    );
     let ep = pull.bind(tcp_ep(0)).await.unwrap();
 
     let push = Socket::new(SocketType::Push, Options::default());
@@ -275,4 +291,20 @@ async fn max_message_size_one_byte_over_drops_connection() {
         r.is_err(),
         "9-byte message must not be delivered when limit is 8"
     );
+}
+
+#[tokio::test]
+async fn max_message_size_counts_part_overhead_inproc() {
+    let ep = inproc_ep("opt-mms-overhead-inproc");
+    let max = std::mem::size_of::<omq_tokio::message::Payload>();
+    let pull = Socket::new(SocketType::Pull, Options::default().max_message_size(max));
+    pull.bind(ep.clone()).await.unwrap();
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    push.send(Message::single("x")).await.unwrap();
+    let r = tokio::time::timeout(Duration::from_millis(200), pull.recv()).await;
+    assert!(r.is_err(), "message overhead must count against the limit");
 }


### PR DESCRIPTION
## Summary

- clarify restored libzmq linger defaults
- make max message size accounting consistent across transports
- guard omq-libzmq LocalCell access by first owner thread
- remove empty latency branch
- rename peer transform bindings for readability

## Verification

- cargo fmt --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features --message-format short