### PR TITLE
Update signaling and Loom docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,12 +41,25 @@ Miri target for unsafe internals:
 cargo +nightly miri test -p yring
 ```
 
+Loom checks:
+
+```sh
+cargo test -p omq-tokio --test omq_loom_signal
+RUSTFLAGS="--cfg loom" cargo test -p yring --features async --test loom
+```
+
+The `omq-tokio` Loom test models `StateSignal` and `DataSignal` lost-wake
+races. The `yring` Loom suite is behind `cfg(loom)` and covers SPSC cursor
+ordering, wraparound, producer drop, async `push_async` wakeups, and upper-layer
+readiness patterns.
+
 Full sweep:
 
 ```sh
 ./scripts/test-all.sh
 OMQ_SKIP_PYOMQ=1 ./scripts/test-all.sh
 OMQ_SKIP_PERF=1 ./scripts/test-all.sh
+OMQ_LOOM=1 ./scripts/test-all.sh
 ```
 
 The full sweep runs `omq_perf_verify` locally. With `.perf_hw` present,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ covered by integration tests. The suite is layered:
   safety, compression (lz4), PLAIN / CURVE auth, mechanism reconnect,
   large-message throughput, multi-socket, inproc cross-thread,
   WebSocket throughput and reconnect. Soak runs sample RSS and FD counts.
-- **Loom** coverage for lock-free inproc queue behavior.
+- **Loom** coverage for `yring` SPSC memory ordering, async wakeups, and
+  `omq-tokio` signal race windows.
 - **Miri** on `yring`.
 - **Release semver review** through `release-plz`.
 
@@ -189,7 +190,7 @@ notification fd for `zmq_poll`/`ZMQ_FD` readiness.
 pipes, inproc, UDP, and WebSocket transports. `omq-libzmq` builds and
 tests on Windows for the supported C API surface.
 
-`pyomq` publishes Linux, macOS and Windows wheels and an sdist
+`pyomq` publishes Linux, macOS, and Windows wheels and an sdist.
 
 Requirements:
 

--- a/bindings/pyomq/doc/architecture.md
+++ b/bindings/pyomq/doc/architecture.md
@@ -22,7 +22,7 @@ src/
                     platform-specific recv wakeup integration
   notify/
     mod.rs          ReadinessSignal: platform-agnostic public API
-    unix.rs         Unix EventFdSignal: eventfd(2) + parking flag
+    unix.rs         Unix signal backend: eventfd on Linux, pipe elsewhere
     windows.rs      Windows WindowsSignal: Win32 event handles + async callback
   context.rs        Context / AsyncContext (stateless factories)
   options.rs        setsockopt/getsockopt: Overlay cache, option dispatch
@@ -38,7 +38,7 @@ src/
 ```
 Python threads ──────────────▶ tokio thread (current_thread, "pyomq-tokio")
   Arc<omq_tokio::Socket>            ├─ send pump per socket (drain yring → socket)
-  held in SocketInner               ├─ recv pump per socket (socket → yring, signal eventfd)
+  held in SocketInner               ├─ recv pump per socket (socket → yring, signal readiness)
                                     └─ socket driver tasks (ConnectionDriver, actor)
 ```
 
@@ -123,16 +123,18 @@ All backends implement:
 - `park_begin()` / `park_end()`: arm/disarm the parking flag (closes
   races in polling loops).
 
-### Unix backend: EventFdSignal (eventfd)
+### Unix backend: EventFdSignal (eventfd or pipe)
 
-`EventFdSignal` wraps a Linux `eventfd(EFD_NONBLOCK)` plus an
-`AtomicBool parking` flag (`notify/unix.rs`).
+`EventFdSignal` is the Unix readiness backend (`notify/unix.rs`). On
+Linux/Android it uses `eventfd(EFD_NONBLOCK | EFD_CLOEXEC)`. On other Unix
+targets, including macOS, it uses a nonblocking close-on-exec pipe. The shared
+`ReadinessSignal` owns the `AtomicBool parking` flag.
 
-- `signal()`: writes to the eventfd only if `parking` is true. On the
+- `signal()`: writes to the backend fd only if `parking` is true. On the
   hot path (consumer not parked), this is a single atomic load with no
   syscall.
 - `park_begin()` / `park_end()`: arm/disarm the parking flag.
-- `wait_timeout(dur)`: `poll(2)` on the eventfd with a timeout.
+- `wait_timeout(dur)`: `poll(2)` on the backend fd with a timeout.
 - `force_wake()`: unconditional write. Used on socket close to unblock
   any parked recv.
 - `dup_fd()`: duplicate the fd for async recv integration.
@@ -142,10 +144,9 @@ the race where a notification arrives between the consumer check and
 the park.
 
 **Async integration:** Python's `asyncio.py` calls `_recv_fd()` to get
-a dup'd eventfd, then registers it with `loop.add_reader(callback)`.
-The recv pump writes the eventfd whenever it pushes a message; the
-kernel wakes the event loop, `callback` fires, and `_try_recv()` is
-invoked.
+a dup'd backend fd, then registers it with `loop.add_reader(callback)`.
+The recv pump writes the fd whenever it pushes a message; the kernel
+wakes the event loop, `callback` fires, and `_try_recv()` is invoked.
 
 ### Windows backend: WindowsSignal (Win32 event handles + async callbacks)
 
@@ -213,7 +214,7 @@ Socket.recv(flags)
       lock consumer, try pop (fast path)
       if Some(msg): return first frame, store rest in rxbuf
       else:
-          # Platform: Unix uses eventfd + poll(2)
+          # Platform: Unix uses ReadinessSignal.wait_timeout() + poll(2)
           # Platform: Windows uses ReadinessSignal.wait_timeout() with Win32 handles
           release GIL, slow path:
               park_begin()
@@ -228,7 +229,7 @@ Socket.recv(flags)
 Each `recv()` returns one frame. If the message is multipart, remaining
 frames go into `rxbuf` and are returned by subsequent `recv()` calls.
 `recv_multipart()` returns all frames at once. Both platforms use
-`ReadinessSignal.wait_timeout()`, which internally handles eventfd
+`ReadinessSignal.wait_timeout()`, which internally handles eventfd/pipe
 on Unix or Win32 event handles on Windows.
 
 ## Async send/recv
@@ -270,7 +271,7 @@ pattern:
 - Waiter future is pending.
 - recv pump on tokio thread finishes forwarding a message, freeing ring space.
 - recv pump calls `send_ready.signal()`.
-- `EventFdSignal.signal()` writes to the eventfd (because `parking=true`).
+- `EventFdSignal.signal()` writes to the backend fd (because `parking=true`).
 - Kernel wakes asyncio event loop via epoll/select.
 - Loop fires the registered callback, which calls `_drain_send_waiters()`.
 - `_drain_send_waiters()` pops waiters from queue and invokes each:
@@ -327,7 +328,7 @@ Similar to send: appends waiter, sets mode, returns future.
 **Wakeup path (Unix):**
 - Waiter future is pending, registered with `loop.add_reader(fd, callback)`.
 - send pump on tokio thread drains yring, calls `recv_ready.signal()`.
-- `EventFdSignal.signal()` writes to eventfd.
+- `EventFdSignal.signal()` writes to the backend fd.
 - Kernel wakes asyncio event loop.
 - Registered fd callback fires:
   - Calls `_drain_recv_waiters()` directly (no intermediate deferral).

--- a/bindings/pyomq/doc/performance.md
+++ b/bindings/pyomq/doc/performance.md
@@ -78,12 +78,13 @@ Results:
 Dead end. The pump and `try_recv` can't coexist on the same socket
 because they're both consumers of the socket's internal recv channel.
 
-### Send backpressure: eventfd park instead of spin
+### Send backpressure: readiness signal instead of spin
 
-When the send yring is full, the Python thread parked on an eventfd
-(`send_ready`) instead of spinning with `thread::yield_now()`. The
-send pump signals the eventfd after each batch drain (every 256
-messages). No CPU waste under backpressure.
+When the send yring is full, the Python thread parks on `send_ready`
+instead of spinning with `thread::yield_now()`. Linux uses `eventfd`,
+macOS/other Unix uses a nonblocking pipe, and Windows uses a Win32
+event/callback backend. The send pump signals after each batch drain
+(every 256 messages). No CPU waste under backpressure.
 
 ### Send pump yield interval: 64 -> 256
 
@@ -103,9 +104,9 @@ the runtime type.
 
 The yring relay avoids `block_on` entirely. Python does lock-free ring
 push/pop. Pump tasks on the tokio thread batch send/recv operations.
-The eventfd notification for recv uses an atomic flag to skip the
-syscall when the consumer isn't parked. Send backpressure parks on
-eventfd instead of spinning.
+The readiness notification for recv uses an atomic flag to skip the
+syscall when the consumer isn't parked. Send backpressure parks on the
+same readiness signal instead of spinning.
 
 ### Attempted: recv prefetch (drain yring batch under one lock)
 
@@ -127,7 +128,7 @@ Results (8 B TCP, N=15):
 
 Reverted. The gains are too small to justify the complexity, and the
 prefetch buffer breaks `poll()`/`wait_any()`: those check the yring and
-eventfd for readiness but don't know about the prefetch buffer. Messages
+readiness signal but don't know about the prefetch buffer. Messages
 drained into the buffer become invisible to poll, causing hangs in
 ZMQStream/tornado integrations (jupyter-client test suite).
 
@@ -159,7 +160,7 @@ REQ/REP: ~8.4k vs ~4.5k (1.86x).
 ### Materialized slot: Mutex -> RwLock
 
 `SocketInner::materialized` guards the lazily-initialized socket state
-(ring producers/consumers, notify fds, pump handles). Every `send()`
+(ring producers/consumers, readiness signals, pump handles). Every `send()`
 and `recv()` locks it to reach `send_prod` / `recv_cons`.
 
 With `Mutex`, the send thread (Python sender) and recv thread (Python
@@ -184,8 +185,8 @@ acquisition + pipe write to wake the asyncio loop). With two recv
 round-trips per REQ/REP exchange, async latency was ~195 µs.
 
 The fix: send pushes directly into the yring (synchronous, no tokio).
-Recv uses `_try_recv` (poll yring) + `_recv_fd` (eventfd registered
-with `loop.add_reader`). No Rust futures bridged to Python. Removed
+Recv uses `_try_recv` (poll yring) + `_recv_fd` (Unix readiness fd
+registered with `loop.add_reader`). No Rust futures bridged to Python. Removed
 `async_send_message`, `async_recv_message`, `tokio_future_into_py`
 from the send/recv path (kept only for control-plane ops like bind).
 
@@ -222,7 +223,7 @@ in Rust via the PID stored in `Materialized`.
 
 - `tokio::task::yield_now()` instead of `tokio::time::sleep(10 us)`.
   Timer wheel granularity was the root cause of the 27x regression.
-- Send backpressure: eventfd park instead of spin loop.
+- Send backpressure: readiness signal park instead of spin loop.
 - Send pump yield interval 64 -> 256, notify once per batch.
 - yring capacity matches HWM (was hardcoded 65536).
 - `Socket::try_send` now returns the message on `Full` (via

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -657,7 +657,7 @@ class _ShadowSocket:
     """Blocking recv bridge over an async socket's native handle.
 
     Returned by Socket.shadow() when given a pyomq.asyncio.Socket.
-    Provides sync recv via select() + eventfd without entering the
+    Provides sync recv via the native readiness signal without entering the
     asyncio event loop, matching pyzmq's shadow(underlying) behavior.
 
     """

--- a/bindings/pyomq/src/notify.rs
+++ b/bindings/pyomq/src/notify.rs
@@ -29,8 +29,8 @@ type SignalBackend = WindowsSignal;
 /// Platform-agnostic readiness signal for async socket wake-up paths.
 ///
 /// The `parking` flag avoids syscalls on the hot path. The consumer
-/// sets it before sleeping; the producer only writes to the eventfd
-/// when it sees the flag.
+/// sets it before sleeping; the producer only writes to the backend
+/// wake transport when it sees the flag.
 pub(crate) struct ReadinessSignal {
     parking: AtomicBool,
     backend: SignalBackend,

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -697,9 +697,9 @@ pub fn wait_any(
             None => Duration::from_millis(100),
         };
 
-        // Native blocking sockets have thread wakeups, not an eventfd.
+        // Native blocking sockets have thread wakeups, not a readiness fd.
         // Poll their try-recv path periodically while retaining the
-        // eventfd fast path for asyncio sockets.
+        // readiness-fd fast path for asyncio sockets.
         recv_signal.wait_timeout(wait_dur.min(Duration::from_millis(10)));
 
         let ready = poll_ready(&sockets);

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -2,7 +2,7 @@
 //! the sync and async wrappers.
 //!
 //! The synchronous wrapper uses `omq_tokio::blocking::Socket` directly.
-//! The asyncio wrapper retains its yring relay and eventfd adapter.
+//! The asyncio wrapper retains its yring relay and readiness adapter.
 
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -6,9 +6,9 @@
 //! - **Send**: `_send_direct` pushes into the send yring (EAGAIN if
 //!   full). The send pump relays to the omq Socket on the tokio thread.
 //! - **Recv**: `_try_recv` pops from the recv yring (returns `None` if
-//!   empty). `_recv_fd` returns a dup'd eventfd that becomes readable
-//!   when the recv pump pushes a message. The Python asyncio wrapper
-//!   registers this fd with `loop.add_reader` to wake the coroutine.
+//!   empty). `_recv_fd` returns a dup'd Unix readiness fd that becomes
+//!   readable when the recv pump pushes a message. The Python asyncio
+//!   wrapper registers this fd with `loop.add_reader` to wake the coroutine.
 //!
 //! Control-plane ops (bind, connect, subscribe, ...) use the sync
 //! dispatch helpers (block on a tokio oneshot).
@@ -105,7 +105,7 @@ impl AsyncSocket {
         }
     }
 
-    // ── Recv (try-poll + eventfd for async notification) ─────────────
+    // ── Recv (try-poll + readiness fd for async notification) ────────
 
     #[pyo3(name = "_try_recv")]
     fn try_recv<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -256,18 +256,32 @@ and other tasks. Standard presets: `DrainBudget::WORKER` (256 messages / 2 MiB)
 for lane workers and deferred fan-out, `DrainBudget::WIRE_DRAIN` (1024 / 1
 MiB) for wire-slot drain.
 
-All producer-to-consumer signaling uses `DataSignal`, an atomic flag plus
-`Notify`. `mark()` fires `notify_one` only on the `false`-to-`true` transition.
-The consumer `clear()`s before draining, then `rearm_if_nonempty()` to self-wake
-if data remains. `reschedule()` fires unconditionally for budget-interrupted
-drains where the consumer already knows data remains. Wire slot, send pipe,
-drop queue, and lane workers all use `DataSignal`.
+Data-ready paths use `DataSignal`, a small atomic state machine plus `Notify`.
+`mark()` fires `notify_one` only on the idle-to-pending transition. The consumer
+calls `begin_drain()` before draining and `clear_after(is_empty)` afterward. A
+producer mark that races with drain clear moves the signal to `DIRTY`, so
+readiness survives stale empty observations. `reschedule()` fires
+unconditionally for budget-interrupted drains where the consumer already knows
+data remains. Wire slots, send pipes, fallback queues, drop queues, and lane
+workers all use `DataSignal`.
+
+State-change waits use `StateSignal`: a generation counter plus `Notify`.
+Waiters capture a generation, enable their waiter, re-check caller state, then
+await only if nothing changed meanwhile. This is used where readiness is not a
+single data queue, for example queue-space release and peer-state changes.
 
 Control commands (subscribe, cancel, add-peer, remove-peer, shutdown) travel on
 dedicated channels separate from data. Lane workers, for example, drain all
 control commands unconditionally before draining data up to budget. This
 guarantees control latency is bounded by one data budget drain, not by queue
 depth.
+
+Loom covers the race windows that would lose these wakeups:
+`omq-tokio/tests/loom_signal.rs` models `DataSignal` rearming, `StateSignal`
+generation checks, queue-space release, and fallback waits that race with peer
+activation. `yring/tests/loom.rs` covers the lower-level SPSC cursor ordering,
+wraparound, producer drop, async `push_async` wakeups, and upper-layer
+readiness patterns built on the ring.
 
 ## Transports
 
@@ -299,7 +313,8 @@ Protocol: `omq-proto/src/message.rs`, `frame_buffer.rs`, `flow.rs`,
 
 Backend: `omq-tokio/src/socket/actor/`, `socket/handle.rs`,
 `engine/driver.rs`, `engine/send_pipe.rs`, `engine/transmit_slot.rs`,
-`engine/signal.rs`, `routing/`, and `transport/`.
+`engine/signal.rs`, `routing/`, `transport/`, and
+`tests/loom_signal.rs`.
 
 To add a socket type, extend `omq_proto::proto::SocketType`, compatibility
 checks, protocol routing, and the matching backend strategy. To add a

--- a/omq-tokio/README.md
+++ b/omq-tokio/README.md
@@ -11,12 +11,12 @@ Built on [omq-proto](https://crates.io/crates/omq-proto) and
 | | |
 |-|-|
 | Multi-threaded | Concurrent `send`/`recv` from multiple tasks is safe |
-| Actor with bypass | `SocketDriver` actor owns mutable state. Common message path bypasses it: `send` pushes into the routing strategy directly, `recv` pulls from the user channel directly. |
-| Arena encoding | Small messages (< 96 KiB) packed into one `BytesMut`, one `write_all` per batch |
-| Shared-queue work stealing | Round-robin types (PUSH/DEALER) share one `flume` queue. Each connection driver polls it in a `select!` arm, draining up to 256 messages per wakeup. |
+| Actor with bypass | `SocketDriver` owns mutable socket state. Common send/recv paths bypass it for non-REQ/REP sockets. |
+| Arena encoding | Small messages (< 4 KiB) pack into a `FrameBuffer` arena. Larger payloads use zero-copy gather-write. |
+| Bounded wakeups | Per-peer transmit slots and `yring` send pipes use `DataSignal` to coalesce wakeups without losing readiness. |
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_classic_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="850">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_pushpull_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="850">
 </p>
 
 ## Usage

--- a/yring/README.md
+++ b/yring/README.md
@@ -90,6 +90,21 @@ The `async` feature (opt-in) adds `AsyncProducer`/`AsyncConsumer` with
 waker integration: the producer wakes the consumer on flush, the
 consumer wakes the producer on release.
 
+## Correctness checks
+
+The unsafe ring core is checked with Miri:
+
+```sh
+cargo +nightly miri test -p yring
+```
+
+The Loom suite models SPSC cursor ordering, wraparound, producer drop,
+`push_async` wakeups, and upper-layer readiness patterns:
+
+```sh
+RUSTFLAGS="--cfg loom" cargo test -p yring --features async --test loom
+```
+
 ## Benchmarks
 
 Cross-thread throughput (M items/s), 2 seconds per configuration,


### PR DESCRIPTION
- Documents current `DataSignal` and `StateSignal` behavior in architecture docs.
- Updates Loom coverage notes for `yring` and `omq-tokio` signal race tests.
- Updates `pyomq` readiness docs for Linux `eventfd`, Unix pipe fallback, and Windows event/callback backends.