### PR TITLE
Add existing test coverage to automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
         run: python -m pip install --upgrade pip "pyzmq>=25"
       - name: report peer versions
         run: python -c "import zmq; print('pyzmq', zmq.__version__, 'libzmq', zmq.zmq_version(), 'curve', zmq.has('curve'))"
+      - name: interop (NULL + STREAM)
+        env:
+          OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
+        run: cargo test -p omq-tokio --test omq_interop_pyzmq_null
       - name: interop (PLAIN)
         env:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
@@ -18,7 +22,7 @@ jobs:
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
       os_matrix: ${{ steps.matrix.outputs.os_matrix }}
       lint_matrix: ${{ steps.matrix.outputs.lint_matrix }}
-      run_pyomq: ${{ steps.matrix.outputs.run_pyomq }}
+      run_pyomq: ${{ steps.scope.outputs.pyomq }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v3
@@ -31,16 +35,46 @@ jobs:
               - '!**/*.md'
               - '!**/*.svg'
               - '!doc/**'
+      - uses: dorny/paths-filter@v3
+        id: scope
+        with:
+          filters: |
+            pyomq:
+              - 'bindings/pyomq/**'
+              - 'omq-proto/**'
+              - 'omq-tokio/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-pyomq.yml'
       - id: matrix
         run: |
-          echo 'test_matrix={"include":[{"toolchain":"stable","os":"ubuntu-latest"},{"toolchain":"stable","os":"ubuntu-24.04-arm"},{"toolchain":"stable","os":"macos-15-intel"},{"toolchain":"stable","os":"macos-15"},{"toolchain":"1.93","os":"ubuntu-latest"},{"toolchain":"stable","os":"windows-latest","target":"x86_64-pc-windows-msvc"}]}' >> "$GITHUB_OUTPUT"
-          echo 'os_matrix={"os":["ubuntu-latest","macos-15-intel","macos-15","windows-latest"]}' >> "$GITHUB_OUTPUT"
-          echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"macOS Intel","kind":"rust","os":"macos-15-intel"},{"name":"macOS ARM64","kind":"rust","os":"macos-15"},{"name":"Windows","kind":"rust","os":"windows-latest"},{"name":"pyomq","kind":"pyomq","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
-          echo 'run_pyomq=true' >> "$GITHUB_OUTPUT"
+          echo 'test_matrix={"include":[{"toolchain":"1.93","os":"ubuntu-latest"},{"toolchain":"stable","os":"macos-15"},{"toolchain":"stable","os":"windows-latest","target":"x86_64-pc-windows-msvc"}]}' >> "$GITHUB_OUTPUT"
+          echo 'os_matrix={"os":["ubuntu-latest","macos-15","windows-latest"]}' >> "$GITHUB_OUTPUT"
+          if [[ "${{ steps.scope.outputs.pyomq }}" == "true" ]]; then
+            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"pyomq","kind":"pyomq","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
+  linux-gate:
+    name: linux gate
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test --workspace --no-fail-fast
 
   test:
     name: cargo test (${{ matrix.toolchain }}, ${{ matrix.os }})
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,7 +96,7 @@ jobs:
 
   encryption:
     name: encryption (curve, ${{ matrix.os }})
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -81,7 +115,7 @@ jobs:
 
   compression:
     name: compression (${{ matrix.os }})
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -100,7 +134,7 @@ jobs:
 
   interop:
     name: interop (pyzmq)
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # pyzmq wheels bundle libzmq + libsodium: the peer is the real
@@ -133,7 +167,7 @@ jobs:
 
   loom:
     name: loom (yring)
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # omq-tokio's loom_signal test needs no cfg and runs in `test`.
@@ -149,7 +183,7 @@ jobs:
 
   miri:
     name: miri (yring)
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # yring holds the only Miri-checkable unsafe: omq-proto is
@@ -170,7 +204,7 @@ jobs:
 
   fuzz-smoke:
     name: fuzz smoke
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # OMQ_FUZZ_ITERS means something different per target, so the two
@@ -197,7 +231,7 @@ jobs:
 
   linux-32bit:
     name: 32-bit linux (${{ matrix.target }})
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -293,7 +327,7 @@ jobs:
 
   pyomq-test:
     name: pyomq-test
-    needs: [changes, lint]
+    needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_pyomq == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -306,7 +340,7 @@ jobs:
           - python-version: "3.14"
             os: windows-latest
           - python-version: "3.14"
-            os: macos-latest
+            os: macos-15
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -334,6 +368,7 @@ jobs:
     needs:
       [
         changes,
+        linux-gate,
         test,
         encryption,
         compression,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,99 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo test -p omq-tokio --features lz4 -- --test-threads=1
 
+  interop:
+    name: interop (pyzmq)
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # pyzmq wheels bundle libzmq + libsodium: the peer is the real
+    # reference implementation.
+    env:
+      OMQ_INTEROP_REQUIRED: "1" # missing peer fails instead of skipping
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v6
+        id: python
+        with: { python-version: "3.14" }
+      - name: install pyzmq
+        run: python -m pip install --upgrade pip "pyzmq>=25"
+      - name: report peer versions
+        run: python -c "import zmq; print('pyzmq', zmq.__version__, 'libzmq', zmq.zmq_version(), 'curve', zmq.has('curve'))"
+      - name: interop (PLAIN)
+        env:
+          OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
+        run: cargo test -p omq-tokio --features plain --test omq_interop_pyzmq_plain
+      - name: interop (CURVE)
+        env:
+          OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
+        run: cargo test -p omq-tokio --features curve --test omq_interop_pyzmq_curve
+
+  loom:
+    name: loom (yring)
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # omq-tokio's loom_signal test needs no cfg and runs in `test`.
+    # RUSTFLAGS replaces the workflow-level value, so repeat -D warnings.
+    env:
+      RUSTFLAGS: --cfg loom -D warnings
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: loom model check
+        run: cargo test -p yring --features async --test loom --release
+
+  miri:
+    name: miri (yring)
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # yring holds the only Miri-checkable unsafe: omq-proto is
+    # forbid(unsafe_code) and omq-tokio's tests are real socket I/O.
+    # No -D warnings: nightly adds lints on its own schedule.
+    env:
+      RUSTFLAGS: ""
+      MIRIFLAGS: -Zmiri-disable-isolation
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly # falls back if nightly lacks miri
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo miri setup
+      - name: miri test
+        run: cargo miri test -p yring --features async
+
+  fuzz-smoke:
+    name: fuzz smoke
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # OMQ_FUZZ_ITERS means something different per target, so the two
+    # get separate budgets: a parser iteration is a buffer parse, a
+    # socket-action iteration drives a live socket (~90ms). The
+    # `extended` workflow runs both far deeper.
+    # --nocapture surfaces OMQ_FUZZ_SEED for reproduction.
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: fuzz parsers
+        env:
+          OMQ_FUZZ_ITERS: "1000000"
+        run: >
+          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release
+          --test omq_fuzz_parsers -- --nocapture
+      - name: fuzz socket actions
+        env:
+          OMQ_FUZZ_ITERS: "200"
+        run: >
+          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release
+          --test omq_fuzz_socket_actions -- --nocapture
+
   linux-32bit:
     name: 32-bit linux (${{ matrix.target }})
     needs: [changes, lint]
@@ -234,7 +327,20 @@ jobs:
 
   ci-success:
     name: CI success
-    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq-test]
+    needs:
+      [
+        changes,
+        test,
+        encryption,
+        compression,
+        interop,
+        loom,
+        miri,
+        fuzz-smoke,
+        linux-32bit,
+        lint,
+        pyomq-test,
+      ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
           echo 'test_matrix={"include":[{"toolchain":"1.93","os":"ubuntu-latest"},{"toolchain":"stable","os":"macos-15"},{"toolchain":"stable","os":"windows-latest","target":"x86_64-pc-windows-msvc"}]}' >> "$GITHUB_OUTPUT"
           echo 'os_matrix={"os":["ubuntu-latest","macos-15","windows-latest"]}' >> "$GITHUB_OUTPUT"
           if [[ "${{ steps.scope.outputs.pyomq }}" == "true" ]]; then
-            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"pyomq","kind":"pyomq","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"macOS Intel","kind":"rust","os":"macos-15-intel"},{"name":"macOS ARM64","kind":"rust","os":"macos-15"},{"name":"Windows","kind":"rust","os":"windows-latest"},{"name":"pyomq","kind":"pyomq","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
           else
-            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+            echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"macOS Intel","kind":"rust","os":"macos-15-intel"},{"name":"macOS ARM64","kind":"rust","os":"macos-15"},{"name":"Windows","kind":"rust","os":"windows-latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   linux-gate:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -105,8 +105,8 @@ jobs:
       - name: transmit slot
         run: cargo test -p omq-tokio --test omq_transmit_slot_stress -- --ignored
 
-  interop-ws:
-    name: interop (libzmq ws)
+  interop-libzmq-draft:
+    name: interop (libzmq draft)
     if: github.repository == 'paddor/omq.rs'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -141,10 +141,19 @@ jobs:
           cc -O2 -o omq-tokio/tests/helpers/zmq_ws_peer \
             omq-tokio/tests/helpers/zmq_ws_peer.c \
             -I"$LIBZMQ_PREFIX/include" -L"$LIBZMQ_PREFIX/lib" -lzmq
+      - name: build zmq_draft_peer helper
+        run: |
+          cc -O2 -o omq-tokio/tests/helpers/zmq_draft_peer \
+            omq-tokio/tests/helpers/zmq_draft_peer.c \
+            -I"$LIBZMQ_PREFIX/include" -L"$LIBZMQ_PREFIX/lib" -lzmq
       - name: interop (ws)
         env:
           LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
         run: cargo test -p omq-tokio --features ws --test omq_interop_libzmq_ws
+      - name: interop (draft sockets)
+        env:
+          LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
+        run: cargo test -p omq-tokio --test omq_interop_libzmq_draft
 
   miri-seeds:
     name: miri (yring, many seeds)

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,7 +1,7 @@
 name: extended
 
-# Long-running suites that would dominate PR CI. `ci.yml` carries the
-# short versions (fuzz smoke, pyzmq interop, loom, miri).
+# Long-running or expensive suites that would dominate PR CI. `ci.yml`
+# carries the short versions (fuzz smoke, pyzmq interop, loom, miri).
 
 on:
   schedule:
@@ -104,6 +104,18 @@ jobs:
         run: cargo test -p omq-tokio --test omq_push_pull -- --ignored
       - name: transmit slot
         run: cargo test -p omq-tokio --test omq_transmit_slot_stress -- --ignored
+
+  ubuntu-arm:
+    name: cargo test (ubuntu-24.04-arm)
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test --workspace --no-fail-fast
 
   interop-libzmq-draft:
     name: interop (libzmq draft)

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,166 @@
+name: extended
+
+# Long-running suites that would dominate PR CI. `ci.yml` carries the
+# short versions (fuzz smoke, pyzmq interop, loom, miri).
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      soak_duration_secs:
+        description: seconds per soak test
+        default: "180"
+      fuzz_scale:
+        description: multiplier on each fuzz target's iteration count
+        default: "1"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+concurrency:
+  group: extended
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.test }})
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        # OMQ_FUZZ_ITERS means something different per target: a parser
+        # iteration is a buffer parse, a socket-action iteration drives
+        # a live socket (~90ms). One number cannot serve both.
+        include:
+          - test: omq_fuzz_parsers
+            iters: 100000000
+          - test: omq_fuzz_socket_actions
+            iters: 2000
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test (fuzz) # --nocapture surfaces OMQ_FUZZ_SEED
+        run: |
+          OMQ_FUZZ_ITERS=$(( ${{ matrix.iters }} * ${{ inputs.fuzz_scale || 1 }} ))
+          export OMQ_FUZZ_ITERS
+          echo "OMQ_FUZZ_ITERS=$OMQ_FUZZ_ITERS"
+          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release \
+            --test ${{ matrix.test }} -- --nocapture
+
+  soak:
+    name: soak (${{ matrix.group }})
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: churn
+            tests: omq_soak_peer_churn omq_soak_pub_sub_churn omq_soak_pub_sub_churn_tcp omq_soak_pub_sub_realworld_churn_tcp omq_soak_router_dealer_churn omq_soak_xpub_xsub_churn
+          - group: reconnect
+            tests: omq_soak_reconnect_all_types omq_soak_reconnect_storm omq_soak_hwm_reconnect omq_soak_mechanism_reconnect
+          - group: mechanism
+            tests: omq_soak_plain omq_soak_curve
+          - group: transport
+            tests: omq_soak_ws omq_soak_compression_lz4 omq_soak_pub_sub_lz4_dict omq_soak_large_throughput
+          - group: runtime
+            tests: omq_soak_cancel_safety omq_soak_inproc_cross_thread omq_soak_multi_socket
+    env:
+      SOAK_FEATURES: soak plain curve lz4 ws
+      OMQ_SOAK_DURATION_SECS: ${{ inputs.soak_duration_secs || '180' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: build soak tests
+        run: cargo test -p omq-tokio --features "$SOAK_FEATURES" --release --no-run
+      - name: run soak group
+        run: |
+          for t in ${{ matrix.tests }}; do
+            echo "::group::$t"
+            cargo test -p omq-tokio --features "$SOAK_FEATURES" --release \
+              --test "$t" -- --nocapture
+            echo "::endgroup::"
+          done
+
+  stress:
+    name: stress
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: connect-before-bind # serial: rounds race each other otherwise
+        run: cargo test -p omq-tokio --test omq_stress_connect_before_bind -- --ignored --test-threads=1
+      - name: push/pull
+        run: cargo test -p omq-tokio --test omq_push_pull -- --ignored
+      - name: transmit slot
+        run: cargo test -p omq-tokio --test omq_transmit_slot_stress -- --ignored
+
+  interop-ws:
+    name: interop (libzmq ws)
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      LIBZMQ_REF: v4.3.5
+      LIBZMQ_PREFIX: /home/runner/.local/libzmq
+      OMQ_INTEROP_REQUIRED: "1" # missing helper fails instead of skipping
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cache libzmq
+        id: libzmq
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.LIBZMQ_PREFIX }}
+          key: libzmq-${{ env.LIBZMQ_REF }}-drafts-${{ runner.os }}
+      # Distro libzmq ships without ENABLE_DRAFTS, so it has no ws://.
+      - name: build libzmq with drafts
+        if: steps.libzmq.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$LIBZMQ_REF" https://github.com/zeromq/libzmq /tmp/libzmq-src
+          cmake -S /tmp/libzmq-src -B /tmp/libzmq-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$LIBZMQ_PREFIX" \
+            -DENABLE_DRAFTS=ON -DENABLE_WS=ON \
+            -DBUILD_TESTS=OFF -DWITH_DOC=OFF
+          cmake --build /tmp/libzmq-build -j"$(nproc)"
+          cmake --install /tmp/libzmq-build
+      - name: build zmq_ws_peer helper
+        run: |
+          cc -O2 -o omq-tokio/tests/helpers/zmq_ws_peer \
+            omq-tokio/tests/helpers/zmq_ws_peer.c \
+            -I"$LIBZMQ_PREFIX/include" -L"$LIBZMQ_PREFIX/lib" -lzmq
+      - name: interop (ws)
+        env:
+          LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
+        run: cargo test -p omq-tokio --features ws --test omq_interop_libzmq_ws
+
+  miri-seeds:
+    name: miri (yring, many seeds)
+    if: github.repository == 'paddor/omq.rs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # No -D warnings: nightly adds lints on its own schedule.
+    env:
+      RUSTFLAGS: ""
+      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-many-seeds=0..16
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly # falls back if nightly lacks miri
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo miri setup
+      - name: miri test
+        run: cargo miri test -p yring --features async

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 *.html
 /*.log
 omq-tokio/tests/helpers/zmq_ws_peer
+omq-tokio/tests/helpers/zmq_draft_peer
 scripts/omq_libzmq_bench_peer
 perf.data*
 /TODO

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,7 +89,7 @@ runs, on Linux only:
 
 | job | what |
 |-----|------|
-| `interop` | pyzmq PLAIN + CURVE (pyzmq wheels bundle libzmq) |
+| `interop` | pyzmq NULL/STREAM + PLAIN + CURVE |
 | `loom` | `yring` loom suite under `--cfg loom`, release |
 | `miri` | `cargo miri test -p yring --features async`, nightly |
 | `fuzz-smoke` | parsers at 1M iters, socket actions at 200 |
@@ -97,17 +97,17 @@ runs, on Linux only:
 `.github/workflows/extended.yml` runs nightly at 03:00 UTC and on
 `workflow_dispatch` (with `soak_duration_secs` / `fuzz_scale` inputs):
 the fuzz targets at 100M / 2000 iters, the soak suite in five groups,
-the `--ignored` stress tests, libzmq `ws://` interop, and Miri under
-`-Zmiri-many-seeds`.
+the `--ignored` stress tests, libzmq draft interop (`ws://`,
+RADIO/DISH, and draft socket types), and Miri under `-Zmiri-many-seeds`.
 
 The interop tests skip when their peer is missing so local runs stay
-green without pyzmq or the `zmq_ws_peer` helper. CI sets
+green without pyzmq or the libzmq helper binaries. CI sets
 `OMQ_INTEROP_REQUIRED=1`, which turns a missing peer into a failure so
 the job cannot pass without testing anything.
 
-The libzmq `ws://` interop job builds libzmq from source with
+The libzmq draft interop job builds libzmq from source with
 `ENABLE_DRAFTS=ON` (distro packages omit it, and without drafts libzmq
-has no `ws://` transport) and caches the install.
+has no `ws://` transport or draft socket API) and caches the install.
 
 ## Fuzz Tests
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,16 @@ cargo test -p omq-tokio --features lz4       --test lz4_tcp --test lz4_pub_sub
 Miri target for unsafe internals:
 
 ```sh
-cargo +nightly miri test -p yring
+cargo +nightly miri test -p yring --features async
+```
+
+Roughly two minutes for the 30 tests. Miri can also interpret for a
+foreign target, which is how to reproduce a CI failure from a
+different host:
+
+```sh
+cargo +nightly miri test -p yring --features async \
+  --target x86_64-unknown-linux-gnu
 ```
 
 Loom checks:
@@ -73,11 +82,44 @@ ARM64, macOS Intel, macOS ARM64, Windows, and MSRV 1.93 on Linux.
 Feature jobs cover CURVE and LZ4 on Linux, macOS Intel, macOS ARM64,
 and Windows. macOS test jobs run serially with `--test-threads=1`.
 
+## Continuous Integration
+
+`.github/workflows/ci.yml` gates every PR. Beyond fmt/clippy/tests it
+runs, on Linux only:
+
+| job | what |
+|-----|------|
+| `interop` | pyzmq PLAIN + CURVE (pyzmq wheels bundle libzmq) |
+| `loom` | `yring` loom suite under `--cfg loom`, release |
+| `miri` | `cargo miri test -p yring --features async`, nightly |
+| `fuzz-smoke` | parsers at 1M iters, socket actions at 200 |
+
+`.github/workflows/extended.yml` runs nightly at 03:00 UTC and on
+`workflow_dispatch` (with `soak_duration_secs` / `fuzz_scale` inputs):
+the fuzz targets at 100M / 2000 iters, the soak suite in five groups,
+the `--ignored` stress tests, libzmq `ws://` interop, and Miri under
+`-Zmiri-many-seeds`.
+
+The interop tests skip when their peer is missing so local runs stay
+green without pyzmq or the `zmq_ws_peer` helper. CI sets
+`OMQ_INTEROP_REQUIRED=1`, which turns a missing peer into a failure so
+the job cannot pass without testing anything.
+
+The libzmq `ws://` interop job builds libzmq from source with
+`ENABLE_DRAFTS=ON` (distro packages omit it, and without drafts libzmq
+has no `ws://` transport) and caches the install.
+
 ## Fuzz Tests
 
 The hand-rolled fuzz suites are off by default. Enable with the `fuzz`
 feature. Set `OMQ_FUZZ_ITERS=<n>` and `OMQ_FUZZ_SEED=<u64>` for long or
 reproducible runs.
+
+`OMQ_FUZZ_ITERS` counts a different unit per target, so one value
+cannot serve both. A `fuzz_parsers` iteration is a buffer parse
+(default 10M, ~7s per 1M); a `fuzz_socket_actions` iteration drives a
+live socket (default 200, ~90ms each). Setting it globally silently
+turns the socket suite into an hours-long run.
 
 ```sh
 cargo test -p omq-tokio --features fuzz

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -192,12 +192,20 @@ name = "omq_inproc_subside"
 path = "tests/inproc_subside.rs"
 
 [[test]]
+name = "omq_interop_libzmq_draft"
+path = "tests/interop_libzmq_draft.rs"
+
+[[test]]
 name = "omq_interop_libzmq_ws"
 path = "tests/interop_libzmq_ws.rs"
 
 [[test]]
 name = "omq_interop_pyzmq_curve"
 path = "tests/interop_pyzmq_curve.rs"
+
+[[test]]
+name = "omq_interop_pyzmq_null"
+path = "tests/interop_pyzmq_null.rs"
 
 [[test]]
 name = "omq_interop_pyzmq_plain"

--- a/omq-tokio/tests/helpers/zmq_draft_peer.c
+++ b/omq-tokio/tests/helpers/zmq_draft_peer.c
@@ -1,0 +1,266 @@
+// Helper for libzmq draft-socket interop tests.
+// Usage:
+//   zmq_draft_peer radio-connect-send ENDPOINT GROUP BODY
+//   zmq_draft_peer dish-connect-recv ENDPOINT GROUP BODY
+//   zmq_draft_peer scatter-connect-send ENDPOINT BODY
+//   zmq_draft_peer gather-connect-recv ENDPOINT BODY
+//   zmq_draft_peer client-connect-request ENDPOINT REQUEST REPLY
+//   zmq_draft_peer server-connect-reply ENDPOINT REQUEST REPLY
+//   zmq_draft_peer channel-connect-request ENDPOINT REQUEST REPLY
+//   zmq_draft_peer peer-connect-request ENDPOINT REQUEST REPLY
+#define ZMQ_BUILD_DRAFT_API
+#include <zmq.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void die_zmq(const char *what) {
+    fprintf(stderr, "%s: %s\n", what, zmq_strerror(zmq_errno()));
+    exit(1);
+}
+
+static void die_msg(const char *what) {
+    fprintf(stderr, "%s\n", what);
+    exit(1);
+}
+
+static void set_timeouts(void *sock) {
+    int linger = 0;
+    int timeout = 5000;
+    if (zmq_setsockopt(sock, ZMQ_LINGER, &linger, sizeof(linger)) != 0)
+        die_zmq("setsockopt linger");
+    if (zmq_setsockopt(sock, ZMQ_RCVTIMEO, &timeout, sizeof(timeout)) != 0)
+        die_zmq("setsockopt rcvtimeo");
+    if (zmq_setsockopt(sock, ZMQ_SNDTIMEO, &timeout, sizeof(timeout)) != 0)
+        die_zmq("setsockopt sndtimeo");
+}
+
+static void send_msg(void *sock, const char *body) {
+    int rc = zmq_send(sock, body, strlen(body), 0);
+    if (rc != (int)strlen(body))
+        die_zmq("zmq_send");
+}
+
+static void recv_expect(void *sock, const char *expected) {
+    char buf[256];
+    int rc = zmq_recv(sock, buf, sizeof(buf), 0);
+    if (rc < 0)
+        die_zmq("zmq_recv");
+    if ((size_t)rc != strlen(expected) || memcmp(buf, expected, (size_t)rc) != 0) {
+        fprintf(stderr, "expected %s, got %.*s\n", expected, rc, buf);
+        exit(1);
+    }
+}
+
+static void radio_connect_send(void *ctx, const char *endpoint, const char *group,
+                               const char *body) {
+    void *sock = zmq_socket(ctx, ZMQ_RADIO);
+    if (!sock)
+        die_zmq("zmq_socket RADIO");
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect RADIO");
+    zmq_sleep(1);
+
+    zmq_msg_t msg;
+    if (zmq_msg_init_size(&msg, strlen(body)) != 0)
+        die_zmq("zmq_msg_init_size");
+    memcpy(zmq_msg_data(&msg), body, strlen(body));
+    if (zmq_msg_set_group(&msg, group) != 0)
+        die_zmq("zmq_msg_set_group");
+    if (zmq_msg_send(&msg, sock, 0) < 0)
+        die_zmq("zmq_msg_send RADIO");
+    zmq_msg_close(&msg);
+    zmq_close(sock);
+}
+
+static void dish_connect_recv(void *ctx, const char *endpoint, const char *group,
+                              const char *body) {
+    void *sock = zmq_socket(ctx, ZMQ_DISH);
+    if (!sock)
+        die_zmq("zmq_socket DISH");
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect DISH");
+    if (zmq_join(sock, group) != 0)
+        die_zmq("zmq_join");
+
+    zmq_msg_t msg;
+    if (zmq_msg_init(&msg) != 0)
+        die_zmq("zmq_msg_init DISH");
+    if (zmq_msg_recv(&msg, sock, 0) < 0)
+        die_zmq("zmq_msg_recv DISH");
+    const char *got_group = zmq_msg_group(&msg);
+    size_t size = zmq_msg_size(&msg);
+    if (!got_group || strcmp(got_group, group) != 0 || size != strlen(body)
+        || memcmp(zmq_msg_data(&msg), body, size) != 0) {
+        fprintf(stderr, "expected group=%s body=%s, got group=%s body=%.*s\n",
+                group, body, got_group ? got_group : "<null>", (int)size,
+                (char *)zmq_msg_data(&msg));
+        exit(1);
+    }
+    zmq_msg_close(&msg);
+    zmq_close(sock);
+}
+
+static void scatter_connect_send(void *ctx, const char *endpoint, const char *body) {
+    void *sock = zmq_socket(ctx, ZMQ_SCATTER);
+    if (!sock)
+        die_zmq("zmq_socket SCATTER");
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect SCATTER");
+    zmq_sleep(1);
+    send_msg(sock, body);
+    zmq_close(sock);
+}
+
+static void gather_connect_recv(void *ctx, const char *endpoint, const char *body) {
+    void *sock = zmq_socket(ctx, ZMQ_GATHER);
+    if (!sock)
+        die_zmq("zmq_socket GATHER");
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect GATHER");
+    recv_expect(sock, body);
+    zmq_close(sock);
+}
+
+static void request_reply(void *ctx, int socket_type, const char *socket_name,
+                          const char *endpoint, const char *request,
+                          const char *reply) {
+    void *sock = zmq_socket(ctx, socket_type);
+    if (!sock)
+        die_zmq(socket_name);
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect");
+    zmq_sleep(1);
+    send_msg(sock, request);
+    recv_expect(sock, reply);
+    zmq_close(sock);
+}
+
+static void server_connect_reply(void *ctx, const char *endpoint, const char *request,
+                                 const char *reply) {
+    void *sock = zmq_socket(ctx, ZMQ_SERVER);
+    if (!sock)
+        die_zmq("zmq_socket SERVER");
+    set_timeouts(sock);
+    if (zmq_connect(sock, endpoint) != 0)
+        die_zmq("zmq_connect SERVER");
+
+    zmq_msg_t in;
+    if (zmq_msg_init(&in) != 0)
+        die_zmq("zmq_msg_init SERVER");
+    if (zmq_msg_recv(&in, sock, 0) < 0)
+        die_zmq("zmq_msg_recv SERVER");
+    uint32_t routing_id = zmq_msg_routing_id(&in);
+    size_t size = zmq_msg_size(&in);
+    if (routing_id == 0 || size != strlen(request)
+        || memcmp(zmq_msg_data(&in), request, size) != 0) {
+        fprintf(stderr, "expected %s, got routing_id=%u body=%.*s\n", request,
+                routing_id, (int)size, (char *)zmq_msg_data(&in));
+        exit(1);
+    }
+    zmq_msg_close(&in);
+
+    zmq_msg_t out;
+    if (zmq_msg_init_size(&out, strlen(reply)) != 0)
+        die_zmq("zmq_msg_init_size SERVER");
+    memcpy(zmq_msg_data(&out), reply, strlen(reply));
+    if (zmq_msg_set_routing_id(&out, routing_id) != 0)
+        die_zmq("zmq_msg_set_routing_id SERVER");
+    if (zmq_msg_send(&out, sock, 0) < 0)
+        die_zmq("zmq_msg_send SERVER");
+    zmq_msg_close(&out);
+    zmq_close(sock);
+}
+
+static void peer_connect_request(void *ctx, const char *endpoint, const char *request,
+                                 const char *reply) {
+    void *sock = zmq_socket(ctx, ZMQ_PEER);
+    if (!sock)
+        die_zmq("zmq_socket PEER");
+    set_timeouts(sock);
+    uint32_t routing_id = zmq_connect_peer(sock, endpoint);
+    if (routing_id == 0)
+        die_zmq("zmq_connect_peer");
+    zmq_sleep(1);
+
+    zmq_msg_t msg;
+    if (zmq_msg_init_size(&msg, strlen(request)) != 0)
+        die_zmq("zmq_msg_init_size PEER");
+    memcpy(zmq_msg_data(&msg), request, strlen(request));
+    if (zmq_msg_set_routing_id(&msg, routing_id) != 0)
+        die_zmq("zmq_msg_set_routing_id");
+    if (zmq_msg_send(&msg, sock, 0) < 0)
+        die_zmq("zmq_msg_send PEER");
+    zmq_msg_close(&msg);
+
+    zmq_msg_t in;
+    if (zmq_msg_init(&in) != 0)
+        die_zmq("zmq_msg_init");
+    if (zmq_msg_recv(&in, sock, 0) < 0)
+        die_zmq("zmq_msg_recv PEER");
+    size_t size = zmq_msg_size(&in);
+    if (size != strlen(reply) || memcmp(zmq_msg_data(&in), reply, size) != 0) {
+        fprintf(stderr, "expected %s, got %.*s\n", reply, (int)size,
+                (char *)zmq_msg_data(&in));
+        exit(1);
+    }
+    zmq_msg_close(&in);
+    zmq_close(sock);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4)
+        die_msg("usage: zmq_draft_peer MODE ENDPOINT ...");
+
+    const char *mode = argv[1];
+    const char *endpoint = argv[2];
+    void *ctx = zmq_ctx_new();
+    if (!ctx)
+        die_zmq("zmq_ctx_new");
+
+    if (strcmp(mode, "radio-connect-send") == 0) {
+        if (argc != 5)
+            die_msg("usage: radio-connect-send ENDPOINT GROUP BODY");
+        radio_connect_send(ctx, endpoint, argv[3], argv[4]);
+    } else if (strcmp(mode, "dish-connect-recv") == 0) {
+        if (argc != 5)
+            die_msg("usage: dish-connect-recv ENDPOINT GROUP BODY");
+        dish_connect_recv(ctx, endpoint, argv[3], argv[4]);
+    } else if (strcmp(mode, "scatter-connect-send") == 0) {
+        if (argc != 4)
+            die_msg("usage: scatter-connect-send ENDPOINT BODY");
+        scatter_connect_send(ctx, endpoint, argv[3]);
+    } else if (strcmp(mode, "gather-connect-recv") == 0) {
+        if (argc != 4)
+            die_msg("usage: gather-connect-recv ENDPOINT BODY");
+        gather_connect_recv(ctx, endpoint, argv[3]);
+    } else if (strcmp(mode, "client-connect-request") == 0) {
+        if (argc != 5)
+            die_msg("usage: client-connect-request ENDPOINT REQUEST REPLY");
+        request_reply(ctx, ZMQ_CLIENT, "zmq_socket CLIENT", endpoint, argv[3], argv[4]);
+    } else if (strcmp(mode, "server-connect-reply") == 0) {
+        if (argc != 5)
+            die_msg("usage: server-connect-reply ENDPOINT REQUEST REPLY");
+        server_connect_reply(ctx, endpoint, argv[3], argv[4]);
+    } else if (strcmp(mode, "channel-connect-request") == 0) {
+        if (argc != 5)
+            die_msg("usage: channel-connect-request ENDPOINT REQUEST REPLY");
+        request_reply(ctx, ZMQ_CHANNEL, "zmq_socket CHANNEL", endpoint, argv[3], argv[4]);
+    } else if (strcmp(mode, "peer-connect-request") == 0) {
+        if (argc != 5)
+            die_msg("usage: peer-connect-request ENDPOINT REQUEST REPLY");
+        peer_connect_request(ctx, endpoint, argv[3], argv[4]);
+    } else {
+        die_msg("unknown mode");
+    }
+
+    zmq_ctx_destroy(ctx);
+    return 0;
+}

--- a/omq-tokio/tests/interop_libzmq_draft.rs
+++ b/omq-tokio/tests/interop_libzmq_draft.rs
@@ -1,0 +1,250 @@
+//! Interop: omq-tokio <-> libzmq draft socket types over TCP.
+//! Requires `zmq_draft_peer` built against libzmq with
+//! `ENABLE_DRAFTS=ON`.
+
+mod test_support;
+
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::{Message, MonitorEvent, Options, Socket, SocketType};
+
+const HELPER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/helpers/zmq_draft_peer");
+
+fn skip_if_no_helper() -> bool {
+    if !std::path::Path::new(HELPER).exists() {
+        assert!(
+            std::env::var_os("OMQ_INTEROP_REQUIRED").is_none(),
+            "OMQ_INTEROP_REQUIRED=1 but zmq_draft_peer helper not found at {HELPER}",
+        );
+        eprintln!("skip: zmq_draft_peer helper not found at {HELPER}");
+        return true;
+    }
+    false
+}
+
+fn spawn_helper(args: &[&str]) -> Child {
+    Command::new(HELPER)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn zmq_draft_peer")
+}
+
+async fn wait_success(child: Child, context: &str) -> Output {
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{context} exited non-zero\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+async fn recv(sock: &Socket, context: &str) -> Message {
+    tokio::time::timeout(Duration::from_secs(5), sock.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: recv timed out"))
+        .unwrap()
+}
+
+async fn wait_for_join(mon: &mut omq_tokio::MonitorStream) {
+    let fut = async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::JoinReceived { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before JOIN: {e:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("JOIN did not arrive");
+}
+
+#[tokio::test]
+async fn libzmq_radio_to_omq_dish() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let dish = Socket::new(SocketType::Dish, Options::default());
+    dish.join("weather").await.unwrap();
+    let endpoint = dish.bind(test_support::tcp_loopback(0)).await.unwrap();
+
+    let child = spawn_helper(&[
+        "radio-connect-send",
+        &endpoint.to_string(),
+        "weather",
+        "sunny",
+    ]);
+
+    let msg = recv(&dish, "libzmq RADIO -> omq DISH").await;
+    assert_eq!(msg, Message::multipart(["weather", "sunny"]));
+    wait_success(child, "libzmq RADIO").await;
+}
+
+#[tokio::test]
+async fn omq_radio_to_libzmq_dish() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let radio = Socket::new(SocketType::Radio, Options::default());
+    let mut mon = radio.monitor();
+    let endpoint = radio.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "dish-connect-recv",
+        &endpoint.to_string(),
+        "weather",
+        "rain",
+    ]);
+
+    wait_for_join(&mut mon).await;
+    radio
+        .send(Message::multipart(["weather", "rain"]))
+        .await
+        .unwrap();
+    wait_success(child, "libzmq DISH").await;
+}
+
+#[tokio::test]
+async fn libzmq_scatter_to_omq_gather() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let gather = Socket::new(SocketType::Gather, Options::default());
+    let endpoint = gather.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "scatter-connect-send",
+        &endpoint.to_string(),
+        "from-scatter",
+    ]);
+
+    let msg = recv(&gather, "libzmq SCATTER -> omq GATHER").await;
+    assert_eq!(msg, Message::single("from-scatter"));
+    wait_success(child, "libzmq SCATTER").await;
+}
+
+#[tokio::test]
+async fn omq_scatter_to_libzmq_gather() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let scatter = Socket::new(SocketType::Scatter, Options::default());
+    let endpoint = scatter.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&["gather-connect-recv", &endpoint.to_string(), "from-scatter"]);
+
+    test_support::wait_for_handshake(&scatter).await;
+    scatter.send(Message::single("from-scatter")).await.unwrap();
+    wait_success(child, "libzmq GATHER").await;
+}
+
+#[tokio::test]
+async fn libzmq_client_to_omq_server() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let server = Socket::new(SocketType::Server, Options::default());
+    let endpoint = server.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "client-connect-request",
+        &endpoint.to_string(),
+        "from-client",
+        "from-server",
+    ]);
+
+    let request = recv(&server, "libzmq CLIENT -> omq SERVER").await;
+    assert_eq!(request.part_bytes(1).unwrap(), &b"from-client"[..]);
+    let routing_id = request.part_bytes(0).unwrap();
+    server
+        .send(Message::multipart([
+            routing_id,
+            Bytes::from_static(b"from-server"),
+        ]))
+        .await
+        .unwrap();
+    wait_success(child, "libzmq CLIENT").await;
+}
+
+#[tokio::test]
+async fn omq_client_to_libzmq_server() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let client = Socket::new(SocketType::Client, Options::default());
+    let endpoint = client.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "server-connect-reply",
+        &endpoint.to_string(),
+        "from-client",
+        "from-server",
+    ]);
+
+    test_support::wait_for_handshake(&client).await;
+    client.send(Message::single("from-client")).await.unwrap();
+    let reply = recv(&client, "omq CLIENT -> libzmq SERVER").await;
+    assert_eq!(reply, Message::single("from-server"));
+    wait_success(child, "libzmq SERVER").await;
+}
+
+#[tokio::test]
+async fn libzmq_channel_to_omq_channel() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let channel = Socket::new(SocketType::Channel, Options::default());
+    let endpoint = channel.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "channel-connect-request",
+        &endpoint.to_string(),
+        "from-channel",
+        "from-omq",
+    ]);
+
+    let request = recv(&channel, "libzmq CHANNEL -> omq CHANNEL").await;
+    assert_eq!(request, Message::single("from-channel"));
+    channel.send(Message::single("from-omq")).await.unwrap();
+    wait_success(child, "libzmq CHANNEL").await;
+}
+
+#[tokio::test]
+async fn libzmq_peer_to_omq_peer() {
+    if skip_if_no_helper() {
+        return;
+    }
+
+    let peer = Socket::new(
+        SocketType::Peer,
+        Options::default().identity(Bytes::from_static(b"omq-peer")),
+    );
+    let endpoint = peer.bind(test_support::tcp_loopback(0)).await.unwrap();
+    let child = spawn_helper(&[
+        "peer-connect-request",
+        &endpoint.to_string(),
+        "from-peer",
+        "from-omq",
+    ]);
+
+    let request = recv(&peer, "libzmq PEER -> omq PEER").await;
+    assert_eq!(request.part_bytes(1).unwrap(), &b"from-peer"[..]);
+    let routing_id = request.part_bytes(0).unwrap();
+    peer.send(Message::multipart([
+        routing_id,
+        Bytes::from_static(b"from-omq"),
+    ]))
+    .await
+    .unwrap();
+    wait_success(child, "libzmq PEER").await;
+}

--- a/omq-tokio/tests/interop_libzmq_ws.rs
+++ b/omq-tokio/tests/interop_libzmq_ws.rs
@@ -15,8 +15,19 @@ use std::time::Duration;
 
 const HELPER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/helpers/zmq_ws_peer");
 
-fn helper_exists() -> bool {
-    std::path::Path::new(HELPER).exists()
+/// The helper is optional locally and mandatory in CI. With
+/// `OMQ_INTEROP_REQUIRED=1` a missing helper fails the test instead of
+/// letting the suite pass without exercising any interop.
+fn skip_if_no_helper() -> bool {
+    if !std::path::Path::new(HELPER).exists() {
+        assert!(
+            std::env::var_os("OMQ_INTEROP_REQUIRED").is_none(),
+            "OMQ_INTEROP_REQUIRED=1 but zmq_ws_peer helper not found at {HELPER}",
+        );
+        eprintln!("SKIP: zmq_ws_peer helper not found at {HELPER}");
+        return true;
+    }
+    false
 }
 
 fn ws_ep(port: u16) -> Endpoint {
@@ -33,8 +44,7 @@ fn get_port(ep: &Endpoint) -> u16 {
 /// omq PULL (bind) <- libzmq PUSH (connect)
 #[tokio::test]
 async fn libzmq_push_to_omq_pull() {
-    if !helper_exists() {
-        eprintln!("SKIP: zmq_ws_peer helper not found at {HELPER}");
+    if skip_if_no_helper() {
         return;
     }
     let pull = Socket::new(SocketType::Pull, Options::default());
@@ -73,8 +83,7 @@ async fn libzmq_push_to_omq_pull() {
 /// omq PUSH (connect) -> libzmq PULL (bind)
 #[tokio::test]
 async fn omq_push_to_libzmq_pull() {
-    if !helper_exists() {
-        eprintln!("SKIP: zmq_ws_peer helper not found at {HELPER}");
+    if skip_if_no_helper() {
         return;
     }
     let port = {

--- a/omq-tokio/tests/interop_pyzmq_curve.rs
+++ b/omq-tokio/tests/interop_pyzmq_curve.rs
@@ -31,8 +31,15 @@ fn pyzmq_curve_available() -> bool {
         .is_ok_and(|s| s.success())
 }
 
+/// The pyzmq peer is optional locally and mandatory in CI. With
+/// `OMQ_INTEROP_REQUIRED=1` a missing peer fails the test instead of
+/// letting the suite pass without exercising any interop.
 fn skip_if_no_pyzmq_curve() -> bool {
     if !pyzmq_curve_available() {
+        assert!(
+            std::env::var_os("OMQ_INTEROP_REQUIRED").is_none(),
+            "OMQ_INTEROP_REQUIRED=1 but python3 + pyzmq with CURVE is not available",
+        );
         eprintln!("skip: python3 + pyzmq with CURVE not available");
         return true;
     }

--- a/omq-tokio/tests/interop_pyzmq_null.rs
+++ b/omq-tokio/tests/interop_pyzmq_null.rs
@@ -1,0 +1,322 @@
+//! Wire-compatibility tests against libzmq via pyzmq, exercising the
+//! NULL mechanism over TCP/IPC and the STREAM socket.
+
+mod test_support;
+
+use std::io::Read;
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn python3_command() -> Command {
+    Command::new(std::env::var_os("OMQ_PYTHON3").unwrap_or_else(|| "python3".into()))
+}
+
+fn pyzmq_available() -> bool {
+    python3_command()
+        .args(["-c", "import zmq"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn skip_if_no_pyzmq() -> bool {
+    if !pyzmq_available() {
+        assert!(
+            std::env::var_os("OMQ_INTEROP_REQUIRED").is_none(),
+            "OMQ_INTEROP_REQUIRED=1 but python3 + pyzmq is not available",
+        );
+        eprintln!("skip: python3 + pyzmq not available");
+        return true;
+    }
+    false
+}
+
+async fn recv(sock: &Socket, context: &str) -> Message {
+    tokio::time::timeout(Duration::from_secs(5), sock.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: recv timed out"))
+        .unwrap()
+}
+
+async fn wait_success(child: Child, context: &str) -> Output {
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{context} exited non-zero\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+async fn rust_pull_from_pyzmq_push(endpoint: Endpoint) {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let endpoint = pull.bind(endpoint).await.unwrap();
+
+    let script = r#"
+import os, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.PUSH)
+s.connect(os.environ["ENDPOINT"])
+for i in range(3):
+    s.send(f"py-null-{i}".encode())
+s.close(linger=2000)
+ctx.term()
+"#;
+
+    let child = python3_command()
+        .args(["-c", script])
+        .env("ENDPOINT", endpoint.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn pyzmq PUSH");
+
+    for i in 0..3 {
+        let msg = recv(&pull, "pyzmq PUSH -> Rust PULL").await;
+        assert_eq!(
+            msg.part_bytes(0).unwrap(),
+            format!("py-null-{i}").as_bytes()
+        );
+    }
+
+    wait_success(child, "pyzmq PUSH").await;
+}
+
+async fn rust_push_to_pyzmq_pull(endpoint: Endpoint) {
+    let script = r#"
+import os, sys, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.PULL)
+endpoint = os.environ["ENDPOINT"]
+if endpoint == "tcp://127.0.0.1:0":
+    port = s.bind_to_random_port("tcp://127.0.0.1")
+    endpoint = f"tcp://127.0.0.1:{port}"
+else:
+    s.bind(endpoint)
+sys.stdout.write(endpoint + "\n"); sys.stdout.flush()
+for _ in range(3):
+    sys.stdout.write(s.recv().decode() + "\n"); sys.stdout.flush()
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let mut child = python3_command()
+        .args(["-c", script])
+        .env("ENDPOINT", endpoint.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn pyzmq PULL");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+    let (endpoint_tx, endpoint_rx) = tokio::sync::oneshot::channel::<Endpoint>();
+    let reader = tokio::task::spawn_blocking(move || {
+        use std::io::{BufRead, BufReader};
+        let mut r = BufReader::new(stdout);
+        let mut first = String::new();
+        r.read_line(&mut first).unwrap();
+        let _ = endpoint_tx.send(first.trim().parse().unwrap());
+        let mut lines = Vec::new();
+        for _ in 0..3 {
+            let mut buf = String::new();
+            if r.read_line(&mut buf).unwrap_or(0) == 0 {
+                break;
+            }
+            lines.push(buf.trim().to_string());
+        }
+        lines
+    });
+    let connect_endpoint = tokio::time::timeout(Duration::from_secs(5), endpoint_rx)
+        .await
+        .expect("pyzmq PULL did not become ready")
+        .unwrap();
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(connect_endpoint).await.unwrap();
+    for i in 0..3 {
+        push.send(Message::single(format!("rust-null-{i}")))
+            .await
+            .unwrap();
+    }
+
+    let lines = if let Ok(r) = tokio::time::timeout(Duration::from_secs(10), reader).await {
+        r.unwrap()
+    } else {
+        let _ = child.kill();
+        let mut err = String::new();
+        let _ = stderr.read_to_string(&mut err);
+        panic!("pyzmq PULL timed out\nstderr={err}");
+    };
+    assert_eq!(
+        lines,
+        (0..3).map(|i| format!("rust-null-{i}")).collect::<Vec<_>>()
+    );
+
+    let status = tokio::task::spawn_blocking(move || child.wait().unwrap())
+        .await
+        .unwrap();
+    assert!(status.success(), "pyzmq PULL exited with {status}");
+}
+
+#[tokio::test]
+async fn null_tcp_pyzmq_push_to_rust_pull() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+    rust_pull_from_pyzmq_push(test_support::tcp_loopback(0)).await;
+}
+
+#[tokio::test]
+async fn null_tcp_rust_push_to_pyzmq_pull() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+    rust_push_to_pyzmq_pull(test_support::tcp_loopback(0)).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn null_ipc_pyzmq_push_to_rust_pull() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+    rust_pull_from_pyzmq_push(test_support::ipc_endpoint("interop-null-py-push")).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn null_ipc_rust_push_to_pyzmq_pull() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+    rust_push_to_pyzmq_pull(test_support::ipc_endpoint("interop-null-py-pull")).await;
+}
+
+#[tokio::test]
+async fn stream_pyzmq_connects_to_rust() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let endpoint = stream.bind(test_support::tcp_loopback(0)).await.unwrap();
+
+    let script = r#"
+import os, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.STREAM)
+s.connect(os.environ["ENDPOINT"])
+ident, empty = s.recv_multipart()
+assert empty == b""
+s.send_multipart([ident, b"from-pyzmq"])
+ident2, body = s.recv_multipart()
+assert ident2 == ident
+assert body == b"from-rust"
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let child = python3_command()
+        .args(["-c", script])
+        .env("ENDPOINT", endpoint.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn pyzmq STREAM");
+
+    let connect = recv(&stream, "STREAM connect notification").await;
+    let identity = connect.part_bytes(0).unwrap();
+    assert!(!identity.is_empty());
+    assert!(connect.part_bytes(1).unwrap().is_empty());
+
+    let data = recv(&stream, "STREAM data from pyzmq").await;
+    assert_eq!(data.part_bytes(0).unwrap(), identity);
+    assert_eq!(data.part_bytes(1).unwrap(), &b"from-pyzmq"[..]);
+
+    stream
+        .send(Message::multipart([
+            identity.clone(),
+            Bytes::from_static(b"from-rust"),
+        ]))
+        .await
+        .unwrap();
+
+    wait_success(child, "pyzmq STREAM").await;
+}
+
+#[tokio::test]
+async fn stream_rust_connects_to_pyzmq() {
+    if skip_if_no_pyzmq() {
+        return;
+    }
+
+    let script = r#"
+import sys, zmq
+ctx = zmq.Context.instance()
+s = ctx.socket(zmq.STREAM)
+port = s.bind_to_random_port("tcp://127.0.0.1")
+sys.stdout.write(f"tcp://127.0.0.1:{port}\n"); sys.stdout.flush()
+ident, empty = s.recv_multipart()
+assert empty == b""
+ident2, body = s.recv_multipart()
+assert ident2 == ident
+assert body == b"from-rust"
+s.send_multipart([ident, b"from-pyzmq"])
+s.close(linger=0)
+ctx.term()
+"#;
+
+    let mut child = python3_command()
+        .args(["-c", script])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn pyzmq STREAM");
+
+    let stdout = child.stdout.take().unwrap();
+    let (endpoint_tx, endpoint_rx) = tokio::sync::oneshot::channel::<String>();
+    let reader = tokio::task::spawn_blocking(move || {
+        use std::io::{BufRead, BufReader};
+        let mut r = BufReader::new(stdout);
+        let mut first = String::new();
+        r.read_line(&mut first).unwrap();
+        let _ = endpoint_tx.send(first.trim().to_string());
+    });
+    let endpoint: Endpoint = tokio::time::timeout(Duration::from_secs(5), endpoint_rx)
+        .await
+        .expect("pyzmq STREAM bind timed out")
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    stream.connect(endpoint).await.unwrap();
+
+    let connect = recv(&stream, "STREAM connect notification").await;
+    let identity = connect.part_bytes(0).unwrap();
+    assert!(!identity.is_empty());
+    assert!(connect.part_bytes(1).unwrap().is_empty());
+
+    stream
+        .send(Message::multipart([
+            identity.clone(),
+            Bytes::from_static(b"from-rust"),
+        ]))
+        .await
+        .unwrap();
+
+    let reply = recv(&stream, "STREAM reply from pyzmq").await;
+    assert_eq!(reply.part_bytes(0).unwrap(), identity);
+    assert_eq!(reply.part_bytes(1).unwrap(), &b"from-pyzmq"[..]);
+
+    reader.await.unwrap();
+    wait_success(child, "pyzmq STREAM").await;
+}

--- a/omq-tokio/tests/interop_pyzmq_plain.rs
+++ b/omq-tokio/tests/interop_pyzmq_plain.rs
@@ -25,8 +25,15 @@ fn pyzmq_available() -> bool {
         .is_ok_and(|s| s.success())
 }
 
+/// The pyzmq peer is optional locally and mandatory in CI. With
+/// `OMQ_INTEROP_REQUIRED=1` a missing peer fails the test instead of
+/// letting the suite pass without exercising any interop.
 fn skip_if_no_pyzmq() -> bool {
     if !pyzmq_available() {
+        assert!(
+            std::env::var_os("OMQ_INTEROP_REQUIRED").is_none(),
+            "OMQ_INTEROP_REQUIRED=1 but python3 + pyzmq is not available",
+        );
         eprintln!("skip: python3 + pyzmq not available");
         return true;
     }

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -602,7 +602,10 @@ mod tests {
 
         fn noop(_: *const ()) {}
 
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, drop_waker);
+        // `wake` consumes the waker, so it must drop the Arc; only
+        // `wake_by_ref` is a no-op. Using noop for both leaks the Arc,
+        // which Miri's leak checker reports.
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, drop_waker, noop, drop_waker);
 
         let (mut p, c) = async_spsc::<u32>(1);
         p.push(1).unwrap();


### PR DESCRIPTION
- Run pyzmq `NULL`, `STREAM`, `PLAIN`, and `CURVE` interop in PR CI.
- Run light parser/socket-action fuzzing, `yring` Loom, and `yring` Miri in PR CI.
- Phase PR CI behind full-platform fmt/clippy and a Linux workspace test gate before slower test jobs.
- Keep PR test coverage on Linux, Windows, and macOS ARM; move Ubuntu ARM to nightly extended CI.
- Path-gate pyomq lint/test jobs to pyomq-relevant changes.
- Add nightly extended CI for full fuzzing, grouped soak tests, ignored stress suites, Miri many-seed runs, Ubuntu ARM, and libzmq draft interop.
- Build libzmq `v4.3.5` with `ENABLE_DRAFTS=ON` in extended CI for `ws://`, `RADIO`/`DISH`, and draft socket types.