### PR TITLE
bench: reduce push/pull receive overhead

### DIFF
--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -13,44 +13,49 @@ small messages (higher is better)
 <line opacity="1" stroke="#374151" stroke-width="1" x1="383" y1="311" x2="383" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="444" y1="311" x2="444" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="311" x2="444" y2="311"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="275" x2="444" y2="275"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="239" x2="444" y2="239"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="202" x2="444" y2="202"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="166" x2="444" y2="166"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="129" x2="444" y2="129"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="93" x2="444" y2="93"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="280" x2="444" y2="280"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="248" x2="444" y2="248"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="216" x2="444" y2="216"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="184" x2="444" y2="184"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="152" x2="444" y2="152"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="120" x2="444" y2="120"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="88" x2="444" y2="88"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="56" x2="444" y2="56"/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,56 79,311 "/>
 <text x="70" y="311" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 0/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,311 79,311 "/>
-<text x="70" y="275" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<text x="70" y="280" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,275 79,275 "/>
-<text x="70" y="239" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,280 79,280 "/>
+<text x="70" y="248" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,239 79,239 "/>
-<text x="70" y="202" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,248 79,248 "/>
+<text x="70" y="216" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,202 79,202 "/>
-<text x="70" y="166" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,216 79,216 "/>
+<text x="70" y="184" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,166 79,166 "/>
-<text x="70" y="129" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,184 79,184 "/>
+<text x="70" y="152" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,129 79,129 "/>
-<text x="70" y="93" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,152 79,152 "/>
+<text x="70" y="120" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,93 79,93 "/>
-<text x="70" y="56" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,120 79,120 "/>
+<text x="70" y="88" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,88 79,88 "/>
+<text x="70" y="56" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16M/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,56 79,56 "/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,312 444,312 "/>
@@ -82,309 +87,306 @@ small messages (higher is better)
 1 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="444,312 444,317 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,252 86,252 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,252 95,251 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,251 104,251 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,251 113,250 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,250 122,250 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,250 131,249 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,249 140,249 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,249 149,250 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,250 158,250 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,251 167,251 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,251 176,252 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,252 185,253 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,253 194,253 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,254 201,254 203,254 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,254 212,255 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,255 221,256 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,256 230,256 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,257 239,257 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,257 248,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,258 257,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,259 262,259 266,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,259 275,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,259 284,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,259 293,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,260 302,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,260 311,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,260 320,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,260 328,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="331,259 337,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="340,259 346,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="349,258 355,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="358,258 364,257 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="367,257 373,257 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="376,256 382,256 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="385,257 391,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,259 400,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,261 409,262 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,263 417,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="420,265 426,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="429,267 435,268 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="438,269 444,270 "/>
-<circle cx="80" cy="252" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="249" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="254" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="259" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="260" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="256" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="270" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,289 86,288 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,288 95,287 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,286 104,285 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,285 113,284 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,284 122,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,282 130,281 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="133,281 139,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="142,280 148,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="151,280 157,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="160,279 166,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="169,279 175,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="178,279 184,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="187,278 193,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="196,278 201,278 202,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="205,277 211,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,275 220,274 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,273 229,272 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,271 237,270 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="240,270 246,268 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="249,268 255,266 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="258,266 262,265 264,265 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="267,265 273,265 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="276,265 282,266 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="285,266 291,266 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="294,266 300,266 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="303,266 309,267 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="312,267 318,267 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="321,267 322,267 327,267 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="330,268 336,268 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="339,268 345,268 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="348,269 354,269 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="357,269 363,270 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="366,270 372,270 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="375,270 381,271 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="384,271 390,272 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="393,272 399,272 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="402,273 408,273 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="411,273 417,274 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="420,274 426,274 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="429,275 435,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="438,275 444,276 "/>
-<circle cx="80" cy="289" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="280" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="278" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="265" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="267" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="271" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="276" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,305 86,305 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,305 95,305 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,305 104,305 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,305 113,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,306 122,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,306 131,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,306 140,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,306 149,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,306 158,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,306 167,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,306 176,307 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,259 86,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,259 95,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,258 104,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,258 113,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,258 122,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,258 131,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,257 140,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,257 149,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,258 158,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,258 167,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,259 176,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,260 185,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,260 194,261 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,261 201,261 203,261 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,261 212,262 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,262 221,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,263 230,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,264 239,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,264 248,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,265 257,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,266 262,266 266,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,266 275,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,266 284,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,266 293,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,267 302,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,267 311,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,267 320,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,267 329,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="332,266 338,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="341,266 347,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="350,265 356,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="359,265 365,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="368,264 374,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="377,263 382,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="385,263 391,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,265 400,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,267 409,268 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,269 418,270 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="421,270 427,272 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="430,272 435,273 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="438,274 444,275 "/>
+<circle cx="80" cy="259" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="257" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="261" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="266" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="267" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="263" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="275" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,292 86,291 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,291 95,290 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,290 104,289 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,288 113,288 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,287 122,286 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,286 131,285 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="134,285 139,284 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="142,284 148,284 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="151,284 157,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="160,283 166,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="169,283 175,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="178,283 184,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="187,282 193,282 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="196,282 201,282 202,282 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="205,281 211,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,279 220,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,278 229,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,276 238,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="241,274 247,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="250,272 255,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="258,271 262,270 264,270 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="267,270 273,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="276,271 282,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="285,271 291,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="294,272 300,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="303,272 309,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="312,273 318,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="321,273 322,273 327,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="330,273 336,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="339,274 345,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="348,274 354,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="357,275 363,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="366,275 372,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="375,276 381,276 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="384,276 390,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="393,277 399,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="402,278 408,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="411,278 417,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="420,279 426,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="429,280 435,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="438,281 444,281 "/>
+<circle cx="80" cy="292" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="284" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="282" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="270" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="273" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="276" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="281" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,306 86,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,306 95,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,306 104,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,306 113,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,307 122,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,307 131,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,307 140,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,307 149,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,307 158,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,307 167,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,307 176,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="179,307 185,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="188,307 194,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="197,307 201,307 203,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,307 212,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,307 221,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="224,307 230,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,307 239,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,307 248,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,307 257,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,307 262,307 266,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,307 275,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,307 284,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,307 293,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="296,307 302,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="305,307 311,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="314,307 320,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="323,307 329,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="332,307 338,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="341,307 347,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="350,307 356,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="359,307 365,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="368,307 374,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="377,307 383,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="386,307 392,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="395,307 401,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="404,307 410,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="413,307 419,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,307 428,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="431,307 437,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="440,307 444,307 "/>
-<circle cx="80" cy="305" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,308 239,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,308 248,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,308 257,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,308 262,308 266,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,308 275,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,308 284,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,308 293,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="296,308 302,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="305,308 311,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="314,308 320,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="323,308 329,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="332,308 338,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="341,308 347,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="350,308 356,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="359,308 365,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="368,308 374,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="377,308 383,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="386,308 392,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="395,308 401,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="404,308 410,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="413,308 419,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,308 428,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="431,308 437,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="440,308 444,308 "/>
+<circle cx="80" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="201" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,162 86,163 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,163 95,163 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,164 104,164 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,165 113,165 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,166 122,166 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,166 131,167 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,167 140,168 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="142,170 147,174 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="149,176 153,180 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="155,182 160,186 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="162,188 167,192 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="169,194 173,198 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="176,200 180,204 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="182,206 187,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="189,212 194,216 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="196,218 200,221 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="203,222 209,223 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="212,224 218,225 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="221,225 227,226 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="230,227 236,228 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="239,228 245,229 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="248,230 254,231 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="256,231 262,232 262,232 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="265,232 271,233 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="274,233 280,234 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="283,234 289,235 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="292,236 298,236 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="301,237 307,237 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="310,238 316,238 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="319,239 322,239 325,240 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="328,240 334,242 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="337,243 342,244 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="345,245 351,246 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="354,247 360,248 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="363,249 369,250 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="372,251 377,253 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="380,253 383,254 386,255 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="389,256 395,257 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="398,258 403,260 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="406,261 412,263 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="415,263 421,265 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="423,266 429,268 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="432,268 438,270 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="441,271 444,272 "/>
-<circle cx="80" cy="162" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="168" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="222" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="232" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="239" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="254" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="272" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,104 86,102 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="88,100 94,98 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="97,97 102,94 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="105,93 110,91 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="113,90 119,87 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="121,86 127,84 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="130,83 135,80 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="138,79 140,78 142,81 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="144,84 147,89 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="149,91 152,96 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="154,99 157,104 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="159,106 162,111 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="164,114 167,119 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="169,121 172,126 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="173,129 177,134 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="178,136 182,141 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="183,144 187,149 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="188,151 192,156 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="193,159 197,164 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="198,166 201,170 202,170 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="205,169 211,169 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="214,168 220,167 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="223,167 229,166 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="232,165 238,165 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="241,164 247,163 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="250,163 256,162 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="259,162 262,161 264,162 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="267,164 272,166 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="275,168 280,170 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="283,172 288,175 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="291,176 296,179 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="299,180 304,183 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="307,184 312,187 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="315,188 320,191 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="323,193 328,196 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="330,197 336,201 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="338,202 343,205 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="346,207 351,210 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="353,212 358,215 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="361,217 366,220 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="368,222 373,225 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="376,226 381,230 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="384,231 389,234 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="392,235 397,238 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="400,239 405,241 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="408,243 414,245 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="416,246 422,249 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="424,250 430,253 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="433,254 438,256 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="441,258 444,259 "/>
-<circle cx="80" cy="104" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="78" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="170" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="161" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="192" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="231" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="259" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,189 86,190 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,190 95,190 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,191 104,191 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,192 113,192 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,193 122,193 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="125,193 131,194 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="134,194 140,195 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,196 147,200 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="150,201 155,204 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="158,206 163,209 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="165,210 171,214 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="173,215 178,218 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="181,220 186,223 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="188,224 194,228 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="196,229 201,232 201,232 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="204,234 209,237 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="211,239 216,242 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="219,244 224,247 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="227,248 232,252 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="234,253 239,256 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="242,258 247,261 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="249,263 254,266 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="257,268 262,271 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="265,271 271,271 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="274,272 280,272 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="283,272 289,272 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="292,272 298,273 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="301,273 307,273 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="310,273 316,274 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="319,274 322,274 325,274 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="328,275 334,276 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="337,276 343,277 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="346,278 351,279 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="354,279 360,280 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="363,281 369,282 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="372,282 378,283 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="381,284 383,284 387,285 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="390,285 396,287 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="399,287 405,288 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="408,289 413,290 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="416,291 422,292 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="425,292 431,293 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="434,294 440,295 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="443,296 444,296 "/>
-<circle cx="80" cy="189" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="195" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="232" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="271" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="274" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="284" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="296" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,178 86,178 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,179 95,179 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,179 104,180 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,180 113,181 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,181 122,181 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,182 131,182 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,182 140,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="142,185 147,189 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="149,191 154,194 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="156,196 161,200 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="163,202 167,206 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="170,208 174,212 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="177,214 181,218 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="184,219 188,223 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="190,225 195,229 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="197,231 201,234 202,234 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="205,234 211,235 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="214,235 220,235 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="223,235 229,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="232,236 238,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="241,237 247,237 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="250,237 256,238 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="259,238 262,238 265,238 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="268,239 274,240 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="277,240 283,241 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="286,241 292,242 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="295,242 301,243 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="304,244 310,244 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="313,245 319,246 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="322,246 322,246 327,247 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="330,248 336,249 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="339,250 345,251 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="348,252 354,253 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="357,254 363,255 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="365,256 371,257 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="374,258 380,259 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="383,260 389,261 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="392,262 398,263 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="401,264 407,265 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="409,266 415,267 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="418,268 424,269 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="427,269 433,271 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="436,271 442,273 "/>
+<circle cx="80" cy="178" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="183" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="234" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="238" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="246" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="260" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="273" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,84 86,85 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="89,85 95,86 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="98,87 104,88 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="107,88 113,89 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="116,89 122,90 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="125,91 130,92 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="133,92 139,93 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="141,95 145,100 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="146,102 150,107 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,110 155,115 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,117 160,122 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="161,125 165,130 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="166,132 170,137 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="171,140 175,145 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="176,147 180,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="181,155 185,160 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="186,162 190,167 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="191,170 195,175 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="196,177 200,182 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="202,184 208,182 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="210,182 216,180 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="219,180 225,178 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="228,177 234,176 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="237,175 243,174 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="245,173 251,172 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="254,171 260,169 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="263,169 268,172 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="271,174 276,176 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="279,178 284,180 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="287,182 292,185 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="295,186 300,189 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="303,190 308,193 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="311,194 316,197 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="319,198 322,200 324,201 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="327,203 332,206 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="334,208 339,211 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="342,212 347,216 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="350,217 355,220 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="357,222 362,225 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="365,227 370,230 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="372,231 378,235 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="380,236 383,238 385,239 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="388,240 394,243 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="396,244 402,247 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="404,248 410,250 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="413,252 418,254 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="421,255 426,258 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="429,259 434,262 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="437,263 443,265 "/>
+<circle cx="80" cy="84" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="93" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="184" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="169" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="200" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="238" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="266" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,200 86,201 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,201 95,202 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,202 104,203 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,204 113,204 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,205 122,206 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="125,206 131,207 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="134,207 139,208 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,209 147,212 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="150,214 155,217 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="158,218 163,221 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="166,222 171,225 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,227 179,230 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="181,231 187,234 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="189,235 195,238 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="197,240 201,242 202,243 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="205,244 210,247 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="213,249 218,252 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="221,253 226,256 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="229,257 234,260 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="236,262 242,265 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="244,266 250,269 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="252,271 257,273 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="260,275 262,276 266,276 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="269,276 275,277 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="278,277 284,277 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="287,277 293,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="296,278 302,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="305,278 311,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="314,279 320,279 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="323,279 329,280 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="332,280 338,281 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="341,282 346,283 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,283 355,284 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,284 364,285 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,286 373,287 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,287 382,288 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,288 391,289 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,290 400,291 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,291 409,292 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,293 418,294 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,294 426,295 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="429,296 435,297 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="438,297 444,298 "/>
+<circle cx="80" cy="200" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="208" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="242" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="276" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="288" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="298" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <text x="712" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 medium/large messages (higher is better)
 </text>
@@ -508,36 +510,36 @@ medium/large messages (higher is better)
 <circle cx="789" cy="170" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="833" cy="178" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="217" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,268 528,243 572,216 615,174 659,144 702,120 746,99 789,88 833,64 877,85 "/>
-<circle cx="485" cy="268" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="528" cy="243" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="572" cy="216" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="174" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="659" cy="144" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="702" cy="120" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="99" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="789" cy="88" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="833" cy="64" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,267 528,241 572,206 615,173 659,147 702,102 746,103 789,94 833,71 877,85 "/>
+<circle cx="485" cy="267" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="528" cy="241" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="572" cy="206" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="173" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="659" cy="147" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="702" cy="102" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="103" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="789" cy="94" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="833" cy="71" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="85" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,240 528,215 572,186 615,165 659,145 702,112 746,106 789,94 833,77 877,85 "/>
-<circle cx="485" cy="240" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="528" cy="215" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="572" cy="186" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="165" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="659" cy="145" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="702" cy="112" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="106" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="789" cy="94" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="833" cy="77" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="85" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,289 528,279 572,274 615,268 659,263 702,262 746,262 789,231 833,149 877,139 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,235 528,211 572,188 615,166 659,146 702,118 746,104 789,109 833,74 877,92 "/>
+<circle cx="485" cy="235" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="528" cy="211" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="572" cy="188" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="166" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="659" cy="146" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="702" cy="118" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="104" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="789" cy="109" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="833" cy="74" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="92" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,289 528,279 572,274 615,267 659,263 702,262 746,261 789,231 833,149 877,139 "/>
 <circle cx="485" cy="289" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="528" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="572" cy="274" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="268" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="267" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="659" cy="263" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="702" cy="262" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="262" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="261" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="789" cy="231" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="833" cy="149" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="139" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
@@ -558,10 +560,10 @@ libzmq
 1 IO
 </text>
 <text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-169%
+167%
 </text>
 <text x="430" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-138%
+139%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -574,7 +576,7 @@ omq
 128%
 </text>
 <text x="430" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-193%
+192%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -587,7 +589,7 @@ CT
 95%
 </text>
 <text x="430" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-89%
+90%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -126,6 +126,32 @@ pub(crate) fn nice_axis(max_val: f64, target_lines: usize) -> (f64, usize) {
     (step * ticks as f64, ticks)
 }
 
+#[derive(Clone, Copy)]
+enum MsgAxisMode {
+    Auto,
+    Fixed2M,
+}
+
+impl MsgAxisMode {
+    fn bounds(self, max_val: f64, target_lines: usize) -> (f64, usize) {
+        match self {
+            MsgAxisMode::Auto => nice_axis(max_val, target_lines),
+            MsgAxisMode::Fixed2M => msg_axis_2m(max_val),
+        }
+    }
+}
+
+const MSG_AXIS_STEP: f64 = 2_000_000.0;
+
+pub(crate) fn msg_axis_2m(max_val: f64) -> (f64, usize) {
+    let ticks = if max_val <= 0.0 {
+        1
+    } else {
+        (max_val / MSG_AXIS_STEP).ceil().max(1.0) as usize
+    };
+    (MSG_AXIS_STEP * ticks as f64, ticks)
+}
+
 // ── hardware detection ─────────────────────────────────────────
 
 pub(crate) fn detect_hardware() -> Option<String> {
@@ -614,6 +640,59 @@ pub(crate) fn draw_throughput_dual_panel(
     snd_label: &str,
     rcv_label: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    draw_throughput_dual_panel_with_msg_axis(
+        out_path,
+        title,
+        sizes,
+        impls,
+        tput,
+        msgs,
+        cpu,
+        snd_label,
+        rcv_label,
+        MsgAxisMode::Auto,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn draw_throughput_dual_panel_fixed_2m_msgs(
+    out_path: &Path,
+    title: &str,
+    sizes: &[u64],
+    impls: &[Impl],
+    tput: &ValMap,
+    msgs: &ValMap,
+    cpu: &BTreeMap<String, CpuData>,
+    snd_label: &str,
+    rcv_label: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    draw_throughput_dual_panel_with_msg_axis(
+        out_path,
+        title,
+        sizes,
+        impls,
+        tput,
+        msgs,
+        cpu,
+        snd_label,
+        rcv_label,
+        MsgAxisMode::Fixed2M,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+fn draw_throughput_dual_panel_with_msg_axis(
+    out_path: &Path,
+    title: &str,
+    sizes: &[u64],
+    impls: &[Impl],
+    tput: &ValMap,
+    msgs: &ValMap,
+    cpu: &BTreeMap<String, CpuData>,
+    snd_label: &str,
+    rcv_label: &str,
+    msg_axis: MsgAxisMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     let present: Vec<&Impl> = impls
         .iter()
         .filter(|imp| {
@@ -661,7 +740,7 @@ pub(crate) fn draw_throughput_dual_panel(
         .flat_map(|m| m.values())
         .copied()
         .fold(0.0_f64, f64::max);
-    let (msgs_max, msgs_ticks) = nice_axis(msgs_raw, n_ticks);
+    let (msgs_max, msgs_ticks) = msg_axis.bounds(msgs_raw, n_ticks);
 
     if !small.is_empty() {
         draw_msgs_panel(

--- a/omq-bench/src/chart/main_tcp.rs
+++ b/omq-bench/src/chart/main_tcp.rs
@@ -1,6 +1,7 @@
 use super::common::{
     self, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_CT, C_RZMQ, C_RZMQ_IOURING, C_ZMQRS,
-    Impl, draw_latency_single_panel, draw_throughput_dual_panel, load_latency, load_tput, out_dir,
+    Impl, draw_latency_single_panel, draw_throughput_dual_panel,
+    draw_throughput_dual_panel_fixed_2m_msgs, load_latency, load_tput, out_dir,
 };
 
 const TPUT_SIZES: &[u64] = &[
@@ -139,7 +140,7 @@ pub(crate) fn generate() {
     let (tput, msgs, cpu) = load_tput("throughput", "tcp", None, PUSHPULL_IMPLS);
     if !tput.is_empty() {
         let out = dir.join("main_pushpull_tcp.svg");
-        draw_throughput_dual_panel(
+        draw_throughput_dual_panel_fixed_2m_msgs(
             &out,
             "PUSH/PULL throughput, TCP loopback, 2-process",
             TPUT_SIZES,

--- a/omq-tokio/src/bin/bench_peer_blocking.rs
+++ b/omq-tokio/src/bin/bench_peer_blocking.rs
@@ -309,7 +309,11 @@ fn warmup_duration() -> Duration {
         .map_or(Duration::ZERO, Duration::from_millis)
 }
 
-fn recv_loop(sock: &blocking::Socket, duration: Duration) -> (u64, f64) {
+fn recv_timer_check_interval(size: usize) -> usize {
+    if size <= 1024 { 4096 } else { 256 }
+}
+
+fn recv_loop(sock: &blocking::Socket, duration: Duration, size: usize) -> (u64, f64) {
     std::thread::sleep(Duration::from_millis(500));
     wait_for_start_barrier();
     drain_warmup(sock);
@@ -317,16 +321,22 @@ fn recv_loop(sock: &blocking::Socket, duration: Duration) -> (u64, f64) {
     let t0 = Instant::now();
     let deadline = t0 + duration;
     let mut count: u64 = 0;
+    let timer_check_interval = recv_timer_check_interval(size);
+    let mut until_timer_check = timer_check_interval;
     loop {
-        if Instant::now() >= deadline {
-            break;
-        }
         if sock.try_recv().is_ok() {
             count += 1;
-            while Instant::now() < deadline && sock.try_recv().is_ok() {
-                count += 1;
+            until_timer_check -= 1;
+            if until_timer_check == 0 {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                until_timer_check = timer_check_interval;
             }
         } else {
+            if Instant::now() >= deadline {
+                break;
+            }
             std::thread::yield_now();
         }
     }
@@ -379,7 +389,7 @@ fn run_pull(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Durat
     pull.connect(ep).expect("pull connect");
 
     let cpu_before = cpu_time_secs();
-    let (count, elapsed) = recv_loop(&pull, duration);
+    let (count, elapsed) = recv_loop(&pull, duration, size);
     let cpu = cpu_time_secs() - cpu_before;
     println!("{count} {elapsed:.6} {size} {cpu:.6}");
 }
@@ -390,7 +400,7 @@ fn run_pull_bind(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: 
     report_bound_port(ctx, &bound);
 
     let cpu_before = cpu_time_secs();
-    let (count, elapsed) = recv_loop(&pull, duration);
+    let (count, elapsed) = recv_loop(&pull, duration, size);
     let cpu = cpu_time_secs() - cpu_before;
     println!("{count} {elapsed:.6} {size} {cpu:.6}");
 }

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -439,6 +439,44 @@ async fn recv_before_deadline(sock: &Socket, deadline: Instant) -> bool {
     )
 }
 
+fn recv_timer_check_interval(size: usize) -> usize {
+    if size <= 1024 { 4096 } else { 256 }
+}
+
+async fn recv_loop(sock: &Socket, duration: Duration, size: usize) -> (u64, f64) {
+    let t0 = Instant::now();
+    let deadline = t0 + duration;
+    let timer_check_interval = recv_timer_check_interval(size);
+    let mut until_timer_check = timer_check_interval;
+    let mut count: u64 = 0;
+
+    loop {
+        if !recv_before_deadline(sock, deadline).await {
+            break;
+        }
+        count += 1;
+        until_timer_check -= 1;
+        if until_timer_check == 0 {
+            if Instant::now() >= deadline {
+                break;
+            }
+            until_timer_check = timer_check_interval;
+        }
+        while sock.try_recv().is_ok() {
+            count += 1;
+            until_timer_check -= 1;
+            if until_timer_check == 0 {
+                if Instant::now() >= deadline {
+                    return (count, t0.elapsed().as_secs_f64());
+                }
+                until_timer_check = timer_check_interval;
+            }
+        }
+    }
+
+    (count, t0.elapsed().as_secs_f64())
+}
+
 async fn run_sub(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration: Duration) {
     let sub = ctx.socket(SocketType::Sub, bench_options_client(size));
     sub.connect(ep.clone()).await.expect("sub connect");
@@ -631,19 +669,7 @@ async fn run_pull_bind(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, dura
     drain_pending(&pull);
 
     let cpu_before = cpu_time_secs();
-    let t0 = Instant::now();
-    let deadline = t0 + duration;
-    let mut count: u64 = 0;
-    loop {
-        if !recv_before_deadline(&pull, deadline).await {
-            break;
-        }
-        count += 1;
-        while Instant::now() < deadline && pull.try_recv().is_ok() {
-            count += 1;
-        }
-    }
-    let elapsed = t0.elapsed().as_secs_f64();
+    let (count, elapsed) = recv_loop(&pull, duration, size).await;
     let cpu = cpu_time_secs() - cpu_before;
     println!("{count} {elapsed:.6} {size} {cpu:.6}");
     eprint_pull_summary(&ep, count, elapsed, size);
@@ -667,19 +693,7 @@ async fn run_inproc(name: String, size: usize, duration: Duration) {
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let t0 = Instant::now();
-    let deadline = t0 + duration;
-    let mut count: u64 = 0;
-    loop {
-        if !recv_before_deadline(&pull, deadline).await {
-            break;
-        }
-        count += 1;
-        while Instant::now() < deadline && pull.try_recv().is_ok() {
-            count += 1;
-        }
-    }
-    let elapsed = t0.elapsed().as_secs_f64();
+    let (count, elapsed) = recv_loop(&pull, duration, size).await;
     println!("{count} {elapsed:.6} {size}");
 }
 
@@ -692,22 +706,7 @@ async fn run_pull(ctx: &omq_tokio::Context, ep: Endpoint, size: usize, duration:
     drain_pending(&pull);
 
     let cpu_before = cpu_time_secs();
-    let t0 = Instant::now();
-    let deadline = t0 + duration;
-    let mut count: u64 = 0;
-    loop {
-        if !recv_before_deadline(&pull, deadline).await {
-            break;
-        }
-        count += 1;
-        while pull.try_recv().is_ok() {
-            count += 1;
-        }
-        if Instant::now() >= deadline {
-            break;
-        }
-    }
-    let elapsed = t0.elapsed().as_secs_f64();
+    let (count, elapsed) = recv_loop(&pull, duration, size).await;
     let cpu = cpu_time_secs() - cpu_before;
     println!("{count} {elapsed:.6} {size} {cpu:.6}");
     eprint_pull_summary(&ep, count, elapsed, size);

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -236,6 +236,50 @@ impl YringSink {
         self.producer.flush();
         (self.signal)();
     }
+
+    #[inline]
+    fn flush_pending(&mut self, pending: &mut bool) {
+        if *pending {
+            self.flush_and_signal();
+            *pending = false;
+        }
+    }
+
+    async fn send_deferred(&mut self, m: Message, pending: &mut bool) -> bool {
+        let mut item = RecvItem::new(m);
+        loop {
+            match self.producer.push(item) {
+                Ok(()) => {
+                    *pending = true;
+                    return true;
+                }
+                Err(returned) => {
+                    item = returned;
+                    self.flush_pending(pending);
+                }
+            }
+            if self.producer.is_consumer_dropped() {
+                return false;
+            }
+            let seen = self.space.generation();
+            let changed = self.space.changed_after(seen);
+            tokio::pin!(changed);
+            match self.producer.push(item) {
+                Ok(()) => {
+                    *pending = true;
+                    return true;
+                }
+                Err(returned) => {
+                    item = returned;
+                    tokio::select! {
+                        biased;
+                        () = changed => {}
+                        () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl RecvSink {
@@ -320,6 +364,24 @@ impl RecvSink {
             return rep.sink.send_plain(body).await;
         }
         self.send_plain(m).await
+    }
+
+    async fn send_with_flush_mode(
+        &mut self,
+        m: Message,
+        defer_yring_flush: bool,
+        pending_yring_flush: &mut bool,
+    ) -> bool {
+        if defer_yring_flush && let Self::Yring(sink) = self {
+            return sink.send_deferred(m, pending_yring_flush).await;
+        }
+        self.send(m).await
+    }
+
+    fn flush_deferred(&mut self, pending_yring_flush: &mut bool) {
+        if let Self::Yring(sink) = self {
+            sink.flush_pending(pending_yring_flush);
+        }
     }
 }
 
@@ -1114,6 +1176,10 @@ async fn drain_decoded_messages(
     let recv_batch_start = Instant::now();
     let mut recv_budget = None;
     let mut recv_batch_time = None;
+    let defer_yring_flush = decoder.is_none()
+        && matches!(receive_profile, ReceiveProfile::Throughput)
+        && matches!(recv_direct, Some(RecvSink::Yring(_)));
+    let mut pending_yring_flush = false;
     while let Some(m) = connection.poll_message() {
         let m = match decoder.as_mut() {
             Some(dec) => match dec.decode(m)? {
@@ -1127,7 +1193,17 @@ async fn drain_decoded_messages(
             recv_batch_time = receive_profile.time(msg_bytes);
             receive_profile.budget(msg_bytes)
         });
-        if !route_message(m, recv_direct, peer_out, peer_id).await {
+        if !route_message(
+            m,
+            recv_direct,
+            peer_out,
+            peer_id,
+            defer_yring_flush,
+            &mut pending_yring_flush,
+        )
+        .await
+        {
+            flush_deferred_recv(recv_direct, &mut pending_yring_flush);
             return Ok(DriverStep::Close);
         }
         let budget_remains = budget.account(msg_bytes);
@@ -1136,10 +1212,18 @@ async fn drain_decoded_messages(
             || (time_check
                 && recv_batch_time.is_some_and(|limit| recv_batch_start.elapsed() >= limit))
         {
+            flush_deferred_recv(recv_direct, &mut pending_yring_flush);
             return Ok(DriverStep::Yield);
         }
     }
+    flush_deferred_recv(recv_direct, &mut pending_yring_flush);
     Ok(DriverStep::Continue)
+}
+
+fn flush_deferred_recv(recv_direct: &mut Option<RecvSink>, pending_yring_flush: &mut bool) {
+    if let Some(sink) = recv_direct {
+        sink.flush_deferred(pending_yring_flush);
+    }
 }
 
 fn enable_transmit_slot_after_handshake(slot: Option<&PeerTransmitSlot>, connection: &Connection) {
@@ -1638,9 +1722,14 @@ async fn route_message(
     recv_direct: &mut Option<RecvSink>,
     peer_out: &mpsc::Sender<(u64, PeerEvent)>,
     peer_id: u64,
+    defer_yring_flush: bool,
+    pending_yring_flush: &mut bool,
 ) -> bool {
     match recv_direct {
-        Some(sink) => sink.send(m).await,
+        Some(sink) => {
+            sink.send_with_flush_mode(m, defer_yring_flush, pending_yring_flush)
+                .await
+        }
         None => peer_out
             .send((peer_id, PeerEvent::Event(Event::Message(m))))
             .await
@@ -1822,6 +1911,30 @@ mod tests {
         sink.flush_and_signal();
 
         assert_eq!(signals.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn yring_sink_deferred_send_signals_once_per_flush() {
+        let (producer, mut consumer) = yring::spsc(4);
+        let signals = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let signals_for_sink = signals.clone();
+        let mut sink = YringSink {
+            producer,
+            signal: Box::new(move || {
+                signals_for_sink.fetch_add(1, Ordering::Relaxed);
+            }),
+            space: Arc::new(StateSignal::new()),
+        };
+        let mut pending = false;
+
+        assert!(sink.send_deferred(Message::single("a"), &mut pending).await);
+        assert!(sink.send_deferred(Message::single("b"), &mut pending).await);
+        assert_eq!(signals.load(Ordering::Relaxed), 0);
+        assert_eq!(consumer.prefetch(), 0);
+
+        sink.flush_pending(&mut pending);
+        assert_eq!(signals.load(Ordering::Relaxed), 1);
+        assert_eq!(consumer.prefetch(), 2);
     }
 
     /// Adapter: pull `(u64, PeerEvent::Event)` off the shared peer-out


### PR DESCRIPTION
- Batch direct yring recv publication in throughput mode so PULL avoids one flush/signal path per decoded message.
- Check PUSH/PULL bench receive deadlines every bounded message interval instead of every message in both blocking and borrowed-runtime peers.
- Regenerate only the main PUSH/PULL TCP chart and use fixed 2M/s tick spacing for its msg/s axis.