### PR TITLE
Release pyomq 0.17.1

### DIFF
--- a/.github/workflows/release-pyomq.yml
+++ b/.github/workflows/release-pyomq.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Disable local CPU rustflags
+        shell: bash
         run: rm -f .cargo/config.toml
       - uses: PyO3/maturin-action@v1
         with:
@@ -46,6 +47,9 @@ jobs:
             python_arch: arm64
     steps:
       - uses: actions/checkout@v7
+      - name: Disable local CPU rustflags
+        shell: bash
+        run: rm -f .cargo/config.toml
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
@@ -74,6 +78,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v7
+      - name: Disable local CPU rustflags
+        run: rm -f .cargo/config.toml
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -119,13 +125,36 @@ jobs:
         with:
           name: wheels-linux-x86_64-auto
           path: dist
-      - run: pip install dist/*.whl pytest
-      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v -p no:asyncio
+      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0'
+      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v
+
+  smoke-test-macos:
+    name: Smoke test macOS (${{ matrix.platform.target }} wheel)
+    runs-on: ${{ matrix.platform.runner }}
+    needs: [macos]
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-15-intel
+            target: x86_64
+          - runner: macos-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: actions/download-artifact@v7
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0'
+      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v
 
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux, windows, macos, sdist, smoke-test]
+    needs: [linux, windows, macos, sdist, smoke-test, smoke-test-macos]
     environment:
       name: pypi
       url: https://pypi.org/p/pyomq

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-24
+
+### Fixed
+
+- macOS wheels no longer compile the Linux-only `eventfd` wakeup path.
+- PyPI release wheel builds no longer inherit local `target-cpu=native`
+  rustflags from the repository checkout.
+- PyPI release smoke tests now install `pytest-asyncio` so async pytest hooks
+  load correctly.
+
+### Changed
+
+- PyPI release workflow now smoke-tests macOS wheels before publishing.
+
 ## [0.17.0] - 2026-07-24
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.17.0"
+version = "0.17.1"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/pyomq/src/notify/unix.rs
+++ b/bindings/pyomq/src/notify/unix.rs
@@ -1,50 +1,116 @@
 use std::time::Duration;
 
 pub(crate) struct EventFdSignal {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     efd: i32,
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    read_fd: i32,
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    write_fd: i32,
 }
 
 impl EventFdSignal {
     pub(crate) fn new() -> Self {
-        let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
-        assert!(efd >= 0, "eventfd creation failed");
-        Self { efd }
-    }
-
-    pub(crate) fn signal(&self, parked: bool) {
-        if parked {
-            self.write_eventfd();
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let efd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+            assert!(efd >= 0, "eventfd creation failed");
+            Self { efd }
         }
-    }
 
-    pub(crate) fn force_wake(&self) {
-        self.write_eventfd();
-    }
-
-    pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
-        let mut pfd = libc::pollfd {
-            fd: self.efd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
-        let ret = unsafe { libc::poll(&mut pfd, 1, ms) };
-        if ret > 0 {
-            let mut val: u64 = 0;
-            unsafe {
-                libc::read(self.efd, &mut val as *mut u64 as *mut libc::c_void, 8);
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            let mut fds = [0; 2];
+            let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+            assert!(rc == 0, "pipe creation failed");
+            for fd in fds {
+                set_nonblocking(fd);
+                set_cloexec(fd);
             }
-            true
-        } else {
-            false
+            Self {
+                read_fd: fds[0],
+                write_fd: fds[1],
+            }
         }
     }
 
-    pub(crate) fn fd(&self) -> i32 {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn read_fd(&self) -> i32 {
         self.efd
     }
 
-    pub(crate) fn dup_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn read_fd(&self) -> i32 {
+        self.read_fd
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn write_signal(&self) {
+        let val: u64 = 1;
+        while unsafe { libc::write(self.efd, &val as *const u64 as *const libc::c_void, 8) } < 0 {
+            if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+                break;
+            }
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn write_signal(&self) {
+        let val: u8 = 1;
+        while unsafe { libc::write(self.write_fd, &val as *const u8 as *const libc::c_void, 1) } < 0
+        {
+            let err = std::io::Error::last_os_error().raw_os_error();
+            if err != Some(libc::EINTR) {
+                break;
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn drain(&self) {
+        let mut val: u64 = 0;
+        unsafe {
+            libc::read(self.efd, &mut val as *mut u64 as *mut libc::c_void, 8);
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn drain(&self) {
+        let mut buf = [0u8; 64];
+        loop {
+            let n = unsafe {
+                libc::read(
+                    self.read_fd,
+                    buf.as_mut_ptr().cast::<libc::c_void>(),
+                    buf.len(),
+                )
+            };
+            if n > 0 {
+                continue;
+            }
+            let err = std::io::Error::last_os_error().raw_os_error();
+            if n < 0 && err == Some(libc::EINTR) {
+                continue;
+            }
+            break;
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn close(&self) {
+        unsafe { libc::close(self.efd) };
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn close(&self) {
+        unsafe {
+            libc::close(self.read_fd);
+            libc::close(self.write_fd);
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn dup_read_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
         use std::os::fd::{FromRawFd, OwnedFd};
         let fd = unsafe { libc::dup(self.efd) };
         if fd < 0 {
@@ -53,18 +119,69 @@ impl EventFdSignal {
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
-    fn write_eventfd(&self) {
-        let val: u64 = 1;
-        while unsafe { libc::write(self.efd, &val as *const u64 as *const libc::c_void, 8) } < 0 {
-            if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
-                break;
-            }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn dup_read_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
+        use std::os::fd::{FromRawFd, OwnedFd};
+        let fd = unsafe { libc::dup(self.read_fd) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
         }
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+
+    pub(crate) fn signal(&self, parked: bool) {
+        if parked {
+            self.write_signal();
+        }
+    }
+
+    pub(crate) fn force_wake(&self) {
+        self.write_signal();
+    }
+
+    pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
+        let mut pfd = libc::pollfd {
+            fd: self.read_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let ret = unsafe { libc::poll(&mut pfd, 1, ms) };
+        if ret > 0 {
+            self.drain();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn fd(&self) -> i32 {
+        self.read_fd()
+    }
+
+    pub(crate) fn dup_fd(&self) -> std::io::Result<std::os::fd::OwnedFd> {
+        self.dup_read_fd()
     }
 }
 
 impl Drop for EventFdSignal {
     fn drop(&mut self) {
-        unsafe { libc::close(self.efd) };
+        self.close();
     }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn set_nonblocking(fd: i32) {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    assert!(flags >= 0, "fcntl(F_GETFL) failed");
+    let rc = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    assert!(rc == 0, "fcntl(F_SETFL) failed");
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn set_cloexec(fd: i32) {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    assert!(flags >= 0, "fcntl(F_GETFD) failed");
+    let rc = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+    assert!(rc == 0, "fcntl(F_SETFD) failed");
 }


### PR DESCRIPTION
- Bumps `pyomq` to `0.17.1`.
- Adds a non-Linux Unix wakeup fallback so macOS wheels avoid Linux-only `eventfd` APIs.
- Installs `pytest-asyncio` in release smoke tests and adds macOS wheel smoke tests.