### PR TITLE
Fix LZ4 fan-out lane control ordering

### DIFF
--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use bytes::Bytes;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
+use tokio::sync::oneshot;
 
 use crate::engine::PeerDriverHandle;
 use omq_proto::error::Result;
@@ -450,7 +451,11 @@ impl FanOutSend {
     }
 
     #[expect(clippy::needless_pass_by_value)]
-    pub(crate) fn peer_subscribe(&self, peer_id: u64, prefix: Bytes) {
+    pub(crate) fn peer_subscribe(
+        &self,
+        peer_id: u64,
+        prefix: Bytes,
+    ) -> Option<oneshot::Receiver<()>> {
         let mut g = self.inner.lock().expect("fanout inner poisoned");
         if let Some(p) = g.peers.get_mut(&peer_id) {
             let became_subscribe_all = filter::add_subscription(&mut p.subscriptions, &prefix);
@@ -459,11 +464,15 @@ impl FanOutSend {
                 g.subscribe_all_count += 1;
             }
             drop(g);
-            if let Some(lane) = lane {
-                self.lanes.send_subscribe(lane, peer_id, prefix.clone());
-            }
+            let ack = if let Some(lane) = lane {
+                self.lanes.send_subscribe(lane, peer_id, prefix.clone())
+            } else {
+                None
+            };
             self.bump_generation();
+            return ack;
         }
+        None
     }
 
     pub(crate) fn peer_cancel(&self, peer_id: u64, prefix: &[u8]) {

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use bytes::Bytes;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
+use tokio::sync::oneshot;
 
 use crate::engine::signal::DataSignal;
 use crate::engine::transmit_slot::{PeerTransmitSlot, TryFrameResult};
@@ -33,6 +34,7 @@ enum LaneControl {
     Subscribe {
         peer_id: u64,
         prefix: Bytes,
+        ack: Option<oneshot::Sender<()>>,
     },
     Cancel {
         peer_id: u64,
@@ -325,8 +327,28 @@ impl FanOutLanes {
         }
     }
 
-    pub(super) fn send_subscribe(&self, lane: usize, peer_id: u64, prefix: Bytes) {
-        self.send_to_lane(lane, LaneControl::Subscribe { peer_id, prefix });
+    pub(super) fn send_subscribe(
+        &self,
+        lane: usize,
+        peer_id: u64,
+        prefix: Bytes,
+    ) -> Option<oneshot::Receiver<()>> {
+        let (ack, rx) = oneshot::channel();
+        let lane = self.normalize_lane(lane);
+        let mut state = self.state.lock().expect("fanout lanes poisoned");
+        if let Some(endpoint) = state.endpoints.get_mut(lane) {
+            Self::push_control(
+                endpoint,
+                LaneControl::Subscribe {
+                    peer_id,
+                    prefix,
+                    ack: Some(ack),
+                },
+            );
+            Some(rx)
+        } else {
+            None
+        }
     }
 
     pub(super) fn send_cancel(&self, lane: usize, peer_id: u64, prefix: Bytes) {
@@ -418,21 +440,10 @@ impl LaneWorker {
         let mut budget = DrainBudget::WORKER;
         loop {
             let mut touched: SmallVec<[u64; 32]> = SmallVec::new();
-            let mut shutdown = false;
-            self.ctrl_notify.begin_drain();
             self.data_signal.begin_drain();
 
             // 1. ALL control commands, unconditionally.
-            self.ctrl_rx.prefetch();
-            while let Some(cmd) = self.ctrl_rx.pop() {
-                if self.handle_control(cmd) {
-                    shutdown = true;
-                }
-            }
-            self.ctrl_rx.release();
-            self.ctrl_notify.clear_after(self.ctrl_rx.is_empty());
-
-            if shutdown {
+            if self.drain_control() {
                 self.flush_touched(&mut touched);
                 self.peers.clear();
                 self.subscribe_all_count = 0;
@@ -460,22 +471,44 @@ impl LaneWorker {
                 self.data_rx.release();
 
                 if !batch.is_empty() {
+                    // Control sent before this data can race with the first
+                    // control drain. Drain once more after observing data so
+                    // subscriptions and compression updates apply first.
+                    if self.drain_control() {
+                        self.flush_touched(&mut touched);
+                        self.peers.clear();
+                        self.subscribe_all_count = 0;
+                        return;
+                    }
                     self.distribute_batch(&batch);
                     for dispatch in &batch {
                         self.dispatch(dispatch, &mut touched).await;
                     }
                 }
             } else {
+                let mut batch: SmallVec<[LaneDispatch; 32]> = SmallVec::new();
                 self.data_rx.prefetch();
                 while let Some(dispatch) = self.data_rx.pop() {
                     drained = true;
                     let msg_bytes = dispatch.msg.byte_len();
-                    self.dispatch(&dispatch, &mut touched).await;
+                    batch.push(dispatch);
                     if !budget.account(msg_bytes) {
                         break;
                     }
                 }
                 self.data_rx.release();
+
+                if !batch.is_empty() {
+                    if self.drain_control() {
+                        self.flush_touched(&mut touched);
+                        self.peers.clear();
+                        self.subscribe_all_count = 0;
+                        return;
+                    }
+                    for dispatch in &batch {
+                        self.dispatch(dispatch, &mut touched).await;
+                    }
+                }
             }
 
             self.flush_touched(&mut touched);
@@ -489,6 +522,20 @@ impl LaneWorker {
                 () = self.data_signal.ready() => {}
             }
         }
+    }
+
+    fn drain_control(&mut self) -> bool {
+        let mut shutdown = false;
+        self.ctrl_notify.begin_drain();
+        self.ctrl_rx.prefetch();
+        while let Some(cmd) = self.ctrl_rx.pop() {
+            if self.handle_control(cmd) {
+                shutdown = true;
+            }
+        }
+        self.ctrl_rx.release();
+        self.ctrl_notify.clear_after(self.ctrl_rx.is_empty());
+        shutdown
     }
 
     fn distribute_batch(&mut self, batch: &[LaneDispatch]) {
@@ -528,11 +575,18 @@ impl LaneWorker {
                     self.subscribe_all_count = self.subscribe_all_count.saturating_sub(1);
                 }
             }
-            LaneControl::Subscribe { peer_id, prefix } => {
+            LaneControl::Subscribe {
+                peer_id,
+                prefix,
+                ack,
+            } => {
                 if let Some(peer) = self.peers.get_mut(&peer_id)
                     && filter::add_subscription(&mut peer.subscriptions, &prefix)
                 {
                     self.subscribe_all_count += 1;
+                }
+                if let Some(ack) = ack {
+                    let _ = ack.send(());
                 }
             }
             LaneControl::Cancel { peer_id, prefix } => {

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -37,6 +37,7 @@ use omq_proto::message::Message;
 use omq_proto::options::Options;
 use omq_proto::proto::SocketType;
 use omq_proto::routing::{FanOutKind, RecvCategory, SendCategory, recv_category, send_category};
+use tokio::sync::oneshot;
 
 /// Max messages one shared-queue consumer batch-encodes before flushing.
 /// Scaled down per peer by [`RoundRobinSend`] to improve distribution
@@ -273,10 +274,15 @@ impl SendStrategy {
     }
 
     /// Record a SUBSCRIBE from a peer. No-op except for `FanOut`.
-    pub(crate) fn peer_subscribe(&self, peer_id: u64, prefix: Bytes) {
+    pub(crate) fn peer_subscribe(
+        &self,
+        peer_id: u64,
+        prefix: Bytes,
+    ) -> Option<oneshot::Receiver<()>> {
         if let Self::FanOut(s) = self {
-            s.peer_subscribe(peer_id, prefix);
+            return s.peer_subscribe(peer_id, prefix);
         }
+        None
     }
 
     /// Record a CANCEL from a peer. No-op except for `FanOut`.

--- a/omq-tokio/src/socket/actor/peer.rs
+++ b/omq-tokio/src/socket/actor/peer.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::socket::actor::lifecycle::PeerLifecycle;
 use omq_proto::WorkloadProfile;
+use std::sync::atomic::Ordering;
 
 impl SocketDriver {
     pub(super) async fn handle_internal_event(&mut self, evt: InternalEvent) {
@@ -296,9 +297,8 @@ impl SocketDriver {
         use omq_proto::proto::Command;
         match cmd {
             Command::Subscribe(prefix) => {
-                self.send_strategy.peer_subscribe(peer_id, prefix.clone());
-                self.subscribe_count
-                    .fetch_add(1, std::sync::atomic::Ordering::Release);
+                let applied = self.send_strategy.peer_subscribe(peer_id, prefix.clone());
+                self.count_subscription_after(applied);
                 self.monitor.publish(MonitorEvent::SubscribeReceived {
                     prefix: prefix.clone(),
                 });
@@ -335,6 +335,19 @@ impl SocketDriver {
             }
             _ => {}
         }
+    }
+
+    fn count_subscription_after(&self, applied: Option<tokio::sync::oneshot::Receiver<()>>) {
+        let Some(applied) = applied else {
+            self.subscribe_count.fetch_add(1, Ordering::Release);
+            return;
+        };
+        let subscribe_count = self.subscribe_count.clone();
+        std::mem::drop(tokio::spawn(async move {
+            if applied.await.is_ok() {
+                subscribe_count.fetch_add(1, Ordering::Release);
+            }
+        }));
     }
 
     /// Handle legacy ZMTP 3.0 subscribe/cancel (single-frame message with

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
 
+const FAN_OUT_READY_TIMEOUT: Duration = Duration::from_secs(5);
+
 fn lz4_loopback() -> Endpoint {
     Endpoint::Lz4Tcp {
         host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
@@ -112,7 +114,7 @@ async fn pub_sub_lz4_io_lane_fan_out_ships_dict_to_late_subscriber() {
         decoded_subs.push(sub);
     }
     publisher
-        .wait_subscribed(N_DECODED_SUBS as u64, Duration::from_secs(1))
+        .wait_subscribed(N_DECODED_SUBS as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("subscriptions did not arrive");
 
@@ -120,7 +122,7 @@ async fn pub_sub_lz4_io_lane_fan_out_ships_dict_to_late_subscriber() {
     raw_sub.connect(tcp_from_lz4(&ep)).await.unwrap();
     raw_sub.subscribe(bytes::Bytes::new()).await.unwrap();
     publisher
-        .wait_subscribed((N_DECODED_SUBS + 1) as u64, Duration::from_secs(1))
+        .wait_subscribed((N_DECODED_SUBS + 1) as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("raw subscriber subscription did not arrive");
 
@@ -200,7 +202,7 @@ async fn pub_sub_lz4_io_lane_fan_out_auto_trains_dict_for_late_subscriber() {
         decoded_subs.push(sub);
     }
     publisher
-        .wait_subscribed(N_DECODED_SUBS as u64, Duration::from_secs(1))
+        .wait_subscribed(N_DECODED_SUBS as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("subscriptions did not arrive");
 
@@ -225,7 +227,7 @@ async fn pub_sub_lz4_io_lane_fan_out_auto_trains_dict_for_late_subscriber() {
     raw_sub.connect(tcp_from_lz4(&ep)).await.unwrap();
     raw_sub.subscribe(bytes::Bytes::new()).await.unwrap();
     publisher
-        .wait_subscribed((N_DECODED_SUBS + 1) as u64, Duration::from_secs(1))
+        .wait_subscribed((N_DECODED_SUBS + 1) as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("raw subscriber subscription did not arrive");
 
@@ -294,7 +296,7 @@ async fn pub_sub_lz4_io_lane_fan_out_deferred_large_message_preserves_order() {
         subs.push(sub);
     }
     publisher
-        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .wait_subscribed(N_SUBS as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("subscriptions did not arrive");
 
@@ -391,7 +393,7 @@ async fn pub_sub_lz4_fan_out() {
         subs.push(s);
     }
     publisher
-        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .wait_subscribed(N_SUBS as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("subscriptions did not arrive");
 
@@ -448,7 +450,7 @@ async fn pub_sub_lz4_fan_out_with_dict() {
         subs.push(s);
     }
     publisher
-        .wait_subscribed(N_SUBS as u64, Duration::from_secs(1))
+        .wait_subscribed(N_SUBS as u64, FAN_OUT_READY_TIMEOUT)
         .await
         .expect("subscriptions did not arrive");
 


### PR DESCRIPTION
- Count `SUBSCRIBE` after fan-out lane applies it, so `wait_subscribed` reflects lane routing state.
- Drain lane control again before dispatching observed data batches, so `Subscribe` and `SetCompression` queued before data apply first.
- Fix late raw `lz4+tcp://` subscriber missing auto-trained dictionary shipment.
- cc @MatthieuDartiailh