### PR TITLE
Show peer versions in main chart legends

### DIFF
--- a/doc/charts/main_pubsub_tcp.svg
+++ b/doc/charts/main_pubsub_tcp.svg
@@ -479,80 +479,80 @@ medium/large messages (higher is better)
 <circle cx="615" cy="288" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="746" cy="285" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="274" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
-<text x="340" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 snd CPU%
 </text>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,366 92,366 "/>
 <text x="98" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-libzmq
+libzmq v4.3.5
 </text>
-<text x="230" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 95%
 </text>
 <polyline fill="none" opacity="1" stroke="#F59E0B" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-libzmq
+libzmq v4.3.5
 </text>
-<text x="230" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 IO
 </text>
-<text x="340" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 163%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 101%
 </text>
 <polyline fill="none" opacity="1" stroke="#B91C1C" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 IO
 </text>
-<text x="340" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 178%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,430 92,430 "/>
 <text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs
+zmq.rs v0.6.0
 </text>
-<text x="230" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 104%
 </text>
 <polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq
+rzmq v0.5.24
 </text>
-<text x="230" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 233%
 </text>
 <polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring
+rzmq-iouring v0.5.24
 </text>
-<text x="230" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 146%
 </text>
 </svg>

--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -543,91 +543,91 @@ medium/large messages (higher is better)
 <circle cx="789" cy="231" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="833" cy="149" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="139" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
-<text x="340" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 snd CPU%
 </text>
-<text x="430" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 rcv CPU%
 </text>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,366 92,366 "/>
 <text x="98" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-libzmq
+libzmq v4.3.5
 </text>
-<text x="230" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 167%
 </text>
-<text x="430" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 139%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 128%
 </text>
-<text x="430" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 192%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 CT
 </text>
-<text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 95%
 </text>
-<text x="430" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 90%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs
+zmq.rs v0.6.0
 </text>
-<text x="230" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 94%
 </text>
-<text x="430" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 99%
 </text>
 <polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,430 92,430 "/>
 <text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq
+rzmq v0.5.24
 </text>
-<text x="230" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 102%
 </text>
-<text x="430" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 111%
 </text>
 <polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring
+rzmq-iouring v0.5.24
 </text>
-<text x="230" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 151%
 </text>
-<text x="430" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 141%
 </text>
 </svg>

--- a/doc/charts/main_reqrep_tcp.svg
+++ b/doc/charts/main_reqrep_tcp.svg
@@ -103,91 +103,91 @@ p50 round-trip latency (lower is better)
 <circle cx="444" cy="119" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="631" cy="113" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="819" cy="107" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
-<text x="340" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 req CPU%
 </text>
-<text x="430" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 rep CPU%
 </text>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,366 92,366 "/>
 <text x="98" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-libzmq
+libzmq v4.3.5
 </text>
-<text x="230" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 57%
 </text>
-<text x="430" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 62%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 1 IO
 </text>
-<text x="340" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 78%
 </text>
-<text x="430" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 84%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 CT
 </text>
-<text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 58%
 </text>
-<text x="430" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 59%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs
+zmq.rs v0.6.0
 </text>
-<text x="230" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 55%
 </text>
-<text x="430" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 57%
 </text>
 <polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,430 92,430 "/>
 <text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq
+rzmq v0.5.24
 </text>
-<text x="230" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 63%
 </text>
-<text x="430" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 68%
 </text>
 <polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring
+rzmq-iouring v0.5.24
 </text>
-<text x="230" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 6 MT
 </text>
-<text x="340" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 95%
 </text>
-<text x="430" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 104%
 </text>
 </svg>

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::path::Path;
+use std::process::Command;
+use std::sync::OnceLock;
 
 use plotters::prelude::*;
 
@@ -40,6 +42,12 @@ pub(crate) struct FairnessEntry {
 }
 
 pub(crate) type FairnessMap = BTreeMap<u64, BTreeMap<String, FairnessEntry>>;
+
+#[derive(Clone, Copy)]
+enum LegendVersionMode {
+    Hide,
+    ShowOtherImpls,
+}
 
 // ── colors ─────────────────────────────────────────────────────
 
@@ -259,6 +267,90 @@ pub(crate) fn postprocess_svg(
 
 // ── legend table ───────────────────────────────────────────────
 
+static IMPL_VERSIONS: OnceLock<BTreeMap<&'static str, String>> = OnceLock::new();
+
+fn impl_versions() -> &'static BTreeMap<&'static str, String> {
+    IMPL_VERSIONS.get_or_init(|| {
+        let mut versions = BTreeMap::new();
+        if let Some(version) = libzmq_version() {
+            versions.insert("libzmq", version);
+        }
+        if let Some(version) = cargo_lock_version("scripts/zmqrs_bench_peer/Cargo.lock", "zeromq") {
+            versions.insert("zmq.rs", version);
+        }
+        if let Some(version) = cargo_lock_version("scripts/rzmq_bench_peer/Cargo.lock", "rzmq") {
+            versions.insert("rzmq", version);
+        }
+        versions
+    })
+}
+
+fn libzmq_version() -> Option<String> {
+    let output = Command::new("pkg-config")
+        .args(["--modversion", "libzmq"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!version.is_empty()).then_some(version)
+}
+
+fn cargo_lock_version(rel_lock_path: &str, package: &str) -> Option<String> {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).parent()?;
+    let content = std::fs::read_to_string(repo.join(rel_lock_path)).ok()?;
+
+    let mut name_matches = false;
+    let mut version = None;
+    for line in content.lines().map(str::trim) {
+        if line == "[[package]]" {
+            if name_matches {
+                return version;
+            }
+            name_matches = false;
+            version = None;
+            continue;
+        }
+        if let Some(name) = quoted_toml_value(line, "name") {
+            name_matches = name == package;
+        } else if let Some(v) = quoted_toml_value(line, "version") {
+            version = Some(v.to_string());
+        }
+    }
+
+    name_matches.then_some(version).flatten()
+}
+
+fn quoted_toml_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let value = line.strip_prefix(key)?.strip_prefix(" = \"")?;
+    let end = value.find('"')?;
+    Some(&value[..end])
+}
+
+fn other_impl_version(key: &str) -> Option<&'static str> {
+    let version_key = if key.starts_with("libzmq") {
+        "libzmq"
+    } else if key == "zmq.rs" {
+        "zmq.rs"
+    } else if matches!(key, "rzmq" | "rzmq-iouring") {
+        "rzmq"
+    } else {
+        return None;
+    };
+    impl_versions().get(version_key).map(String::as_str)
+}
+
+fn legend_label(imp: &Impl, version_mode: LegendVersionMode) -> String {
+    match version_mode {
+        LegendVersionMode::Hide => imp.label.to_string(),
+        LegendVersionMode::ShowOtherImpls => other_impl_version(imp.key).map_or_else(
+            || imp.label.to_string(),
+            |version| format!("{} v{version}", imp.label),
+        ),
+    }
+}
+
 pub(crate) fn draw_legend_table(
     table_area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>,
     impls: &[&Impl],
@@ -266,15 +358,33 @@ pub(crate) fn draw_legend_table(
     snd_label: &str,
     rcv_label: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    draw_legend_table_with_versions(
+        table_area,
+        impls,
+        cpu,
+        snd_label,
+        rcv_label,
+        LegendVersionMode::Hide,
+    )
+}
+
+fn draw_legend_table_with_versions(
+    table_area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>,
+    impls: &[&Impl],
+    cpu: &BTreeMap<String, CpuData>,
+    snd_label: &str,
+    rcv_label: &str,
+    version_mode: LegendVersionMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     let style_hdr = ("sans-serif", 11).into_font().color(&MUTED_TEXT_COLOR);
     let style_val = ("sans-serif", 11).into_font().color(&TEXT_COLOR);
     let style_dim = ("sans-serif", 11).into_font().color(&MUTED_TEXT_COLOR);
 
     let col_swatch = 78;
     let col_name = col_swatch + 20;
-    let col_threads = 230;
-    let col_snd = 340;
-    let col_rcv = 430;
+    let col_threads = 250;
+    let col_snd = 360;
+    let col_rcv = 450;
     let row_h = 16i32;
 
     table_area.draw_text("threads", &style_hdr, (col_threads, 4))?;
@@ -295,7 +405,8 @@ pub(crate) fn draw_legend_table(
             vec![(col_swatch, y + 6), (col_swatch + 14, y + 6)],
             imp.color.stroke_width(2),
         ))?;
-        table_area.draw_text(imp.label, &style_val, (col_name, y))?;
+        let label = legend_label(imp, version_mode);
+        table_area.draw_text(&label, &style_val, (col_name, y))?;
 
         let threads = if imp.threads.is_empty() {
             format!("{cores} MT")
@@ -651,11 +762,39 @@ pub(crate) fn draw_throughput_dual_panel(
         snd_label,
         rcv_label,
         MsgAxisMode::Auto,
+        LegendVersionMode::Hide,
     )
 }
 
 #[expect(clippy::too_many_arguments)]
-pub(crate) fn draw_throughput_dual_panel_fixed_2m_msgs(
+pub(crate) fn draw_throughput_dual_panel_with_versions(
+    out_path: &Path,
+    title: &str,
+    sizes: &[u64],
+    impls: &[Impl],
+    tput: &ValMap,
+    msgs: &ValMap,
+    cpu: &BTreeMap<String, CpuData>,
+    snd_label: &str,
+    rcv_label: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    draw_throughput_dual_panel_with_msg_axis(
+        out_path,
+        title,
+        sizes,
+        impls,
+        tput,
+        msgs,
+        cpu,
+        snd_label,
+        rcv_label,
+        MsgAxisMode::Auto,
+        LegendVersionMode::ShowOtherImpls,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn draw_throughput_dual_panel_fixed_2m_msgs_with_versions(
     out_path: &Path,
     title: &str,
     sizes: &[u64],
@@ -677,6 +816,7 @@ pub(crate) fn draw_throughput_dual_panel_fixed_2m_msgs(
         snd_label,
         rcv_label,
         MsgAxisMode::Fixed2M,
+        LegendVersionMode::ShowOtherImpls,
     )
 }
 
@@ -692,6 +832,7 @@ fn draw_throughput_dual_panel_with_msg_axis(
     snd_label: &str,
     rcv_label: &str,
     msg_axis: MsgAxisMode,
+    version_mode: LegendVersionMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let present: Vec<&Impl> = impls
         .iter()
@@ -759,7 +900,14 @@ fn draw_throughput_dual_panel_with_msg_axis(
         )?;
     }
 
-    draw_legend_table(&table_area, &present, cpu, snd_label, rcv_label)?;
+    draw_legend_table_with_versions(
+        &table_area,
+        &present,
+        cpu,
+        snd_label,
+        rcv_label,
+        version_mode,
+    )?;
     root.present()?;
     drop(root);
 
@@ -908,6 +1056,50 @@ pub(crate) fn draw_latency_single_panel(
     cpu: &BTreeMap<String, CpuData>,
     lat_range: (f64, f64),
 ) -> Result<(), Box<dyn std::error::Error>> {
+    draw_latency_single_panel_with_version_mode(
+        out_path,
+        title,
+        sizes,
+        impls,
+        lat,
+        cpu,
+        lat_range,
+        LegendVersionMode::Hide,
+    )
+}
+
+pub(crate) fn draw_latency_single_panel_with_versions(
+    out_path: &Path,
+    title: &str,
+    sizes: &[u64],
+    impls: &[Impl],
+    lat: &ValMap,
+    cpu: &BTreeMap<String, CpuData>,
+    lat_range: (f64, f64),
+) -> Result<(), Box<dyn std::error::Error>> {
+    draw_latency_single_panel_with_version_mode(
+        out_path,
+        title,
+        sizes,
+        impls,
+        lat,
+        cpu,
+        lat_range,
+        LegendVersionMode::ShowOtherImpls,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+fn draw_latency_single_panel_with_version_mode(
+    out_path: &Path,
+    title: &str,
+    sizes: &[u64],
+    impls: &[Impl],
+    lat: &ValMap,
+    cpu: &BTreeMap<String, CpuData>,
+    lat_range: (f64, f64),
+    version_mode: LegendVersionMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     let present: Vec<&Impl> = impls
         .iter()
         .filter(|imp| {
@@ -973,7 +1165,14 @@ pub(crate) fn draw_latency_single_panel(
         )?;
     }
 
-    draw_legend_table(&table_area, &present, cpu, "req CPU%", "rep CPU%")?;
+    draw_legend_table_with_versions(
+        &table_area,
+        &present,
+        cpu,
+        "req CPU%",
+        "rep CPU%",
+        version_mode,
+    )?;
     root.present()?;
     drop(root);
 

--- a/omq-bench/src/chart/main_tcp.rs
+++ b/omq-bench/src/chart/main_tcp.rs
@@ -1,7 +1,8 @@
 use super::common::{
     self, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_CT, C_RZMQ, C_RZMQ_IOURING, C_ZMQRS,
-    Impl, draw_latency_single_panel, draw_throughput_dual_panel,
-    draw_throughput_dual_panel_fixed_2m_msgs, load_latency, load_tput, out_dir,
+    Impl, draw_latency_single_panel_with_versions,
+    draw_throughput_dual_panel_fixed_2m_msgs_with_versions,
+    draw_throughput_dual_panel_with_versions, load_latency, load_tput, out_dir,
 };
 
 const TPUT_SIZES: &[u64] = &[
@@ -140,7 +141,7 @@ pub(crate) fn generate() {
     let (tput, msgs, cpu) = load_tput("throughput", "tcp", None, PUSHPULL_IMPLS);
     if !tput.is_empty() {
         let out = dir.join("main_pushpull_tcp.svg");
-        draw_throughput_dual_panel_fixed_2m_msgs(
+        draw_throughput_dual_panel_fixed_2m_msgs_with_versions(
             &out,
             "PUSH/PULL throughput, TCP loopback, 2-process",
             TPUT_SIZES,
@@ -159,7 +160,7 @@ pub(crate) fn generate() {
     let (tput, msgs, cpu) = load_tput("pub_sub", "tcp", Some(32), PUBSUB_IMPLS);
     if !tput.is_empty() {
         let out = dir.join("main_pubsub_tcp.svg");
-        draw_throughput_dual_panel(
+        draw_throughput_dual_panel_with_versions(
             &out,
             "PUB/SUB throughput (32 peers), TCP loopback, 2-process",
             PUBSUB_SIZES,
@@ -179,7 +180,7 @@ pub(crate) fn generate() {
     if !lat.is_empty() {
         let out = dir.join("main_reqrep_tcp.svg");
         let range = common::auto_lat_range(&lat);
-        draw_latency_single_panel(
+        draw_latency_single_panel_with_versions(
             &out,
             "REQ/REP latency, TCP loopback, 2-process",
             LAT_SIZES,


### PR DESCRIPTION
- Add version-aware legend rendering for main TCP charts.
- Read libzmq via pkg-config and Rust peer versions from checked-in peer Cargo.lock files.
- Regenerate main TCP SVG chart outputs.