### PR TITLE
expose bind_to_random_port on async socket

### DIFF
--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -496,6 +496,18 @@ class _BaseSocket(_SocketOptionsBase):
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
+    def bind_to_random_port(
+        self,
+        addr: str,
+        min_port: int = 49152,
+        max_port: int = 65536,
+        max_tries: int = 100,
+    ) -> int:
+        ep = self.bind(f"{addr}:0")
+        if isinstance(ep, bytes):
+            ep = ep.decode()
+        return int(ep.rsplit(":", 1)[1])
+
     def connect(self, endpoint: str | bytes) -> None:
         if isinstance(endpoint, bytes):
             endpoint = endpoint.decode("utf-8")
@@ -719,18 +731,6 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
     ) -> Any:
         frames = self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
-
-    def bind_to_random_port(
-        self,
-        addr: str,
-        min_port: int = 49152,
-        max_port: int = 65536,
-        max_tries: int = 100,
-    ) -> int:
-        ep = self.bind(f"{addr}:0")
-        if isinstance(ep, bytes):
-            ep = ep.decode()
-        return int(ep.rsplit(":", 1)[1])
 
     def poll(self, timeout: int | None = None, flags: int = POLLIN) -> int:
         p = Poller()

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -1,6 +1,9 @@
 """pyzmq-compatible API surface tests."""
 
+import pytest
+
 import pyomq as zmq
+import pyomq.asyncio as zmq_async
 
 
 # ── Serialization methods ────────────────────────────────────────────
@@ -266,8 +269,9 @@ def test_track_true_send_returns_tracker():
 # ── bind_to_random_port ─────────────────────────────────────────────
 
 
-def test_bind_to_random_port():
-    ctx = zmq.Context()
+@pytest.mark.parametrize("ctx_factory", [zmq.Context, zmq.asyncio.Context])
+def test_bind_to_random_port(ctx_factory):
+    ctx = ctx_factory()
     sock = ctx.socket(zmq.PULL)
     try:
         port = sock.bind_to_random_port("tcp://127.0.0.1")


### PR DESCRIPTION
This was why I though bind_to_random_port was missing originally and I missed it in the previous refactor.