### PR TITLE
Honor DropOldest for fan-out sockets

### DIFF
--- a/omq-proto/src/frame_buffer.rs
+++ b/omq-proto/src/frame_buffer.rs
@@ -286,6 +286,23 @@ impl FrameBuffer {
         }
     }
 
+    pub fn pop_front_entry(&mut self) -> bool {
+        self.commit_arena_range();
+        let Some(entry) = self.entries.pop_front() else {
+            return false;
+        };
+        let len = match entry {
+            Entry::Arena { len, .. } => len as usize,
+            Entry::External(bytes) => bytes.len(),
+        };
+        self.total_bytes = self.total_bytes.saturating_sub(len);
+        if self.entries.is_empty() && self.arena.len() == self.arena_mark as usize {
+            self.arena.clear();
+            self.arena_mark = 0;
+        }
+        true
+    }
+
     pub fn push_shared_chunks(&mut self, chunks: &[Bytes]) {
         self.commit_arena_range();
         for chunk in chunks {
@@ -555,5 +572,19 @@ mod tests {
 
         let drained: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
         assert_eq!(raw, drained);
+    }
+
+    #[test]
+    fn pop_front_entry_drops_oldest_committed_chunk() {
+        let mut eq = FrameBuffer::one_shot();
+        eq.push_raw(vec![Bytes::from_static(b"first")]);
+        eq.push_raw(vec![Bytes::from_static(b"second")]);
+
+        assert!(eq.pop_front_entry());
+
+        let mut chunks = Vec::new();
+        eq.drain(&mut chunks, 1024);
+        assert_eq!(chunks, vec![Bytes::from_static(b"second")]);
+        assert!(eq.is_empty());
     }
 }

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -715,6 +715,10 @@ impl Default for ReconnectPolicy {
 /// no-peer round-robin sockets queue into a pre-ready pipe until `send_hwm`
 /// is reached, then apply this policy. Native OMQ has no `ZMQ_IMMEDIATE`
 /// option; `omq-libzmq` implements `ZMQ_IMMEDIATE` at the C layer.
+///
+/// `PUB`, `XPUB`, and `RADIO` honor `DropOldest` for per-peer fan-out
+/// queues. Other fan-out sockets keep the native drop-newest behavior unless
+/// `xpub_nodrop` asks them to wait.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OnMute {

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -9,9 +9,10 @@ use std::io;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use super::signal::{DataSignal, StateSignal};
+use omq_proto::fan_out_frame::FanOutFrame;
 use omq_proto::frame_buffer::FrameBuffer;
 use omq_proto::handle_frame::{
     HandleFrameCaps, HandleFrameDecision, HandleFrameState, decide_handle_frame,
@@ -195,6 +196,33 @@ impl PeerTransmitSlot {
         eq.push_pre_framed(data);
         self.queued_msgs.fetch_add(1, Ordering::Relaxed);
         self.mark_above_lwm_if_needed(eq.total_bytes(), self.queued_msgs.load(Ordering::Relaxed));
+        TryFrameResult::Ok
+    }
+
+    pub(crate) fn try_push_fanout_drop_oldest(&self, frame: &FanOutFrame<'_>) -> TryFrameResult {
+        if self.dead.load(Ordering::Acquire) {
+            return TryFrameResult::Dead;
+        }
+        // Store one encoded fan-out message per entry so full-slot eviction
+        // can remove the oldest whole message instead of an arbitrary chunk.
+        let chunk = fanout_frame_chunk(frame);
+        let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
+        let mut queued_msgs = self.queued_msgs.load(Ordering::Relaxed);
+        while eq.total_bytes().saturating_add(chunk.len()) >= self.cap
+            || queued_msgs >= self.msg_cap
+        {
+            if !eq.pop_front_entry() {
+                self.above_lwm.store(true, Ordering::Relaxed);
+                return TryFrameResult::Full;
+            }
+            queued_msgs = queued_msgs.saturating_sub(1);
+        }
+        eq.push_raw(vec![chunk]);
+        queued_msgs += 1;
+        self.queued_msgs.store(queued_msgs, Ordering::Relaxed);
+        self.mark_above_lwm_if_needed(eq.total_bytes(), queued_msgs);
+        drop(eq);
+        self.signal_encoded();
         TryFrameResult::Ok
     }
 
@@ -392,9 +420,25 @@ impl PeerTransmitSlot {
     }
 }
 
+fn fanout_frame_chunk(frame: &FanOutFrame<'_>) -> Bytes {
+    match frame {
+        FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+        FanOutFrame::Chunks(chunks) if chunks.len() == 1 => chunks[0].clone(),
+        FanOutFrame::Chunks(chunks) => {
+            let len = chunks.iter().map(Bytes::len).sum();
+            let mut buf = BytesMut::with_capacity(len);
+            for chunk in *chunks {
+                buf.extend_from_slice(chunk);
+            }
+            buf.freeze()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
     use tokio::time::{Duration, timeout};
 
     fn test_slot() -> Arc<PeerTransmitSlot> {
@@ -415,6 +459,15 @@ mod tests {
         slot
     }
 
+    fn fanout_bytes(msg: &Message) -> Bytes {
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, msg, &mut chunks, 1, 8 * 1024);
+        let bytes = fanout_frame_chunk(&frame);
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
     #[test]
     fn transmit_slot_caps_queued_messages_independent_of_bytes() {
         let slot = test_slot();
@@ -428,6 +481,40 @@ mod tests {
         let mut chunks = Vec::new();
         slot.drain(&mut chunks, 1024);
         assert_eq!(slot.try_encode(&msg), TryFrameResult::Ok);
+    }
+
+    #[test]
+    fn fanout_drop_oldest_slot_keeps_newest_messages() {
+        let slot = PeerTransmitSlot::new(
+            1,
+            false,
+            None,
+            omq_proto::frame_buffer::ARENA_THRESHOLD,
+            omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            TRANSMIT_SLOT_CAP_DEFAULT,
+            2,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+
+        let first = Message::single("first");
+        let second = Message::single("second");
+        let third = Message::single("third");
+
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        for msg in [&first, &second, &third] {
+            let frame = build_fan_out_frame(&mut eq, msg, &mut chunks, 1, 8 * 1024);
+            assert_eq!(slot.try_push_fanout_drop_oldest(&frame), TryFrameResult::Ok);
+            clear_fan_out_frame(&mut eq, &mut chunks);
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(actual, vec![fanout_bytes(&second), fanout_bytes(&third)]);
     }
 
     #[tokio::test]

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -22,7 +22,8 @@ use tokio::sync::oneshot;
 use crate::engine::PeerDriverHandle;
 use omq_proto::error::Result;
 use omq_proto::message::Message;
-use omq_proto::options::Options;
+use omq_proto::options::{OnMute, Options};
+use omq_proto::proto::SocketType;
 
 use super::peer_outbound::PeerOutbound;
 use super::subscription::SubscriptionSet;
@@ -50,6 +51,19 @@ fn yield_interval(peer_count: usize, msg_bytes: usize) -> u32 {
     peer_interval.min(byte_interval)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FanOutMutePolicy {
+    Block,
+    DropNewest,
+    DropOldest,
+}
+
+impl FanOutMutePolicy {
+    pub(super) fn is_lossy(self) -> bool {
+        !matches!(self, Self::Block)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Submitter {
     lanes: Arc<FanOutLanes>,
@@ -60,7 +74,7 @@ pub(crate) struct Submitter {
     mode: FanOutMode,
     send_count: Arc<AtomicU32>,
     xpub_nodrop: bool,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     #[cfg(feature = "lz4")]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
@@ -76,17 +90,23 @@ impl Clone for Submitter {
             mode: self.mode,
             send_count: self.send_count.clone(),
             xpub_nodrop: self.xpub_nodrop,
-            lossy: self.lossy,
+            mute_policy: self.mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: self.dict_training.clone(),
         }
     }
 }
 
-fn fan_out_is_lossy(options: &Options) -> bool {
-    // TODO: Fan-out mute currently drops newest. Supporting DropOldest needs
-    // per-peer oldest eviction in PeerTransmitSlot or a fan-out-specific queue.
-    !options.xpub_nodrop
+fn fan_out_mute_policy(socket_type: SocketType, options: &Options) -> FanOutMutePolicy {
+    if options.xpub_nodrop {
+        return FanOutMutePolicy::Block;
+    }
+    match (socket_type, options.on_mute) {
+        (SocketType::Pub | SocketType::XPub | SocketType::Radio, OnMute::DropOldest) => {
+            FanOutMutePolicy::DropOldest
+        }
+        _ => FanOutMutePolicy::DropNewest,
+    }
 }
 
 fn deactivate_fanout_target(
@@ -168,8 +188,13 @@ impl Submitter {
 
         if !fallback_targets.is_empty() {
             let mut deactivate = |target: &PeerOutbound| self.deactivate_target(target);
-            fallback::dispatch_to_targets(&fallback_targets, msg, self.lossy, &mut deactivate)
-                .map_err(omq_proto::error::TrySendError::Error)?;
+            fallback::dispatch_to_targets(
+                &fallback_targets,
+                msg,
+                self.mute_policy,
+                &mut deactivate,
+            )
+            .map_err(omq_proto::error::TrySendError::Error)?;
         }
 
         if has_lane_peers {
@@ -237,7 +262,12 @@ impl Submitter {
 
         if !fallback_targets.is_empty() {
             let mut deactivate = |target: &PeerOutbound| self.deactivate_target(target);
-            fallback::dispatch_to_targets(&fallback_targets, msg, self.lossy, &mut deactivate)?;
+            fallback::dispatch_to_targets(
+                &fallback_targets,
+                msg,
+                self.mute_policy,
+                &mut deactivate,
+            )?;
         }
 
         if has_lane_peers {
@@ -295,7 +325,7 @@ pub(crate) struct FanOutSend {
     generation: Arc<AtomicU64>,
     mode: FanOutMode,
     xpub_nodrop: bool,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     #[cfg(feature = "lz4")]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
@@ -352,12 +382,13 @@ impl FanOutInner {
 
 impl FanOutSend {
     pub(crate) fn new(
+        socket_type: SocketType,
         options: &Options,
         mode: FanOutMode,
         io_pool: &crate::context::IoPoolHandle,
     ) -> Self {
-        let lossy = fan_out_is_lossy(options);
-        let lanes = FanOutLanes::spawn(options, mode, lossy, io_pool);
+        let mute_policy = fan_out_mute_policy(socket_type, options);
+        let lanes = FanOutLanes::spawn(options, mode, mute_policy, io_pool);
         let inner = Arc::new(Mutex::new(FanOutInner {
             peers: FxHashMap::default(),
             subscribe_all_count: 0,
@@ -376,7 +407,7 @@ impl FanOutSend {
             generation,
             mode,
             xpub_nodrop: options.xpub_nodrop,
-            lossy,
+            mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: Arc::new(Mutex::new(compression::new_dict_training(options))),
         }
@@ -396,7 +427,7 @@ impl FanOutSend {
             mode: self.mode,
             send_count: Arc::new(AtomicU32::new(0)),
             xpub_nodrop: self.xpub_nodrop,
-            lossy: self.lossy,
+            mute_policy: self.mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: self.dict_training.clone(),
         }
@@ -619,7 +650,9 @@ impl FanOutSend {
 
 #[cfg(test)]
 mod tests {
-    use super::yield_interval;
+    use super::{FanOutMode, FanOutMutePolicy, FanOutSend, fan_out_mute_policy, yield_interval};
+    use omq_proto::options::{OnMute, Options};
+    use omq_proto::proto::SocketType;
 
     #[test]
     fn yield_interval_scales_with_message_size() {
@@ -634,5 +667,46 @@ mod tests {
     fn yield_interval_yields_every_send_without_active_targets() {
         assert_eq!(yield_interval(0, 16), 1);
         assert_eq!(yield_interval(0, 16 * 1024), 1);
+    }
+
+    #[test]
+    fn drop_oldest_policy_is_pub_xpub_radio_only() {
+        let options = Options::default().on_mute(OnMute::DropOldest);
+
+        assert_eq!(
+            fan_out_mute_policy(SocketType::Pub, &options),
+            FanOutMutePolicy::DropOldest
+        );
+        assert_eq!(
+            fan_out_mute_policy(SocketType::Radio, &options),
+            FanOutMutePolicy::DropOldest
+        );
+        assert_eq!(
+            fan_out_mute_policy(SocketType::XPub, &options),
+            FanOutMutePolicy::DropOldest
+        );
+
+        let mut nodrop_options = options;
+        nodrop_options.xpub_nodrop = true;
+        assert_eq!(
+            fan_out_mute_policy(SocketType::XPub, &nodrop_options),
+            FanOutMutePolicy::Block
+        );
+    }
+
+    #[tokio::test]
+    async fn fan_out_send_new_wires_drop_oldest_policy() {
+        let options = Options::default().on_mute(OnMute::DropOldest);
+        let io_pool = crate::context::IoPoolHandle::none();
+
+        for (socket_type, mode) in [
+            (SocketType::Pub, FanOutMode::SubscriptionPrefix),
+            (SocketType::XPub, FanOutMode::SubscriptionPrefix),
+            (SocketType::Radio, FanOutMode::Group),
+        ] {
+            let send = FanOutSend::new(socket_type, &options, mode, &io_pool);
+            assert_eq!(send.mute_policy, FanOutMutePolicy::DropOldest);
+            send.shutdown();
+        }
     }
 }

--- a/omq-tokio/src/routing/fan_out/fallback.rs
+++ b/omq-tokio/src/routing/fan_out/fallback.rs
@@ -12,19 +12,19 @@ use omq_proto::fan_out_frame::{
 use omq_proto::frame_buffer::FrameBuffer;
 use omq_proto::message::Message;
 
-use super::FAN_OUT_TOTAL_COPY_BUDGET;
+use super::{FAN_OUT_TOTAL_COPY_BUDGET, FanOutMutePolicy};
 
 pub(super) fn dispatch_to_targets(
     targets: &[PeerOutbound],
     msg: &Message,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
 ) -> Result<()> {
     match targets.len() {
         0 => Ok(()),
-        1 => match targets[0].try_encode(msg) {
+        1 if mute_policy != FanOutMutePolicy::DropOldest => match targets[0].try_encode(msg) {
             TryFrameResult::Full => {
-                if drop_on_full {
+                if mute_policy == FanOutMutePolicy::DropNewest {
                     deactivate(&targets[0]);
                 }
                 Ok(())
@@ -35,7 +35,9 @@ pub(super) fn dispatch_to_targets(
             #[cfg(feature = "ws")]
             if targets.iter().any(PeerOutbound::is_ws) {
                 for t in targets {
-                    if t.try_encode(msg) == TryFrameResult::Full && drop_on_full {
+                    if t.try_encode(msg) == TryFrameResult::Full
+                        && mute_policy == FanOutMutePolicy::DropNewest
+                    {
                         deactivate(t);
                     }
                 }
@@ -57,7 +59,7 @@ pub(super) fn dispatch_to_targets(
                         targets,
                         msg,
                         &mut drain.borrow_mut(),
-                        drop_on_full,
+                        mute_policy,
                         deactivate,
                     );
                     Ok(())
@@ -70,17 +72,19 @@ pub(super) fn dispatch_to_targets(
 fn push_to_peers(
     targets: &[PeerOutbound],
     msg: &Message,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
-    push_wire: impl Fn(&PeerTransmitSlot) -> TryFrameResult,
+    push_wire: impl Fn(&PeerTransmitSlot, FanOutMutePolicy) -> TryFrameResult,
 ) {
     for t in targets {
         match t {
             PeerOutbound::Wire { slot, .. } => {
-                if drop_on_full && !slot.fanout_active() {
+                if mute_policy == FanOutMutePolicy::DropNewest && !slot.fanout_active() {
                     continue;
                 }
-                if push_wire(slot) == TryFrameResult::Full && drop_on_full {
+                if push_wire(slot, mute_policy) == TryFrameResult::Full
+                    && mute_policy == FanOutMutePolicy::DropNewest
+                {
                     deactivate(t);
                 }
             }
@@ -96,14 +100,24 @@ fn dispatch_encoded(
     targets: &[PeerOutbound],
     msg: &Message,
     chunks: &mut Vec<Bytes>,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
 ) {
     match finish_fan_out_frame(eq, chunks, targets.len(), FAN_OUT_TOTAL_COPY_BUDGET) {
         FanOutFrame::Arena(raw) => {
-            push_to_peers(targets, msg, drop_on_full, deactivate, |slot| {
-                slot.try_push_pre_framed_no_signal(raw)
-            });
+            let frame = FanOutFrame::Arena(raw);
+            push_to_peers(
+                targets,
+                msg,
+                mute_policy,
+                deactivate,
+                |slot, policy| match policy {
+                    FanOutMutePolicy::DropOldest => slot.try_push_fanout_drop_oldest(&frame),
+                    FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => {
+                        slot.try_push_pre_framed_no_signal(raw)
+                    }
+                },
+            );
             for t in targets {
                 if let PeerOutbound::Wire { slot, .. } = t {
                     slot.signal_encoded();
@@ -111,10 +125,164 @@ fn dispatch_encoded(
             }
         }
         FanOutFrame::Chunks(encoded) => {
-            push_to_peers(targets, msg, drop_on_full, deactivate, |slot| {
-                slot.try_push_encoded(encoded)
-            });
+            let frame = FanOutFrame::Chunks(encoded);
+            push_to_peers(
+                targets,
+                msg,
+                mute_policy,
+                deactivate,
+                |slot, policy| match policy {
+                    FanOutMutePolicy::DropOldest => slot.try_push_fanout_drop_oldest(&frame),
+                    FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => {
+                        slot.try_push_encoded(encoded)
+                    }
+                },
+            );
         }
     }
     clear_fan_out_frame(eq, chunks);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
+
+    use super::*;
+
+    #[test]
+    fn drop_oldest_single_target_fallback_keeps_newest_frames() {
+        let slot = test_slot_with_msg_cap(2);
+        let (inbox, _rx) = tokio::sync::mpsc::channel(1);
+        let target = PeerOutbound::Wire {
+            slot: slot.clone(),
+            inbox,
+            direct: None,
+        };
+        let mut deactivated = false;
+
+        for body in ["first", "second", "third"] {
+            dispatch_to_targets(
+                std::slice::from_ref(&target),
+                &Message::single(body),
+                FanOutMutePolicy::DropOldest,
+                &mut |_| {
+                    deactivated = true;
+                },
+            )
+            .unwrap();
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(
+            actual,
+            vec![encoded_message("second"), encoded_message("third")]
+        );
+        assert!(!deactivated);
+    }
+
+    #[test]
+    fn drop_newest_multi_target_fallback_keeps_oldest_frames() {
+        let slot1 = test_slot_with_msg_cap(2);
+        let slot2 = test_slot_with_msg_cap(2);
+        let outbound_a = test_wire_target(&slot1);
+        let outbound_b = test_wire_target(&slot2);
+        let outbounds = [outbound_a, outbound_b];
+        let mut deactivated = Vec::new();
+
+        for body in ["first", "second", "third"] {
+            dispatch_to_targets(
+                &outbounds,
+                &Message::single(body),
+                FanOutMutePolicy::DropNewest,
+                &mut |target| {
+                    if let PeerOutbound::Wire { slot, .. } = target {
+                        deactivated.push(slot.peer_id);
+                    }
+                },
+            )
+            .unwrap();
+        }
+
+        for slot in [&slot1, &slot2] {
+            let mut actual = Vec::new();
+            slot.drain(&mut actual, 1024);
+            assert_eq!(
+                actual,
+                vec![encoded_messages_for_targets(
+                    &["first", "second"],
+                    outbounds.len()
+                )]
+            );
+        }
+        assert_eq!(deactivated, vec![1, 1]);
+    }
+
+    fn test_wire_target(
+        slot: &Arc<crate::engine::transmit_slot::PeerTransmitSlot>,
+    ) -> PeerOutbound {
+        let (inbox, _rx) = tokio::sync::mpsc::channel(1);
+        PeerOutbound::Wire {
+            slot: slot.clone(),
+            inbox,
+            direct: None,
+        }
+    }
+
+    fn test_slot_with_msg_cap(
+        msg_cap: usize,
+    ) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
+        let slot = crate::engine::transmit_slot::PeerTransmitSlot::new(
+            1,
+            false,
+            None,
+            omq_proto::frame_buffer::ARENA_THRESHOLD,
+            omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            crate::engine::transmit_slot::TRANSMIT_SLOT_CAP_DEFAULT,
+            msg_cap,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+        slot
+    }
+
+    fn encoded_message(body: &str) -> Bytes {
+        encoded_message_for_targets(body, 1)
+    }
+
+    fn encoded_message_for_targets(body: &str, target_count: usize) -> Bytes {
+        let msg = Message::single(body.to_owned());
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, &msg, &mut chunks, target_count, 8 * 1024);
+        let bytes = match &frame {
+            FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+            FanOutFrame::Chunks(chunks) if chunks.len() == 1 => chunks[0].clone(),
+            FanOutFrame::Chunks(chunks) => {
+                let len = chunks.iter().map(Bytes::len).sum();
+                let mut buf = bytes::BytesMut::with_capacity(len);
+                for chunk in *chunks {
+                    buf.extend_from_slice(chunk);
+                }
+                buf.freeze()
+            }
+        };
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
+    fn encoded_messages_for_targets(bodies: &[&str], target_count: usize) -> Bytes {
+        let mut bytes = bytes::BytesMut::new();
+        for body in bodies {
+            let encoded = encoded_message_for_targets(body, target_count);
+            bytes.extend_from_slice(&encoded);
+        }
+        bytes.freeze()
+    }
 }

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -20,8 +20,8 @@ use omq_proto::options::Options;
 #[cfg(feature = "lz4")]
 use omq_proto::proto::transform::MessageEncoder;
 
-use super::FAN_OUT_TOTAL_COPY_BUDGET;
 use super::filter::{self, FanOutMode};
+use super::{FAN_OUT_TOTAL_COPY_BUDGET, FanOutMutePolicy};
 
 const LANE_CTRL_RING_CAP: usize = 64;
 
@@ -105,7 +105,7 @@ pub(super) struct FanOutLanes {
     state: Mutex<FanOutLaneState>,
     active_flags: Arc<Vec<AtomicBool>>,
     distributor: Mutex<LaneDistributor>,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
 }
 
 impl std::fmt::Debug for LaneDistributor {
@@ -153,7 +153,7 @@ struct LaneWorker {
     data_space: Arc<StateSignal>,
     ctrl_notify: Arc<DataSignal>,
     mode: FanOutMode,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     peers: FxHashMap<u64, LanePeer>,
     subscribe_all_count: usize,
     eq: FrameBuffer,
@@ -168,7 +168,7 @@ impl std::fmt::Debug for LaneWorker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LaneWorker")
             .field("mode", &self.mode)
-            .field("lossy", &self.lossy)
+            .field("mute_policy", &self.mute_policy)
             .field("peers", &self.peers.len())
             .field("distribution_targets", &self.distribution_targets.len())
             .finish_non_exhaustive()
@@ -179,7 +179,7 @@ impl FanOutLanes {
     pub(super) fn spawn(
         options: &Options,
         mode: FanOutMode,
-        lossy: bool,
+        mute_policy: FanOutMutePolicy,
         io_pool: &crate::context::IoPoolHandle,
     ) -> Arc<Self> {
         let pipe_cap = options.send_hwm.max(1) as usize;
@@ -263,7 +263,7 @@ impl FanOutLanes {
                     data_space,
                     ctrl_notify: ctrl_notify.clone(),
                     mode,
-                    lossy,
+                    mute_policy,
                     peers: FxHashMap::default(),
                     subscribe_all_count: 0,
                     eq: FrameBuffer::one_shot(),
@@ -285,7 +285,7 @@ impl FanOutLanes {
             state: Mutex::new(FanOutLaneState { endpoints }),
             active_flags,
             distributor: Mutex::new(distributor),
-            lossy,
+            mute_policy,
         })
     }
 
@@ -426,7 +426,7 @@ impl FanOutLanes {
                 dist.signal.mark();
                 Ok(())
             }
-            Err(returned) if self.lossy => {
+            Err(returned) if self.mute_policy.is_lossy() => {
                 dist.tx.flush();
                 dist.signal.mark();
                 drop(returned);
@@ -450,7 +450,7 @@ impl FanOutLanes {
                         dist.signal.mark();
                         return;
                     }
-                    Err(returned) if self.lossy => {
+                    Err(returned) if self.mute_policy.is_lossy() => {
                         dist.tx.flush();
                         dist.signal.mark();
                         drop(returned);
@@ -625,7 +625,7 @@ impl LaneWorker {
     }
 
     async fn distribute_batch(&mut self, batch: &[LaneDispatch]) -> bool {
-        if self.lossy {
+        if self.mute_policy.is_lossy() {
             self.distribute_batch_lossy(batch);
             return false;
         }
@@ -642,7 +642,7 @@ impl LaneWorker {
                         let target = &mut self.distribution_targets[target_idx];
                         match target.data_tx.push(dispatch.clone()) {
                             Ok(()) => None,
-                            Err(returned) if self.lossy => {
+                            Err(returned) if self.mute_policy.is_lossy() => {
                                 drop(returned);
                                 None
                             }
@@ -787,7 +787,7 @@ impl LaneWorker {
         dispatch: &LaneDispatch,
         touched: &mut SmallVec<[u64; 32]>,
     ) -> bool {
-        if self.lossy {
+        if self.mute_policy.is_lossy() {
             self.dispatch_lossy(dispatch, touched);
             return false;
         }
@@ -985,7 +985,13 @@ impl LaneWorker {
             for &peer_id in &peer_ids {
                 if let Some(peer) = self.peers.get_mut(&peer_id)
                     && !peer.dict_shipped
-                    && Self::push_frame_to_peer_lossy(peer_id, peer, &frame, touched)
+                    && Self::push_frame_to_peer_lossy(
+                        self.mute_policy,
+                        peer_id,
+                        peer,
+                        &frame,
+                        touched,
+                    )
                 {
                     peer.dict_shipped = true;
                     peer.slot.mark_fanout_dict_shipped();
@@ -1015,7 +1021,7 @@ impl LaneWorker {
                 if has_dict && !peer.dict_shipped {
                     continue;
                 }
-                Self::push_frame_to_peer_lossy(peer_id, peer, &encoded, touched);
+                Self::push_frame_to_peer_lossy(self.mute_policy, peer_id, peer, &encoded, touched);
             }
         }
 
@@ -1023,14 +1029,18 @@ impl LaneWorker {
     }
 
     fn push_frame_to_peer_lossy(
+        mute_policy: FanOutMutePolicy,
         peer_id: u64,
         peer: &mut LanePeer,
         frame: &FanOutFrame<'_>,
         touched: &mut SmallVec<[u64; 32]>,
     ) -> bool {
-        let result = match frame {
-            FanOutFrame::Arena(raw) => peer.slot.try_push_pre_framed_no_signal(raw),
-            FanOutFrame::Chunks(chunks) => peer.slot.try_push_encoded(chunks),
+        let result = match mute_policy {
+            FanOutMutePolicy::DropOldest => peer.slot.try_push_fanout_drop_oldest(frame),
+            FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => match frame {
+                FanOutFrame::Arena(raw) => peer.slot.try_push_pre_framed_no_signal(raw),
+                FanOutFrame::Chunks(chunks) => peer.slot.try_push_encoded(chunks),
+            },
         };
         match result {
             TryFrameResult::Ok => {
@@ -1039,7 +1049,9 @@ impl LaneWorker {
             }
             TryFrameResult::Dead | TryFrameResult::Ineligible => false,
             TryFrameResult::Full => {
-                peer.slot.deactivate_fanout();
+                if mute_policy == FanOutMutePolicy::DropNewest {
+                    peer.slot.deactivate_fanout();
+                }
                 false
             }
         }
@@ -1066,7 +1078,7 @@ impl LaneWorker {
                         return PushFrameResult::Pushed;
                     }
                     TryFrameResult::Dead => return PushFrameResult::Skipped,
-                    TryFrameResult::Full if self.lossy => {
+                    TryFrameResult::Full if self.mute_policy.is_lossy() => {
                         peer.slot.deactivate_fanout();
                         return PushFrameResult::Skipped;
                     }
@@ -1076,7 +1088,9 @@ impl LaneWorker {
                         peer.slot.signal_encoded();
                         (space, seen)
                     }
-                    TryFrameResult::Ineligible if self.lossy => return PushFrameResult::Skipped,
+                    TryFrameResult::Ineligible if self.mute_policy.is_lossy() => {
+                        return PushFrameResult::Skipped;
+                    }
                     TryFrameResult::Ineligible => {
                         unreachable!("pre-framed fanout push cannot be ineligible")
                     }
@@ -1118,8 +1132,17 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
 
+    use bytes::Bytes;
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
+    use omq_proto::frame_buffer::FrameBuffer;
+    use rustc_hash::{FxHashMap, FxHashSet};
+    use smallvec::SmallVec;
+
+    use crate::routing::subscription::SubscriptionSet;
+
     use super::{
-        FanOutLaneState, FanOutLanes, LaneDispatch, LaneDistributor, LaneEndpoint, LanePeerAdd,
+        FanOutLaneState, FanOutLanes, FanOutMode, FanOutMutePolicy, LaneDispatch, LaneDistributor,
+        LaneEndpoint, LanePeer, LanePeerAdd, LaneWorker,
     };
 
     #[test]
@@ -1183,7 +1206,7 @@ mod tests {
                 signal: Arc::new(crate::engine::signal::DataSignal::new()),
                 space: data_space.clone(),
             }),
-            lossy: false,
+            mute_policy: FanOutMutePolicy::Block,
         };
 
         lanes.try_dispatch(test_dispatch("one")).unwrap();
@@ -1214,6 +1237,102 @@ mod tests {
             .expect("dispatch did not wake after space signal");
     }
 
+    #[test]
+    fn drop_oldest_lossy_dispatch_keeps_newest_per_peer_frames() {
+        let (_data_tx, data_rx) = yring::spsc::<LaneDispatch>(4);
+        let (_ctrl_tx, ctrl_rx) = yring::spsc(4);
+        let slot = test_slot_with_msg_cap(7, 2);
+        let mut subscriptions = SubscriptionSet::new();
+        subscriptions.add(b"");
+        let mut peers = FxHashMap::default();
+        peers.insert(
+            7,
+            LanePeer {
+                subscriptions,
+                groups: FxHashSet::default(),
+                any_groups: false,
+                slot: slot.clone(),
+                dict_shipped: false,
+            },
+        );
+        let mut worker = LaneWorker {
+            data_rx,
+            ctrl_rx,
+            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
+            data_space: Arc::new(crate::engine::signal::StateSignal::new()),
+            ctrl_notify: Arc::new(crate::engine::signal::DataSignal::new()),
+            mode: FanOutMode::SubscriptionPrefix,
+            mute_policy: FanOutMutePolicy::DropOldest,
+            peers,
+            subscribe_all_count: 1,
+            eq: FrameBuffer::one_shot(),
+            chunks: Vec::new(),
+            #[cfg(feature = "lz4")]
+            encoder: None,
+            distribution_targets: Vec::new(),
+            active_flags: None,
+        };
+        let mut touched = SmallVec::new();
+
+        for body in ["first", "second", "third"] {
+            worker.dispatch_lossy(&test_dispatch(body), &mut touched);
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(
+            actual,
+            vec![encoded_dispatch("second"), encoded_dispatch("third")]
+        );
+    }
+
+    #[test]
+    fn drop_newest_lossy_dispatch_keeps_oldest_per_peer_frames() {
+        let (_data_tx, data_rx) = yring::spsc::<LaneDispatch>(4);
+        let (_ctrl_tx, ctrl_rx) = yring::spsc(4);
+        let slot = test_slot_with_msg_cap(7, 2);
+        let mut subscriptions = SubscriptionSet::new();
+        subscriptions.add(b"");
+        let mut peers = FxHashMap::default();
+        peers.insert(
+            7,
+            LanePeer {
+                subscriptions,
+                groups: FxHashSet::default(),
+                any_groups: false,
+                slot: slot.clone(),
+                dict_shipped: false,
+            },
+        );
+        let mut worker = LaneWorker {
+            data_rx,
+            ctrl_rx,
+            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
+            data_space: Arc::new(crate::engine::signal::StateSignal::new()),
+            ctrl_notify: Arc::new(crate::engine::signal::DataSignal::new()),
+            mode: FanOutMode::SubscriptionPrefix,
+            mute_policy: FanOutMutePolicy::DropNewest,
+            peers,
+            subscribe_all_count: 1,
+            eq: FrameBuffer::one_shot(),
+            chunks: Vec::new(),
+            #[cfg(feature = "lz4")]
+            encoder: None,
+            distribution_targets: Vec::new(),
+            active_flags: None,
+        };
+        let mut touched = SmallVec::new();
+
+        for body in ["first", "second", "third"] {
+            worker.dispatch_lossy(&test_dispatch(body), &mut touched);
+        }
+
+        assert!(!slot.fanout_active());
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(actual, vec![encoded_dispatches(&["first", "second"])]);
+    }
+
     fn test_lanes(count: usize) -> FanOutLanes {
         FanOutLanes {
             state: std::sync::Mutex::new(FanOutLaneState {
@@ -1225,7 +1344,7 @@ mod tests {
                     .collect::<Vec<_>>(),
             ),
             distributor: test_distributor(),
-            lossy: true,
+            mute_policy: FanOutMutePolicy::DropNewest,
         }
     }
 
@@ -1243,6 +1362,13 @@ mod tests {
     }
 
     fn test_slot(peer_id: u64) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
+        test_slot_with_msg_cap(peer_id, 16)
+    }
+
+    fn test_slot_with_msg_cap(
+        peer_id: u64,
+        msg_cap: usize,
+    ) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
         crate::engine::transmit_slot::PeerTransmitSlot::new(
             peer_id,
             false,
@@ -1250,7 +1376,7 @@ mod tests {
             4096,
             16 * 1024,
             64 * 1024,
-            16,
+            msg_cap,
             #[cfg(feature = "ws")]
             false,
             #[cfg(feature = "ws")]
@@ -1274,5 +1400,37 @@ mod tests {
             msg,
             group: None,
         }
+    }
+
+    fn encoded_dispatch(body: &str) -> Bytes {
+        let msg = omq_proto::message::Message::from_slice(body.as_bytes());
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, &msg, &mut chunks, 1, 8 * 1024);
+        let bytes = match frame {
+            omq_proto::fan_out_frame::FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+            omq_proto::fan_out_frame::FanOutFrame::Chunks(chunks) if chunks.len() == 1 => {
+                chunks[0].clone()
+            }
+            omq_proto::fan_out_frame::FanOutFrame::Chunks(chunks) => {
+                let len = chunks.iter().map(Bytes::len).sum();
+                let mut buf = bytes::BytesMut::with_capacity(len);
+                for chunk in chunks {
+                    buf.extend_from_slice(chunk);
+                }
+                buf.freeze()
+            }
+        };
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
+    fn encoded_dispatches(bodies: &[&str]) -> Bytes {
+        let mut bytes = bytes::BytesMut::new();
+        for body in bodies {
+            let encoded = encoded_dispatch(body);
+            bytes.extend_from_slice(&encoded);
+        }
+        bytes.freeze()
     }
 }

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -182,12 +182,13 @@ impl SendStrategy {
         match send_category(t) {
             SendCategory::None => Self::None,
             SendCategory::FanOut(FanOutKind::SubscriptionPrefix) => Self::FanOut(FanOutSend::new(
+                t,
                 options,
                 FanOutMode::SubscriptionPrefix,
                 io_pool,
             )),
             SendCategory::FanOut(FanOutKind::Group) => {
-                Self::FanOut(FanOutSend::new(options, FanOutMode::Group, io_pool))
+                Self::FanOut(FanOutSend::new(t, options, FanOutMode::Group, io_pool))
             }
             SendCategory::IdentityRouted => Self::Identity(IdentitySend::new(t, options)),
             SendCategory::RoundRobin


### PR DESCRIPTION
- Adds per-peer fan-out `DropOldest` handling for `PUB`, `XPUB`, and `RADIO` while preserving `xpub_nodrop` blocking behavior.
- Stores encoded fan-out messages as one slot entry so eviction removes whole messages.
- Adds deterministic regressions for `DropOldest` and `DropNewest` policy wiring, fallback dispatch, lane dispatch, slot eviction, and `FrameBuffer` entry eviction.