### PR TITLE
Add type annotations to pyomq and limit code duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             os: ubuntu-latest
           - python-version: "3.14"
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo clippy --workspace --all-targets --all-features
 
-  pyomq:
-    name: pyomq
+  pyomq-lint:
+    name: pyomq-lint
     needs: [changes, lint]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_pyomq == 'true'
     runs-on: ubuntu-latest
@@ -166,8 +166,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v6
-        with: { python-version: "3.14" }
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
       - name: create virtualenv and install python deps
         working-directory: bindings/pyomq
         run: |
@@ -189,18 +190,49 @@ jobs:
         working-directory: bindings/pyomq
         if: always()
         run: .venv/bin/ty check .
+
+  pyomq-test:
+    name: pyomq-test
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_pyomq == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.9"
+            os: ubuntu-latest
+          - python-version: "3.14"
+            os: ubuntu-latest
+          - python-version: "3.14"
+            os: windows-latest
+          - python-version: "3.14"
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: create virtualenv and install python deps
+        working-directory: bindings/pyomq
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install --group test --group dev
+      - name: build pyomq
+        working-directory: bindings/pyomq
+        run: .venv/bin/pip install .
       - name: cargo test
         working-directory: bindings/pyomq
-        if: always()
         run: cargo test
       - name: pytest
         working-directory: bindings/pyomq
-        if: always()
         run: .venv/bin/pytest -v -k "not test_perf" -W error
 
   ci-success:
     name: CI success
-    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq]
+    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq-lint, pyomq-test]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
       - name: type check
         working-directory: bindings/pyomq
         if: always()
-        run: .venv/bin/ty check .
+        run: |
+          .venv/bin/ty check . --python-platform linux
+          .venv/bin/ty check . --python-platform win32
 
   pyomq-test:
     name: pyomq-test
@@ -217,18 +219,17 @@ jobs:
       - name: create virtualenv and install python deps
         working-directory: bindings/pyomq
         run: |
-          python -m venv .venv
-          .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install --group test --group dev
+          pip install --upgrade pip
+          pip install --group test --group dev
       - name: build pyomq
         working-directory: bindings/pyomq
-        run: .venv/bin/pip install .
+        run: pip install .
       - name: cargo test
         working-directory: bindings/pyomq
         run: cargo test
       - name: pytest
         working-directory: bindings/pyomq
-        run: .venv/bin/pytest -v -k "not test_perf" -W error
+        run: pytest -v -k "not test_perf" -W error
 
   ci-success:
     name: CI success

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 *.so
+*.pyd
 *.html
 /*.log
 omq-tokio/tests/helpers/zmq_ws_peer

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -25,6 +25,9 @@ classifiers = [
     "Programming Language :: Rust",
     "Topic :: System :: Networking",
 ]
+dependencies = [
+    "typing_extensions>=4.0.0; python_version < '3.11'",
+]
 
 [dependency-groups]
 test = [

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.17.1"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Patrik Wenger", email = "paddor@gmail.com" }]
 keywords = ["zeromq", "omq", "messaging", "pyzmq", "zmq"]
 classifiers = [

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -38,8 +38,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    SupportsIndex,
-    SupportsBytes,
     overload,
 )
 

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -269,49 +269,6 @@ _TYPE_NAMES: Final[Dict[int, str]] = {
     STREAM: "STREAM",
 }
 
-_SOCKOPT_NAMES: Final[Dict[str, int]] = {
-    "affinity": AFFINITY,
-    "identity": IDENTITY,
-    "routing_id": ROUTING_ID,
-    "subscribe": SUBSCRIBE,
-    "unsubscribe": UNSUBSCRIBE,
-    "rcvmore": RCVMORE,
-    "sndhwm": SNDHWM,
-    "rcvhwm": RCVHWM,
-    "linger": LINGER,
-    "reconnect_ivl": RECONNECT_IVL,
-    "reconnect_ivl_max": RECONNECT_IVL_MAX,
-    "backlog": BACKLOG,
-    "maxmsgsize": MAXMSGSIZE,
-    "rcvtimeo": RCVTIMEO,
-    "sndtimeo": SNDTIMEO,
-    "ipv6": IPV6,
-    "immediate": IMMEDIATE,
-    "router_mandatory": ROUTER_MANDATORY,
-    "tcp_keepalive": TCP_KEEPALIVE,
-    "tcp_keepalive_idle": TCP_KEEPALIVE_IDLE,
-    "tcp_keepalive_cnt": TCP_KEEPALIVE_CNT,
-    "tcp_keepalive_intvl": TCP_KEEPALIVE_INTVL,
-    "heartbeat_ivl": HEARTBEAT_IVL,
-    "heartbeat_ttl": HEARTBEAT_TTL,
-    "heartbeat_timeout": HEARTBEAT_TIMEOUT,
-    "handshake_ivl": HANDSHAKE_IVL,
-    "conflate": CONFLATE,
-    "curve_server": CURVE_SERVER,
-    "curve_publickey": CURVE_PUBLICKEY,
-    "curve_secretkey": CURVE_SECRETKEY,
-    "curve_serverkey": CURVE_SERVERKEY,
-    "on_mute": OMQ_ON_MUTE,
-    "compression_dict": OMQ_COMPRESSION_DICT,
-    "compression_auto_train": OMQ_COMPRESSION_AUTO_TRAIN,
-    "sndbuf": SNDBUF,
-    "rcvbuf": RCVBUF,
-    "mechanism": MECHANISM,
-    "plain_server": PLAIN_SERVER,
-    "plain_username": PLAIN_USERNAME,
-    "plain_password": PLAIN_PASSWORD,
-}
-
 
 # ── MessageTracker / Message / Frame (pyzmq compat) ─────────────────
 
@@ -362,6 +319,76 @@ Frame = Message
 # ── Socket wrapper ───────────────────────────────────────────────────
 
 
+# Socket option descriptor for IDE autocomplete support
+class _SocketOptionDescriptor:
+    """Descriptor for socket options providing IDE autocomplete."""
+
+    def __init__(self, option_code: int) -> None:
+        self.option_code = option_code
+
+    def __get__(self, obj: Any, objtype: Optional[Type[Any]] = None) -> Any:
+        if obj is None:
+            return self
+        if self.option_code == LAST_ENDPOINT:
+            return obj._last_endpoint
+        return obj.getsockopt(self.option_code)
+
+    def __set__(self, obj: Any, value: Any) -> None:
+        obj.setsockopt(self.option_code, value)
+
+
+class _SocketOptionsBase:
+    """Base class with socket option descriptors for IDE autocomplete."""
+
+    # Socket options
+    affinity = _SocketOptionDescriptor(AFFINITY)
+    identity = _SocketOptionDescriptor(IDENTITY)
+    routing_id = _SocketOptionDescriptor(ROUTING_ID)
+    subscribe = _SocketOptionDescriptor(SUBSCRIBE)
+    unsubscribe = _SocketOptionDescriptor(UNSUBSCRIBE)
+    rcvmore = _SocketOptionDescriptor(RCVMORE)
+    sndhwm = _SocketOptionDescriptor(SNDHWM)
+    rcvhwm = _SocketOptionDescriptor(RCVHWM)
+    linger = _SocketOptionDescriptor(LINGER)
+    reconnect_ivl = _SocketOptionDescriptor(RECONNECT_IVL)
+    reconnect_ivl_max = _SocketOptionDescriptor(RECONNECT_IVL_MAX)
+    backlog = _SocketOptionDescriptor(BACKLOG)
+    maxmsgsize = _SocketOptionDescriptor(MAXMSGSIZE)
+    rcvtimeo = _SocketOptionDescriptor(RCVTIMEO)
+    sndtimeo = _SocketOptionDescriptor(SNDTIMEO)
+    ipv6 = _SocketOptionDescriptor(IPV6)
+    immediate = _SocketOptionDescriptor(IMMEDIATE)
+    router_mandatory = _SocketOptionDescriptor(ROUTER_MANDATORY)
+    tcp_keepalive = _SocketOptionDescriptor(TCP_KEEPALIVE)
+    tcp_keepalive_idle = _SocketOptionDescriptor(TCP_KEEPALIVE_IDLE)
+    tcp_keepalive_cnt = _SocketOptionDescriptor(TCP_KEEPALIVE_CNT)
+    tcp_keepalive_intvl = _SocketOptionDescriptor(TCP_KEEPALIVE_INTVL)
+    heartbeat_ivl = _SocketOptionDescriptor(HEARTBEAT_IVL)
+    heartbeat_ttl = _SocketOptionDescriptor(HEARTBEAT_TTL)
+    heartbeat_timeout = _SocketOptionDescriptor(HEARTBEAT_TIMEOUT)
+    handshake_ivl = _SocketOptionDescriptor(HANDSHAKE_IVL)
+    conflate = _SocketOptionDescriptor(CONFLATE)
+    curve_server = _SocketOptionDescriptor(CURVE_SERVER)
+    curve_publickey = _SocketOptionDescriptor(CURVE_PUBLICKEY)
+    curve_secretkey = _SocketOptionDescriptor(CURVE_SECRETKEY)
+    curve_serverkey = _SocketOptionDescriptor(CURVE_SERVERKEY)
+    on_mute = _SocketOptionDescriptor(OMQ_ON_MUTE)
+    compression_dict = _SocketOptionDescriptor(OMQ_COMPRESSION_DICT)
+    compression_auto_train = _SocketOptionDescriptor(OMQ_COMPRESSION_AUTO_TRAIN)
+    sndbuf = _SocketOptionDescriptor(SNDBUF)
+    rcvbuf = _SocketOptionDescriptor(RCVBUF)
+    mechanism = _SocketOptionDescriptor(MECHANISM)
+    plain_server = _SocketOptionDescriptor(PLAIN_SERVER)
+    plain_username = _SocketOptionDescriptor(PLAIN_USERNAME)
+    plain_password = _SocketOptionDescriptor(PLAIN_PASSWORD)
+
+    @property
+    def last_endpoint(self) -> Optional[Union[bytes, str]]:
+        return self._last_endpoint
+
+    _last_endpoint: Optional[Union[bytes, str]]
+
+
 class _SocketMeta(type):
     """Metaclass for Socket that allows checking for async Socket instances."""
 
@@ -375,13 +402,12 @@ class _SocketMeta(type):
         return False
 
 
-class Socket(metaclass=_SocketMeta):
+class Socket(_SocketOptionsBase, metaclass=_SocketMeta):
     """Synchronous ZMQ socket wrapper."""
 
     _sock: _native.Socket
     _context: Context
     _closed: bool
-    _last_endpoint: Optional[Union[bytes, str]]
     _pid: int
     _binds: List[Union[str, bytes]]
     _connects: List[Union[str, bytes]]
@@ -405,26 +431,6 @@ class Socket(metaclass=_SocketMeta):
         if isinstance(socket, _zmq_async.Socket):
             return _ShadowSocket(socket)
         return socket
-
-    def __getattr__(self, name: str) -> Any:
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            if opt == LAST_ENDPOINT:
-                return self._last_endpoint
-            return self.getsockopt(opt)
-        raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'"
-        )
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        if name.startswith("_"):
-            object.__setattr__(self, name, value)
-            return
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            self.setsockopt(opt, value)
-            return
-        object.__setattr__(self, name, value)
 
     def __repr__(self) -> str:
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
@@ -735,7 +741,7 @@ class Socket(metaclass=_SocketMeta):
 # ── Shadow socket (sync recv bridge over async handle) ──────────────
 
 
-class _ShadowSocket:
+class _ShadowSocket(_SocketOptionsBase):
     """Blocking recv bridge over an async socket's native handle.
 
     Returned by Socket.shadow() when given a pyomq.asyncio.Socket.
@@ -748,7 +754,6 @@ class _ShadowSocket:
     _native: _native.AsyncSocket
     _context: Context
     _closed: bool
-    _last_endpoint: Optional[Union[bytes, str]]
     _recv_waiter_pending: bool
     _send_waiter_pending: bool
     _recv_wakeup_event: threading.Event
@@ -765,26 +770,6 @@ class _ShadowSocket:
             self._send_waiter_pending = False
             self._recv_wakeup_event = async_socket._recv_wakeup_event
             self._send_wakeup_event = async_socket._send_wakeup_event
-
-    def __getattr__(self, name: str) -> Any:
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            if opt == LAST_ENDPOINT:
-                return self._last_endpoint
-            return self.getsockopt(opt)
-        raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'"
-        )
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        if name.startswith("_"):
-            object.__setattr__(self, name, value)
-            return
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            self.setsockopt(opt, value)
-            return
-        object.__setattr__(self, name, value)
 
     @property
     def closed(self) -> bool:

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -13,6 +13,9 @@ For asynchronous code::
     import pyomq.asyncio as zmq_async
 """
 
+from __future__ import annotations
+from collections.abc import Buffer
+
 import errno as _errno
 import itertools
 import json
@@ -22,6 +25,21 @@ import select as _select
 import sys
 import threading
 import weakref
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    SupportsIndex,
+    SupportsBytes,
+)
 
 from . import _native  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from . import error as error  # noqa: F401
@@ -109,97 +127,97 @@ from .error import (  # noqa: F401  re-exports
 
 # ── Constants ─────────────────────────────────────────────────────────
 
-POLLIN = 1
-POLLOUT = 2
-POLLERR = 4
-POLLPRI = 32
-HWM = 1
-_WAKEUP_MODE_NONE = 0
-_WAKEUP_MODE_ASYNC = 1
-_WAKEUP_MODE_SYNC = 2
-_IS_WINDOWS = sys.platform == "win32"
+POLLIN: Final[int] = 1
+POLLOUT: Final[int] = 2
+POLLERR: Final[int] = 4
+POLLPRI: Final[int] = 32
+HWM: Final[int] = 1
+_WAKEUP_MODE_NONE: Final[int] = 0
+_WAKEUP_MODE_ASYNC: Final[int] = 1
+_WAKEUP_MODE_SYNC: Final[int] = 2
+_IS_WINDOWS: Final[bool] = sys.platform == "win32"
 
-ROUTING_ID = 5
-LAST_ENDPOINT = 32
-FD = 14
-EVENTS = 15
-MECHANISM = 43
-SNDBUF = 11
-RCVBUF = 12
-RATE = 8
-CONNECT_TIMEOUT = 79
-XPUB_VERBOSE = 40
-PROBE_ROUTER = 51
-REQ_CORRELATE = 52
-REQ_RELAXED = 53
-ROUTER_HANDOVER = 56
-IPV4ONLY = 31
-TCP_ACCEPT_FILTER = 38
-TCP_MAXRT = 80
-MULTICAST_HOPS = 25
-RECOVERY_IVL = 9
-RECONNECT_STOP = 109
-PLAIN_SERVER = 44
-PLAIN_USERNAME = 45
-PLAIN_PASSWORD = 46
-ZAP_DOMAIN = 55
+ROUTING_ID: Final[int] = 5
+LAST_ENDPOINT: Final[int] = 32
+FD: Final[int] = 14
+EVENTS: Final[int] = 15
+MECHANISM: Final[int] = 43
+SNDBUF: Final[int] = 11
+RCVBUF: Final[int] = 12
+RATE: Final[int] = 8
+CONNECT_TIMEOUT: Final[int] = 79
+XPUB_VERBOSE: Final[int] = 40
+PROBE_ROUTER: Final[int] = 51
+REQ_CORRELATE: Final[int] = 52
+REQ_RELAXED: Final[int] = 53
+ROUTER_HANDOVER: Final[int] = 56
+IPV4ONLY: Final[int] = 31
+TCP_ACCEPT_FILTER: Final[int] = 38
+TCP_MAXRT: Final[int] = 80
+MULTICAST_HOPS: Final[int] = 25
+RECOVERY_IVL: Final[int] = 9
+RECONNECT_STOP: Final[int] = 109
+PLAIN_SERVER: Final[int] = 44
+PLAIN_USERNAME: Final[int] = 45
+PLAIN_PASSWORD: Final[int] = 46
+ZAP_DOMAIN: Final[int] = 55
 
-FORWARDER = 2
-QUEUE = 3
-STREAMER = 1
+FORWARDER: Final[int] = 2
+QUEUE: Final[int] = 3
+STREAMER: Final[int] = 1
 
-NULL = 0
-PLAIN = 1
-CURVE = 2
+NULL: Final[int] = 0
+PLAIN: Final[int] = 1
+CURVE: Final[int] = 2
 
-ETERM = 156384765
-ENOTSOCK = 108
-COPY_THRESHOLD = 65536
+ETERM: Final[int] = 156384765
+ENOTSOCK: Final[int] = 108
+COPY_THRESHOLD: Final[int] = 65536
 
 # errno constants (pyzmq exposes these at top level)
-EAGAIN = _errno.EAGAIN
-ENOTSUP = _errno.ENOTSUP
-EINVAL = _errno.EINVAL
-EFAULT = _errno.EFAULT
-ENOMEM = _errno.ENOMEM
-ENODEV = _errno.ENODEV
-EMSGSIZE = _errno.EMSGSIZE
-EAFNOSUPPORT = _errno.EAFNOSUPPORT
-ENETUNREACH = _errno.ENETUNREACH
-ECONNABORTED = _errno.ECONNABORTED
-ECONNRESET = _errno.ECONNRESET
-ENOTCONN = _errno.ENOTCONN
-ETIMEDOUT = _errno.ETIMEDOUT
-EHOSTUNREACH = _errno.EHOSTUNREACH
-ENETRESET = _errno.ENETRESET
-EADDRINUSE = _errno.EADDRINUSE
-EADDRNOTAVAIL = _errno.EADDRNOTAVAIL
+EAGAIN: Final[int] = _errno.EAGAIN
+ENOTSUP: Final[int] = _errno.ENOTSUP
+EINVAL: Final[int] = _errno.EINVAL
+EFAULT: Final[int] = _errno.EFAULT
+ENOMEM: Final[int] = _errno.ENOMEM
+ENODEV: Final[int] = _errno.ENODEV
+EMSGSIZE: Final[int] = _errno.EMSGSIZE
+EAFNOSUPPORT: Final[int] = _errno.EAFNOSUPPORT
+ENETUNREACH: Final[int] = _errno.ENETUNREACH
+ECONNABORTED: Final[int] = _errno.ECONNABORTED
+ECONNRESET: Final[int] = _errno.ECONNRESET
+ENOTCONN: Final[int] = _errno.ENOTCONN
+ETIMEDOUT: Final[int] = _errno.ETIMEDOUT
+EHOSTUNREACH: Final[int] = _errno.EHOSTUNREACH
+ENETRESET: Final[int] = _errno.ENETRESET
+EADDRINUSE: Final[int] = _errno.EADDRINUSE
+EADDRNOTAVAIL: Final[int] = _errno.EADDRNOTAVAIL
 
-__version__ = version()
-zmq_version_info = (4, 3, 4)
+__version__: Final[str] = version()
+zmq_version_info: Final[Tuple[int, int, int]] = (4, 3, 4)
 
 
 # ── Top-level functions ──────────────────────────────────────────────
 
 
-def strerror(errnum):
+def strerror(errnum: int) -> str:
     return os.strerror(errnum)
 
 
-def zmq_version():
+def zmq_version() -> str:
     return "%d.%d.%d" % zmq_version_info
 
 
-def pyomq_version():
+def pyomq_version() -> str:
     return __version__
 
 
-def pyomq_version_info():
+def pyomq_version_info() -> Tuple[int, ...]:
     parts = __version__.split(".")
     return tuple(int(p) for p in parts[:3])
 
 
-def has(capability):
+def has(capability: str) -> bool:
     cap = capability.lower()
     if cap in ("ipc", "inproc"):
         return True
@@ -208,13 +226,13 @@ def has(capability):
     return False
 
 
-def curve_keypair():
+def curve_keypair() -> Tuple[bytes, bytes]:
     if not hasattr(_native, "curve_keypair"):
         raise ZMQNotImplementedError("curve feature not compiled")
     return _native.curve_keypair()
 
 
-def curve_public(secret):
+def curve_public(secret: Union[bytes, str]) -> bytes:
     if not hasattr(_native, "curve_public"):
         raise ZMQNotImplementedError("curve feature not compiled")
     if isinstance(secret, str):
@@ -228,7 +246,7 @@ if hasattr(_native, "PeerInfo"):
 
 # ── Socket option attribute map ──────────────────────────────────────
 
-_TYPE_NAMES = {
+_TYPE_NAMES: Final[Dict[int, str]] = {
     PAIR: "PAIR",
     PUB: "PUB",
     SUB: "SUB",
@@ -251,7 +269,7 @@ _TYPE_NAMES = {
     STREAM: "STREAM",
 }
 
-_SOCKOPT_NAMES = {
+_SOCKOPT_NAMES: Final[Dict[str, int]] = {
     "affinity": AFFINITY,
     "identity": IDENTITY,
     "routing_id": ROUTING_ID,
@@ -303,18 +321,30 @@ class NotDone(ZMQBaseError):
 
 
 class MessageTracker:
-    def __init__(self, *args, _pending=False, **kwargs):
+    """Tracks the delivery status of a message (pyzmq compatibility)."""
+
+    done: bool
+
+    def __init__(self, *args: Any, _pending: bool = False, **kwargs: Any) -> None:
         self.done = not _pending
 
-    def wait(self, timeout=None):
+    def wait(self, timeout: Optional[int] = None) -> None:
         if not self.done:
             raise NotDone
 
 
 class Message(bytes):
-    tracker = None
+    """Message class that extends bytes (pyzmq compatibility)."""
 
-    def __new__(cls, data=b"", track=False):
+    tracker: Optional[MessageTracker] = None
+
+    def __new__(
+        cls,
+        data: Union[
+            Iterable[SupportsIndex], SupportsIndex, SupportsBytes, Buffer
+        ] = b"",
+        track: bool = False,
+    ):
         return super().__new__(cls, data)
 
     @property
@@ -333,7 +363,9 @@ Frame = Message
 
 
 class _SocketMeta(type):
-    def __instancecheck__(cls, instance):
+    """Metaclass for Socket that allows checking for async Socket instances."""
+
+    def __instancecheck__(cls, instance: Any) -> bool:
         if type.__instancecheck__(cls, instance):
             return True
         if cls is Socket:
@@ -344,11 +376,17 @@ class _SocketMeta(type):
 
 
 class Socket(metaclass=_SocketMeta):
-    _sock: _native.Socket
-    _context: "Context"
-    _closed: bool
+    """Synchronous ZMQ socket wrapper."""
 
-    def __init__(self, _sock, _context):
+    _sock: _native.Socket
+    _context: Context
+    _closed: bool
+    _last_endpoint: Optional[Union[bytes, str]]
+    _pid: int
+    _binds: List[Union[str, bytes]]
+    _connects: List[Union[str, bytes]]
+
+    def __init__(self, _sock: _native.Socket, _context: Context) -> None:
         self._sock = _sock
         self._context = _context
         self._closed = False
@@ -357,18 +395,18 @@ class Socket(metaclass=_SocketMeta):
         self._binds = []
         self._connects = []
 
-    def __class_getitem__(cls, item):
+    def __class_getitem__(cls, item: Any) -> Type[Socket]:
         return cls
 
     @classmethod
-    def shadow(cls, socket):
+    def shadow(cls, socket: Any) -> Union[Socket, _ShadowSocket]:
         from . import asyncio as _zmq_async
 
         if isinstance(socket, _zmq_async.Socket):
             return _ShadowSocket(socket)
         return socket
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         opt = _SOCKOPT_NAMES.get(name)
         if opt is not None:
             if opt == LAST_ENDPOINT:
@@ -378,7 +416,7 @@ class Socket(metaclass=_SocketMeta):
             f"'{type(self).__name__}' object has no attribute '{name}'"
         )
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
             object.__setattr__(self, name, value)
             return
@@ -388,36 +426,36 @@ class Socket(metaclass=_SocketMeta):
             return
         object.__setattr__(self, name, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
         return f"<pyomq.Socket(pyomq.{st}) at {id(self):#x}>"
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._closed
 
     @property
-    def context(self):
+    def context(self) -> Context:
         return self._context
 
     @property
-    def socket_type(self):
+    def socket_type(self) -> int:
         return self._sock.getsockopt(TYPE)
 
     @property
-    def underlying(self):
+    def underlying(self) -> Socket:
         return self
 
     # ── I/O ──────────────────────────────────────────────────────────
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self.getsockopt(FD)
 
     @property
-    def last_endpoint(self):
+    def last_endpoint(self) -> Optional[Union[bytes, str]]:
         return self._last_endpoint
 
-    def _check_fork(self):
+    def _check_fork(self) -> None:
         pid = os.getpid()
         if pid == self._pid:
             return
@@ -433,7 +471,7 @@ class Socket(metaclass=_SocketMeta):
             except _native.ZMQError:
                 pass
 
-    def bind(self, endpoint):
+    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
         try:
             ep = self._sock.bind(self._context._namespace_inproc(endpoint))
             self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
@@ -442,7 +480,7 @@ class Socket(metaclass=_SocketMeta):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def connect(self, endpoint):
+    def connect(self, endpoint: Union[str, bytes]) -> None:
         if isinstance(endpoint, bytes):
             endpoint = endpoint.decode("utf-8")
         try:
@@ -454,27 +492,36 @@ class Socket(metaclass=_SocketMeta):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unbind(self, endpoint):
+    def unbind(self, endpoint: Union[str, bytes]) -> None:
         try:
             return self._sock.unbind(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def disconnect(self, endpoint):
+    def disconnect(self, endpoint: Union[str, bytes]) -> None:
         try:
             return self._sock.disconnect(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def send(self, data, flags=0, copy=True, track=False):
+    def send(
+        self,
+        data: Union[bytes, str],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Optional[MessageTracker]:
         try:
             self._sock.send(data, flags)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
         if track:
             return MessageTracker(_pending=True)
+        return None
 
-    def recv(self, flags=0, copy=True, track=False):
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> Union[bytes, Frame]:
         try:
             data = self._sock.recv(flags)
         except _native.ZMQError as e:
@@ -483,7 +530,13 @@ class Socket(metaclass=_SocketMeta):
             return Frame(data)
         return data
 
-    def send_multipart(self, parts, flags=0, copy=True, track=False):
+    def send_multipart(
+        self,
+        parts: Iterable[Union[bytes, str]],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Optional[MessageTracker]:
         parts = [p.encode("utf-8") if isinstance(p, str) else p for p in parts]
         try:
             self._sock.send_multipart(parts, flags)
@@ -491,8 +544,11 @@ class Socket(metaclass=_SocketMeta):
             raise error.from_native(e) from None
         if track:
             return MessageTracker(_pending=True)
+        return None
 
-    def recv_multipart(self, flags=0, copy=True, track=False):
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> List[Union[bytes, Frame]]:
         try:
             parts = self._sock.recv_multipart(flags)
         except _native.ZMQError as e:
@@ -503,41 +559,59 @@ class Socket(metaclass=_SocketMeta):
 
     # ── Serialization helpers ────────────────────────────────────────
 
-    def send_string(self, u, flags=0, encoding="utf-8"):
+    def send_string(
+        self, u: str, flags: int = 0, encoding: str = "utf-8"
+    ) -> Optional[MessageTracker]:
         return self.send(u.encode(encoding), flags)
 
-    def recv_string(self, flags=0, encoding="utf-8"):
+    def recv_string(self, flags: int = 0, encoding: str = "utf-8") -> str:
         return self.recv(flags).decode(encoding)
 
-    def send_json(self, obj, flags=0, **kwargs):
+    def send_json(
+        self, obj: Any, flags: int = 0, **kwargs: Any
+    ) -> Optional[MessageTracker]:
         return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
-    def recv_json(self, flags=0, **kwargs):
+    def recv_json(self, flags: int = 0, **kwargs: Any) -> Any:
         return json.loads(self.recv(flags), **kwargs)
 
-    def send_pyobj(self, obj, flags=0, protocol=-1):
+    def send_pyobj(
+        self, obj: Any, flags: int = 0, protocol: int = -1
+    ) -> Optional[MessageTracker]:
         return self.send(pickle.dumps(obj, protocol), flags)
 
-    def recv_pyobj(self, flags=0):
+    def recv_pyobj(self, flags: int = 0) -> Any:
         return pickle.loads(self.recv(flags))
 
-    def send_serialized(self, msg, serialize, flags=0, copy=True, **kwargs):
+    def send_serialized(
+        self,
+        msg: Any,
+        serialize: Callable[[Any], List[bytes]],
+        flags: int = 0,
+        copy: bool = True,
+        **kwargs: Any,
+    ) -> Optional[MessageTracker]:
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
-    def recv_serialized(self, deserialize, flags=0, copy=True):
+    def recv_serialized(
+        self,
+        deserialize: Callable[[List[bytes]], Any],
+        flags: int = 0,
+        copy: bool = True,
+    ) -> Any:
         frames = self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
     # ── Options ──────────────────────────────────────────────────────
 
-    def setsockopt(self, option, value):
+    def setsockopt(self, option: int, value: Any) -> Any:
         try:
             return self._sock.setsockopt(option, value)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def getsockopt(self, option):
+    def getsockopt(self, option: int) -> Any:
         if option == LAST_ENDPOINT:
             return self._last_endpoint
         try:
@@ -545,16 +619,18 @@ class Socket(metaclass=_SocketMeta):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def set(self, option, value):
+    def set(self, option: int, value: Any) -> Any:
         return self.setsockopt(option, value)
 
-    def get(self, option):
+    def get(self, option: int) -> Any:
         return self.getsockopt(option)
 
-    def setsockopt_string(self, option, value, encoding="utf-8"):
+    def setsockopt_string(
+        self, option: int, value: str, encoding: str = "utf-8"
+    ) -> Any:
         return self.setsockopt(option, value.encode(encoding))
 
-    def getsockopt_string(self, option, encoding="utf-8"):
+    def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
         v = self.getsockopt(option)
         if isinstance(v, bytes):
             return v.decode(encoding)
@@ -563,7 +639,7 @@ class Socket(metaclass=_SocketMeta):
     set_string = setsockopt_string
     get_string = getsockopt_string
 
-    def set_curve_auth(self, auth):
+    def set_curve_auth(self, auth: Any) -> Any:
         try:
             return self._sock.set_curve_auth(auth)
         except _native.ZMQError as e:
@@ -571,36 +647,36 @@ class Socket(metaclass=_SocketMeta):
         except AttributeError:
             raise ZMQNotImplementedError("curve feature not compiled")
 
-    def set_hwm(self, value):
+    def set_hwm(self, value: int) -> None:
         self.setsockopt(SNDHWM, value)
         self.setsockopt(RCVHWM, value)
 
-    def get_hwm(self):
+    def get_hwm(self) -> int:
         return self.getsockopt(SNDHWM)
 
     hwm = property(get_hwm, set_hwm)
 
     # ── Subscriptions ────────────────────────────────────────────────
 
-    def subscribe(self, prefix):
+    def subscribe(self, prefix: Union[bytes, str]) -> None:
         try:
             return self._sock.subscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unsubscribe(self, prefix):
+    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
         try:
             return self._sock.unsubscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def join(self, group):
+    def join(self, group: Union[bytes, str]) -> None:
         try:
             return self._sock.join(group)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def leave(self, group):
+    def leave(self, group: Union[bytes, str]) -> None:
         try:
             return self._sock.leave(group)
         except _native.ZMQError as e:
@@ -608,32 +684,38 @@ class Socket(metaclass=_SocketMeta):
 
     # ── Monitoring ───────────────────────────────────────────────────
 
-    def monitor(self):
+    def monitor(self) -> Any:
         return self._sock.monitor()
 
-    def connections(self):
+    def connections(self) -> Any:
         return self._sock.connections()
 
-    def connection_info(self, connection_id):
+    def connection_info(self, connection_id: int) -> Any:
         return self._sock.connection_info(connection_id)
 
     # ── Lifecycle ────────────────────────────────────────────────────
 
-    def close(self, linger=None):
+    def close(self, linger: Optional[int] = None) -> None:
         if not self._closed:
             self._closed = True
             self._sock.close(linger)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    def bind_to_random_port(self, addr, min_port=49152, max_port=65536, max_tries=100):
+    def bind_to_random_port(
+        self,
+        addr: str,
+        min_port: int = 49152,
+        max_port: int = 65536,
+        max_tries: int = 100,
+    ) -> int:
         ep = self.bind(f"{addr}:0")
         if isinstance(ep, bytes):
             ep = ep.decode()
         return int(ep.rsplit(":", 1)[1])
 
-    def poll(self, timeout=None, flags=POLLIN):
+    def poll(self, timeout: Optional[int] = None, flags: int = POLLIN) -> int:
         p = Poller()
         p.register(self, flags)
         evts = p.poll(timeout)
@@ -642,10 +724,10 @@ class Socket(metaclass=_SocketMeta):
                 return mask
         return 0
 
-    def __enter__(self):
+    def __enter__(self) -> Socket:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> bool:
         self.close()
         return False
 
@@ -662,7 +744,17 @@ class _ShadowSocket:
 
     """
 
-    def __init__(self, async_socket):
+    _async_socket: Any  # pyomq.asyncio.Socket
+    _native: _native.AsyncSocket
+    _context: Context
+    _closed: bool
+    _last_endpoint: Optional[Union[bytes, str]]
+    _recv_waiter_pending: bool
+    _send_waiter_pending: bool
+    _recv_wakeup_event: threading.Event
+    _send_wakeup_event: threading.Event
+
+    def __init__(self, async_socket: Any) -> None:
         self._async_socket = async_socket
         self._native = async_socket._sock
         self._context = async_socket._context
@@ -674,7 +766,7 @@ class _ShadowSocket:
             self._recv_wakeup_event = async_socket._recv_wakeup_event
             self._send_wakeup_event = async_socket._send_wakeup_event
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         opt = _SOCKOPT_NAMES.get(name)
         if opt is not None:
             if opt == LAST_ENDPOINT:
@@ -684,7 +776,7 @@ class _ShadowSocket:
             f"'{type(self).__name__}' object has no attribute '{name}'"
         )
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
             object.__setattr__(self, name, value)
             return
@@ -695,51 +787,51 @@ class _ShadowSocket:
         object.__setattr__(self, name, value)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._closed or self._async_socket._closed
 
     @property
-    def context(self):
+    def context(self) -> Context:
         return self._context
 
     @property
-    def socket_type(self):
+    def socket_type(self) -> int:
         return self._native.getsockopt(TYPE)
 
     @property
-    def underlying(self):
+    def underlying(self) -> _ShadowSocket:
         return self
 
-    def getsockopt(self, option):
+    def getsockopt(self, option: int) -> Any:
         try:
             return self._native.getsockopt(option)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def setsockopt(self, option, value):
+    def setsockopt(self, option: int, value: Any) -> Any:
         try:
             return self._native.setsockopt(option, value)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def set(self, option, value):
+    def set(self, option: int, value: Any) -> Any:
         return self.setsockopt(option, value)
 
-    def get(self, option):
+    def get(self, option: int) -> Any:
         return self.getsockopt(option)
 
     if _IS_WINDOWS:
 
-        def _register_wakeup_hooks(self):
+        def _register_wakeup_hooks(self) -> None:
             self._async_socket._register_wakeup_hooks()
     else:
 
-        def _register_wakeup_hooks(self):
+        def _register_wakeup_hooks(self) -> None:
             return None
 
     if _IS_WINDOWS:
 
-        def _blocking_recv(self, try_fn):
+        def _blocking_recv(self, try_fn: Callable[[], Any]) -> Any:
             if self._recv_waiter_pending:
                 raise RuntimeError(
                     "cannot have more than one pending recv waiter on a shadow socket"
@@ -779,7 +871,7 @@ class _ShadowSocket:
                 )
     else:
 
-        def _blocking_recv(self, try_fn):
+        def _blocking_recv(self, try_fn: Callable[[], Any]) -> Any:
             try:
                 result = try_fn()
             except _native.ZMQError as e:
@@ -811,31 +903,49 @@ class _ShadowSocket:
             finally:
                 os.close(fd)
 
-    def recv(self, flags=0, copy=True, track=False):
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> Union[bytes, Frame]:
         data = self._blocking_recv(self._native._try_recv)
         if not copy:
             return Frame(data)
         return data
 
-    def recv_multipart(self, flags=0, copy=True, track=False):
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> List[Union[bytes, Frame]]:
         parts = self._blocking_recv(self._native._try_recv_multipart)
         if not copy:
             return [Frame(p) for p in parts]
         return parts
 
-    def send(self, data, flags=0, copy=True, track=False):
+    def send(
+        self,
+        data: Union[bytes, str],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Optional[MessageTracker]:
         self._blocking_send(lambda: self._native.send(data, flags))
         if track:
             return MessageTracker(_pending=True)
+        return None
 
-    def send_multipart(self, parts, flags=0, copy=True, track=False):
+    def send_multipart(
+        self,
+        parts: List[Union[bytes, str]],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Optional[MessageTracker]:
         self._blocking_send(lambda: self._native.send_multipart(parts, flags))
         if track:
             return MessageTracker(_pending=True)
+        return None
 
     if _IS_WINDOWS:
 
-        def _blocking_send(self, send_fn):
+        def _blocking_send(self, send_fn: Callable[[], None]) -> None:
             if self._send_waiter_pending:
                 raise RuntimeError(
                     "cannot have more than one pending send waiter on a shadow socket"
@@ -875,7 +985,7 @@ class _ShadowSocket:
                 )
     else:
 
-        def _blocking_send(self, send_fn):
+        def _blocking_send(self, send_fn: Callable[[], None]) -> None:
             try:
                 send_fn()
                 return
@@ -907,23 +1017,32 @@ class _ShadowSocket:
             finally:
                 os.close(fd)
 
-    def close(self, linger=None):
+    def close(self, linger: Optional[int] = None) -> None:
         pass
 
 
 # ── Context wrapper ──────────────────────────────────────────────────
 
-_next_ctx_id = itertools.count(1)
+_next_ctx_id: Iterator[int] = itertools.count(1)
 
-_INPROC_PREFIX = "inproc://"
+_INPROC_PREFIX: Final[str] = "inproc://"
 
 
 class Context:
-    _instance = None
-    _instance_lock = threading.Lock()
-    _socket_class = None  # set after Socket is defined
+    """Synchronous ZMQ context."""
 
-    def __init__(self, io_threads=1, *, _shadow_ctx=None):
+    _instance: Optional[Context] = None
+    _instance_lock: threading.Lock = threading.Lock()
+    _socket_class: Optional[Type[Socket]] = None  # set after Socket is defined
+    _ctx: _native.Context
+    _is_shadow: bool
+    _closed: bool
+    _sockets: weakref.WeakSet[Socket]
+    _ctx_id: int
+
+    def __init__(
+        self, io_threads: int = 1, *, _shadow_ctx: Optional[Context] = None
+    ) -> None:
         if _shadow_ctx is not None:
             self._ctx = _shadow_ctx._ctx
             self._is_shadow = True
@@ -934,7 +1053,7 @@ class Context:
         self._sockets = weakref.WeakSet()
         self._ctx_id = next(_next_ctx_id)
 
-    def _namespace_inproc(self, endpoint):
+    def _namespace_inproc(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
         # libzmq scopes inproc per-context; omq's registry is global. pytest
         # holds frame references to locals (traceback capture), so __del__
         # never fires and the old socket's registry entry stays alive. Next
@@ -958,14 +1077,19 @@ class Context:
                 return f"inproc://{ns_str}{endpoint[len(_INPROC_PREFIX) :]}"
         return endpoint
 
-    def __class_getitem__(cls, item):
+    def __class_getitem__(cls, item: Any) -> Type[Context]:
         return cls
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._closed
 
-    def socket(self, socket_type, socket_class=None, **kwargs):
+    def socket(
+        self,
+        socket_type: int,
+        socket_class: Optional[Type[Socket]] = None,
+        **kwargs: Any,
+    ) -> Socket:
         native = self._ctx.socket(socket_type)
         cls = socket_class or Socket
         s = object.__new__(cls)
@@ -980,21 +1104,21 @@ class Context:
         return s
 
     @classmethod
-    def shadow(cls, address):
+    def shadow(cls, address: Union[Context, int]) -> Context:
         if isinstance(address, Context):
             return cls(_shadow_ctx=address)
         if isinstance(address, int):
-            return cls(_shadow_ctx=Context.instance())
+            return cls(_shadow_ctx=cls.instance())
         raise TypeError(f"expected Context or int, got {type(address).__name__}")
 
     @classmethod
-    def instance(cls, io_threads=1):
+    def instance(cls, io_threads: int = 1) -> Context:
         with cls._instance_lock:
             if cls._instance is None or cls._instance._closed:
                 cls._instance = cls(io_threads)
             return cls._instance
 
-    def term(self):
+    def term(self) -> None:
         self._closed = True
         for s in list(self._sockets):
             if not s.closed:
@@ -1003,7 +1127,7 @@ class Context:
         if not self._is_shadow:
             self._ctx.term()
 
-    def destroy(self, linger=None):
+    def destroy(self, linger: Optional[int] = None) -> None:
         for s in list(self._sockets):
             if not s.closed:
                 if linger is not None:
@@ -1012,14 +1136,14 @@ class Context:
         self._sockets.clear()
         self.term()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self._closed:
             self.term()
 
-    def __enter__(self):
+    def __enter__(self) -> Context:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> bool:
         self.term()
         return False
 
@@ -1031,25 +1155,29 @@ Context._socket_class = Socket
 
 
 class Poller:
-    def __init__(self):
+    """Synchronous poller for ZMQ sockets."""
+
+    _sockets: Dict[int, Tuple[Socket, int]]
+
+    def __init__(self) -> None:
         self._sockets = {}  # native_socket_id -> (Socket, flags)
 
-    def register(self, socket, flags=POLLIN):
+    def register(self, socket: Socket, flags: int = POLLIN) -> None:
         self._sockets[socket._sock.socket_id()] = (socket, flags)
 
-    def unregister(self, socket):
+    def unregister(self, socket: Socket) -> None:
         self._sockets.pop(socket._sock.socket_id(), None)
 
-    def modify(self, socket, flags):
+    def modify(self, socket: Socket, flags: int) -> None:
         k = socket._sock.socket_id()
         if k in self._sockets:
             self._sockets[k] = (socket, flags)
 
     @property
-    def sockets(self):
+    def sockets(self) -> List[Tuple[Socket, int]]:
         return [(s, f) for s, f in self._sockets.values()]
 
-    def poll(self, timeout=None):
+    def poll(self, timeout: Optional[int] = None) -> List[Tuple[Socket, int]]:
         if not self._sockets:
             return []
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
@@ -1065,7 +1193,12 @@ class Poller:
 # ── select ──────────────────────────────────────────────────────────
 
 
-def select(rlist, wlist, xlist, timeout=None):
+def select(
+    rlist: Iterable[Socket],
+    wlist: Iterable[Socket],
+    xlist: Iterable[Socket],
+    timeout: Optional[float] = None,
+) -> Tuple[List[Socket], List[Socket], List[Socket]]:
     if timeout is not None:
         timeout_ms = int(timeout * 1000)
     else:
@@ -1076,7 +1209,9 @@ def select(rlist, wlist, xlist, timeout=None):
     for s in wlist:
         p.register(s, POLLOUT)
     evts = p.poll(timeout_ms)
-    rready, wready, xready = [], [], []
+    rready: List[Socket] = []
+    wready: List[Socket] = []
+    xready: List[Socket] = []
     for sock, mask in evts:
         if mask & POLLIN:
             rready.append(sock)
@@ -1088,7 +1223,7 @@ def select(rlist, wlist, xlist, timeout=None):
 # ── proxy ────────────────────────────────────────────────────────────
 
 
-def proxy(frontend, backend, capture=None):
+def proxy(frontend: Socket, backend: Socket, capture: Optional[Socket] = None) -> None:
     _native.native_proxy(
         frontend._sock,
         backend._sock,
@@ -1096,7 +1231,12 @@ def proxy(frontend, backend, capture=None):
     )
 
 
-def proxy_steerable(frontend, backend, capture=None, control=None):
+def proxy_steerable(
+    frontend: Socket,
+    backend: Socket,
+    capture: Optional[Socket] = None,
+    control: Optional[Socket] = None,
+) -> None:
     _native.native_proxy(
         frontend._sock,
         backend._sock,
@@ -1105,7 +1245,7 @@ def proxy_steerable(frontend, backend, capture=None, control=None):
     )
 
 
-def device(device_type, frontend, backend):
+def device(device_type: int, frontend: Socket, backend: Socket) -> None:
     proxy(frontend, backend)
 
 

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -484,6 +484,14 @@ class _SocketOptionsBase:
     set_string = setsockopt_string
     get_string = getsockopt_string
 
+
+class _BaseSocket(_SocketOptionsBase):
+    """Base class for Socket and asyncio.Socket.
+
+    Split from _SocketOptionsBase since _ShadowSocket has a smaller API.
+
+    """
+
     def set_curve_auth(self, auth: Any) -> Any:
         try:
             return self._sock.set_curve_auth(auth)
@@ -611,7 +619,7 @@ class _SocketMeta(type):
         return False
 
 
-class Socket(_SocketOptionsBase, metaclass=_SocketMeta):
+class Socket(_BaseSocket, metaclass=_SocketMeta):
     """Synchronous ZMQ socket wrapper."""
 
     _sock: _native.Socket

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -14,8 +14,8 @@ For asynchronous code::
 """
 
 from __future__ import annotations
-from collections.abc import Buffer
 
+import builtins
 import errno as _errno
 import itertools
 import json
@@ -34,12 +34,19 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Protocol,
     Tuple,
     Type,
     Union,
     SupportsIndex,
     SupportsBytes,
+    overload,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from . import _native  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from . import error as error  # noqa: F401
@@ -132,10 +139,12 @@ POLLOUT: Final[int] = 2
 POLLERR: Final[int] = 4
 POLLPRI: Final[int] = 32
 HWM: Final[int] = 1
+
+# Windows specific constants
+_IS_WINDOWS: Final[bool] = sys.platform == "win32"
 _WAKEUP_MODE_NONE: Final[int] = 0
 _WAKEUP_MODE_ASYNC: Final[int] = 1
 _WAKEUP_MODE_SYNC: Final[int] = 2
-_IS_WINDOWS: Final[bool] = sys.platform == "win32"
 
 ROUTING_ID: Final[int] = 5
 LAST_ENDPOINT: Final[int] = 32
@@ -297,19 +306,18 @@ class Message(bytes):
 
     def __new__(
         cls,
-        data: Union[
-            Iterable[SupportsIndex], SupportsIndex, SupportsBytes, Buffer
-        ] = b"",
+        # Work around teh fact in the scope bytes is the descriptor
+        data: builtins.bytes = b"",
         track: bool = False,
     ):
         return super().__new__(cls, data)
 
     @property
-    def bytes(self):
+    def bytes(self) -> builtins.bytes:
         return bytes(self)
 
     @property
-    def buffer(self):
+    def buffer(self) -> memoryview:
         return memoryview(bytes(self))
 
 
@@ -317,6 +325,40 @@ Frame = Message
 
 
 # ── Socket wrapper ───────────────────────────────────────────────────
+
+
+class _NativeSocket(Protocol):
+    """Protocol for native socket implementation (sync or async)."""
+
+    def getsockopt(self, option: int) -> Any: ...
+
+    def setsockopt(self, option: int, value: Any) -> Any: ...
+
+    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]: ...
+
+    def connect(self, endpoint: Union[str, bytes]) -> None: ...
+
+    def unbind(self, endpoint: Union[str, bytes]) -> None: ...
+
+    def disconnect(self, endpoint: Union[str, bytes]) -> None: ...
+
+    def subscribe(self, prefix: Union[bytes, str]) -> None: ...
+
+    def unsubscribe(self, prefix: Union[bytes, str]) -> None: ...
+
+    def join(self, group: Union[bytes, str]) -> None: ...
+
+    def leave(self, group: Union[bytes, str]) -> None: ...
+
+    def monitor(self) -> Any: ...
+
+    def connections(self) -> Any: ...
+
+    def connection_info(self, connection_id: int) -> Any: ...
+
+    def set_curve_auth(self, auth: Any) -> Any: ...
+
+    def close(self, linger: Optional[int] = None) -> None: ...
 
 
 # Socket option descriptor for IDE autocomplete support
@@ -338,14 +380,18 @@ class _SocketOptionDescriptor:
 
 
 class _SocketOptionsBase:
-    """Base class with socket option descriptors for IDE autocomplete."""
+    """Base class with socket option descriptors and shared methods."""
+
+    # Attributes (subclasses must define these)
+    _sock: _NativeSocket
+    _context: Context
+    _closed: bool
+    _last_endpoint: Optional[Union[bytes, str]]
 
     # Socket options
     affinity = _SocketOptionDescriptor(AFFINITY)
     identity = _SocketOptionDescriptor(IDENTITY)
     routing_id = _SocketOptionDescriptor(ROUTING_ID)
-    subscribe = _SocketOptionDescriptor(SUBSCRIBE)
-    unsubscribe = _SocketOptionDescriptor(UNSUBSCRIBE)
     rcvmore = _SocketOptionDescriptor(RCVMORE)
     sndhwm = _SocketOptionDescriptor(SNDHWM)
     rcvhwm = _SocketOptionDescriptor(RCVHWM)
@@ -382,11 +428,176 @@ class _SocketOptionsBase:
     plain_username = _SocketOptionDescriptor(PLAIN_USERNAME)
     plain_password = _SocketOptionDescriptor(PLAIN_PASSWORD)
 
+    # ── Shared properties ────────────────────────────────────────────
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def context(self) -> Context:
+        return self._context
+
+    @property
+    def socket_type(self) -> int:
+        return self._sock.getsockopt(TYPE)
+
     @property
     def last_endpoint(self) -> Optional[Union[bytes, str]]:
         return self._last_endpoint
 
-    _last_endpoint: Optional[Union[bytes, str]]
+    @property
+    def underlying(self) -> _SocketOptionsBase:
+        return self
+
+    # ── Options ──────────────────────────────────────────────────────
+
+    def setsockopt(self, option: int, value: Any) -> Any:
+        try:
+            return self._sock.setsockopt(option, value)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def getsockopt(self, option: int) -> Any:
+        if option == LAST_ENDPOINT:
+            return self._last_endpoint
+        try:
+            return self._sock.getsockopt(option)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def set(self, option: int, value: Any) -> Any:
+        return self.setsockopt(option, value)
+
+    def get(self, option: int) -> Any:
+        return self.getsockopt(option)
+
+    def setsockopt_string(
+        self, option: int, value: str, encoding: str = "utf-8"
+    ) -> Any:
+        return self.setsockopt(option, value.encode(encoding))
+
+    def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
+        v = self.getsockopt(option)
+        if isinstance(v, bytes):
+            return v.decode(encoding)
+        return str(v)
+
+    set_string = setsockopt_string
+    get_string = getsockopt_string
+
+    def set_curve_auth(self, auth: Any) -> Any:
+        try:
+            return self._sock.set_curve_auth(auth)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+        except AttributeError:
+            raise ZMQNotImplementedError("curve feature not compiled")
+
+    def set_hwm(self, value: int) -> None:
+        self.setsockopt(SNDHWM, value)
+        self.setsockopt(RCVHWM, value)
+
+    def get_hwm(self) -> int:
+        return self.getsockopt(SNDHWM)
+
+    hwm = property(get_hwm, set_hwm)
+
+    # ── Shared I/O methods ───────────────────────────────────────────
+
+    def fileno(self) -> int:
+        return self.getsockopt(FD)
+
+    @overload
+    def bind(self, endpoint: str) -> str: ...
+
+    @overload
+    def bind(self, endpoint: bytes) -> bytes: ...
+
+    def bind(self, endpoint):
+        try:
+            ep = self._sock.bind(self._context._namespace_inproc(endpoint))
+            self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
+            return ep
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def connect(self, endpoint: Union[str, bytes]) -> None:
+        if isinstance(endpoint, bytes):
+            endpoint = endpoint.decode("utf-8")
+        try:
+            self._sock.connect(self._context._namespace_inproc(endpoint))
+            self._last_endpoint = (
+                endpoint.encode() if isinstance(endpoint, str) else endpoint
+            )
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def unbind(self, endpoint: Union[str, bytes]) -> None:
+        try:
+            return self._sock.unbind(self._context._namespace_inproc(endpoint))
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def disconnect(self, endpoint: Union[str, bytes]) -> None:
+        try:
+            return self._sock.disconnect(self._context._namespace_inproc(endpoint))
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    # ── Subscriptions ────────────────────────────────────────────────
+
+    def subscribe(self, prefix: Union[bytes, str]) -> None:
+        try:
+            return self._sock.subscribe(prefix)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
+        try:
+            return self._sock.unsubscribe(prefix)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def join(self, group: Union[bytes, str]) -> None:
+        try:
+            return self._sock.join(group)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    def leave(self, group: Union[bytes, str]) -> None:
+        try:
+            return self._sock.leave(group)
+        except _native.ZMQError as e:
+            raise error.from_native(e) from None
+
+    # ── Monitoring ───────────────────────────────────────────────────
+
+    def monitor(self) -> Any:
+        return self._sock.monitor()
+
+    def connections(self) -> Any:
+        return self._sock.connections()
+
+    def connection_info(self, connection_id: int) -> Any:
+        return self._sock.connection_info(connection_id)
+
+    # ── Lifecycle ────────────────────────────────────────────────────
+
+    def close(self, linger: Optional[int] = None) -> None:
+        if not self._closed:
+            self._closed = True
+            self._sock.close(linger)
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: Any) -> bool:
+        self.close()
+        return False
 
 
 class _SocketMeta(type):
@@ -436,79 +647,7 @@ class Socket(_SocketOptionsBase, metaclass=_SocketMeta):
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
         return f"<pyomq.Socket(pyomq.{st}) at {id(self):#x}>"
 
-    @property
-    def closed(self) -> bool:
-        return self._closed
-
-    @property
-    def context(self) -> Context:
-        return self._context
-
-    @property
-    def socket_type(self) -> int:
-        return self._sock.getsockopt(TYPE)
-
-    @property
-    def underlying(self) -> Socket:
-        return self
-
     # ── I/O ──────────────────────────────────────────────────────────
-
-    def fileno(self) -> int:
-        return self.getsockopt(FD)
-
-    @property
-    def last_endpoint(self) -> Optional[Union[bytes, str]]:
-        return self._last_endpoint
-
-    def _check_fork(self) -> None:
-        pid = os.getpid()
-        if pid == self._pid:
-            return
-        self._pid = pid
-        for ep in self._binds:
-            try:
-                self._sock.bind(self._context._namespace_inproc(ep))
-            except _native.ZMQError:
-                pass
-        for ep in self._connects:
-            try:
-                self._sock.connect(self._context._namespace_inproc(ep))
-            except _native.ZMQError:
-                pass
-
-    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
-        try:
-            ep = self._sock.bind(self._context._namespace_inproc(endpoint))
-            self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
-            self._binds.append(endpoint)
-            return ep
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def connect(self, endpoint: Union[str, bytes]) -> None:
-        if isinstance(endpoint, bytes):
-            endpoint = endpoint.decode("utf-8")
-        try:
-            self._sock.connect(self._context._namespace_inproc(endpoint))
-            self._last_endpoint = (
-                endpoint.encode() if isinstance(endpoint, str) else endpoint
-            )
-            self._connects.append(endpoint)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def unbind(self, endpoint: Union[str, bytes]) -> None:
-        try:
-            return self._sock.unbind(self._context._namespace_inproc(endpoint))
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def disconnect(self, endpoint: Union[str, bytes]) -> None:
-        try:
-            return self._sock.disconnect(self._context._namespace_inproc(endpoint))
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
 
     def send(
         self,
@@ -609,106 +748,6 @@ class Socket(_SocketOptionsBase, metaclass=_SocketMeta):
         frames = self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
-    # ── Options ──────────────────────────────────────────────────────
-
-    def setsockopt(self, option: int, value: Any) -> Any:
-        try:
-            return self._sock.setsockopt(option, value)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def getsockopt(self, option: int) -> Any:
-        if option == LAST_ENDPOINT:
-            return self._last_endpoint
-        try:
-            return self._sock.getsockopt(option)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def set(self, option: int, value: Any) -> Any:
-        return self.setsockopt(option, value)
-
-    def get(self, option: int) -> Any:
-        return self.getsockopt(option)
-
-    def setsockopt_string(
-        self, option: int, value: str, encoding: str = "utf-8"
-    ) -> Any:
-        return self.setsockopt(option, value.encode(encoding))
-
-    def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
-        v = self.getsockopt(option)
-        if isinstance(v, bytes):
-            return v.decode(encoding)
-        return str(v)
-
-    set_string = setsockopt_string
-    get_string = getsockopt_string
-
-    def set_curve_auth(self, auth: Any) -> Any:
-        try:
-            return self._sock.set_curve_auth(auth)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-        except AttributeError:
-            raise ZMQNotImplementedError("curve feature not compiled")
-
-    def set_hwm(self, value: int) -> None:
-        self.setsockopt(SNDHWM, value)
-        self.setsockopt(RCVHWM, value)
-
-    def get_hwm(self) -> int:
-        return self.getsockopt(SNDHWM)
-
-    hwm = property(get_hwm, set_hwm)
-
-    # ── Subscriptions ────────────────────────────────────────────────
-
-    def subscribe(self, prefix: Union[bytes, str]) -> None:
-        try:
-            return self._sock.subscribe(prefix)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
-        try:
-            return self._sock.unsubscribe(prefix)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def join(self, group: Union[bytes, str]) -> None:
-        try:
-            return self._sock.join(group)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def leave(self, group: Union[bytes, str]) -> None:
-        try:
-            return self._sock.leave(group)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    # ── Monitoring ───────────────────────────────────────────────────
-
-    def monitor(self) -> Any:
-        return self._sock.monitor()
-
-    def connections(self) -> Any:
-        return self._sock.connections()
-
-    def connection_info(self, connection_id: int) -> Any:
-        return self._sock.connection_info(connection_id)
-
-    # ── Lifecycle ────────────────────────────────────────────────────
-
-    def close(self, linger: Optional[int] = None) -> None:
-        if not self._closed:
-            self._closed = True
-            self._sock.close(linger)
-
-    def __del__(self) -> None:
-        self.close()
-
     def bind_to_random_port(
         self,
         addr: str,
@@ -729,13 +768,6 @@ class Socket(_SocketOptionsBase, metaclass=_SocketMeta):
             if sock is self:
                 return mask
         return 0
-
-    def __enter__(self) -> Socket:
-        return self
-
-    def __exit__(self, *args: Any) -> bool:
-        self.close()
-        return False
 
 
 # ── Shadow socket (sync recv bridge over async handle) ──────────────
@@ -1083,8 +1115,6 @@ class Context:
         s._closed = False
         s._last_endpoint = None
         s._pid = os.getpid()
-        s._binds = []
-        s._connects = []
         self._sockets.add(s)
         return s
 

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -28,16 +28,10 @@ import weakref
 from typing import (
     Any,
     Callable,
-    Dict,
     Final,
     Iterable,
     Iterator,
-    List,
-    Optional,
     Protocol,
-    Tuple,
-    Type,
-    Union,
     overload,
 )
 
@@ -201,7 +195,7 @@ EADDRINUSE: Final[int] = _errno.EADDRINUSE
 EADDRNOTAVAIL: Final[int] = _errno.EADDRNOTAVAIL
 
 __version__: Final[str] = version()
-zmq_version_info: Final[Tuple[int, int, int]] = (4, 3, 4)
+zmq_version_info: Final[tuple[int, int, int]] = (4, 3, 4)
 
 
 # ── Top-level functions ──────────────────────────────────────────────
@@ -219,7 +213,7 @@ def pyomq_version() -> str:
     return __version__
 
 
-def pyomq_version_info() -> Tuple[int, ...]:
+def pyomq_version_info() -> tuple[int, ...]:
     parts = __version__.split(".")
     return tuple(int(p) for p in parts[:3])
 
@@ -233,13 +227,13 @@ def has(capability: str) -> bool:
     return False
 
 
-def curve_keypair() -> Tuple[bytes, bytes]:
+def curve_keypair() -> tuple[bytes, bytes]:
     if not hasattr(_native, "curve_keypair"):
         raise ZMQNotImplementedError("curve feature not compiled")
     return _native.curve_keypair()
 
 
-def curve_public(secret: Union[bytes, str]) -> bytes:
+def curve_public(secret: bytes | str) -> bytes:
     if not hasattr(_native, "curve_public"):
         raise ZMQNotImplementedError("curve feature not compiled")
     if isinstance(secret, str):
@@ -253,7 +247,7 @@ if hasattr(_native, "PeerInfo"):
 
 # ── Socket option attribute map ──────────────────────────────────────
 
-_TYPE_NAMES: Final[Dict[int, str]] = {
+_TYPE_NAMES: Final[dict[int, str]] = {
     PAIR: "PAIR",
     PUB: "PUB",
     SUB: "SUB",
@@ -292,7 +286,7 @@ class MessageTracker:
     def __init__(self, *args: Any, _pending: bool = False, **kwargs: Any) -> None:
         self.done = not _pending
 
-    def wait(self, timeout: Optional[int] = None) -> None:
+    def wait(self, timeout: int | None = None) -> None:
         if not self.done:
             raise NotDone
 
@@ -300,7 +294,7 @@ class MessageTracker:
 class Message(bytes):
     """Message class that extends bytes (pyzmq compatibility)."""
 
-    tracker: Optional[MessageTracker] = None
+    tracker: MessageTracker | None = None
 
     def __new__(
         cls,
@@ -332,21 +326,21 @@ class _NativeSocket(Protocol):
 
     def setsockopt(self, option: int, value: Any) -> Any: ...
 
-    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]: ...
+    def bind(self, endpoint: str | bytes) -> str | bytes: ...
 
-    def connect(self, endpoint: Union[str, bytes]) -> None: ...
+    def connect(self, endpoint: str | bytes) -> None: ...
 
-    def unbind(self, endpoint: Union[str, bytes]) -> None: ...
+    def unbind(self, endpoint: str | bytes) -> None: ...
 
-    def disconnect(self, endpoint: Union[str, bytes]) -> None: ...
+    def disconnect(self, endpoint: str | bytes) -> None: ...
 
-    def subscribe(self, prefix: Union[bytes, str]) -> None: ...
+    def subscribe(self, prefix: bytes | str) -> None: ...
 
-    def unsubscribe(self, prefix: Union[bytes, str]) -> None: ...
+    def unsubscribe(self, prefix: bytes | str) -> None: ...
 
-    def join(self, group: Union[bytes, str]) -> None: ...
+    def join(self, group: bytes | str) -> None: ...
 
-    def leave(self, group: Union[bytes, str]) -> None: ...
+    def leave(self, group: bytes | str) -> None: ...
 
     def monitor(self) -> Any: ...
 
@@ -356,7 +350,7 @@ class _NativeSocket(Protocol):
 
     def set_curve_auth(self, auth: Any) -> Any: ...
 
-    def close(self, linger: Optional[int] = None) -> None: ...
+    def close(self, linger: int | None = None) -> None: ...
 
 
 # Socket option descriptor for IDE autocomplete support
@@ -366,7 +360,7 @@ class _SocketOptionDescriptor:
     def __init__(self, option_code: int) -> None:
         self.option_code = option_code
 
-    def __get__(self, obj: Any, objtype: Optional[Type[Any]] = None) -> Any:
+    def __get__(self, obj: Any, objtype: type[Any] | None = None) -> Any:
         if obj is None:
             return self
         if self.option_code == LAST_ENDPOINT:
@@ -384,7 +378,7 @@ class _SocketOptionsBase:
     _sock: _NativeSocket
     _context: Context
     _closed: bool
-    _last_endpoint: Optional[Union[bytes, str]]
+    _last_endpoint: bytes | str | None
 
     # Socket options
     affinity = _SocketOptionDescriptor(AFFINITY)
@@ -441,7 +435,7 @@ class _SocketOptionsBase:
         return self._sock.getsockopt(TYPE)
 
     @property
-    def last_endpoint(self) -> Optional[Union[bytes, str]]:
+    def last_endpoint(self) -> bytes | str | None:
         return self._last_endpoint
 
     @property
@@ -528,7 +522,7 @@ class _BaseSocket(_SocketOptionsBase):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def connect(self, endpoint: Union[str, bytes]) -> None:
+    def connect(self, endpoint: str | bytes) -> None:
         if isinstance(endpoint, bytes):
             endpoint = endpoint.decode("utf-8")
         try:
@@ -539,13 +533,13 @@ class _BaseSocket(_SocketOptionsBase):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unbind(self, endpoint: Union[str, bytes]) -> None:
+    def unbind(self, endpoint: str | bytes) -> None:
         try:
             return self._sock.unbind(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def disconnect(self, endpoint: Union[str, bytes]) -> None:
+    def disconnect(self, endpoint: str | bytes) -> None:
         try:
             return self._sock.disconnect(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
@@ -553,25 +547,25 @@ class _BaseSocket(_SocketOptionsBase):
 
     # ── Subscriptions ────────────────────────────────────────────────
 
-    def subscribe(self, prefix: Union[bytes, str]) -> None:
+    def subscribe(self, prefix: bytes | str) -> None:
         try:
             return self._sock.subscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
+    def unsubscribe(self, prefix: bytes | str) -> None:
         try:
             return self._sock.unsubscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def join(self, group: Union[bytes, str]) -> None:
+    def join(self, group: bytes | str) -> None:
         try:
             return self._sock.join(group)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def leave(self, group: Union[bytes, str]) -> None:
+    def leave(self, group: bytes | str) -> None:
         try:
             return self._sock.leave(group)
         except _native.ZMQError as e:
@@ -590,7 +584,7 @@ class _BaseSocket(_SocketOptionsBase):
 
     # ── Lifecycle ────────────────────────────────────────────────────
 
-    def close(self, linger: Optional[int] = None) -> None:
+    def close(self, linger: int | None = None) -> None:
         if not self._closed:
             self._closed = True
             self._sock.close(linger)
@@ -626,8 +620,8 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
     _context: Context
     _closed: bool
     _pid: int
-    _binds: List[Union[str, bytes]]
-    _connects: List[Union[str, bytes]]
+    _binds: list[str | bytes]
+    _connects: list[str | bytes]
 
     def __init__(self, _sock: _native.Socket, _context: Context) -> None:
         self._sock = _sock
@@ -638,11 +632,11 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
         self._binds = []
         self._connects = []
 
-    def __class_getitem__(cls, item: Any) -> Type[Socket]:
+    def __class_getitem__(cls, item: Any) -> type[Socket]:
         return cls
 
     @classmethod
-    def shadow(cls, socket: Any) -> Union[Socket, _ShadowSocket]:
+    def shadow(cls, socket: Any) -> Socket | _ShadowSocket:
         from . import asyncio as _zmq_async
 
         if isinstance(socket, _zmq_async.Socket):
@@ -657,11 +651,11 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send(
         self,
-        data: Union[bytes, str],
+        data: bytes | str,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         try:
             self._sock.send(data, flags)
         except _native.ZMQError as e:
@@ -672,7 +666,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Union[bytes, Frame]:
+    ) -> bytes | Frame:
         try:
             data = self._sock.recv(flags)
         except _native.ZMQError as e:
@@ -683,11 +677,11 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send_multipart(
         self,
-        parts: Iterable[Union[bytes, str]],
+        parts: Iterable[bytes | str],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         parts = [p.encode("utf-8") if isinstance(p, str) else p for p in parts]
         try:
             self._sock.send_multipart(parts, flags)
@@ -699,7 +693,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> List[Union[bytes, Frame]]:
+    ) -> list[bytes | Frame]:
         try:
             parts = self._sock.recv_multipart(flags)
         except _native.ZMQError as e:
@@ -712,7 +706,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send_string(
         self, u: str, flags: int = 0, encoding: str = "utf-8"
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         return self.send(u.encode(encoding), flags)
 
     def recv_string(self, flags: int = 0, encoding: str = "utf-8") -> str:
@@ -720,7 +714,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send_json(
         self, obj: Any, flags: int = 0, **kwargs: Any
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
     def recv_json(self, flags: int = 0, **kwargs: Any) -> Any:
@@ -728,7 +722,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send_pyobj(
         self, obj: Any, flags: int = 0, protocol: int = -1
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         return self.send(pickle.dumps(obj, protocol), flags)
 
     def recv_pyobj(self, flags: int = 0) -> Any:
@@ -737,17 +731,17 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
     def send_serialized(
         self,
         msg: Any,
-        serialize: Callable[[Any], List[bytes]],
+        serialize: Callable[[Any], list[bytes]],
         flags: int = 0,
         copy: bool = True,
         **kwargs: Any,
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
     def recv_serialized(
         self,
-        deserialize: Callable[[List[bytes]], Any],
+        deserialize: Callable[[list[bytes]], Any],
         flags: int = 0,
         copy: bool = True,
     ) -> Any:
@@ -766,7 +760,7 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
             ep = ep.decode()
         return int(ep.rsplit(":", 1)[1])
 
-    def poll(self, timeout: Optional[int] = None, flags: int = POLLIN) -> int:
+    def poll(self, timeout: int | None = None, flags: int = POLLIN) -> int:
         p = Poller()
         p.register(self, flags)
         evts = p.poll(timeout)
@@ -928,7 +922,7 @@ class _ShadowSocket(_SocketOptionsBase):
 
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Union[bytes, Frame]:
+    ) -> bytes | Frame:
         data = self._blocking_recv(self._native._try_recv)
         if not copy:
             return Frame(data)
@@ -936,7 +930,7 @@ class _ShadowSocket(_SocketOptionsBase):
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> List[Union[bytes, Frame]]:
+    ) -> list[bytes | Frame]:
         parts = self._blocking_recv(self._native._try_recv_multipart)
         if not copy:
             return [Frame(p) for p in parts]
@@ -944,11 +938,11 @@ class _ShadowSocket(_SocketOptionsBase):
 
     def send(
         self,
-        data: Union[bytes, str],
+        data: bytes | str,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         self._blocking_send(lambda: self._native.send(data, flags))
         if track:
             return MessageTracker(_pending=True)
@@ -956,11 +950,11 @@ class _ShadowSocket(_SocketOptionsBase):
 
     def send_multipart(
         self,
-        parts: List[Union[bytes, str]],
+        parts: list[bytes | str],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Optional[MessageTracker]:
+    ) -> MessageTracker | None:
         self._blocking_send(lambda: self._native.send_multipart(parts, flags))
         if track:
             return MessageTracker(_pending=True)
@@ -1040,7 +1034,7 @@ class _ShadowSocket(_SocketOptionsBase):
             finally:
                 os.close(fd)
 
-    def close(self, linger: Optional[int] = None) -> None:
+    def close(self, linger: int | None = None) -> None:
         pass
 
 
@@ -1054,9 +1048,9 @@ _INPROC_PREFIX: Final[str] = "inproc://"
 class Context:
     """Synchronous ZMQ context."""
 
-    _instance: Optional[Context] = None
+    _instance: Context | None = None
     _instance_lock: threading.Lock = threading.Lock()
-    _socket_class: Optional[Type[Socket]] = None  # set after Socket is defined
+    _socket_class: type[Socket] | None = None  # set after Socket is defined
     _ctx: _native.Context
     _is_shadow: bool
     _closed: bool
@@ -1064,7 +1058,7 @@ class Context:
     _ctx_id: int
 
     def __init__(
-        self, io_threads: int = 1, *, _shadow_ctx: Optional[Context] = None
+        self, io_threads: int = 1, *, _shadow_ctx: Context | None = None
     ) -> None:
         if _shadow_ctx is not None:
             self._ctx = _shadow_ctx._ctx
@@ -1076,7 +1070,7 @@ class Context:
         self._sockets = weakref.WeakSet()
         self._ctx_id = next(_next_ctx_id)
 
-    def _namespace_inproc(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
+    def _namespace_inproc(self, endpoint: str | bytes) -> str | bytes:
         # libzmq scopes inproc per-context; omq's registry is global. pytest
         # holds frame references to locals (traceback capture), so __del__
         # never fires and the old socket's registry entry stays alive. Next
@@ -1100,7 +1094,7 @@ class Context:
                 return f"inproc://{ns_str}{endpoint[len(_INPROC_PREFIX) :]}"
         return endpoint
 
-    def __class_getitem__(cls, item: Any) -> Type[Context]:
+    def __class_getitem__(cls, item: Any) -> type[Context]:
         return cls
 
     @property
@@ -1110,7 +1104,7 @@ class Context:
     def socket(
         self,
         socket_type: int,
-        socket_class: Optional[Type[Socket]] = None,
+        socket_class: type[Socket] | None = None,
         **kwargs: Any,
     ) -> Socket:
         native = self._ctx.socket(socket_type)
@@ -1125,7 +1119,7 @@ class Context:
         return s
 
     @classmethod
-    def shadow(cls, address: Union[Context, int]) -> Context:
+    def shadow(cls, address: Context | int) -> Context:
         if isinstance(address, Context):
             return cls(_shadow_ctx=address)
         if isinstance(address, int):
@@ -1148,7 +1142,7 @@ class Context:
         if not self._is_shadow:
             self._ctx.term()
 
-    def destroy(self, linger: Optional[int] = None) -> None:
+    def destroy(self, linger: int | None = None) -> None:
         for s in list(self._sockets):
             if not s.closed:
                 if linger is not None:
@@ -1178,7 +1172,7 @@ Context._socket_class = Socket
 class Poller:
     """Synchronous poller for ZMQ sockets."""
 
-    _sockets: Dict[int, Tuple[Socket, int]]
+    _sockets: dict[int, tuple[Socket, int]]
 
     def __init__(self) -> None:
         self._sockets = {}  # native_socket_id -> (Socket, flags)
@@ -1195,10 +1189,10 @@ class Poller:
             self._sockets[k] = (socket, flags)
 
     @property
-    def sockets(self) -> List[Tuple[Socket, int]]:
+    def sockets(self) -> list[tuple[Socket, int]]:
         return [(s, f) for s, f in self._sockets.values()]
 
-    def poll(self, timeout: Optional[int] = None) -> List[Tuple[Socket, int]]:
+    def poll(self, timeout: int | None = None) -> list[tuple[Socket, int]]:
         if not self._sockets:
             return []
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
@@ -1218,8 +1212,8 @@ def select(
     rlist: Iterable[Socket],
     wlist: Iterable[Socket],
     xlist: Iterable[Socket],
-    timeout: Optional[float] = None,
-) -> Tuple[List[Socket], List[Socket], List[Socket]]:
+    timeout: float | None = None,
+) -> tuple[list[Socket], list[Socket], list[Socket]]:
     if timeout is not None:
         timeout_ms = int(timeout * 1000)
     else:
@@ -1230,9 +1224,9 @@ def select(
     for s in wlist:
         p.register(s, POLLOUT)
     evts = p.poll(timeout_ms)
-    rready: List[Socket] = []
-    wready: List[Socket] = []
-    xready: List[Socket] = []
+    rready: list[Socket] = []
+    wready: list[Socket] = []
+    xready: list[Socket] = []
     for sock, mask in evts:
         if mask & POLLIN:
             rready.append(sock)
@@ -1244,7 +1238,7 @@ def select(
 # ── proxy ────────────────────────────────────────────────────────────
 
 
-def proxy(frontend: Socket, backend: Socket, capture: Optional[Socket] = None) -> None:
+def proxy(frontend: Socket, backend: Socket, capture: Socket | None = None) -> None:
     _native.native_proxy(
         frontend._sock,
         backend._sock,
@@ -1255,8 +1249,8 @@ def proxy(frontend: Socket, backend: Socket, capture: Optional[Socket] = None) -
 def proxy_steerable(
     frontend: Socket,
     backend: Socket,
-    capture: Optional[Socket] = None,
-    control: Optional[Socket] = None,
+    capture: Socket | None = None,
+    control: Socket | None = None,
 ) -> None:
     _native.native_proxy(
         frontend._sock,

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -25,19 +25,16 @@ import sys
 import threading
 import weakref
 from collections import deque
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Awaitable, Callable, Dict, Final, List, Optional, Tuple, Union
 
 from . import _native  # type: ignore[attr-defined]
 from . import error
 from . import Context as _SyncContext
 from . import _next_ctx_id
 from . import (
-    FD,
-    POLLIN,
-    SNDHWM,
-    RCVHWM,
     LINGER,
     _TYPE_NAMES,
+    POLLIN,
     _SocketOptionsBase,
 )
 
@@ -54,8 +51,8 @@ def _resolved_future(result: Any) -> asyncio.Future[Any]:
     return fut
 
 
-_EAGAIN = _errno.EAGAIN
-_MISSING = object()
+_EAGAIN: Final[int] = _errno.EAGAIN
+_MISSING: Final[object] = object()
 
 
 class _DoneFuture:
@@ -72,7 +69,7 @@ class _DoneFuture:
         return True
 
 
-_SEND_DONE = _DoneFuture()
+_SEND_DONE: Final[_DoneFuture] = _DoneFuture()
 
 
 class _RecvFuture:
@@ -209,60 +206,6 @@ class Socket(_SocketOptionsBase):
     def __repr__(self) -> str:
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
         return f"<pyomq.asyncio.Socket(pyomq.{st}) at {id(self):#x}>"
-
-    @property
-    def closed(self) -> bool:
-        return self._closed
-
-    @property
-    def context(self) -> Context:
-        return self._context
-
-    @property
-    def last_endpoint(self) -> Optional[Union[bytes, str]]:
-        return self._last_endpoint
-
-    @property
-    def socket_type(self) -> int:
-        return self._sock.getsockopt(_native.TYPE)
-
-    @property
-    def underlying(self) -> Socket:
-        return self
-
-    # ── I/O ──────────────────────────────────────────────────────────
-
-    def fileno(self) -> int:
-        return self.getsockopt(FD)
-
-    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
-        try:
-            ep = self._sock.bind(self._context._namespace_inproc(endpoint))
-            self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
-            return ep
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def connect(self, endpoint: Union[str, bytes]) -> None:
-        try:
-            self._sock.connect(self._context._namespace_inproc(endpoint))
-            self._last_endpoint = (
-                endpoint.encode() if isinstance(endpoint, str) else endpoint
-            )
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def unbind(self, endpoint: Union[str, bytes]) -> None:
-        try:
-            return self._sock.unbind(self._context._namespace_inproc(endpoint))
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def disconnect(self, endpoint: Union[str, bytes]) -> None:
-        try:
-            return self._sock.disconnect(self._context._namespace_inproc(endpoint))
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
 
     def send(
         self,
@@ -609,109 +552,15 @@ class Socket(_SocketOptionsBase):
         frames = await self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
-    # ── Options (sync -- matches pyzmq) ──────────────────────────────
-
-    def setsockopt(self, option: int, value: Any) -> Any:
-        try:
-            return self._sock.setsockopt(option, value)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def getsockopt(self, option: int) -> Any:
-        from pyomq import LAST_ENDPOINT
-
-        if option == LAST_ENDPOINT:
-            return self._last_endpoint
-        try:
-            return self._sock.getsockopt(option)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def set(self, option: int, value: Any) -> Any:
-        return self.setsockopt(option, value)
-
-    def get(self, option: int) -> Any:
-        return self.getsockopt(option)
-
-    def setsockopt_string(
-        self, option: int, value: str, encoding: str = "utf-8"
-    ) -> Any:
-        return self.setsockopt(option, value.encode(encoding))
-
-    def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
-        v = self.getsockopt(option)
-        if isinstance(v, bytes):
-            return v.decode(encoding)
-        return str(v)
-
-    set_string = setsockopt_string
-    get_string = getsockopt_string
-
-    def set_curve_auth(self, auth: Any) -> Any:
-        try:
-            return self._sock.set_curve_auth(auth)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-        except AttributeError:
-            from . import ZMQNotImplementedError
-
-            raise ZMQNotImplementedError("curve feature not compiled")
-
-    def set_hwm(self, value: int) -> None:
-        self.setsockopt(SNDHWM, value)
-        self.setsockopt(RCVHWM, value)
-
-    def get_hwm(self) -> int:
-        return self.getsockopt(SNDHWM)
-
-    hwm = property(get_hwm, set_hwm)
-
     # ── Subscriptions ────────────────────────────────────────────────
 
-    def subscribe(self, prefix: Union[bytes, str]) -> None:
-        try:
-            return self._sock.subscribe(prefix)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
-        try:
-            return self._sock.unsubscribe(prefix)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def join(self, group: Union[bytes, str]) -> None:
-        try:
-            return self._sock.join(group)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
-
-    def leave(self, group: Union[bytes, str]) -> None:
-        try:
-            return self._sock.leave(group)
-        except _native.ZMQError as e:
-            raise error.from_native(e) from None
+    # Note: subscribe(), unsubscribe(), join(), leave() inherited from base
 
     # ── Monitoring ───────────────────────────────────────────────────
 
-    def monitor(self) -> Any:
-        return self._sock.monitor()
-
-    def connections(self) -> Any:
-        return self._sock.connections()
-
-    def connection_info(self, connection_id: int) -> Any:
-        return self._sock.connection_info(connection_id)
+    # Note: monitor(), connections(), connection_info() inherited from base
 
     # ── Lifecycle ────────────────────────────────────────────────────
-
-    def close(self, linger: Optional[int] = None) -> None:
-        if not self._closed:
-            self._closed = True
-            self._sock.close(linger)
-
-    def __del__(self) -> None:
-        self.close()
 
     async def poll(self, timeout: Optional[int] = None, flags: int = POLLIN) -> int:
         p = Poller()
@@ -721,13 +570,6 @@ class Socket(_SocketOptionsBase):
             if sock is self:
                 return mask
         return 0
-
-    def __enter__(self) -> Socket:
-        return self
-
-    def __exit__(self, *args: Any) -> bool:
-        self.close()
-        return False
 
     async def __aenter__(self) -> Socket:
         return self
@@ -801,8 +643,11 @@ class Context(_SyncContext):
         return self._closed
 
     def socket(
-        self, socket_type: int, socket_class: Optional[type] = None, **kwargs: Any
-    ) -> Any:
+        self,
+        socket_type: int,
+        socket_class: Optional[type[Socket]] = None,
+        **kwargs: Any,
+    ) -> Socket:  # ty: ignore
         native = self._ctx.socket(socket_type)
         cls = socket_class or Socket
         s = object.__new__(cls)

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -35,7 +35,7 @@ from . import (
     LINGER,
     _TYPE_NAMES,
     POLLIN,
-    _SocketOptionsBase,
+    _BaseSocket,
 )
 
 _IS_WINDOWS = sys.platform == "win32"
@@ -174,7 +174,7 @@ class _RecvFuture:
         return (yield from fut.__await__())
 
 
-class Socket(_SocketOptionsBase):
+class Socket(_BaseSocket):
     """Async ZMQ socket wrapper."""
 
     _sock: _native.AsyncSocket

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -13,6 +13,8 @@ Use::
     sock.close()
 """
 
+from __future__ import annotations
+
 import asyncio
 import errno as _errno
 import json
@@ -23,6 +25,7 @@ import sys
 import threading
 import weakref
 from collections import deque
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
 from . import _native  # type: ignore[attr-defined]
 from . import error
@@ -45,9 +48,9 @@ _WAKEUP_MODE_ASYNC = 1
 _WAKEUP_MODE_SYNC = 2
 
 
-def _resolved_future(result):
+def _resolved_future(result: Any) -> asyncio.Future[Any]:
     loop = asyncio.get_running_loop()
-    fut = loop.create_future()
+    fut: asyncio.Future[Any] = loop.create_future()
     fut.set_result(result)
     return fut
 
@@ -59,14 +62,14 @@ _MISSING = object()
 class _DoneFuture:
     """Lightweight awaitable that resolves immediately to None."""
 
-    def __await__(self):
+    def __await__(self) -> Any:
         return
         yield  # makes this a generator
 
-    def result(self):
+    def result(self) -> None:
         return None
 
-    def done(self):
+    def done(self) -> bool:
         return True
 
 
@@ -78,13 +81,18 @@ class _RecvFuture:
 
     __slots__ = ("_try_fn", "_fd", "_result", "_exception")
 
-    def __init__(self, try_fn, fd):
+    _try_fn: Callable[[], Any]
+    _fd: int
+    _result: Any
+    _exception: Optional[Exception]
+
+    def __init__(self, try_fn: Callable[[], Any], fd: int) -> None:
         self._try_fn = try_fn
         self._fd = fd
         self._result = _MISSING
         self._exception = None
 
-    def done(self):
+    def done(self) -> bool:
         if self._result is not _MISSING or self._exception is not None:
             return True
         try:
@@ -97,7 +105,7 @@ class _RecvFuture:
             return True
         return False
 
-    def result(self):
+    def result(self) -> Any:
         if self._exception is not None:
             raise self._exception
         if self._result is not _MISSING:
@@ -122,7 +130,7 @@ class _RecvFuture:
                 os.close(self._fd)
                 self._fd = -1
 
-    def __await__(self):
+    def __await__(self) -> Any:
         if self.done():
             if self._fd >= 0:
                 os.close(self._fd)
@@ -132,12 +140,12 @@ class _RecvFuture:
             return self._result
 
         loop = asyncio.get_running_loop()
-        fut = loop.create_future()
+        fut: asyncio.Future[Any] = loop.create_future()
         fd = self._fd
         self._fd = -1
         try_fn = self._try_fn
 
-        def _on_readable():
+        def _on_readable() -> None:
             try:
                 os.read(fd, 8)
             except OSError:
@@ -160,7 +168,7 @@ class _RecvFuture:
                 if not fut.done():
                     fut.set_result(r)
 
-        def _on_cancel(f):
+        def _on_cancel(f: asyncio.Future[Any]) -> None:
             if f.cancelled():
                 loop.remove_reader(fd)
                 os.close(fd)
@@ -171,11 +179,20 @@ class _RecvFuture:
 
 
 class Socket:
-    _sock: _native.AsyncSocket
-    _context: "Context"
-    _closed: bool
+    """Async ZMQ socket wrapper."""
 
-    def _init_socket_state(self, _sock, _context):
+    _sock: _native.AsyncSocket
+    _context: Context
+    _closed: bool
+    _last_endpoint: Optional[Union[bytes, str]]
+    _loop: Optional[asyncio.AbstractEventLoop]
+    _recv_waiters: deque[Callable[[], bool]]
+    _send_waiters: deque[Callable[[], bool]]
+    _recv_wakeup_event: threading.Event
+    _send_wakeup_event: threading.Event
+    _wakeup_registered: bool
+
+    def _init_socket_state(self, _sock: _native.AsyncSocket, _context: Context) -> None:
         self._sock = _sock
         self._context = _context
         self._closed = False
@@ -188,10 +205,10 @@ class Socket:
             self._send_wakeup_event = threading.Event()
             self._wakeup_registered = False
 
-    def __init__(self, _sock, _context):
+    def __init__(self, _sock: _native.AsyncSocket, _context: Context) -> None:
         self._init_socket_state(_sock, _context)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         opt = _SOCKOPT_NAMES.get(name)
         if opt is not None:
             if opt == LAST_ENDPOINT:
@@ -201,7 +218,7 @@ class Socket:
             f"'{type(self).__name__}' object has no attribute '{name}'"
         )
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name.startswith("_"):
             object.__setattr__(self, name, value)
             return
@@ -211,36 +228,36 @@ class Socket:
             return
         object.__setattr__(self, name, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
         return f"<pyomq.asyncio.Socket(pyomq.{st}) at {id(self):#x}>"
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._closed
 
     @property
-    def context(self):
+    def context(self) -> Context:
         return self._context
 
     @property
-    def last_endpoint(self):
+    def last_endpoint(self) -> Optional[Union[bytes, str]]:
         return self._last_endpoint
 
     @property
-    def socket_type(self):
+    def socket_type(self) -> int:
         return self._sock.getsockopt(_native.TYPE)
 
     @property
-    def underlying(self):
+    def underlying(self) -> Socket:
         return self
 
     # ── I/O ──────────────────────────────────────────────────────────
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self.getsockopt(FD)
 
-    def bind(self, endpoint):
+    def bind(self, endpoint: Union[str, bytes]) -> Union[str, bytes]:
         try:
             ep = self._sock.bind(self._context._namespace_inproc(endpoint))
             self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
@@ -248,7 +265,7 @@ class Socket:
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def connect(self, endpoint):
+    def connect(self, endpoint: Union[str, bytes]) -> None:
         try:
             self._sock.connect(self._context._namespace_inproc(endpoint))
             self._last_endpoint = (
@@ -257,19 +274,25 @@ class Socket:
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unbind(self, endpoint):
+    def unbind(self, endpoint: Union[str, bytes]) -> None:
         try:
             return self._sock.unbind(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def disconnect(self, endpoint):
+    def disconnect(self, endpoint: Union[str, bytes]) -> None:
         try:
             return self._sock.disconnect(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def send(self, data, flags=0, copy=True, track=False):
+    def send(
+        self,
+        data: Union[bytes, str],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Awaitable[Optional[Any]]:
         try:
             self._sock.send(data, flags)
         except _native.ZMQError as e:
@@ -278,18 +301,26 @@ class Socket:
             raise error.from_native(e) from None
         return _SEND_DONE
 
-    def recv(self, flags=0, copy=True, track=False):
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> Awaitable[Union[bytes, Any]]:
         if not copy:
             from pyomq import Frame
 
-            async def _wrap():
+            async def _wrap() -> Any:
                 data = await self._add_recv_event(self._sock._try_recv)
                 return Frame(data)
 
             return asyncio.ensure_future(_wrap())
         return self._add_recv_event(self._sock._try_recv)
 
-    def send_multipart(self, parts, flags=0, copy=True, track=False):
+    def send_multipart(
+        self,
+        parts: List[Union[bytes, str]],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> Awaitable[Optional[Any]]:
         try:
             self._sock.send_multipart(parts, flags)
         except _native.ZMQError as e:
@@ -298,11 +329,13 @@ class Socket:
             raise error.from_native(e) from None
         return _SEND_DONE
 
-    def recv_multipart(self, flags=0, copy=True, track=False):
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> Awaitable[Union[List[bytes], List[Any]]]:
         if not copy:
             from pyomq import Frame
 
-            async def _wrap():
+            async def _wrap() -> List[Any]:
                 parts = await self._add_recv_event(self._sock._try_recv_multipart)
                 return [Frame(p) for p in parts]
 
@@ -311,7 +344,7 @@ class Socket:
 
     if _IS_WINDOWS:
 
-        def _register_wakeup_hooks(self):
+        def _register_wakeup_hooks(self) -> None:
             if not self._wakeup_registered:
                 self._sock._set_wakeup_hooks(
                     recv_async=self._schedule_recv_drain,
@@ -321,13 +354,23 @@ class Socket:
                 )
                 self._wakeup_registered = True
 
-        def _set_wakeup_modes(self, *, recv_mode=None, send_mode=None):
+        def _set_wakeup_modes(
+            self,
+            *,
+            recv_mode: Optional[int] = None,
+            send_mode: Optional[int] = None,
+        ) -> None:
             self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
-        def _clear_wakeup_modes(self, *, recv_mode=None, send_mode=None):
+        def _clear_wakeup_modes(
+            self,
+            *,
+            recv_mode: Optional[int] = None,
+            send_mode: Optional[int] = None,
+        ) -> None:
             self._sock._clear_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
-        def _schedule_recv_drain(self):
+        def _schedule_recv_drain(self) -> None:
             loop = self._loop
             if loop is None or loop.is_closed():
                 self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
@@ -335,7 +378,7 @@ class Socket:
                 return
             loop.call_soon_threadsafe(self._drain_recv_waiters)
 
-        def _schedule_send_drain(self):
+        def _schedule_send_drain(self) -> None:
             loop = self._loop
             if loop is None or loop.is_closed():
                 self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
@@ -343,7 +386,7 @@ class Socket:
                 return
             loop.call_soon_threadsafe(self._drain_send_waiters)
 
-        def _drain_recv_waiters(self):
+        def _drain_recv_waiters(self) -> None:
             """Invoke each waiter until one returns False (not ready)."""
             waiters = self._recv_waiters
             try:
@@ -362,7 +405,7 @@ class Socket:
                 else:
                     self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC)
 
-        def _drain_send_waiters(self):
+        def _drain_send_waiters(self) -> None:
             """Invoke each waiter until one returns False (not ready)."""
             waiters = self._send_waiters
             try:
@@ -381,7 +424,13 @@ class Socket:
                 else:
                     self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC)
 
-        def _add_waitable(self, try_fn, waiters, set_mode, clear_mode):
+        def _add_waitable(
+            self,
+            try_fn: Callable[[], Any],
+            waiters: deque[Callable[[], bool]],
+            set_mode: Callable[[], None],
+            clear_mode: Callable[[], None],
+        ) -> asyncio.Future[Any]:
             """Register a Windows waiter that resolves when try_fn returns
             non-None. try_fn must return None when not ready and raise on
             real errors."""
@@ -393,7 +442,7 @@ class Socket:
                 return _resolved_future(result)
 
             self._register_wakeup_hooks()
-            fut = loop.create_future()
+            fut: asyncio.Future[Any] = loop.create_future()
 
             def _waiter() -> bool:
                 if fut.done():
@@ -427,8 +476,8 @@ class Socket:
 
             return fut
 
-        def _add_recv_event(self, try_fn):
-            def safe_try():
+        def _add_recv_event(self, try_fn: Callable[[], Any]) -> asyncio.Future[Any]:
+            def safe_try() -> Any:
                 try:
                     return try_fn()
                 except _native.ZMQError as e:
@@ -441,8 +490,10 @@ class Socket:
                 lambda: self._clear_wakeup_modes(recv_mode=_WAKEUP_MODE_ASYNC),
             )
 
-        def _send_with_backpressure(self, data, flags):
-            def try_send():
+        def _send_with_backpressure(
+            self, data: Union[bytes, str], flags: int
+        ) -> asyncio.Future[Any]:
+            def try_send() -> Optional[bool]:
                 try:
                     self._sock.send(data, flags)
                     return True
@@ -458,8 +509,10 @@ class Socket:
                 lambda: self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
             )
 
-        def _send_multipart_with_backpressure(self, parts, flags):
-            def try_send():
+        def _send_multipart_with_backpressure(
+            self, parts: List[Union[bytes, str]], flags: int
+        ) -> asyncio.Future[Any]:
+            def try_send() -> Optional[bool]:
                 try:
                     self._sock.send_multipart(parts, flags)
                     return True
@@ -476,7 +529,9 @@ class Socket:
             )
     else:
 
-        def _add_recv_event(self, try_fn):
+        def _add_recv_event(
+            self, try_fn: Callable[[], Any]
+        ) -> Union[asyncio.Future[Any], _RecvFuture]:
             # Fast path: message already available, no event loop needed.
             try:
                 result = try_fn()
@@ -498,29 +553,33 @@ class Socket:
 
             return _RecvFuture(try_fn, fd)
 
-        def _send_with_backpressure(self, data, flags):
+        def _send_with_backpressure(
+            self, data: Union[bytes, str], flags: int
+        ) -> _RecvFuture:
             fd = self._sock._send_fd()
 
-            def try_send():
+            def try_send() -> Optional[bool]:
                 try:
                     self._sock.send(data, flags)
                     return True
                 except _native.ZMQError as e:
-                    if e.errno == _errno.EAGAIN:
+                    if e.errno == _EAGAIN:
                         return None
                     raise
 
             return _RecvFuture(try_send, fd)
 
-        def _send_multipart_with_backpressure(self, parts, flags):
+        def _send_multipart_with_backpressure(
+            self, parts: List[Union[bytes, str]], flags: int
+        ) -> _RecvFuture:
             fd = self._sock._send_fd()
 
-            def try_send():
+            def try_send() -> Optional[bool]:
                 try:
                     self._sock.send_multipart(parts, flags)
                     return True
                 except _native.ZMQError as e:
-                    if e.errno == _errno.EAGAIN:
+                    if e.errno == _EAGAIN:
                         return None
                     raise
 
@@ -528,41 +587,59 @@ class Socket:
 
     # ── Serialization helpers ────────────────────────────────────────
 
-    def send_string(self, u, flags=0, encoding="utf-8"):
+    def send_string(
+        self, u: str, flags: int = 0, encoding: str = "utf-8"
+    ) -> Awaitable[Optional[Any]]:
         return self.send(u.encode(encoding), flags)
 
-    async def recv_string(self, flags=0, encoding="utf-8"):
+    async def recv_string(self, flags: int = 0, encoding: str = "utf-8") -> str:
         return (await self.recv(flags)).decode(encoding)
 
-    def send_json(self, obj, flags=0, **kwargs):
+    def send_json(
+        self, obj: Any, flags: int = 0, **kwargs: Any
+    ) -> Awaitable[Optional[Any]]:
         return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
-    async def recv_json(self, flags=0, **kwargs):
+    async def recv_json(self, flags: int = 0, **kwargs: Any) -> Any:
         return json.loads(await self.recv(flags), **kwargs)
 
-    def send_pyobj(self, obj, flags=0, protocol=-1):
+    def send_pyobj(
+        self, obj: Any, flags: int = 0, protocol: int = -1
+    ) -> Awaitable[Optional[Any]]:
         return self.send(pickle.dumps(obj, protocol), flags)
 
-    async def recv_pyobj(self, flags=0):
+    async def recv_pyobj(self, flags: int = 0) -> Any:
         return pickle.loads(await self.recv(flags))
 
-    def send_serialized(self, msg, serialize, flags=0, copy=True, **kwargs):
+    def send_serialized(
+        self,
+        msg: Any,
+        serialize: Callable[[Any], List[Union[bytes, str]]],
+        flags: int = 0,
+        copy: bool = True,
+        **kwargs: Any,
+    ) -> Awaitable[Optional[Any]]:
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
-    async def recv_serialized(self, deserialize, flags=0, copy=True):
+    async def recv_serialized(
+        self,
+        deserialize: Callable[[List[bytes]], Any],
+        flags: int = 0,
+        copy: bool = True,
+    ) -> Any:
         frames = await self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
     # ── Options (sync -- matches pyzmq) ──────────────────────────────
 
-    def setsockopt(self, option, value):
+    def setsockopt(self, option: int, value: Any) -> Any:
         try:
             return self._sock.setsockopt(option, value)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def getsockopt(self, option):
+    def getsockopt(self, option: int) -> Any:
         from pyomq import LAST_ENDPOINT
 
         if option == LAST_ENDPOINT:
@@ -572,16 +649,18 @@ class Socket:
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def set(self, option, value):
+    def set(self, option: int, value: Any) -> Any:
         return self.setsockopt(option, value)
 
-    def get(self, option):
+    def get(self, option: int) -> Any:
         return self.getsockopt(option)
 
-    def setsockopt_string(self, option, value, encoding="utf-8"):
+    def setsockopt_string(
+        self, option: int, value: str, encoding: str = "utf-8"
+    ) -> Any:
         return self.setsockopt(option, value.encode(encoding))
 
-    def getsockopt_string(self, option, encoding="utf-8"):
+    def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
         v = self.getsockopt(option)
         if isinstance(v, bytes):
             return v.decode(encoding)
@@ -590,7 +669,7 @@ class Socket:
     set_string = setsockopt_string
     get_string = getsockopt_string
 
-    def set_curve_auth(self, auth):
+    def set_curve_auth(self, auth: Any) -> Any:
         try:
             return self._sock.set_curve_auth(auth)
         except _native.ZMQError as e:
@@ -600,52 +679,63 @@ class Socket:
 
             raise ZMQNotImplementedError("curve feature not compiled")
 
-    def set_hwm(self, value):
+    def set_hwm(self, value: int) -> None:
         self.setsockopt(SNDHWM, value)
         self.setsockopt(RCVHWM, value)
 
-    def get_hwm(self):
+    def get_hwm(self) -> int:
         return self.getsockopt(SNDHWM)
 
     hwm = property(get_hwm, set_hwm)
 
     # ── Subscriptions ────────────────────────────────────────────────
 
-    def subscribe(self, prefix):
+    def subscribe(self, prefix: Union[bytes, str]) -> None:
         try:
             return self._sock.subscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unsubscribe(self, prefix):
+    def unsubscribe(self, prefix: Union[bytes, str]) -> None:
         try:
             return self._sock.unsubscribe(prefix)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def join(self, group):
+    def join(self, group: Union[bytes, str]) -> None:
         try:
             return self._sock.join(group)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def leave(self, group):
+    def leave(self, group: Union[bytes, str]) -> None:
         try:
             return self._sock.leave(group)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
+    # ── Monitoring ───────────────────────────────────────────────────
+
+    def monitor(self) -> Any:
+        return self._sock.monitor()
+
+    def connections(self) -> Any:
+        return self._sock.connections()
+
+    def connection_info(self, connection_id: int) -> Any:
+        return self._sock.connection_info(connection_id)
+
     # ── Lifecycle ────────────────────────────────────────────────────
 
-    def close(self, linger=None):
+    def close(self, linger: Optional[int] = None) -> None:
         if not self._closed:
             self._closed = True
             self._sock.close(linger)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    async def poll(self, timeout=None, flags=POLLIN):
+    async def poll(self, timeout: Optional[int] = None, flags: int = POLLIN) -> int:
         p = Poller()
         p.register(self, flags)
         evts = await p.poll(timeout)
@@ -654,41 +744,45 @@ class Socket:
                 return mask
         return 0
 
-    def __enter__(self):
+    def __enter__(self) -> Socket:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> bool:
         self.close()
         return False
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Socket:
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args: Any) -> bool:
         self.close()
         return False
 
 
 class Poller:
-    def __init__(self):
+    """Async poller for ZMQ sockets."""
+
+    _sockets: Dict[int, Tuple[Socket, int]]
+
+    def __init__(self) -> None:
         self._sockets = {}
 
-    def register(self, socket, flags=POLLIN):
+    def register(self, socket: Socket, flags: int = POLLIN) -> None:
         self._sockets[socket._sock.socket_id()] = (socket, flags)
 
-    def unregister(self, socket):
+    def unregister(self, socket: Socket) -> None:
         self._sockets.pop(socket._sock.socket_id(), None)
 
-    def modify(self, socket, flags):
+    def modify(self, socket: Socket, flags: int) -> None:
         k = socket._sock.socket_id()
         if k in self._sockets:
             self._sockets[k] = (socket, flags)
 
     @property
-    def sockets(self):
+    def sockets(self) -> List[Tuple[Socket, int]]:
         return [(s, f) for s, f in self._sockets.values()]
 
-    async def poll(self, timeout=None):
+    async def poll(self, timeout: Optional[int] = None) -> List[Tuple[Socket, int]]:
         if not self._sockets:
             return []
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
@@ -703,9 +797,17 @@ class Poller:
 
 
 class Context(_SyncContext):
-    _socket_class = None
+    """Async context for creating ZMQ sockets."""
 
-    def __init__(self, io_threads=1, *, _shadow_ctx=None):
+    _socket_class: Optional[type] = None
+    _ctx: _native.AsyncContext
+    _closed: bool
+    _sockets: weakref.WeakSet[Socket]
+    _ctx_id: int
+
+    def __init__(
+        self, io_threads: int = 1, *, _shadow_ctx: Optional[_SyncContext] = None
+    ) -> None:
         if _shadow_ctx is not None:
             self._ctx = _shadow_ctx._ctx
             self._is_shadow = True
@@ -717,10 +819,12 @@ class Context(_SyncContext):
         self._ctx_id = next(_next_ctx_id)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._closed
 
-    def socket(self, socket_type, socket_class=None, **kwargs):
+    def socket(
+        self, socket_type: int, socket_class: Optional[type] = None, **kwargs: Any
+    ) -> Any:
         native = self._ctx.socket(socket_type)
         cls = socket_class or Socket
         s = object.__new__(cls)
@@ -735,14 +839,14 @@ class Context(_SyncContext):
         self._sockets.add(s)
         return s
 
-    def term(self):
+    def term(self) -> None:
         self._closed = True
         for s in list(self._sockets):
             if not s.closed:
                 s.close()
         self._sockets.clear()
 
-    def destroy(self, linger=None):
+    def destroy(self, linger: Optional[int] = None) -> None:
         for s in list(self._sockets):
             if not s.closed:
                 if linger is not None:
@@ -751,14 +855,14 @@ class Context(_SyncContext):
         self._sockets.clear()
         self.term()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self._closed:
             self.term()
 
-    def __enter__(self):
+    def __enter__(self) -> Context:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> bool:
         self.term()
         return False
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -25,8 +25,7 @@ import sys
 import threading
 import weakref
 from collections import deque
-from typing import Any, Awaitable, Callable, Dict, Final, List, Optional, Tuple, Union
-
+from typing import Any, Awaitable, Callable, Final
 from . import _native  # type: ignore[attr-defined]
 from . import error
 from . import Context as _SyncContext
@@ -80,7 +79,7 @@ class _RecvFuture:
     _try_fn: Callable[[], Any]
     _fd: int
     _result: Any
-    _exception: Optional[Exception]
+    _exception: Exception | None
 
     def __init__(self, try_fn: Callable[[], Any], fd: int) -> None:
         self._try_fn = try_fn
@@ -180,7 +179,7 @@ class Socket(_BaseSocket):
     _sock: _native.AsyncSocket
     _context: Context
     _closed: bool
-    _loop: Optional[asyncio.AbstractEventLoop]
+    _loop: asyncio.AbstractEventLoop | None
     _recv_waiters: deque[Callable[[], bool]]
     _send_waiters: deque[Callable[[], bool]]
     _recv_wakeup_event: threading.Event
@@ -209,11 +208,11 @@ class Socket(_BaseSocket):
 
     def send(
         self,
-        data: Union[bytes, str],
+        data: bytes | str,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         try:
             self._sock.send(data, flags)
         except _native.ZMQError as e:
@@ -224,7 +223,7 @@ class Socket(_BaseSocket):
 
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Awaitable[Union[bytes, Any]]:
+    ) -> Awaitable[bytes | Any]:
         if not copy:
             from pyomq import Frame
 
@@ -237,11 +236,11 @@ class Socket(_BaseSocket):
 
     def send_multipart(
         self,
-        parts: List[Union[bytes, str]],
+        parts: list[bytes | str],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         try:
             self._sock.send_multipart(parts, flags)
         except _native.ZMQError as e:
@@ -252,11 +251,11 @@ class Socket(_BaseSocket):
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Awaitable[Union[List[bytes], List[Any]]]:
+    ) -> Awaitable[list[bytes] | list[Any]]:
         if not copy:
             from pyomq import Frame
 
-            async def _wrap() -> List[Any]:
+            async def _wrap() -> list[Any]:
                 parts = await self._add_recv_event(self._sock._try_recv_multipart)
                 return [Frame(p) for p in parts]
 
@@ -278,16 +277,16 @@ class Socket(_BaseSocket):
         def _set_wakeup_modes(
             self,
             *,
-            recv_mode: Optional[int] = None,
-            send_mode: Optional[int] = None,
+            recv_mode: int | None = None,
+            send_mode: int | None = None,
         ) -> None:
             self._sock._set_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
         def _clear_wakeup_modes(
             self,
             *,
-            recv_mode: Optional[int] = None,
-            send_mode: Optional[int] = None,
+            recv_mode: int | None = None,
+            send_mode: int | None = None,
         ) -> None:
             self._sock._clear_wakeup_modes(recv_mode=recv_mode, send_mode=send_mode)
 
@@ -412,9 +411,9 @@ class Socket(_BaseSocket):
             )
 
         def _send_with_backpressure(
-            self, data: Union[bytes, str], flags: int
+            self, data: bytes | str, flags: int
         ) -> asyncio.Future[Any]:
-            def try_send() -> Optional[bool]:
+            def try_send() -> bool | None:
                 try:
                     self._sock.send(data, flags)
                     return True
@@ -431,9 +430,9 @@ class Socket(_BaseSocket):
             )
 
         def _send_multipart_with_backpressure(
-            self, parts: List[Union[bytes, str]], flags: int
+            self, parts: list[bytes | str], flags: int
         ) -> asyncio.Future[Any]:
-            def try_send() -> Optional[bool]:
+            def try_send() -> bool | None:
                 try:
                     self._sock.send_multipart(parts, flags)
                     return True
@@ -452,7 +451,7 @@ class Socket(_BaseSocket):
 
         def _add_recv_event(
             self, try_fn: Callable[[], Any]
-        ) -> Union[asyncio.Future[Any], _RecvFuture]:
+        ) -> asyncio.Future[Any] | _RecvFuture:
             # Fast path: message already available, no event loop needed.
             try:
                 result = try_fn()
@@ -474,12 +473,10 @@ class Socket(_BaseSocket):
 
             return _RecvFuture(try_fn, fd)
 
-        def _send_with_backpressure(
-            self, data: Union[bytes, str], flags: int
-        ) -> _RecvFuture:
+        def _send_with_backpressure(self, data: bytes | str, flags: int) -> _RecvFuture:
             fd = self._sock._send_fd()
 
-            def try_send() -> Optional[bool]:
+            def try_send() -> bool | None:
                 try:
                     self._sock.send(data, flags)
                     return True
@@ -491,11 +488,11 @@ class Socket(_BaseSocket):
             return _RecvFuture(try_send, fd)
 
         def _send_multipart_with_backpressure(
-            self, parts: List[Union[bytes, str]], flags: int
+            self, parts: list[bytes | str], flags: int
         ) -> _RecvFuture:
             fd = self._sock._send_fd()
 
-            def try_send() -> Optional[bool]:
+            def try_send() -> bool | None:
                 try:
                     self._sock.send_multipart(parts, flags)
                     return True
@@ -510,7 +507,7 @@ class Socket(_BaseSocket):
 
     def send_string(
         self, u: str, flags: int = 0, encoding: str = "utf-8"
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         return self.send(u.encode(encoding), flags)
 
     async def recv_string(self, flags: int = 0, encoding: str = "utf-8") -> str:
@@ -518,7 +515,7 @@ class Socket(_BaseSocket):
 
     def send_json(
         self, obj: Any, flags: int = 0, **kwargs: Any
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
     async def recv_json(self, flags: int = 0, **kwargs: Any) -> Any:
@@ -526,7 +523,7 @@ class Socket(_BaseSocket):
 
     def send_pyobj(
         self, obj: Any, flags: int = 0, protocol: int = -1
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         return self.send(pickle.dumps(obj, protocol), flags)
 
     async def recv_pyobj(self, flags: int = 0) -> Any:
@@ -535,17 +532,17 @@ class Socket(_BaseSocket):
     def send_serialized(
         self,
         msg: Any,
-        serialize: Callable[[Any], List[Union[bytes, str]]],
+        serialize: Callable[[Any], list[bytes | str]],
         flags: int = 0,
         copy: bool = True,
         **kwargs: Any,
-    ) -> Awaitable[Optional[Any]]:
+    ) -> Awaitable[Any | None]:
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
     async def recv_serialized(
         self,
-        deserialize: Callable[[List[bytes]], Any],
+        deserialize: Callable[[list[bytes]], Any],
         flags: int = 0,
         copy: bool = True,
     ) -> Any:
@@ -562,7 +559,7 @@ class Socket(_BaseSocket):
 
     # ── Lifecycle ────────────────────────────────────────────────────
 
-    async def poll(self, timeout: Optional[int] = None, flags: int = POLLIN) -> int:
+    async def poll(self, timeout: int | None = None, flags: int = POLLIN) -> int:
         p = Poller()
         p.register(self, flags)
         evts = await p.poll(timeout)
@@ -582,7 +579,7 @@ class Socket(_BaseSocket):
 class Poller:
     """Async poller for ZMQ sockets."""
 
-    _sockets: Dict[int, Tuple[Socket, int]]
+    _sockets: dict[int, tuple[Socket, int]]
 
     def __init__(self) -> None:
         self._sockets = {}
@@ -599,10 +596,10 @@ class Poller:
             self._sockets[k] = (socket, flags)
 
     @property
-    def sockets(self) -> List[Tuple[Socket, int]]:
+    def sockets(self) -> list[tuple[Socket, int]]:
         return [(s, f) for s, f in self._sockets.values()]
 
-    async def poll(self, timeout: Optional[int] = None) -> List[Tuple[Socket, int]]:
+    async def poll(self, timeout: int | None = None) -> list[tuple[Socket, int]]:
         if not self._sockets:
             return []
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
@@ -619,14 +616,14 @@ class Poller:
 class Context(_SyncContext):
     """Async context for creating ZMQ sockets."""
 
-    _socket_class: Optional[type] = None
+    _socket_class: type | None = None
     _ctx: _native.AsyncContext
     _closed: bool
     _sockets: weakref.WeakSet[Socket]
     _ctx_id: int
 
     def __init__(
-        self, io_threads: int = 1, *, _shadow_ctx: Optional[_SyncContext] = None
+        self, io_threads: int = 1, *, _shadow_ctx: _SyncContext | None = None
     ) -> None:
         if _shadow_ctx is not None:
             self._ctx = _shadow_ctx._ctx
@@ -645,7 +642,7 @@ class Context(_SyncContext):
     def socket(
         self,
         socket_type: int,
-        socket_class: Optional[type[Socket]] = None,
+        socket_class: type[Socket] | None = None,
         **kwargs: Any,
     ) -> Socket:  # ty: ignore
         native = self._ctx.socket(socket_type)
@@ -669,7 +666,7 @@ class Context(_SyncContext):
                 s.close()
         self._sockets.clear()
 
-    def destroy(self, linger: Optional[int] = None) -> None:
+    def destroy(self, linger: int | None = None) -> None:
         for s in list(self._sockets):
             if not s.closed:
                 if linger is not None:

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -37,9 +37,8 @@ from . import (
     SNDHWM,
     RCVHWM,
     LINGER,
-    LAST_ENDPOINT,
     _TYPE_NAMES,
-    _SOCKOPT_NAMES,
+    _SocketOptionsBase,
 )
 
 _IS_WINDOWS = sys.platform == "win32"
@@ -178,13 +177,12 @@ class _RecvFuture:
         return (yield from fut.__await__())
 
 
-class Socket:
+class Socket(_SocketOptionsBase):
     """Async ZMQ socket wrapper."""
 
     _sock: _native.AsyncSocket
     _context: Context
     _closed: bool
-    _last_endpoint: Optional[Union[bytes, str]]
     _loop: Optional[asyncio.AbstractEventLoop]
     _recv_waiters: deque[Callable[[], bool]]
     _send_waiters: deque[Callable[[], bool]]
@@ -207,26 +205,6 @@ class Socket:
 
     def __init__(self, _sock: _native.AsyncSocket, _context: Context) -> None:
         self._init_socket_state(_sock, _context)
-
-    def __getattr__(self, name: str) -> Any:
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            if opt == LAST_ENDPOINT:
-                return self._last_endpoint
-            return self.getsockopt(opt)
-        raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'"
-        )
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        if name.startswith("_"):
-            object.__setattr__(self, name, value)
-            return
-        opt = _SOCKOPT_NAMES.get(name)
-        if opt is not None:
-            self.setsockopt(opt, value)
-            return
-        object.__setattr__(self, name, value)
 
     def __repr__(self) -> str:
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))

--- a/bindings/pyomq/python/pyomq/error.py
+++ b/bindings/pyomq/python/pyomq/error.py
@@ -5,8 +5,11 @@ pyzmq's hierarchy. ``ZMQBindError`` is a sibling of ``ZMQError`` under
 ``ZMQBaseError``, not a subclass of ``ZMQError``.
 """
 
+from __future__ import annotations
+
 import builtins
 import errno as _errno
+from typing import Any, Dict, Optional, Type
 
 from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
@@ -36,7 +39,7 @@ class ZMQVersionError(builtins.NotImplementedError, ZMQBaseError):
     """Feature requires a newer libzmq than the emulated version."""
 
 
-_BY_ERRNO = {
+_BY_ERRNO: Dict[int, Type[ZMQError]] = {
     _errno.EAGAIN: Again,
     _errno.ETIMEDOUT: Again,
     156: ContextTerminated,

--- a/bindings/pyomq/python/pyomq/error.py
+++ b/bindings/pyomq/python/pyomq/error.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import builtins
 import errno as _errno
-from typing import Dict, Type, Final
+from typing import Final
 
 from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
@@ -39,7 +39,7 @@ class ZMQVersionError(builtins.NotImplementedError, ZMQBaseError):
     """Feature requires a newer libzmq than the emulated version."""
 
 
-_BY_ERRNO: Final[Dict[int, Type[ZMQError]]] = {
+_BY_ERRNO: Final[dict[int, type[ZMQError]]] = {
     _errno.EAGAIN: Again,
     _errno.ETIMEDOUT: Again,
     156: ContextTerminated,

--- a/bindings/pyomq/python/pyomq/error.py
+++ b/bindings/pyomq/python/pyomq/error.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import builtins
 import errno as _errno
-from typing import Any, Dict, Optional, Type
+from typing import Dict, Type, Final
 
 from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
 from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
@@ -39,7 +39,7 @@ class ZMQVersionError(builtins.NotImplementedError, ZMQBaseError):
     """Feature requires a newer libzmq than the emulated version."""
 
 
-_BY_ERRNO: Dict[int, Type[ZMQError]] = {
+_BY_ERRNO: Final[Dict[int, Type[ZMQError]]] = {
     _errno.EAGAIN: Again,
     _errno.ETIMEDOUT: Again,
     156: ContextTerminated,

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -35,7 +35,7 @@ class ZMQStream:
     def __init__(self, socket: pyomq.Socket, io_loop: Optional[Any] = None) -> None:
         IOLoop = _get_IOLoop()
         self.socket = socket
-        self.io_loop = io_loop or IOLoop.current()
+        self.io_loop = io_loop or IOLoop.current()  # type: ignore[ty:unresolved-attribute]
         self._recv_callback = None
         self._recv_copy = True
         self._send_callback = None
@@ -148,7 +148,7 @@ class ZMQStream:
             if self._closed or self._watching:
                 return
             try:
-                io_loop.add_handler(fd, handler, _get_IOLoop().READ)
+                io_loop.add_handler(fd, handler, _get_IOLoop().READ)  # type: ignore[ty:unresolved-attribute]
                 self._watching = True
             except Exception:
                 pass

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Callable, Optional, Union, List
+from typing import Any, Callable
 
 import pyomq
 
@@ -25,14 +25,14 @@ class ZMQStream:
 
     socket: pyomq.Socket
     io_loop: Any  # tornado.ioloop.IOLoop
-    _recv_callback: Optional[Callable[[Any], Any]]
+    _recv_callback: Callable[[Any], Any] | None
     _recv_copy: bool
-    _send_callback: Optional[Callable[[Any, Optional[Any]], Any]]
+    _send_callback: Callable[[Any, Any | None], Any] | None
     _closed: bool
     _fd: int
     _watching: bool
 
-    def __init__(self, socket: pyomq.Socket, io_loop: Optional[Any] = None) -> None:
+    def __init__(self, socket: pyomq.Socket, io_loop: Any | None = None) -> None:
         IOLoop = _get_IOLoop()
         self.socket = socket
         self.io_loop = io_loop or IOLoop.current()  # type: ignore[ty:unresolved-attribute]
@@ -43,9 +43,7 @@ class ZMQStream:
         self._fd = socket.getsockopt(pyomq.FD)
         self._watching = False
 
-    def on_recv(
-        self, callback: Optional[Callable[[Any], Any]], copy: bool = True
-    ) -> None:
+    def on_recv(self, callback: Callable[[Any], Any] | None, copy: bool = True) -> None:
         """Set a callback to be invoked when messages are received."""
         self._recv_callback = callback
         self._recv_copy = copy
@@ -54,7 +52,7 @@ class ZMQStream:
         else:
             self._stop_watching()
 
-    def on_send(self, callback: Optional[Callable[[Any, Optional[Any]], Any]]) -> None:
+    def on_send(self, callback: Callable[[Any, Any | None], Any] | None) -> None:
         """Set a callback to be invoked when sends complete."""
         self._send_callback = callback
 
@@ -68,11 +66,11 @@ class ZMQStream:
 
     def send(
         self,
-        msg: Union[bytes, str],
+        msg: bytes | str,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-        callback: Optional[Callable[[Any, Any], Any]] = None,
+        callback: Callable[[Any, Any], Any] | None = None,
         **kwargs: Any,
     ) -> Any:
         """Send a message."""
@@ -83,11 +81,11 @@ class ZMQStream:
 
     def send_multipart(
         self,
-        msg_list: List[Union[bytes, str]],
+        msg_list: list[bytes | str],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-        callback: Optional[Callable[[Any, Any], Any]] = None,
+        callback: Callable[[Any, Any], Any] | None = None,
         **kwargs: Any,
     ) -> Any:
         """Send a multipart message."""
@@ -101,14 +99,12 @@ class ZMQStream:
             self._send_callback(msg_list, None)
         return result
 
-    def flush(self, flag: int = 3, limit: Optional[int] = None) -> None:
+    def flush(self, flag: int = 3, limit: int | None = None) -> None:
         """Flush pending messages."""
         if flag & 1 and self._recv_callback:
             self._handle_recv()
 
-    def _handle_events(
-        self, fd: Optional[int] = None, events: Optional[int] = None
-    ) -> None:
+    def _handle_events(self, fd: int | None = None, events: int | None = None) -> None:
         """Internal handler for IOLoop events."""
         if self._closed:
             return
@@ -168,7 +164,7 @@ class ZMQStream:
         except Exception:
             pass
 
-    def close(self, linger: Optional[int] = None) -> None:
+    def close(self, linger: int | None = None) -> None:
         """Close the stream and unregister from IOLoop."""
         if self._closed:
             return

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -5,20 +5,34 @@ signals readability, drains available messages and invokes the
 on_recv callback.
 """
 
+from __future__ import annotations
+
 import asyncio
 import os
+from typing import Any, Callable, Optional, Union
 
 import pyomq
 
 
-def _get_IOLoop():
+def _get_IOLoop() -> type:
     from tornado.ioloop import IOLoop
 
     return IOLoop
 
 
 class ZMQStream:
-    def __init__(self, socket, io_loop=None):
+    """Integration layer for pyomq sockets with Tornado IOLoop."""
+
+    socket: pyomq.Socket
+    io_loop: Any  # tornado.ioloop.IOLoop
+    _recv_callback: Optional[Callable[[Any], Any]]
+    _recv_copy: bool
+    _send_callback: Optional[Callable[[Any, Optional[Any]], Any]]
+    _closed: bool
+    _fd: int
+    _watching: bool
+
+    def __init__(self, socket: pyomq.Socket, io_loop: Optional[Any] = None) -> None:
         IOLoop = _get_IOLoop()
         self.socket = socket
         self.io_loop = io_loop or IOLoop.current()
@@ -29,7 +43,10 @@ class ZMQStream:
         self._fd = socket.getsockopt(pyomq.FD)
         self._watching = False
 
-    def on_recv(self, callback, copy=True):
+    def on_recv(
+        self, callback: Optional[Callable[[Any], Any]], copy: bool = True
+    ) -> None:
+        """Set a callback to be invoked when messages are received."""
         self._recv_callback = callback
         self._recv_copy = copy
         if callback is not None:
@@ -37,24 +54,43 @@ class ZMQStream:
         else:
             self._stop_watching()
 
-    def on_send(self, callback):
+    def on_send(self, callback: Optional[Callable[[Any, Optional[Any]], Any]]) -> None:
+        """Set a callback to be invoked when sends complete."""
         self._send_callback = callback
 
-    def stop_on_recv(self):
+    def stop_on_recv(self) -> None:
+        """Stop receiving messages."""
         self.on_recv(None)
 
-    def stop_on_send(self):
+    def stop_on_send(self) -> None:
+        """Stop receiving send completion callbacks."""
         self._send_callback = None
 
-    def send(self, msg, flags=0, copy=True, track=False, callback=None, **kwargs):
+    def send(
+        self,
+        msg: Union[bytes, str],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+        callback: Optional[Callable[[Any, Any], Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a message."""
         result = self.socket.send(msg, flags=flags, copy=copy, track=track)
         if self._send_callback:
             self._send_callback(msg, None)
         return result
 
     def send_multipart(
-        self, msg_list, flags=0, copy=True, track=False, callback=None, **kwargs
-    ):
+        self,
+        msg_list: list[Union[bytes, str]],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+        callback: Optional[Callable[[Any, Any], Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a multipart message."""
         result = self.socket.send_multipart(
             msg_list,
             flags=flags,
@@ -65,11 +101,15 @@ class ZMQStream:
             self._send_callback(msg_list, None)
         return result
 
-    def flush(self, flag=3, limit=None):
+    def flush(self, flag: int = 3, limit: Optional[int] = None) -> None:
+        """Flush pending messages."""
         if flag & 1 and self._recv_callback:
             self._handle_recv()
 
-    def _handle_events(self, fd=None, events=None):
+    def _handle_events(
+        self, fd: Optional[int] = None, events: Optional[int] = None
+    ) -> None:
+        """Internal handler for IOLoop events."""
         if self._closed:
             return
         try:
@@ -78,7 +118,8 @@ class ZMQStream:
             pass
         self._handle_recv()
 
-    def _handle_recv(self):
+    def _handle_recv(self) -> None:
+        """Drain and invoke callback for all available messages."""
         if self._recv_callback is None:
             return
         while True:
@@ -95,14 +136,15 @@ class ZMQStream:
             if asyncio.iscoroutine(result):
                 asyncio.ensure_future(result)
 
-    def _start_watching(self):
+    def _start_watching(self) -> None:
+        """Register the socket FD with the IOLoop."""
         if self._closed or self._watching:
             return
         fd = self._fd
         handler = self._handle_events
         io_loop = self.io_loop
 
-        def _do_add():
+        def _do_add() -> None:
             if self._closed or self._watching:
                 return
             try:
@@ -116,7 +158,8 @@ class ZMQStream:
         except RuntimeError:
             _do_add()
 
-    def _stop_watching(self):
+    def _stop_watching(self) -> None:
+        """Unregister the socket FD from the IOLoop."""
         if not self._watching:
             return
         self._watching = False
@@ -125,18 +168,22 @@ class ZMQStream:
         except Exception:
             pass
 
-    def close(self, linger=None):
+    def close(self, linger: Optional[int] = None) -> None:
+        """Close the stream and unregister from IOLoop."""
         if self._closed:
             return
         self._closed = True
         self._stop_watching()
 
-    def setsockopt(self, opt, value):
-        self.socket.setsockopt(opt, value)
+    def setsockopt(self, opt: int, value: Any) -> Any:
+        """Set a socket option."""
+        return self.socket.setsockopt(opt, value)
 
-    def getsockopt(self, opt):
+    def getsockopt(self, opt: int) -> Any:
+        """Get a socket option."""
         return self.socket.getsockopt(opt)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
+        """Whether the stream is closed."""
         return self._closed

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, List
 
 import pyomq
 
@@ -83,7 +83,7 @@ class ZMQStream:
 
     def send_multipart(
         self,
-        msg_list: list[Union[bytes, str]],
+        msg_list: List[Union[bytes, str]],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -97,6 +97,17 @@ impl ContextInner {
         Ok(handle)
     }
 
+    pub fn can_drive_runtime(&self) -> bool {
+        if self.terminated.load(Ordering::Acquire) {
+            return false;
+        }
+        self.state
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|rt| rt.pid == std::process::id())
+    }
+
     pub fn runtime_handle(&self) -> PyResult<Handle> {
         self.ensure_runtime()
     }
@@ -285,7 +296,11 @@ impl ContextInner {
         self.terminated.store(true, Ordering::Release);
         let state = self.state.lock().unwrap().take();
         if let Some(s) = state {
-            s.ctx.term();
+            if s.pid == std::process::id() {
+                s.ctx.term();
+            } else {
+                std::mem::forget(s);
+            }
         }
     }
 
@@ -333,7 +348,11 @@ impl ContextInner {
 impl Drop for ContextInner {
     fn drop(&mut self) {
         if let Some(s) = self.state.get_mut().unwrap().take() {
-            s.ctx.term();
+            if s.pid == std::process::id() {
+                s.ctx.term();
+            } else {
+                std::mem::forget(s);
+            }
         }
     }
 }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -94,6 +94,8 @@ pub(crate) struct SocketInner {
     pub subscriptions: Mutex<Vec<Bytes>>,
     pub endpoints: Mutex<Vec<(omq_tokio::Endpoint, bool)>>,
     has_tcp_endpoint: AtomicBool,
+    send_fork_gen: AtomicU32,
+    parent_send_fork_gen: AtomicU32,
     parent_fork_gen: AtomicU32,
     post_fork: AtomicBool,
     pub sndbuf: Mutex<SendBuffer>,
@@ -115,6 +117,8 @@ impl SocketInner {
             subscriptions: Mutex::new(Vec::new()),
             endpoints: Mutex::new(Vec::new()),
             has_tcp_endpoint: AtomicBool::new(false),
+            send_fork_gen: AtomicU32::new(FORK_GEN.load(Ordering::Relaxed)),
+            parent_send_fork_gen: AtomicU32::new(PARENT_FORK_GEN.load(Ordering::Relaxed)),
             parent_fork_gen: AtomicU32::new(PARENT_FORK_GEN.load(Ordering::Relaxed)),
             post_fork: AtomicBool::new(FORKED.load(Ordering::Relaxed)),
             sndbuf: Mutex::new(SendBuffer::default()),
@@ -813,12 +817,29 @@ impl Socket {
     fn send_message(&self, py: Python<'_>, msg: omq_tokio::Message) -> PyResult<()> {
         let sock = self.inner.ensure_blocking_socket()?;
         let timeout = self.inner.overlay.lock().unwrap().sndtimeo;
-        let post_fork = self.inner.post_fork.swap(false, Ordering::AcqRel);
+        let fork_gen = FORK_GEN.load(Ordering::Acquire);
+        let child_fork = self.inner.send_fork_gen.load(Ordering::Acquire) != fork_gen;
+        if child_fork {
+            self.inner
+                .send_fork_gen
+                .store(fork_gen, Ordering::Release);
+        }
+        let parent_fork_gen = PARENT_FORK_GEN.load(Ordering::Acquire);
+        let parent_fork =
+            self.inner.parent_send_fork_gen.load(Ordering::Acquire) != parent_fork_gen;
+        if parent_fork {
+            self.inner
+                .parent_send_fork_gen
+                .store(parent_fork_gen, Ordering::Release);
+        }
+        let post_fork =
+            self.inner.post_fork.swap(false, Ordering::AcqRel) || child_fork || parent_fork;
         if post_fork {
             let tcp = self.inner.has_tcp_endpoint.load(Ordering::Acquire);
+            let wait = timeout.unwrap_or(Duration::from_secs(1));
             py.detach(|| {
                 if tcp {
-                    let _ = sock.wait_connected(1, Duration::from_secs(1));
+                    let _ = sock.wait_connected(1, wait);
                 }
                 std::thread::sleep(Duration::from_millis(100));
             });

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -54,7 +54,7 @@ extern "C" fn atfork_parent() {
 #[cfg(unix)]
 pub(crate) fn register_atfork() {
     ATFORK_REGISTERED.call_once(|| unsafe {
-        libc::pthread_atfork(Some(atfork_parent), None, Some(atfork_child));
+        libc::pthread_atfork(None, Some(atfork_parent), Some(atfork_child));
     });
 }
 
@@ -313,6 +313,14 @@ impl SocketInner {
     pub fn take_materialized(&self) -> Option<Materialized> {
         self.closed.store(true, Ordering::Relaxed);
         let materialized = self.materialized.write().unwrap().take();
+        let fork_gen = FORK_GEN.load(Ordering::Relaxed);
+        if materialized
+            .as_ref()
+            .is_some_and(|state| state.fork_gen != fork_gen)
+        {
+            std::mem::forget(materialized);
+            return None;
+        }
         if let Some(ref state) = materialized {
             state.recv_ready.force_wake();
             state.send_ready.force_wake();
@@ -322,7 +330,15 @@ impl SocketInner {
 
     pub fn take_blocking_materialized(&self) -> Option<BlockingMaterialized> {
         self.closed.store(true, Ordering::Relaxed);
-        self.blocking_materialized.write().unwrap().take()
+        let materialized = self.blocking_materialized.write().unwrap().take();
+        if materialized
+            .as_ref()
+            .is_some_and(|state| state.fork_gen != FORK_GEN.load(Ordering::Relaxed))
+        {
+            std::mem::forget(materialized);
+            return None;
+        }
+        materialized
     }
 
     pub fn close_linger(&self, linger: Option<i64>) -> Option<Duration> {
@@ -760,7 +776,9 @@ impl Socket {
     #[pyo3(signature = (linger=None))]
     fn close(&self, py: Python<'_>, linger: Option<i64>) -> PyResult<()> {
         let linger = self.inner.close_linger(linger);
-        if let Some(m) = self.inner.take_blocking_materialized() {
+        if let Some(m) = self.inner.take_blocking_materialized()
+            && self.inner.ctx.can_drive_runtime()
+        {
             py.detach(|| m.socket.close_with_linger(linger))
                 .map_err(map_err)?;
         }

--- a/bindings/pyomq/tests/conftest.py
+++ b/bindings/pyomq/tests/conftest.py
@@ -55,7 +55,10 @@ def ipc_endpoint(request) -> str:
     if sys.platform == "win32":
         return f"ipc://pyomq-{tag}"
     # Linux abstract namespace: no filesystem entry, auto-cleaned on close.
-    return f"ipc://@pyomq-{tag}"
+    elif sys.platform == "linux":
+        return f"ipc://@pyomq-{tag}"
+    else:
+        return f"ipc://pyomq-{tag}"
 
 
 def wait_for(predicate, timeout: float = 2.0, interval: float = 0.01) -> bool:

--- a/bindings/pyomq/tests/soak/conftest.py
+++ b/bindings/pyomq/tests/soak/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from typing import List, Tuple
 
 
 def soak_duration() -> float:
@@ -35,7 +36,7 @@ class ResourceMonitor:
     def __init__(self):
         import threading
 
-        self._samples: list[tuple[float, int]] = []
+        self._samples: List[Tuple[float, int]] = []
         self._stop = False
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -52,7 +53,7 @@ class ResourceMonitor:
 
 
 class ResourceReport:
-    def __init__(self, samples: list[tuple[float, int]]):
+    def __init__(self, samples: List[Tuple[float, int]]):
         self.samples = samples
 
     def assert_no_leak(self, label: str):

--- a/bindings/pyomq/tests/soak/conftest.py
+++ b/bindings/pyomq/tests/soak/conftest.py
@@ -36,7 +36,7 @@ class ResourceMonitor:
     def __init__(self):
         import threading
 
-        self._samples: List[Tuple[float, int]] = []
+        self._samples: list[tuple[float, int]] = []
         self._stop = False
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -53,7 +53,7 @@ class ResourceMonitor:
 
 
 class ResourceReport:
-    def __init__(self, samples: List[Tuple[float, int]]):
+    def __init__(self, samples: list[tuple[float, int]]):
         self.samples = samples
 
     def assert_no_leak(self, label: str):

--- a/bindings/pyomq/tests/soak/test_multipart.py
+++ b/bindings/pyomq/tests/soak/test_multipart.py
@@ -23,14 +23,14 @@ FRAME_B = 128
 NUM_FRAMES = 3
 
 
-def build_multipart(seq: int) -> List[bytes]:
+def build_multipart(seq: int) -> list[bytes]:
     header = struct.pack("<Q", seq)
     body = bytes((seq + i) & 0xFF for i in range(FRAME_B))
     trailer = struct.pack("<Q", seq ^ 0xFFFFFFFFFFFFFFFF)
     return [header, body, trailer]
 
 
-def validate_multipart(parts: List[bytes], min_seq: int) -> int:
+def validate_multipart(parts: list[bytes], min_seq: int) -> int:
     assert len(parts) == NUM_FRAMES, (
         f"frame count mismatch: got {len(parts)}, expected {NUM_FRAMES}"
     )

--- a/bindings/pyomq/tests/soak/test_multipart.py
+++ b/bindings/pyomq/tests/soak/test_multipart.py
@@ -15,6 +15,7 @@ import threading
 import time
 
 import pyomq as zmq
+from typing import List
 
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
@@ -22,14 +23,14 @@ FRAME_B = 128
 NUM_FRAMES = 3
 
 
-def build_multipart(seq: int) -> list[bytes]:
+def build_multipart(seq: int) -> List[bytes]:
     header = struct.pack("<Q", seq)
     body = bytes((seq + i) & 0xFF for i in range(FRAME_B))
     trailer = struct.pack("<Q", seq ^ 0xFFFFFFFFFFFFFFFF)
     return [header, body, trailer]
 
 
-def validate_multipart(parts: list[bytes], min_seq: int) -> int:
+def validate_multipart(parts: List[bytes], min_seq: int) -> int:
     assert len(parts) == NUM_FRAMES, (
         f"frame count mismatch: got {len(parts)}, expected {NUM_FRAMES}"
     )

--- a/bindings/pyomq/tests/soak/test_peer_churn.py
+++ b/bindings/pyomq/tests/soak/test_peer_churn.py
@@ -13,6 +13,7 @@ import random
 import time
 
 import pyomq as zmq
+from pyomq import Socket
 
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
@@ -32,7 +33,7 @@ def test_peer_churn():
     push.setsockopt(zmq.SNDHWM, 1024)
     ep = push.bind(tcp_ep())
 
-    peers: list[tuple[object, bool]] = []
+    peers: list[tuple[Socket, bool]] = []
     for _ in range(NUM_PEERS):
         p = ctx.socket(zmq.PULL)
         p.setsockopt(zmq.RCVTIMEO, 0)

--- a/bindings/pyomq/tests/soak/test_peer_churn.py
+++ b/bindings/pyomq/tests/soak/test_peer_churn.py
@@ -34,7 +34,7 @@ def test_peer_churn():
     push.setsockopt(zmq.SNDHWM, 1024)
     ep = push.bind(tcp_ep())
 
-    peers: List[Tuple[Socket, bool]] = []
+    peers: list[tuple[Socket, bool]] = []
     for _ in range(NUM_PEERS):
         p = ctx.socket(zmq.PULL)
         p.setsockopt(zmq.RCVTIMEO, 0)

--- a/bindings/pyomq/tests/soak/test_peer_churn.py
+++ b/bindings/pyomq/tests/soak/test_peer_churn.py
@@ -11,6 +11,7 @@ in a realistic range (well under 10/sec on average).
 
 import random
 import time
+from typing import List, Tuple
 
 import pyomq as zmq
 from pyomq import Socket
@@ -33,7 +34,7 @@ def test_peer_churn():
     push.setsockopt(zmq.SNDHWM, 1024)
     ep = push.bind(tcp_ep())
 
-    peers: list[tuple[Socket, bool]] = []
+    peers: List[Tuple[Socket, bool]] = []
     for _ in range(NUM_PEERS):
         p = ctx.socket(zmq.PULL)
         p.setsockopt(zmq.RCVTIMEO, 0)

--- a/bindings/pyomq/tests/test_async.py
+++ b/bindings/pyomq/tests/test_async.py
@@ -286,7 +286,7 @@ async def test_async_close_wakes_pending_recv(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     try:
         pull.bind(tcp_endpoint)
-        recv_task = asyncio.create_task(pull.recv())
+        recv_task = pull.recv()
         await asyncio.sleep(0.05)
         pull.close()
         with pytest.raises(Exception):

--- a/bindings/pyomq/tests/test_async_compat.py
+++ b/bindings/pyomq/tests/test_async_compat.py
@@ -198,7 +198,7 @@ async def test_async_attr_unknown_raises():
     sock = ctx.socket(zmq.PUSH)
     try:
         with pytest.raises(AttributeError):
-            _ = sock.nonexistent_attribute
+            _ = sock.nonexistent_attribute  # type: ignore[ty:unresolved-attribute]
     finally:
         sock.close()
 

--- a/bindings/pyomq/tests/test_fork.py
+++ b/bindings/pyomq/tests/test_fork.py
@@ -2,6 +2,7 @@
 
 import os
 import select
+import sys
 import time
 
 import pytest
@@ -14,6 +15,10 @@ pytestmark = pytest.mark.filterwarnings(
 pytestmark = [
     pytestmark,
     pytest.mark.skipif(os.name == "nt", reason="fork is Unix-only"),
+    pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason="macOS does not reliably fork after Rust runtime threads exist",
+    ),
 ]
 
 FORK_TIMEOUT_MS = 5_000

--- a/bindings/pyomq/tests/test_fork.py
+++ b/bindings/pyomq/tests/test_fork.py
@@ -24,7 +24,7 @@ def _waitpid_timeout(pid):
     """Reap a child, killing it if the forked operation wedges."""
     deadline = time.monotonic() + FORK_TIMEOUT_S
     while time.monotonic() < deadline:
-        waited, status = os.waitpid(pid, os.WNOHANG)  # ty: ignore
+        waited, status = os.waitpid(pid, os.WNOHANG)  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
         if waited == pid:
             if os.waitstatus_to_exitcode(status) != 0:
                 pytest.fail("forked child exited with an error")
@@ -54,7 +54,7 @@ def test_socket_works_after_fork():
     ep = push.bind("tcp://127.0.0.1:0")
 
     r, w = os.pipe()
-    pid = os.fork()  # ty: ignore
+    pid = os.fork()  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
     if pid == 0:
         os.close(r)
         _child_recv(ep, w)
@@ -92,7 +92,7 @@ def test_pre_materialized_socket_works_after_fork():
 
     r, w = os.pipe()
     ack_r, ack_w = os.pipe()
-    pid = os.fork()  # ty: ignore
+    pid = os.fork()  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
     if pid == 0:
         os.close(r)
         # Child: the parent's push socket is stale. Create a fresh one.

--- a/bindings/pyomq/tests/test_fork.py
+++ b/bindings/pyomq/tests/test_fork.py
@@ -24,7 +24,7 @@ def _waitpid_timeout(pid):
     """Reap a child, killing it if the forked operation wedges."""
     deadline = time.monotonic() + FORK_TIMEOUT_S
     while time.monotonic() < deadline:
-        waited, status = os.waitpid(pid, os.WNOHANG)
+        waited, status = os.waitpid(pid, os.WNOHANG)  # ty: ignore
         if waited == pid:
             if os.waitstatus_to_exitcode(status) != 0:
                 pytest.fail("forked child exited with an error")
@@ -54,7 +54,7 @@ def test_socket_works_after_fork():
     ep = push.bind("tcp://127.0.0.1:0")
 
     r, w = os.pipe()
-    pid = os.fork()
+    pid = os.fork()  # ty: ignore
     if pid == 0:
         os.close(r)
         _child_recv(ep, w)
@@ -92,7 +92,7 @@ def test_pre_materialized_socket_works_after_fork():
 
     r, w = os.pipe()
     ack_r, ack_w = os.pipe()
-    pid = os.fork()
+    pid = os.fork()  # ty: ignore
     if pid == 0:
         os.close(r)
         # Child: the parent's push socket is stale. Create a fresh one.

--- a/bindings/pyomq/tests/test_interop_curve.py
+++ b/bindings/pyomq/tests/test_interop_curve.py
@@ -95,7 +95,7 @@ def test_pyomq_curve_server_pyzmq_curve_client_req_rep(tcp_endpoint):
 def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
     if sys.platform == "win32":
         with pytest.warns(DeprecationWarning):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # ty: ignore
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 
@@ -133,7 +133,7 @@ def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
 def test_pyzmq_curve_server_pyomq_curve_client_req_rep(tcp_endpoint):
     if sys.platform == "win32":
         with pytest.warns(DeprecationWarning):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # ty: ignore
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 

--- a/bindings/pyomq/tests/test_interop_curve.py
+++ b/bindings/pyomq/tests/test_interop_curve.py
@@ -95,7 +95,9 @@ def test_pyomq_curve_server_pyzmq_curve_client_req_rep(tcp_endpoint):
 def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
     if sys.platform == "win32":
         with pytest.warns(DeprecationWarning):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # ty: ignore
+            asyncio.set_event_loop_policy(  # ty: ignore[deprecated, unused-ignore-comment, unused-ignore-comment]
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 
@@ -133,7 +135,9 @@ def test_pyzmq_curve_server_pyomq_curve_client_push_pull(tcp_endpoint):
 def test_pyzmq_curve_server_pyomq_curve_client_req_rep(tcp_endpoint):
     if sys.platform == "win32":
         with pytest.warns(DeprecationWarning):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # ty: ignore
+            asyncio.set_event_loop_policy(  # ty: ignore[deprecated, unused-ignore-comment, unused-ignore-comment]
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
     server_pub, server_sec = zmq_pyzmq.curve_keypair()
     client_pub, client_sec = pyomq.curve_keypair()
 

--- a/bindings/pyomq/tests/test_socket_attrs.py
+++ b/bindings/pyomq/tests/test_socket_attrs.py
@@ -100,7 +100,7 @@ def test_unknown_attr_raises():
     sock = ctx.socket(zmq.PUSH)
     try:
         with pytest.raises(AttributeError):
-            _ = sock.nonexistent_attribute
+            _ = sock.nonexistent_attribute  # type: ignore[ty:unresolved-attribute]
     finally:
         sock.close()
         ctx.term()

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -289,6 +289,7 @@ enum RuntimeOwnership {
 
 struct ContextInner {
     ownership: RuntimeOwnership,
+    owner_pid: u32,
     io_threads: usize,
     terminated: AtomicBool,
 }
@@ -297,6 +298,7 @@ impl std::fmt::Debug for ContextInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ContextInner")
             .field("io_threads", &self.io_threads)
+            .field("owner_pid", &self.owner_pid)
             .field(
                 "owned",
                 &matches!(self.ownership, RuntimeOwnership::Owned { .. }),
@@ -307,6 +309,10 @@ impl std::fmt::Debug for ContextInner {
 }
 
 impl ContextInner {
+    fn is_owner_process(&self) -> bool {
+        self.owner_pid == std::process::id()
+    }
+
     fn primary_handle(&self) -> &Handle {
         match &self.ownership {
             RuntimeOwnership::Owned { pool } => pool.primary_handle(),
@@ -347,6 +353,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 ownership: RuntimeOwnership::Owned { pool },
+                owner_pid: std::process::id(),
                 io_threads,
                 terminated: AtomicBool::new(false),
             }),
@@ -367,6 +374,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 ownership: RuntimeOwnership::Borrowed { handle },
+                owner_pid: std::process::id(),
                 io_threads: 0,
                 terminated: AtomicBool::new(false),
             }),
@@ -400,6 +408,10 @@ impl Context {
             !self.inner.terminated.load(Ordering::Acquire),
             "Context::socket() called on a terminated context"
         );
+        assert!(
+            self.inner.is_owner_process(),
+            "Context::socket() called on a context inherited across fork"
+        );
         let _guard = self.inner.primary_handle().enter();
         let io_pool = self.inner.io_pool_handle();
         Socket::new_with_io_pool(socket_type, options, &io_pool)
@@ -429,6 +441,10 @@ impl Context {
         assert!(
             !self.inner.terminated.load(Ordering::Acquire),
             "Context::block_on() called on a terminated context"
+        );
+        assert!(
+            self.inner.is_owner_process(),
+            "Context::block_on() called on a context inherited across fork"
         );
         let guard = pool.primary_job_tx.lock().expect("job_tx poisoned");
         let job_tx = guard
@@ -466,6 +482,9 @@ impl Context {
         if self.inner.terminated.swap(true, Ordering::AcqRel) {
             return;
         }
+        if !self.inner.is_owner_process() {
+            return;
+        }
         if let RuntimeOwnership::Owned { ref pool } = self.inner.ownership {
             pool.shutdown();
         }
@@ -480,6 +499,9 @@ impl Default for Context {
 
 impl Drop for ContextInner {
     fn drop(&mut self) {
+        if !self.is_owner_process() {
+            return;
+        }
         if let RuntimeOwnership::Owned { ref pool } = self.ownership {
             pool.shutdown();
         }

--- a/omq-tokio/src/routing/identity.rs
+++ b/omq-tokio/src/routing/identity.rs
@@ -88,6 +88,7 @@ pub(crate) struct Submitter {
 impl Submitter {
     pub(crate) fn shutdown(&self) {
         let mut g = self.inner.lock().expect("identity inner poisoned");
+        g.closed = true;
         g.peers.clear();
         g.identity_to_peer.clear();
     }
@@ -209,13 +210,18 @@ impl Submitter {
         msg: Message,
     ) -> core::result::Result<(), TrySendError> {
         let mut g = self.inner.lock().expect("identity inner poisoned");
+        let closed = g.closed;
         let Some(peer) = g.peers.get_mut(&peer_id) else {
-            return Err(TrySendError::Error(Error::Unroutable));
+            if closed {
+                return Err(TrySendError::Closed);
+            }
+            return Ok(());
         };
-        peer.target.try_send(msg).map_err(|e| match e {
-            SendPipeError::Full(m) => TrySendError::Full(m),
-            SendPipeError::Closed(_) => TrySendError::Closed,
-        })
+        match peer.target.try_send(msg) {
+            Err(SendPipeError::Full(m)) => Err(TrySendError::Full(m)),
+            Err(SendPipeError::Closed(_)) if closed => Err(TrySendError::Closed),
+            Ok(()) | Err(SendPipeError::Closed(_)) => Ok(()),
+        }
     }
 
     fn try_send_to(
@@ -259,6 +265,7 @@ pub(crate) struct IdentitySend {
 struct IdentityInner {
     peers: FxHashMap<u64, IdentityPeer>,
     identity_to_peer: FxHashMap<Bytes, u64>,
+    closed: bool,
 }
 
 #[derive(Debug)]
@@ -282,6 +289,7 @@ impl IdentitySend {
             inner: Arc::new(Mutex::new(IdentityInner {
                 peers: FxHashMap::default(),
                 identity_to_peer: FxHashMap::default(),
+                closed: false,
             })),
             router_mandatory: options.router_mandatory,
             latency_profile,
@@ -355,6 +363,7 @@ impl IdentitySend {
 
     pub(crate) fn shutdown(&self) {
         let mut g = self.inner.lock().expect("identity inner poisoned");
+        g.closed = true;
         g.peers.clear();
         g.identity_to_peer.clear();
     }

--- a/omq-tokio/src/socket/actor/lifecycle.rs
+++ b/omq-tokio/src/socket/actor/lifecycle.rs
@@ -22,23 +22,6 @@ impl<'a> PeerLifecycle<'a> {
         let peer = self.driver.peers.remove(&peer_id);
         if let Some(ref p) = peer {
             self.driver.io_pool.release_thread(p.io_thread);
-            if self.driver.socket_type == SocketType::Rep && self.driver.uses_latency_profile() {
-                if self
-                    .driver
-                    .rep_current
-                    .lock()
-                    .expect("rep current")
-                    .as_ref()
-                    .is_some_and(|(current_peer_id, _)| *current_peer_id == peer_id)
-                {
-                    self.driver.rep_current.lock().expect("rep current").take();
-                }
-                self.driver
-                    .rep_pending
-                    .lock()
-                    .expect("rep pending")
-                    .retain(|(pending_peer_id, _)| *pending_peer_id != peer_id);
-            }
         }
         self.publish_disconnect(peer.as_ref(), reason);
         Self::invalidate_spsc(peer.as_ref());
@@ -172,14 +155,6 @@ impl<'a> PeerLifecycle<'a> {
                     .lock()
                     .expect("type_state")
                     .on_peer_disconnected();
-            }
-            SocketType::Rep if self.driver.peers.is_empty() => {
-                self.driver
-                    .type_state
-                    .lock()
-                    .expect("type_state")
-                    .on_peer_disconnected();
-                self.driver.rep_pending.lock().expect("rep pending").clear();
             }
             _ => {}
         }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -195,9 +195,8 @@ pub(crate) struct SocketDriver {
     /// REQ / REP envelope + alternation state. Shared with the socket
     /// handle so `Socket::send` can call `pre_send` without an actor hop.
     type_state: Arc<Mutex<TypeState>>,
-    /// REP latency route: envelope of the request currently being served.
+    /// REP latency route: envelopes for requests waiting in the receive pipe.
     rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, RepEnvelope)>>>,
-    rep_current: Arc<Mutex<Option<(u64, RepEnvelope)>>>,
     /// REQ alternation flag. Shared with the socket handle for lock-free
     /// send/recv on REQ. Actor resets on peer disconnect.
     req_awaiting_reply: Arc<AtomicBool>,
@@ -238,7 +237,6 @@ impl SocketDriver {
         spsc: super::recv::SpscHandles,
         type_state: Arc<Mutex<TypeState>>,
         rep_pending: Arc<Mutex<std::collections::VecDeque<(u64, RepEnvelope)>>>,
-        rep_current: Arc<Mutex<Option<(u64, RepEnvelope)>>>,
         req_awaiting_reply: Arc<AtomicBool>,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
         subscribe_count: Arc<AtomicU64>,
@@ -265,7 +263,6 @@ impl SocketDriver {
             recv_strategy,
             type_state,
             rep_pending,
-            rep_current,
             req_awaiting_reply,
             monitor,
             subscriptions: Vec::new(),

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -654,9 +654,9 @@ impl Socket {
     /// expires. Returns the peer count at the time the threshold was met,
     /// or `Error::Timeout` if the deadline is reached first.
     ///
-    /// This is a data-plane readiness check. It polls `connections()`
-    /// rather than relying on `MonitorStream` events, which are
-    /// diagnostic and may lag under load.
+    /// This is a data-plane readiness check. It waits for ZMTP peers to
+    /// finish handshaking rather than only being accepted by the listener.
+    /// `STREAM` peers are ready as soon as the raw TCP connection exists.
     pub async fn wait_connected(
         &self,
         min_peers: usize,
@@ -665,8 +665,13 @@ impl Socket {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             let conns = self.connections().await?;
-            if conns.len() >= min_peers {
-                return Ok(conns.len());
+            let ready = if self.inner.socket_type == SocketType::Stream {
+                conns.len()
+            } else {
+                conns.iter().filter(|conn| conn.peer_info.is_some()).count()
+            };
+            if ready >= min_peers {
+                return Ok(ready);
             }
             if tokio::time::Instant::now() >= deadline {
                 return Err(Error::Timeout);

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -162,7 +162,6 @@ impl Socket {
             spsc.clone(),
             type_state.clone(),
             rep_pending.clone(),
-            rep_current.clone(),
             req_awaiting_reply.clone(),
             recv_sink_config,
             subscribe_count.clone(),

--- a/omq-tokio/tests/monitor.rs
+++ b/omq-tokio/tests/monitor.rs
@@ -1,11 +1,14 @@
 //! Monitor stream integration tests.
 
+mod test_support;
+
 use std::time::Duration;
 
 use omq_tokio::{
     ConnectionStatus, DisconnectReason, Endpoint, Message, MonitorEvent, Options, Socket,
     SocketType,
 };
+use tokio::net::TcpStream;
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
@@ -298,6 +301,34 @@ async fn connection_info_returns_status_post_handshake() {
 
     // Unknown id → None.
     assert!(server.connection_info(999_999).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn wait_connected_ignores_pre_handshake_tcp_peers() {
+    let server = Socket::new(SocketType::Pair, Options::default());
+    let port = test_support::bind_loopback(&server).await;
+    let mut mon = server.monitor();
+
+    let _raw = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::Accepted { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before Accepted: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("raw TCP peer was not accepted");
+
+    assert!(
+        server
+            .wait_connected(1, Duration::from_millis(50))
+            .await
+            .is_err(),
+        "pre-handshake peer must not satisfy wait_connected"
+    );
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -482,6 +482,36 @@ async fn push_send_before_peer_connects_queues() {
     }
 }
 
+#[tokio::test]
+async fn push_tcp_send_before_peer_connects_queues() {
+    let push = Socket::new(SocketType::Push, Options::default());
+    let port = test_support::bind_loopback(&push).await;
+
+    for i in 0..5 {
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            push.send(Message::single(format!("early-{i}"))),
+        )
+        .await
+        .expect("send before TCP peer must not block")
+        .unwrap();
+    }
+
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    pull.connect(test_support::tcp_loopback(port))
+        .await
+        .unwrap();
+
+    for i in 0..5 {
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let expected = format!("early-{i}");
+        assert_eq!(m.part_bytes(0).unwrap(), expected.as_bytes());
+    }
+}
+
 /// TCP PUSH/PULL with peer churn: PULL connects, receives, disconnects;
 /// new PULL connects and must receive subsequent messages.
 #[tokio::test]

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -200,6 +200,36 @@ async fn rep_survives_client_disconnect_mid_cycle() {
 }
 
 #[tokio::test]
+async fn rep_reply_to_disconnected_client_is_accepted() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let ep = rep.bind(tcp_ep(0)).await.unwrap();
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&req).await;
+
+    req.send(Message::single("drop-me")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), rep.recv())
+        .await
+        .expect("REP recv timed out")
+        .unwrap();
+    assert_eq!(got, Message::single("drop-me"));
+
+    req.close_with_linger(Some(Duration::ZERO)).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !rep.connections().await.unwrap().is_empty() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("REP still had live peer");
+
+    rep.send(Message::single("dropped-reply"))
+        .await
+        .expect("REP reply to a disconnected peer must be accepted");
+}
+
+#[tokio::test]
 async fn req_rep_1000_cycles_tcp() {
     // 1 000 sequential request-reply cycles over TCP.
     // Scales beyond inproc to reveal framing races, backpressure issues,


### PR DESCRIPTION
- module level variables are all marked Final
- classes attributes and methods are all type annotated
- code shared between different socket is regrouped under common class which explicitly exposes all options (rather than using `__getattr__, __setattr__`)
- CI is extended to test pyomd on all OS, and to test minimal supported Python version

One open question regarding _ShadowSocket. Curently it has a reduced surface API (no bind, unbind, join, leave, etc) Is that on purpose ? I believe it represents a deviation from pyzmq.