### PR TITLE
ci: relax extended yring miri timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,7 @@ fail-fast = false
 failure-output = "immediate-final"
 status-level = "slow"
 final-status-level = "slow"
+
+[profile.extended-miri]
+inherits = "default-miri"
+slow-timeout = { period = "10m", terminate-after = 1, grace-period = "10s" }

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -203,4 +203,4 @@ jobs:
           tool: cargo-nextest
       - run: cargo miri setup
       - name: miri test
-        run: cargo miri nextest run -p yring --features async
+        run: cargo miri nextest run --profile extended-miri -p yring --features async


### PR DESCRIPTION
- Add an `extended-miri` nextest profile with a 10m per-test cap for scheduled many-seed yring Miri.
- Keep the default PR Miri profile unchanged at the tighter 360s cap.
- Point only the extended cron Miri job at the longer profile.