### PR TITLE
Fix pyomq context shadow native wrappers

### DIFF
--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -1043,14 +1043,19 @@ class Context(metaclass=_ContextMeta):
         self, io_threads: int = 1, *, _shadow_ctx: Context | None = None
     ) -> None:
         if _shadow_ctx is not None:
-            self._ctx = _shadow_ctx._ctx
+            if isinstance(_shadow_ctx._ctx, _native.AsyncContext):
+                self._ctx = _native.Context.shadow_async(_shadow_ctx._ctx)
+            else:
+                self._ctx = _shadow_ctx._ctx
             self._is_shadow = True
         else:
             self._ctx = _native.Context(io_threads)
             self._is_shadow = False
         self._closed = False
         self._sockets = weakref.WeakSet()
-        self._ctx_id = next(_next_ctx_id)
+        self._ctx_id = (
+            _shadow_ctx._ctx_id if _shadow_ctx is not None else next(_next_ctx_id)
+        )
 
     def _namespace_inproc(self, endpoint: str | bytes) -> str | bytes:
         # libzmq scopes inproc per-context; omq's registry is global. pytest

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -614,14 +614,19 @@ class Context(_SyncContext):
         self, io_threads: int = 1, *, _shadow_ctx: _SyncContext | None = None
     ) -> None:
         if _shadow_ctx is not None:
-            self._ctx = _shadow_ctx._ctx
+            if isinstance(_shadow_ctx._ctx, _native.Context):
+                self._ctx = _native.AsyncContext.shadow_sync(_shadow_ctx._ctx)
+            else:
+                self._ctx = _shadow_ctx._ctx
             self._is_shadow = True
         else:
             self._ctx = _native.AsyncContext(io_threads)
             self._is_shadow = False
         self._closed = False
         self._sockets = weakref.WeakSet()
-        self._ctx_id = next(_next_ctx_id)
+        self._ctx_id = (
+            _shadow_ctx._ctx_id if _shadow_ctx is not None else next(_next_ctx_id)
+        )
 
     @property
     def closed(self) -> bool:

--- a/bindings/pyomq/src/context.rs
+++ b/bindings/pyomq/src/context.rs
@@ -57,6 +57,13 @@ impl Context {
         }
     }
 
+    #[staticmethod]
+    fn shadow_async(context: PyRef<'_, AsyncContext>) -> Self {
+        Context {
+            ctx: context.ctx.clone(),
+        }
+    }
+
     /// Construct a new socket of the given libzmq type code.
     #[pyo3(signature = (socket_type, /))]
     fn socket(&self, py: Python<'_>, socket_type: i32) -> PyResult<Socket> {
@@ -101,6 +108,13 @@ impl AsyncContext {
     fn new(io_threads: i32) -> Self {
         AsyncContext {
             ctx: ContextInner::new(io_threads.max(1) as usize),
+        }
+    }
+
+    #[staticmethod]
+    fn shadow_sync(context: PyRef<'_, Context>) -> Self {
+        AsyncContext {
+            ctx: context.ctx.clone(),
         }
     }
 

--- a/bindings/pyomq/tests/test_shadow.py
+++ b/bindings/pyomq/tests/test_shadow.py
@@ -1,5 +1,7 @@
 """_ShadowSocket, Socket.shadow(), and Context.shadow() tests."""
 
+import asyncio
+
 import pytest
 
 import pyomq as zmq
@@ -46,6 +48,55 @@ def test_context_shadow_int_uses_instance():
     shadow = zmq.Context.shadow(0)
     assert shadow._ctx is zmq.Context.instance()._ctx
     shadow.term()
+
+
+@pytest.mark.asyncio
+async def test_context_shadow_async_creates_sync_native_socket(inproc_endpoint):
+    ctx = zmq_async.Context()
+    shadow = zmq.Context.shadow(ctx)
+    pull = shadow.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    try:
+        assert type(shadow) is zmq.Context
+        assert type(shadow._ctx) is zmq._native.Context
+        assert shadow._ctx_id == ctx._ctx_id
+        assert type(pull) is zmq.Socket
+        assert type(pull._sock) is zmq._native.Socket
+
+        pull.setsockopt(zmq.RCVTIMEO, 1000)
+        ep = pull.bind(inproc_endpoint)
+        push.connect(ep)
+        await push.send(b"hello")
+        assert pull.recv() == b"hello"
+    finally:
+        pull.close()
+        push.close()
+        shadow.term()
+        ctx.term()
+
+
+@pytest.mark.asyncio
+async def test_async_context_shadow_sync_creates_async_native_socket(inproc_endpoint):
+    ctx = zmq.Context()
+    shadow = zmq_async.Context.shadow(ctx)
+    pull = shadow.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    try:
+        assert type(shadow) is zmq_async.Context
+        assert type(shadow._ctx) is zmq._native.AsyncContext
+        assert shadow._ctx_id == ctx._ctx_id
+        assert type(pull) is zmq_async.Socket
+        assert type(pull._sock) is zmq._native.AsyncSocket
+
+        ep = pull.bind(inproc_endpoint)
+        push.connect(ep)
+        push.send(b"hello")
+        assert await asyncio.wait_for(pull.recv(), timeout=1.0) == b"hello"
+    finally:
+        pull.close()
+        push.close()
+        shadow.term()
+        ctx.term()
 
 
 # ── Socket.shadow ───────────────────────────────────────────────────


### PR DESCRIPTION
- Fixes #222.
- Adds native sync/async context shadow constructors over the same Rust `ContextInner`.
- Preserves shadow context `_ctx_id` so `inproc://` names stay scoped to the original context.
- Covers both `zmq.Context.shadow(zmq_async.Context())` and `zmq_async.Context.shadow(zmq.Context())`.