### PR TITLE
Prepare pyomq 0.17.0 release

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-24
+
+### Added
+
+- Windows support, including Win32-backed readiness signals for sync and
+  asyncio sockets.
+- PyPI release workflow now builds Linux, macOS, and Windows wheels.
+- CI now runs ruff linting and ty type checks for pyomq.
+
 ### Fixed
 
 - Windows async readiness drains now consume the latched wakeup bit, avoiding
   repeated stale drain callbacks after a waiter remains blocked.
 - Windows readiness signals no longer latch wakeups when no waiter is armed,
   reducing stale async callbacks during sustained receive drains.
+- Windows shadow sync-over-async waits now recheck readiness after clearing
+  the event, avoiding a lost wake between clear and wait.
 
 ### Changed
 

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.16.4"
+version = "0.17.0"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -13,6 +13,7 @@ import pyomq
 
 def _get_IOLoop():
     from tornado.ioloop import IOLoop
+
     return IOLoop
 
 
@@ -45,17 +46,20 @@ class ZMQStream:
     def stop_on_send(self):
         self._send_callback = None
 
-    def send(self, msg, flags=0, copy=True, track=False, callback=None,
-             **kwargs):
+    def send(self, msg, flags=0, copy=True, track=False, callback=None, **kwargs):
         result = self.socket.send(msg, flags=flags, copy=copy, track=track)
         if self._send_callback:
             self._send_callback(msg, None)
         return result
 
-    def send_multipart(self, msg_list, flags=0, copy=True, track=False,
-                       callback=None, **kwargs):
+    def send_multipart(
+        self, msg_list, flags=0, copy=True, track=False, callback=None, **kwargs
+    ):
         result = self.socket.send_multipart(
-            msg_list, flags=flags, copy=copy, track=track,
+            msg_list,
+            flags=flags,
+            copy=copy,
+            track=track,
         )
         if self._send_callback:
             self._send_callback(msg_list, None)
@@ -80,7 +84,8 @@ class ZMQStream:
         while True:
             try:
                 parts = self.socket.recv_multipart(
-                    pyomq.NOBLOCK, copy=self._recv_copy,
+                    pyomq.NOBLOCK,
+                    copy=self._recv_copy,
                 )
             except pyomq.Again:
                 break

--- a/bindings/pyomq/tests/soak/test_fan_out.py
+++ b/bindings/pyomq/tests/soak/test_fan_out.py
@@ -59,9 +59,7 @@ def test_fan_out():
                 msg = subs[idx].recv()
                 seq = struct.unpack("<Q", msg[:8])[0]
                 expected = bytes([seq & 0xFF] * MSG_SIZE)
-                assert msg[8:] == expected, (
-                    f"sub[{idx}] corruption at seq {seq}"
-                )
+                assert msg[8:] == expected, f"sub[{idx}] corruption at seq {seq}"
                 recv_counts[idx] += 1
             except zmq.Again:
                 pass

--- a/bindings/pyomq/tests/soak/test_io_threads.py
+++ b/bindings/pyomq/tests/soak/test_io_threads.py
@@ -17,7 +17,7 @@ import time
 
 from conftest import soak_duration
 
-WORKER_SCRIPT = '''
+WORKER_SCRIPT = """
 import struct
 import sys
 import threading
@@ -121,7 +121,7 @@ print(f"io_threads={IO_THREADS} throughput={tput:.0f}msg/s recvd={recvd} "
       f"corrupt={corrupt} cycles={cycles} rtt={rtt:.0f}us "
       f"ok={throughput_ok and latency_ok}")
 sys.exit(0 if throughput_ok and latency_ok else 1)
-'''
+"""
 
 
 def test_io_threads_variants():
@@ -130,11 +130,12 @@ def test_io_threads_variants():
 
     results = {}
     for n_threads in [1, 2, 4]:
-        print(f"\n[io_threads] running with io_threads={n_threads}, "
-              f"duration={per_variant:.0f}s")
+        print(
+            f"\n[io_threads] running with io_threads={n_threads}, "
+            f"duration={per_variant:.0f}s"
+        )
         result = subprocess.run(
-            [sys.executable, "-c", WORKER_SCRIPT,
-             str(n_threads), str(per_variant)],
+            [sys.executable, "-c", WORKER_SCRIPT, str(n_threads), str(per_variant)],
             capture_output=True,
             text=True,
             timeout=per_variant + 30,

--- a/bindings/pyomq/tests/soak/test_multipart.py
+++ b/bindings/pyomq/tests/soak/test_multipart.py
@@ -35,22 +35,16 @@ def validate_multipart(parts: list[bytes], min_seq: int) -> int:
     )
 
     seq = struct.unpack("<Q", parts[0])[0]
-    assert seq >= min_seq, (
-        f"sequence went backwards: got {seq}, expected >= {min_seq}"
-    )
+    assert seq >= min_seq, f"sequence went backwards: got {seq}, expected >= {min_seq}"
 
     assert len(parts[1]) == FRAME_B, (
         f"body frame size: got {len(parts[1])}, expected {FRAME_B}"
     )
     expected_body = bytes((seq + i) & 0xFF for i in range(FRAME_B))
-    assert parts[1] == expected_body, (
-        f"body corruption at seq {seq}"
-    )
+    assert parts[1] == expected_body, f"body corruption at seq {seq}"
 
     expected_trailer = struct.pack("<Q", seq ^ 0xFFFFFFFFFFFFFFFF)
-    assert parts[2] == expected_trailer, (
-        f"trailer corruption at seq {seq}"
-    )
+    assert parts[2] == expected_trailer, f"trailer corruption at seq {seq}"
 
     return seq
 

--- a/bindings/pyomq/tests/soak/test_poller.py
+++ b/bindings/pyomq/tests/soak/test_poller.py
@@ -78,12 +78,9 @@ def test_poller_multi_socket():
                 msg = sock.recv(flags=zmq.NOBLOCK)
                 seq = struct.unpack("<QI", msg[:12])
                 assert seq[1] == ch_idx, (
-                    f"channel mismatch: got {seq[1]}, "
-                    f"expected {ch_idx}"
+                    f"channel mismatch: got {seq[1]}, expected {ch_idx}"
                 )
-                assert msg[12:] == b"P" * 48, (
-                    f"corruption on channel {ch_idx}"
-                )
+                assert msg[12:] == b"P" * 48, f"corruption on channel {ch_idx}"
                 recv_counts[ch_idx] += 1
             except zmq.Again:
                 pass
@@ -93,8 +90,7 @@ def test_poller_multi_socket():
             elapsed = now - start
             total = sum(recv_counts)
             print(
-                f"[poller] {elapsed:.0f}s, "
-                f"total recvd {total}, per-ch: {recv_counts}"
+                f"[poller] {elapsed:.0f}s, total recvd {total}, per-ch: {recv_counts}"
             )
             last_log = now
 
@@ -105,8 +101,7 @@ def test_poller_multi_socket():
     elapsed = time.monotonic() - start
     total = sum(recv_counts)
     print(
-        f"[poller] done: total recvd {total} in {elapsed:.1f}s, "
-        f"per-ch: {recv_counts}"
+        f"[poller] done: total recvd {total} in {elapsed:.1f}s, per-ch: {recv_counts}"
     )
 
     for i, count in enumerate(recv_counts):

--- a/bindings/pyomq/tests/soak/test_reconnect_storm.py
+++ b/bindings/pyomq/tests/soak/test_reconnect_storm.py
@@ -14,10 +14,9 @@ from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 
 def _is_eaddrinuse(exc):
-    return (
-        getattr(exc, "errno", None) == errno.EADDRINUSE
-        or "Address already in use" in str(exc)
-    )
+    return getattr(
+        exc, "errno", None
+    ) == errno.EADDRINUSE or "Address already in use" in str(exc)
 
 
 def _new_pull(ctx):

--- a/bindings/pyomq/tests/test_async_auth.py
+++ b/bindings/pyomq/tests/test_async_auth.py
@@ -84,9 +84,11 @@ async def test_async_curve_auth_callback_receives_identity(tcp_endpoint):
         router.curve_publickey = server_pub
         router.curve_secretkey = server_sec
         router.set_curve_auth(
-            lambda peer: captured.append(peer.identity) is None
-            and peer.public_key == client_pub
-            and peer.identity == b"async-client"
+            lambda peer: (
+                captured.append(peer.identity) is None
+                and peer.public_key == client_pub
+                and peer.identity == b"async-client"
+            )
         )
 
         dealer.identity = b"async-client"

--- a/bindings/pyomq/tests/test_async_compat.py
+++ b/bindings/pyomq/tests/test_async_compat.py
@@ -8,6 +8,7 @@ import pyomq.asyncio as zmq_async
 
 async def test_async_again_exception(tcp_endpoint):
     import asyncio
+
     ctx = zmq_async.Context()
     pull = ctx.socket(zmq.PULL)
     try:

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -5,6 +5,7 @@ import pyomq as zmq
 
 # ── Serialization methods ────────────────────────────────────────────
 
+
 def test_send_recv_string(tcp_endpoint):
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
@@ -83,6 +84,7 @@ def test_send_recv_pyobj(tcp_endpoint):
 
 def test_send_recv_pyobj_protocol(tcp_endpoint):
     import pickle
+
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -100,6 +102,7 @@ def test_send_recv_pyobj_protocol(tcp_endpoint):
 
 
 # ── Socket properties & aliases ─────────────────────────────────────
+
 
 def test_socket_type_property():
     ctx = zmq.Context()
@@ -218,6 +221,7 @@ def test_track_true_send_returns_tracker():
 
 # ── bind_to_random_port ─────────────────────────────────────────────
 
+
 def test_bind_to_random_port():
     ctx = zmq.Context()
     sock = ctx.socket(zmq.PULL)
@@ -246,6 +250,7 @@ def test_bind_to_random_port_returns_different_ports():
 
 # ── Context.instance() ──────────────────────────────────────────────
 
+
 def test_context_instance_singleton():
     # Reset singleton state for isolation
     zmq.Context._instance = None
@@ -271,6 +276,7 @@ def test_context_instance_survives_close():
 
 # ── send_serialized / recv_serialized ───────────────────────────────
 
+
 def test_send_recv_serialized(tcp_endpoint):
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
@@ -295,6 +301,7 @@ def test_send_recv_serialized(tcp_endpoint):
 
 
 # ── set_hwm / get_hwm ──────────────────────────────────────────────
+
 
 def test_set_hwm_get_hwm():
     ctx = zmq.Context()
@@ -322,6 +329,7 @@ def test_hwm_property():
 
 # ── set_string / get_string aliases ────────────────────────────────
 
+
 def test_set_string_get_string():
     ctx = zmq.Context()
     sock = ctx.socket(zmq.DEALER)
@@ -334,6 +342,7 @@ def test_set_string_get_string():
 
 
 # ── Socket.poll() ──────────────────────────────────────────────────
+
 
 def test_socket_poll_timeout():
     ctx = zmq.Context()
@@ -356,6 +365,7 @@ def test_socket_poll_ready(tcp_endpoint):
         push.connect(ep)
         push.send(b"data")
         import time
+
         time.sleep(0.05)
         result = pull.poll(timeout=1000)
         assert result & zmq.POLLIN
@@ -366,6 +376,7 @@ def test_socket_poll_ready(tcp_endpoint):
 
 
 # ── Socket.__repr__() ──────────────────────────────────────────────
+
 
 def test_socket_repr():
     ctx = zmq.Context()
@@ -381,6 +392,7 @@ def test_socket_repr():
 
 # ── Socket.underlying ──────────────────────────────────────────────
 
+
 def test_socket_underlying():
     ctx = zmq.Context()
     sock = ctx.socket(zmq.PUSH)
@@ -393,6 +405,7 @@ def test_socket_underlying():
 
 # ── Context.closed ─────────────────────────────────────────────────
 
+
 def test_context_closed_property():
     ctx = zmq.Context()
     assert ctx.closed is False
@@ -401,6 +414,7 @@ def test_context_closed_property():
 
 
 # ── Context.destroy(linger) ────────────────────────────────────────
+
 
 def test_context_destroy_closes_sockets():
     ctx = zmq.Context()
@@ -425,6 +439,7 @@ def test_context_destroy_no_linger():
 
 # ── Poller.sockets property ────────────────────────────────────────
 
+
 def test_poller_sockets_property():
     ctx = zmq.Context()
     sock = ctx.socket(zmq.PULL)
@@ -443,6 +458,7 @@ def test_poller_sockets_property():
 
 # ── select() ───────────────────────────────────────────────────────
 
+
 def test_select_timeout():
     ctx = zmq.Context()
     sock = ctx.socket(zmq.PULL)
@@ -459,6 +475,7 @@ def test_select_timeout():
 
 def test_select_ready(tcp_endpoint):
     import time
+
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -476,6 +493,7 @@ def test_select_ready(tcp_endpoint):
 
 
 # ── Constants ────────────────────────────────────────────────────────
+
 
 def test_dontwait_constant():
     assert zmq.DONTWAIT == 1
@@ -530,6 +548,7 @@ def test_new_constants_match_pyzmq():
 
 # ── Version & module attributes ─────────────────────────────────────
 
+
 def test_version_string():
     assert isinstance(zmq.__version__, str)
     assert len(zmq.__version__) > 0
@@ -582,12 +601,14 @@ def test_strerror():
 
 # ── Exceptions ─────────────────────────────────────────────────────
 
+
 def test_zmq_version_error():
     assert issubclass(zmq.ZMQVersionError, zmq.ZMQBaseError)
     assert issubclass(zmq.ZMQVersionError, NotImplementedError)
 
 
 # ── proxy ────────────────────────────────────────────────────────────
+
 
 def test_proxy_req_rep(tcp_endpoint):
     import threading
@@ -608,7 +629,9 @@ def test_proxy_req_rep(tcp_endpoint):
         client.connect(fe_ep)
 
         proxy_thread = threading.Thread(
-            target=zmq.proxy, args=(frontend, backend), daemon=True,
+            target=zmq.proxy,
+            args=(frontend, backend),
+            daemon=True,
         )
         proxy_thread.start()
 
@@ -647,7 +670,9 @@ def test_proxy_req_rep_two_clients_preserves_routes(tcp_endpoint):
         client_b.connect(fe_ep)
 
         proxy_thread = threading.Thread(
-            target=zmq.proxy, args=(frontend, backend), daemon=True,
+            target=zmq.proxy,
+            args=(frontend, backend),
+            daemon=True,
         )
         proxy_thread.start()
 
@@ -694,7 +719,8 @@ def test_proxy_with_capture(tcp_endpoint):
         client.connect(fe_ep)
 
         proxy_thread = threading.Thread(
-            target=zmq.proxy, args=(frontend, backend, capture),
+            target=zmq.proxy,
+            args=(frontend, backend, capture),
             daemon=True,
         )
         proxy_thread.start()

--- a/bindings/pyomq/tests/test_connect_before_bind.py
+++ b/bindings/pyomq/tests/test_connect_before_bind.py
@@ -20,8 +20,10 @@ TCP_BIND_RETRIES = 20
 
 # ── helpers ──────────────────────────────────────────────────────────
 
+
 def _unbound_tcp_endpoint():
     import socket
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         port = s.getsockname()[1]
@@ -29,10 +31,9 @@ def _unbound_tcp_endpoint():
 
 
 def _is_eaddrinuse(exc):
-    return (
-        getattr(exc, "errno", None) == errno.EADDRINUSE
-        or "Address already in use" in str(exc)
-    )
+    return getattr(
+        exc, "errno", None
+    ) == errno.EADDRINUSE or "Address already in use" in str(exc)
 
 
 def _run_tcp_cbb(run, delay):
@@ -62,6 +63,7 @@ async def _run_tcp_cbb_async(run, delay):
 
 
 # ── sync PUSH/PULL ──────────────────────────────────────────────────
+
 
 def _sync_push_pull_cbb(ep, delay):
     ctx = zmq.Context()
@@ -95,6 +97,7 @@ def test_sync_push_pull_cbb_tcp(delay):
 
 
 # ── sync REQ/REP ────────────────────────────────────────────────────
+
 
 def _sync_req_rep_cbb(ep, delay):
     ctx = zmq.Context()
@@ -131,6 +134,7 @@ def test_sync_req_rep_cbb_tcp(delay):
 
 # ── sync PAIR ───────────────────────────────────────────────────────
 
+
 def _sync_pair_cbb(ep, delay):
     ctx = zmq.Context()
     a = ctx.socket(zmq.PAIR)
@@ -166,8 +170,10 @@ def test_sync_pair_cbb_tcp(delay):
 
 # ── async PUSH/PULL ─────────────────────────────────────────────────
 
+
 async def _async_push_pull_cbb(ep, delay):
     import asyncio
+
     ctx = zmq_async.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
@@ -202,8 +208,10 @@ async def test_async_push_pull_cbb_tcp(delay):
 
 # ── async REQ/REP ───────────────────────────────────────────────────
 
+
 async def _async_req_rep_cbb(ep, delay):
     import asyncio
+
     ctx = zmq_async.Context()
     req = ctx.socket(zmq.REQ)
     rep = ctx.socket(zmq.REP)
@@ -240,8 +248,10 @@ async def test_async_req_rep_cbb_tcp(delay):
 
 # ── async PAIR ──────────────────────────────────────────────────────
 
+
 async def _async_pair_cbb(ep, delay):
     import asyncio
+
     ctx = zmq_async.Context()
     a = ctx.socket(zmq.PAIR)
     b = ctx.socket(zmq.PAIR)

--- a/bindings/pyomq/tests/test_device.py
+++ b/bindings/pyomq/tests/test_device.py
@@ -19,7 +19,9 @@ def test_device_forwards_messages(tcp_endpoint):
         sender.connect(fe_ep)
         receiver.connect(be_ep)
 
-        t = threading.Thread(target=zmq.device, args=(zmq.STREAMER, frontend, backend), daemon=True)
+        t = threading.Thread(
+            target=zmq.device, args=(zmq.STREAMER, frontend, backend), daemon=True
+        )
         t.start()
 
         time.sleep(0.1)

--- a/bindings/pyomq/tests/test_exceptions.py
+++ b/bindings/pyomq/tests/test_exceptions.py
@@ -125,6 +125,7 @@ def test_zmqbaseerror_catches_binderror():
 
 def test_from_native_unknown_errno():
     from pyomq import _native
+
     exc = _native.ZMQError("test error")
     exc.errno = 9999
     promoted = zmq.error.from_native(exc)

--- a/bindings/pyomq/tests/test_inproc_throughput.py
+++ b/bindings/pyomq/tests/test_inproc_throughput.py
@@ -44,4 +44,6 @@ def test_inproc_throughput_above_500k():
         best = max(best, rate)
         if best > MIN_RATE:
             return
-    assert best > MIN_RATE, f"inproc throughput {best/1e6:.2f}M msg/s, expected >0.65M"
+    assert best > MIN_RATE, (
+        f"inproc throughput {best / 1e6:.2f}M msg/s, expected >0.65M"
+    )

--- a/bindings/pyomq/tests/test_message_compat.py
+++ b/bindings/pyomq/tests/test_message_compat.py
@@ -56,6 +56,7 @@ def test_isinstance_sync_socket():
 
 def test_isinstance_async_socket():
     import pyomq.asyncio as zmq_async
+
     ctx = zmq_async.Context()
     s = ctx.socket(zmq.PUSH)
     try:

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -15,6 +15,7 @@ def _push():
 
 # Group A: direct value mapping.
 
+
 def test_linger_round_trip():
     ctx, s = _push()
     try:
@@ -94,6 +95,7 @@ def test_type_is_readonly():
 
 # Group B: wrapper-only.
 
+
 def test_rcvtimeo_raises_eagain():
     ctx = zmq.Context()
     s = ctx.socket(zmq.PULL)
@@ -124,6 +126,7 @@ def test_immediate_and_ipv6_accepted_as_noops():
 
 # Group C: TCP keepalive.
 
+
 def test_tcp_keepalive_round_trip():
     ctx, s = _push()
     try:
@@ -152,6 +155,7 @@ def test_tcp_keepalive_disabled():
 
 # Group C "not implemented" raises ZMQError.
 
+
 def test_unsupported_options_raise():
     ctx, s = _push()
     try:
@@ -164,6 +168,7 @@ def test_unsupported_options_raise():
 
 
 # Group D: newly readable options (Phase 4).
+
 
 def test_reconnect_ivl_round_trip():
     ctx, s = _push()
@@ -211,6 +216,7 @@ def test_handshake_ivl_round_trip():
 
 # Group E: SNDBUF / RCVBUF round-trip.
 
+
 def test_sndbuf_round_trip():
     ctx, s = _push()
     try:
@@ -233,6 +239,7 @@ def test_rcvbuf_round_trip():
 
 # Group F: PLAIN auth option round-trip.
 
+
 def test_plain_options_round_trip():
     ctx, s = _push()
     try:
@@ -249,12 +256,21 @@ def test_plain_options_round_trip():
 
 # Group G: no-op options don't raise.
 
+
 def test_noop_options_accepted():
     ctx, s = _push()
     try:
-        for opt in (zmq.XPUB_VERBOSE, zmq.PROBE_ROUTER, zmq.REQ_CORRELATE,
-                     zmq.REQ_RELAXED, zmq.ROUTER_HANDOVER, zmq.ZAP_DOMAIN,
-                     zmq.RATE, zmq.CONNECT_TIMEOUT, zmq.RECOVERY_IVL):
+        for opt in (
+            zmq.XPUB_VERBOSE,
+            zmq.PROBE_ROUTER,
+            zmq.REQ_CORRELATE,
+            zmq.REQ_RELAXED,
+            zmq.ROUTER_HANDOVER,
+            zmq.ZAP_DOMAIN,
+            zmq.RATE,
+            zmq.CONNECT_TIMEOUT,
+            zmq.RECOVERY_IVL,
+        ):
             s.setsockopt(opt, 0)
     finally:
         s.close()
@@ -299,7 +315,6 @@ def test_on_mute_rejects_invalid():
     finally:
         s.close()
         ctx.term()
-
 
         ctx.term()
 

--- a/bindings/pyomq/tests/test_pubsub.py
+++ b/bindings/pyomq/tests/test_pubsub.py
@@ -17,8 +17,8 @@ def test_pub_sub_prefix_filter(tcp_endpoint):
         # to propagate.
         time.sleep(0.2)
         pub.send(b"sports/score-12")  # filtered
-        pub.send(b"weather/sunny")    # delivered
-        pub.send(b"weather/rain")     # delivered
+        pub.send(b"weather/sunny")  # delivered
+        pub.send(b"weather/rain")  # delivered
         sub.setsockopt(zmq.RCVTIMEO, 500)
         got = [sub.recv() for _ in range(2)]
         assert got == [b"weather/sunny", b"weather/rain"]

--- a/bindings/pyomq/tests/test_socket_types.py
+++ b/bindings/pyomq/tests/test_socket_types.py
@@ -59,7 +59,9 @@ def test_push_pull():
     push.connect(ep)
     push.send(b"hello")
     assert pull.recv() == b"hello"
-    push.close(); pull.close(); ctx.term()
+    push.close()
+    pull.close()
+    ctx.term()
 
 
 def test_pub_sub():
@@ -80,7 +82,9 @@ def test_pub_sub():
             continue
     else:
         pytest.fail("SUB never received")
-    pub.close(); sub.close(); ctx.term()
+    pub.close()
+    sub.close()
+    ctx.term()
 
 
 def test_xpub_xsub():
@@ -106,7 +110,9 @@ def test_xpub_xsub():
             time.sleep(0.05)
     else:
         pytest.fail("XSUB never received")
-    xpub.close(); xsub.close(); ctx.term()
+    xpub.close()
+    xsub.close()
+    ctx.term()
 
 
 def test_req_rep():
@@ -120,7 +126,9 @@ def test_req_rep():
     assert rep.recv() == b"q"
     rep.send(b"a")
     assert req.recv() == b"a"
-    req.close(); rep.close(); ctx.term()
+    req.close()
+    rep.close()
+    ctx.term()
 
 
 def test_dealer_router():
@@ -137,7 +145,9 @@ def test_dealer_router():
     assert parts == [b"dlr-1", b"hello"]
     router.send_multipart([b"dlr-1", b"world"])
     assert dealer.recv() == b"world"
-    dealer.close(); router.close(); ctx.term()
+    dealer.close()
+    router.close()
+    ctx.term()
 
 
 def test_pair_pair():
@@ -151,7 +161,9 @@ def test_pair_pair():
     assert b.recv() == b"x"
     b.send(b"y")
     assert a.recv() == b"y"
-    a.close(); b.close(); ctx.term()
+    a.close()
+    b.close()
+    ctx.term()
 
 
 def test_client_server():
@@ -168,7 +180,9 @@ def test_client_server():
     assert parts == [b"cli-1", b"ping"]
     server.send_multipart([b"cli-1", b"pong"])
     assert client.recv() == b"pong"
-    client.close(); server.close(); ctx.term()
+    client.close()
+    server.close()
+    ctx.term()
 
 
 def test_scatter_gather():
@@ -183,7 +197,9 @@ def test_scatter_gather():
         scatter.send(f"m{i}".encode())
     got = sorted([gather.recv() for _ in range(3)])
     assert got == [b"m0", b"m1", b"m2"]
-    scatter.close(); gather.close(); ctx.term()
+    scatter.close()
+    gather.close()
+    ctx.term()
 
 
 def test_channel_pair():
@@ -198,7 +214,9 @@ def test_channel_pair():
     assert b.recv() == b"hi"
     b.send(b"there")
     assert a.recv() == b"there"
-    a.close(); b.close(); ctx.term()
+    a.close()
+    b.close()
+    ctx.term()
 
 
 def test_peer_peer():
@@ -217,7 +235,9 @@ def test_peer_peer():
     a.send_multipart([b"peer-b", b"hello b"])
     parts = b.recv_multipart()
     assert parts == [b"peer-a", b"hello b"]
-    a.close(); b.close(); ctx.term()
+    a.close()
+    b.close()
+    ctx.term()
 
 
 def test_radio_dish_udp_with_groups():
@@ -247,7 +267,9 @@ def test_radio_dish_udp_with_groups():
     assert parts == [b"weather", b"sunny"]
 
     dish.leave(b"weather")
-    radio.close(); dish.close(); ctx.term()
+    radio.close()
+    dish.close()
+    ctx.term()
 
 
 def test_stream_raw_tcp():
@@ -279,4 +301,5 @@ def test_stream_raw_tcp():
     assert echoed == b"world"
 
     raw.close()
-    stream.close(); ctx.term()
+    stream.close()
+    ctx.term()


### PR DESCRIPTION
- Bumps `pyomq` package metadata and lockfile to `0.17.0`.
- Adds `0.17.0` changelog notes for Windows support, wheel coverage, and diagnostics.
- Applies `ruff format` to existing `pyomq` Python files.