### PR TITLE
Release pyomq 0.18.3

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.3] - 2026-07-31
+
+### Changed
+
+- *(deps)* Bump `omq-tokio` to 0.20.2, fixing large byte-stream `PUB`
+  fan-out delivery over IPC and TCP.
+
 ## [0.18.2] - 2026-07-28
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.18.2"
+version = "0.18.3"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.18.2"
+version = "0.18.3"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- Release `pyomq` `0.18.3`.
- Lock `pyomq` to `omq-tokio` `0.20.2`.