### PR TITLE
Clean up fan-out, CI, pyomq, and transport dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
       os_matrix: ${{ steps.matrix.outputs.os_matrix }}
+      lint_matrix: ${{ steps.matrix.outputs.lint_matrix }}
       run_pyomq: ${{ steps.matrix.outputs.run_pyomq }}
     steps:
       - uses: actions/checkout@v7
@@ -29,12 +30,12 @@ jobs:
               - '**'
               - '!**/*.md'
               - '!**/*.svg'
-              - '!**/*.py'
               - '!doc/**'
       - id: matrix
         run: |
           echo 'test_matrix={"include":[{"toolchain":"stable","os":"ubuntu-latest"},{"toolchain":"stable","os":"ubuntu-24.04-arm"},{"toolchain":"stable","os":"macos-15-intel"},{"toolchain":"stable","os":"macos-15"},{"toolchain":"1.93","os":"ubuntu-latest"},{"toolchain":"stable","os":"windows-latest","target":"x86_64-pc-windows-msvc"}]}' >> "$GITHUB_OUTPUT"
           echo 'os_matrix={"os":["ubuntu-latest","macos-15-intel","macos-15","windows-latest"]}' >> "$GITHUB_OUTPUT"
+          echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"macOS Intel","kind":"rust","os":"macos-15-intel"},{"name":"macOS ARM64","kind":"rust","os":"macos-15"},{"name":"Windows","kind":"rust","os":"windows-latest"},{"name":"pyomq","kind":"pyomq","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
           echo 'run_pyomq=true' >> "$GITHUB_OUTPUT"
 
   test:
@@ -133,62 +134,62 @@ jobs:
           cross test --target ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_draft
 
   lint:
-    name: fmt + clippy
+    name: fmt + clippy (${{ matrix.name }})
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.changes.outputs.os_matrix) }}
+      matrix: ${{ fromJSON(needs.changes.outputs.lint_matrix) }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: install Rust (fmt/clippy)
+        if: matrix.kind == 'rust'
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: install Rust (pyomq)
+        if: matrix.kind == 'pyomq'
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all --check
+      - name: cargo fmt
+        if: matrix.kind == 'rust'
+        run: cargo fmt --all --check
       - name: clippy (Linux)
-        if: runner.os == 'Linux'
+        if: matrix.kind == 'rust' && runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets --all-features
       - name: clippy (Windows)
-        if: runner.os == 'Windows'
+        if: matrix.kind == 'rust' && runner.os == 'Windows'
         run: cargo clippy --workspace --all-targets --all-features
       - name: clippy (macOS)
-        if: runner.os == 'macOS'
+        if: matrix.kind == 'rust' && runner.os == 'macOS'
         run: cargo clippy --workspace --all-targets --all-features
-
-  pyomq-lint:
-    name: pyomq-lint
-    needs: [changes, lint]
-    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_pyomq == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v7
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         with:
           python-version: "3.14"
       - name: create virtualenv and install python deps
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
         run: |
           python -m venv .venv
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install --group test --group dev
       - name: build pyomq
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
         run: .venv/bin/pip install .
       - name: formatting
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
-        if: always()
         run: .venv/bin/ruff format .
       - name: linting
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
-        if: always()
         run: .venv/bin/ruff check .
       - name: type check
+        if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
-        if: always()
         run: |
           .venv/bin/ty check . --python-platform linux
           .venv/bin/ty check . --python-platform win32
@@ -233,7 +234,7 @@ jobs:
 
   ci-success:
     name: CI success
-    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq-lint, pyomq-test]
+    needs: [changes, test, encryption, compression, linux-32bit, lint, pyomq-test]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -149,14 +149,9 @@ impl Overlay {
         };
         #[cfg(feature = "plain")]
         if self.plain_server {
-            opts.mechanism = omq_proto::options::MechanismConfig::PlainServer {
-                authenticator: omq_proto::proto::mechanism::Authenticator::new(|_| true),
-            };
+            opts = opts.plain_server(|_| true);
         } else if let (Some(u), Some(p)) = (&self.plain_username, &self.plain_password) {
-            opts.mechanism = omq_proto::options::MechanismConfig::PlainClient {
-                username: u.clone(),
-                password: p.clone(),
-            };
+            opts = opts.plain_client(u.clone(), p.clone());
         }
         #[cfg(feature = "curve")]
         if self.curve_server {
@@ -173,10 +168,7 @@ impl Overlay {
                     .curve_authenticator
                     .as_ref()
                     .map(crate::auth::build_authenticator);
-                opts.mechanism = omq_proto::options::MechanismConfig::CurveServer {
-                    our_keypair: keypair,
-                    options: curve_options,
-                };
+                opts = opts.curve_server_with_options(keypair, curve_options);
             }
         } else if let (Some(pk), Some(sk), Some(svk)) = (
             &self.curve_publickey,
@@ -193,10 +185,7 @@ impl Overlay {
             let server_public = backend::CurvePublicKey::from_z85(svk_str)
                 .map_err(|e| bad_key_detail("CURVE_SERVERKEY", &e))?;
             let keypair = backend::CurveKeypair { public, secret };
-            opts.mechanism = omq_proto::options::MechanismConfig::CurveClient {
-                our_keypair: keypair,
-                server_public,
-            };
+            opts = opts.curve_client(keypair, server_public);
         }
         Ok(opts)
     }

--- a/omq-libzmq/tests/basic.rs
+++ b/omq-libzmq/tests/basic.rs
@@ -148,15 +148,11 @@ fn push_pull_inproc() {
 
 #[test]
 fn push_pull_tcp() {
-    let port = helpers::free_port();
-    let addr_str = format!("tcp://127.0.0.1:{port}");
-    let addr = CString::new(addr_str).unwrap();
-
     let ctx = zmq_ctx_new();
     let pull = zmq_socket(ctx, ZMQ_PULL);
     let push = zmq_socket(ctx, ZMQ_PUSH);
 
-    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    let addr = helpers::bind_random_tcp(pull);
     assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
 
     std::thread::sleep(Duration::from_millis(50));

--- a/omq-libzmq/tests/draft.rs
+++ b/omq-libzmq/tests/draft.rs
@@ -132,16 +132,13 @@ fn server_client_roundtrip() {
 /// SCATTER/GATHER over TCP.
 #[test]
 fn scatter_gather_tcp() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let scatter = zmq_socket(ctx, ZMQ_SCATTER);
     let gather = zmq_socket(ctx, ZMQ_GATHER);
     assert_eq!(get_type(scatter), ZMQ_SCATTER);
     assert_eq!(get_type(gather), ZMQ_GATHER);
 
-    zmq_bind(gather, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(gather);
     zmq_connect(scatter, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
     set_timeo(scatter, 2000);
@@ -322,12 +319,9 @@ fn peer_inproc() {
 /// SERVER/CLIENT over TCP with multiple clients.
 #[test]
 fn server_multiple_clients_tcp() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let server = zmq_socket(ctx, ZMQ_SERVER);
-    zmq_bind(server, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(server);
     set_timeo(server, 2000);
 
     let mut clients = Vec::new();

--- a/omq-libzmq/tests/helpers.rs
+++ b/omq-libzmq/tests/helpers.rs
@@ -1,11 +1,43 @@
-#[allow(dead_code)]
-pub(crate) fn free_port() -> u16 {
-    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
-    let l = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
-    l.local_addr().unwrap().port()
+#![allow(dead_code)]
+
+use std::ffi::{CStr, CString, c_void};
+
+use omq_zmq::{zmq_bind, zmq_getsockopt};
+
+const ZMQ_LAST_ENDPOINT: i32 = 32;
+
+pub(crate) fn bind_random_tcp(sock: *mut c_void) -> CString {
+    bind_random(sock, "tcp://127.0.0.1:0")
 }
 
-#[allow(dead_code)]
-pub(crate) fn tcp_addr(port: u16) -> String {
-    format!("tcp://127.0.0.1:{port}\0")
+pub(crate) fn bind_random_lz4_tcp(sock: *mut c_void) -> CString {
+    bind_random(sock, "lz4+tcp://127.0.0.1:0")
+}
+
+fn bind_random(sock: *mut c_void, endpoint: &str) -> CString {
+    let bind_addr = CString::new(endpoint).unwrap();
+    assert_eq!(
+        zmq_bind(sock, bind_addr.as_ptr()),
+        0,
+        "bind {endpoint} failed, errno={}",
+        omq_zmq::zmq_errno(),
+    );
+    last_endpoint(sock)
+}
+
+pub(crate) fn last_endpoint(sock: *mut c_void) -> CString {
+    let mut buf = [0u8; 256];
+    let mut len = buf.len();
+    assert_eq!(
+        zmq_getsockopt(
+            sock,
+            ZMQ_LAST_ENDPOINT,
+            buf.as_mut_ptr().cast(),
+            &raw mut len,
+        ),
+        0,
+        "ZMQ_LAST_ENDPOINT failed, errno={}",
+        omq_zmq::zmq_errno(),
+    );
+    CStr::from_bytes_until_nul(&buf[..len]).unwrap().to_owned()
 }

--- a/omq-libzmq/tests/libzmq_dealer_router.rs
+++ b/omq-libzmq/tests/libzmq_dealer_router.rs
@@ -118,14 +118,11 @@ fn dealer_router_identity_routing() {
 /// DEALER/ROUTER over TCP
 #[test]
 fn dealer_router_tcp() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let router = zmq_socket(ctx, ZMQ_ROUTER);
     let dealer = zmq_socket(ctx, ZMQ_DEALER);
 
-    zmq_bind(router, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(router);
     set_identity(dealer, b"d1");
     zmq_connect(dealer, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
@@ -205,10 +202,7 @@ fn multiple_dealers_one_router() {
     let ctx = zmq_ctx_new();
     let router = zmq_socket(ctx, ZMQ_ROUTER);
 
-    let port = helpers::free_port();
-    let addr_str = format!("tcp://127.0.0.1:{port}");
-    let addr = CString::new(addr_str.clone()).unwrap();
-    zmq_bind(router, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(router);
 
     set_timeo(router, ZMQ_RCVTIMEO, TIMEOUT_MS);
     set_timeo(router, ZMQ_SNDTIMEO, TIMEOUT_MS);
@@ -216,8 +210,7 @@ fn multiple_dealers_one_router() {
     for i in 0..N {
         let d = zmq_socket(ctx, ZMQ_DEALER);
         set_identity(d, format!("d{i}").as_bytes());
-        let a = CString::new(addr_str.clone()).unwrap();
-        zmq_connect(d, a.as_ptr());
+        zmq_connect(d, addr.as_ptr());
         set_timeo(d, ZMQ_RCVTIMEO, TIMEOUT_MS);
         dealers.push(d);
     }
@@ -293,13 +286,8 @@ fn req_through_dealer_router() {
     let req = zmq_socket(ctx, ZMQ_REQ);
     let rep = zmq_socket(ctx, ZMQ_REP);
 
-    let port_fe = helpers::free_port();
-    let port_be = helpers::free_port();
-    let addr_fe = CString::new(format!("tcp://127.0.0.1:{port_fe}")).unwrap();
-    let addr_be = CString::new(format!("tcp://127.0.0.1:{port_be}")).unwrap();
-
-    zmq_bind(router_fe, addr_fe.as_ptr());
-    zmq_bind(dealer_be, addr_be.as_ptr());
+    let addr_fe = helpers::bind_random_tcp(router_fe);
+    let addr_be = helpers::bind_random_tcp(dealer_be);
     zmq_connect(req, addr_fe.as_ptr());
     zmq_connect(rep, addr_be.as_ptr());
     std::thread::sleep(Duration::from_millis(150));

--- a/omq-libzmq/tests/libzmq_pair_tcp.rs
+++ b/omq-libzmq/tests/libzmq_pair_tcp.rs
@@ -26,15 +26,12 @@ fn set_timeo(sock: *mut std::ffi::c_void, opt: i32, ms: i32) {
 /// from `libzmq/tests/test_pair_tcp.cpp`
 #[test]
 fn pair_tcp_basic() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let sb = zmq_socket(ctx, ZMQ_PAIR); // server/bind
     let sc = zmq_socket(ctx, ZMQ_PAIR); // client/connect
     assert!(!sb.is_null() && !sc.is_null());
 
-    assert_eq!(zmq_bind(sb, addr.as_ptr()), 0, "bind failed");
+    let addr = helpers::bind_random_tcp(sb);
     assert_eq!(zmq_connect(sc, addr.as_ptr()), 0, "connect failed");
 
     // Allow handshake time.
@@ -69,14 +66,11 @@ fn pair_tcp_basic() {
 
 #[test]
 fn pair_tcp_multipart() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let sb = zmq_socket(ctx, ZMQ_PAIR);
     let sc = zmq_socket(ctx, ZMQ_PAIR);
 
-    zmq_bind(sb, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(sb);
     zmq_connect(sc, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
 
@@ -109,14 +103,11 @@ fn pair_tcp_multipart() {
 fn pair_tcp_many_messages() {
     const N: usize = 100;
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let sb = zmq_socket(ctx, ZMQ_PAIR);
     let sc = zmq_socket(ctx, ZMQ_PAIR);
 
-    zmq_bind(sb, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(sb);
     zmq_connect(sc, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
 
@@ -152,14 +143,11 @@ fn pair_tcp_many_messages() {
 #[test]
 fn pair_tcp_truncation() {
     // libzmq behavior: zmq_recv truncates to buf_len but returns actual frame length.
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let sb = zmq_socket(ctx, ZMQ_PAIR);
     let sc = zmq_socket(ctx, ZMQ_PAIR);
 
-    zmq_bind(sb, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(sb);
     zmq_connect(sc, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
 

--- a/omq-libzmq/tests/libzmq_pub_sub.rs
+++ b/omq-libzmq/tests/libzmq_pub_sub.rs
@@ -67,14 +67,11 @@ fn pub_sub_basic_inproc() {
 
 #[test]
 fn pub_sub_topic_filter_tcp() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let pub_ = zmq_socket(ctx, ZMQ_PUB);
     let sub = zmq_socket(ctx, ZMQ_SUB);
 
-    zmq_bind(pub_, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pub_);
     subscribe(sub, b"topic.A");
     zmq_connect(sub, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(200));

--- a/omq-libzmq/tests/libzmq_push_pull.rs
+++ b/omq-libzmq/tests/libzmq_push_pull.rs
@@ -29,14 +29,11 @@ fn set_timeo(sock: *mut std::ffi::c_void, opt: i32, ms: i32) {
 fn push_pull_basic_tcp() {
     const N: usize = 10;
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let pull = zmq_socket(ctx, ZMQ_PULL);
     let push = zmq_socket(ctx, ZMQ_PUSH);
 
-    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    let addr = helpers::bind_random_tcp(pull);
     assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
     std::thread::sleep(Duration::from_millis(100));
 
@@ -68,19 +65,14 @@ fn push_pull_multiple_pushers() {
     const N_PUSHERS: usize = 3;
     const MSG_PER_PUSHER: usize = 5;
 
-    let port = helpers::free_port();
-    let addr_str = format!("tcp://127.0.0.1:{port}");
-    let addr = CString::new(addr_str.clone()).unwrap();
-
     let ctx = zmq_ctx_new();
     let pull = zmq_socket(ctx, ZMQ_PULL);
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pull);
 
     let mut pushers = Vec::new();
     for _ in 0..N_PUSHERS {
         let p = zmq_socket(ctx, ZMQ_PUSH);
-        let a = CString::new(addr_str.clone()).unwrap();
-        zmq_connect(p, a.as_ptr());
+        zmq_connect(p, addr.as_ptr());
         pushers.push(p);
     }
 
@@ -113,18 +105,14 @@ fn push_pull_multiple_pullers() {
     const N_PULLERS: usize = 3;
     const TOTAL: usize = 30;
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let push = zmq_socket(ctx, ZMQ_PUSH);
-    zmq_bind(push, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(push);
 
     let mut pullers = Vec::new();
     for _ in 0..N_PULLERS {
         let p = zmq_socket(ctx, ZMQ_PULL);
-        let a = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-        zmq_connect(p, a.as_ptr());
+        zmq_connect(p, addr.as_ptr());
         pullers.push(p);
     }
 
@@ -208,9 +196,7 @@ fn push_dontwait_eagain_semantics() {
     let push = zmq_socket(ctx, ZMQ_PUSH);
     let pull = zmq_socket(ctx, ZMQ_PULL);
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pull);
     zmq_connect(push, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
 

--- a/omq-libzmq/tests/libzmq_req_rep.rs
+++ b/omq-libzmq/tests/libzmq_req_rep.rs
@@ -75,14 +75,11 @@ fn req_rep_basic_inproc() {
 
 #[test]
 fn req_rep_basic_tcp() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let rep = zmq_socket(ctx, ZMQ_REP);
     let req = zmq_socket(ctx, ZMQ_REQ);
 
-    zmq_bind(rep, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(rep);
     zmq_connect(req, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
 
@@ -160,18 +157,14 @@ fn req_rep_multiple_clients() {
     let ctx = zmq_ctx_new();
     let rep = zmq_socket(ctx, ZMQ_REP);
 
-    let port = helpers::free_port();
-    let addr_str = format!("tcp://127.0.0.1:{port}");
-    let addr = CString::new(addr_str.clone()).unwrap();
-    zmq_bind(rep, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(rep);
 
     set_timeo(rep, ZMQ_RCVTIMEO, TIMEOUT_MS);
     set_timeo(rep, ZMQ_SNDTIMEO, TIMEOUT_MS);
     let mut reqs = Vec::new();
     for _ in 0..N {
         let r = zmq_socket(ctx, ZMQ_REQ);
-        let a = CString::new(addr_str.clone()).unwrap();
-        zmq_connect(r, a.as_ptr());
+        zmq_connect(r, addr.as_ptr());
         set_timeo(r, ZMQ_RCVTIMEO, TIMEOUT_MS);
         set_timeo(r, ZMQ_SNDTIMEO, TIMEOUT_MS);
         reqs.push(r);

--- a/omq-libzmq/tests/monitor.rs
+++ b/omq-libzmq/tests/monitor.rs
@@ -8,8 +8,8 @@ use std::mem::size_of;
 use std::time::Duration;
 
 use omq_zmq::{
-    zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_recv, zmq_setsockopt,
-    zmq_socket, zmq_socket_monitor,
+    zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_recv, zmq_setsockopt, zmq_socket,
+    zmq_socket_monitor,
 };
 
 const ZMQ_PUSH: i32 = 8;
@@ -77,19 +77,14 @@ fn monitor_receives_listening_and_accepted() {
     zmq_connect(mon, mon_addr.as_ptr());
     set_timeo(mon, 2000);
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pull);
 
     // Should receive LISTENING event.
     let ev = recv_monitor_event(mon);
     assert!(ev.is_some(), "expected LISTENING event");
     let (id, ep) = ev.unwrap();
     assert_eq!(id, ZMQ_EVENT_LISTENING, "event={id:#06x}");
-    assert!(
-        ep.contains(&port.to_string()),
-        "endpoint should contain port"
-    );
+    assert_eq!(ep, addr.to_str().unwrap());
 
     // Connect a PUSH socket.
     let push = zmq_socket(ctx, ZMQ_PUSH);
@@ -134,9 +129,7 @@ fn monitor_event_filter() {
     zmq_connect(mon, mon_addr.as_ptr());
     set_timeo(mon, 1000);
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pull);
 
     // Connect a peer (generates ACCEPTED, but we're not subscribed).
     let push = zmq_socket(ctx, ZMQ_PUSH);

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -266,9 +266,7 @@ fn bound_push_after_last_peer_disconnect_is_muted_like_libzmq() {
     set_i32(push, ZMQ_SNDTIMEO, 500);
     set_i32(pull, ZMQ_RCVTIMEO, 500);
 
-    let port = helpers::free_port();
-    let endpoint = std::ffi::CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-    assert_eq!(zmq_bind(push, endpoint.as_ptr()), 0);
+    let endpoint = helpers::bind_random_tcp(push);
     assert_eq!(zmq_connect(pull, endpoint.as_ptr()), 0);
 
     let first = b"first";
@@ -748,10 +746,8 @@ fn silent_noop_options_accepted() {
 fn last_endpoint_after_bind() {
     let ctx = zmq_ctx_new();
     let s = zmq_socket(ctx, ZMQ_PULL);
-    let port = helpers::free_port();
-    let addr_str = format!("tcp://127.0.0.1:{port}");
-    let addr = std::ffi::CString::new(addr_str.clone()).unwrap();
-    zmq_bind(s, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(s);
+    let addr_str = addr.to_str().unwrap();
 
     let mut buf = [0u8; 256];
     let len = get_bytes(s, ZMQ_LAST_ENDPOINT, &mut buf);

--- a/omq-libzmq/tests/proxy.rs
+++ b/omq-libzmq/tests/proxy.rs
@@ -509,14 +509,10 @@ fn proxy_large_message() {
     let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
     let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
 
-    let port_fe = helpers::free_port();
-    let port_be = helpers::free_port();
-    let addr_fe = CString::new(format!("tcp://127.0.0.1:{port_fe}")).unwrap();
-    let addr_be = CString::new(format!("tcp://127.0.0.1:{port_be}")).unwrap();
     let addr_ctrl = CString::new("inproc://proxy-ctrl-large").unwrap();
 
-    zmq_bind(fe, addr_fe.as_ptr());
-    zmq_bind(be, addr_be.as_ptr());
+    let addr_fe = helpers::bind_random_tcp(fe);
+    let addr_be = helpers::bind_random_tcp(be);
     zmq_bind(ctrl_a, addr_ctrl.as_ptr());
     zmq_connect(src, addr_fe.as_ptr());
     zmq_connect(dst, addr_be.as_ptr());

--- a/omq-libzmq/tests/security.rs
+++ b/omq-libzmq/tests/security.rs
@@ -3,14 +3,13 @@
 
 mod helpers;
 
-use std::ffi::{CString, c_void};
+use std::ffi::c_void;
 use std::mem::size_of;
 use std::time::Duration;
 
 use omq_zmq::{
-    zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_curve_keypair,
-    zmq_curve_public, zmq_recv, zmq_send, zmq_setsockopt, zmq_socket, zmq_z85_decode,
-    zmq_z85_encode,
+    zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_curve_keypair, zmq_curve_public,
+    zmq_recv, zmq_send, zmq_setsockopt, zmq_socket, zmq_z85_decode, zmq_z85_encode,
 };
 
 const ZMQ_PUSH: i32 = 8;
@@ -134,13 +133,10 @@ fn curve_req_rep_tcp() {
     zmq_curve_keypair(cli_pub.as_mut_ptr().cast(), cli_sec.as_mut_ptr().cast());
 
     let ctx = zmq_ctx_new();
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let rep = zmq_socket(ctx, ZMQ_REP);
     set_i32(rep, ZMQ_CURVE_SERVER, 1);
     set_bytes(rep, ZMQ_CURVE_SECRETKEY, &srv_sec[..40]);
-    zmq_bind(rep, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(rep);
     set_timeo(rep, 5000);
 
     let req = zmq_socket(ctx, ZMQ_REQ);
@@ -185,12 +181,9 @@ fn curve_req_rep_tcp() {
 #[test]
 fn plain_push_pull_tcp() {
     let ctx = zmq_ctx_new();
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let pull = zmq_socket(ctx, ZMQ_PULL);
     set_i32(pull, ZMQ_PLAIN_SERVER, 1);
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pull);
     set_timeo(pull, 5000);
 
     let push = zmq_socket(ctx, ZMQ_PUSH);

--- a/omq-libzmq/tests/transports.rs
+++ b/omq-libzmq/tests/transports.rs
@@ -181,14 +181,11 @@ fn ipc_abstract_pub_sub() {
 
 #[test]
 fn tcp_pub_sub() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let pub_ = zmq_socket(ctx, ZMQ_PUB);
     let sub = zmq_socket(ctx, ZMQ_SUB);
 
-    zmq_bind(pub_, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pub_);
     zmq_setsockopt(sub, ZMQ_SUBSCRIBE, b"".as_ptr().cast(), 0);
     zmq_connect(sub, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
@@ -208,15 +205,12 @@ fn tcp_pub_sub() {
 
 #[test]
 fn tcp_pub_sub_multiple_subscribers() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let pub_ = zmq_socket(ctx, ZMQ_PUB);
     let sub1 = zmq_socket(ctx, ZMQ_SUB);
     let sub2 = zmq_socket(ctx, ZMQ_SUB);
 
-    zmq_bind(pub_, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(pub_);
     zmq_setsockopt(sub1, ZMQ_SUBSCRIBE, b"".as_ptr().cast(), 0);
     zmq_setsockopt(sub2, ZMQ_SUBSCRIBE, b"".as_ptr().cast(), 0);
     zmq_connect(sub1, addr.as_ptr());
@@ -246,14 +240,11 @@ fn tcp_pub_sub_multiple_subscribers() {
 
 #[test]
 fn lz4_tcp_push_pull() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("lz4+tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let push = zmq_socket(ctx, ZMQ_PUSH);
     let pull = zmq_socket(ctx, ZMQ_PULL);
 
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_lz4_tcp(pull);
     zmq_connect(push, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
     set_timeo(push, 2000);
@@ -275,14 +266,11 @@ fn lz4_tcp_push_pull() {
 
 #[test]
 fn lz4_tcp_multiple_messages() {
-    let port = helpers::free_port();
-    let addr = CString::new(format!("lz4+tcp://127.0.0.1:{port}")).unwrap();
-
     let ctx = zmq_ctx_new();
     let push = zmq_socket(ctx, ZMQ_PUSH);
     let pull = zmq_socket(ctx, ZMQ_PULL);
 
-    zmq_bind(pull, addr.as_ptr());
+    let addr = helpers::bind_random_lz4_tcp(pull);
     zmq_connect(push, addr.as_ptr());
     std::thread::sleep(Duration::from_millis(100));
     set_timeo(push, 2000);

--- a/omq-libzmq/tests/xpub_xsub.rs
+++ b/omq-libzmq/tests/xpub_xsub.rs
@@ -106,9 +106,7 @@ fn xpub_receives_sub_notifications() {
     set_linger_zero(xpub);
     set_linger_zero(sub);
 
-    let port = helpers::free_port();
-    let addr = CString::new(format!("tcp://127.0.0.1:{port}")).unwrap();
-    zmq_bind(xpub, addr.as_ptr());
+    let addr = helpers::bind_random_tcp(xpub);
     set_timeo(xpub, 2000);
 
     zmq_setsockopt(sub, ZMQ_SUBSCRIBE, b"news".as_ptr().cast(), 4);
@@ -164,17 +162,12 @@ fn xpub_xsub_proxy_pattern() {
     set_linger_zero(xpub);
     set_linger_zero(sub);
 
-    let port_be = helpers::free_port();
-    let port_fe = helpers::free_port();
-    let addr_be = CString::new(format!("tcp://127.0.0.1:{port_be}")).unwrap();
-    let addr_fe = CString::new(format!("tcp://127.0.0.1:{port_fe}")).unwrap();
-
     // Backend: PUB -> XSUB
-    zmq_bind(xsub, addr_be.as_ptr());
+    let addr_be = helpers::bind_random_tcp(xsub);
     zmq_connect(pub_, addr_be.as_ptr());
 
     // Frontend: XPUB -> SUB
-    zmq_bind(xpub, addr_fe.as_ptr());
+    let addr_fe = helpers::bind_random_tcp(xpub);
     zmq_setsockopt(sub, ZMQ_SUBSCRIBE, b"".as_ptr().cast(), 0);
     zmq_connect(sub, addr_fe.as_ptr());
 

--- a/omq-proto/src/frame_buffer.rs
+++ b/omq-proto/src/frame_buffer.rs
@@ -286,6 +286,23 @@ impl FrameBuffer {
         }
     }
 
+    pub fn pop_front_entry(&mut self) -> bool {
+        self.commit_arena_range();
+        let Some(entry) = self.entries.pop_front() else {
+            return false;
+        };
+        let len = match entry {
+            Entry::Arena { len, .. } => len as usize,
+            Entry::External(bytes) => bytes.len(),
+        };
+        self.total_bytes = self.total_bytes.saturating_sub(len);
+        if self.entries.is_empty() && self.arena.len() == self.arena_mark as usize {
+            self.arena.clear();
+            self.arena_mark = 0;
+        }
+        true
+    }
+
     pub fn push_shared_chunks(&mut self, chunks: &[Bytes]) {
         self.commit_arena_range();
         for chunk in chunks {
@@ -555,5 +572,19 @@ mod tests {
 
         let drained: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
         assert_eq!(raw, drained);
+    }
+
+    #[test]
+    fn pop_front_entry_drops_oldest_committed_chunk() {
+        let mut eq = FrameBuffer::one_shot();
+        eq.push_raw(vec![Bytes::from_static(b"first")]);
+        eq.push_raw(vec![Bytes::from_static(b"second")]);
+
+        assert!(eq.pop_front_entry());
+
+        let mut chunks = Vec::new();
+        eq.drain(&mut chunks, 1024);
+        assert_eq!(chunks, vec![Bytes::from_static(b"second")]);
+        assert!(eq.is_empty());
     }
 }

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -715,6 +715,10 @@ impl Default for ReconnectPolicy {
 /// no-peer round-robin sockets queue into a pre-ready pipe until `send_hwm`
 /// is reached, then apply this policy. Native OMQ has no `ZMQ_IMMEDIATE`
 /// option; `omq-libzmq` implements `ZMQ_IMMEDIATE` at the C layer.
+///
+/// `PUB`, `XPUB`, and `RADIO` honor `DropOldest` for per-peer fan-out
+/// queues. Other fan-out sockets keep the native drop-newest behavior unless
+/// `xpub_nodrop` asks them to wait.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OnMute {

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -9,9 +9,10 @@ use std::io;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use super::signal::{DataSignal, StateSignal};
+use omq_proto::fan_out_frame::FanOutFrame;
 use omq_proto::frame_buffer::FrameBuffer;
 use omq_proto::handle_frame::{
     HandleFrameCaps, HandleFrameDecision, HandleFrameState, decide_handle_frame,
@@ -195,6 +196,33 @@ impl PeerTransmitSlot {
         eq.push_pre_framed(data);
         self.queued_msgs.fetch_add(1, Ordering::Relaxed);
         self.mark_above_lwm_if_needed(eq.total_bytes(), self.queued_msgs.load(Ordering::Relaxed));
+        TryFrameResult::Ok
+    }
+
+    pub(crate) fn try_push_fanout_drop_oldest(&self, frame: &FanOutFrame<'_>) -> TryFrameResult {
+        if self.dead.load(Ordering::Acquire) {
+            return TryFrameResult::Dead;
+        }
+        // Store one encoded fan-out message per entry so full-slot eviction
+        // can remove the oldest whole message instead of an arbitrary chunk.
+        let chunk = fanout_frame_chunk(frame);
+        let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
+        let mut queued_msgs = self.queued_msgs.load(Ordering::Relaxed);
+        while eq.total_bytes().saturating_add(chunk.len()) >= self.cap
+            || queued_msgs >= self.msg_cap
+        {
+            if !eq.pop_front_entry() {
+                self.above_lwm.store(true, Ordering::Relaxed);
+                return TryFrameResult::Full;
+            }
+            queued_msgs = queued_msgs.saturating_sub(1);
+        }
+        eq.push_raw(vec![chunk]);
+        queued_msgs += 1;
+        self.queued_msgs.store(queued_msgs, Ordering::Relaxed);
+        self.mark_above_lwm_if_needed(eq.total_bytes(), queued_msgs);
+        drop(eq);
+        self.signal_encoded();
         TryFrameResult::Ok
     }
 
@@ -392,9 +420,25 @@ impl PeerTransmitSlot {
     }
 }
 
+fn fanout_frame_chunk(frame: &FanOutFrame<'_>) -> Bytes {
+    match frame {
+        FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+        FanOutFrame::Chunks(chunks) if chunks.len() == 1 => chunks[0].clone(),
+        FanOutFrame::Chunks(chunks) => {
+            let len = chunks.iter().map(Bytes::len).sum();
+            let mut buf = BytesMut::with_capacity(len);
+            for chunk in *chunks {
+                buf.extend_from_slice(chunk);
+            }
+            buf.freeze()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
     use tokio::time::{Duration, timeout};
 
     fn test_slot() -> Arc<PeerTransmitSlot> {
@@ -415,6 +459,15 @@ mod tests {
         slot
     }
 
+    fn fanout_bytes(msg: &Message) -> Bytes {
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, msg, &mut chunks, 1, 8 * 1024);
+        let bytes = fanout_frame_chunk(&frame);
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
     #[test]
     fn transmit_slot_caps_queued_messages_independent_of_bytes() {
         let slot = test_slot();
@@ -428,6 +481,40 @@ mod tests {
         let mut chunks = Vec::new();
         slot.drain(&mut chunks, 1024);
         assert_eq!(slot.try_encode(&msg), TryFrameResult::Ok);
+    }
+
+    #[test]
+    fn fanout_drop_oldest_slot_keeps_newest_messages() {
+        let slot = PeerTransmitSlot::new(
+            1,
+            false,
+            None,
+            omq_proto::frame_buffer::ARENA_THRESHOLD,
+            omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            TRANSMIT_SLOT_CAP_DEFAULT,
+            2,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+
+        let first = Message::single("first");
+        let second = Message::single("second");
+        let third = Message::single("third");
+
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        for msg in [&first, &second, &third] {
+            let frame = build_fan_out_frame(&mut eq, msg, &mut chunks, 1, 8 * 1024);
+            assert_eq!(slot.try_push_fanout_drop_oldest(&frame), TryFrameResult::Ok);
+            clear_fan_out_frame(&mut eq, &mut chunks);
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(actual, vec![fanout_bytes(&second), fanout_bytes(&third)]);
     }
 
     #[tokio::test]

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -22,7 +22,8 @@ use tokio::sync::oneshot;
 use crate::engine::PeerDriverHandle;
 use omq_proto::error::Result;
 use omq_proto::message::Message;
-use omq_proto::options::Options;
+use omq_proto::options::{OnMute, Options};
+use omq_proto::proto::SocketType;
 
 use super::peer_outbound::PeerOutbound;
 use super::subscription::SubscriptionSet;
@@ -50,6 +51,19 @@ fn yield_interval(peer_count: usize, msg_bytes: usize) -> u32 {
     peer_interval.min(byte_interval)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FanOutMutePolicy {
+    Block,
+    DropNewest,
+    DropOldest,
+}
+
+impl FanOutMutePolicy {
+    pub(super) fn is_lossy(self) -> bool {
+        !matches!(self, Self::Block)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Submitter {
     lanes: Arc<FanOutLanes>,
@@ -60,7 +74,7 @@ pub(crate) struct Submitter {
     mode: FanOutMode,
     send_count: Arc<AtomicU32>,
     xpub_nodrop: bool,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     #[cfg(feature = "lz4")]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
@@ -76,17 +90,23 @@ impl Clone for Submitter {
             mode: self.mode,
             send_count: self.send_count.clone(),
             xpub_nodrop: self.xpub_nodrop,
-            lossy: self.lossy,
+            mute_policy: self.mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: self.dict_training.clone(),
         }
     }
 }
 
-fn fan_out_is_lossy(options: &Options) -> bool {
-    // TODO: Fan-out mute currently drops newest. Supporting DropOldest needs
-    // per-peer oldest eviction in PeerTransmitSlot or a fan-out-specific queue.
-    !options.xpub_nodrop
+fn fan_out_mute_policy(socket_type: SocketType, options: &Options) -> FanOutMutePolicy {
+    if options.xpub_nodrop {
+        return FanOutMutePolicy::Block;
+    }
+    match (socket_type, options.on_mute) {
+        (SocketType::Pub | SocketType::XPub | SocketType::Radio, OnMute::DropOldest) => {
+            FanOutMutePolicy::DropOldest
+        }
+        _ => FanOutMutePolicy::DropNewest,
+    }
 }
 
 fn deactivate_fanout_target(
@@ -168,8 +188,13 @@ impl Submitter {
 
         if !fallback_targets.is_empty() {
             let mut deactivate = |target: &PeerOutbound| self.deactivate_target(target);
-            fallback::dispatch_to_targets(&fallback_targets, msg, self.lossy, &mut deactivate)
-                .map_err(omq_proto::error::TrySendError::Error)?;
+            fallback::dispatch_to_targets(
+                &fallback_targets,
+                msg,
+                self.mute_policy,
+                &mut deactivate,
+            )
+            .map_err(omq_proto::error::TrySendError::Error)?;
         }
 
         if has_lane_peers {
@@ -237,7 +262,12 @@ impl Submitter {
 
         if !fallback_targets.is_empty() {
             let mut deactivate = |target: &PeerOutbound| self.deactivate_target(target);
-            fallback::dispatch_to_targets(&fallback_targets, msg, self.lossy, &mut deactivate)?;
+            fallback::dispatch_to_targets(
+                &fallback_targets,
+                msg,
+                self.mute_policy,
+                &mut deactivate,
+            )?;
         }
 
         if has_lane_peers {
@@ -295,7 +325,7 @@ pub(crate) struct FanOutSend {
     generation: Arc<AtomicU64>,
     mode: FanOutMode,
     xpub_nodrop: bool,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     #[cfg(feature = "lz4")]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
@@ -352,12 +382,13 @@ impl FanOutInner {
 
 impl FanOutSend {
     pub(crate) fn new(
+        socket_type: SocketType,
         options: &Options,
         mode: FanOutMode,
         io_pool: &crate::context::IoPoolHandle,
     ) -> Self {
-        let lossy = fan_out_is_lossy(options);
-        let lanes = FanOutLanes::spawn(options, mode, lossy, io_pool);
+        let mute_policy = fan_out_mute_policy(socket_type, options);
+        let lanes = FanOutLanes::spawn(options, mode, mute_policy, io_pool);
         let inner = Arc::new(Mutex::new(FanOutInner {
             peers: FxHashMap::default(),
             subscribe_all_count: 0,
@@ -376,7 +407,7 @@ impl FanOutSend {
             generation,
             mode,
             xpub_nodrop: options.xpub_nodrop,
-            lossy,
+            mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: Arc::new(Mutex::new(compression::new_dict_training(options))),
         }
@@ -396,7 +427,7 @@ impl FanOutSend {
             mode: self.mode,
             send_count: Arc::new(AtomicU32::new(0)),
             xpub_nodrop: self.xpub_nodrop,
-            lossy: self.lossy,
+            mute_policy: self.mute_policy,
             #[cfg(feature = "lz4")]
             dict_training: self.dict_training.clone(),
         }
@@ -619,7 +650,9 @@ impl FanOutSend {
 
 #[cfg(test)]
 mod tests {
-    use super::yield_interval;
+    use super::{FanOutMode, FanOutMutePolicy, FanOutSend, fan_out_mute_policy, yield_interval};
+    use omq_proto::options::{OnMute, Options};
+    use omq_proto::proto::SocketType;
 
     #[test]
     fn yield_interval_scales_with_message_size() {
@@ -634,5 +667,46 @@ mod tests {
     fn yield_interval_yields_every_send_without_active_targets() {
         assert_eq!(yield_interval(0, 16), 1);
         assert_eq!(yield_interval(0, 16 * 1024), 1);
+    }
+
+    #[test]
+    fn drop_oldest_policy_is_pub_xpub_radio_only() {
+        let options = Options::default().on_mute(OnMute::DropOldest);
+
+        assert_eq!(
+            fan_out_mute_policy(SocketType::Pub, &options),
+            FanOutMutePolicy::DropOldest
+        );
+        assert_eq!(
+            fan_out_mute_policy(SocketType::Radio, &options),
+            FanOutMutePolicy::DropOldest
+        );
+        assert_eq!(
+            fan_out_mute_policy(SocketType::XPub, &options),
+            FanOutMutePolicy::DropOldest
+        );
+
+        let mut nodrop_options = options;
+        nodrop_options.xpub_nodrop = true;
+        assert_eq!(
+            fan_out_mute_policy(SocketType::XPub, &nodrop_options),
+            FanOutMutePolicy::Block
+        );
+    }
+
+    #[tokio::test]
+    async fn fan_out_send_new_wires_drop_oldest_policy() {
+        let options = Options::default().on_mute(OnMute::DropOldest);
+        let io_pool = crate::context::IoPoolHandle::none();
+
+        for (socket_type, mode) in [
+            (SocketType::Pub, FanOutMode::SubscriptionPrefix),
+            (SocketType::XPub, FanOutMode::SubscriptionPrefix),
+            (SocketType::Radio, FanOutMode::Group),
+        ] {
+            let send = FanOutSend::new(socket_type, &options, mode, &io_pool);
+            assert_eq!(send.mute_policy, FanOutMutePolicy::DropOldest);
+            send.shutdown();
+        }
     }
 }

--- a/omq-tokio/src/routing/fan_out/fallback.rs
+++ b/omq-tokio/src/routing/fan_out/fallback.rs
@@ -12,19 +12,19 @@ use omq_proto::fan_out_frame::{
 use omq_proto::frame_buffer::FrameBuffer;
 use omq_proto::message::Message;
 
-use super::FAN_OUT_TOTAL_COPY_BUDGET;
+use super::{FAN_OUT_TOTAL_COPY_BUDGET, FanOutMutePolicy};
 
 pub(super) fn dispatch_to_targets(
     targets: &[PeerOutbound],
     msg: &Message,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
 ) -> Result<()> {
     match targets.len() {
         0 => Ok(()),
-        1 => match targets[0].try_encode(msg) {
+        1 if mute_policy != FanOutMutePolicy::DropOldest => match targets[0].try_encode(msg) {
             TryFrameResult::Full => {
-                if drop_on_full {
+                if mute_policy == FanOutMutePolicy::DropNewest {
                     deactivate(&targets[0]);
                 }
                 Ok(())
@@ -35,7 +35,9 @@ pub(super) fn dispatch_to_targets(
             #[cfg(feature = "ws")]
             if targets.iter().any(PeerOutbound::is_ws) {
                 for t in targets {
-                    if t.try_encode(msg) == TryFrameResult::Full && drop_on_full {
+                    if t.try_encode(msg) == TryFrameResult::Full
+                        && mute_policy == FanOutMutePolicy::DropNewest
+                    {
                         deactivate(t);
                     }
                 }
@@ -57,7 +59,7 @@ pub(super) fn dispatch_to_targets(
                         targets,
                         msg,
                         &mut drain.borrow_mut(),
-                        drop_on_full,
+                        mute_policy,
                         deactivate,
                     );
                     Ok(())
@@ -70,17 +72,19 @@ pub(super) fn dispatch_to_targets(
 fn push_to_peers(
     targets: &[PeerOutbound],
     msg: &Message,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
-    push_wire: impl Fn(&PeerTransmitSlot) -> TryFrameResult,
+    push_wire: impl Fn(&PeerTransmitSlot, FanOutMutePolicy) -> TryFrameResult,
 ) {
     for t in targets {
         match t {
             PeerOutbound::Wire { slot, .. } => {
-                if drop_on_full && !slot.fanout_active() {
+                if mute_policy == FanOutMutePolicy::DropNewest && !slot.fanout_active() {
                     continue;
                 }
-                if push_wire(slot) == TryFrameResult::Full && drop_on_full {
+                if push_wire(slot, mute_policy) == TryFrameResult::Full
+                    && mute_policy == FanOutMutePolicy::DropNewest
+                {
                     deactivate(t);
                 }
             }
@@ -96,14 +100,24 @@ fn dispatch_encoded(
     targets: &[PeerOutbound],
     msg: &Message,
     chunks: &mut Vec<Bytes>,
-    drop_on_full: bool,
+    mute_policy: FanOutMutePolicy,
     deactivate: &mut impl FnMut(&PeerOutbound),
 ) {
     match finish_fan_out_frame(eq, chunks, targets.len(), FAN_OUT_TOTAL_COPY_BUDGET) {
         FanOutFrame::Arena(raw) => {
-            push_to_peers(targets, msg, drop_on_full, deactivate, |slot| {
-                slot.try_push_pre_framed_no_signal(raw)
-            });
+            let frame = FanOutFrame::Arena(raw);
+            push_to_peers(
+                targets,
+                msg,
+                mute_policy,
+                deactivate,
+                |slot, policy| match policy {
+                    FanOutMutePolicy::DropOldest => slot.try_push_fanout_drop_oldest(&frame),
+                    FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => {
+                        slot.try_push_pre_framed_no_signal(raw)
+                    }
+                },
+            );
             for t in targets {
                 if let PeerOutbound::Wire { slot, .. } = t {
                     slot.signal_encoded();
@@ -111,10 +125,164 @@ fn dispatch_encoded(
             }
         }
         FanOutFrame::Chunks(encoded) => {
-            push_to_peers(targets, msg, drop_on_full, deactivate, |slot| {
-                slot.try_push_encoded(encoded)
-            });
+            let frame = FanOutFrame::Chunks(encoded);
+            push_to_peers(
+                targets,
+                msg,
+                mute_policy,
+                deactivate,
+                |slot, policy| match policy {
+                    FanOutMutePolicy::DropOldest => slot.try_push_fanout_drop_oldest(&frame),
+                    FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => {
+                        slot.try_push_encoded(encoded)
+                    }
+                },
+            );
         }
     }
     clear_fan_out_frame(eq, chunks);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
+
+    use super::*;
+
+    #[test]
+    fn drop_oldest_single_target_fallback_keeps_newest_frames() {
+        let slot = test_slot_with_msg_cap(2);
+        let (inbox, _rx) = tokio::sync::mpsc::channel(1);
+        let target = PeerOutbound::Wire {
+            slot: slot.clone(),
+            inbox,
+            direct: None,
+        };
+        let mut deactivated = false;
+
+        for body in ["first", "second", "third"] {
+            dispatch_to_targets(
+                std::slice::from_ref(&target),
+                &Message::single(body),
+                FanOutMutePolicy::DropOldest,
+                &mut |_| {
+                    deactivated = true;
+                },
+            )
+            .unwrap();
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(
+            actual,
+            vec![encoded_message("second"), encoded_message("third")]
+        );
+        assert!(!deactivated);
+    }
+
+    #[test]
+    fn drop_newest_multi_target_fallback_keeps_oldest_frames() {
+        let slot1 = test_slot_with_msg_cap(2);
+        let slot2 = test_slot_with_msg_cap(2);
+        let outbound_a = test_wire_target(&slot1);
+        let outbound_b = test_wire_target(&slot2);
+        let outbounds = [outbound_a, outbound_b];
+        let mut deactivated = Vec::new();
+
+        for body in ["first", "second", "third"] {
+            dispatch_to_targets(
+                &outbounds,
+                &Message::single(body),
+                FanOutMutePolicy::DropNewest,
+                &mut |target| {
+                    if let PeerOutbound::Wire { slot, .. } = target {
+                        deactivated.push(slot.peer_id);
+                    }
+                },
+            )
+            .unwrap();
+        }
+
+        for slot in [&slot1, &slot2] {
+            let mut actual = Vec::new();
+            slot.drain(&mut actual, 1024);
+            assert_eq!(
+                actual,
+                vec![encoded_messages_for_targets(
+                    &["first", "second"],
+                    outbounds.len()
+                )]
+            );
+        }
+        assert_eq!(deactivated, vec![1, 1]);
+    }
+
+    fn test_wire_target(
+        slot: &Arc<crate::engine::transmit_slot::PeerTransmitSlot>,
+    ) -> PeerOutbound {
+        let (inbox, _rx) = tokio::sync::mpsc::channel(1);
+        PeerOutbound::Wire {
+            slot: slot.clone(),
+            inbox,
+            direct: None,
+        }
+    }
+
+    fn test_slot_with_msg_cap(
+        msg_cap: usize,
+    ) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
+        let slot = crate::engine::transmit_slot::PeerTransmitSlot::new(
+            1,
+            false,
+            None,
+            omq_proto::frame_buffer::ARENA_THRESHOLD,
+            omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            crate::engine::transmit_slot::TRANSMIT_SLOT_CAP_DEFAULT,
+            msg_cap,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+        slot
+    }
+
+    fn encoded_message(body: &str) -> Bytes {
+        encoded_message_for_targets(body, 1)
+    }
+
+    fn encoded_message_for_targets(body: &str, target_count: usize) -> Bytes {
+        let msg = Message::single(body.to_owned());
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, &msg, &mut chunks, target_count, 8 * 1024);
+        let bytes = match &frame {
+            FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+            FanOutFrame::Chunks(chunks) if chunks.len() == 1 => chunks[0].clone(),
+            FanOutFrame::Chunks(chunks) => {
+                let len = chunks.iter().map(Bytes::len).sum();
+                let mut buf = bytes::BytesMut::with_capacity(len);
+                for chunk in *chunks {
+                    buf.extend_from_slice(chunk);
+                }
+                buf.freeze()
+            }
+        };
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
+    fn encoded_messages_for_targets(bodies: &[&str], target_count: usize) -> Bytes {
+        let mut bytes = bytes::BytesMut::new();
+        for body in bodies {
+            let encoded = encoded_message_for_targets(body, target_count);
+            bytes.extend_from_slice(&encoded);
+        }
+        bytes.freeze()
+    }
 }

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -20,8 +20,8 @@ use omq_proto::options::Options;
 #[cfg(feature = "lz4")]
 use omq_proto::proto::transform::MessageEncoder;
 
-use super::FAN_OUT_TOTAL_COPY_BUDGET;
 use super::filter::{self, FanOutMode};
+use super::{FAN_OUT_TOTAL_COPY_BUDGET, FanOutMutePolicy};
 
 const LANE_CTRL_RING_CAP: usize = 64;
 
@@ -105,7 +105,7 @@ pub(super) struct FanOutLanes {
     state: Mutex<FanOutLaneState>,
     active_flags: Arc<Vec<AtomicBool>>,
     distributor: Mutex<LaneDistributor>,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
 }
 
 impl std::fmt::Debug for LaneDistributor {
@@ -153,7 +153,7 @@ struct LaneWorker {
     data_space: Arc<StateSignal>,
     ctrl_notify: Arc<DataSignal>,
     mode: FanOutMode,
-    lossy: bool,
+    mute_policy: FanOutMutePolicy,
     peers: FxHashMap<u64, LanePeer>,
     subscribe_all_count: usize,
     eq: FrameBuffer,
@@ -168,7 +168,7 @@ impl std::fmt::Debug for LaneWorker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LaneWorker")
             .field("mode", &self.mode)
-            .field("lossy", &self.lossy)
+            .field("mute_policy", &self.mute_policy)
             .field("peers", &self.peers.len())
             .field("distribution_targets", &self.distribution_targets.len())
             .finish_non_exhaustive()
@@ -179,7 +179,7 @@ impl FanOutLanes {
     pub(super) fn spawn(
         options: &Options,
         mode: FanOutMode,
-        lossy: bool,
+        mute_policy: FanOutMutePolicy,
         io_pool: &crate::context::IoPoolHandle,
     ) -> Arc<Self> {
         let pipe_cap = options.send_hwm.max(1) as usize;
@@ -263,7 +263,7 @@ impl FanOutLanes {
                     data_space,
                     ctrl_notify: ctrl_notify.clone(),
                     mode,
-                    lossy,
+                    mute_policy,
                     peers: FxHashMap::default(),
                     subscribe_all_count: 0,
                     eq: FrameBuffer::one_shot(),
@@ -285,7 +285,7 @@ impl FanOutLanes {
             state: Mutex::new(FanOutLaneState { endpoints }),
             active_flags,
             distributor: Mutex::new(distributor),
-            lossy,
+            mute_policy,
         })
     }
 
@@ -426,7 +426,7 @@ impl FanOutLanes {
                 dist.signal.mark();
                 Ok(())
             }
-            Err(returned) if self.lossy => {
+            Err(returned) if self.mute_policy.is_lossy() => {
                 dist.tx.flush();
                 dist.signal.mark();
                 drop(returned);
@@ -450,7 +450,7 @@ impl FanOutLanes {
                         dist.signal.mark();
                         return;
                     }
-                    Err(returned) if self.lossy => {
+                    Err(returned) if self.mute_policy.is_lossy() => {
                         dist.tx.flush();
                         dist.signal.mark();
                         drop(returned);
@@ -625,7 +625,7 @@ impl LaneWorker {
     }
 
     async fn distribute_batch(&mut self, batch: &[LaneDispatch]) -> bool {
-        if self.lossy {
+        if self.mute_policy.is_lossy() {
             self.distribute_batch_lossy(batch);
             return false;
         }
@@ -642,7 +642,7 @@ impl LaneWorker {
                         let target = &mut self.distribution_targets[target_idx];
                         match target.data_tx.push(dispatch.clone()) {
                             Ok(()) => None,
-                            Err(returned) if self.lossy => {
+                            Err(returned) if self.mute_policy.is_lossy() => {
                                 drop(returned);
                                 None
                             }
@@ -787,7 +787,7 @@ impl LaneWorker {
         dispatch: &LaneDispatch,
         touched: &mut SmallVec<[u64; 32]>,
     ) -> bool {
-        if self.lossy {
+        if self.mute_policy.is_lossy() {
             self.dispatch_lossy(dispatch, touched);
             return false;
         }
@@ -985,7 +985,13 @@ impl LaneWorker {
             for &peer_id in &peer_ids {
                 if let Some(peer) = self.peers.get_mut(&peer_id)
                     && !peer.dict_shipped
-                    && Self::push_frame_to_peer_lossy(peer_id, peer, &frame, touched)
+                    && Self::push_frame_to_peer_lossy(
+                        self.mute_policy,
+                        peer_id,
+                        peer,
+                        &frame,
+                        touched,
+                    )
                 {
                     peer.dict_shipped = true;
                     peer.slot.mark_fanout_dict_shipped();
@@ -1015,7 +1021,7 @@ impl LaneWorker {
                 if has_dict && !peer.dict_shipped {
                     continue;
                 }
-                Self::push_frame_to_peer_lossy(peer_id, peer, &encoded, touched);
+                Self::push_frame_to_peer_lossy(self.mute_policy, peer_id, peer, &encoded, touched);
             }
         }
 
@@ -1023,14 +1029,18 @@ impl LaneWorker {
     }
 
     fn push_frame_to_peer_lossy(
+        mute_policy: FanOutMutePolicy,
         peer_id: u64,
         peer: &mut LanePeer,
         frame: &FanOutFrame<'_>,
         touched: &mut SmallVec<[u64; 32]>,
     ) -> bool {
-        let result = match frame {
-            FanOutFrame::Arena(raw) => peer.slot.try_push_pre_framed_no_signal(raw),
-            FanOutFrame::Chunks(chunks) => peer.slot.try_push_encoded(chunks),
+        let result = match mute_policy {
+            FanOutMutePolicy::DropOldest => peer.slot.try_push_fanout_drop_oldest(frame),
+            FanOutMutePolicy::DropNewest | FanOutMutePolicy::Block => match frame {
+                FanOutFrame::Arena(raw) => peer.slot.try_push_pre_framed_no_signal(raw),
+                FanOutFrame::Chunks(chunks) => peer.slot.try_push_encoded(chunks),
+            },
         };
         match result {
             TryFrameResult::Ok => {
@@ -1039,7 +1049,9 @@ impl LaneWorker {
             }
             TryFrameResult::Dead | TryFrameResult::Ineligible => false,
             TryFrameResult::Full => {
-                peer.slot.deactivate_fanout();
+                if mute_policy == FanOutMutePolicy::DropNewest {
+                    peer.slot.deactivate_fanout();
+                }
                 false
             }
         }
@@ -1066,7 +1078,7 @@ impl LaneWorker {
                         return PushFrameResult::Pushed;
                     }
                     TryFrameResult::Dead => return PushFrameResult::Skipped,
-                    TryFrameResult::Full if self.lossy => {
+                    TryFrameResult::Full if self.mute_policy.is_lossy() => {
                         peer.slot.deactivate_fanout();
                         return PushFrameResult::Skipped;
                     }
@@ -1076,7 +1088,9 @@ impl LaneWorker {
                         peer.slot.signal_encoded();
                         (space, seen)
                     }
-                    TryFrameResult::Ineligible if self.lossy => return PushFrameResult::Skipped,
+                    TryFrameResult::Ineligible if self.mute_policy.is_lossy() => {
+                        return PushFrameResult::Skipped;
+                    }
                     TryFrameResult::Ineligible => {
                         unreachable!("pre-framed fanout push cannot be ineligible")
                     }
@@ -1118,8 +1132,17 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
 
+    use bytes::Bytes;
+    use omq_proto::fan_out_frame::{build_fan_out_frame, clear_fan_out_frame};
+    use omq_proto::frame_buffer::FrameBuffer;
+    use rustc_hash::{FxHashMap, FxHashSet};
+    use smallvec::SmallVec;
+
+    use crate::routing::subscription::SubscriptionSet;
+
     use super::{
-        FanOutLaneState, FanOutLanes, LaneDispatch, LaneDistributor, LaneEndpoint, LanePeerAdd,
+        FanOutLaneState, FanOutLanes, FanOutMode, FanOutMutePolicy, LaneDispatch, LaneDistributor,
+        LaneEndpoint, LanePeer, LanePeerAdd, LaneWorker,
     };
 
     #[test]
@@ -1183,7 +1206,7 @@ mod tests {
                 signal: Arc::new(crate::engine::signal::DataSignal::new()),
                 space: data_space.clone(),
             }),
-            lossy: false,
+            mute_policy: FanOutMutePolicy::Block,
         };
 
         lanes.try_dispatch(test_dispatch("one")).unwrap();
@@ -1214,6 +1237,102 @@ mod tests {
             .expect("dispatch did not wake after space signal");
     }
 
+    #[test]
+    fn drop_oldest_lossy_dispatch_keeps_newest_per_peer_frames() {
+        let (_data_tx, data_rx) = yring::spsc::<LaneDispatch>(4);
+        let (_ctrl_tx, ctrl_rx) = yring::spsc(4);
+        let slot = test_slot_with_msg_cap(7, 2);
+        let mut subscriptions = SubscriptionSet::new();
+        subscriptions.add(b"");
+        let mut peers = FxHashMap::default();
+        peers.insert(
+            7,
+            LanePeer {
+                subscriptions,
+                groups: FxHashSet::default(),
+                any_groups: false,
+                slot: slot.clone(),
+                dict_shipped: false,
+            },
+        );
+        let mut worker = LaneWorker {
+            data_rx,
+            ctrl_rx,
+            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
+            data_space: Arc::new(crate::engine::signal::StateSignal::new()),
+            ctrl_notify: Arc::new(crate::engine::signal::DataSignal::new()),
+            mode: FanOutMode::SubscriptionPrefix,
+            mute_policy: FanOutMutePolicy::DropOldest,
+            peers,
+            subscribe_all_count: 1,
+            eq: FrameBuffer::one_shot(),
+            chunks: Vec::new(),
+            #[cfg(feature = "lz4")]
+            encoder: None,
+            distribution_targets: Vec::new(),
+            active_flags: None,
+        };
+        let mut touched = SmallVec::new();
+
+        for body in ["first", "second", "third"] {
+            worker.dispatch_lossy(&test_dispatch(body), &mut touched);
+        }
+
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(
+            actual,
+            vec![encoded_dispatch("second"), encoded_dispatch("third")]
+        );
+    }
+
+    #[test]
+    fn drop_newest_lossy_dispatch_keeps_oldest_per_peer_frames() {
+        let (_data_tx, data_rx) = yring::spsc::<LaneDispatch>(4);
+        let (_ctrl_tx, ctrl_rx) = yring::spsc(4);
+        let slot = test_slot_with_msg_cap(7, 2);
+        let mut subscriptions = SubscriptionSet::new();
+        subscriptions.add(b"");
+        let mut peers = FxHashMap::default();
+        peers.insert(
+            7,
+            LanePeer {
+                subscriptions,
+                groups: FxHashSet::default(),
+                any_groups: false,
+                slot: slot.clone(),
+                dict_shipped: false,
+            },
+        );
+        let mut worker = LaneWorker {
+            data_rx,
+            ctrl_rx,
+            data_signal: Arc::new(crate::engine::signal::DataSignal::new()),
+            data_space: Arc::new(crate::engine::signal::StateSignal::new()),
+            ctrl_notify: Arc::new(crate::engine::signal::DataSignal::new()),
+            mode: FanOutMode::SubscriptionPrefix,
+            mute_policy: FanOutMutePolicy::DropNewest,
+            peers,
+            subscribe_all_count: 1,
+            eq: FrameBuffer::one_shot(),
+            chunks: Vec::new(),
+            #[cfg(feature = "lz4")]
+            encoder: None,
+            distribution_targets: Vec::new(),
+            active_flags: None,
+        };
+        let mut touched = SmallVec::new();
+
+        for body in ["first", "second", "third"] {
+            worker.dispatch_lossy(&test_dispatch(body), &mut touched);
+        }
+
+        assert!(!slot.fanout_active());
+        let mut actual = Vec::new();
+        slot.drain(&mut actual, 1024);
+        assert_eq!(actual, vec![encoded_dispatches(&["first", "second"])]);
+    }
+
     fn test_lanes(count: usize) -> FanOutLanes {
         FanOutLanes {
             state: std::sync::Mutex::new(FanOutLaneState {
@@ -1225,7 +1344,7 @@ mod tests {
                     .collect::<Vec<_>>(),
             ),
             distributor: test_distributor(),
-            lossy: true,
+            mute_policy: FanOutMutePolicy::DropNewest,
         }
     }
 
@@ -1243,6 +1362,13 @@ mod tests {
     }
 
     fn test_slot(peer_id: u64) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
+        test_slot_with_msg_cap(peer_id, 16)
+    }
+
+    fn test_slot_with_msg_cap(
+        peer_id: u64,
+        msg_cap: usize,
+    ) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
         crate::engine::transmit_slot::PeerTransmitSlot::new(
             peer_id,
             false,
@@ -1250,7 +1376,7 @@ mod tests {
             4096,
             16 * 1024,
             64 * 1024,
-            16,
+            msg_cap,
             #[cfg(feature = "ws")]
             false,
             #[cfg(feature = "ws")]
@@ -1274,5 +1400,37 @@ mod tests {
             msg,
             group: None,
         }
+    }
+
+    fn encoded_dispatch(body: &str) -> Bytes {
+        let msg = omq_proto::message::Message::from_slice(body.as_bytes());
+        let mut eq = FrameBuffer::one_shot();
+        let mut chunks = Vec::new();
+        let frame = build_fan_out_frame(&mut eq, &msg, &mut chunks, 1, 8 * 1024);
+        let bytes = match frame {
+            omq_proto::fan_out_frame::FanOutFrame::Arena(raw) => Bytes::copy_from_slice(raw),
+            omq_proto::fan_out_frame::FanOutFrame::Chunks(chunks) if chunks.len() == 1 => {
+                chunks[0].clone()
+            }
+            omq_proto::fan_out_frame::FanOutFrame::Chunks(chunks) => {
+                let len = chunks.iter().map(Bytes::len).sum();
+                let mut buf = bytes::BytesMut::with_capacity(len);
+                for chunk in chunks {
+                    buf.extend_from_slice(chunk);
+                }
+                buf.freeze()
+            }
+        };
+        clear_fan_out_frame(&mut eq, &mut chunks);
+        bytes
+    }
+
+    fn encoded_dispatches(bodies: &[&str]) -> Bytes {
+        let mut bytes = bytes::BytesMut::new();
+        for body in bodies {
+            let encoded = encoded_dispatch(body);
+            bytes.extend_from_slice(&encoded);
+        }
+        bytes.freeze()
     }
 }

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -182,12 +182,13 @@ impl SendStrategy {
         match send_category(t) {
             SendCategory::None => Self::None,
             SendCategory::FanOut(FanOutKind::SubscriptionPrefix) => Self::FanOut(FanOutSend::new(
+                t,
                 options,
                 FanOutMode::SubscriptionPrefix,
                 io_pool,
             )),
             SendCategory::FanOut(FanOutKind::Group) => {
-                Self::FanOut(FanOutSend::new(options, FanOutMode::Group, io_pool))
+                Self::FanOut(FanOutSend::new(t, options, FanOutMode::Group, io_pool))
             }
             SendCategory::IdentityRouted => Self::Identity(IdentitySend::new(t, options)),
             SendCategory::RoundRobin

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "ws")]
-use super::AnyListener;
 use super::{
     Canceled, ConnectionStatus, DialerEntry, DisconnectReason, Duration, Endpoint, Error,
     InternalEvent, ListenerEntry, MonitorEvent, PeerIdent, Result, SocketDriver, SocketType,
@@ -311,7 +309,7 @@ impl SocketDriver {
         }
         reject_encrypted_inproc(&endpoint, &self.options.mechanism)?;
         let snapshot = self.inproc_snapshot();
-        let mut listener = bind_any(
+        let bound = bind_any(
             &endpoint,
             &snapshot,
             &self.spsc.recv_signal,
@@ -321,32 +319,8 @@ impl SocketDriver {
             &self.options.wss_tls,
         )
         .await?;
-        #[cfg(feature = "ws")]
-        let resolved = if endpoint.is_ws_family() {
-            let local = match &listener {
-                AnyListener::Ws(l) => l.local_addr,
-                _ => unreachable!(),
-            };
-            let plain = endpoint.underlying_ws();
-            let resolved_plain = match &plain {
-                Endpoint::Ws { path, .. } => Endpoint::Ws {
-                    host: omq_proto::endpoint::Host::Ip(local.ip()),
-                    port: local.port(),
-                    path: path.clone(),
-                },
-                Endpoint::Wss { path, .. } => Endpoint::Wss {
-                    host: omq_proto::endpoint::Host::Ip(local.ip()),
-                    port: local.port(),
-                    path: path.clone(),
-                },
-                _ => unreachable!(),
-            };
-            endpoint.rewrap_ws(resolved_plain)
-        } else {
-            endpoint.rewrap_tcp(listener.local_endpoint().clone())
-        };
-        #[cfg(not(feature = "ws"))]
-        let resolved = endpoint.rewrap_tcp(listener.local_endpoint().clone());
+        let mut listener = bound.listener;
+        let resolved = bound.endpoint;
         self.monitor.publish(MonitorEvent::Listening {
             endpoint: resolved.clone(),
         });

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -18,10 +18,9 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-#[cfg(feature = "ws")]
-use super::dispatch::AnyListener;
 use super::dispatch::{
     AnyConn, AnyStream, bind_any, connect_any, generated_identity, peer_ident_socket_addr,
+    preflight_connect_endpoint_resolution,
 };
 use super::monitor::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorPublisher, PeerCommandKind, PeerInfo,
@@ -379,6 +378,8 @@ impl SocketDriver {
                     let res = self.start_dial_udp(endpoint).await;
                     let _ = ack.send(res);
                 } else if let Err(e) = reject_encrypted_inproc(&endpoint, &self.options.mechanism) {
+                    let _ = ack.send(Err(e));
+                } else if let Err(e) = preflight_connect_endpoint_resolution(&endpoint).await {
                     let _ = ack.send(Err(e));
                 } else if self.should_ignore_duplicate_connect(&endpoint) {
                     let _ = ack.send(Ok(()));

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -49,7 +49,7 @@ impl DirectTcpWriter {
     }
 }
 
-use omq_proto::endpoint::Endpoint;
+use omq_proto::endpoint::{Endpoint, Host};
 use omq_proto::error::{Error, Result};
 
 use crate::transport::ipc::IpcStream;
@@ -339,6 +339,11 @@ impl AnyConn {
     }
 }
 
+pub(super) struct BoundListener {
+    pub(super) listener: AnyListener,
+    pub(super) endpoint: Endpoint,
+}
+
 pub(super) enum AnyListener {
     Tcp(crate::transport::tcp::TcpListener),
     Inproc(crate::transport::InprocListener),
@@ -354,13 +359,7 @@ impl AnyListener {
             Self::Inproc(l) => l.local_endpoint(),
             Self::Ipc(l) => l.local_endpoint(),
             #[cfg(feature = "ws")]
-            Self::Ws(_) => {
-                static DUMMY: Endpoint = Endpoint::Tcp {
-                    host: omq_proto::endpoint::Host::Wildcard,
-                    port: 0,
-                };
-                &DUMMY
-            }
+            Self::Ws(l) => l.local_endpoint(),
         }
     }
 
@@ -407,19 +406,18 @@ pub(super) async fn bind_any(
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
     #[cfg(feature = "ws")] wss_tls: &omq_proto::options::WssTls,
-) -> Result<AnyListener> {
+) -> Result<BoundListener> {
     if endpoint.is_tcp_family() {
-        return Ok(AnyListener::Tcp(
-            TcpTransport::bind(&endpoint.underlying_tcp()).await?,
-        ));
+        let listener = AnyListener::Tcp(TcpTransport::bind(&endpoint.underlying_tcp()).await?);
+        let resolved = endpoint.rewrap_tcp(listener.local_endpoint().clone());
+        return Ok(BoundListener {
+            listener,
+            endpoint: resolved,
+        });
     }
     #[cfg(feature = "ws")]
     if endpoint.is_ws_family() {
         let plain = endpoint.underlying_ws();
-        let (host, port) = match &plain {
-            Endpoint::Ws { host, port, .. } | Endpoint::Wss { host, port, .. } => (host, *port),
-            _ => unreachable!(),
-        };
         let tls_acc = if matches!(plain, Endpoint::Wss { .. }) {
             let cert = wss_tls.server_cert_pem.as_deref().ok_or_else(|| {
                 Error::Protocol("wss:// bind requires server_cert_pem in WssTls options".into())
@@ -431,19 +429,84 @@ pub(super) async fn bind_any(
         } else {
             None
         };
-        let l = crate::transport::ws::bind(host, port, tls_acc).await?;
-        return Ok(AnyListener::Ws(l));
+        let listener = AnyListener::Ws(crate::transport::ws::bind(&plain, tls_acc).await?);
+        let resolved = endpoint.rewrap_ws(listener.local_endpoint().clone());
+        return Ok(BoundListener {
+            listener,
+            endpoint: resolved,
+        });
     }
     match endpoint {
-        Endpoint::Inproc { name } => Ok(AnyListener::Inproc(inproc_transport::bind(
-            name,
-            snapshot.clone(),
-            recv_signal.clone(),
-            blocking_recv_waker.clone(),
-            max_message_size,
-        )?)),
-        Endpoint::Ipc(_) => Ok(AnyListener::Ipc(IpcTransport::bind(endpoint).await?)),
+        Endpoint::Inproc { name } => {
+            let listener = AnyListener::Inproc(inproc_transport::bind(
+                name,
+                snapshot.clone(),
+                recv_signal.clone(),
+                blocking_recv_waker.clone(),
+                max_message_size,
+            )?);
+            let resolved = listener.local_endpoint().clone();
+            Ok(BoundListener {
+                listener,
+                endpoint: resolved,
+            })
+        }
+        Endpoint::Ipc(_) => {
+            let listener = AnyListener::Ipc(IpcTransport::bind(endpoint).await?);
+            let resolved = listener.local_endpoint().clone();
+            Ok(BoundListener {
+                listener,
+                endpoint: resolved,
+            })
+        }
         other => Err(Error::UnsupportedScheme(other.scheme().to_string())),
+    }
+}
+
+/// Validate connect-side DNS synchronously before registering a dialer.
+/// No socket connect happens here; reconnect attempts resolve again later.
+pub(super) async fn preflight_connect_endpoint_resolution(endpoint: &Endpoint) -> Result<()> {
+    if endpoint.is_tcp_family() {
+        let plain = endpoint.underlying_tcp();
+        let Endpoint::Tcp { host, port } = &plain else {
+            unreachable!();
+        };
+        return preflight_connect_host(host, *port).await;
+    }
+    #[cfg(feature = "ws")]
+    if endpoint.is_ws_family() {
+        let plain = endpoint.underlying_ws();
+        let (host, port) = match &plain {
+            Endpoint::Ws { host, port, .. } | Endpoint::Wss { host, port, .. } => (host, *port),
+            _ => unreachable!(),
+        };
+        return preflight_connect_host(host, port).await;
+    }
+    match endpoint {
+        Endpoint::Inproc { .. } | Endpoint::Ipc(_) => Ok(()),
+        other => Err(Error::UnsupportedScheme(other.scheme().to_string())),
+    }
+}
+
+async fn preflight_connect_host(host: &Host, port: u16) -> Result<()> {
+    match host {
+        Host::Wildcard => Err(Error::InvalidEndpoint(
+            "cannot connect to wildcard host".into(),
+        )),
+        Host::Ip(_) => Ok(()),
+        Host::Name(name) => {
+            let mut addrs = tokio::net::lookup_host(format!("{name}:{port}"))
+                .await
+                .map_err(Error::Io)?;
+            if addrs.next().is_some() {
+                Ok(())
+            } else {
+                Err(Error::Io(io::Error::other(format!(
+                    "no addresses for {name}:{port}"
+                ))))
+            }
+        }
+        _ => unreachable!(),
     }
 }
 
@@ -542,9 +605,45 @@ pub(super) use omq_proto::message::generated_identity;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use omq_proto::proto::SocketType;
     use tokio::io::AsyncWrite;
     #[cfg(unix)]
     use tokio::net::UnixStream;
+
+    fn snapshot() -> InprocPeerSnapshot {
+        InprocPeerSnapshot {
+            socket_type: SocketType::Pair,
+            identity: Bytes::new(),
+        }
+    }
+
+    fn recv_signal() -> Arc<DataSignal> {
+        Arc::new(DataSignal::new())
+    }
+
+    fn blocking_recv_waker() -> Arc<crate::socket::recv::BlockingRecvWaker> {
+        crate::socket::recv::BlockingRecvWaker::new()
+    }
+
+    async fn bind_result_for_test(endpoint: &Endpoint) -> Result<BoundListener> {
+        #[cfg(feature = "ws")]
+        let wss_tls = omq_proto::options::WssTls::default();
+        bind_any(
+            endpoint,
+            &snapshot(),
+            &recv_signal(),
+            &blocking_recv_waker(),
+            None,
+            #[cfg(feature = "ws")]
+            &wss_tls,
+        )
+        .await
+    }
+
+    async fn bind_for_test(endpoint: &Endpoint) -> BoundListener {
+        bind_result_for_test(endpoint).await.unwrap()
+    }
 
     #[test]
     fn any_stream_tcp_reports_write_vectored() {
@@ -581,5 +680,203 @@ mod tests {
             assert!(any.is_write_vectored());
             let _ = std::fs::remove_file(&path);
         });
+    }
+
+    #[tokio::test]
+    async fn bind_any_returns_resolved_tcp_endpoint() {
+        let endpoint = Endpoint::Tcp {
+            host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+            port: 0,
+        };
+        let bound = bind_for_test(&endpoint).await;
+
+        match bound.endpoint {
+            Endpoint::Tcp {
+                host: Host::Ip(ip),
+                port,
+            } => {
+                assert_eq!(ip, std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+                assert_ne!(port, 0);
+            }
+            other => panic!("expected resolved TCP endpoint, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_any_rejects_unresolved_tcp_name() {
+        let endpoint = Endpoint::Tcp {
+            host: Host::Name("omq-bind-preflight.invalid".into()),
+            port: 5555,
+        };
+
+        assert!(bind_result_for_test(&endpoint).await.is_err());
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn bind_any_returns_resolved_ws_endpoint() {
+        let endpoint = Endpoint::Ws {
+            host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+            port: 0,
+            path: "/z".into(),
+        };
+        let bound = bind_for_test(&endpoint).await;
+
+        match bound.listener.local_endpoint() {
+            Endpoint::Ws {
+                host: Host::Ip(ip),
+                port,
+                path,
+            } => {
+                assert_eq!(*ip, std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+                assert_ne!(*port, 0);
+                assert_eq!(path, "/z");
+            }
+            other => panic!("expected resolved WS listener endpoint, got {other:?}"),
+        }
+        match bound.endpoint {
+            Endpoint::Ws {
+                host: Host::Ip(ip),
+                port,
+                path,
+            } => {
+                assert_eq!(ip, std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+                assert_ne!(port, 0);
+                assert_eq!(path, "/z");
+            }
+            other => panic!("expected resolved WS endpoint, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn bind_any_rejects_unresolved_ws_name() {
+        let endpoint = Endpoint::Ws {
+            host: Host::Name("omq-bind-ws-preflight.invalid".into()),
+            port: 5555,
+            path: "/z".into(),
+        };
+
+        assert!(bind_result_for_test(&endpoint).await.is_err());
+    }
+
+    #[cfg(all(feature = "lz4", feature = "ws"))]
+    #[tokio::test]
+    async fn bind_any_returns_resolved_lz4_ws_endpoint() {
+        let endpoint = Endpoint::Lz4Ws {
+            host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+            port: 0,
+            path: "/lz4".into(),
+        };
+        let bound = bind_for_test(&endpoint).await;
+
+        match bound.endpoint {
+            Endpoint::Lz4Ws {
+                host: Host::Ip(ip),
+                port,
+                path,
+            } => {
+                assert_eq!(ip, std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+                assert_ne!(port, 0);
+                assert_eq!(path, "/lz4");
+            }
+            other => panic!("expected resolved LZ4 WS endpoint, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_preflight_rejects_tcp_wildcard() {
+        let endpoint = Endpoint::Tcp {
+            host: Host::Wildcard,
+            port: 5555,
+        };
+
+        assert!(matches!(
+            preflight_connect_endpoint_resolution(&endpoint).await,
+            Err(Error::InvalidEndpoint(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn connect_preflight_rejects_unresolved_tcp_name() {
+        let endpoint = Endpoint::Tcp {
+            host: Host::Name("omq-connect-preflight.invalid".into()),
+            port: 5555,
+        };
+
+        assert!(
+            preflight_connect_endpoint_resolution(&endpoint)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_preflight_accepts_named_tcp_without_socket_connect() {
+        let endpoint = Endpoint::Tcp {
+            host: Host::Name("127.0.0.1".into()),
+            port: 9,
+        };
+
+        preflight_connect_endpoint_resolution(&endpoint)
+            .await
+            .unwrap();
+    }
+
+    #[cfg(feature = "lz4")]
+    #[tokio::test]
+    async fn connect_preflight_accepts_named_lz4_tcp_without_socket_connect() {
+        let endpoint = Endpoint::Lz4Tcp {
+            host: Host::Name("127.0.0.1".into()),
+            port: 9,
+        };
+
+        preflight_connect_endpoint_resolution(&endpoint)
+            .await
+            .unwrap();
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn connect_preflight_rejects_unresolved_ws_name() {
+        let endpoint = Endpoint::Ws {
+            host: Host::Name("omq-connect-ws-preflight.invalid".into()),
+            port: 5555,
+            path: "/z".into(),
+        };
+
+        assert!(
+            preflight_connect_endpoint_resolution(&endpoint)
+                .await
+                .is_err()
+        );
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn connect_preflight_accepts_named_ws_without_socket_connect() {
+        let endpoint = Endpoint::Ws {
+            host: Host::Name("127.0.0.1".into()),
+            port: 9,
+            path: "/z".into(),
+        };
+
+        preflight_connect_endpoint_resolution(&endpoint)
+            .await
+            .unwrap();
+    }
+
+    #[cfg(all(feature = "lz4", feature = "ws"))]
+    #[tokio::test]
+    async fn connect_preflight_accepts_named_lz4_ws_without_socket_connect() {
+        let endpoint = Endpoint::Lz4Ws {
+            host: Host::Name("127.0.0.1".into()),
+            port: 9,
+            path: "/z".into(),
+        };
+
+        preflight_connect_endpoint_resolution(&endpoint)
+            .await
+            .unwrap();
     }
 }

--- a/omq-tokio/src/transport/ws.rs
+++ b/omq-tokio/src/transport/ws.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+use omq_proto::endpoint::{Endpoint, Host};
 use omq_proto::error::{Error, Result};
 use omq_proto::proto::ws_handshake;
 
@@ -139,22 +140,35 @@ fn ws_err(e: impl std::fmt::Display) -> Error {
 
 pub(crate) struct WsListener {
     pub(crate) inner: TcpListener,
-    pub(crate) local_addr: SocketAddr,
+    endpoint: Endpoint,
     pub(crate) tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
 }
 
+impl WsListener {
+    pub(crate) fn local_endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+}
+
 pub(crate) async fn bind(
-    host: &omq_proto::endpoint::Host,
-    port: u16,
+    endpoint: &Endpoint,
     tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
 ) -> Result<WsListener> {
     use std::net::{IpAddr, Ipv4Addr};
-    let addr = match host {
-        omq_proto::endpoint::Host::Wildcard => {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+    let (host, port, path) = match endpoint {
+        Endpoint::Ws { host, port, path } | Endpoint::Wss { host, port, path } => {
+            (host, *port, path)
         }
-        omq_proto::endpoint::Host::Ip(ip) => SocketAddr::new(*ip, port),
-        omq_proto::endpoint::Host::Name(name) => tokio::net::lookup_host(format!("{name}:{port}"))
+        other => {
+            return Err(Error::InvalidEndpoint(format!(
+                "WS transport got non-WS endpoint: {other}"
+            )));
+        }
+    };
+    let addr = match host {
+        Host::Wildcard => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+        Host::Ip(ip) => SocketAddr::new(*ip, port),
+        Host::Name(name) => tokio::net::lookup_host(format!("{name}:{port}"))
             .await
             .map_err(Error::Io)?
             .next()
@@ -163,9 +177,22 @@ pub(crate) async fn bind(
     };
     let listener = super::tcp::reuse_addr_bind(addr)?;
     let local = listener.local_addr().map_err(Error::Io)?;
+    let resolved = match endpoint {
+        Endpoint::Ws { .. } => Endpoint::Ws {
+            host: Host::Ip(local.ip()),
+            port: local.port(),
+            path: path.clone(),
+        },
+        Endpoint::Wss { .. } => Endpoint::Wss {
+            host: Host::Ip(local.ip()),
+            port: local.port(),
+            path: path.clone(),
+        },
+        _ => unreachable!(),
+    };
     Ok(WsListener {
         inner: listener,
-        local_addr: local,
+        endpoint: resolved,
         tls_acceptor,
     })
 }

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -33,6 +33,13 @@ fn tcp_ep(port: u16) -> Endpoint {
     }
 }
 
+fn tcp_name_ep(host: &str, port: u16) -> Endpoint {
+    Endpoint::Tcp {
+        host: Host::Name(host.into()),
+        port,
+    }
+}
+
 #[cfg(feature = "lz4")]
 fn lz4_ep(port: u16) -> Endpoint {
     Endpoint::Lz4Tcp {
@@ -84,6 +91,19 @@ async fn push_pull_connect_before_bind_ipc() {
 #[tokio::test]
 async fn push_pull_connect_before_bind_tcp() {
     push_pull_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+#[tokio::test]
+async fn push_pull_named_tcp_connect_before_bind() {
+    push_pull_connect_before_bind(tcp_name_ep("127.0.0.1", free_tcp_port())).await;
+}
+
+#[tokio::test]
+async fn unresolved_tcp_name_connect_fails_immediately() {
+    let push = Socket::new(SocketType::Push, opts());
+    let endpoint = tcp_name_ep("omq-connect-preflight.invalid", 5555);
+
+    assert!(push.connect(endpoint).await.is_err());
 }
 
 // -- REQ/REP -----------------------------------------------------------------

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -185,7 +185,7 @@ async fn pub_sub_lz4_io_lane_fan_out_ships_dict_to_late_subscriber() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test]
 async fn pub_sub_lz4_io_lane_fan_out_auto_trains_dict_for_late_subscriber() {
     const N_DECODED_SUBS: usize = 4;
     const N_TRAINING_MSGS: usize = 100;
@@ -211,18 +211,21 @@ async fn pub_sub_lz4_io_lane_fan_out_auto_trains_dict_for_late_subscriber() {
             "{{\"kind\":\"quote\",\"venue\":\"XNAS\",\"symbol\":\"OMQ\",\"seq\":{i},\"bid\":101.25,\"ask\":101.27,\"depth\":[10125,10126,10127],\"pad\":\"{}\"}}",
             "A".repeat(160)
         ));
-        publisher.send(Message::single(payload)).await.unwrap();
-    }
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            publisher.send(Message::single(payload)),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("publisher send timed out for training payload {i}"))
+        .unwrap();
 
-    for (idx, sub) in decoded_subs.iter().enumerate() {
-        for i in 0..N_TRAINING_MSGS {
+        for (idx, sub) in decoded_subs.iter().enumerate() {
             tokio::time::timeout(Duration::from_secs(5), sub.recv())
                 .await
                 .unwrap_or_else(|_| panic!("decoded sub {idx} missed training payload {i}"))
                 .unwrap();
         }
     }
-
     let raw_sub = Socket::new(SocketType::Sub, Options::default());
     raw_sub.connect(tcp_from_lz4(&ep)).await.unwrap();
     raw_sub.subscribe(bytes::Bytes::new()).await.unwrap();
@@ -235,10 +238,13 @@ async fn pub_sub_lz4_io_lane_fan_out_auto_trains_dict_for_late_subscriber() {
         "{{\"kind\":\"quote\",\"venue\":\"XNAS\",\"symbol\":\"OMQ\",\"seq\":1000,\"bid\":101.25,\"ask\":101.27,\"depth\":[10125,10126,10127],\"pad\":\"{}\"}}",
         "A".repeat(192)
     ));
-    publisher
-        .send(Message::single(late_payload.clone()))
-        .await
-        .unwrap();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        publisher.send(Message::single(late_payload.clone())),
+    )
+    .await
+    .expect("publisher send timed out for late payload")
+    .unwrap();
 
     let dict_msg = tokio::time::timeout(Duration::from_secs(5), raw_sub.recv())
         .await


### PR DESCRIPTION
## What changed

- Implement `DropOldest` for fan-out sockets: `PUB`, `RADIO`, and `XPUB`.
- Keep `DropNewest` behavior explicit and tested so it does not regress.
- Move `pyomq` linting into the main fmt/clippy CI matrix.
- Keep Python changes from being ignored by the CI change filter.
- Use backend security option builders in `pyomq`.
- Move resolved bind endpoint handling into transport dispatch.
- Preflight name resolution during `connect()` / `bind()` while keeping reconnect retries lazy.
- Replace released-port libzmq test binds with `tcp://127.0.0.1:0` plus `ZMQ_LAST_ENDPOINT`.
