### PR TITLE
Allow large IPC PUB messages

### DIFF
--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -172,7 +172,10 @@ impl PeerTransmitSlot {
         }
         let bytes = chunks.iter().map(Bytes::len).sum();
         let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
-        if self.is_full(&eq) || eq.total_bytes().saturating_add(bytes) >= self.cap {
+        let queued_msgs = self.queued_msgs.load(Ordering::Relaxed);
+        if queued_msgs >= self.msg_cap
+            || (queued_msgs > 0 && eq.total_bytes().saturating_add(bytes) >= self.cap)
+        {
             self.above_lwm.store(true, Ordering::Relaxed);
             return TryFrameResult::Full;
         }
@@ -208,8 +211,9 @@ impl PeerTransmitSlot {
         let chunk = fanout_frame_chunk(frame);
         let mut eq = self.eq.lock().expect("transmit_slot eq poisoned");
         let mut queued_msgs = self.queued_msgs.load(Ordering::Relaxed);
-        while eq.total_bytes().saturating_add(chunk.len()) >= self.cap
-            || queued_msgs >= self.msg_cap
+        while queued_msgs > 0
+            && (eq.total_bytes().saturating_add(chunk.len()) >= self.cap
+                || queued_msgs >= self.msg_cap)
         {
             if !eq.pop_front_entry() {
                 self.above_lwm.store(true, Ordering::Relaxed);

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -521,6 +521,29 @@ async fn pub_io_lane_fanout_subscription_filter() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pub_sub_ipc_large_message_exceeds_transmit_slot_cap() {
+    let ep = test_support::ipc_endpoint("pub-sub-large-message");
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    pub_.bind(ep.clone()).await.unwrap();
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    sub.connect(ep).await.unwrap();
+    pub_.wait_subscribed(1, Duration::from_secs(1))
+        .await
+        .expect("subscription did not arrive");
+
+    let body = vec![0x55; 1024 * 1024];
+    pub_.send(Message::single(body.clone())).await.unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+        .await
+        .expect("subscriber timed out")
+        .unwrap();
+    assert_eq!(msg.part_bytes(0).unwrap(), body.as_slice());
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pub_io_lane_fanout_block_on_mute_does_not_block_slow_sub() {
     const SUBS: usize = 6;


### PR DESCRIPTION
- Treat `PeerTransmitSlot` byte cap as queued-backlog cap.
- Let an empty fanout transmit slot accept one oversized encoded message.
- Add IPC `PUB`/`SUB` regression above default transmit slot cap.