### PR TITLE
ci: add per-test timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 3, grace-period = "10s" }
+
+[profile.ci]
+inherits = "default"
+fail-fast = false
+failure-output = "immediate-final"
+status-level = "slow"
+final-status-level = "slow"
+
+[profile.extended]
+inherits = "ci"
+slow-timeout = { period = "10m", terminate-after = 3, grace-period = "10s" }
+
+[profile.default-miri]
+slow-timeout = { period = "120s", terminate-after = 3, grace-period = "10s" }
+fail-fast = false
+failure-output = "immediate-final"
+status-level = "slow"
+final-status-level = "slow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'
+              - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release-pyomq.yml'
       - id: matrix
@@ -63,20 +64,25 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test
-        run: cargo test --workspace --no-fail-fast
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest
+        run: cargo nextest run --profile ci --workspace
 
   test:
-    name: cargo test (${{ matrix.toolchain }}, ${{ matrix.os }})
+    name: cargo nextest (${{ matrix.toolchain }}, ${{ matrix.os }})
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.test_matrix) }}
@@ -87,18 +93,22 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target || '' }}
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest
         if: runner.os != 'macOS'
-        run: cargo test --workspace --no-fail-fast
-      - name: cargo test (macOS)
+        run: cargo nextest run --profile ci --workspace
+      - name: cargo nextest (macOS)
         if: runner.os == 'macOS'
-        run: cargo test --workspace --no-fail-fast -- --test-threads=1
+        run: cargo nextest run --profile ci --workspace --test-threads=1
 
   encryption:
     name: encryption (curve, ${{ matrix.os }})
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.os_matrix) }}
@@ -106,18 +116,22 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test (curve)
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest (curve)
         if: runner.os != 'macOS'
-        run: cargo test -p omq-tokio --features curve
-      - name: cargo test (curve, macOS)
+        run: cargo nextest run --profile ci -p omq-tokio --features curve
+      - name: cargo nextest (curve, macOS)
         if: runner.os == 'macOS'
-        run: cargo test -p omq-tokio --features curve -- --test-threads=1
+        run: cargo nextest run --profile ci -p omq-tokio --features curve --test-threads=1
 
   compression:
     name: compression (${{ matrix.os }})
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.os_matrix) }}
@@ -125,18 +139,22 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test (lz4)
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest (lz4)
         if: runner.os != 'macOS'
-        run: cargo test -p omq-tokio --features lz4
-      - name: cargo test (lz4, macOS)
+        run: cargo nextest run --profile ci -p omq-tokio --features lz4
+      - name: cargo nextest (lz4, macOS)
         if: runner.os == 'macOS'
-        run: cargo test -p omq-tokio --features lz4 -- --test-threads=1
+        run: cargo nextest run --profile ci -p omq-tokio --features lz4 --test-threads=1
 
   interop:
     name: interop (pyzmq)
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # pyzmq wheels bundle libzmq + libsodium: the peer is the real
     # reference implementation.
     env:
@@ -145,6 +163,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: actions/setup-python@v6
         id: python
         with: { python-version: "3.14" }
@@ -155,21 +176,22 @@ jobs:
       - name: interop (NULL + STREAM)
         env:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
-        run: cargo test -p omq-tokio --test omq_interop_pyzmq_null
+        run: cargo nextest run --profile ci -p omq-tokio --test omq_interop_pyzmq_null
       - name: interop (PLAIN)
         env:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
-        run: cargo test -p omq-tokio --features plain --test omq_interop_pyzmq_plain
+        run: cargo nextest run --profile ci -p omq-tokio --features plain --test omq_interop_pyzmq_plain
       - name: interop (CURVE)
         env:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
-        run: cargo test -p omq-tokio --features curve --test omq_interop_pyzmq_curve
+        run: cargo nextest run --profile ci -p omq-tokio --features curve --test omq_interop_pyzmq_curve
 
   loom:
     name: loom (yring)
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # omq-tokio's loom_signal test needs no cfg and runs in `test`.
     # RUSTFLAGS replaces the workflow-level value, so repeat -D warnings.
     env:
@@ -178,14 +200,18 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: loom model check
-        run: cargo test -p yring --features async --test loom --release
+        run: cargo nextest run --profile ci -p yring --features async --test loom --release
 
   miri:
     name: miri (yring)
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # yring holds the only Miri-checkable unsafe: omq-proto is
     # forbid(unsafe_code) and omq-tokio's tests are real socket I/O.
     # No -D warnings: nightly adds lints on its own schedule.
@@ -198,42 +224,52 @@ jobs:
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - run: cargo miri setup
       - name: miri test
-        run: cargo miri test -p yring --features async
+        run: cargo miri nextest run -p yring --features async
 
   fuzz-smoke:
     name: fuzz smoke
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # OMQ_FUZZ_ITERS means something different per target, so the two
     # get separate budgets: a parser iteration is a buffer parse, a
     # socket-action iteration drives a live socket (~90ms). The
     # `extended` workflow runs both far deeper.
-    # --nocapture surfaces OMQ_FUZZ_SEED for reproduction.
+    # nextest prints captured output on failure, including OMQ_FUZZ_SEED.
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: fuzz parsers
         env:
           OMQ_FUZZ_ITERS: "1000000"
         run: >
-          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release
-          --test omq_fuzz_parsers -- --nocapture
+          cargo nextest run --profile ci -p omq-tokio
+          --features "fuzz plain curve lz4 ws" --release
+          --test omq_fuzz_parsers
       - name: fuzz socket actions
         env:
           OMQ_FUZZ_ITERS: "200"
         run: >
-          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release
-          --test omq_fuzz_socket_actions -- --nocapture
+          cargo nextest run --profile ci -p omq-tokio
+          --features "fuzz plain curve lz4 ws" --release
+          --test omq_fuzz_socket_actions
 
   linux-32bit:
     name: 32-bit linux (${{ matrix.target }})
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -252,17 +288,17 @@ jobs:
       - name: compile workspace
         run: cross check --target ${{ matrix.target }} --workspace --all-targets --all-features
       - name: yring tests
-        run: cross test --target ${{ matrix.target }} -p yring --all-features
+        run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p yring --all-features
       - name: tokio tcp smoke tests
-        run: cross test --target ${{ matrix.target }} -p omq-tokio --test omq_tcp_smoke
+        run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-tokio --test omq_tcp_smoke
       - name: proto lz4 tests
-        run: cross test --target ${{ matrix.target }} -p omq-proto --features lz4 --lib
+        run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-proto --features lz4 --lib
       - name: libzmq ABI and inproc tests
         run: |
-          cross test --target ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_ctx
-          cross test --target ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_multipart
-          cross test --target ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_proxy
-          cross test --target ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_draft
+          bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_ctx
+          bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_multipart
+          bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_proxy
+          bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-libzmq --test omq_libzmq_draft
 
   lint:
     name: fmt + clippy (${{ matrix.name }})
@@ -330,6 +366,7 @@ jobs:
     needs: [changes, linux-gate]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_pyomq == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -345,6 +382,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -356,9 +396,9 @@ jobs:
       - name: build pyomq
         working-directory: bindings/pyomq
         run: pip install .
-      - name: cargo test
+      - name: cargo nextest
         working-directory: bindings/pyomq
-        run: cargo test
+        run: cargo nextest run --profile ci --config-file ../../.config/nextest.toml
       - name: pytest
         working-directory: bindings/pyomq
         run: pytest -v -k "not test_perf" -W error

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -44,13 +44,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test (fuzz) # --nocapture surfaces OMQ_FUZZ_SEED
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest (fuzz)
         run: |
           OMQ_FUZZ_ITERS=$(( ${{ matrix.iters }} * ${{ inputs.fuzz_scale || 1 }} ))
           export OMQ_FUZZ_ITERS
           echo "OMQ_FUZZ_ITERS=$OMQ_FUZZ_ITERS"
-          cargo test -p omq-tokio --features "fuzz plain curve lz4 ws" --release \
-            --test ${{ matrix.test }} -- --nocapture
+          cargo nextest run --profile extended -p omq-tokio \
+            --features "fuzz plain curve lz4 ws" --release \
+            --test ${{ matrix.test }}
 
   soak:
     name: soak (${{ matrix.group }})
@@ -78,14 +82,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: build soak tests
         run: cargo test -p omq-tokio --features "$SOAK_FEATURES" --release --no-run
       - name: run soak group
         run: |
           for t in ${{ matrix.tests }}; do
             echo "::group::$t"
-            cargo test -p omq-tokio --features "$SOAK_FEATURES" --release \
-              --test "$t" -- --nocapture
+            cargo nextest run --profile extended -p omq-tokio \
+              --features "$SOAK_FEATURES" --release --test "$t"
             echo "::endgroup::"
           done
 
@@ -98,15 +105,18 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: connect-before-bind # serial: rounds race each other otherwise
-        run: cargo test -p omq-tokio --test omq_stress_connect_before_bind -- --ignored --test-threads=1
+        run: cargo nextest run --profile extended -p omq-tokio --test omq_stress_connect_before_bind --run-ignored=only --test-threads=1
       - name: push/pull
-        run: cargo test -p omq-tokio --test omq_push_pull -- --ignored
+        run: cargo nextest run --profile extended -p omq-tokio --test omq_push_pull --run-ignored=only
       - name: transmit slot
-        run: cargo test -p omq-tokio --test omq_transmit_slot_stress -- --ignored
+        run: cargo nextest run --profile extended -p omq-tokio --test omq_transmit_slot_stress --run-ignored=only
 
   ubuntu-arm:
-    name: cargo test (ubuntu-24.04-arm)
+    name: cargo nextest (ubuntu-24.04-arm)
     if: github.repository == 'paddor/omq.rs'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
@@ -114,8 +124,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test
-        run: cargo test --workspace --no-fail-fast
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: cargo nextest
+        run: cargo nextest run --profile ci --workspace
 
   interop-libzmq-draft:
     name: interop (libzmq draft)
@@ -130,6 +143,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: cache libzmq
         id: libzmq
         uses: actions/cache@v4
@@ -161,11 +177,11 @@ jobs:
       - name: interop (ws)
         env:
           LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
-        run: cargo test -p omq-tokio --features ws --test omq_interop_libzmq_ws
+        run: cargo nextest run --profile ci -p omq-tokio --features ws --test omq_interop_libzmq_ws
       - name: interop (draft sockets)
         env:
           LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
-        run: cargo test -p omq-tokio --test omq_interop_libzmq_draft
+        run: cargo nextest run --profile ci -p omq-tokio --test omq_interop_libzmq_draft
 
   miri-seeds:
     name: miri (yring, many seeds)
@@ -182,6 +198,9 @@ jobs:
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - run: cargo miri setup
       - name: miri test
-        run: cargo miri test -p yring --features async
+        run: cargo miri nextest run -p yring --features async

--- a/.github/workflows/release-pyomq.yml
+++ b/.github/workflows/release-pyomq.yml
@@ -116,6 +116,7 @@ jobs:
     name: Smoke test (x86_64 wheel)
     runs-on: ubuntu-latest
     needs: [linux]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -125,13 +126,14 @@ jobs:
         with:
           name: wheels-linux-x86_64-auto
           path: dist
-      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0'
-      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v
+      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0' 'pytest-timeout>=2.4'
+      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v --timeout=60 --timeout-method=thread
 
   smoke-test-macos:
     name: Smoke test macOS (${{ matrix.platform.target }} wheel)
     runs-on: ${{ matrix.platform.runner }}
     needs: [macos]
+    timeout-minutes: 20
     strategy:
       matrix:
         platform:
@@ -148,8 +150,8 @@ jobs:
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
-      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0'
-      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v
+      - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0' 'pytest-timeout>=2.4'
+      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v --timeout=60 --timeout-method=thread
 
   publish:
     name: Publish to PyPI

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = []
 test = [
     "pytest>=7",
     "pytest-asyncio>=1.4.0",
+    "pytest-timeout>=2.4",
     "pyzmq>=25",
     "tornado>=6",
 ]
@@ -48,6 +49,8 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 addopts = "--ignore=tests/soak"
+timeout = 60
+timeout_method = "thread"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E402", "E702", "F401", "F841"]

--- a/scripts/ci-cross-test-timeout.sh
+++ b/scripts/ci-cross-test-timeout.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <target-triple> <cargo-test-args...>" >&2
+  exit 2
+fi
+
+target="$1"
+shift
+timeout_seconds="${OMQ_TEST_TIMEOUT_SECONDS:-180}"
+
+list_output="$(mktemp)"
+trap 'rm -f "$list_output"' EXIT
+
+timeout --kill-after=10s "${timeout_seconds}s" \
+  cross test --target "$target" "$@" -- --list --format terse > "$list_output"
+mapfile -t tests < <(sed -n 's/: test$//p' "$list_output")
+
+if [[ "${#tests[@]}" -eq 0 ]]; then
+  echo "no tests found: cross test --target $target $*" >&2
+  exit 1
+fi
+
+for test_name in "${tests[@]}"; do
+  echo "::group::$test_name"
+  timeout --kill-after=10s "${timeout_seconds}s" \
+    cross test --target "$target" "$@" "$test_name" -- --exact
+  echo "::endgroup::"
+done


### PR DESCRIPTION
- Replaces native Rust CI test runs with `cargo-nextest` profiles that enforce per-test slow timeouts.
- Keeps job-level timeouts as outer caps for full jobs.
- Adds a 32-bit `cross` helper that enumerates tests and runs each exact test under GNU `timeout`.
- Enables `pytest-timeout` for `pyomq` CI and release smoke tests.
