### PR TITLE
Release pyomq 0.18.2

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-07-28
+
+### Added
+
+- `pyomq.asyncio.Socket` now exposes `bind_to_random_port()`.
+
+### Fixed
+
+- `pyomq.Context.instance()` and `pyomq.asyncio.Context.instance()` now keep
+  separate singleton contexts.
+- `Context().instance()` remains available on sync and asyncio context objects.
+
 ## [0.18.1] - 2026-07-28
 
 ### Changed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.18.1"
+version = "0.18.2"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- Bump `pyomq` package metadata to `0.18.2`.
- Document async `bind_to_random_port()` and `Context.instance()` fixes.