### PR TITLE
Rename readiness signal types

### DIFF
--- a/bindings/pyomq/doc/architecture.md
+++ b/bindings/pyomq/doc/architecture.md
@@ -16,7 +16,7 @@ src/
                     curve_keypair, has_feature
   runtime.rs        tokio runtime on dedicated thread; materialize,
                     wait_any, proxy
-  socket.rs         sync Socket + SocketInner + RecvNotify (eventfd) +
+  socket.rs         sync Socket + SocketInner + EventFdSignal (eventfd) +
                     Monitor (connection event stream)
   socket_async.rs   AsyncSocket: send (sync yring push), _try_recv,
                     _recv_fd / _send_fd for eventfd polling
@@ -83,8 +83,8 @@ Materialization:
 2. Create yring producer/consumer pairs (capacities from SNDHWM/RCVHWM).
 3. Post job to the tokio thread: build the socket, spawn send and recv
    pump tasks.
-4. Store `Materialized { id, socket, send_prod, recv_cons, recv_notify,
-   send_pump, recv_pump }` in the `SocketInner`.
+4. Store `Materialized { id, socket, send_prod, recv_cons, recv_ready,
+   send_ready, recv_space, send_pump, recv_pump }` in the `SocketInner`.
 
 This lets Python code do `setsockopt` freely before the socket exists
 on the tokio thread.
@@ -98,17 +98,17 @@ into `socket.send()`. Yields every 256 messages to prevent a single
 high-volume socket from starving others on the runtime.
 
 **Recv pump.** Drains `socket.recv()` into a `Producer<Message>` (read
-by Python). On ring-full, waits on `recv_space` (`tokio::sync::Notify`,
-signaled by the Python consumer after draining). After pushing, signals
-the per-socket `RecvNotify` eventfd and the global `RECV_READY` flag
-(used by `wait_any`).
+by Python). On ring-full, waits on `recv_space` (`StateSignal`, signaled
+by the Python consumer after draining). After pushing, signals the
+per-socket `EventFdSignal` and the process-global recv signal used by
+`wait_any`.
 
-## RecvNotify (eventfd)
+## EventFdSignal (eventfd)
 
-`RecvNotify` wraps a Linux `eventfd(EFD_NONBLOCK)` plus an
+`EventFdSignal` wraps a Linux `eventfd(EFD_NONBLOCK)` plus an
 `AtomicBool parking` flag.
 
-- `notify()`: writes to the eventfd only if `parking` is true. On the
+- `signal()`: writes to the eventfd only if `parking` is true. On the
   hot path (consumer not parked), this is a single atomic load with no
   syscall.
 - `park_begin()` / `park_end()`: arm/disarm the parking flag.

--- a/bindings/pyomq/doc/performance.md
+++ b/bindings/pyomq/doc/performance.md
@@ -81,7 +81,7 @@ because they're both consumers of the socket's internal recv channel.
 ### Send backpressure: eventfd park instead of spin
 
 When the send yring is full, the Python thread parked on an eventfd
-(`send_notify`) instead of spinning with `thread::yield_now()`. The
+(`send_ready`) instead of spinning with `thread::yield_now()`. The
 send pump signals the eventfd after each batch drain (every 256
 messages). No CPU waste under backpressure.
 
@@ -99,7 +99,7 @@ to always `multi_thread` with `worker_threads(n.max(1))`. The
 Handle::block_on dead end above was about removing the yring, not
 the runtime type.
 
-### Current: multi_thread + yring + yield_now() + batched send_notify: ~1.5M msg/s
+### Current: multi_thread + yring + yield_now() + batched send_ready: ~1.5M msg/s
 
 The yring relay avoids `block_on` entirely. Python does lock-free ring
 push/pop. Pump tasks on the tokio thread batch send/recv operations.
@@ -203,12 +203,12 @@ the send yring, inproc PUSH/PULL hung ~2-4% of the time.
 Fix: flush unconditionally wakes the consumer. One extra
 `AtomicWaker::wake()` per flush (a no-op when no waker is registered).
 
-### Recv pump: Notify instead of yield_now spin-loop
+### Recv pump: StateSignal instead of yield_now spin-loop
 
 The recv pump spun with `tokio::task::yield_now()` when the recv yring
 was full. Under specific timing this prevented forward progress.
-Replaced with `recv_space: tokio::sync::Notify` signaled by the Python
-consumer after each `prefetch_and_pop`. The recv pump awaits the Notify
+Replaced with `recv_space: StateSignal` signaled by the Python
+consumer after each `prefetch_and_pop`. The recv pump awaits the signal
 instead of spinning.
 
 ### Python _check_fork() removed from hot path

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -782,22 +782,27 @@ def run_proxy(lib_name):
     sys.stdout.flush()
     if client is not None:
         _measure_proxy_native(lib_name, client, 1.0)
-        pp = max(_measure_proxy_native(lib_name, client)
-                 for _ in range(N_ROUNDS))
+        pushpull_rate = max(
+            _measure_proxy_native(lib_name, client) for _ in range(N_ROUNDS)
+        )
     else:
         _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
-        pp = max(_measure_proxy_subprocess(lib_name, "pushpull", 200_000)
-                 for _ in range(N_ROUNDS))
-    print(f" {fmt_rate(pp)}")
+        pushpull_rate = max(
+            _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
+            for _ in range(N_ROUNDS)
+        )
+    print(f" {fmt_rate(pushpull_rate)}")
 
     sys.stdout.write("  REQ/REP ...")
     sys.stdout.flush()
     _measure_proxy_subprocess(lib_name, "reqrep", 10_000)
-    rr = max(_measure_proxy_subprocess(lib_name, "reqrep", 10_000)
-             for _ in range(N_ROUNDS))
-    print(f" {fmt_rate(rr)}")
+    reqrep_rate = max(
+        _measure_proxy_subprocess(lib_name, "reqrep", 10_000)
+        for _ in range(N_ROUNDS)
+    )
+    print(f" {fmt_rate(reqrep_rate)}")
 
-    return pp, rr
+    return pushpull_rate, reqrep_rate
 
 
 # ── SVG chart generation ────────────────────────────────────────────

--- a/bindings/pyomq/src/context.rs
+++ b/bindings/pyomq/src/context.rs
@@ -12,8 +12,8 @@ use crate::runtime::ContextInner;
 use crate::socket::Socket;
 use crate::socket_async::AsyncSocket;
 
-fn map_socket_type(st: i32) -> PyResult<omq_tokio::SocketType> {
-    Ok(match st {
+fn map_socket_type(socket_type_id: i32) -> PyResult<omq_tokio::SocketType> {
+    Ok(match socket_type_id {
         constants::PAIR => omq_tokio::SocketType::Pair,
         constants::PUB => omq_tokio::SocketType::Pub,
         constants::SUB => omq_tokio::SocketType::Sub,

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -115,7 +115,7 @@ impl Default for Overlay {
 }
 
 impl Overlay {
-    /// Materialise an `backend::Options` from the overlay. Used
+    /// Materialize an `backend::Options` from the overlay. Used
     /// when the underlying Socket is first built.
     pub fn to_options(&self) -> PyResult<backend::Options> {
         #[allow(unused_mut)]
@@ -517,8 +517,8 @@ pub fn getsockopt<'py>(
     drop(sock.overlay.lock().unwrap()); // ensure poison-detection on every call path
     match option {
         constants::TYPE => {
-            let st = sock.socket_type;
-            let v: i32 = match st {
+            let socket_type = sock.socket_type;
+            let option_value: i32 = match socket_type {
                 backend::SocketType::Pair => constants::PAIR,
                 backend::SocketType::Pub => constants::PUB,
                 backend::SocketType::Sub => constants::SUB,
@@ -541,7 +541,7 @@ pub fn getsockopt<'py>(
                 backend::SocketType::Channel => constants::CHANNEL,
                 _ => -1,
             };
-            Ok(int_to_bound(py, v as i64))
+            Ok(int_to_bound(py, option_value as i64))
         }
         constants::RCVMORE => {
             let more = !sock.rxbuf.lock().unwrap().is_empty();
@@ -752,18 +752,19 @@ pub fn getsockopt<'py>(
         )),
         constants::FD => {
             sock.materialize()?;
-            let mat = sock.materialized.read().unwrap();
-            let m = mat.as_ref().unwrap();
-            m.recv_notify.arm_persistent();
-            Ok(int_to_bound(py, m.recv_notify.fd() as i64))
+            let materialized_guard = sock.materialized.read().unwrap();
+            let materialized = materialized_guard.as_ref().unwrap();
+            materialized.recv_ready.arm_persistent();
+            Ok(int_to_bound(py, materialized.recv_ready.fd() as i64))
         }
         constants::EVENTS => {
             let has_data = if !sock.rxbuf.lock().unwrap().is_empty() {
                 true
             } else {
-                let mat = sock.materialized.read().unwrap();
-                mat.as_ref()
-                    .is_some_and(|m| !m.recv_cons.lock().unwrap().is_empty())
+                let materialized_guard = sock.materialized.read().unwrap();
+                materialized_guard
+                    .as_ref()
+                    .is_some_and(|materialized| !materialized.recv_cons.lock().unwrap().is_empty())
             };
             let flags: i64 = if has_data { 1 } else { 0 };
             Ok(int_to_bound(py, flags))

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -33,22 +33,23 @@ struct RuntimeState {
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-static GLOBAL_RECV_READY: Mutex<Option<(u32, Arc<crate::socket::RecvNotify>)>> = Mutex::new(None);
+static GLOBAL_RECV_SIGNAL: Mutex<Option<(u32, Arc<crate::socket::EventFdSignal>)>> =
+    Mutex::new(None);
 
-/// Process-global recv notification for `wait_any`. Recv pumps from all
+/// Process-global recv signal for `wait_any`. Recv pumps from all
 /// contexts signal this after pushing a message; `wait_any` parks on it.
 /// Recreated after fork (PID guard).
-pub(crate) fn global_recv_ready() -> Arc<crate::socket::RecvNotify> {
-    let mut guard = GLOBAL_RECV_READY.lock().unwrap();
+pub(crate) fn global_recv_signal() -> Arc<crate::socket::EventFdSignal> {
+    let mut guard = GLOBAL_RECV_SIGNAL.lock().unwrap();
     let pid = std::process::id();
-    if let Some((p, rr)) = guard.as_ref()
-        && *p == pid
+    if let Some((cached_pid, signal)) = guard.as_ref()
+        && *cached_pid == pid
     {
-        return rr.clone();
+        return signal.clone();
     }
-    let rr = Arc::new(crate::socket::RecvNotify::new());
-    *guard = Some((pid, rr.clone()));
-    rr
+    let signal = Arc::new(crate::socket::EventFdSignal::new());
+    *guard = Some((pid, signal.clone()));
+    signal
 }
 
 /// Allocate the next socket id. Strictly monotonic; never recycled.
@@ -148,60 +149,60 @@ impl ContextInner {
         options: omq_tokio::Options,
         send_cons: yring::AsyncConsumer<omq_tokio::Message>,
         mut recv_prod: yring::Producer<omq_tokio::Message>,
-        recv_notify: Arc<crate::socket::RecvNotify>,
-        send_notify: Arc<crate::socket::RecvNotify>,
+        recv_ready: Arc<crate::socket::EventFdSignal>,
+        send_ready: Arc<crate::socket::EventFdSignal>,
         recv_space: Arc<omq_tokio::engine::StateSignal>,
     ) -> PyResult<(u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>)> {
         let handle = self.ensure_runtime()?;
         let (otx, orx) = flume::bounded(1);
-        let grr = global_recv_ready();
+        let recv_all_signal = global_recv_signal();
         handle.spawn(async move {
             let id = next_id();
             let sock = Arc::new(InnerSocket::new(socket_type, options));
 
             const SEND_YIELD_INTERVAL: u32 = 256;
-            let s = sock.clone();
+            let send_socket = sock.clone();
             let send_pump = tokio::spawn(async move {
                 futures::pin_mut!(send_cons);
                 let mut batch = 0u32;
                 while let Some(msg) = futures::StreamExt::next(&mut send_cons).await {
-                    let _ = s.send(msg).await;
-                    send_notify.notify();
+                    let _ = send_socket.send(msg).await;
+                    send_ready.signal();
                     batch += 1;
                     if batch >= SEND_YIELD_INTERVAL {
                         batch = 0;
                         tokio::task::yield_now().await;
                     }
                 }
-                send_notify.notify();
+                send_ready.signal();
             });
 
-            let s = sock.clone();
+            let recv_socket = sock.clone();
             let recv_pump = tokio::spawn(async move {
-                while let Ok(msg) = s.recv().await {
-                    let mut m = msg;
+                while let Ok(msg) = recv_socket.recv().await {
+                    let mut pending_msg = msg;
                     loop {
-                        match recv_prod.push(m) {
+                        match recv_prod.push(pending_msg) {
                             Ok(()) => {
                                 recv_prod.flush();
-                                recv_notify.notify();
-                                grr.notify();
+                                recv_ready.signal();
+                                recv_all_signal.signal();
                                 break;
                             }
                             Err(returned) => {
-                                m = returned;
+                                pending_msg = returned;
                                 let seen = recv_space.generation();
                                 let changed = recv_space.changed_after(seen);
                                 tokio::pin!(changed);
-                                match recv_prod.push(m) {
+                                match recv_prod.push(pending_msg) {
                                     Ok(()) => {
                                         recv_prod.flush();
-                                        recv_notify.notify();
-                                        grr.notify();
+                                        recv_ready.signal();
+                                        recv_all_signal.signal();
                                         break;
                                     }
                                     Err(returned2) => {
-                                        m = returned2;
+                                        pending_msg = returned2;
                                         changed.await;
                                     }
                                 }
@@ -337,15 +338,17 @@ impl Drop for ContextInner {
 
 #[allow(dead_code)]
 fn drain_recv_ring(inner: &Arc<crate::socket::SocketInner>) -> Vec<omq_tokio::Message> {
-    let mat = inner.materialized.read().unwrap();
-    let Some(m) = mat.as_ref() else { return vec![] };
-    let mut cons = m.recv_cons.lock().unwrap();
+    let materialized_guard = inner.materialized.read().unwrap();
+    let Some(materialized) = materialized_guard.as_ref() else {
+        return vec![];
+    };
+    let mut cons = materialized.recv_cons.lock().unwrap();
     let mut msgs = Vec::new();
     while let Some(msg) = cons.prefetch_and_pop() {
         msgs.push(msg);
     }
     if !msgs.is_empty() {
-        m.recv_space.notify_changed();
+        materialized.recv_space.notify_changed();
     }
     msgs
 }
@@ -353,9 +356,9 @@ fn drain_recv_ring(inner: &Arc<crate::socket::SocketInner>) -> Vec<omq_tokio::Me
 #[allow(dead_code)]
 fn push_to_capture(cap: &Arc<crate::socket::SocketInner>, msg: &omq_tokio::Message) {
     let copy = omq_tokio::Message::multipart(msg.iter());
-    let mat = cap.materialized.read().unwrap();
-    if let Some(m) = mat.as_ref() {
-        let mut prod = m.send_prod.lock().unwrap();
+    let materialized_guard = cap.materialized.read().unwrap();
+    if let Some(materialized) = materialized_guard.as_ref() {
+        let mut prod = materialized.send_prod.lock().unwrap();
         let _ = prod.push_and_flush(copy);
     }
 }
@@ -369,26 +372,26 @@ pub fn proxy(
     cap_inner: Option<Arc<crate::socket::SocketInner>>,
     ctrl_inner: Option<Arc<crate::socket::SocketInner>>,
 ) {
-    let fe_mat = fe_inner.materialized.read().unwrap();
-    let fe_m = fe_mat.as_ref().unwrap();
-    fe_m.send_pump.abort();
-    fe_m.recv_pump.abort();
-    let fe_sock = fe_m.socket.clone();
-    drop(fe_mat);
+    let fe_materialized_guard = fe_inner.materialized.read().unwrap();
+    let fe_materialized = fe_materialized_guard.as_ref().unwrap();
+    fe_materialized.send_pump.abort();
+    fe_materialized.recv_pump.abort();
+    let fe_sock = fe_materialized.socket.clone();
+    drop(fe_materialized_guard);
 
-    let be_mat = be_inner.materialized.read().unwrap();
-    let be_m = be_mat.as_ref().unwrap();
-    be_m.send_pump.abort();
-    be_m.recv_pump.abort();
-    let be_sock = be_m.socket.clone();
-    drop(be_mat);
+    let be_materialized_guard = be_inner.materialized.read().unwrap();
+    let be_materialized = be_materialized_guard.as_ref().unwrap();
+    be_materialized.send_pump.abort();
+    be_materialized.recv_pump.abort();
+    let be_sock = be_materialized.socket.clone();
+    drop(be_materialized_guard);
 
-    let ctrl_sock = ctrl_inner.as_ref().map(|c| {
-        let mat = c.materialized.read().unwrap();
-        let m = mat.as_ref().unwrap();
-        m.send_pump.abort();
-        m.recv_pump.abort();
-        m.socket.clone()
+    let ctrl_sock = ctrl_inner.as_ref().map(|ctrl| {
+        let materialized_guard = ctrl.materialized.read().unwrap();
+        let materialized = materialized_guard.as_ref().unwrap();
+        materialized.send_pump.abort();
+        materialized.recv_pump.abort();
+        materialized.socket.clone()
     });
 
     let fe_drained = drain_recv_ring(&fe_inner);
@@ -642,12 +645,12 @@ pub fn wait_any(
                 if !inner.rxmsgs.lock().unwrap().is_empty() {
                     return true;
                 }
-                let mat = inner.materialized.read().unwrap();
-                if let Some(m) = mat.as_ref() {
-                    let cons = m.recv_cons.lock().unwrap();
+                let materialized_guard = inner.materialized.read().unwrap();
+                if let Some(materialized) = materialized_guard.as_ref() {
+                    let cons = materialized.recv_cons.lock().unwrap();
                     !cons.is_empty()
                 } else {
-                    drop(mat);
+                    drop(materialized_guard);
                     let Ok(sock) = inner.ensure_blocking_socket() else {
                         return false;
                     };
@@ -669,13 +672,13 @@ pub fn wait_any(
         return ready;
     }
 
-    let rr = global_recv_ready();
+    let recv_signal = global_recv_signal();
     let deadline = timeout_ms.map(|ms| std::time::Instant::now() + Duration::from_millis(ms));
 
-    rr.park_begin();
+    recv_signal.park_begin();
     let ready = poll_ready(&sockets);
     if !ready.is_empty() {
-        rr.park_end();
+        recv_signal.park_end();
         return ready;
     }
 
@@ -684,7 +687,7 @@ pub fn wait_any(
             Some(d) => {
                 let now = std::time::Instant::now();
                 if now >= d {
-                    rr.park_end();
+                    recv_signal.park_end();
                     return vec![];
                 }
                 d - now
@@ -695,15 +698,15 @@ pub fn wait_any(
         // Native blocking sockets have thread wakeups, not an eventfd.
         // Poll their try-recv path periodically while retaining the
         // eventfd fast path for asyncio sockets.
-        rr.wait_timeout(wait_dur.min(Duration::from_millis(10)));
+        recv_signal.wait_timeout(wait_dur.min(Duration::from_millis(10)));
 
         let ready = poll_ready(&sockets);
         if !ready.is_empty() {
-            rr.park_end();
+            recv_signal.park_end();
             return ready;
         }
         if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
-            rr.park_end();
+            recv_signal.park_end();
             return vec![];
         }
     }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -29,21 +29,20 @@ pub(crate) struct SendBuffer {
     pub parts: Vec<Bytes>,
 }
 
-/// Notification primitive for the recv path: tokio pump signals Python
-/// thread via eventfd when a message is pushed into the yring.
+/// Eventfd-backed readiness signal for Python-facing async paths.
 ///
 /// The `parking` flag avoids syscalls on the hot path. The consumer
 /// sets it before sleeping; the producer only writes to the eventfd
 /// when it sees the flag.
-pub(crate) struct RecvNotify {
+pub(crate) struct EventFdSignal {
     efd: i32,
     parking: AtomicBool,
 }
 
-unsafe impl Send for RecvNotify {}
-unsafe impl Sync for RecvNotify {}
+unsafe impl Send for EventFdSignal {}
+unsafe impl Sync for EventFdSignal {}
 
-impl RecvNotify {
+impl EventFdSignal {
     pub fn new() -> Self {
         let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
         assert!(efd >= 0, "eventfd creation failed");
@@ -53,7 +52,7 @@ impl RecvNotify {
         }
     }
 
-    pub fn notify(&self) {
+    pub fn signal(&self) {
         if self.parking.load(Ordering::Acquire) {
             self.write_eventfd();
         }
@@ -121,7 +120,7 @@ impl RecvNotify {
     }
 }
 
-impl Drop for RecvNotify {
+impl Drop for EventFdSignal {
     fn drop(&mut self) {
         unsafe { libc::close(self.efd) };
     }
@@ -159,8 +158,8 @@ pub(crate) struct Materialized {
     pub socket: Arc<omq_tokio::Socket>,
     pub send_prod: Mutex<yring::AsyncProducer<omq_tokio::Message>>,
     pub recv_cons: Mutex<yring::Consumer<omq_tokio::Message>>,
-    pub recv_notify: Arc<RecvNotify>,
-    pub send_notify: Arc<RecvNotify>,
+    pub recv_ready: Arc<EventFdSignal>,
+    pub send_ready: Arc<EventFdSignal>,
     pub recv_space: Arc<omq_tokio::engine::StateSignal>,
     pub send_pump: JoinHandle<()>,
     pub recv_pump: JoinHandle<()>,
@@ -226,15 +225,15 @@ impl SocketInner {
         if self.closed.load(Ordering::Relaxed) {
             return Err(map_err(omq_proto::error::Error::Closed));
         }
-        let fgen = FORK_GEN.load(Ordering::Relaxed);
+        let fork_gen = FORK_GEN.load(Ordering::Relaxed);
         {
             let slot = self.materialized.read().unwrap();
-            if slot.as_ref().is_some_and(|m| m.fork_gen == fgen) {
+            if slot.as_ref().is_some_and(|m| m.fork_gen == fork_gen) {
                 return Ok(());
             }
         }
         let mut slot = self.materialized.write().unwrap();
-        if slot.as_ref().is_some_and(|m| m.fork_gen == fgen) {
+        if slot.as_ref().is_some_and(|m| m.fork_gen == fork_gen) {
             return Ok(());
         }
         *slot = None;
@@ -243,27 +242,27 @@ impl SocketInner {
         let recv_cap = opts.recv_hwm.max(1) as usize;
         let (send_prod, send_cons) = yring::async_spsc(send_cap);
         let (recv_prod, recv_cons) = yring::spsc(recv_cap);
-        let recv_notify = Arc::new(RecvNotify::new());
-        let send_notify = Arc::new(RecvNotify::new());
+        let recv_ready = Arc::new(EventFdSignal::new());
+        let send_ready = Arc::new(EventFdSignal::new());
         let recv_space = Arc::new(omq_tokio::engine::StateSignal::new());
-        let st = self.socket_type;
+        let socket_type = self.socket_type;
         let (id, socket, send_pump, recv_pump) = self.ctx.materialize(
-            st,
+            socket_type,
             opts,
             send_cons,
             recv_prod,
-            recv_notify.clone(),
-            send_notify.clone(),
+            recv_ready.clone(),
+            send_ready.clone(),
             recv_space.clone(),
         )?;
         *slot = Some(Materialized {
             id,
-            fork_gen: fgen,
+            fork_gen,
             socket,
             send_prod: Mutex::new(send_prod),
             recv_cons: Mutex::new(recv_cons),
-            recv_notify,
-            send_notify,
+            recv_ready,
+            send_ready,
             recv_space,
             send_pump,
             recv_pump,
@@ -272,9 +271,9 @@ impl SocketInner {
     }
 
     pub fn ensure_id(&self) -> PyResult<u64> {
-        let fgen = FORK_GEN.load(Ordering::Relaxed);
+        let fork_gen = FORK_GEN.load(Ordering::Relaxed);
         if let Some(m) = self.blocking_materialized.read().unwrap().as_ref()
-            && m.fork_gen == fgen
+            && m.fork_gen == fork_gen
         {
             return Ok(m.id);
         }
@@ -286,18 +285,18 @@ impl SocketInner {
         if self.closed.load(Ordering::Relaxed) {
             return Err(map_err(omq_proto::error::Error::Closed));
         }
-        let fgen = FORK_GEN.load(Ordering::Relaxed);
+        let fork_gen = FORK_GEN.load(Ordering::Relaxed);
         if self
             .blocking_materialized
             .read()
             .unwrap()
             .as_ref()
-            .is_some_and(|m| m.fork_gen == fgen)
+            .is_some_and(|m| m.fork_gen == fork_gen)
         {
             return Ok(());
         }
         let mut slot = self.blocking_materialized.write().unwrap();
-        if slot.as_ref().is_some_and(|m| m.fork_gen == fgen) {
+        if slot.as_ref().is_some_and(|m| m.fork_gen == fork_gen) {
             return Ok(());
         }
         // The inherited blocking socket owns the parent's runtime. Dropping
@@ -316,7 +315,7 @@ impl SocketInner {
         }
         *slot = Some(BlockingMaterialized {
             id,
-            fork_gen: fgen,
+            fork_gen,
             socket,
         });
         Ok(())
@@ -400,11 +399,11 @@ impl SocketInner {
     /// the next op and exit; the registry entry is removed separately.
     pub fn take_materialized(&self) -> Option<Materialized> {
         self.closed.store(true, Ordering::Relaxed);
-        let mat = self.materialized.write().unwrap().take();
-        if let Some(ref m) = mat {
-            m.recv_notify.force_wake();
+        let materialized = self.materialized.write().unwrap().take();
+        if let Some(ref state) = materialized {
+            state.recv_ready.force_wake();
         }
-        mat
+        materialized
     }
 
     pub fn take_blocking_materialized(&self) -> Option<BlockingMaterialized> {

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -82,9 +82,9 @@ impl AsyncSocket {
             return Ok(());
         };
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard.as_ref().unwrap();
-        let mut prod = mat.send_prod.lock().unwrap();
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard.as_ref().unwrap();
+        let mut prod = materialized.send_prod.lock().unwrap();
         match prod.push_and_flush(msg) {
             Ok(_) => Ok(()),
             Err(_) => Err(timeout_err()),
@@ -96,9 +96,9 @@ impl AsyncSocket {
         let _ = flags;
         let msg = conversions::message_from_pylist(parts)?;
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard.as_ref().unwrap();
-        let mut prod = mat.send_prod.lock().unwrap();
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard.as_ref().unwrap();
+        let mut prod = materialized.send_prod.lock().unwrap();
         match prod.push_and_flush(msg) {
             Ok(_) => Ok(()),
             Err(_) => Err(timeout_err()),
@@ -113,11 +113,13 @@ impl AsyncSocket {
             return Ok(PyBytes::new(py, &head).into_any());
         }
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
-        let mut cons = mat.recv_cons.lock().unwrap();
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard
+            .as_ref()
+            .ok_or_else(|| map_err(PError::Closed))?;
+        let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
-            mat.recv_space.notify_changed();
+            materialized.recv_space.notify_changed();
             let mut parts: Vec<Bytes> = msg.iter().collect();
             let head = if parts.is_empty() {
                 Bytes::new()
@@ -142,11 +144,13 @@ impl AsyncSocket {
             );
         }
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
-        let mut cons = mat.recv_cons.lock().unwrap();
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard
+            .as_ref()
+            .ok_or_else(|| map_err(PError::Closed))?;
+        let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
-            mat.recv_space.notify_changed();
+            materialized.recv_space.notify_changed();
             Ok(conversions::parts_to_pylist(py, msg)?.into_any())
         } else {
             Ok(py.None().bind(py).clone())
@@ -156,15 +160,15 @@ impl AsyncSocket {
     #[pyo3(name = "_recv_fd")]
     fn recv_fd(&self) -> PyResult<i32> {
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard
             .as_ref()
             .ok_or_else(|| crate::error::map_err(PError::Closed))?;
-        let recv_notify = mat.recv_notify.clone();
-        let owned_fd = recv_notify
+        let recv_ready = materialized.recv_ready.clone();
+        let owned_fd = recv_ready
             .dup_fd()
             .map_err(|e| crate::error::map_err(PError::Io(e)))?;
-        recv_notify.park_begin();
+        recv_ready.park_begin();
         use std::os::fd::IntoRawFd;
         Ok(owned_fd.into_raw_fd())
     }
@@ -172,15 +176,15 @@ impl AsyncSocket {
     #[pyo3(name = "_send_fd")]
     fn send_fd(&self) -> PyResult<i32> {
         self.inner.materialize()?;
-        let mat_guard = self.inner.materialized.read().unwrap();
-        let mat = mat_guard
+        let materialized_guard = self.inner.materialized.read().unwrap();
+        let materialized = materialized_guard
             .as_ref()
             .ok_or_else(|| crate::error::map_err(PError::Closed))?;
-        let send_notify = mat.send_notify.clone();
-        let owned_fd = send_notify
+        let send_ready = materialized.send_ready.clone();
+        let owned_fd = send_ready
             .dup_fd()
             .map_err(|e| crate::error::map_err(PError::Io(e)))?;
-        send_notify.park_begin();
+        send_ready.park_begin();
         use std::os::fd::IntoRawFd;
         Ok(owned_fd.into_raw_fd())
     }

--- a/omq-libzmq/tests/xpub_xsub.rs
+++ b/omq-libzmq/tests/xpub_xsub.rs
@@ -6,7 +6,7 @@ mod helpers;
 
 use std::ffi::{CString, c_void};
 use std::mem::size_of;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_getsockopt, zmq_recv,
@@ -20,6 +20,8 @@ const ZMQ_XSUB: i32 = 10;
 const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_SNDTIMEO: i32 = 28;
 const ZMQ_SUBSCRIBE: i32 = 6;
+const ZMQ_LINGER: i32 = 17;
+const ZMQ_DONTWAIT: i32 = 1;
 #[allow(dead_code)]
 const ZMQ_RCVMORE: i32 = 13;
 #[allow(dead_code)]
@@ -41,6 +43,16 @@ fn set_timeo(sock: *mut c_void, ms: i32) {
     );
 }
 
+fn set_linger_zero(sock: *mut c_void) {
+    let ms: i32 = 0;
+    zmq_setsockopt(
+        sock,
+        ZMQ_LINGER,
+        (&ms as *const i32).cast(),
+        size_of::<i32>(),
+    );
+}
+
 fn get_type(sock: *mut c_void) -> i32 {
     let mut v: i32 = 0;
     let mut sz = size_of::<i32>();
@@ -54,6 +66,8 @@ fn xpub_xsub_basic() {
     let ctx = zmq_ctx_new();
     let xpub = zmq_socket(ctx, ZMQ_XPUB);
     let xsub = zmq_socket(ctx, ZMQ_XSUB);
+    set_linger_zero(xpub);
+    set_linger_zero(xsub);
     assert_eq!(get_type(xpub), ZMQ_XPUB);
     assert_eq!(get_type(xsub), ZMQ_XSUB);
 
@@ -89,6 +103,8 @@ fn xpub_receives_sub_notifications() {
     let ctx = zmq_ctx_new();
     let xpub = zmq_socket(ctx, ZMQ_XPUB);
     let sub = zmq_socket(ctx, ZMQ_SUB);
+    set_linger_zero(xpub);
+    set_linger_zero(sub);
 
     let port = helpers::free_port();
     let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
@@ -121,10 +137,14 @@ fn xpub_receives_sub_notifications() {
     // Publish a non-matching message.
     zmq_send(xpub, b"sports score".as_ptr().cast(), 12, 0);
 
-    // Should not reach SUB (500ms timeout).
-    set_timeo(sub, 500);
-    let rc = zmq_recv(sub, buf.as_mut_ptr().cast(), buf.len(), 0);
-    assert!(rc < 0, "sub should not receive non-matching msg");
+    // Should not reach SUB. Use nonblocking polls to avoid depending on
+    // platform timeout behavior in this filtering test.
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        let rc = zmq_recv(sub, buf.as_mut_ptr().cast(), buf.len(), ZMQ_DONTWAIT);
+        assert!(rc < 0, "sub should not receive non-matching msg");
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     zmq_close(sub);
     zmq_close(xpub);
@@ -139,6 +159,10 @@ fn xpub_xsub_proxy_pattern() {
     let xsub = zmq_socket(ctx, ZMQ_XSUB);
     let xpub = zmq_socket(ctx, ZMQ_XPUB);
     let sub = zmq_socket(ctx, ZMQ_SUB);
+    set_linger_zero(pub_);
+    set_linger_zero(xsub);
+    set_linger_zero(xpub);
+    set_linger_zero(sub);
 
     let port_be = helpers::free_port();
     let port_fe = helpers::free_port();

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -315,7 +315,7 @@ impl SocketDriver {
         let mut listener = bind_any(
             &endpoint,
             &snapshot,
-            &self.spsc.recv_notify,
+            &self.spsc.recv_signal,
             &self.spsc.blocking_recv_waker,
             self.options.max_message_size,
             #[cfg(feature = "ws")]
@@ -400,7 +400,7 @@ impl SocketDriver {
         let monitor_ep = endpoint.clone();
         let tx_for_delay = tx.clone();
         let snapshot = self.inproc_snapshot();
-        let recv_notify = self.spsc.recv_notify.clone();
+        let recv_signal = self.spsc.recv_signal.clone();
         let blocking_recv_waker = self.spsc.blocking_recv_waker.clone();
         let max_message_size = self.options.max_message_size;
         #[cfg(feature = "ws")]
@@ -414,7 +414,7 @@ impl SocketDriver {
                     connect_any(
                         &ep_for_dial,
                         &snapshot,
-                        &recv_notify,
+                        &recv_signal,
                         &blocking_recv_waker,
                         max_message_size,
                         #[cfg(feature = "ws")]

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -65,7 +65,7 @@ impl SocketDriver {
 
     /// Snapshot for inproc bind/connect: socket type + identity. The
     /// inproc transport hands this to its peer at connect time so the
-    /// synthesised handshake can populate `PeerProperties` without a
+    /// synthesized handshake can populate `PeerProperties` without a
     /// real wire exchange.
     pub(super) fn inproc_snapshot(&self) -> InprocPeerSnapshot {
         InprocPeerSnapshot {
@@ -488,7 +488,7 @@ pub(super) async fn inproc_peer_driver(
     }
 
     let result: () = async {
-        // Synthesised handshake. Same event the codec would emit;
+        // Synthesized handshake. Same event the codec would emit;
         // runs through the same handle_peer_event path.
         if emit_event(
             &peer_out,
@@ -626,7 +626,7 @@ pub(super) async fn inproc_peer_driver(
     .await;
     let () = result;
     if let Some(ref ring) = spsc {
-        ring.recv_notify.wake_all();
+        ring.recv_signal.wake_all();
     }
     blocking_recv_waker.wake();
     let _ = peer_out.send((peer_id, PeerEvent::Closed)).await;

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -481,13 +481,13 @@ fn attach_yring_recv_bypass(
         .unwrap_or_else(|| {
             let cap = socket.options.recv_hwm.max(16) as usize;
             let (prod, cons) = yring::spsc(cap);
-            let recv_notify = socket.spsc.recv_notify.clone();
+            let recv_signal = socket.spsc.recv_signal.clone();
             let blocking_waker = socket.spsc.blocking_recv_waker.clone();
             let space = Arc::new(StateSignal::new());
             let sink = crate::engine::RecvSink::Yring(crate::engine::YringSink {
                 producer: prod,
                 signal: Box::new(move || {
-                    recv_notify.mark();
+                    recv_signal.mark();
                     blocking_waker.wake();
                 }),
                 space: space.clone(),

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -403,7 +403,7 @@ impl AnyListener {
 pub(super) async fn bind_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
-    recv_notify: &std::sync::Arc<DataSignal>,
+    recv_signal: &std::sync::Arc<DataSignal>,
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] wss_tls: &omq_proto::options::WssTls,
@@ -438,7 +438,7 @@ pub(super) async fn bind_any(
         Endpoint::Inproc { name } => Ok(AnyListener::Inproc(inproc_transport::bind(
             name,
             snapshot.clone(),
-            recv_notify.clone(),
+            recv_signal.clone(),
             blocking_recv_waker.clone(),
             max_message_size,
         )?)),
@@ -451,7 +451,7 @@ pub(super) async fn bind_any(
 pub(super) async fn connect_any(
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
-    recv_notify: &std::sync::Arc<DataSignal>,
+    recv_signal: &std::sync::Arc<DataSignal>,
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] accept_invalid_certs: bool,
@@ -499,7 +499,7 @@ pub(super) async fn connect_any(
             let conn = inproc_transport::connect_with_max_message_size(
                 name,
                 snapshot.clone(),
-                recv_notify.clone(),
+                recv_signal.clone(),
                 blocking_recv_waker.clone(),
                 max_message_size,
             )

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -19,8 +19,8 @@ pub(crate) type SpscConsumers = Arc<RwLock<Vec<Arc<InprocRx>>>>;
 /// Single-peer send fast path ring. Actor sets/clears.
 pub(crate) type SpscSendRing = Arc<ArcSwapOption<InprocTx>>;
 
-/// Shared recv notification. All inproc producers notify this.
-pub(crate) type SpscRecvNotify = Arc<DataSignal>;
+/// Shared recv data signal. All inproc producers mark this.
+pub(crate) type SpscRecvSignal = Arc<DataSignal>;
 
 /// Notified by the actor when the consumers Vec changes. Wakes
 /// any `recv()` that's blocked so it re-drains with the updated list.
@@ -279,7 +279,7 @@ pub(crate) struct SpscHandles {
     pub consumer_generation: SpscConsumerGeneration,
     pub send_ring: SpscSendRing,
     pub send_ring_available: Arc<AtomicBool>,
-    pub recv_notify: SpscRecvNotify,
+    pub recv_signal: SpscRecvSignal,
     pub activated: SpscActivated,
     pub tcp_consumers: TcpConsumers,
     pub blocking_recv_waker: Arc<BlockingRecvWaker>,
@@ -292,7 +292,7 @@ impl SpscHandles {
             consumer_generation: Arc::new(AtomicU64::new(0)),
             send_ring: Arc::new(ArcSwapOption::empty()),
             send_ring_available: Arc::new(AtomicBool::new(false)),
-            recv_notify: Arc::new(DataSignal::new()),
+            recv_signal: Arc::new(DataSignal::new()),
             activated: Arc::new(StateSignal::new()),
             tcp_consumers: Arc::new(RwLock::new(Vec::new())),
             blocking_recv_waker,
@@ -312,8 +312,8 @@ pub(crate) struct SpscAwareRecv {
     /// Generation counter. Bumped by the actor on any consumer add/remove
     /// (inproc or TCP).
     consumer_generation: SpscConsumerGeneration,
-    /// Shared recv notification. All drivers/senders notify this.
-    recv_notify: SpscRecvNotify,
+    /// Shared recv data signal. All drivers/senders mark this.
+    recv_signal: SpscRecvSignal,
     /// Notified when consumers Vec changes (new peer added).
     activated: SpscActivated,
     /// Single-peer send fast path ring (None when sender has >1 peer).
@@ -494,7 +494,7 @@ impl SpscAwareRecv {
             consumers: handles.consumers,
             tcp_consumers: handles.tcp_consumers,
             consumer_generation: handles.consumer_generation,
-            recv_notify: handles.recv_notify,
+            recv_signal: handles.recv_signal,
             activated: handles.activated,
             send_ring: handles.send_ring,
             send_ring_available: handles.send_ring_available,
@@ -559,7 +559,7 @@ impl SpscAwareRecv {
             return DrainResult::Message(msg);
         }
 
-        self.recv_notify.begin_drain();
+        self.recv_signal.begin_drain();
         self.recv_pipe_notify.begin_drain();
         self.refresh_snapshot(&mut guard);
 
@@ -574,7 +574,7 @@ impl SpscAwareRecv {
         let has_peers = !state.inproc.is_empty() || !state.tcp.is_empty();
         if result.is_none()
             && Self::state_is_empty(state)
-            && (self.recv_notify.clear_after(Self::state_is_empty(state))
+            && (self.recv_signal.clear_after(Self::state_is_empty(state))
                 || self
                     .recv_pipe_notify
                     .clear_after(state.recv_consumer.is_empty()))
@@ -723,7 +723,7 @@ impl SpscAwareRecv {
                 DrainResult::Empty => {}
             }
 
-            let recv_ready = self.recv_notify.ready();
+            let recv_ready = self.recv_signal.ready();
             let pipe_ready = self.recv_pipe_notify.ready();
             let activated_seen = self.activated.generation();
             let activated = self.activated.changed_after(activated_seen);
@@ -817,7 +817,7 @@ impl SpscAwareRecv {
         }
         let _ = pair.producer.push(RecvItem::new(msg));
         pair.producer.flush();
-        pair.recv_notify.mark();
+        pair.recv_signal.mark();
         pair.blocking_recv_waker.wake();
         SpscPush::Sent
     }

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -7,7 +7,7 @@
 //! `mpsc` channels rather than serialising bytes through a duplex
 //! stream and re-parsing on the other side. The peer's socket
 //! type and identity are exchanged during connect, not over the
-//! wire, so the synthesised handshake completes immediately.
+//! wire, so the synthesized handshake completes immediately.
 //!
 //! Buffer capacity (whole messages, not bytes) defaults to
 //! `Options::send_hwm` at the `SocketDriver` layer where each
@@ -70,7 +70,7 @@ impl BlockingSpace {
 #[derive(Debug)]
 pub struct InprocTx {
     pub producer: yring::ProducerOwner<RecvItem>,
-    pub(crate) recv_notify: Arc<DataSignal>,
+    pub(crate) recv_signal: Arc<DataSignal>,
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub max_message_size: Option<usize>,
     pub space_notify: Arc<StateSignal>,
@@ -90,7 +90,7 @@ impl InprocTx {
 pub struct InprocRx {
     pub consumer: Mutex<yring::Consumer<RecvItem>>,
     pub batch_remaining: std::sync::atomic::AtomicUsize,
-    pub(crate) recv_notify: Arc<DataSignal>,
+    pub(crate) recv_signal: Arc<DataSignal>,
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub space_notify: Arc<StateSignal>,
     pub(crate) blocking_space: Arc<BlockingSpace>,
@@ -151,7 +151,7 @@ struct InprocConnectRequest {
     connector: InprocPeerSnapshot,
     connector_to_listener_rx: mpsc::Receiver<InboundFrame>,
     listener_to_connector_tx: mpsc::Sender<InboundFrame>,
-    connector_recv_notify: Arc<DataSignal>,
+    connector_recv_signal: Arc<DataSignal>,
     connector_blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     connector_max_message_size: Option<usize>,
     accept_ack: oneshot::Sender<InprocAck>,
@@ -174,7 +174,7 @@ static REGISTRY: LazyLock<Mutex<FxHashMap<String, mpsc::Sender<InprocConnectRequ
 pub(crate) fn bind(
     name: &str,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<DataSignal>,
+    recv_signal: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocListener> {
@@ -196,7 +196,7 @@ pub(crate) fn bind(
             name: name.to_string(),
         },
         snapshot,
-        recv_notify,
+        recv_signal,
         blocking_recv_waker,
         max_message_size,
         incoming: rx,
@@ -206,7 +206,7 @@ pub(crate) fn bind(
 pub(crate) async fn connect_with_max_message_size(
     name: &str,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<DataSignal>,
+    recv_signal: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
 ) -> Result<InprocConn> {
@@ -225,7 +225,7 @@ pub(crate) async fn connect_with_max_message_size(
         connector: snapshot,
         connector_to_listener_rx: c2l_rx,
         listener_to_connector_tx: l2c_tx,
-        connector_recv_notify: recv_notify,
+        connector_recv_signal: recv_signal,
         connector_blocking_recv_waker: blocking_recv_waker,
         connector_max_message_size: max_message_size,
         accept_ack: ack_tx,
@@ -254,7 +254,7 @@ pub struct InprocListener {
     name: String,
     endpoint: omq_proto::endpoint::Endpoint,
     snapshot: InprocPeerSnapshot,
-    recv_notify: Arc<DataSignal>,
+    recv_signal: Arc<DataSignal>,
     blocking_recv_waker: Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     incoming: mpsc::Receiver<InprocConnectRequest>,
@@ -280,7 +280,7 @@ impl InprocListener {
             connector,
             connector_to_listener_rx,
             listener_to_connector_tx,
-            connector_recv_notify,
+            connector_recv_signal,
             connector_blocking_recv_waker,
             connector_max_message_size,
             accept_ack,
@@ -298,10 +298,10 @@ impl InprocListener {
         {
             let (p, c) = yring::spsc(DEFAULT_INPROC_HWM);
             let listener_is_recv = is_recv_side(self.snapshot.socket_type);
-            let notify = if listener_is_recv {
-                self.recv_notify.clone()
+            let ring_recv_signal = if listener_is_recv {
+                self.recv_signal.clone()
             } else {
-                connector_recv_notify
+                connector_recv_signal
             };
             let mms = if listener_is_recv {
                 self.max_message_size
@@ -312,7 +312,7 @@ impl InprocListener {
             let blocking_space = Arc::new(BlockingSpace::new());
             let tx = Arc::new(InprocTx {
                 producer: yring::ProducerOwner::new(p),
-                recv_notify: notify,
+                recv_signal: ring_recv_signal,
                 recv_ready: ready.clone(),
                 max_message_size: mms,
                 space_notify: Arc::new(StateSignal::new()),
@@ -326,7 +326,7 @@ impl InprocListener {
             let rx = Arc::new(InprocRx {
                 consumer: Mutex::new(c),
                 batch_remaining: std::sync::atomic::AtomicUsize::new(0),
-                recv_notify: tx.recv_notify.clone(),
+                recv_signal: tx.recv_signal.clone(),
                 recv_ready: ready,
                 space_notify: tx.space_notify.clone(),
                 blocking_space,

--- a/omq-tokio/tests/inproc_recv_race.rs
+++ b/omq-tokio/tests/inproc_recv_race.rs
@@ -1,14 +1,14 @@
 //! Regression tests for c331369: lost-wakeup race and hang on inproc
 //! peer exit in tokio recv (`SpscAwareRecv`).
 //!
-//! Bug 1: `recv_notify.notified()` created after `try_drain_consumers()`
-//! returned empty. A `notify_one()` firing in that gap was lost.
+//! Bug 1: recv signal wait created after `try_drain_consumers()`
+//! returned empty. A wake firing in that gap was lost.
 //!
 //! Bug 2: inproc peer driver exit sent `PeerEvent::Closed` to the actor,
-//! but the receiver was stuck on `recv_notify.notified()` (biased first
+//! but the receiver was stuck on the recv signal wait (biased first
 //! in select) and never polled `self.rx`. Messages arriving via the
 //! actor path (from other peers) were invisible until a new inproc
-//! message happened to wake `recv_notify`.
+//! message happened to mark the recv signal.
 
 use std::time::Duration;
 
@@ -32,7 +32,7 @@ fn tcp_ep() -> Endpoint {
 /// Bug 2: after an inproc peer exits, `recv()` must still be able to
 /// pick up messages arriving via the actor path (`self.rx`).
 ///
-/// Before the fix, `recv()` was stuck on `recv_notify.notified()` and
+/// Before the fix, `recv()` was stuck on the recv signal wait and
 /// never polled `self.rx`, so the TCP peer's message was invisible.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn recv_after_inproc_peer_close_sees_tcp_messages() {
@@ -70,14 +70,14 @@ async fn recv_after_inproc_peer_close_sees_tcp_messages() {
 
     let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
         .await
-        .expect("pull.recv() hung after inproc peer closed (bug #2: recv stuck on recv_notify)")
+        .expect("pull.recv() hung after inproc peer closed (bug #2: recv stuck on recv signal)")
         .unwrap();
     assert_eq!(msg, Message::single("from-tcp"));
 }
 
 /// Bug 2 variant: after an inproc peer exits, messages from a second
-/// inproc peer (arriving via SPSC + `recv_notify`) must still be received.
-/// The recv loop must unblock from the stale `recv_notify` wait and
+/// inproc peer (arriving via SPSC + `recv_signal`) must still be received.
+/// The recv loop must unblock from the stale recv signal wait and
 /// re-drain consumers.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn recv_after_inproc_peer_close_sees_new_inproc_messages() {
@@ -113,8 +113,8 @@ async fn recv_after_inproc_peer_close_sees_new_inproc_messages() {
     assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"b");
 }
 
-/// Bug 1: lost wakeup when `notify_one()` fires between
-/// `try_drain_consumers()` returning empty and `notified()` future creation.
+/// Bug 1: lost wakeup when recv signal wait is armed after
+/// `try_drain_consumers()` already returned empty.
 /// Stress by sending many messages with interleaved yields.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn recv_no_lost_wakeup_under_rapid_sends() {


### PR DESCRIPTION
- `pyomq`: rename eventfd bridge from `RecvNotify` to `EventFdSignal`.
- `pyomq`: rename per-socket readiness fields to `recv_ready` and `send_ready`.
- `omq-tokio`: rename SPSC `DataSignal` aliases and fields to `recv_signal`.
- `omq-libzmq`: make XPUB/XSUB test avoid infinite linger and timeout-dependent negative receive.