### PR TITLE
Add experimental zstd+tcp transport

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -72,11 +72,11 @@ jobs:
           - group: mechanism
             tests: omq_soak_plain omq_soak_curve
           - group: transport
-            tests: omq_soak_ws omq_soak_compression_lz4 omq_soak_pub_sub_lz4_dict omq_soak_large_throughput
+            tests: omq_soak_ws omq_soak_compression_lz4 omq_soak_pub_sub_lz4_dict omq_soak_compression_zstd omq_soak_pub_sub_zstd_dict omq_soak_large_throughput
           - group: runtime
             tests: omq_soak_cancel_safety omq_soak_inproc_cross_thread omq_soak_multi_socket
     env:
-      SOAK_FEATURES: soak plain curve lz4 ws
+      SOAK_FEATURES: soak plain curve lz4 zstd ws
       OMQ_SOAK_DURATION_SECS: ${{ inputs.soak_duration_secs || '180' }}
     steps:
       - uses: actions/checkout@v7

--- a/BENCHMARKS_COMPRESSION.md
+++ b/BENCHMARKS_COMPRESSION.md
@@ -1,44 +1,49 @@
 # Compression Transport Benchmarks
 
 Realistic JSON event-log payloads over TCP loopback (2-process setup).
-LZ4 default compression. Dictionary auto-training is off by default
-(2 KiB capacity when enabled).
+Dictionary auto-training is off by default. When enabled, the default
+dictionary capacity is 2 KiB.
 
 Virtual throughput = msg/s x uncompressed size (effective app data rate
 on a constrained link). Charts show projected throughput at 1 Gbps,
 100 Mbps, and 10 Mbps.
 
-- **Auto-dict off by default:** when enabled, the encoder trains a
-  2 KiB dict from the first 100 messages, ships it once, then uses it
-  for all subsequent compression. Small-message throughput improves
-  significantly with dict.
-- **Pure Rust:** lz4+tcp uses lz4rip, no C compiler required.
+- `lz4+tcp://`: low CPU cost, high message rate, modest wire savings.
+- `zstd+tcp://`: higher CPU cost, better wire ratio. Useful when the
+  link is the bottleneck.
+- Auto-dict: trains once, ships once per direction per connection, then
+  lowers the small-message compression threshold.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/pushpull/lz4_tcp.svg" alt="PUSH/PULL lz4+tcp: projected throughput at link speed" width="850">
 </p>
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/pushpull/zstd_tcp.svg" alt="PUSH/PULL zstd+tcp: projected throughput at link speed" width="850">
+</p>
+
+Wire formats:
+
+- [`lz4+tcp://` RFC](doc/lz4-rfc.md)
+- [`zstd+tcp://` RFC](doc/zstd-rfc.md)
+
 ### Compression thresholds
 
-Messages below a minimum size skip compression entirely and pass
-through as plaintext. The defaults reflect extensive benchmarking
-across link speeds and dict sizes:
+Messages below a minimum size pass through as plaintext.
 
 | Transport | No dict | With dict |
 |-----------|---------|-----------|
 | lz4+tcp   | 512 B   | 64 B      |
+| zstd+tcp  | 512 B   | 64 B      |
 
-Operators on high-bandwidth links who send many small messages can
-raise the threshold further via `Options::compression_threshold()` to
-avoid the CPU overhead of compressing messages that already fit in a
-single packet.
+`Options::compression_threshold()` overrides the transport default.
 
 ### Dict size
 
-When enabled, auto-trained dict capacity defaults to 2 KiB. Benchmarks across dict
-sizes (256 B to 8 KiB) show that a 2 KiB dict captures most of the
-compressible structure in typical JSON payloads. Larger dicts (4-8 KiB)
-produce marginally better wire ratios at 2 KiB+ message sizes but hurt
-throughput at smaller sizes due to L1/L2 cache pressure during
-compression. The default max accepted dict size from a peer is 8 KiB.
+Auto-trained dict capacity defaults to 2 KiB. The receiver accepts at
+most 8 KiB by default.
 
+LZ4 trains from the first 100 messages. Zstd trains after 1000 samples
+or 100 KiB, whichever comes first, ignoring samples larger than 2048
+bytes. Both transports ship at most one dictionary per direction per
+connection.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,7 +132,7 @@ OMQ_FUZZ_ITERS=500000000 cargo test -p omq-tokio --features fuzz --release -- --
 Soak tests cover peer churn, reconnect storms, reconnect all types,
 PUB/SUB churn, ROUTER/DEALER churn, HWM reconnect, WebSocket
 throughput, WebSocket reconnect, large-message throughput, compression
-with lz4, PLAIN, CURVE, multi-socket, inproc cross-thread,
+with lz4/zstd, PLAIN, CURVE, multi-socket, inproc cross-thread,
 and cancel safety.
 
 Set duration with `OMQ_SOAK_DURATION_SECS` (default 600s). `Context::new()`
@@ -141,7 +141,7 @@ dedicated IO threads; `Context::current()` is the explicit current-thread
 Tokio integration mode.
 
 ```sh
-FEATURES="soak lz4 plain curve ws"
+FEATURES="soak lz4 zstd plain curve ws"
 cargo test -p omq-tokio --features "$FEATURES" --release --no-run
 OMQ_SOAK_DURATION_SECS=600 cargo test -p omq-tokio \
   --features "$FEATURES" --release --test omq_soak_peer_churn -- --nocapture

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,15 +24,15 @@ Lints: `missing_debug_implementations` = **deny**,
 cargo test -p omq-tokio
 cargo test -p omq-proto
 cargo test -p yring
-cargo test -p omq-tokio --test req_rep -- some_test_name
+cargo test -p omq-tokio --test omq_req_rep -- some_test_name
 ```
 
 Feature-gated tests:
 
 ```sh
-cargo test -p omq-tokio --features plain     --test plain
-cargo test -p omq-tokio --features curve     --test curve
-cargo test -p omq-tokio --features lz4       --test lz4_tcp --test lz4_pub_sub
+cargo test -p omq-tokio --features plain     --test omq_plain
+cargo test -p omq-tokio --features curve     --test omq_curve
+cargo test -p omq-tokio --features lz4       --test omq_lz4_tcp --test omq_lz4_pub_sub
 ```
 
 Miri target for unsafe internals:
@@ -77,10 +77,11 @@ runs a smaller smoke gate for obvious TCP/inproc regressions. The perf
 gate skips when `CI` or `GITHUB_ACTIONS` is set.
 
 GitHub CI runs `cargo fmt` and clippy on Linux, macOS Intel, macOS
-ARM64, and Windows. It runs workspace tests on Linux x86_64, Linux
-ARM64, macOS Intel, macOS ARM64, Windows, and MSRV 1.93 on Linux.
-Feature jobs cover CURVE and LZ4 on Linux, macOS Intel, macOS ARM64,
-and Windows. macOS test jobs run serially with `--test-threads=1`.
+ARM64, and Windows. It runs workspace tests on Linux x86_64 with MSRV
+1.93, macOS ARM64, and Windows. Feature jobs cover CURVE and LZ4 on
+Linux, macOS ARM64, and Windows. macOS test jobs run serially with
+`--test-threads=1`. PR CI also runs 32-bit Linux cross-checks.
+Extended CI adds Ubuntu ARM64.
 
 ## Continuous Integration
 
@@ -157,7 +158,7 @@ OMQ_SOAK_DURATION_SECS=120 python3 -m pytest tests/soak/ -v --tb=short
 ## Stress Tests
 
 ```sh
-cargo test -p omq-tokio --test stress_connect_before_bind -- --test-threads=1
+cargo test -p omq-tokio --test omq_stress_connect_before_bind -- --test-threads=1
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ OMQ_SOAK_DURATION_SECS=600 cargo test -p omq-tokio \
 
 ## Platform and requirements
 
-**Linux is the primary development and benchmarking platform.** CI
-required checks cover Linux x86_64, Linux ARM64, macOS Intel, macOS
-ARM64, and Windows. macOS jobs run the Rust tests serially because
-socket/timer timing is more sensitive on hosted runners.
+**Linux is the primary development and benchmarking platform.** PR CI
+required checks cover Linux x86_64, macOS ARM64, and Windows Rust tests,
+plus 32-bit Linux cross-checks. Fmt and clippy also run on macOS Intel.
+Extended CI covers Ubuntu ARM64. macOS jobs run the Rust tests serially
+because socket/timer timing is more sensitive on hosted runners.
 
 **macOS** is covered in CI for both Intel and ARM64 runners.
 `omq-tokio` uses mio / kqueue. `omq-libzmq` uses a pipe-backed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 
 - Tokio backend for Linux, macOS, and Windows
 - 20 socket types: stable ZMQ patterns plus draft CLIENT/SERVER, RADIO/DISH, SCATTER/GATHER, CHANNEL/PEER, and STREAM
-- 9 transports: TCP, IPC, inproc, UDP, WS, WSS, `lz4+tcp://`, `lz4+ws://`, and `lz4+wss://`
+- 9 stable transports: TCP, IPC, inproc, UDP, WS, WSS, `lz4+tcp://`,
+  `lz4+ws://`, and `lz4+wss://`; experimental `zstd+tcp://` compression
+  transport behind the `zstd` feature
 - 3 security mechanisms: NULL, PLAIN, CURVE
 - No C compiler, no libzmq, no libsodium
 - Python binding ([pyomq](bindings/pyomq/)), C API ([omq-libzmq](omq-libzmq/))
@@ -103,6 +105,7 @@ TCP / IPC / inproc / UDP, no C compiler required. Enable any of:
 | `plain`           | PLAIN username/password auth (RFC 24)             | -                                |
 | `curve`           | CURVE encrypted-handshake mechanism (RFC 26)      | `crypto_box`, `crypto_secretbox` |
 | `lz4`             | `lz4+tcp://` compression transport ([RFC](doc/lz4-rfc.md)) | `lz4rip` |
+| `zstd`            | Experimental `zstd+tcp://` compression transport  | `zrip`                           |
 | `ws`              | WebSocket (`ws://`) and secure WebSocket (`wss://`) transports | `rustls`, `rustls-native-certs` |
 
 ## Design highlights

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `zstd+tcp://` support in the published wheel feature set.
+- `OMQ_COMPRESSION_LEVEL` / `Socket.compression_level` for zstd levels.
+
 ## [0.18.3] - 2026-07-31
 
 ### Changed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "thiserror",
  "x25519-dalek",
  "zeroize",
+ "zrip",
 ]
 
 [[package]]
@@ -1137,4 +1138,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zrip"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6514da35b51d81bfc515782396980ac909fe46925fd19701b36329ddec46e8"
+dependencies = [
+ "zrip-core",
+ "zrip-decode",
+ "zrip-encode",
+]
+
+[[package]]
+name = "zrip-core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9335acd94c1f09f729178fc339f9d49790254c1e98ba076f88df3a3f534c4e7d"
+
+[[package]]
+name = "zrip-decode"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c26a2ea54a97d013b6f2a430b659fb77e0d5feb0aa3f80cb8c141d6827beba"
+dependencies = [
+ "zrip-core",
+]
+
+[[package]]
+name = "zrip-encode"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e7e22b665b947f0240b44805713e87a15c34e86d0891cbe2856c575c5cda1d"
+dependencies = [
+ "zrip-core",
 ]

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 plain = ["omq-tokio/plain"]
 curve = ["omq-tokio/curve"]
 lz4 = ["omq-tokio/lz4"]
+zstd = ["omq-tokio/zstd"]
 
 [dependencies]
 omq-proto = { path = "../../omq-proto", default-features = false }

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -10,7 +10,7 @@ uv pip install pyomq
 uv pip install 'pyomq[test]'   # adds pytest, pyzmq for the interop suite
 ```
 
-The published wheel includes optional features: plain, curve, lz4.
+The published wheel includes optional features: plain, curve, lz4, zstd.
 Use `pyomq.has("curve")` at runtime to check availability.
 
 Published wheels currently target Linux. Other platforms can build from
@@ -51,7 +51,7 @@ Sync and `asyncio` APIs both ship in this release. All 20 ZMTP socket types are 
 - **Draft**: SERVER, CLIENT (RFC 41), RADIO, DISH (RFC 48), GATHER, SCATTER (RFC 49), PEER, CHANNEL (RFC 51).
 
 Transports: `tcp://`, `ipc://`, `inproc://`, and `udp://` (RADIO/DISH only).
-Optional features built into the wheel: `plain`, `curve`, `lz4`.
+Optional features built into the wheel: `plain`, `curve`, `lz4`, `zstd`.
 
 DISH groups: use `socket.join(b"group")` / `socket.leave(b"group")` to manage
 subscriptions; messages are sent as multipart `[group, body]`.
@@ -92,7 +92,8 @@ Run `scripts/update_perf.py` (after `maturin develop --release`) to re-measure, 
 
 ## Compression transports
 
-OMQ.rs adds a transparent LZ4 compression transport on top of TCP: `lz4+tcp://`.
+OMQ.rs adds transparent compression transports on top of TCP:
+`lz4+tcp://` and experimental `zstd+tcp://`.
 Swap the scheme in your endpoint string and everything else stays the same:
 
 ```python
@@ -103,24 +104,26 @@ pull = ctx.socket(zmq.PULL)
 pull.connect("lz4+tcp://127.0.0.1:5555")
 ```
 
-Both peers must use a matching compression endpoint. Payloads below ~512 B are
-sent as-is (the codec detects that compression would expand them).
+Both peers must use a matching compression endpoint. Payloads below the
+transport threshold are sent as-is when compression would not help.
 
-`lz4+tcp://` supports dictionary auto-training (off by default). When enabled,
-it samples the first 100 outbound messages, builds a 2 KiB dict, and ships it
-to the peer once. After that the compression threshold drops from 512 B to
-128 B, so small structured messages start compressing too. Pure Rust (lz4rip),
-no C compiler required.
+Compression transports support static dictionaries and dictionary
+auto-training (off by default). Auto-training samples outbound messages,
+builds a 2 KiB dict, and ships it once per connection. Static dicts are set
+with `compression_dict`. `zstd+tcp://` also accepts `compression_level`.
+Pure Rust (`lz4rip` / `zrip`), no C compiler required.
 
 Enable it on sockets that send compressible traffic before `bind()`/`connect()`:
 
 ```python
 push.compression_auto_train = 1
 # or: push.setsockopt(zmq.OMQ_COMPRESSION_AUTO_TRAIN, 1)
+push.compression_level = 1  # zstd+tcp only
 ```
 
 See [BENCHMARKS_COMPRESSION.md](https://github.com/paddor/omq.rs/blob/main/BENCHMARKS_COMPRESSION.md) for throughput charts and benchmark details.
-Wire format: [LZ4 transport RFC](https://github.com/paddor/omq.rs/blob/main/doc/lz4-rfc.md).
+Wire formats: [LZ4](https://github.com/paddor/omq.rs/blob/main/doc/lz4-rfc.md),
+[Zstd](https://github.com/paddor/omq.rs/blob/main/doc/zstd-rfc.md).
 
 ## CURVE authentication
 

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -60,7 +60,7 @@ exclude = ["tests/soak/**"]
 
 [tool.maturin]
 # Stable ABI - one wheel covers all supported Python versions.
-features = ["pyo3/abi3-py311", "plain", "curve", "lz4"]
+features = ["pyo3/abi3-py311", "plain", "curve", "lz4", "zstd"]
 # The native module lives at pyomq._native; pyomq itself is a pure
 # Python package re-exporting from it.
 module-name = "pyomq._native"

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -103,6 +103,7 @@ from ._native import (  # type: ignore[attr-defined]  # ty:ignore[unresolved-imp
     CURVE_SERVERKEY,
     # omq-specific options
     OMQ_ON_MUTE,
+    OMQ_COMPRESSION_LEVEL,
     OMQ_COMPRESSION_DICT,
     OMQ_COMPRESSION_AUTO_TRAIN,
     OMQ_ON_MUTE_BLOCK,
@@ -386,6 +387,7 @@ class _SocketOptionsBase:
     curve_secretkey = _SocketOptionDescriptor(CURVE_SECRETKEY)
     curve_serverkey = _SocketOptionDescriptor(CURVE_SERVERKEY)
     on_mute = _SocketOptionDescriptor(OMQ_ON_MUTE)
+    compression_level = _SocketOptionDescriptor(OMQ_COMPRESSION_LEVEL)
     compression_dict = _SocketOptionDescriptor(OMQ_COMPRESSION_DICT)
     compression_auto_train = _SocketOptionDescriptor(OMQ_COMPRESSION_AUTO_TRAIN)
     sndbuf = _SocketOptionDescriptor(SNDBUF)
@@ -1339,6 +1341,7 @@ __all__ = [
     "CURVE_SECRETKEY",
     "CURVE_SERVERKEY",
     "OMQ_ON_MUTE",
+    "OMQ_COMPRESSION_LEVEL",
     "OMQ_COMPRESSION_DICT",
     "OMQ_COMPRESSION_AUTO_TRAIN",
     "OMQ_ON_MUTE_BLOCK",

--- a/bindings/pyomq/src/constants.rs
+++ b/bindings/pyomq/src/constants.rs
@@ -64,6 +64,7 @@ pub const CURVE_SERVERKEY: i32 = 50;
 
 // omq-specific options (no libzmq equivalent):
 pub const OMQ_ON_MUTE: i32 = 1004;
+pub const OMQ_COMPRESSION_LEVEL: i32 = 1005;
 pub const OMQ_COMPRESSION_DICT: i32 = 1006;
 pub const OMQ_COMPRESSION_AUTO_TRAIN: i32 = 1007;
 
@@ -161,6 +162,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
         CURVE_SECRETKEY,
         CURVE_SERVERKEY,
         OMQ_ON_MUTE,
+        OMQ_COMPRESSION_LEVEL,
         OMQ_COMPRESSION_DICT,
         OMQ_COMPRESSION_AUTO_TRAIN,
         OMQ_ON_MUTE_BLOCK,

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -162,6 +162,8 @@ fn has_feature(name: &str) -> bool {
         "plain" => true,
         #[cfg(feature = "lz4")]
         "lz4" => true,
+        #[cfg(feature = "zstd")]
+        "zstd" => true,
         _ => false,
     }
 }

--- a/bindings/pyomq/src/options.rs
+++ b/bindings/pyomq/src/options.rs
@@ -24,6 +24,9 @@ use crate::constants;
 use crate::error::{map_err, not_implemented};
 use omq_tokio as backend;
 
+const ZSTD_LEVEL_MIN: i32 = -8;
+const ZSTD_LEVEL_MAX: i32 = 4;
+
 #[cfg(feature = "curve")]
 fn bad_key(name: &str) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(format!("invalid {name}"))
@@ -68,6 +71,7 @@ pub struct Overlay {
     #[cfg(feature = "curve")]
     pub curve_authenticator: Option<crate::auth::CurveAuthenticator>,
     pub on_mute: OnMute,
+    pub compression_level: Option<i32>,
     pub compression_dict: Option<Bytes>,
     pub compression_auto_train: bool,
     pub reconnect_stop: i32,
@@ -107,6 +111,7 @@ impl Default for Overlay {
             #[cfg(feature = "curve")]
             curve_authenticator: None,
             on_mute: OnMute::Block,
+            compression_level: None,
             compression_dict: None,
             compression_auto_train: false,
             reconnect_stop: 0,
@@ -140,6 +145,7 @@ impl Overlay {
                 (Some(min), Some(max)) => ReconnectPolicy::Exponential { min, max },
             },
             on_mute: self.on_mute,
+            compression_level: self.compression_level,
             compression_dict: self.compression_dict.clone(),
             compression_auto_train: self.compression_auto_train,
             arena_threshold: Some(64 * 1024),
@@ -231,6 +237,7 @@ impl Overlay {
             #[cfg(feature = "curve")]
             curve_authenticator: None,
             on_mute: o.on_mute,
+            compression_level: o.compression_level,
             compression_dict: o.compression_dict.clone(),
             compression_auto_train: o.compression_auto_train,
             reconnect_stop: i32::from(o.reconnect_stop_conn_refused),
@@ -441,12 +448,21 @@ pub fn setsockopt(
                 }
             };
         }
+        constants::OMQ_COMPRESSION_LEVEL => {
+            let level = value.extract::<i32>()?;
+            if !(ZSTD_LEVEL_MIN..=ZSTD_LEVEL_MAX).contains(&level) {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "zstd compression level must be {ZSTD_LEVEL_MIN}..={ZSTD_LEVEL_MAX}, got {level}"
+                )));
+            }
+            ov.compression_level = Some(level);
+        }
         constants::OMQ_COMPRESSION_DICT => {
             let v: &[u8] = value.extract()?;
             if v.is_empty() {
                 ov.compression_dict = None;
             } else {
-                const DICT_MAX: usize = 64 * 1024 - 4;
+                const DICT_MAX: usize = 8 * 1024;
                 if v.len() > DICT_MAX {
                     return Err(pyo3::exceptions::PyValueError::new_err(format!(
                         "compression dict must be at most {DICT_MAX} bytes, got {}",
@@ -708,6 +724,10 @@ pub fn getsockopt<'py>(
                 OnMute::DropOldest => 2,
                 _ => unreachable!(),
             };
+            Ok(int_to_bound(py, v))
+        }
+        constants::OMQ_COMPRESSION_LEVEL => {
+            let v = sock.overlay.lock().unwrap().compression_level.unwrap_or(0) as i64;
             Ok(int_to_bound(py, v))
         }
         constants::OMQ_COMPRESSION_DICT => {

--- a/bindings/pyomq/tests/test_compression.py
+++ b/bindings/pyomq/tests/test_compression.py
@@ -1,0 +1,82 @@
+"""Compression transport smoke tests."""
+
+import pytest
+
+import pyomq as zmq
+
+pytestmark = pytest.mark.skipif(not zmq.has("zstd"), reason="zstd feature not compiled")
+
+ZSTD_DICT = bytes.fromhex(
+    "37a430ecbeaadd5c811120841042664644444444244902002114c418638c21841042"
+    "082184104208214444444444444444240900005110638c31c618630c21c418636666"
+    "864692040080000000c000000000010000"
+)
+
+
+def _zstd(endpoint: str) -> str:
+    return endpoint.replace("tcp://", "zstd+tcp://", 1)
+
+
+def _payload(seq: int, size: int = 1024) -> bytes:
+    head = f'{{"kind":"quote","symbol":"OMQ","seq":{seq},"pad":"'.encode()
+    tail = b'"}'
+    return head + (b"A" * (size - len(head) - len(tail))) + tail
+
+
+def test_zstd_push_pull_custom_level(tcp_endpoint):
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    try:
+        pull.rcvtimeo = 2000
+        push.compression_level = 1
+        assert push.compression_level == 1
+        ep = pull.bind(_zstd(tcp_endpoint))
+        push.connect(ep)
+        msg = _payload(1, 4096)
+        push.send(msg)
+        assert pull.recv() == msg
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_zstd_push_pull_static_dict(tcp_endpoint):
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    try:
+        pull.rcvtimeo = 2000
+        push.compression_level = 1
+        push.compression_dict = ZSTD_DICT
+        assert push.compression_dict == ZSTD_DICT
+        ep = pull.bind(_zstd(tcp_endpoint))
+        push.connect(ep)
+        msg = _payload(2)
+        push.send(msg)
+        assert pull.recv() == msg
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_zstd_push_pull_auto_train(tcp_endpoint):
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    try:
+        pull.rcvtimeo = 2000
+        push.compression_auto_train = 1
+        assert push.compression_auto_train == 1
+        ep = pull.bind(_zstd(tcp_endpoint))
+        push.connect(ep)
+        messages = [_payload(i) for i in range(130)]
+        for msg in messages:
+            push.send(msg)
+        assert [pull.recv() for _ in messages] == messages
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -283,7 +283,7 @@ def test_has_feature():
     assert zmq.has("pgm") is False
     assert isinstance(zmq.has("curve"), bool)
     assert isinstance(zmq.has("lz4"), bool)
-    assert zmq.has("zstd") is False
+    assert zmq.has("zstd") is True
     assert isinstance(zmq.has("plain"), bool)
     assert zmq.has("gssapi") is False
     assert zmq.has("INPROC") is True
@@ -333,10 +333,34 @@ def test_compression_dict_round_trip():
         ctx.term()
 
 
+def test_compression_level_round_trip():
+    ctx, s = _push()
+    try:
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_LEVEL) == 0
+        s.setsockopt(zmq.OMQ_COMPRESSION_LEVEL, 1)
+        assert s.getsockopt(zmq.OMQ_COMPRESSION_LEVEL) == 1
+        s.compression_level = 3
+        assert s.compression_level == 3
+    finally:
+        s.close()
+        ctx.term()
+
+
+def test_compression_level_rejects_invalid():
+    ctx, s = _push()
+    try:
+        for level in (-9, 5):
+            with pytest.raises((zmq.ZMQError, ValueError)):
+                s.setsockopt(zmq.OMQ_COMPRESSION_LEVEL, level)
+    finally:
+        s.close()
+        ctx.term()
+
+
 def test_compression_dict_rejects_oversize():
     ctx, s = _push()
     try:
-        oversize = b"\x00" * (64 * 1024)
+        oversize = b"\x00" * (8 * 1024 + 1)
         with pytest.raises((zmq.ZMQError, ValueError)):
             s.setsockopt(zmq.OMQ_COMPRESSION_DICT, oversize)
     finally:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -315,7 +315,7 @@ round-robin sends with no ready pipe mute.
 ## Mechanisms And Monitoring
 
 Mechanisms live under `omq-proto/src/proto/mechanism/`: NULL is always on;
-PLAIN, CURVE, LZ4, and WS are feature-gated.
+PLAIN and CURVE are feature-gated. LZ4 and WS are transport features.
 
 `Socket::monitor()` returns a `Stream<Item = MonitorEvent>`. Events carry owned
 `PeerInfo` snapshots for listening, accept/connect, delayed connect,

--- a/doc/charts/pushpull/zstd_tcp.svg
+++ b/doc/charts/pushpull/zstd_tcp.svg
@@ -1,0 +1,2641 @@
+<svg viewBox="0 0 800 1094" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="800" height="1094" opacity="1" fill="#000000" stroke="none"/>
+<text x="400" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUSH/PULL Zstd L1 compression, structural JSON payload, 2 KiB dict, TCP loopback, 2-process</text>
+<text x="400" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 6 cores, performance governor, turbo off</text>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="307" x2="80" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="172" y1="307" x2="172" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="264" y1="307" x2="264" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="357" y1="307" x2="357" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="449" y1="307" x2="449" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="542" y1="307" x2="542" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="634" y1="307" x2="634" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="727" y1="307" x2="727" y2="62"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="307" x2="727" y2="307"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="267" x2="727" y2="267"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="226" x2="727" y2="226"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="185" x2="727" y2="185"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="144" x2="727" y2="144"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="103" x2="727" y2="103"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="62" x2="727" y2="62"/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,62 79,307 "/>
+<text x="70" y="307" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,307 79,307 "/>
+<text x="70" y="267" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,267 79,267 "/>
+<text x="70" y="226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,226 79,226 "/>
+<text x="70" y="185" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,185 79,185 "/>
+<text x="70" y="144" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,144 79,144 "/>
+<text x="70" y="103" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,103 79,103 "/>
+<text x="70" y="62" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,62 79,62 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,308 727,308 "/>
+<text x="80" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,308 80,313 "/>
+<text x="172" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="172,308 172,313 "/>
+<text x="264" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="264,308 264,313 "/>
+<text x="357" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="357,308 357,313 "/>
+<text x="449" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="449,308 449,313 "/>
+<text x="542" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="542,308 542,313 "/>
+<text x="634" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="634,308 634,313 "/>
+<text x="727" y="318" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="727,308 727,313 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,62 728,308 "/>
+<text x="738" y="308" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,308 733,308 "/>
+<text x="738" y="267" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+100 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,267 733,267 "/>
+<text x="738" y="226" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+200 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,226 733,226 "/>
+<text x="738" y="185" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+300 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,185 733,185 "/>
+<text x="738" y="144" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+400 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,144 733,144 "/>
+<text x="738" y="103" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+500 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,103 733,103 "/>
+<text x="738" y="62" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+600 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,62 733,62 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,148 84,153 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="85,155 89,160 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="91,162 95,167 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="96,169 100,174 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="102,177 106,181 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,184 111,188 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="113,191 117,196 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="118,198 122,203 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="124,205 127,210 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="129,212 133,217 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="135,219 138,224 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="140,227 144,231 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="146,234 149,238 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="151,241 155,246 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="157,248 160,253 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="162,255 166,260 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="168,262 171,267 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,269 179,270 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="182,271 188,273 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="191,274 197,276 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="199,277 205,279 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="208,280 214,282 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="216,283 222,284 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="225,285 231,287 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="234,288 239,290 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="242,291 248,293 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="251,294 256,296 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="259,296 264,298 265,298 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="268,298 274,299 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="277,299 283,299 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="286,300 292,300 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="295,300 301,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="304,301 310,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="313,302 319,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="322,302 328,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="331,303 337,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="340,304 346,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,304 355,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,305 364,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,305 373,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,305 382,306 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,306 391,306 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,306 400,306 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,306 409,306 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,306 418,306 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,306 427,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="430,307 436,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="439,307 445,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="448,307 449,307 454,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="457,307 463,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="466,307 472,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="475,307 481,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="484,307 490,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="493,307 499,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="502,307 508,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="511,307 517,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="520,307 526,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="529,307 535,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="538,307 542,307 544,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="547,307 553,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="556,307 562,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="565,307 571,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="574,307 580,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="583,307 589,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="592,307 598,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="601,307 607,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="610,307 616,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="619,307 625,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="628,307 634,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="637,307 643,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="646,307 652,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="655,307 661,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="664,307 670,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="673,307 679,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="682,307 688,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="691,307 697,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="700,307 706,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="709,307 715,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="718,307 724,307 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="727,307 727,307 "/>
+<circle cx="80" cy="148" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="268" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="298" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="305" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="307" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="307" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="307" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="307" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,269 86,269 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,269 95,270 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,270 104,270 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,270 113,271 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,271 122,271 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,271 131,272 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,272 140,272 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,272 149,273 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,273 158,273 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,273 167,274 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,274 172,274 176,275 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="179,276 184,277 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="187,278 193,280 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="196,280 202,282 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="205,283 211,284 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="213,285 219,286 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="222,287 228,289 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="231,289 237,291 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="240,292 245,293 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="248,294 254,295 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="257,296 263,298 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="266,298 272,299 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="275,299 281,299 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="284,299 290,300 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="293,300 299,301 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="302,301 308,301 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="311,302 317,302 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="320,302 326,303 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="329,303 335,303 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="338,304 344,304 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="347,304 353,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="356,305 357,305 362,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="365,305 371,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="374,305 380,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="383,306 389,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="392,306 398,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="401,306 407,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="410,306 416,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="419,306 425,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="428,307 434,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="437,307 443,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="446,307 449,307 452,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="455,307 461,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="464,307 470,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="473,307 479,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="482,307 488,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="491,307 497,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="500,307 506,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="509,307 515,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="518,307 524,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="527,307 533,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="536,307 542,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="545,307 551,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="554,307 560,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="563,307 569,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="572,307 578,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="581,307 587,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="590,307 596,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="599,307 605,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="608,307 614,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="617,307 623,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="626,307 632,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="635,307 641,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="644,307 650,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="653,307 659,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="662,307 668,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="671,307 677,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="680,307 686,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="689,307 695,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="698,307 704,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="707,307 713,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="716,307 722,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="725,307 727,307 "/>
+<circle cx="80" cy="269" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="274" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="298" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="305" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,272 86,274 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="89,274 94,276 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="97,277 103,278 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="106,279 112,281 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="115,281 121,283 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="123,284 129,285 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="132,286 138,288 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="141,289 147,290 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="149,291 155,292 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="158,293 164,295 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="167,296 172,297 173,297 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="176,297 182,298 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="185,298 191,298 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="194,298 200,299 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="203,299 209,299 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="212,299 218,299 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="221,300 227,300 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="230,300 236,300 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="239,301 245,301 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="248,301 254,301 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="257,302 263,302 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="266,302 272,302 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="275,302 281,303 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="284,303 290,303 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="293,303 299,303 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="302,303 308,303 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="311,304 317,304 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="319,304 325,304 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="328,304 334,304 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="337,304 343,305 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="346,305 352,305 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="355,305 357,305 361,305 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="364,305 370,305 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="373,305 379,305 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="382,306 388,306 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="391,306 397,306 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="400,306 406,306 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="409,306 415,306 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="418,306 424,306 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="427,307 433,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="436,307 442,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="445,307 449,307 451,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="454,307 460,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="463,307 469,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="472,307 478,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="481,307 487,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="490,307 496,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="499,307 505,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="508,307 514,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="517,307 523,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="526,307 532,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="535,307 541,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="544,307 550,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="553,307 559,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="562,307 568,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="571,307 577,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="580,307 586,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="589,307 595,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="598,307 604,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="607,307 613,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="616,307 622,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="625,307 631,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="634,307 640,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="643,307 649,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="652,307 658,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="661,307 667,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="670,307 676,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="679,307 685,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="688,307 694,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="697,307 703,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="706,307 712,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="715,307 721,307 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="724,307 727,307 "/>
+<circle cx="80" cy="272" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="297" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="302" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="305" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="307" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="307" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="307" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="307" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="80,189 82,190 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="84,192 86,193 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="88,195 90,196 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="92,197 94,199 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="97,200 98,201 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="101,203 102,204 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="105,206 106,207 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="109,209 111,210 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="113,212 115,213 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="117,214 119,216 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="121,217 123,218 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="125,220 127,221 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="130,223 131,224 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="134,226 135,227 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="138,229 139,230 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="142,231 144,233 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="146,234 148,235 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="150,237 152,238 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="154,240 156,241 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="158,243 160,244 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="163,246 164,247 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="167,248 168,249 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="171,251 172,252 172,252 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="175,253 177,254 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="180,255 182,256 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="184,257 186,258 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="189,259 191,260 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="194,261 195,262 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="198,263 200,264 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="203,265 205,266 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="207,267 209,268 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="212,269 214,270 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="216,271 218,272 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="221,273 223,274 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="226,275 227,276 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="230,277 232,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="235,279 237,280 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="239,281 241,282 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="244,283 246,284 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="249,285 250,286 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="253,287 255,288 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="258,289 260,290 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="262,291 264,292 264,292 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="267,292 269,292 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="272,293 274,293 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="277,293 279,293 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="282,294 284,294 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="287,294 289,294 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="292,295 294,295 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="297,295 299,295 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="302,296 304,296 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="307,296 309,296 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="312,297 314,297 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="317,297 319,297 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="322,298 324,298 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="327,298 329,298 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="332,299 334,299 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="337,299 339,299 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="342,300 344,300 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="347,300 349,300 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="352,300 354,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="357,301 357,301 359,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="362,301 364,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="367,301 369,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="372,301 374,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="377,301 379,301 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="382,302 384,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="387,302 389,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="392,302 394,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="397,302 399,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="402,302 404,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="407,302 409,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="412,302 414,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="417,302 419,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="422,302 424,302 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="427,303 429,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="432,303 434,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="437,303 439,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="442,303 444,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="447,303 449,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="452,303 454,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="457,303 459,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="462,303 464,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="467,303 469,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="472,303 474,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="477,303 479,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="482,303 484,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="487,303 489,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="492,303 494,303 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="497,304 499,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="502,304 504,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="507,304 509,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="512,304 514,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="517,304 519,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="522,304 524,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="527,304 529,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="532,304 534,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="537,304 539,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="542,304 542,304 544,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="547,304 549,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="552,304 554,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="557,304 559,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="562,304 564,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="567,304 569,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="572,304 574,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="577,304 579,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="582,304 584,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="587,304 589,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="592,304 594,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="597,304 599,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="602,304 604,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="607,304 609,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="612,304 614,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="617,304 619,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="622,304 624,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="627,304 629,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="632,304 634,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="637,304 639,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="642,304 644,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="647,304 649,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="652,304 654,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="657,304 659,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="662,304 664,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="667,304 669,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="672,304 674,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="677,304 679,304 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="682,305 684,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="687,305 689,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="692,305 694,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="697,305 699,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="702,305 704,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="707,305 709,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="712,305 714,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="717,305 719,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="722,305 724,305 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="727,305 727,305 "/>
+<text x="80" y="189" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+97%
+</text>
+<text x="172" y="252" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+45%
+</text>
+<text x="264" y="292" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+13%
+</text>
+<text x="357" y="301" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+5%
+</text>
+<text x="449" y="303" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+3%
+</text>
+<text x="542" y="304" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+3%
+</text>
+<text x="634" y="304" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+2%
+</text>
+<text x="727" y="305" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+2%
+</text>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="80,161 82,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="85,161 87,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="90,161 92,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="95,161 97,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="100,161 102,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="105,161 107,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="110,161 112,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="115,161 117,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="120,161 122,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="125,161 127,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="130,162 132,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="135,162 137,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="140,162 142,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="145,162 147,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="150,162 152,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="155,162 157,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="160,162 162,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="165,162 167,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="170,162 172,162 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="174,164 175,166 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="177,168 179,169 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="181,172 182,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="184,175 186,177 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="188,179 189,180 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="191,183 192,184 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="194,186 196,188 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="198,190 199,191 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="201,193 203,195 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="205,197 206,199 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="208,201 209,202 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="211,204 213,206 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="215,208 216,210 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="218,212 220,213 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="222,215 223,217 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="225,219 226,221 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="228,223 230,224 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="232,226 233,228 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="235,230 237,232 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="239,234 240,235 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="242,237 243,239 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="246,241 247,243 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="249,245 250,246 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="252,248 254,250 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="256,252 257,254 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="259,256 260,257 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="263,259 264,261 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="266,259 268,258 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="270,256 271,255 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="274,253 275,251 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="278,249 279,248 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="281,246 283,245 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="285,243 287,242 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="289,240 290,238 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="293,236 294,235 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="296,233 298,232 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="300,230 302,228 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="304,227 306,225 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="308,223 309,222 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="312,220 313,219 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="315,217 317,215 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="319,213 321,212 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="323,210 325,209 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="327,207 328,206 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="331,204 332,202 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="334,200 336,199 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="338,197 340,196 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="342,194 343,193 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="346,191 347,189 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="350,187 351,186 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="353,184 355,183 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="357,181 359,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="362,181 364,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="367,181 369,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="372,181 374,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="377,181 379,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="382,181 384,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="387,181 389,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="392,181 394,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="397,181 399,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="402,181 404,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="407,181 409,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="412,181 414,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="417,181 419,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="422,181 424,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="427,181 429,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="432,181 434,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="437,181 439,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="442,181 444,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="447,181 449,181 449,181 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="451,179 452,177 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="454,175 455,173 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="457,171 458,169 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="460,167 461,165 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="463,163 465,161 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="466,159 468,157 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="469,155 471,153 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="473,151 474,149 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="476,147 477,145 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="479,143 480,141 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="482,139 483,138 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="485,135 486,134 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="488,131 489,130 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="491,127 492,126 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="494,123 495,122 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="497,119 498,118 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="500,115 501,114 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="503,112 505,110 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="506,108 508,106 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="509,104 511,102 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="513,100 514,98 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="516,96 517,94 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="519,92 520,90 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="522,88 523,86 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="525,84 526,82 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="528,80 529,78 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="531,76 532,74 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="534,72 535,71 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="537,68 538,67 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="540,64 541,63 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="544,63 546,63 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="549,64 551,64 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="554,65 556,65 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="559,66 561,67 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="563,67 565,68 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="568,69 570,69 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="573,70 575,70 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="578,71 580,71 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="583,72 585,73 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="588,73 590,74 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="593,75 595,75 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="597,76 599,76 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="602,77 604,78 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="607,78 609,79 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="612,79 614,80 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="617,81 619,81 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="622,82 624,82 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="627,83 628,84 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="631,84 633,85 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="636,86 637,88 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="640,90 641,91 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="644,93 645,94 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="648,96 649,97 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="651,99 653,100 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="655,102 657,103 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="659,105 661,106 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="663,108 665,109 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="667,111 669,113 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="671,114 673,116 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="675,118 676,119 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="679,121 680,122 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="683,124 684,125 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="687,127 688,128 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="691,130 692,131 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="694,133 696,134 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="698,136 700,137 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="702,139 704,141 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="706,142 708,144 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="710,146 712,147 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="714,149 716,150 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="718,152 720,153 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="722,155 723,156 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="726,158 727,159 "/>
+<text x="80" y="161" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+120%
+</text>
+<text x="172" y="162" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+119%
+</text>
+<text x="264" y="261" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+38%
+</text>
+<text x="357" y="181" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+103%
+</text>
+<text x="449" y="181" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+103%
+</text>
+<text x="542" y="62" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+279%
+</text>
+<text x="634" y="85" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+182%
+</text>
+<text x="727" y="159" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+121%
+</text>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="80,172 82,172 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="85,172 87,172 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="90,172 92,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="95,171 97,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="100,171 102,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="105,171 107,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="110,171 112,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="115,170 117,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="120,170 122,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="125,170 127,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="130,170 132,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="135,170 137,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="140,169 142,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="145,169 147,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="150,169 152,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="155,169 157,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="160,169 162,168 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="165,168 167,168 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="170,168 172,168 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="175,168 177,168 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="180,169 182,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="185,169 187,169 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="190,170 192,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="195,170 197,170 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="200,171 202,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="205,171 207,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="210,172 212,172 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="215,172 217,172 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="220,173 222,173 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="225,173 227,173 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="230,174 232,174 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="235,174 237,174 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="240,175 242,175 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="245,175 247,175 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="250,176 252,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="255,176 257,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="259,177 261,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="264,177 266,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="269,177 271,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="274,177 276,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="279,177 281,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="284,177 286,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="289,177 291,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="294,177 296,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="299,177 301,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="304,177 306,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="309,177 311,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="314,176 316,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="319,176 321,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="324,176 326,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="329,176 331,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="334,176 336,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="339,176 341,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="344,176 346,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="349,176 351,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="354,176 356,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="359,176 361,176 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="364,176 366,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="369,177 371,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="374,177 376,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="379,177 381,177 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="384,177 386,178 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="389,178 391,178 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="394,178 396,178 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="399,178 401,178 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="404,179 406,179 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="409,179 411,179 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="414,179 416,179 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="419,179 421,179 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="424,180 426,180 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="429,180 431,180 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="434,180 436,180 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="439,180 441,181 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="444,181 446,181 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="449,181 450,179 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="452,177 454,175 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="455,173 457,171 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="458,169 460,167 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="462,165 463,163 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="465,161 466,159 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="468,157 469,156 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="471,153 472,152 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="474,149 475,148 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="477,145 478,144 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="480,141 481,140 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="483,137 484,136 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="486,133 487,132 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="489,130 490,128 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="492,126 494,124 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="495,122 497,120 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="498,118 500,116 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="502,114 503,112 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="505,110 506,108 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="508,106 509,104 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="511,102 512,100 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="514,98 515,96 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="517,94 518,92 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="520,90 521,89 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="523,86 524,85 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="526,82 527,81 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="529,78 530,77 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="532,74 534,73 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="535,70 537,69 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="538,66 540,65 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="542,63 542,62 543,62 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="546,63 548,63 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="551,64 553,64 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="556,64 558,65 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="561,65 563,66 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="566,66 568,67 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="571,67 573,67 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="576,68 578,68 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="581,69 583,69 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="586,70 588,70 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="591,70 593,71 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="595,71 597,72 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="600,72 602,73 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="605,73 607,73 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="610,74 612,74 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="615,75 617,75 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="620,76 622,76 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="625,76 627,77 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="630,77 632,78 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="635,79 636,80 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="638,82 640,83 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="642,85 644,87 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="646,89 647,90 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="650,92 651,93 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="653,95 655,96 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="657,98 659,100 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="661,102 662,103 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="665,105 666,106 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="668,108 670,110 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="672,112 674,113 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="676,115 677,116 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="680,118 681,120 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="683,122 685,123 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="687,125 689,126 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="691,128 692,130 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="695,132 696,133 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="698,135 700,136 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="702,138 704,139 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="706,141 707,143 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="710,145 711,146 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="713,148 715,149 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="717,151 719,153 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="721,155 722,156 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="725,158 726,159 "/>
+<text x="80" y="172" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+110%
+</text>
+<text x="172" y="168" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+114%
+</text>
+<text x="264" y="177" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+106%
+</text>
+<text x="357" y="176" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+107%
+</text>
+<text x="449" y="181" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+103%
+</text>
+<text x="542" y="62" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+334%
+</text>
+<text x="634" y="78" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+187%
+</text>
+<text x="727" y="160" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+120%
+</text>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,257 172,257 265,257 357,257 450,257 542,257 635,257 728,257 "/>
+<circle cx="80" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="257" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,296 172,265 265,258 357,261 450,232 542,74 635,116 728,186 "/>
+<circle cx="80" cy="296" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="265" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="258" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="261" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="232" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="74" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="116" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="186" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,297 172,294 265,279 357,250 450,232 542,86 635,141 728,197 "/>
+<circle cx="80" cy="297" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="294" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="279" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="250" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="232" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="86" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="141" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="197" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="647" x2="80" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="172" y1="647" x2="172" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="264" y1="647" x2="264" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="357" y1="647" x2="357" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="449" y1="647" x2="449" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="542" y1="647" x2="542" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="634" y1="647" x2="634" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="727" y1="647" x2="727" y2="402"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="647" x2="727" y2="647"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="607" x2="727" y2="607"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="566" x2="727" y2="566"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="525" x2="727" y2="525"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="484" x2="727" y2="484"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="443" x2="727" y2="443"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="402" x2="727" y2="402"/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,402 79,647 "/>
+<text x="70" y="647" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,647 79,647 "/>
+<text x="70" y="607" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+200K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,607 79,607 "/>
+<text x="70" y="566" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+400K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,566 79,566 "/>
+<text x="70" y="525" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+600K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,525 79,525 "/>
+<text x="70" y="484" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+800K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,484 79,484 "/>
+<text x="70" y="443" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,443 79,443 "/>
+<text x="70" y="402" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.2M/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,402 79,402 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,648 727,648 "/>
+<text x="80" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,648 80,653 "/>
+<text x="172" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="172,648 172,653 "/>
+<text x="264" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="264,648 264,653 "/>
+<text x="357" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="357,648 357,653 "/>
+<text x="449" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="449,648 449,653 "/>
+<text x="542" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="542,648 542,653 "/>
+<text x="634" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="634,648 634,653 "/>
+<text x="727" y="658" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="727,648 727,653 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,402 728,648 "/>
+<text x="738" y="648" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,648 733,648 "/>
+<text x="738" y="607" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,607 733,607 "/>
+<text x="738" y="566" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+20 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,566 733,566 "/>
+<text x="738" y="525" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+30 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,525 733,525 "/>
+<text x="738" y="484" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+40 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,484 733,484 "/>
+<text x="738" y="443" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+50 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,443 733,443 "/>
+<text x="738" y="402" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+60 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,402 733,402 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,488 84,493 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="85,495 89,500 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="91,502 95,507 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="96,509 100,514 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="102,517 106,521 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,524 111,528 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="113,531 117,536 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="118,538 122,543 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="124,545 127,550 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="129,552 133,557 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="135,559 138,564 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="140,567 144,571 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="146,574 149,578 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="151,581 155,586 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="157,588 160,593 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="162,595 166,600 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="168,602 171,607 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,609 179,610 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="182,611 188,613 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="191,614 197,616 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="199,617 205,619 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="208,620 214,622 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="216,623 222,624 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="225,625 231,627 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="234,628 239,630 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="242,631 248,633 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="251,634 256,636 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="259,636 264,638 265,638 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="268,638 274,639 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="277,639 283,639 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="286,640 292,640 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="295,640 301,641 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="304,641 310,641 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="313,642 319,642 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="322,642 328,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="331,643 337,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="340,644 346,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,644 355,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,645 364,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,645 373,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,645 382,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,646 391,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,646 400,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,646 409,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,646 418,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,646 427,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="430,647 436,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="439,647 445,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="448,647 449,647 454,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="457,647 463,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="466,647 472,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="475,647 481,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="484,647 490,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="493,647 499,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="502,647 508,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="511,647 517,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="520,647 526,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="529,647 535,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="538,647 542,647 544,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="547,647 553,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="556,647 562,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="565,647 571,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="574,647 580,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="583,647 589,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="592,647 598,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="601,647 607,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="610,647 616,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="619,647 625,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="628,647 634,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="637,647 643,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="646,647 652,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="655,647 661,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="664,647 670,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="673,647 679,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="682,647 688,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="691,647 697,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="700,647 706,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="709,647 715,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="718,647 724,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="727,647 727,647 "/>
+<circle cx="80" cy="488" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="608" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="638" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="645" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="647" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="647" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="647" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="647" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,520 84,524 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="86,526 91,530 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="93,533 97,537 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="99,539 104,543 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="106,545 110,549 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,551 116,556 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="119,558 123,562 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,564 129,568 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="131,570 136,575 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="138,577 142,581 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="144,583 149,587 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="151,589 155,593 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="157,596 161,600 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="164,602 168,606 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,608 172,610 175,611 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="178,612 184,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="187,614 192,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="195,617 201,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="204,620 210,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="212,622 218,624 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="221,625 227,627 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="230,628 235,629 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="238,630 244,632 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="247,633 253,635 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="256,635 261,637 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="264,638 270,638 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="273,638 279,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="282,639 288,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="291,639 297,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="300,640 306,640 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="309,640 315,640 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="318,640 324,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="327,641 333,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="336,641 342,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="345,641 351,642 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,642 357,642 360,642 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,642 369,642 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,642 378,643 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,643 387,643 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,643 396,643 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,643 405,644 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,644 414,644 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="417,644 423,644 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="426,644 432,644 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="435,645 441,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="444,645 449,645 450,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="453,645 459,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="462,645 468,645 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="471,645 477,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="480,646 486,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="489,646 495,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="498,646 504,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="507,646 513,646 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="516,646 522,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="525,647 531,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="534,647 540,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="543,647 549,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="552,647 558,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="561,647 567,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="570,647 576,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="579,647 585,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="588,647 594,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="597,647 603,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="606,647 612,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,647 621,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="624,647 630,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="633,647 634,647 639,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="642,647 648,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="651,647 657,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="660,647 666,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="669,647 675,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="678,647 684,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="687,647 693,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="696,647 702,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="705,647 711,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="714,647 720,647 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="723,647 727,647 "/>
+<circle cx="80" cy="520" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="610" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="638" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="642" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="645" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="647" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="647" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="647" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,520 85,523 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="88,524 93,527 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="96,529 101,531 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="104,533 109,536 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="112,537 117,540 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="120,541 125,544 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="127,546 133,549 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="135,550 141,553 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="143,554 149,557 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="151,559 156,562 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="159,563 164,566 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="167,567 172,570 172,570 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="175,572 180,575 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="183,576 188,579 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="190,581 196,584 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="198,585 203,588 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="206,590 211,593 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="214,594 219,597 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="221,599 227,602 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="229,604 234,607 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="237,608 242,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="245,613 250,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="252,617 258,620 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="260,622 264,624 266,624 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="269,625 274,626 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="277,626 283,628 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="286,628 292,629 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="295,630 301,631 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="304,631 310,632 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="313,633 319,634 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="322,635 328,636 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="331,636 336,637 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="339,638 345,639 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="348,639 354,640 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="357,641 363,641 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="366,641 372,642 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="375,642 381,642 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="384,642 390,642 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="393,643 399,643 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="402,643 408,643 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="411,643 417,644 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="420,644 426,644 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="429,644 435,644 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="438,645 444,645 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="447,645 449,645 453,645 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="456,645 462,645 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="465,645 471,645 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="474,646 480,646 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="483,646 489,646 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="492,646 498,646 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="501,646 507,646 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="510,646 516,646 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="519,647 525,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="528,647 534,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="537,647 542,647 543,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="546,647 552,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="555,647 561,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="564,647 570,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="573,647 579,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="582,647 588,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="591,647 597,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="600,647 606,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="609,647 615,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="618,647 624,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="627,647 633,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="636,647 642,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="645,647 651,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="654,647 660,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="663,647 669,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="672,647 678,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="681,647 687,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="690,647 696,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="699,647 705,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="708,647 714,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="717,647 723,647 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="726,647 727,647 "/>
+<circle cx="80" cy="520" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="570" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="624" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="641" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="645" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="647" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="647" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="647" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="80,636 82,636 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="85,636 87,636 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="90,637 92,637 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="95,637 97,637 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="100,637 102,637 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="105,638 107,638 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="110,638 112,638 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="115,638 117,638 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="120,639 122,639 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="125,639 127,639 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="130,639 132,639 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="135,640 137,640 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="140,640 142,640 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="145,640 147,640 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="150,641 152,641 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="155,641 157,641 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="160,641 162,641 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="165,642 167,642 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="170,642 172,642 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="175,642 177,642 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="180,642 182,642 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="185,643 187,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="190,643 192,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="195,643 197,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="200,643 202,643 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="205,643 207,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="210,644 212,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="215,644 217,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="220,644 222,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="225,644 227,644 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="230,645 232,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="235,645 237,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="240,645 242,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="245,645 247,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="250,645 252,645 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="255,646 257,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="260,646 262,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="265,646 267,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="270,646 272,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="275,646 277,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="280,646 282,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="285,646 287,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="290,646 292,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="295,646 297,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="300,646 302,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="305,646 307,646 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="310,646 312,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="315,647 317,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="320,647 322,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="325,647 327,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="330,647 332,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="335,647 337,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="340,647 342,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="345,647 347,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="350,647 352,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="355,647 357,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="360,647 362,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="365,647 367,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="370,647 372,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="375,647 377,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="380,647 382,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="385,647 387,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="390,647 392,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="395,647 397,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="400,647 402,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="405,647 407,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="410,647 412,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="415,647 417,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="420,647 422,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="425,647 427,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="430,647 432,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="435,647 437,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="440,647 442,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="445,647 447,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="450,647 452,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="455,647 457,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="460,647 462,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="465,647 467,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="470,647 472,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="475,647 477,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="480,647 482,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="485,647 487,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="490,647 492,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="495,647 497,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="500,647 502,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="505,647 507,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="510,647 512,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="515,647 517,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="520,647 522,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="525,647 527,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="530,647 532,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="535,647 537,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="540,647 542,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="545,647 547,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="550,647 552,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="555,647 557,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="560,647 562,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="565,647 567,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="570,647 572,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="575,647 577,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="580,647 582,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="585,647 587,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="590,647 592,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="595,647 597,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="600,647 602,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="605,647 607,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="610,647 612,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="615,647 617,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="620,647 622,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="625,647 627,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="630,647 632,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="635,647 637,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="640,647 642,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="645,647 647,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="650,647 652,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="655,647 657,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="660,647 662,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="665,647 667,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="670,647 672,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="675,647 677,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="680,647 682,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="685,647 687,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="690,647 692,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="695,647 697,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="700,647 702,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="705,647 707,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="710,647 712,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="715,647 717,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="720,647 722,647 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="725,647 727,647 "/>
+<text x="80" y="636" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+10%
+</text>
+<text x="172" y="642" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+5%
+</text>
+<text x="264" y="646" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+1%
+</text>
+<text x="357" y="647" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+1%
+</text>
+<text x="449" y="647" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="542" y="647" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="634" y="647" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="727" y="647" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="80,599 82,600 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="85,601 87,601 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="89,602 91,603 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="94,604 96,605 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="99,606 101,606 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="104,607 106,608 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="108,609 110,610 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="113,610 115,611 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="118,612 120,613 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="123,614 124,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="127,615 129,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="132,617 134,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="137,619 139,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="141,620 143,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="146,622 148,623 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="151,624 153,624 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="156,625 157,626 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="160,627 162,628 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="165,629 167,629 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="170,630 172,631 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="175,631 177,632 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="180,632 182,632 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="184,633 186,633 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="189,633 191,634 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="194,634 196,634 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="199,635 201,635 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="204,635 206,635 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="209,636 211,636 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="214,637 216,637 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="219,637 221,637 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="224,638 226,638 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="229,638 231,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="234,639 236,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="239,640 241,640 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="244,640 246,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="249,641 251,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="254,642 256,642 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="259,642 261,643 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="264,643 264,643 266,643 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="269,642 271,641 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="273,640 275,640 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="278,639 280,639 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="283,638 285,637 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="288,637 290,636 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="293,635 295,635 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="298,634 300,633 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="302,633 304,632 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="307,631 309,631 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="312,630 314,630 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="317,629 319,628 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="322,627 324,627 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="327,626 329,626 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="331,625 333,624 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="336,624 338,623 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="341,622 343,622 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="346,621 348,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="351,620 353,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="356,618 357,618 358,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="361,618 363,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="366,618 368,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="371,618 373,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="376,618 378,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="381,619 383,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="386,619 388,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="391,619 393,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="396,619 398,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="401,619 403,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="406,619 408,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="411,619 412,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="415,619 417,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="420,619 422,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="425,619 427,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="430,620 432,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="435,620 437,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="440,620 442,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="445,620 447,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="450,620 452,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="455,620 457,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="460,619 462,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="465,619 467,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="470,618 472,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="475,618 477,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="480,618 482,617 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="485,617 487,617 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="490,617 492,617 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="495,617 497,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="500,616 502,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="505,616 507,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="510,615 512,615 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="515,615 517,615 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="520,615 522,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="525,614 527,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="530,614 532,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="535,614 537,613 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="540,613 542,613 542,613 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="545,613 547,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="550,614 552,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="555,614 557,614 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="560,615 562,615 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="565,615 567,615 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="570,616 572,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="575,616 577,616 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="580,617 582,617 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="585,617 587,617 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="590,618 592,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="595,618 597,618 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="600,619 602,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="605,619 607,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="610,620 612,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="615,620 617,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="620,621 622,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="625,621 627,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="630,622 632,622 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="635,622 637,622 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="640,622 642,622 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="645,622 647,622 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="650,621 652,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="655,621 657,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="660,621 662,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="665,621 667,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="670,621 672,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="675,621 677,621 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="680,621 682,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="685,620 687,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="690,620 692,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="695,620 697,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="700,620 702,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="705,620 707,620 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="710,620 712,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="715,619 717,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="720,619 722,619 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="725,619 727,619 "/>
+<text x="80" y="599" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+40%
+</text>
+<text x="172" y="631" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+13%
+</text>
+<text x="264" y="643" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+4%
+</text>
+<text x="357" y="618" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+24%
+</text>
+<text x="449" y="620" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+23%
+</text>
+<text x="542" y="613" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+28%
+</text>
+<text x="634" y="622" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+21%
+</text>
+<text x="727" y="619" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+23%
+</text>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="80,599 82,598 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="84,597 86,596 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="89,594 91,593 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="93,592 95,591 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="98,589 99,588 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="102,587 104,586 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="106,585 108,584 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="111,582 113,581 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="115,580 117,579 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="120,578 121,577 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="124,575 126,574 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="128,573 130,572 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="133,570 134,569 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="137,568 139,567 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="142,566 143,565 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="146,563 148,562 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="150,561 152,560 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="155,558 156,557 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="159,556 161,555 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="163,554 165,553 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="168,551 170,550 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="172,549 174,550 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="177,551 179,552 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="181,553 183,554 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="186,556 188,556 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="190,558 192,559 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="195,560 197,561 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="199,562 201,563 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="204,564 206,565 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="208,566 210,567 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="213,569 215,569 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="217,571 219,572 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="222,573 224,574 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="226,575 228,576 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="231,577 233,578 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="235,579 237,580 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="240,581 242,582 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="244,584 246,585 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="249,586 251,587 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="253,588 255,589 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="258,590 260,591 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="262,592 264,593 264,593 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="267,594 269,594 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="272,595 274,596 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="277,596 279,597 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="282,598 284,598 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="287,599 289,599 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="291,600 293,601 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="296,601 298,602 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="301,603 303,603 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="306,604 308,604 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="311,605 313,606 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="316,606 318,607 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="320,608 322,608 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="325,609 327,609 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="330,610 332,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="335,611 337,612 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="340,613 342,613 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="345,614 347,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="350,615 351,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="354,616 356,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="359,617 361,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="364,617 366,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="369,617 371,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="374,617 376,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="379,617 381,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="384,617 386,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="389,617 391,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="394,617 396,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="399,617 401,617 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="404,616 406,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="409,616 411,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="414,616 416,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="419,616 421,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="424,616 426,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="429,616 431,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="434,616 436,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="439,616 441,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="444,616 446,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="449,616 451,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="454,615 456,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="459,615 461,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="464,615 466,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="469,614 471,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="474,614 476,613 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="479,613 481,613 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="484,613 486,612 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="489,612 491,612 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="494,612 496,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="499,611 501,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="504,611 506,610 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="509,610 511,610 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="514,610 516,610 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="519,609 521,609 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="524,609 526,609 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="529,608 531,608 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="534,608 536,608 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="539,607 541,607 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="544,607 546,607 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="549,608 551,608 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="554,608 556,608 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="559,609 561,609 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="564,609 566,609 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="569,610 571,610 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="574,610 576,610 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="579,611 581,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="584,611 586,611 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="589,612 591,612 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="594,612 596,612 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="599,613 601,613 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="604,613 606,613 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="609,614 610,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="613,614 615,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="618,614 620,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="623,615 625,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="628,615 630,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="633,616 634,616 635,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="638,616 640,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="643,616 645,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="648,616 650,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="653,616 655,616 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="658,615 660,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="663,615 665,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="668,615 670,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="673,615 675,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="678,615 680,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="683,615 685,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="688,615 690,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="693,615 695,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="698,615 700,615 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="703,615 705,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="708,614 710,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="713,614 715,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="718,614 720,614 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="723,614 725,614 "/>
+<text x="80" y="599" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+39%
+</text>
+<text x="172" y="549" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+80%
+</text>
+<text x="264" y="593" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+44%
+</text>
+<text x="357" y="617" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+25%
+</text>
+<text x="449" y="616" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+25%
+</text>
+<text x="542" y="607" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+33%
+</text>
+<text x="634" y="616" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+26%
+</text>
+<text x="727" y="614" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+28%
+</text>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,597 172,597 265,597 357,597 450,597 542,597 635,597 728,597 "/>
+<circle cx="80" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="597" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,607 172,600 265,598 357,539 450,481 542,414 635,425 728,414 "/>
+<circle cx="80" cy="607" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="600" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="598" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="539" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="481" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="414" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="425" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="414" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,607 172,549 265,526 357,510 450,461 542,426 635,420 728,402 "/>
+<circle cx="80" cy="607" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="549" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="526" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="510" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="461" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="426" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="420" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="402" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="987" x2="80" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="172" y1="987" x2="172" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="264" y1="987" x2="264" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="357" y1="987" x2="357" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="449" y1="987" x2="449" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="542" y1="987" x2="542" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="634" y1="987" x2="634" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="727" y1="987" x2="727" y2="742"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="987" x2="727" y2="987"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="947" x2="727" y2="947"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="906" x2="727" y2="906"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="865" x2="727" y2="865"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="824" x2="727" y2="824"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="783" x2="727" y2="783"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="742" x2="727" y2="742"/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,742 79,987 "/>
+<text x="70" y="987" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,987 79,987 "/>
+<text x="70" y="947" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+20K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,947 79,947 "/>
+<text x="70" y="906" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+40K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,906 79,906 "/>
+<text x="70" y="865" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+60K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,865 79,865 "/>
+<text x="70" y="824" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+80K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,824 79,824 "/>
+<text x="70" y="783" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+100K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,783 79,783 "/>
+<text x="70" y="742" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+120K/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,742 79,742 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,988 727,988 "/>
+<text x="80" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,988 80,993 "/>
+<text x="172" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="172,988 172,993 "/>
+<text x="264" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 B
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="264,988 264,993 "/>
+<text x="357" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="357,988 357,993 "/>
+<text x="449" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="449,988 449,993 "/>
+<text x="542" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="542,988 542,993 "/>
+<text x="634" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="634,988 634,993 "/>
+<text x="727" y="998" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+256 KiB
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="727,988 727,993 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,742 728,988 "/>
+<text x="738" y="988" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,988 733,988 "/>
+<text x="738" y="947" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,947 733,947 "/>
+<text x="738" y="906" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,906 733,906 "/>
+<text x="738" y="865" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,865 733,865 "/>
+<text x="738" y="824" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,824 733,824 "/>
+<text x="738" y="783" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,783 733,783 "/>
+<text x="738" y="742" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6 MB/s
+</text>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="728,742 733,742 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,828 84,833 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="85,835 89,840 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="91,842 95,847 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="96,849 100,854 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="102,857 106,861 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,864 111,868 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="113,871 117,876 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="118,878 122,883 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="124,885 127,890 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="129,892 133,897 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="135,899 138,904 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="140,907 144,911 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="146,914 149,918 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="151,921 155,926 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="157,928 160,933 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="162,935 166,940 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="168,942 171,947 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,949 179,950 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="182,951 188,953 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="191,954 197,956 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="199,957 205,959 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="208,960 214,962 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="216,963 222,964 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="225,965 231,967 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="234,968 239,970 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="242,971 248,973 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="251,974 256,976 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="259,976 264,978 265,978 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="268,978 274,979 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="277,979 283,979 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="286,980 292,980 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="295,980 301,981 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="304,981 310,981 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="313,982 319,982 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="322,982 328,983 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="331,983 337,983 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="340,984 346,984 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,984 355,985 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,985 364,985 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,985 373,985 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,985 382,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,986 391,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,986 400,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,986 409,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,986 418,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,986 427,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="430,987 436,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="439,987 445,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="448,987 449,987 454,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="457,987 463,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="466,987 472,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="475,987 481,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="484,987 490,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="493,987 499,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="502,987 508,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="511,987 517,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="520,987 526,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="529,987 535,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="538,987 542,987 544,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="547,987 553,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="556,987 562,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="565,987 571,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="574,987 580,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="583,987 589,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="592,987 598,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="601,987 607,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="610,987 616,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="619,987 625,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="628,987 634,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="637,987 643,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="646,987 652,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="655,987 661,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="664,987 670,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="673,987 679,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="682,987 688,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="691,987 697,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="700,987 706,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="709,987 715,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="718,987 724,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="727,987 727,987 "/>
+<circle cx="80" cy="828" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="948" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="978" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="985" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="987" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="987" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="987" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="987" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,860 84,864 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="86,866 91,870 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="93,873 97,877 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="99,879 104,883 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="106,885 110,889 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="112,891 116,896 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="119,898 123,902 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,904 129,908 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="131,910 136,915 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="138,917 142,921 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="144,923 149,927 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="151,929 155,933 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="157,936 161,940 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="164,942 168,946 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,948 172,950 175,951 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="178,952 184,954 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="187,954 192,956 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="195,957 201,959 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="204,960 210,961 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="212,962 218,964 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="221,965 227,967 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="230,968 235,969 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="238,970 244,972 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="247,973 253,975 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="256,975 261,977 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="264,978 270,978 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="273,978 279,979 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="282,979 288,979 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="291,979 297,979 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="300,980 306,980 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="309,980 315,980 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="318,980 324,981 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="327,981 333,981 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="336,981 342,981 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="345,981 351,982 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="354,982 357,982 360,982 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="363,982 369,982 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="372,982 378,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="381,983 387,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="390,983 396,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="399,983 405,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="408,984 414,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="417,984 423,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="426,984 432,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="435,985 441,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="444,985 449,985 450,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="453,985 459,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="462,985 468,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="471,985 477,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="480,986 486,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="489,986 495,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="498,986 504,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="507,986 513,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="516,986 522,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="525,987 531,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="534,987 540,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="543,987 549,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="552,987 558,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="561,987 567,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="570,987 576,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="579,987 585,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="588,987 594,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="597,987 603,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="606,987 612,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="615,987 621,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="624,987 630,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="633,987 634,987 639,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="642,987 648,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="651,987 657,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="660,987 666,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="669,987 675,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="678,987 684,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="687,987 693,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="696,987 702,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="705,987 711,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="714,987 720,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="723,987 727,987 "/>
+<circle cx="80" cy="860" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="950" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="978" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="982" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="985" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="987" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="987" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="987" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,860 85,863 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="88,864 93,867 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="96,869 101,871 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="104,873 109,876 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="112,877 117,880 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="120,881 125,884 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="127,886 133,889 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="135,890 141,893 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="143,894 149,897 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="151,899 156,902 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="159,903 164,906 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="167,907 172,910 172,910 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="175,912 180,915 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="183,916 188,919 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="190,921 196,924 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="198,925 203,928 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="206,930 211,933 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="214,934 219,937 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="221,939 227,942 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="229,944 234,947 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="237,948 242,951 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="245,953 250,956 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="252,957 258,960 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="260,962 264,964 266,964 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="269,965 274,966 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="277,966 283,968 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="286,968 292,969 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="295,970 301,971 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="304,971 310,972 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="313,973 319,974 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="322,975 328,976 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="331,976 336,977 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="339,978 345,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="348,979 354,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="357,981 363,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="366,981 372,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="375,982 381,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="384,982 390,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="393,983 399,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="402,983 408,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="411,983 417,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="420,984 426,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="429,984 435,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="438,985 444,985 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="447,985 449,985 453,985 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="456,985 462,985 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="465,985 471,985 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="474,986 480,986 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="483,986 489,986 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="492,986 498,986 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="501,986 507,986 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="510,986 516,986 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="519,987 525,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="528,987 534,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="537,987 542,987 543,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="546,987 552,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="555,987 561,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="564,987 570,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="573,987 579,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="582,987 588,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="591,987 597,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="600,987 606,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="609,987 615,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="618,987 624,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="627,987 633,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="636,987 642,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="645,987 651,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="654,987 660,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="663,987 669,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="672,987 678,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="681,987 687,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="690,987 696,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="699,987 705,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="708,987 714,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="717,987 723,987 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="726,987 727,987 "/>
+<circle cx="80" cy="860" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="910" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="264" cy="964" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="981" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="449" cy="985" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="987" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="634" cy="987" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="727" cy="987" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="80,986 82,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="85,986 87,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="90,986 92,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="95,986 97,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="100,986 102,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="105,986 107,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="110,986 112,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="115,986 117,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="120,986 122,986 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="125,986 127,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="130,987 132,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="135,987 137,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="140,987 142,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="145,987 147,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="150,987 152,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="155,987 157,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="160,987 162,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="165,987 167,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="170,987 172,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="175,987 177,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="180,987 182,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="185,987 187,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="190,987 192,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="195,987 197,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="200,987 202,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="205,987 207,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="210,987 212,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="215,987 217,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="220,987 222,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="225,987 227,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="230,987 232,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="235,987 237,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="240,987 242,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="245,987 247,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="250,987 252,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="255,987 257,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="260,987 262,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="265,987 267,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="270,987 272,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="275,987 277,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="280,987 282,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="285,987 287,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="290,987 292,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="295,987 297,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="300,987 302,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="305,987 307,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="310,987 312,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="315,987 317,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="320,987 322,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="325,987 327,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="330,987 332,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="335,987 337,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="340,987 342,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="345,987 347,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="350,987 352,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="355,987 357,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="360,987 362,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="365,987 367,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="370,987 372,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="375,987 377,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="380,987 382,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="385,987 387,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="390,987 392,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="395,987 397,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="400,987 402,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="405,987 407,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="410,987 412,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="415,987 417,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="420,987 422,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="425,987 427,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="430,987 432,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="435,987 437,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="440,987 442,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="445,987 447,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="450,987 452,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="455,987 457,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="460,987 462,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="465,987 467,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="470,987 472,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="475,987 477,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="480,987 482,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="485,987 487,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="490,987 492,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="495,987 497,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="500,987 502,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="505,987 507,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="510,987 512,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="515,987 517,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="520,987 522,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="525,987 527,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="530,987 532,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="535,987 537,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="540,987 542,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="545,987 547,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="550,987 552,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="555,987 557,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="560,987 562,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="565,987 567,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="570,987 572,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="575,987 577,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="580,987 582,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="585,987 587,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="590,987 592,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="595,987 597,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="600,987 602,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="605,987 607,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="610,987 612,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="615,987 617,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="620,987 622,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="625,987 627,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="630,987 632,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="635,987 637,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="640,987 642,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="645,987 647,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="650,987 652,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="655,987 657,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="660,987 662,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="665,987 667,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="670,987 672,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="675,987 677,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="680,987 682,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="685,987 687,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="690,987 692,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="695,987 697,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="700,987 702,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="705,987 707,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="710,987 712,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="715,987 717,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="720,987 722,987 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="1" points="725,987 727,987 "/>
+<text x="80" y="986" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+1%
+</text>
+<text x="172" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="264" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="357" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="449" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="542" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="634" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<text x="727" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#FACC15">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="80,983 82,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="85,983 87,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="90,983 92,983 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="95,983 97,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="100,984 102,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="105,984 107,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="110,984 112,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="115,984 117,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="120,984 122,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="125,984 127,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="130,985 132,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="135,985 137,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="140,985 142,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="145,985 147,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="150,985 152,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="155,985 157,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="160,986 162,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="165,986 167,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="170,986 172,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="175,986 177,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="180,986 182,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="185,986 187,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="190,986 192,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="195,986 197,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="200,986 202,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="205,986 207,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="210,986 212,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="215,986 217,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="220,987 222,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="225,987 227,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="230,987 232,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="235,987 237,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="240,987 242,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="245,987 247,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="250,987 252,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="255,987 257,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="260,987 262,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="265,987 267,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="270,987 272,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="275,987 277,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="280,987 282,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="285,987 287,987 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="290,986 292,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="295,986 297,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="300,986 302,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="305,986 307,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="310,986 312,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="315,986 317,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="320,986 322,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="325,986 327,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="330,986 332,986 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="335,985 337,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="340,985 342,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="345,985 347,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="350,985 352,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="355,985 357,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="360,985 362,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="365,985 367,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="370,985 372,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="375,985 377,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="380,985 382,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="385,985 387,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="390,985 392,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="395,985 397,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="400,985 402,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="405,985 407,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="410,985 412,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="415,985 417,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="420,985 422,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="425,985 427,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="430,985 432,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="435,985 437,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="440,985 442,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="445,985 447,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="450,985 452,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="455,985 457,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="460,985 462,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="465,985 467,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="470,985 472,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="475,985 477,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="480,985 482,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="485,985 487,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="490,985 492,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="495,985 497,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="500,984 502,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="505,984 507,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="510,984 512,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="515,984 517,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="520,984 522,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="525,984 527,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="530,984 532,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="535,984 537,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="540,984 542,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="545,984 547,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="550,984 552,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="555,984 557,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="560,984 562,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="565,984 567,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="570,984 572,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="575,984 577,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="580,984 582,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="585,984 587,984 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="590,985 592,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="595,985 597,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="600,985 602,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="605,985 607,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="610,985 612,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="615,985 617,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="620,985 622,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="625,985 627,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="630,985 632,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="635,985 637,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="640,985 642,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="645,985 647,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="650,985 652,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="655,985 657,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="660,985 662,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="665,985 667,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="670,985 672,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="675,985 677,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="680,985 682,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="685,985 687,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="690,985 692,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="695,985 697,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="700,985 702,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="705,985 707,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="710,985 712,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="715,985 717,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="720,985 722,985 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="1" points="725,985 727,985 "/>
+<text x="80" y="983" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+4%
+</text>
+<text x="172" y="986" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+1%
+</text>
+<text x="264" y="987" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+0%
+</text>
+<text x="357" y="985" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+2%
+</text>
+<text x="449" y="985" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+2%
+</text>
+<text x="542" y="984" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+3%
+</text>
+<text x="634" y="985" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+2%
+</text>
+<text x="727" y="985" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#60A5FA">
+2%
+</text>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="80,983 82,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="85,983 87,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="90,982 92,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="95,982 97,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="100,982 102,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="105,982 107,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="110,981 112,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="115,981 117,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="120,981 122,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="125,981 127,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="130,980 132,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="135,980 137,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="140,980 142,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="145,979 147,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="150,979 152,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="155,979 157,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="160,979 162,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="165,978 167,978 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="170,978 172,978 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="175,978 177,978 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="180,978 182,978 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="185,979 187,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="190,979 192,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="195,979 197,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="200,979 202,979 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="205,979 207,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="210,980 212,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="215,980 217,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="220,980 222,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="225,980 227,980 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="230,981 232,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="235,981 237,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="240,981 242,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="245,981 247,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="250,981 252,981 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="255,982 257,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="260,982 262,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="265,982 267,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="270,982 272,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="275,982 277,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="280,982 282,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="285,982 287,982 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="290,983 292,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="295,983 297,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="300,983 302,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="305,983 307,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="310,983 312,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="315,983 317,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="320,983 322,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="325,983 327,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="330,983 332,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="335,984 337,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="340,984 342,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="345,984 347,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="350,984 352,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="355,984 357,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="360,984 362,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="365,984 367,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="370,984 372,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="375,984 377,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="380,984 382,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="385,984 387,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="390,984 392,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="395,984 397,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="400,984 402,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="405,984 407,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="410,984 412,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="415,984 417,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="420,984 422,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="425,984 427,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="430,984 432,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="435,984 437,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="440,984 442,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="445,984 447,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="450,984 452,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="455,984 457,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="460,984 462,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="465,984 467,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="470,984 472,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="475,984 477,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="480,984 482,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="485,984 487,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="490,984 492,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="495,984 497,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="500,983 502,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="505,983 507,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="510,983 512,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="515,983 517,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="520,983 522,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="525,983 527,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="530,983 532,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="535,983 537,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="540,983 542,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="545,983 547,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="550,983 552,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="555,983 557,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="560,983 562,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="565,983 567,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="570,983 572,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="575,983 577,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="580,983 582,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="585,983 587,983 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="590,984 592,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="595,984 597,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="600,984 602,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="605,984 607,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="610,984 612,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="615,984 617,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="620,984 622,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="625,984 627,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="630,984 632,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="635,984 637,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="640,984 642,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="645,984 647,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="650,984 652,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="655,984 657,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="660,984 662,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="665,984 667,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="670,984 672,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="675,984 677,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="680,984 682,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="685,984 687,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="690,984 692,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="695,984 697,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="700,984 702,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="705,984 707,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="710,984 712,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="715,984 717,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="720,984 722,984 "/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="1" points="725,984 727,984 "/>
+<text x="80" y="983" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+4%
+</text>
+<text x="172" y="978" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+8%
+</text>
+<text x="264" y="982" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+4%
+</text>
+<text x="357" y="984" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+3%
+</text>
+<text x="449" y="984" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+3%
+</text>
+<text x="542" y="983" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+3%
+</text>
+<text x="634" y="984" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+3%
+</text>
+<text x="727" y="984" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#A78BFA">
+3%
+</text>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,937 172,937 265,937 357,937 450,937 542,937 635,937 728,937 "/>
+<circle cx="80" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="937" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,947 172,940 265,938 357,879 450,821 542,754 635,765 728,754 "/>
+<circle cx="80" cy="947" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="940" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="938" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="879" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="821" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="754" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="765" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="754" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="80,947 172,889 265,866 357,850 450,801 542,766 635,760 728,742 "/>
+<circle cx="80" cy="947" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="172" cy="889" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="265" cy="866" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="357" cy="850" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="450" cy="801" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="542" cy="766" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="635" cy="760" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<circle cx="728" cy="742" r="2.5" opacity="1" fill="#A78BFA" stroke="none" stroke-width="1"/>
+<text x="380" y="1020" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
+--- dashed = msg/s (left axis)
+</text>
+<text x="380" y="1034" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
+─── solid = GB/s (right axis)
+</text>
+<text x="380" y="1048" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
+... dotted = compression CPU%
+</text>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,1026 92,1026 "/>
+<text x="98" y="1020" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+tcp (no compression)
+</text>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,1042 92,1042 "/>
+<text x="98" y="1036" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+zstd+tcp
+</text>
+<polyline fill="none" opacity="1" stroke="#A78BFA" stroke-width="2" points="78,1058 92,1058 "/>
+<text x="98" y="1052" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+zstd+tcp + dict
+</text>
+
+<text x="400" y="50" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#F9FAFB">1 Gbps link</text>
+<text x="400" y="390" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#F9FAFB">100 Mbps link</text>
+<text x="400" y="730" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#F9FAFB">10 Mbps link</text></svg>

--- a/doc/zstd-rfc.md
+++ b/doc/zstd-rfc.md
@@ -1,0 +1,485 @@
+# ZMTP-Zstd: Zstandard-Compressed TCP Transport for ZMTP
+
+| Field    | Value                                              |
+|----------|----------------------------------------------------|
+| Status   | Draft                                              |
+| Editor   | Patrik Wenger                                      |
+| Scheme   | `zstd+tcp://`                                      |
+| Requires | [RFC 37/ZMTP 3.1](https://rfc.zeromq.org/spec/37/) |
+
+
+## 1. Abstract
+
+This specification defines `zstd+tcp://`, a TCP transport for ZMTP 3.1
+that applies per-part Zstandard compression after the ZMTP handshake.
+Both peers use the `zstd+tcp://` scheme in their endpoint URIs. The ZMTP
+greeting and handshake proceed over raw TCP exactly as they would over
+`tcp://`. After the handshake completes, every message part on the wire
+is individually encoded with a 4-byte sentinel dispatch that
+distinguishes uncompressed plaintext, Zstandard-compressed frames, and
+dictionary shipments. No ZMTP properties, command frames, or
+negotiation are involved. Compression is an intrinsic property of the
+transport, like encryption is an intrinsic property of TLS.
+
+
+## 2. Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in
+[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+
+## 3. Motivation
+
+Zstandard at low compression levels encodes in single-digit microseconds
+per kilobyte, decompresses faster still, and on dictionary-trained
+workloads compresses small frames to a fraction of their size. For most
+ZMTP deployments compression can be treated as almost free CPU-wise,
+while recovering large fractions of the wire budget.
+
+Network-bound or bandwidth-constrained deployments (publish/subscribe
+fan-out, cross-region replication, IoT telemetry) trade a small amount
+of CPU for a large reduction in wire time. Zstandard's dictionary mode
+is a good fit for the small-message profile typical of ZMQ workloads.
+
+ZMTP applications today either accept the wire cost or layer ad-hoc,
+per-payload compression into the application format. The latter requires
+both sides to opt in and bakes compression into the payload rather than
+the transport. `zstd+tcp://` replaces it with a transport-level
+mechanism that any ZMTP application benefits from without changes to the
+payload.
+
+### 3.1 Why a transport scheme
+
+Compression could live at three layers. Each has a fatal flaw except the
+transport layer.
+
+**Socket-level wrapper** (too high). A wrapper above routing knows
+nothing about transports. It compresses local connections (pure
+overhead) and cannot act on new connections naturally. Dictionary
+shipping requires per-connection state, but a wrapper only sees messages
+after routing has dispatched them. Reconnect handling requires hooking
+into connection lifecycle events that are awkward from outside.
+
+**ZMTP connection layer** (too low). Embedding compression into each
+ZMTP connection means fan-out patterns compress the same message N times
+(once per subscriber connection). The connection layer has no
+socket-wide view, so there is no way to share compression work across
+connections.
+
+**Transport layer** (right). `zstd+tcp://` makes transport selection
+explicit in the endpoint URI. Only TCP connections get compressed. Local
+transports are unaffected even on the same socket. Dictionary lifetime
+matches connection lifetime naturally (new connection = new wrapper =
+re-ship dictionary). No negotiation is needed; both peers use
+`zstd+tcp://`. The codec is socket-wide (shared across connections), so
+fan-out patterns compress once and reuse the result.
+
+### 3.2 Why not negotiate
+
+ZMTP 3.1 already supports unknown READY properties. An unaware peer
+silently ignores them. A negotiation-based design could fall back to
+plaintext when the peer does not understand compression. But this
+introduces complexity (profile matching, asymmetric per-direction state,
+passive senders) for a marginal benefit: in practice, compression is a
+deployment decision, not a runtime discovery. Both peers are configured
+to use `zstd+tcp://` or they are not. The transport scheme approach
+eliminates the entire negotiation surface and its edge cases.
+
+### 3.3 Why Zstandard
+
+Zstandard at low levels matches LZ4 on encode latency, beats it on
+decompression speed and ratio at every realistic ZMQ payload size, and
+has a first-class dictionary story. The decompression advantage is
+particularly important for fan-out patterns (PUB/SUB, RADIO/DISH): the
+publisher pays one compress, every subscriber pays decompress, so
+per-subscriber CPU dominates the total budget.
+
+
+## 4. Goals and Non-goals
+
+### 4.1 Goals
+
+- Transparent to application code: send/receive operations see plaintext.
+- Per-part sender decision: opt out for short or incompressible parts.
+- Works for legacy multipart socket types (PUSH/PULL, PUB/SUB, ...) and
+  draft single-frame types alike.
+- Small-message-friendly via an optional shared dictionary, either
+  supplied out of band or automatically trained from early traffic.
+- No ZMTP-level negotiation, no new READY properties, no new command
+  frames.
+
+### 4.2 Non-goals
+
+- New ZMTP mechanism, new socket type, new greeting, new frame flag bit.
+- Compression of the ZMTP greeting or command frames (READY, SUBSCRIBE,
+  PING, PONG, ...).
+- Application to non-TCP transports (`inproc://` is zero-copy;
+  compression is pure overhead; `ipc://` rarely benefits).
+- Replacing or weakening CurveZMQ or any other security mechanism.
+  See Sec. 9.
+- Streaming / context-takeover compression. Each part is decodable in
+  isolation with no dependency on a previous part's LZ77 history.
+
+
+## 5. Terminology
+
+| Term                | Meaning                                                              |
+|---------------------|----------------------------------------------------------------------|
+| Part                | One ZMTP message frame body. A multipart message has multiple parts. |
+| Sentinel            | The first 4 bytes of a post-handshake part on the wire (Sec. 6.1).   |
+| Uncompressed part   | A wire part whose sentinel is `00 00 00 00`.                         |
+| Compressed part     | A wire part whose first 4 bytes are the Zstandard magic `28 B5 2F FD`. |
+| Dictionary part     | A wire part whose first 4 bytes are `37 A4 30 EC` (Sec. 7).         |
+| Dictionary message  | A single-part ZMTP message consisting of exactly one dictionary part. |
+
+
+## 6. Part Encoding
+
+After the ZMTP handshake completes, every message part on the wire is
+individually encoded. The ZMTP MORE flag is carried on the wire frame
+header as normal. Multipart messages are encoded part by part; each
+part is independent.
+
+### 6.1 Sentinel dispatch
+
+The first 4 bytes of each wire part determine how it is decoded.
+
+| Sentinel (hex)   | Meaning                              |
+|------------------|--------------------------------------|
+| `00 00 00 00`    | Uncompressed plaintext (Sec. 6.3)    |
+| `28 B5 2F FD`    | Zstandard compressed frame (Sec. 6.4)|
+| `37 A4 30 EC`    | Dictionary shipment (Sec. 7)         |
+
+All other 4-byte values are reserved. A receiver that encounters an
+unknown sentinel MUST close the connection.
+
+### 6.2 Compression level
+
+This specification suggests **level 1** as an implementation default.
+This keeps encode throughput high while improving wire ratio over
+negative fast levels. This is not a wire requirement. Implementations
+may choose any default level that fits their deployment goals, and
+bandwidth-constrained deployments may choose higher levels such as 3.
+
+The compression level is a sender choice and is not communicated on the
+wire. The receiver decodes any valid Zstandard frame regardless of the
+level used to encode it. Implementations SHOULD expose the level as a
+configurable parameter.
+
+### 6.3 Uncompressed sentinel `00 00 00 00`
+
+```
++------------------+-------------------+
+| 00 00 00 00      | plaintext payload |
+| (4 bytes)        | (N bytes)         |
++------------------+-------------------+
+```
+
+The sender uses this sentinel when it decides not to compress the part.
+The 4-byte overhead is the price of per-part selective compression
+without an extra flag bit in the ZMTP frame header.
+
+Four zero bytes cannot collide with a valid Zstandard frame magic or the
+dictionary sentinel, so no ambiguity arises.
+
+### 6.4 Compressed Zstandard frame
+
+```
++------------------+
+| Zstandard frame  |
+| (M bytes)        |
++------------------+
+```
+
+The wire part IS the Zstandard frame. Its first 4 bytes are the
+standard Zstandard frame magic `28 B5 2F FD`. No additional framing is
+added.
+
+The sender MUST configure the encoder to write the `Frame_Content_Size`
+field in the Zstandard frame header (RFC 8878 Sec. 3.1.1.1.2). This
+field is required for the receiver's budget enforcement (Sec. 6.6).
+
+### 6.5 Sender rules
+
+For each outgoing message part, the sender proceeds as follows:
+
+1. Compute `min_size`:
+   - If a dictionary is currently installed: **64 bytes**.
+   - Otherwise: **512 bytes**.
+
+   These thresholds reflect empirical measurement: without a dictionary,
+   Zstandard cannot usefully compress typical payloads below ~512 bytes;
+   with a dictionary, even 64-byte payloads compress to ~20 bytes.
+   Implementations MAY tune these thresholds.
+
+2. If `plaintext_size < min_size`, prepend `00 00 00 00` and emit.
+
+3. Otherwise, run the Zstandard encoder. The encoder MUST write the
+   `Frame_Content_Size` field. If the compressed output's size is
+   >= `plaintext_size - 4` (net saving <= 0 after accounting for the
+   4-byte sentinel of the uncompressed alternative), prepend
+   `00 00 00 00` and emit the plaintext instead. Otherwise emit the
+   Zstandard frame as-is.
+
+4. If the plaintext's first 4 bytes happen to be `28 B5 2F FD` or
+   `37 A4 30 EC` and the sender chooses not to compress, the sender
+   MUST still prepend `00 00 00 00` to avoid sentinel ambiguity.
+   Step 2 and step 3's fallback path already guarantee this.
+
+### 6.6 Receiver rules
+
+For each incoming wire part, the receiver proceeds as follows:
+
+1. Read the first 4 bytes as the sentinel. If the part is shorter than
+   4 bytes, close the connection.
+
+2. Sentinel `00 00 00 00`: the remaining `N - 4` bytes are plaintext.
+   Return them.
+
+3. Sentinel `28 B5 2F FD`: the entire wire part is a Zstandard frame.
+   - Read the `Frame_Content_Size` field from the Zstandard header. If
+     the field is absent, close the connection.
+   - If the connection enforces a maximum message size, add this part's
+     declared content size to the running decompressed total for the
+     current multipart message (parts chained by the ZMTP MORE flag).
+     If the running total would exceed the maximum, close the connection
+     without invoking the decoder.
+   - Invoke the decoder in a bounded mode that aborts if it would write
+     more bytes than `Frame_Content_Size` declared. On such an abort,
+     close the connection.
+   - Return the decompressed plaintext.
+
+4. Sentinel `37 A4 30 EC`: dictionary shipment. See Sec. 7.
+
+5. Any other sentinel: close the connection.
+
+The maximum message size always refers to the **decompressed** plaintext
+summed across all parts of a multipart message. A multipart message
+whose total wire length is small but whose total decompressed size
+exceeds the limit MUST be rejected before decoder invocation.
+
+
+## 7. Dictionary Shipment
+
+### 7.1 Dictionary message format
+
+A dictionary is shipped as a **single-part ZMTP message** (no MORE flag)
+whose body is exactly a Zstandard dictionary blob in ZDICT format. ZDICT
+blobs begin with the dictionary magic `37 A4 30 EC`; this transport uses
+those first 4 bytes as the dictionary sentinel:
+
+```
++------------------+------------------------+
+| 37 A4 30 EC      | rest of ZDICT blob     |
+| (4 bytes)        | (D - 4 bytes)          |
++------------------+------------------------+
+```
+
+The sentinel `37 A4 30 EC` is the standard Zstandard dictionary magic
+(`DICT_MAGIC`, little-endian). It is intentionally reused as this
+transport's dictionary discriminator because a ZDICT blob already carries
+it and it does not collide with the Zstandard frame magic or the
+uncompressed sentinel.
+
+The complete `D` bytes, including the leading `37 A4 30 EC` magic, are
+the raw dictionary as it should be passed to the Zstandard decoder's
+dictionary-load operation.
+
+### 7.2 Constraints
+
+- A dictionary message MUST be a single-part ZMTP message (MORE flag
+  not set on the frame header). A dictionary sentinel in a multipart
+  message's non-final or non-only part is a protocol error.
+
+- A dictionary message MUST NOT exceed **8 KiB** total. Since the
+  message body is exactly the ZDICT blob, this is also the maximum
+  dictionary size. A receiver that receives a dictionary message larger
+  than 8 KiB MUST close the connection.
+
+- A sender MUST send at most **one** dictionary message per direction
+  per connection. A receiver that receives a second dictionary message
+  on the same connection MUST close the connection.
+
+- A dictionary message MUST be sent BEFORE any compressed part that
+  references the dictionary. In practice this means the sender ships
+  the dictionary before (or immediately after training triggers during)
+  the first compressed write that would benefit from it.
+
+### 7.3 Receiver handling
+
+When the receiver encounters a dictionary part:
+
+1. Validate the constraints in Sec. 7.2.
+2. Install the complete message body as the decompression dictionary for
+   this connection. The leading `37 A4 30 EC` bytes are part of the ZDICT
+   blob and MUST NOT be stripped.
+4. Discard the message. It is not delivered to the application.
+
+If all parts of a ZMTP message are dictionary parts (which is always
+the case, since dictionary messages are single-part), the receiver
+loops to receive the next message.
+
+### 7.4 Dictionary scope
+
+The dictionary a sender ships applies to a single direction of a single
+connection. Each peer may independently ship its own dictionary for its
+own send direction. The common deployment is one-directional: a
+publisher ships its dictionary; subscribers decode with it and send
+nothing (or uncompressed traffic) back.
+
+The sender's dictionary is typically socket-wide: trained once from
+early traffic across all connections and reused. But this is an
+implementation choice. The wire protocol carries no dictionary identity
+or scope metadata.
+
+An implementation MAY pool training samples and share the resulting
+auto-trained dictionary across all `zstd+tcp://` connections of a
+single socket. This is beneficial when a socket binds or connects
+multiple `zstd+tcp://` endpoints: samples from one endpoint accelerate
+training for all of them, and newly opened connections benefit from a
+dictionary trained by their predecessors. Connections that were
+configured with an explicit out-of-band dictionary MUST NOT participate
+in shared training; they use their own dictionary independently.
+
+### 7.5 Automatic dictionary training
+
+A sender MAY train a dictionary automatically from early traffic.
+The training algorithm, trigger condition, and parameters are
+implementation choices. The following wire-level constraints MUST be
+respected:
+
+- A trained dictionary MUST NOT exceed the maximum dictionary size
+  (Sec. 7.2: 8 KiB).
+- A sender MUST ship at most one dictionary per direction per
+  connection (Sec. 7.2).
+- If training fails (the sample set was too small or too uniform),
+  the sender MUST stay in no-dictionary mode for the rest of the
+  socket's lifetime. It MUST NOT retry training.
+
+The following parameters are RECOMMENDED for implementations that
+support auto-training:
+
+| Parameter              | Recommended value                        |
+|------------------------|------------------------------------------|
+| Dictionary capacity    | 2 KiB                                    |
+| Training trigger       | 1000 samples OR 100 KiB (first reached)  |
+| Max sample length      | 2048 bytes                               |
+| Training algorithm     | FastCOVER                                |
+
+Whether auto-training is enabled by default is an implementation
+choice. Applications MAY disable it or supply an out-of-band
+dictionary instead.
+
+### 7.6 Dictionary ID
+
+Auto-trained dictionaries SHOULD be patched with a random dictionary ID
+in the Zstandard user range (32768 to 2^31 - 1) to avoid collisions
+with Zstandard's built-in dictionary IDs. Out-of-band dictionaries
+retain whatever dictionary ID they were created with.
+
+
+## 8. ZMTP Interaction
+
+### 8.1 Greeting and handshake
+
+The ZMTP greeting and security mechanism handshake proceed over raw TCP
+exactly as specified by RFC 37. `zstd+tcp://` does not modify the
+greeting, mechanism, READY properties, or any command frames. The
+compression layer activates only after the handshake is complete and the
+connection is ready for message traffic.
+
+### 8.2 Command frames
+
+ZMTP command frames (READY, SUBSCRIBE, CANCEL, JOIN, LEAVE, PING,
+PONG) are never compressed. They are sent and received as standard ZMTP
+command frames. Only message frames (the COMMAND bit not set in the
+frame header) are subject to sentinel-dispatched encoding.
+
+### 8.3 Socket type compatibility
+
+`zstd+tcp://` is compatible with all ZMTP socket types. The socket type
+negotiation in the READY handshake is unaffected.
+
+### 8.4 Peer requirement
+
+Both peers of a connection MUST use `zstd+tcp://`. There is no
+fallback to plaintext TCP and no negotiation. A `zstd+tcp://` peer
+connecting to a plain `tcp://` peer (or vice versa) will see garbled
+data or sentinel errors and the connection will fail.
+
+
+## 9. Security Considerations
+
+### 9.1 Compression combined with encryption (CRIME / BREACH)
+
+Combining length-revealing compression with a secure channel that
+carries attacker-influenced plaintext enables CRIME- and BREACH-style
+side-channel attacks. An attacker who can inject chosen bytes into the
+plaintext and observe the ciphertext length can extract secrets byte
+by byte.
+
+Implementations SHOULD refuse to layer `zstd+tcp://` inside an
+encrypted tunnel when the plaintext contains attacker-controlled
+content. Deployments that accept this risk MUST do so with explicit
+opt-in.
+
+### 9.2 Length side-channel
+
+Compression makes the wire length of a part depend on its content. An
+on-path observer can learn something about the plaintext from the
+compressed length alone. Deployments that care about traffic analysis
+MUST NOT rely on `zstd+tcp://` to hide payload shape.
+
+### 9.3 Dictionary contents
+
+When auto-training is enabled, the receiver loads dictionary bytes
+chosen by the peer. The Zstandard reference dictionary loader is
+hardened against malformed inputs, but implementations MUST enforce the
+8 KiB cap on dictionary messages (Sec. 7.2) and SHOULD NOT cache
+received dictionaries across connections.
+
+### 9.4 Decompression bombs
+
+A small compressed frame can decompress to many megabytes of plaintext.
+The receiver rules in Sec. 6.6 mitigate this:
+
+1. Every compressed part MUST carry `Frame_Content_Size`. The receiver
+   checks the declared total against the maximum message size before
+   invoking the decoder, so a bomb is rejected on its header alone.
+2. The decoder is invoked in bounded mode. It aborts if it would write
+   more bytes than declared. A peer that lies in the header cannot
+   expand a part past its declared size.
+
+Implementations SHOULD set a conservative maximum message size on
+`zstd+tcp://` connections even if they would otherwise leave it
+unbounded.
+
+
+## 10. Constants
+
+| Constant                | Value                                         |
+|-------------------------|-----------------------------------------------|
+| Uncompressed sentinel   | `00 00 00 00`                                 |
+| Zstd frame sentinel     | `28 B5 2F FD` (Zstandard frame magic)         |
+| Dictionary sentinel     | `37 A4 30 EC`                                 |
+| Suggested default level | 1                                             |
+| Min compress, no dict   | 512 bytes                                     |
+| Min compress, with dict | 64 bytes                                      |
+| Max dictionary size     | 8 KiB                                         |
+| Train max samples       | 1000                                          |
+| Train max bytes         | 100 KiB                                       |
+| Train max sample length | 2048 bytes                                    |
+| Dictionary capacity     | 2 KiB                                         |
+
+
+## 11. References
+
+- [RFC 37/ZMTP 3.1](https://rfc.zeromq.org/spec/37/)
+- [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119)
+- [RFC 8878: Zstandard Compression Data Format](https://datatracker.ietf.org/doc/html/rfc8878)
+- [Zstandard dictionary builder](https://github.com/facebook/zstd/blob/dev/lib/dictBuilder/zdict.h)
+- [CRIME attack](https://en.wikipedia.org/wiki/CRIME)
+- [BREACH attack](https://en.wikipedia.org/wiki/BREACH)
+- [`lz4+tcp://` RFC](lz4-rfc.md)

--- a/omq-bench/src/bench/mod.rs
+++ b/omq-bench/src/bench/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod comparisons;
 pub(crate) mod compression;
 pub(crate) mod pushpull_lz4;
+pub(crate) mod pushpull_zstd;

--- a/omq-bench/src/bench/pushpull_lz4.rs
+++ b/omq-bench/src/bench/pushpull_lz4.rs
@@ -230,6 +230,7 @@ pub(crate) fn run(args: PushpullLz4Args) {
                     msgs_s: Some(msgs_s),
                     mbps: Some(mbps),
                     dict_size: None,
+                    compression_level: None,
                 };
                 jsonl::append_jsonl(&jsonl_path, &row);
                 eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s");
@@ -281,6 +282,7 @@ pub(crate) fn run(args: PushpullLz4Args) {
                         msgs_s: Some(msgs_s),
                         mbps: Some(mbps),
                         dict_size: Some(dict_cap),
+                        compression_level: None,
                     };
                     jsonl::append_jsonl(&jsonl_path, &row);
                     eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s  wire {wire_bytes}");

--- a/omq-bench/src/bench/pushpull_zstd.rs
+++ b/omq-bench/src/bench/pushpull_zstd.rs
@@ -1,0 +1,297 @@
+use crate::cli::PushpullZstdArgs;
+use crate::jsonl::{self, PushpullLz4Row};
+use crate::process;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+const CHART_SIZES: &[u64] = &[16, 64, 256, 1024, 4096, 16384, 65536, 262_144];
+const QUICK_SIZES: &[u64] = &[64, 1024, 16384];
+
+fn size_label(n: u64) -> String {
+    if n >= 1_048_576 {
+        format!("{} MiB", n / 1_048_576)
+    } else if n >= 1024 {
+        format!("{} KiB", n / 1024)
+    } else {
+        format!("{n} B")
+    }
+}
+
+static mut PORT_COUNTER: u16 = 17600;
+
+fn next_port() -> u16 {
+    unsafe {
+        let p = PORT_COUNTER;
+        PORT_COUNTER += 1;
+        p
+    }
+}
+
+struct Peers {
+    blocking: PathBuf,
+    tokio: PathBuf,
+}
+
+fn build_peers() -> Peers {
+    eprintln!("  building omq_bench_peer_blocking (zstd)...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "omq-tokio",
+            "--bin",
+            "omq_bench_peer_blocking",
+            "--features",
+            "zstd",
+            "-q",
+        ])
+        .status()
+        .expect("failed to run cargo build");
+    assert!(status.success(), "build failed");
+
+    eprintln!("  building omq_bench_peer_tokio (zstd)...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "omq-tokio",
+            "--bin",
+            "omq_bench_peer_tokio",
+            "--features",
+            "zstd",
+            "-q",
+        ])
+        .status()
+        .expect("failed to run cargo build");
+    assert!(status.success(), "build failed");
+
+    Peers {
+        blocking: PathBuf::from("target/release/omq_bench_peer_blocking"),
+        tokio: PathBuf::from("target/release/omq_bench_peer_tokio"),
+    }
+}
+
+fn get_wire_size(binary: &str, transport: &str, size: u64, dict_file: Option<&str>) -> u64 {
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+    let size_str = size.to_string();
+    let mut env = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    let output = process::capture(
+        &[binary, "wire-size", &ep, &size_str],
+        &env,
+        None,
+        Duration::from_secs(10),
+    )
+    .unwrap_or_default();
+    output.trim().parse().unwrap_or(size)
+}
+
+fn train_dict(binary: &str, path: &str, capacity: u64) {
+    let cap_str = capacity.to_string();
+    process::capture(
+        &[binary, "train-zstd-dict", path, &cap_str],
+        &[],
+        None,
+        Duration::from_secs(30),
+    );
+}
+
+fn run_cell(
+    binary: &str,
+    transport: &str,
+    size: u64,
+    duration: f64,
+    dict_file: Option<&str>,
+) -> Option<(f64, f64, f64)> {
+    let size_str = size.to_string();
+    let dur_str = format!("{duration:.1}");
+    let port = next_port();
+    let ep = format!("{transport}://127.0.0.1:{port}");
+
+    let mut push_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        push_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+
+    let mut push_proc = process::spawn(
+        &[binary, "push", &ep, &size_str],
+        &push_env,
+        Some(process::MEASURED_CPU),
+    );
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let pull_transport = if transport.contains("zstd") {
+        "tcp"
+    } else {
+        transport
+    };
+    let pull_ep = format!("{pull_transport}://127.0.0.1:{port}");
+
+    let mut pull_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
+    if let Some(df) = dict_file {
+        pull_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+
+    let output = process::capture(
+        &[binary, "pull", &pull_ep, &size_str, &dur_str],
+        &pull_env,
+        Some(process::OTHER_CPU),
+        Duration::from_secs(duration as u64 + 30),
+    );
+
+    let push_cpu = process::read_proc_cpu(push_proc.pid());
+    push_proc.kill();
+
+    let output = output?;
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let count: f64 = parts[0].parse().ok()?;
+    let elapsed: f64 = parts[1].parse().ok()?;
+    if elapsed <= 0.0 || count <= 0.0 {
+        return None;
+    }
+    let msgs_s = count / elapsed;
+    let mbps = (count * size as f64) / elapsed / 1_000_000.0;
+    Some((msgs_s, mbps, push_cpu))
+}
+
+fn make_run_id() -> String {
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y%m%dT%H%M%SZ"])
+        .output()
+        .expect("failed to run date");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::too_many_lines)]
+pub(crate) fn run(args: PushpullZstdArgs) {
+    let sizes = if let Some(ref s) = args.sizes {
+        s.clone()
+    } else if args.quick {
+        QUICK_SIZES.to_vec()
+    } else {
+        CHART_SIZES.to_vec()
+    };
+
+    let duration = if args.quick { 1.5 } else { args.duration };
+    let rounds = if args.quick { 1 } else { args.rounds };
+
+    let transports: Vec<&str> = args.transports.split(',').collect();
+    let peers = build_peers();
+    let bench_bin = peers.blocking.to_str().unwrap();
+    let util_bin = peers.tokio.to_str().unwrap();
+    let run_id = make_run_id();
+    let jsonl_path = jsonl::cache_dir().join("results_pushpull_zstd.jsonl");
+
+    eprintln!("PUSH/PULL Zstd benchmark");
+    eprintln!(
+        "Transports: {transports:?}, sizes: {}, rounds: {rounds}",
+        sizes.len()
+    );
+
+    for transport in &transports {
+        eprintln!("\n=== {transport} ===");
+
+        for &size in &sizes {
+            eprint!("{:>8}", size_label(size));
+
+            let wire_bytes = get_wire_size(util_bin, transport, size, None);
+
+            let mut best: Option<(f64, f64, f64)> = None;
+            for _ in 0..rounds {
+                if let Some(result) = run_cell(bench_bin, transport, size, duration, None)
+                    && best.as_ref().is_none_or(|b| result.0 > b.0)
+                {
+                    best = Some(result);
+                }
+            }
+
+            if let Some((msgs_s, mbps, cpu_time)) = best {
+                let row = PushpullLz4Row {
+                    run_id: run_id.clone(),
+                    pattern: "pushpull_zstd".to_string(),
+                    transport: transport.to_string(),
+                    peers: 1,
+                    msg_size: size,
+                    wire_bytes,
+                    msg_count: Some(msgs_s * duration),
+                    elapsed: Some(duration),
+                    cpu_time: Some(cpu_time),
+                    msgs_s: Some(msgs_s),
+                    mbps: Some(mbps),
+                    dict_size: None,
+                };
+                jsonl::append_jsonl(&jsonl_path, &row);
+                eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s");
+            } else {
+                eprint!("  {:>10}", "-");
+            }
+            eprintln!();
+        }
+    }
+
+    // Dict: train once up front from diverse JSON records, then reuse it.
+    for &dict_cap in &args.dict_sizes {
+        let dict_path = format!("/tmp/omq-bench-zstd-dict-{dict_cap}.bin");
+        eprintln!("\nTraining zstd dict (capacity={dict_cap})...");
+        train_dict(util_bin, &dict_path, dict_cap);
+
+        for transport in &transports {
+            if !transport.contains("zstd") {
+                continue;
+            }
+            eprintln!("--- {transport} + dict (dict_size={dict_cap}) ---");
+
+            for &size in &sizes {
+                eprint!("{:>8}", size_label(size));
+
+                let wire_bytes = get_wire_size(util_bin, transport, size, Some(&dict_path));
+
+                let mut best: Option<(f64, f64, f64)> = None;
+                for _ in 0..rounds {
+                    if let Some(result) =
+                        run_cell(bench_bin, transport, size, duration, Some(&dict_path))
+                        && best.as_ref().is_none_or(|b| result.0 > b.0)
+                    {
+                        best = Some(result);
+                    }
+                }
+
+                if let Some((msgs_s, mbps, cpu_time)) = best {
+                    let row = PushpullLz4Row {
+                        run_id: run_id.clone(),
+                        pattern: "pushpull_zstd_dict".to_string(),
+                        transport: transport.to_string(),
+                        peers: 1,
+                        msg_size: size,
+                        wire_bytes,
+                        msg_count: Some(msgs_s * duration),
+                        elapsed: Some(duration),
+                        cpu_time: Some(cpu_time),
+                        msgs_s: Some(msgs_s),
+                        mbps: Some(mbps),
+                        dict_size: Some(dict_cap),
+                    };
+                    jsonl::append_jsonl(&jsonl_path, &row);
+                    eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s  wire {wire_bytes}");
+                } else {
+                    eprint!("  {:>10}", "-");
+                }
+                eprintln!();
+            }
+        }
+        let _ = std::fs::remove_file(&dict_path);
+    }
+
+    eprintln!("\nResults appended to {}", jsonl_path.display());
+}

--- a/omq-bench/src/bench/pushpull_zstd.rs
+++ b/omq-bench/src/bench/pushpull_zstd.rs
@@ -74,13 +74,23 @@ fn build_peers() -> Peers {
     }
 }
 
-fn get_wire_size(binary: &str, transport: &str, size: u64, dict_file: Option<&str>) -> u64 {
+fn get_wire_size(
+    binary: &str,
+    transport: &str,
+    size: u64,
+    dict_file: Option<&str>,
+    level: Option<i32>,
+) -> u64 {
     let port = next_port();
     let ep = format!("{transport}://127.0.0.1:{port}");
     let size_str = size.to_string();
     let mut env = vec![("OMQ_BENCH_PAYLOAD", "json")];
     if let Some(df) = dict_file {
         env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    let level_val = level.map(|l| l.to_string());
+    if let Some(level) = &level_val {
+        env.push(("OMQ_BENCH_ZSTD_LEVEL", level.as_str()));
     }
     let output = process::capture(
         &[binary, "wire-size", &ep, &size_str],
@@ -108,6 +118,7 @@ fn run_cell(
     size: u64,
     duration: f64,
     dict_file: Option<&str>,
+    level: Option<i32>,
 ) -> Option<(f64, f64, f64)> {
     let size_str = size.to_string();
     let dur_str = format!("{duration:.1}");
@@ -117,6 +128,10 @@ fn run_cell(
     let mut push_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
     if let Some(df) = dict_file {
         push_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    let level_val = level.map(|l| l.to_string());
+    if let Some(level) = &level_val {
+        push_env.push(("OMQ_BENCH_ZSTD_LEVEL", level.as_str()));
     }
 
     let mut push_proc = process::spawn(
@@ -137,6 +152,9 @@ fn run_cell(
     let mut pull_env: Vec<(&str, &str)> = vec![("OMQ_BENCH_PAYLOAD", "json")];
     if let Some(df) = dict_file {
         pull_env.push(("OMQ_BENCH_DICT_FILE", df));
+    }
+    if let Some(level) = &level_val {
+        pull_env.push(("OMQ_BENCH_ZSTD_LEVEL", level.as_str()));
     }
 
     let output = process::capture(
@@ -195,8 +213,9 @@ pub(crate) fn run(args: PushpullZstdArgs) {
 
     eprintln!("PUSH/PULL Zstd benchmark");
     eprintln!(
-        "Transports: {transports:?}, sizes: {}, rounds: {rounds}",
-        sizes.len()
+        "Transports: {transports:?}, sizes: {}, rounds: {rounds}, level: {}",
+        sizes.len(),
+        args.level.map_or("default".to_string(), |l| l.to_string()),
     );
 
     for transport in &transports {
@@ -205,11 +224,12 @@ pub(crate) fn run(args: PushpullZstdArgs) {
         for &size in &sizes {
             eprint!("{:>8}", size_label(size));
 
-            let wire_bytes = get_wire_size(util_bin, transport, size, None);
+            let wire_bytes = get_wire_size(util_bin, transport, size, None, args.level);
 
             let mut best: Option<(f64, f64, f64)> = None;
             for _ in 0..rounds {
-                if let Some(result) = run_cell(bench_bin, transport, size, duration, None)
+                if let Some(result) =
+                    run_cell(bench_bin, transport, size, duration, None, args.level)
                     && best.as_ref().is_none_or(|b| result.0 > b.0)
                 {
                     best = Some(result);
@@ -230,6 +250,7 @@ pub(crate) fn run(args: PushpullZstdArgs) {
                     msgs_s: Some(msgs_s),
                     mbps: Some(mbps),
                     dict_size: None,
+                    compression_level: args.level,
                 };
                 jsonl::append_jsonl(&jsonl_path, &row);
                 eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s");
@@ -255,13 +276,19 @@ pub(crate) fn run(args: PushpullZstdArgs) {
             for &size in &sizes {
                 eprint!("{:>8}", size_label(size));
 
-                let wire_bytes = get_wire_size(util_bin, transport, size, Some(&dict_path));
+                let wire_bytes =
+                    get_wire_size(util_bin, transport, size, Some(&dict_path), args.level);
 
                 let mut best: Option<(f64, f64, f64)> = None;
                 for _ in 0..rounds {
-                    if let Some(result) =
-                        run_cell(bench_bin, transport, size, duration, Some(&dict_path))
-                        && best.as_ref().is_none_or(|b| result.0 > b.0)
+                    if let Some(result) = run_cell(
+                        bench_bin,
+                        transport,
+                        size,
+                        duration,
+                        Some(&dict_path),
+                        args.level,
+                    ) && best.as_ref().is_none_or(|b| result.0 > b.0)
                     {
                         best = Some(result);
                     }
@@ -281,6 +308,7 @@ pub(crate) fn run(args: PushpullZstdArgs) {
                         msgs_s: Some(msgs_s),
                         mbps: Some(mbps),
                         dict_size: Some(dict_cap),
+                        compression_level: args.level,
                     };
                     jsonl::append_jsonl(&jsonl_path, &row);
                     eprint!("  {msgs_s:>10.0} msg/s  {mbps:>8.1} MB/s  wire {wire_bytes}");

--- a/omq-bench/src/chart/mod.rs
+++ b/omq-bench/src/chart/mod.rs
@@ -4,3 +4,5 @@ pub(crate) mod fanio;
 pub(crate) mod lz4;
 pub(crate) mod main_tcp;
 pub(crate) mod pubsub;
+mod pushpull_compression;
+pub(crate) mod zstd;

--- a/omq-bench/src/chart/pushpull_compression.rs
+++ b/omq-bench/src/chart/pushpull_compression.rs
@@ -1,0 +1,402 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use plotters::prelude::*;
+
+use super::common::{
+    AXIS_COLOR, BACKGROUND_COLOR, GRID_COLOR, Impl, MUTED_TEXT_COLOR, TEXT_COLOR, TITLE_FILL,
+    ValMap, detect_hardware, fmt_gbps, fmt_msgs, fmt_size, nice_step, out_dir, postprocess_svg,
+};
+use crate::jsonl::{self, PushpullLz4Row};
+
+pub(crate) struct Series {
+    pub(crate) key: &'static str,
+    pub(crate) label: &'static str,
+    pub(crate) color: RGBColor,
+}
+
+pub(crate) struct CompressionChart {
+    pub(crate) cache_file: &'static str,
+    pub(crate) pattern_prefix: &'static str,
+    pub(crate) dict_pattern: &'static str,
+    pub(crate) dict_series_key: &'static str,
+    pub(crate) output_file: &'static str,
+    pub(crate) title: &'static str,
+    pub(crate) series: &'static [Series],
+    pub(crate) compression_level: Option<i32>,
+}
+
+const LINK_SPEEDS: &[(f64, &str)] = &[
+    (1e9 / 8.0, "1 Gbps link"),
+    (100e6 / 8.0, "100 Mbps link"),
+    (10e6 / 8.0, "10 Mbps link"),
+];
+const CPU_PANEL_MAX: f64 = 200.0;
+
+struct CompressionData {
+    cpu_msgs: BTreeMap<String, f64>,
+    cpu_pct: BTreeMap<String, f64>,
+    wire_bytes: BTreeMap<String, u64>,
+}
+
+fn load_data(chart: &CompressionChart, sizes: &[u64]) -> BTreeMap<u64, CompressionData> {
+    let path = jsonl::cache_dir().join(chart.cache_file);
+    let rows: Vec<(usize, PushpullLz4Row)> = jsonl::load_jsonl(&path);
+
+    let mut seen: BTreeMap<(String, u64), usize> = BTreeMap::new();
+    let mut out: BTreeMap<u64, CompressionData> = BTreeMap::new();
+
+    for (seq, row) in &rows {
+        if !row.pattern.starts_with(chart.pattern_prefix) {
+            continue;
+        }
+        if !sizes.contains(&row.msg_size) {
+            continue;
+        }
+        if let Some(level) = chart.compression_level
+            && row
+                .compression_level
+                .is_some_and(|row_level| row_level != level)
+        {
+            continue;
+        }
+
+        let series_key = if row.pattern == chart.dict_pattern {
+            chart.dict_series_key.to_string()
+        } else {
+            row.transport.clone()
+        };
+
+        let key = (series_key.clone(), row.msg_size);
+        if seen.get(&key).is_some_and(|&prev| *seq < prev) {
+            continue;
+        }
+        seen.insert(key, *seq);
+
+        let entry = out.entry(row.msg_size).or_insert_with(|| CompressionData {
+            cpu_msgs: BTreeMap::new(),
+            cpu_pct: BTreeMap::new(),
+            wire_bytes: BTreeMap::new(),
+        });
+
+        if let Some(v) = row.msgs_s {
+            entry.cpu_msgs.insert(series_key.clone(), v);
+        }
+        if let (Some(cpu_time), Some(elapsed)) = (row.cpu_time, row.elapsed)
+            && elapsed > 0.0
+        {
+            entry
+                .cpu_pct
+                .insert(series_key.clone(), cpu_time / elapsed * 100.0);
+        }
+        entry.wire_bytes.insert(series_key, row.wire_bytes);
+    }
+
+    out
+}
+
+fn project(data: &BTreeMap<u64, CompressionData>, link_bps: f64) -> (ValMap, ValMap, ValMap) {
+    let mut tput: ValMap = BTreeMap::new();
+    let mut msgs: ValMap = BTreeMap::new();
+    let mut cpu: ValMap = BTreeMap::new();
+
+    for (&msg_size, compression) in data {
+        for (series_key, &cpu_msgs_s) in &compression.cpu_msgs {
+            let wire = compression
+                .wire_bytes
+                .get(series_key)
+                .copied()
+                .unwrap_or(msg_size);
+            let link_msgs_s = if wire > 0 {
+                link_bps / wire as f64
+            } else {
+                f64::INFINITY
+            };
+            let eff_msgs_s = cpu_msgs_s.min(link_msgs_s);
+            let eff_mbps = eff_msgs_s * msg_size as f64 / 1_000_000.0;
+
+            msgs.entry(msg_size)
+                .or_default()
+                .insert(series_key.clone(), eff_msgs_s);
+            tput.entry(msg_size)
+                .or_default()
+                .insert(series_key.clone(), eff_mbps);
+            if let Some(&cpu_pct) = compression.cpu_pct.get(series_key) {
+                let ratio = if cpu_msgs_s > 0.0 {
+                    eff_msgs_s / cpu_msgs_s
+                } else {
+                    0.0
+                };
+                cpu.entry(msg_size)
+                    .or_default()
+                    .insert(series_key.clone(), cpu_pct * ratio);
+            }
+        }
+    }
+
+    (tput, msgs, cpu)
+}
+
+fn series_as_impls(chart: &CompressionChart) -> Vec<Impl> {
+    chart
+        .series
+        .iter()
+        .map(|s| Impl {
+            key: s.key,
+            label: s.label,
+            threads: "-",
+            color: s.color,
+        })
+        .collect()
+}
+
+#[expect(clippy::too_many_lines)]
+pub(crate) fn generate(chart: &CompressionChart) {
+    let sizes: Vec<u64> = vec![16, 64, 256, 1024, 4096, 16384, 65536, 262_144];
+    let data = load_data(chart, &sizes);
+    if data.is_empty() {
+        return;
+    }
+
+    let dir = out_dir().join("pushpull");
+    std::fs::create_dir_all(&dir).ok();
+    let out = dir.join(chart.output_file);
+
+    let impls = series_as_impls(chart);
+    let present: Vec<&Impl> = impls
+        .iter()
+        .filter(|imp| {
+            data.values()
+                .any(|compression| compression.cpu_msgs.contains_key(imp.key))
+        })
+        .collect();
+
+    let row_count = LINK_SPEEDS.len() as u32;
+    let panel_h = 280u32;
+    let row_gap = 60u32;
+    let legend_row_h = 16u32;
+    let table_h = 20 + present.len() as u32 * legend_row_h + 10;
+    let top_margin = 56u32;
+    let chart_total = row_count * panel_h + (row_count - 1) * row_gap + top_margin;
+    let total_h = chart_total + table_h;
+    let width = 800u32;
+    let hw_label = detect_hardware();
+    let n_ticks = 6usize;
+
+    let root = SVGBackend::new(&out, (width, total_h)).into_drawing_area();
+    root.fill(&BACKGROUND_COLOR).unwrap();
+
+    let mut row_titles: Vec<(u32, String)> = Vec::new();
+
+    for (idx, &(link_bps, label)) in LINK_SPEEDS.iter().enumerate() {
+        let (tput, msgs, cpu) = project(&data, link_bps);
+
+        let y_top = top_margin + idx as u32 * (panel_h + row_gap);
+        let row_area = root.clone().shrink((0, y_top), (width, panel_h));
+
+        row_titles.push((y_top - 6, label.to_string()));
+
+        let msgs_raw = sizes
+            .iter()
+            .filter_map(|s| msgs.get(s))
+            .flat_map(std::collections::BTreeMap::values)
+            .copied()
+            .fold(0.0_f64, f64::max);
+        let msgs_step = nice_step(msgs_raw, n_ticks);
+        let msgs_max = msgs_step * n_ticks as f64;
+        let gbs_raw = sizes
+            .iter()
+            .filter_map(|s| tput.get(s))
+            .flat_map(std::collections::BTreeMap::values)
+            .map(|v| v / 1000.0)
+            .fold(0.0_f64, f64::max);
+        let gbs_step = nice_step(gbs_raw, n_ticks);
+        let gbs_max = gbs_step * n_ticks as f64;
+
+        if msgs_max <= 0.0 || gbs_max <= 0.0 {
+            continue;
+        }
+
+        let mut chart_area = ChartBuilder::on(&row_area)
+            .set_label_area_size(LabelAreaPosition::Bottom, 28)
+            .set_label_area_size(LabelAreaPosition::Left, 70)
+            .set_label_area_size(LabelAreaPosition::Right, 62)
+            .margin_top(6)
+            .margin_left(10)
+            .margin_right(10)
+            .build_cartesian_2d(0.0..(sizes.len() - 1) as f64, 0.0..msgs_max)
+            .unwrap()
+            .set_secondary_coord(0.0..(sizes.len() - 1) as f64, 0.0..gbs_max);
+
+        chart_area
+            .configure_mesh()
+            .x_labels(sizes.len())
+            .x_label_formatter(&|v| {
+                sizes
+                    .get(v.round() as usize)
+                    .map_or(String::new(), |&s| fmt_size(s))
+            })
+            .y_labels(n_ticks + 1)
+            .y_label_formatter(&|v| fmt_msgs(*v))
+            .y_label_style(("sans-serif", 10).into_font().color(&TEXT_COLOR))
+            .x_label_style(("sans-serif", 10).into_font().color(&TEXT_COLOR))
+            .light_line_style(TRANSPARENT)
+            .bold_line_style(GRID_COLOR)
+            .axis_style(AXIS_COLOR)
+            .draw()
+            .unwrap();
+
+        chart_area
+            .configure_secondary_axes()
+            .y_labels(n_ticks + 1)
+            .y_label_formatter(&|v| fmt_gbps(*v))
+            .label_style(("sans-serif", 10).into_font().color(&TEXT_COLOR))
+            .axis_style(AXIS_COLOR)
+            .draw()
+            .unwrap();
+
+        for imp in &present {
+            let pts: Vec<(f64, f64)> = sizes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &sz)| msgs.get(&sz)?.get(imp.key).map(|&v| (i as f64, v)))
+                .collect();
+            if pts.is_empty() {
+                continue;
+            }
+            chart_area
+                .draw_series(DashedLineSeries::new(
+                    pts.iter().copied(),
+                    6,
+                    3,
+                    imp.color.stroke_width(2),
+                ))
+                .unwrap();
+            chart_area
+                .draw_series(
+                    pts.iter()
+                        .map(|&(x, y)| Circle::new((x, y), 2, imp.color.filled())),
+                )
+                .unwrap();
+        }
+
+        for imp in &present {
+            let pts: Vec<(f64, f64, f64)> = sizes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &sz)| {
+                    let cpu_pct = cpu.get(&sz)?.get(imp.key)?;
+                    Some((
+                        i as f64,
+                        cpu_pct.min(CPU_PANEL_MAX) / CPU_PANEL_MAX * msgs_max,
+                        *cpu_pct,
+                    ))
+                })
+                .collect();
+            if pts.is_empty() {
+                continue;
+            }
+            chart_area
+                .draw_series(DashedLineSeries::new(
+                    pts.iter().map(|&(x, y, _)| (x, y)),
+                    2,
+                    3,
+                    imp.color.stroke_width(1),
+                ))
+                .unwrap();
+            chart_area
+                .draw_series(pts.iter().map(|&(x, y, cpu_pct)| {
+                    Text::new(
+                        format!("{cpu_pct:.0}%"),
+                        (x, y),
+                        ("sans-serif", 7).into_font().color(&imp.color),
+                    )
+                }))
+                .unwrap();
+        }
+
+        for imp in &present {
+            let pts: Vec<(f64, f64)> = sizes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &sz)| {
+                    tput.get(&sz)
+                        .and_then(|m| m.get(imp.key))
+                        .map(|&v| (i as f64, v / 1000.0))
+                })
+                .collect();
+            if pts.is_empty() {
+                continue;
+            }
+            chart_area
+                .draw_secondary_series(LineSeries::new(pts.clone(), imp.color.stroke_width(2)))
+                .unwrap();
+            chart_area
+                .draw_secondary_series(
+                    pts.iter()
+                        .map(|&(x, y)| Circle::new((x, y), 2, imp.color.filled())),
+                )
+                .unwrap();
+        }
+    }
+
+    let table_area = root.clone().shrink((0, chart_total), (width, table_h));
+    let style_val = ("sans-serif", 11).into_font().color(&TEXT_COLOR);
+    let style_dim = ("sans-serif", 10).into_font().color(&MUTED_TEXT_COLOR);
+    let col_swatch = 78i32;
+    let col_name = col_swatch + 20;
+    let col_note = 380i32;
+
+    table_area
+        .draw_text("--- dashed = msg/s (left axis)", &style_dim, (col_note, 4))
+        .unwrap();
+    table_area
+        .draw_text(
+            "\u{2500}\u{2500}\u{2500} solid = GB/s (right axis)",
+            &style_dim,
+            (col_note, 18),
+        )
+        .unwrap();
+    table_area
+        .draw_text("... dotted = compression CPU%", &style_dim, (col_note, 32))
+        .unwrap();
+
+    for (i, imp) in present.iter().enumerate() {
+        #[expect(clippy::cast_possible_wrap)]
+        let y = 4 + i as i32 * legend_row_h.cast_signed();
+
+        table_area
+            .draw(&PathElement::new(
+                vec![(col_swatch, y + 6), (col_swatch + 14, y + 6)],
+                imp.color.stroke_width(2),
+            ))
+            .unwrap();
+        table_area
+            .draw_text(imp.label, &style_val, (col_name, y))
+            .unwrap();
+    }
+
+    root.present().unwrap();
+    drop(root);
+
+    postprocess_svg(&out, width, total_h, chart.title, hw_label.as_deref()).unwrap();
+
+    let mut svg = std::fs::read_to_string(&out).unwrap();
+    let mid = width / 2;
+    let mut extra = String::new();
+    for (y, label) in &row_titles {
+        write!(
+            extra,
+            "\n<text x=\"{mid}\" y=\"{y}\" text-anchor=\"middle\" \
+             font-family=\"sans-serif\" font-size=\"13\" font-weight=\"bold\" \
+             fill=\"{TITLE_FILL}\">{label}</text>",
+        )
+        .unwrap();
+    }
+    if let Some(pos) = svg.rfind("</svg>") {
+        svg.insert_str(pos, &extra);
+    }
+    std::fs::write(&out, svg).unwrap();
+
+    eprintln!("Written: {}", out.display());
+}

--- a/omq-bench/src/chart/zstd.rs
+++ b/omq-bench/src/chart/zstd.rs
@@ -9,26 +9,26 @@ const SERIES: &[Series] = &[
         color: RGBColor(250, 204, 21),
     },
     Series {
-        key: "lz4+tcp",
-        label: "lz4+tcp",
+        key: "zstd+tcp",
+        label: "zstd+tcp",
         color: RGBColor(96, 165, 250),
     },
     Series {
-        key: "lz4+tcp+dict",
-        label: "lz4+tcp + dict",
+        key: "zstd+tcp+dict",
+        label: "zstd+tcp + dict",
         color: RGBColor(167, 139, 250),
     },
 ];
 
 const CHART: CompressionChart = CompressionChart {
-    cache_file: "results_pushpull_lz4.jsonl",
-    pattern_prefix: "pushpull_lz4",
-    dict_pattern: "pushpull_lz4_dict",
-    dict_series_key: "lz4+tcp+dict",
-    output_file: "lz4_tcp.svg",
-    title: "PUSH/PULL LZ4 compression, structural JSON payload, 2 KiB dict, TCP loopback, 2-process",
+    cache_file: "results_pushpull_zstd.jsonl",
+    pattern_prefix: "pushpull_zstd",
+    dict_pattern: "pushpull_zstd_dict",
+    dict_series_key: "zstd+tcp+dict",
+    output_file: "zstd_tcp.svg",
+    title: "PUSH/PULL Zstd L1 compression, structural JSON payload, 2 KiB dict, TCP loopback, 2-process",
     series: SERIES,
-    compression_level: None,
+    compression_level: Some(1),
 };
 
 pub(crate) fn generate() {

--- a/omq-bench/src/cli.rs
+++ b/omq-bench/src/cli.rs
@@ -42,6 +42,8 @@ pub(crate) enum RunSub {
     Comparisons(ComparisonsArgs),
     /// PUSH/PULL with LZ4 compression.
     PushpullLz4(PushpullLz4Args),
+    /// PUSH/PULL with experimental Zstd compression.
+    PushpullZstd(PushpullZstdArgs),
     /// Push/pull compression benchmarks.
     Compression(CompressionArgs),
 }
@@ -171,6 +173,33 @@ pub(crate) struct ComparisonsArgs {
 pub(crate) struct PushpullLz4Args {
     /// Transports (comma-separated).
     #[arg(long, default_value = "tcp,lz4+tcp")]
+    pub transports: String,
+
+    /// Message sizes (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub sizes: Option<Vec<u64>>,
+
+    /// Duration per measurement in seconds.
+    #[arg(long, default_value_t = 2.0)]
+    pub duration: f64,
+
+    /// Best-of-N rounds.
+    #[arg(long, default_value_t = 3)]
+    pub rounds: u32,
+
+    /// Quick mode: 3 sizes, 1 round, 1.5s.
+    #[arg(long)]
+    pub quick: bool,
+
+    /// Dict sizes to train (comma-separated).
+    #[arg(long, value_delimiter = ',', default_values_t = [2048])]
+    pub dict_sizes: Vec<u64>,
+}
+
+#[derive(Parser)]
+pub(crate) struct PushpullZstdArgs {
+    /// Transports (comma-separated).
+    #[arg(long, default_value = "tcp,zstd+tcp")]
     pub transports: String,
 
     /// Message sizes (comma-separated).

--- a/omq-bench/src/cli.rs
+++ b/omq-bench/src/cli.rs
@@ -34,6 +34,8 @@ pub(crate) enum ChartSub {
     Fanio,
     /// PUB/SUB LZ4 compression chart.
     Lz4,
+    /// PUSH/PULL Zstd compression chart.
+    Zstd,
 }
 
 #[derive(Subcommand)]
@@ -221,6 +223,10 @@ pub(crate) struct PushpullZstdArgs {
     /// Dict sizes to train (comma-separated).
     #[arg(long, value_delimiter = ',', default_values_t = [2048])]
     pub dict_sizes: Vec<u64>,
+
+    /// Zstd compression level (-8..=4). Omitted uses transport default.
+    #[arg(long)]
+    pub level: Option<i32>,
 }
 
 #[derive(Parser)]

--- a/omq-bench/src/jsonl.rs
+++ b/omq-bench/src/jsonl.rs
@@ -134,6 +134,8 @@ pub(crate) struct PushpullLz4Row {
     pub mbps: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dict_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compression_level: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/omq-bench/src/main.rs
+++ b/omq-bench/src/main.rs
@@ -26,12 +26,14 @@ fn main() {
             Some(ChartSub::Pubsub) => chart::pubsub::generate(),
             Some(ChartSub::Fanio) => chart::fanio::generate(),
             Some(ChartSub::Lz4) => chart::lz4::generate(),
+            Some(ChartSub::Zstd) => chart::zstd::generate(),
             None => {
                 chart::main_tcp::generate();
                 chart::comparison::generate();
                 chart::pubsub::generate();
                 chart::fanio::generate();
                 chart::lz4::generate();
+                chart::zstd::generate();
             }
         },
     });

--- a/omq-bench/src/main.rs
+++ b/omq-bench/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
         Command::Run { sub } => match sub {
             RunSub::Comparisons(args) => bench::comparisons::run(args),
             RunSub::PushpullLz4(args) => bench::pushpull_lz4::run(args),
+            RunSub::PushpullZstd(args) => bench::pushpull_zstd::run(args),
             RunSub::Compression(args) => bench::compression::run(args),
         },
         Command::Chart { sub } => match sub {

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -49,7 +49,6 @@ features = ["std"]
 optional = true
 
 [dependencies.zrip]
-path = "../../../zrip"
 version = "0.8.4"
 default-features = false
 features = ["std", "frame", "dict_builder"]

--- a/omq-proto/Cargo.toml
+++ b/omq-proto/Cargo.toml
@@ -20,10 +20,12 @@ workspace = true
 # No C compiler required, no crypto deps. Opt in to features:
 #   curve     CURVE encrypted-handshake (RFC 26)
 #   lz4       lz4+tcp:// transport (pure Rust; lz4rip)
+#   zstd      zstd+tcp:// transport (pure Rust; zrip)
 default = []
 curve = ["dep:crypto_box", "dep:crypto_secretbox", "dep:subtle", "dep:x25519-dalek", "dep:zeroize"]
 plain = []
 lz4 = ["dep:lz4rip"]
+zstd = ["dep:zrip"]
 ws = []
 soak = []
 
@@ -44,6 +46,13 @@ zeroize = { version = "1.8.0", features = ["zeroize_derive"], optional = true }
 version = "0.11.2"
 default-features = false
 features = ["std"]
+optional = true
+
+[dependencies.zrip]
+path = "../../../zrip"
+version = "0.8.4"
+default-features = false
+features = ["std", "frame", "dict_builder"]
 optional = true
 
 [[bench]]

--- a/omq-proto/README.md
+++ b/omq-proto/README.md
@@ -20,7 +20,7 @@ payloads are below 4 GiB.
 | Mechanisms | NULL, PLAIN, CURVE |
 | Transforms | LZ4 frame-level compression |
 | `Endpoint` | Parser for `tcp://`, `ipc://` (Unix sockets / Windows named pipes), `inproc://`, `udp://`, `lz4+tcp://`, `ws://`, `wss://` |
-| `SocketType` | 19 types (11 stable + 8 draft) with compatibility matrix |
+| `SocketType` | 20 types (11 stable, 8 draft, plus STREAM) with compatibility matrix |
 | `SubscriptionSet` | Prefix-trie for PUB/SUB topic filtering |
 | Monitor types | `MonitorEvent`, `DisconnectReason`, `PeerInfo` |
 

--- a/omq-proto/src/endpoint.rs
+++ b/omq-proto/src/endpoint.rs
@@ -48,6 +48,9 @@ pub enum Endpoint {
     /// `lz4+tcp://host:port` LZ4-compressed TCP. Requires the `lz4` feature.
     #[cfg(feature = "lz4")]
     Lz4Tcp { host: Host, port: u16 },
+    /// `zstd+tcp://host:port` Zstd-compressed TCP. Requires the `zstd` feature.
+    #[cfg(feature = "zstd")]
+    ZstdTcp { host: Host, port: u16 },
     /// `ws://host:port/path` ZeroMQ over WebSocket (RFC 45). Requires the
     /// `ws` feature.
     #[cfg(feature = "ws")]
@@ -140,6 +143,10 @@ impl FromStr for Endpoint {
             "udp" => parse_udp(rest),
             #[cfg(feature = "lz4")]
             "lz4+tcp" => parse_host_port(rest).map(|(host, port)| Endpoint::Lz4Tcp { host, port }),
+            #[cfg(feature = "zstd")]
+            "zstd+tcp" => {
+                parse_host_port(rest).map(|(host, port)| Endpoint::ZstdTcp { host, port })
+            }
             #[cfg(feature = "ws")]
             "ws" => parse_ws(rest, false),
             #[cfg(feature = "ws")]
@@ -173,6 +180,8 @@ impl fmt::Display for Endpoint {
             },
             #[cfg(feature = "lz4")]
             Self::Lz4Tcp { host, port } => write!(f, "lz4+tcp://{host}:{port}"),
+            #[cfg(feature = "zstd")]
+            Self::ZstdTcp { host, port } => write!(f, "zstd+tcp://{host}:{port}"),
             #[cfg(feature = "ws")]
             Self::Ws { host, port, path } => write!(f, "ws://{host}:{port}{path}"),
             #[cfg(feature = "ws")]
@@ -198,6 +207,11 @@ impl Endpoint {
                 host: host.clone(),
                 port: *port,
             },
+            #[cfg(feature = "zstd")]
+            Endpoint::ZstdTcp { host, port } => Endpoint::Tcp {
+                host: host.clone(),
+                port: *port,
+            },
             _ => self.clone(),
         }
     }
@@ -212,6 +226,10 @@ impl Endpoint {
             (Endpoint::Lz4Tcp { .. }, Endpoint::Tcp { host, port }) => {
                 Endpoint::Lz4Tcp { host, port }
             }
+            #[cfg(feature = "zstd")]
+            (Endpoint::ZstdTcp { .. }, Endpoint::Tcp { host, port }) => {
+                Endpoint::ZstdTcp { host, port }
+            }
             (_, resolved) => resolved,
         }
     }
@@ -224,6 +242,8 @@ impl Endpoint {
             Endpoint::Tcp { .. } => true,
             #[cfg(feature = "lz4")]
             Endpoint::Lz4Tcp { .. } => true,
+            #[cfg(feature = "zstd")]
+            Endpoint::ZstdTcp { .. } => true,
             _ => false,
         }
     }
@@ -291,6 +311,8 @@ impl Endpoint {
             Endpoint::Udp { .. } => "udp",
             #[cfg(feature = "lz4")]
             Endpoint::Lz4Tcp { .. } => "lz4+tcp",
+            #[cfg(feature = "zstd")]
+            Endpoint::ZstdTcp { .. } => "zstd+tcp",
             #[cfg(feature = "ws")]
             Endpoint::Ws { .. } => "ws",
             #[cfg(feature = "ws")]

--- a/omq-proto/src/lib.rs
+++ b/omq-proto/src/lib.rs
@@ -1,7 +1,7 @@
 //! Sans-I/O core for omq.
 //!
 //! ZMTP codec, message + payload types, frame parsing, mechanism
-//! handshakes (NULL / CURVE), compression transforms
+//! handshakes (NULL / PLAIN / CURVE), compression transforms
 //! (lz4), endpoint parsing, options, and the prefix-
 //! subscription matcher. None of this depends on a runtime.
 #![forbid(unsafe_code)]

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -16,8 +16,8 @@ use crate::proto::mechanism::{Authenticator, MechanismPeerInfo};
 #[cfg(feature = "curve")]
 use crate::proto::mechanism::{CurveKeypair, CurvePublicKey, CurveServerOptions};
 use crate::socket_ref::SocketRef;
-/// Upper bound for `Options::compression_dict`. Both transports
-/// cap at 8 KiB. Inlined as a const so the `compression_dict`
+/// Upper bound for `Options::compression_dict`. Compression transports cap
+/// dictionaries at 8 KiB. Inlined as a const so the `compression_dict`
 /// setter works regardless of which compression features are enabled.
 const COMPRESSION_DICT_MAX: usize = 8 * 1024;
 
@@ -155,17 +155,16 @@ pub struct Options {
     /// Active security mechanism. Defaults to `Null` (no encryption).
     pub mechanism: MechanismSetup,
 
-    /// Outbound compression dictionary. Used by `lz4+tcp://`; ignored
-    /// on plain transports. The dict is shipped to the peer once per
+    /// Outbound compression dictionary. Used by compression transports;
+    /// ignored on plain transports. The dict is shipped to the peer once per
     /// connection; subsequent parts are compressed against it.
     /// Must be 1..=8192 bytes.
     pub compression_dict: Option<Bytes>,
 
     /// Auto-trained dictionaries. Defaults to off.
-    /// When no `compression_dict` is configured on an `lz4+tcp://`
+    /// When no `compression_dict` is configured on a compression
     /// connection, the encoder feeds outbound message parts to a
-    /// `DictTrainer` until it saturates (bloom-filter diversity
-    /// plateaus), then trains a dict (capacity controlled by
+    /// dict trainer until it saturates, then trains a dict (capacity controlled by
     /// `compression_dict_capacity`, default 2 KiB) and ships it.
     /// After that the per-part compression threshold drops from
     /// 512 B to 64 B and small messages ride the dict.
@@ -189,8 +188,7 @@ pub struct Options {
     pub compression_dict_capacity: Option<usize>,
 
     /// Maximum dictionary size (bytes) accepted from a peer. Dicts
-    /// larger than this are rejected. Default: 8192 for both
-    /// transports.
+    /// larger than this are rejected. Default: 8192 for compression transports.
     pub max_recv_dict_size: Option<usize>,
 
     /// Minimum message size (bytes) before compression is offloaded to
@@ -619,8 +617,8 @@ impl Options {
         self
     }
 
-    /// Set the outbound compression dictionary. Used by `lz4+tcp://`.
-    /// Validated by [`Options::validate`]: must be 1..=8192 bytes (RFC §6.2).
+    /// Set the outbound compression dictionary. Used by compression transports.
+    /// Validated by [`Options::validate`]: must be 1..=8192 bytes.
     /// Disables auto-training when set.
     #[must_use]
     pub fn compression_dict(mut self, dict: impl Into<Bytes>) -> Self {
@@ -628,7 +626,7 @@ impl Options {
         self
     }
 
-    /// Enable auto-trained dictionaries (`lz4+tcp://`).
+    /// Enable auto-trained dictionaries for compression transports.
     /// Off by default. See [`Options::compression_auto_train`] for
     /// semantics.
     #[must_use]
@@ -656,7 +654,8 @@ impl Options {
     }
 
     /// Set the maximum dictionary size accepted from a peer.
-    /// Dicts larger than this are rejected at decode time.
+    /// Dicts larger than this are rejected at decode time. Transport hard caps
+    /// still apply.
     #[must_use]
     pub fn max_recv_dict_size(mut self, max: usize) -> Self {
         self.max_recv_dict_size = Some(max);

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -42,6 +42,9 @@ pub const DEFAULT_MAX_PENDING_HANDSHAKES: usize = 128;
 /// - The same socket types with a `connect()` endpoint allocate a pre-ready
 ///   pipe at `connect()` time. Sends may queue there before the peer reaches
 ///   READY. Native OMQ has no `ZMQ_IMMEDIATE` option to disable that queue.
+const ZSTD_LEVEL_MIN: i32 = -8;
+const ZSTD_LEVEL_MAX: i32 = 4;
+
 // Compression fields (compression_dict through compression_offload_threshold)
 // could be grouped into a sub-struct, but the public API change would touch
 // every backend file that accesses them.
@@ -182,6 +185,11 @@ pub struct Options {
     /// where compressing tiny messages wastes CPU.
     pub compression_threshold: Option<usize>,
 
+    /// Compression level for `zstd+tcp://`. `None` uses the transport
+    /// default. Supported zrip levels are -8..=4; level 0 maps to zrip's
+    /// library default (currently level 1). Ignored by `lz4+tcp://`.
+    pub compression_level: Option<i32>,
+
     /// Auto-train dict capacity in bytes. Controls the maximum size of
     /// the dictionary produced by auto-training. Default: 2048.
     /// Ignored when `compression_dict` is set.
@@ -237,7 +245,9 @@ pub struct Options {
     pub wss_tls: WssTls,
 }
 
-/// TLS configuration for WSS endpoints.
+/// TLS configuration for WSS endpoints. This covers server certificates
+/// and client-side server certificate validation only. Mutual TLS/client
+/// certificate authentication is not implemented.
 #[cfg(feature = "ws")]
 #[derive(Clone, Debug, Default)]
 pub struct WssTls {
@@ -277,6 +287,7 @@ impl Default for Options {
             compression_dict: None,
             compression_auto_train: false,
             compression_threshold: None,
+            compression_level: None,
             compression_dict_capacity: None,
             max_recv_dict_size: None,
             compression_offload_threshold: Some(8192),
@@ -339,6 +350,13 @@ impl Options {
             return Err(crate::error::Error::Config(format!(
                 "compression dict must be 1..={COMPRESSION_DICT_MAX} bytes, got {}",
                 dict.len()
+            )));
+        }
+        if let Some(level) = self.compression_level
+            && !(ZSTD_LEVEL_MIN..=ZSTD_LEVEL_MAX).contains(&level)
+        {
+            return Err(crate::error::Error::Config(format!(
+                "zstd compression level must be {ZSTD_LEVEL_MIN}..={ZSTD_LEVEL_MAX}, got {level}",
             )));
         }
         #[cfg(feature = "plain")]
@@ -645,6 +663,16 @@ impl Options {
         self
     }
 
+    /// Set the `zstd+tcp://` compression level.
+    ///
+    /// Supported zrip levels are -8..=4. Level 0 maps to zrip's library
+    /// default, currently level 1. Ignored by LZ4 compression.
+    #[must_use]
+    pub fn compression_level(mut self, level: i32) -> Self {
+        self.compression_level = Some(level);
+        self
+    }
+
     /// Set the auto-train dictionary capacity in bytes
     /// (default 2048). Ignored when `compression_dict` is set.
     #[must_use]
@@ -806,6 +834,7 @@ mod tests {
         assert_eq!(o.tcp_keepalive, KeepAlive::Default);
         assert!(!o.conflate);
         assert!(!o.router_mandatory);
+        assert_eq!(o.compression_level, None);
         assert_eq!(o.on_mute, OnMute::Block);
         assert_eq!(o.large_message_threshold, Some(128 * 1024));
     }
@@ -824,6 +853,15 @@ mod tests {
             ..Options::default()
         };
         assert!(o.validate().is_err());
+    }
+
+    #[test]
+    fn validates_zstd_compression_level() {
+        assert!(Options::new().compression_level(1).validate().is_ok());
+        assert!(Options::new().compression_level(-8).validate().is_ok());
+        assert!(Options::new().compression_level(4).validate().is_ok());
+        assert!(Options::new().compression_level(5).validate().is_err());
+        assert!(Options::new().compression_level(-9).validate().is_err());
     }
 
     #[cfg(feature = "curve")]
@@ -899,6 +937,7 @@ mod tests {
             .heartbeat_interval(Duration::from_secs(1))
             .max_message_size(1024)
             .conflate(true)
+            .compression_level(1)
             .router_mandatory(true)
             .on_mute(OnMute::DropNewest);
         assert_eq!(o.send_hwm, 42);
@@ -909,6 +948,7 @@ mod tests {
         assert_eq!(o.heartbeat_interval, Some(Duration::from_secs(1)));
         assert_eq!(o.max_message_size, Some(1024));
         assert!(o.conflate);
+        assert_eq!(o.compression_level, Some(1));
         assert!(o.router_mandatory);
         assert_eq!(o.on_mute, OnMute::DropNewest);
     }

--- a/omq-proto/src/proto/mod.rs
+++ b/omq-proto/src/proto/mod.rs
@@ -34,7 +34,7 @@ pub use connection::{Connection, ConnectionConfig, Event, Role};
 pub use frame::{MAX_FRAME_HEADER_LEN, MAX_SHORT_FRAME_SIZE};
 pub use greeting::{Greeting, MechanismName, VERSION_SNIFF_LEN, ZMTP_MAJOR, ZMTP_MINOR};
 
-/// All 19 ZMTP socket types.
+/// All 20 ZMTP socket types.
 ///
 /// The value carries the wire-level ASCII name returned by [`Self::as_str`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/omq-proto/src/proto/transform/common.rs
+++ b/omq-proto/src/proto/transform/common.rs
@@ -10,6 +10,7 @@
 use bytes::{Bytes, BytesMut};
 
 use crate::error::{Error, Result};
+#[cfg(feature = "lz4")]
 use crate::message::Message;
 use crate::message::Payload;
 
@@ -72,6 +73,7 @@ pub(super) fn validate_dict(dict: &Bytes, label: &str, max_bytes: usize) -> Resu
 
 /// Build a single-part ZMTP message carrying a dict shipment:
 /// `sentinel | dict_bytes`.
+#[cfg(feature = "lz4")]
 pub(super) fn build_dict_shipment(sentinel: [u8; 4], dict: &Bytes) -> Message {
     let mut frame = BytesMut::with_capacity(4 + dict.len());
     frame.extend_from_slice(&sentinel);

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -2,7 +2,7 @@
 //! boundary and the ZMTP codec.
 //!
 //! Transforms wrap each [`crate::message::Message`] going out and coming in.
-//! Compression transports (`lz4+tcp://`) live here: they
+//! Compression transports (`lz4+tcp://`, `zstd+tcp://`) live here: they
 //! prepend a 4-byte sentinel to each message part and optionally compress
 //! the body. Distinct from the per-frame `CurveTransform` inside
 //! [`crate::proto::Connection`], which encrypts at the ZMTP frame layer
@@ -17,18 +17,22 @@
 //! This split lets runtime code hold encoder and decoder state
 //! independently so dict-compressed sends do not contend with reads.
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 mod common;
 #[cfg(feature = "lz4")]
 pub mod lz4;
+#[cfg(feature = "zstd")]
+pub mod zstd;
 
 #[cfg(feature = "lz4")]
 pub use lz4::{Lz4Decoder, Lz4Encoder};
+#[cfg(feature = "zstd")]
+pub use zstd::{ZstdDecoder, ZstdEncoder, train_zdict};
 
 use smallvec::SmallVec;
 
 use crate::endpoint::Endpoint;
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use crate::endpoint::Host;
 use crate::error::Result;
 use crate::message::Message;
@@ -40,6 +44,8 @@ use crate::options::Options;
 pub enum CompressionKind {
     #[cfg(feature = "lz4")]
     Lz4,
+    #[cfg(feature = "zstd")]
+    Zstd,
 }
 
 impl CompressionKind {
@@ -50,17 +56,22 @@ impl CompressionKind {
             Endpoint::Lz4Tcp { .. } => Some(Self::Lz4),
             #[cfg(all(feature = "lz4", feature = "ws"))]
             Endpoint::Lz4Ws { .. } | Endpoint::Lz4Wss { .. } => Some(Self::Lz4),
+            #[cfg(feature = "zstd")]
+            Endpoint::ZstdTcp { .. } => Some(Self::Zstd),
             _ => None,
         }
     }
 
     /// TCP endpoint for this compression kind. Used where a backend lane
     /// needs an encoder without owning a real peer endpoint.
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     #[must_use]
     pub fn tcp_endpoint(self, host: Host, port: u16) -> Endpoint {
         match self {
+            #[cfg(feature = "lz4")]
             Self::Lz4 => Endpoint::Lz4Tcp { host, port },
+            #[cfg(feature = "zstd")]
+            Self::Zstd => Endpoint::ZstdTcp { host, port },
         }
     }
 }
@@ -76,6 +87,8 @@ pub type TransformedOut = SmallVec<[Message; 2]>;
 pub enum MessageEncoder {
     #[cfg(feature = "lz4")]
     Lz4(Box<Lz4Encoder>),
+    #[cfg(feature = "zstd")]
+    Zstd(Box<ZstdEncoder>),
 }
 
 /// Receive-side message transform. Symmetric to [`MessageEncoder`].
@@ -83,6 +96,8 @@ pub enum MessageEncoder {
 pub enum MessageDecoder {
     #[cfg(feature = "lz4")]
     Lz4(Lz4Decoder),
+    #[cfg(feature = "zstd")]
+    Zstd(ZstdDecoder),
 }
 
 impl MessageEncoder {
@@ -101,39 +116,51 @@ impl MessageEncoder {
                 bytes::Bytes::from_static(SENTINEL),
                 t.passthrough_threshold()?,
             )),
-            #[cfg(not(feature = "lz4"))]
-            _ => unreachable!("MessageEncoder is uninhabited without lz4 feature"),
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => Some((
+                bytes::Bytes::from_static(SENTINEL),
+                t.passthrough_threshold()?,
+            )),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
+            _ => unreachable!("MessageEncoder is uninhabited without compression features"),
         }
     }
 
     /// Build the per-connection encoder+decoder pair implied by an endpoint
-    /// scheme. Returns `None` for plain `tcp://` / `ipc://` / `inproc://` /
-    /// `udp://`. Picks up `Options::compression_dict`,
+    /// scheme. Returns `Ok(None)` for plain `tcp://` / `ipc://` /
+    /// `inproc://` / `udp://`. Picks up `Options::compression_dict`,
     /// `Options::compression_auto_train`, and `Options::max_message_size`.
     #[allow(unused_variables)]
-    pub fn for_endpoint(endpoint: &Endpoint, options: &Options) -> Option<(Self, MessageDecoder)> {
-        let kind = CompressionKind::for_endpoint(endpoint)?;
+    pub fn for_endpoint(
+        endpoint: &Endpoint,
+        options: &Options,
+    ) -> Result<Option<(Self, MessageDecoder)>> {
+        let Some(kind) = CompressionKind::for_endpoint(endpoint) else {
+            return Ok(None);
+        };
         Self::for_compression_kind(kind, options)
     }
 
     /// Build the per-connection encoder+decoder pair for a compression kind.
+    /// Returns `Err` when a configured static dict is invalid.
     #[allow(unused_variables)]
     pub fn for_compression_kind(
         kind: CompressionKind,
         options: &Options,
-    ) -> Option<(Self, MessageDecoder)> {
+    ) -> Result<Option<(Self, MessageDecoder)>> {
         match kind {
             #[cfg(feature = "lz4")]
-            CompressionKind::Lz4 => Some(Self::build_lz4(options)),
+            CompressionKind::Lz4 => Ok(Some(Self::build_lz4(options)?)),
+            #[cfg(feature = "zstd")]
+            CompressionKind::Zstd => Ok(Some(Self::build_zstd(options)?)),
         }
     }
 
     #[cfg(feature = "lz4")]
-    fn build_lz4(options: &Options) -> (Self, MessageDecoder) {
+    fn build_lz4(options: &Options) -> Result<(Self, MessageDecoder)> {
         use lz4::{Lz4Decoder, Lz4Encoder};
         let mut enc = if let Some(d) = options.compression_dict.clone() {
-            Lz4Encoder::with_send_dict(d)
-                .expect("compression_dict validated at Options::compression_dict")
+            Lz4Encoder::with_send_dict(d)?
         } else {
             let mut e = Lz4Encoder::new();
             if options.compression_auto_train {
@@ -152,7 +179,36 @@ impl MessageEncoder {
         if let Some(m) = options.max_recv_dict_size {
             dec = dec.with_max_recv_dict_size(m);
         }
-        (MessageEncoder::Lz4(Box::new(enc)), MessageDecoder::Lz4(dec))
+        Ok((MessageEncoder::Lz4(Box::new(enc)), MessageDecoder::Lz4(dec)))
+    }
+
+    #[cfg(feature = "zstd")]
+    fn build_zstd(options: &Options) -> Result<(Self, MessageDecoder)> {
+        use zstd::{ZstdDecoder, ZstdEncoder};
+        let mut enc = if let Some(d) = options.compression_dict.clone() {
+            ZstdEncoder::with_send_dict(d)?
+        } else {
+            let mut e = ZstdEncoder::new();
+            if options.compression_auto_train {
+                e = e.with_auto_train();
+            }
+            if let Some(c) = options.compression_dict_capacity {
+                e = e.with_dict_capacity(c);
+            }
+            e
+        }
+        .with_max_message_size(options.max_message_size);
+        if let Some(t) = options.compression_threshold {
+            enc = enc.with_threshold(t);
+        }
+        let mut dec = ZstdDecoder::new().with_max_message_size(options.max_message_size);
+        if let Some(m) = options.max_recv_dict_size {
+            dec = dec.with_max_recv_dict_size(m);
+        }
+        Ok((
+            MessageEncoder::Zstd(Box::new(enc)),
+            MessageDecoder::Zstd(dec),
+        ))
     }
 
     /// Transform an outbound user message into 1+ wire messages.
@@ -160,10 +216,12 @@ impl MessageEncoder {
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(t) => t.encode(msg),
-            #[cfg(not(feature = "lz4"))]
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => t.encode(msg),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
             _ => {
                 let _ = msg;
-                unreachable!("MessageEncoder is uninhabited without lz4 feature")
+                unreachable!("MessageEncoder is uninhabited without compression features")
             }
         }
     }
@@ -175,7 +233,11 @@ impl MessageEncoder {
         if out.first().is_some_and(lz4::is_dict_shipment) {
             return Some(out.remove(0));
         }
-        #[cfg(not(feature = "lz4"))]
+        #[cfg(feature = "zstd")]
+        if out.first().is_some_and(zstd::is_dict_shipment) {
+            return Some(out.remove(0));
+        }
+        #[cfg(not(any(feature = "lz4", feature = "zstd")))]
         let _ = out;
         None
     }
@@ -185,7 +247,9 @@ impl MessageEncoder {
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(t) => t.can_offload(),
-            #[cfg(not(feature = "lz4"))]
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => t.can_offload(),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
             _ => unreachable!(),
         }
     }
@@ -196,7 +260,9 @@ impl MessageEncoder {
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(t) => Self::Lz4(Box::new(t.new_offload())),
-            #[cfg(not(feature = "lz4"))]
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => Self::Zstd(Box::new(t.new_offload())),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
             _ => unreachable!(),
         }
     }
@@ -207,6 +273,8 @@ impl MessageEncoder {
         match (self, primary) {
             #[cfg(feature = "lz4")]
             (Self::Lz4(me), Self::Lz4(p)) => me.sync_dict(p),
+            #[cfg(feature = "zstd")]
+            (Self::Zstd(me), Self::Zstd(p)) => me.sync_dict(p),
             _ => {}
         }
     }
@@ -217,6 +285,8 @@ impl MessageEncoder {
         match (self, other) {
             #[cfg(feature = "lz4")]
             (Self::Lz4(_), Self::Lz4(_)) => true,
+            #[cfg(feature = "zstd")]
+            (Self::Zstd(_), Self::Zstd(_)) => true,
             _ => false,
         }
     }
@@ -225,15 +295,20 @@ impl MessageEncoder {
 impl MessageDecoder {
     /// Transform an inbound wire message. `None` means the message was
     /// consumed by the transport (dict shipment) and must not surface.
-    #[cfg_attr(not(feature = "lz4"), allow(clippy::needless_pass_by_value))]
+    #[cfg_attr(
+        not(any(feature = "lz4", feature = "zstd")),
+        allow(clippy::needless_pass_by_value)
+    )]
     pub fn decode(&mut self, msg: Message) -> Result<Option<Message>> {
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(t) => t.decode(msg),
-            #[cfg(not(feature = "lz4"))]
+            #[cfg(feature = "zstd")]
+            Self::Zstd(t) => t.decode(msg),
+            #[cfg(not(any(feature = "lz4", feature = "zstd")))]
             _ => {
                 let _ = msg;
-                unreachable!("MessageDecoder is uninhabited without lz4 feature")
+                unreachable!("MessageDecoder is uninhabited without compression features")
             }
         }
     }

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -28,9 +28,42 @@ pub use lz4::{Lz4Decoder, Lz4Encoder};
 use smallvec::SmallVec;
 
 use crate::endpoint::Endpoint;
+#[cfg(feature = "lz4")]
+use crate::endpoint::Host;
 use crate::error::Result;
 use crate::message::Message;
 use crate::options::Options;
+
+/// Compression transform selected by an endpoint scheme.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CompressionKind {
+    #[cfg(feature = "lz4")]
+    Lz4,
+}
+
+impl CompressionKind {
+    /// Compression implied by an endpoint scheme.
+    pub fn for_endpoint(endpoint: &Endpoint) -> Option<Self> {
+        match endpoint {
+            #[cfg(feature = "lz4")]
+            Endpoint::Lz4Tcp { .. } => Some(Self::Lz4),
+            #[cfg(all(feature = "lz4", feature = "ws"))]
+            Endpoint::Lz4Ws { .. } | Endpoint::Lz4Wss { .. } => Some(Self::Lz4),
+            _ => None,
+        }
+    }
+
+    /// TCP endpoint for this compression kind. Used where a backend lane
+    /// needs an encoder without owning a real peer endpoint.
+    #[cfg(feature = "lz4")]
+    #[must_use]
+    pub fn tcp_endpoint(self, host: Host, port: u16) -> Endpoint {
+        match self {
+            Self::Lz4 => Endpoint::Lz4Tcp { host, port },
+        }
+    }
+}
 
 /// A transform that may produce up to a small number of wire messages from
 /// one user message (e.g. a dict shipment ahead of the first compressed
@@ -79,12 +112,19 @@ impl MessageEncoder {
     /// `Options::compression_auto_train`, and `Options::max_message_size`.
     #[allow(unused_variables)]
     pub fn for_endpoint(endpoint: &Endpoint, options: &Options) -> Option<(Self, MessageDecoder)> {
-        match endpoint {
+        let kind = CompressionKind::for_endpoint(endpoint)?;
+        Self::for_compression_kind(kind, options)
+    }
+
+    /// Build the per-connection encoder+decoder pair for a compression kind.
+    #[allow(unused_variables)]
+    pub fn for_compression_kind(
+        kind: CompressionKind,
+        options: &Options,
+    ) -> Option<(Self, MessageDecoder)> {
+        match kind {
             #[cfg(feature = "lz4")]
-            Endpoint::Lz4Tcp { .. } => Some(Self::build_lz4(options)),
-            #[cfg(all(feature = "lz4", feature = "ws"))]
-            Endpoint::Lz4Ws { .. } | Endpoint::Lz4Wss { .. } => Some(Self::build_lz4(options)),
-            _ => None,
+            CompressionKind::Lz4 => Some(Self::build_lz4(options)),
         }
     }
 

--- a/omq-proto/src/proto/transform/mod.rs
+++ b/omq-proto/src/proto/transform/mod.rs
@@ -201,6 +201,9 @@ impl MessageEncoder {
         if let Some(t) = options.compression_threshold {
             enc = enc.with_threshold(t);
         }
+        if let Some(level) = options.compression_level {
+            enc = enc.with_level(level);
+        }
         let mut dec = ZstdDecoder::new().with_max_message_size(options.max_message_size);
         if let Some(m) = options.max_recv_dict_size {
             dec = dec.with_max_recv_dict_size(m);

--- a/omq-proto/src/proto/transform/zstd.rs
+++ b/omq-proto/src/proto/transform/zstd.rs
@@ -1,0 +1,526 @@
+//! `zstd+tcp://` per-part transform backed by zrip.
+//!
+//! Dict shipment is a single-part ZMTP message containing ZDICT-format bytes.
+//! The ZDICT magic (`37 A4 30 EC`) is the shipment discriminator. Compressed
+//! parts are raw Zstd frames and must carry `Frame_Content_Size`.
+
+use bytes::Bytes;
+use smallvec::SmallVec;
+use zrip::dict::Dictionary;
+use zrip::{CompressContext, DecompressContext};
+
+use crate::error::{Error, Result};
+use crate::message::{Message, Payload};
+
+use super::TransformedOut;
+use super::common::{
+    ENVELOPE_PLAIN, SENTINEL_PLAIN, plaintext_payload, take_budget, validate_dict,
+};
+
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+const ZDICT_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
+const MIN_COMPRESS_NO_DICT: usize = 512;
+const MIN_COMPRESS_WITH_DICT: usize = 64;
+const MAX_DECOMPRESSED_SIZE: usize = 0x4000_0000 - 1;
+const TRAIN_MAX_SAMPLES: usize = 1000;
+const TRAIN_MAX_BYTES: usize = 100 * 1024;
+const TRAIN_MAX_SAMPLE_LEN: usize = 2048;
+const USER_DICT_ID_MIN: u32 = 32_768;
+const USER_DICT_ID_MAX: u32 = 0x7FFF_FFFF;
+
+pub const MAX_DICT_BYTES: usize = 8 * 1024;
+pub const DEFAULT_LEVEL: i32 = -3;
+pub const DEFAULT_DICT_CAPACITY: usize = 2048;
+
+pub fn train_zdict(samples: &[&[u8]], capacity: usize) -> Option<Bytes> {
+    use zrip::dict::fastcover::{FastCoverParams, select_segments};
+    use zrip::dict::finalize::finalize_dictionary;
+
+    if samples.is_empty() || capacity == 0 {
+        return None;
+    }
+    let capacity = capacity.min(MAX_DICT_BYTES);
+    let content = select_segments(samples, capacity, &FastCoverParams::default());
+    let mut dict = finalize_dictionary(&content, samples, capacity);
+    patch_user_dict_id(&mut dict).ok()?;
+    Dictionary::from_bytes(&dict).ok()?;
+    Some(Bytes::from(dict))
+}
+
+pub fn is_dict_shipment(msg: &Message) -> bool {
+    msg.len() == 1
+        && msg
+            .part_bytes(0)
+            .is_some_and(|part| part.starts_with(&ZDICT_MAGIC))
+}
+
+struct TrainState {
+    samples: Vec<Vec<u8>>,
+    total_bytes: usize,
+}
+
+pub struct ZstdEncoder {
+    send_dict: Option<Bytes>,
+    send_dict_shipped: bool,
+    max_message_size: Option<usize>,
+    level: i32,
+    cctx: Option<CompressContext>,
+    train: Option<TrainState>,
+    threshold_override: Option<usize>,
+    dict_capacity: usize,
+}
+
+impl std::fmt::Debug for ZstdEncoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZstdEncoder")
+            .field("send_dict_len", &self.send_dict.as_ref().map(Bytes::len))
+            .field("send_dict_shipped", &self.send_dict_shipped)
+            .field("max_message_size", &self.max_message_size)
+            .field("level", &self.level)
+            .field(
+                "auto_train",
+                &self
+                    .train
+                    .as_ref()
+                    .map(|t| (t.samples.len(), t.total_bytes)),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for ZstdEncoder {
+    fn default() -> Self {
+        Self {
+            send_dict: None,
+            send_dict_shipped: false,
+            max_message_size: None,
+            level: DEFAULT_LEVEL,
+            cctx: None,
+            train: None,
+            threshold_override: None,
+            dict_capacity: DEFAULT_DICT_CAPACITY,
+        }
+    }
+}
+
+impl ZstdEncoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_auto_train(mut self) -> Self {
+        if self.send_dict.is_none() {
+            self.train = Some(TrainState {
+                samples: Vec::with_capacity(64),
+                total_bytes: 0,
+            });
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn with_threshold(mut self, threshold: usize) -> Self {
+        self.threshold_override = Some(threshold);
+        self
+    }
+
+    #[must_use]
+    pub fn with_dict_capacity(mut self, capacity: usize) -> Self {
+        self.dict_capacity = capacity.min(MAX_DICT_BYTES);
+        self
+    }
+
+    pub fn with_send_dict(dict: Bytes) -> Result<Self> {
+        validate_dict(&dict, "Zstd", MAX_DICT_BYTES)?;
+        if dict.len() < 4 || dict[..4] != ZDICT_MAGIC {
+            return Err(Error::Protocol(
+                "Zstd dictionary must start with ZDICT magic".into(),
+            ));
+        }
+        Dictionary::from_bytes(&dict)
+            .map_err(|e| Error::Protocol(format!("invalid zstd dictionary: {e}")))?;
+        Ok(Self {
+            send_dict: Some(dict),
+            train: None,
+            ..Self::default()
+        })
+    }
+
+    #[must_use]
+    pub fn with_level(mut self, level: i32) -> Self {
+        self.level = level;
+        self.cctx = None;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_message_size(mut self, max: Option<usize>) -> Self {
+        self.max_message_size = max;
+        self
+    }
+
+    pub fn passthrough_threshold(&self) -> Option<usize> {
+        if self.threshold_override.is_some() {
+            Some(self.effective_threshold())
+        } else if self.train.is_some() {
+            None
+        } else if self.send_dict.is_none() {
+            Some(MIN_COMPRESS_NO_DICT)
+        } else {
+            None
+        }
+    }
+
+    pub fn can_offload(&self) -> bool {
+        self.train.is_none() && (self.send_dict.is_none() || self.send_dict_shipped)
+    }
+
+    #[must_use]
+    pub fn new_offload(&self) -> Self {
+        Self {
+            send_dict: self.send_dict.clone(),
+            send_dict_shipped: true,
+            max_message_size: self.max_message_size,
+            level: self.level,
+            cctx: None,
+            train: None,
+            threshold_override: self.threshold_override,
+            dict_capacity: self.dict_capacity,
+        }
+    }
+
+    pub fn sync_dict(&mut self, primary: &Self) {
+        let same = match (&self.send_dict, &primary.send_dict) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.as_ptr() == b.as_ptr() && a.len() == b.len(),
+            _ => false,
+        };
+        if !same {
+            self.send_dict.clone_from(&primary.send_dict);
+            self.cctx = None;
+        }
+    }
+
+    pub fn encode(&mut self, msg: &Message) -> Result<TransformedOut> {
+        for part in &msg.parts_payload() {
+            self.maybe_train(&part.as_bytes());
+        }
+
+        let mut out: TransformedOut = SmallVec::new();
+        if let Some(dict) = self.send_dict.clone()
+            && !self.send_dict_shipped
+        {
+            out.push(Message::single(dict));
+            self.send_dict_shipped = true;
+        }
+        let mut wire = Message::new();
+        for part in &msg.parts_payload() {
+            wire.push_part_payload(self.encode_part(part)?);
+        }
+        out.push(wire);
+        Ok(out)
+    }
+
+    fn effective_threshold(&self) -> usize {
+        self.threshold_override
+            .unwrap_or(if self.send_dict.is_some() {
+                MIN_COMPRESS_WITH_DICT
+            } else {
+                MIN_COMPRESS_NO_DICT
+            })
+    }
+
+    fn maybe_train(&mut self, plain: &[u8]) {
+        let Some(state) = self.train.as_mut() else {
+            return;
+        };
+        if plain.len() >= TRAIN_MAX_SAMPLE_LEN {
+            return;
+        }
+        state.samples.push(plain.to_vec());
+        state.total_bytes += plain.len();
+        if state.samples.len() < TRAIN_MAX_SAMPLES && state.total_bytes < TRAIN_MAX_BYTES {
+            return;
+        }
+        let state = self.train.take().unwrap();
+        let samples: Vec<&[u8]> = state.samples.iter().map(Vec::as_slice).collect();
+        let Some(dict) = train_zdict(&samples, self.dict_capacity) else {
+            return;
+        };
+        self.send_dict = Some(dict);
+        self.send_dict_shipped = false;
+        self.cctx = None;
+    }
+
+    fn ensure_cctx(&mut self) -> Result<&mut CompressContext> {
+        if self.cctx.is_none() {
+            let ctx = if let Some(dict_raw) = &self.send_dict {
+                let dict = Dictionary::from_bytes(dict_raw).map_err(|e| decompress_err(&e))?;
+                CompressContext::with_dict(self.level, dict).map_err(|e| compress_err(&e))?
+            } else {
+                CompressContext::new(self.level).map_err(|e| compress_err(&e))?
+            };
+            self.cctx = Some(ctx);
+        }
+        Ok(self.cctx.as_mut().unwrap())
+    }
+
+    fn encode_part(&mut self, part: &Payload) -> Result<Payload> {
+        let plain = part.as_bytes();
+        if plain.len() < self.effective_threshold() {
+            return Ok(plaintext_payload(&plain));
+        }
+        let compressed = self
+            .ensure_cctx()?
+            .compress(&plain)
+            .map_err(|e| compress_err(&e))?;
+        if compressed.len() >= plain.len().saturating_sub(ENVELOPE_PLAIN) {
+            return Ok(plaintext_payload(&plain));
+        }
+        Ok(Payload::from_bytes(Bytes::copy_from_slice(&compressed)))
+    }
+}
+
+pub struct ZstdDecoder {
+    recv_dict: Option<Bytes>,
+    max_message_size: Option<usize>,
+    max_recv_dict_size: usize,
+    dctx: DecompressContext,
+}
+
+impl std::fmt::Debug for ZstdDecoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZstdDecoder")
+            .field("recv_dict_len", &self.recv_dict.as_ref().map(Bytes::len))
+            .field("max_message_size", &self.max_message_size)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for ZstdDecoder {
+    fn default() -> Self {
+        Self {
+            recv_dict: None,
+            max_message_size: None,
+            max_recv_dict_size: MAX_DICT_BYTES,
+            dctx: DecompressContext::new(),
+        }
+    }
+}
+
+impl ZstdDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_max_message_size(mut self, max: Option<usize>) -> Self {
+        self.max_message_size = max;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_recv_dict_size(mut self, max: usize) -> Self {
+        self.max_recv_dict_size = max.min(MAX_DICT_BYTES);
+        self
+    }
+
+    pub fn decode(&mut self, msg: Message) -> Result<Option<Message>> {
+        let mut out = Message::new();
+        let parts = msg.into_parts_payload();
+        let multipart = parts.len() > 1;
+        let mut budget_left = self.max_message_size;
+        for (idx, part) in parts.into_iter().enumerate() {
+            let bytes = part.as_bytes();
+            if bytes.len() < 4 {
+                return Err(Error::Protocol(
+                    "zstd part shorter than 4-byte sentinel".into(),
+                ));
+            }
+            let sentinel: [u8; 4] = bytes[..4].try_into().unwrap();
+            match sentinel {
+                SENTINEL_PLAIN => {
+                    let body_len = bytes.len() - 4;
+                    take_budget(&mut budget_left, body_len)?;
+                    out.push_part_payload(Payload::from_bytes(bytes.slice(4..)));
+                }
+                ZSTD_MAGIC => out.push_part_payload(self.decode_zstd(&bytes, &mut budget_left)?),
+                ZDICT_MAGIC => {
+                    if multipart || idx != 0 {
+                        return Err(Error::Protocol(
+                            "zstd dict shipment must be a single-part message".into(),
+                        ));
+                    }
+                    if self.recv_dict.is_some() {
+                        return Err(Error::Protocol(
+                            "zstd dict shipped twice on the same connection".into(),
+                        ));
+                    }
+                    validate_dict(&bytes, "Zstd", self.max_recv_dict_size)?;
+                    let dict = Dictionary::from_bytes(&bytes).map_err(|e| decompress_err(&e))?;
+                    self.dctx = DecompressContext::with_dict(dict);
+                    self.recv_dict = Some(bytes);
+                    return Ok(None);
+                }
+                _ => return Err(Error::Protocol("unknown zstd sentinel".into())),
+            }
+        }
+        Ok(Some(out))
+    }
+
+    fn decode_zstd(&mut self, bytes: &Bytes, budget: &mut Option<usize>) -> Result<Payload> {
+        let header =
+            zrip::frame::header::parse_frame_header(bytes).map_err(|e| decompress_err(&e))?;
+        let declared = header.frame_content_size.ok_or_else(|| {
+            Error::Protocol("zstd frame missing required Frame_Content_Size".into())
+        })?;
+        let decompressed_size = usize::try_from(declared)
+            .map_err(|_| Error::Protocol("zstd declared size exceeds usize".into()))?;
+        if decompressed_size > MAX_DECOMPRESSED_SIZE {
+            return Err(Error::Protocol(
+                "zstd declared size exceeds absolute limit".into(),
+            ));
+        }
+        take_budget(budget, decompressed_size)?;
+        let result = self
+            .dctx
+            .decompress_with_limit(bytes, decompressed_size)
+            .map_err(|e| decompress_err(&e))?;
+        if result.len() != decompressed_size {
+            return Err(Error::Protocol(
+                "zstd decompressed length disagrees with declared".into(),
+            ));
+        }
+        Ok(Payload::from_bytes(Bytes::from(result.into_owned())))
+    }
+}
+
+fn patch_user_dict_id(dict: &mut [u8]) -> core::result::Result<(), ()> {
+    if dict.len() < 8 || dict[..4] != ZDICT_MAGIC {
+        return Err(());
+    }
+    let span = USER_DICT_ID_MAX - USER_DICT_ID_MIN + 1;
+    let id = USER_DICT_ID_MIN + (rand::random::<u32>() % span);
+    dict[4..8].copy_from_slice(&id.to_le_bytes());
+    Ok(())
+}
+
+fn compress_err(e: &zrip::CompressError) -> Error {
+    Error::Protocol(format!("zstd: {e}"))
+}
+
+fn decompress_err(e: &zrip::DecompressError) -> Error {
+    Error::Protocol(format!("zstd: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trained_dict() -> Bytes {
+        let samples: Vec<&[u8]> = (0..200)
+            .map(|_| &b"the-quick-brown-fox-jumps-over-the-lazy-dog\n"[..])
+            .collect();
+        train_zdict(&samples, MAX_DICT_BYTES).expect("training must succeed")
+    }
+
+    #[test]
+    fn roundtrip_plain_and_compressed() {
+        let plain = vec![b'A'; 4096];
+        let mut enc = ZstdEncoder::new();
+        let mut dec = ZstdDecoder::new();
+        let wire = enc.encode(&Message::single(plain.clone())).unwrap();
+        let bytes = wire[0].part_bytes(0).unwrap();
+        assert_eq!(&bytes[..4], &ZSTD_MAGIC);
+        let out = dec
+            .decode(wire.into_iter().next().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(out.part_bytes(0).unwrap().to_vec(), plain);
+
+        let wire = enc.encode(&Message::single("hi")).unwrap();
+        let bytes = wire[0].part_bytes(0).unwrap();
+        assert_eq!(&bytes[..4], &SENTINEL_PLAIN);
+    }
+
+    #[test]
+    fn frame_content_size_is_present() {
+        let plain = vec![b'A'; 4096];
+        let mut enc = ZstdEncoder::new();
+        let wire = enc.encode(&Message::single(plain.clone())).unwrap();
+        let bytes = wire[0].part_bytes(0).unwrap();
+        let header = zrip::frame::header::parse_frame_header(&bytes).unwrap();
+        assert_eq!(header.frame_content_size, Some(plain.len() as u64));
+    }
+
+    #[test]
+    fn dict_roundtrip() {
+        let dict = trained_dict();
+        let plain = b"the-quick-brown-fox-jumps-over-the-lazy-dog\n".repeat(2);
+        let mut enc = ZstdEncoder::with_send_dict(dict.clone()).unwrap();
+        let mut dec = ZstdDecoder::new();
+        let wire = enc.encode(&Message::single(plain.clone())).unwrap();
+        assert_eq!(wire.len(), 2);
+        assert_eq!(wire[0].part_bytes(0).unwrap().as_ref(), &dict[..]);
+        assert!(dec.decode(wire[0].clone()).unwrap().is_none());
+        assert_eq!(dec.recv_dict.as_ref().unwrap().as_ref(), &dict[..]);
+        let recovered = dec.decode(wire[1].clone()).unwrap().unwrap();
+        assert_eq!(recovered.part_bytes(0).unwrap().to_vec(), plain);
+    }
+
+    #[test]
+    fn raw_zdict_blob_is_a_dict_shipment() {
+        let dict = trained_dict();
+        let mut dec = ZstdDecoder::new();
+        assert!(dec.decode(Message::single(dict)).unwrap().is_none());
+    }
+
+    #[test]
+    fn dict_cap_applies_to_zdict_blob() {
+        let mut shipment = vec![0u8; MAX_DICT_BYTES + 1];
+        shipment[..4].copy_from_slice(&ZDICT_MAGIC);
+        let mut dec = ZstdDecoder::new().with_max_recv_dict_size(usize::MAX);
+        let err = dec
+            .decode(Message::single(Bytes::from(shipment)))
+            .unwrap_err();
+        match err {
+            Error::Protocol(msg) => assert!(msg.contains("exceeds max")),
+            other => panic!("expected protocol error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn budget_checked_before_decode() {
+        let plain = vec![b'k'; 4096];
+        let mut enc = ZstdEncoder::new();
+        let wire = enc.encode(&Message::single(plain)).unwrap();
+        let mut dec = ZstdDecoder::new().with_max_message_size(Some(1024));
+        assert!(matches!(
+            dec.decode(wire.into_iter().next().unwrap()).unwrap_err(),
+            Error::MessageTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn auto_train_ships_dict_and_blocks_offload() {
+        let mut enc = ZstdEncoder::new().with_auto_train();
+        assert!(!enc.can_offload());
+        let mut dec = ZstdDecoder::new();
+        let sample = br#"{"event":"login","user":"alice","ip":"10.0.0.1","ok":true}"#;
+        for _ in 0..2000 {
+            let wire = enc.encode(&Message::single(sample.as_slice())).unwrap();
+            for part in wire {
+                let _ = dec.decode(part).unwrap();
+            }
+            if enc.send_dict.is_some() {
+                break;
+            }
+        }
+        assert!(enc.send_dict.is_some(), "auto-train never produced dict");
+        let dict = enc.send_dict.clone().unwrap();
+        assert_eq!(&dict[..4], &ZDICT_MAGIC);
+        let id = u32::from_le_bytes(dict[4..8].try_into().unwrap());
+        assert!((USER_DICT_ID_MIN..=USER_DICT_ID_MAX).contains(&id));
+    }
+}

--- a/omq-proto/src/proto/transform/zstd.rs
+++ b/omq-proto/src/proto/transform/zstd.rs
@@ -29,7 +29,7 @@ const USER_DICT_ID_MIN: u32 = 32_768;
 const USER_DICT_ID_MAX: u32 = 0x7FFF_FFFF;
 
 pub const MAX_DICT_BYTES: usize = 8 * 1024;
-pub const DEFAULT_LEVEL: i32 = -3;
+pub const DEFAULT_LEVEL: i32 = 1;
 pub const DEFAULT_DICT_CAPACITY: usize = 2048;
 
 pub fn train_zdict(samples: &[&[u8]], capacity: usize) -> Option<Bytes> {
@@ -452,6 +452,36 @@ mod tests {
         let bytes = wire[0].part_bytes(0).unwrap();
         let header = zrip::frame::header::parse_frame_header(&bytes).unwrap();
         assert_eq!(header.frame_content_size, Some(plain.len() as u64));
+    }
+
+    #[test]
+    fn options_custom_level_reaches_encoder() {
+        use crate::options::Options;
+        use crate::proto::transform::{CompressionKind, MessageEncoder};
+
+        let options = Options::new().compression_level(1);
+        let (enc, _) = MessageEncoder::for_compression_kind(CompressionKind::Zstd, &options)
+            .unwrap()
+            .unwrap();
+        match enc {
+            MessageEncoder::Zstd(enc) => assert_eq!(enc.level, 1),
+            #[cfg(feature = "lz4")]
+            MessageEncoder::Lz4(_) => panic!("expected zstd encoder"),
+        }
+    }
+
+    #[test]
+    fn custom_level_roundtrip() {
+        let plain = vec![b'A'; 4096];
+        let mut enc = ZstdEncoder::new().with_level(1);
+        let mut dec = ZstdDecoder::new();
+        let wire = enc.encode(&Message::single(plain.clone())).unwrap();
+        assert_eq!(enc.level, 1);
+        let out = dec
+            .decode(wire.into_iter().next().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(out.part_bytes(0).unwrap().to_vec(), plain);
     }
 
     #[test]

--- a/omq-proto/tests/endpoint.rs
+++ b/omq-proto/tests/endpoint.rs
@@ -117,6 +117,18 @@ fn lz4_tcp() {
     );
 }
 
+#[cfg(feature = "zstd")]
+#[test]
+fn zstd_tcp() {
+    assert_eq!(
+        parse("zstd+tcp://host:9"),
+        Endpoint::ZstdTcp {
+            host: Host::Name("host".into()),
+            port: 9
+        }
+    );
+}
+
 #[test]
 fn unsupported_scheme() {
     assert!(matches!(
@@ -183,6 +195,12 @@ fn display_roundtrip() {
     #[cfg(feature = "lz4")]
     {
         let c = "lz4+tcp://host:9";
+        let parsed: Endpoint = c.parse().unwrap();
+        assert_eq!(parsed.to_string(), c);
+    }
+    #[cfg(feature = "zstd")]
+    {
+        let c = "zstd+tcp://host:9";
         let parsed: Endpoint = c.parse().unwrap();
         assert_eq!(parsed.to_string(), c);
     }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -273,6 +273,10 @@ name = "omq_soak_compression_lz4"
 path = "tests/omq_soak_compression_lz4.rs"
 
 [[test]]
+name = "omq_soak_compression_zstd"
+path = "tests/omq_soak_compression_zstd.rs"
+
+[[test]]
 name = "omq_soak_curve"
 path = "tests/omq_soak_curve.rs"
 
@@ -315,6 +319,10 @@ path = "tests/omq_soak_pub_sub_churn_tcp.rs"
 [[test]]
 name = "omq_soak_pub_sub_lz4_dict"
 path = "tests/omq_soak_pub_sub_lz4_dict.rs"
+
+[[test]]
+name = "omq_soak_pub_sub_zstd_dict"
+path = "tests/omq_soak_pub_sub_zstd_dict.rs"
 
 [[test]]
 name = "omq_soak_pub_sub_realworld_churn_tcp"

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 curve = ["omq-proto/curve"]
 plain = ["omq-proto/plain"]
 lz4 = ["omq-proto/lz4"]
+zstd = ["omq-proto/zstd"]
 ws = ["omq-proto/ws", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-types", "dep:tokio-rustls"]
 # Enables the fuzz test suites (`tests/fuzz_*.rs`). Off by default -
 # those targets do ~1 M iterations each and dominate runtime of
@@ -174,6 +175,10 @@ path = "tests/handshake_timeout.rs"
 [[test]]
 name = "omq_heartbeat"
 path = "tests/heartbeat.rs"
+
+[[test]]
+name = "omq_zstd_tcp"
+path = "tests/zstd_tcp.rs"
 
 [[test]]
 name = "omq_inproc_rebind"

--- a/omq-tokio/src/bin/bench_peer_blocking.rs
+++ b/omq-tokio/src/bin/bench_peer_blocking.rs
@@ -5,6 +5,7 @@
 //! own IO thread; send/recv block the calling thread via
 //! `Context::block_on`.
 
+use std::fmt::Write as _;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -203,6 +204,10 @@ fn bench_options(msg_size: usize) -> Options {
         let buf = msg_size * 2;
         o = o.recv_buffer_size(buf).send_buffer_size(buf);
     }
+    if let Ok(path) = std::env::var("OMQ_BENCH_DICT_FILE") {
+        let dict = Bytes::from(std::fs::read(&path).expect("read dict file"));
+        o = o.compression_dict(dict);
+    }
     o
 }
 
@@ -261,7 +266,131 @@ fn send_fast(sock: &blocking::Socket, msg: Message) {
 }
 
 fn bench_payload(size: usize) -> Bytes {
-    Bytes::from(vec![b'x'; size])
+    if std::env::var("OMQ_BENCH_PAYLOAD").as_deref() == Ok("json") {
+        json_payload_random(size)
+    } else {
+        Bytes::from(vec![b'x'; size])
+    }
+}
+
+fn json_payload_random(target_bytes: usize) -> Bytes {
+    let mut out = String::with_capacity(target_bytes + 512);
+    let mut state: u32 = rand_seed();
+    while out.len() < target_bytes {
+        json_record(&mut out, &mut state);
+    }
+    out.truncate(target_bytes);
+    Bytes::from(out)
+}
+
+fn rand_seed() -> u32 {
+    let mut buf = [0u8; 4];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| {
+            use std::io::Read;
+            f.read_exact(&mut buf)?;
+            Ok(())
+        })
+        .expect("/dev/urandom");
+    u32::from_ne_bytes(buf)
+}
+
+fn xorshift32(state: &mut u32) -> u32 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *state = x;
+    x
+}
+
+fn json_record(out: &mut String, state: &mut u32) {
+    const LEVELS: &[&str] = &["DEBUG", "INFO", "WARN", "ERROR", "TRACE"];
+    const SERVICES: &[&str] = &[
+        "api-gateway",
+        "auth-svc",
+        "order-svc",
+        "payment-svc",
+        "notify-svc",
+        "inventory-svc",
+        "shipping-svc",
+        "billing-svc",
+        "search-svc",
+        "user-svc",
+        "session-svc",
+        "analytics-svc",
+        "cache-svc",
+        "config-svc",
+        "audit-svc",
+        "rate-limiter",
+    ];
+    const METHODS: &[&str] = &["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
+    const PATHS: &[&str] = &[
+        "/v1/widgets",
+        "/v1/users",
+        "/v1/orders",
+        "/v2/events",
+        "/v1/health",
+        "/v1/sessions",
+        "/v1/payments",
+        "/v2/search",
+        "/v1/inventory",
+        "/v1/shipping",
+        "/v1/analytics",
+        "/v2/config",
+    ];
+    const REGIONS: &[&str] = &[
+        "us-east-1",
+        "us-west-2",
+        "eu-west-1",
+        "ap-south-1",
+        "eu-central-1",
+        "ap-northeast-1",
+        "sa-east-1",
+        "ca-central-1",
+    ];
+    const STATUSES: &[u16] = &[
+        200, 201, 202, 204, 301, 302, 304, 400, 401, 403, 404, 405, 409, 422, 429, 500, 502, 503,
+        504,
+    ];
+    const MSGS: &[&str] = &[
+        "request handled successfully",
+        "resource created",
+        "cache miss, fetched from origin",
+        "rate limit approaching threshold",
+        "upstream timeout, retrying",
+        "authentication token refreshed",
+        "database connection pool exhausted",
+        "circuit breaker tripped",
+        "message queued for async processing",
+        "TLS handshake completed",
+        "request routed to fallback backend",
+        "payload validation passed",
+        "idempotency key matched existing result",
+        "graceful shutdown initiated",
+        "health check passed all probes",
+        "retry attempt succeeded after backoff",
+    ];
+
+    let trace_id = xorshift32(state);
+    let span_id = xorshift32(state);
+    let user_id = xorshift32(state);
+    let r = xorshift32(state) as usize;
+    let level = LEVELS[r % LEVELS.len()];
+    let service = SERVICES[(r >> 4) % SERVICES.len()];
+    let method = METHODS[(r >> 8) % METHODS.len()];
+    let path = PATHS[(r >> 12) % PATHS.len()];
+    let region = REGIONS[(r >> 16) % REGIONS.len()];
+    let status = STATUSES[(r >> 20) % STATUSES.len()];
+    let latency = (xorshift32(state) % 5000) + 1;
+    let r2 = xorshift32(state) as usize;
+    let msg = MSGS[r2 % MSGS.len()];
+    let host_id = xorshift32(state);
+    let _ = write!(
+        out,
+        r#"{{"ts":"2026-04-27T12:34:56.{trace_id:08x}Z","level":"{level}","service":"{service}","trace_id":"{trace_id:08x}{span_id:08x}","span_id":"{span_id:08x}","user_id":"u-{user_id:08x}","method":"{method}","path":"{path}/{trace_id:08x}","status":{status},"latency_ms":{latency},"region":"{region}","host":"{service}-{host_id:08x}.svc.cluster.local","msg":"{msg}"}}{nl}"#,
+        nl = '\n',
+    );
 }
 
 fn quantile(sorted: &[f64], probability: f64) -> f64 {

--- a/omq-tokio/src/bin/bench_peer_blocking.rs
+++ b/omq-tokio/src/bin/bench_peer_blocking.rs
@@ -208,6 +208,9 @@ fn bench_options(msg_size: usize) -> Options {
         let dict = Bytes::from(std::fs::read(&path).expect("read dict file"));
         o = o.compression_dict(dict);
     }
+    if let Ok(val) = std::env::var("OMQ_BENCH_ZSTD_LEVEL") {
+        o = o.compression_level(val.parse().expect("OMQ_BENCH_ZSTD_LEVEL"));
+    }
     o
 }
 

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -207,9 +207,17 @@ async fn async_main(args: Vec<String>, ctx: omq_tokio::Context) {
         Some("train-dict") => {
             let path = &args[2];
             let capacity: usize = args.get(3).map_or(2048, |s| s.parse().expect("capacity"));
-            let dict = train_json_dict(capacity);
+            let dict = train_lz4_json_dict(capacity);
             std::fs::write(path, &dict).expect("write dict file");
             eprintln!("Trained {} byte dict -> {path}", dict.len());
+        }
+        #[cfg(feature = "zstd")]
+        Some("train-zstd-dict") => {
+            let path = &args[2];
+            let capacity: usize = args.get(3).map_or(2048, |s| s.parse().expect("capacity"));
+            let dict = train_zstd_json_dict(capacity);
+            std::fs::write(path, &dict).expect("write dict file");
+            eprintln!("Trained {} byte zstd dict -> {path}", dict.len());
         }
         Some("inproc-latency") => {
             let name = args[2].clone();
@@ -1119,7 +1127,7 @@ fn bench_payload(size: usize) -> Bytes {
     }
 }
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 fn json_payload_seeded(target_bytes: usize, seed: u32) -> Bytes {
     let mut out = String::with_capacity(target_bytes + 512);
     let mut state: u32 = seed;
@@ -1250,11 +1258,8 @@ fn json_record(out: &mut String, state: &mut u32) {
     );
 }
 
-#[cfg(feature = "lz4")]
-fn train_json_dict(capacity: usize) -> Vec<u8> {
-    use omq_proto::proto::transform::lz4::DictTrainer;
-
-    let mut trainer = DictTrainer::new(capacity);
+#[cfg(any(feature = "lz4", feature = "zstd"))]
+fn json_dict_samples() -> Vec<Bytes> {
     // Bias toward common message sizes (512B, 1 KiB) with a few at other sizes.
     let sample_sizes: &[(usize, usize)] = &[
         (64, 2),
@@ -1265,19 +1270,39 @@ fn train_json_dict(capacity: usize) -> Vec<u8> {
         (2048, 4),
         (4096, 4),
     ];
+    let mut samples = Vec::new();
     for &(size, count) in sample_sizes {
         for i in 1..=count {
-            let payload = json_payload_seeded(size, i as u32);
-            trainer.add_sample(&payload);
+            samples.push(json_payload_seeded(size, i as u32));
         }
     }
+    samples
+}
+
+#[cfg(feature = "lz4")]
+fn train_lz4_json_dict(capacity: usize) -> Vec<u8> {
+    use omq_proto::proto::transform::lz4::DictTrainer;
+
+    let mut trainer = DictTrainer::new(capacity);
+    for payload in json_dict_samples() {
+        trainer.add_sample(&payload);
+    }
     trainer.train()
+}
+
+#[cfg(feature = "zstd")]
+fn train_zstd_json_dict(capacity: usize) -> Vec<u8> {
+    let samples = json_dict_samples();
+    let refs: Vec<&[u8]> = samples.iter().map(Bytes::as_ref).collect();
+    omq_proto::proto::transform::train_zdict(&refs, capacity)
+        .expect("zstd dictionary training must produce a dict")
+        .to_vec()
 }
 
 fn wire_size(ep: &Endpoint, size: usize) -> usize {
     use omq_proto::proto::transform::MessageEncoder;
     let options = bench_options(size);
-    let Some((mut enc, _dec)) = MessageEncoder::for_endpoint(ep, &options) else {
+    let Ok(Some((mut enc, _dec))) = MessageEncoder::for_endpoint(ep, &options) else {
         return size;
     };
     let payload = json_payload_random(size);

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -591,6 +591,9 @@ fn bench_options(msg_size: usize) -> Options {
         let dict = Bytes::from(std::fs::read(&path).expect("read dict file"));
         o = o.compression_dict(dict);
     }
+    if let Ok(val) = std::env::var("OMQ_BENCH_ZSTD_LEVEL") {
+        o = o.compression_level(val.parse().expect("OMQ_BENCH_ZSTD_LEVEL"));
+    }
     if let Ok(val) = std::env::var("OMQ_BENCH_ARENA_THRESHOLD") {
         o = o.arena_threshold(val.parse().expect("OMQ_BENCH_ARENA_THRESHOLD"));
     }

--- a/omq-tokio/src/engine/compression_pool.rs
+++ b/omq-tokio/src/engine/compression_pool.rs
@@ -36,7 +36,7 @@ impl CompressionPool {
     /// Borrow a pool encoder matching the primary's variant, syncing
     /// its dict state. Returns `None` when all `cap` encoders are
     /// in flight. New encoders are created on demand up to `cap`.
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     pub(crate) fn try_take(&self, primary: &MessageEncoder) -> Option<MessageEncoder> {
         {
             let mut pool = self.encoders.lock().unwrap();
@@ -56,7 +56,7 @@ impl CompressionPool {
         Some(MessageEncoder::new_offload(primary))
     }
 
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     pub(crate) fn put(&self, enc: MessageEncoder) {
         self.encoders.lock().unwrap().push(enc);
         self.in_flight.fetch_sub(1, Ordering::Relaxed);

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -1591,7 +1591,7 @@ fn submit_to_pipeline(
     threshold: usize,
     pipeline: &mut OffloadPipeline,
 ) {
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     if msg.byte_len() >= threshold
         && let Some(mut pool_enc) = pool.try_take(encoder)
     {
@@ -1637,7 +1637,7 @@ fn drain_offload_result(
     connection: &Connection,
     eq: &mut FrameBuffer,
 ) -> Result<()> {
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     if let (Some(enc), Some(pool)) = (pool_enc, pool) {
         pool.put(enc);
     }

--- a/omq-tokio/src/engine/transmit_slot.rs
+++ b/omq-tokio/src/engine/transmit_slot.rs
@@ -18,6 +18,7 @@ use omq_proto::handle_frame::{
     HandleFrameCaps, HandleFrameDecision, HandleFrameState, decide_handle_frame,
 };
 use omq_proto::message::Message;
+use omq_proto::proto::transform::CompressionKind;
 
 pub(crate) const TRANSMIT_SLOT_CAP_DEFAULT: usize = 512 * 1024;
 #[cfg(test)]
@@ -42,6 +43,7 @@ pub(crate) struct PeerTransmitSlot {
     pub(crate) space_available: Arc<StateSignal>,
     pub(crate) handshake_done: AtomicBool,
     pub(crate) has_transform: bool,
+    pub(crate) compression_kind: Option<CompressionKind>,
     pub(crate) transform_passthrough: Option<(Bytes, usize)>,
     #[cfg(feature = "ws")]
     is_ws: bool,
@@ -79,6 +81,7 @@ impl PeerTransmitSlot {
     pub(crate) fn new(
         peer_id: u64,
         has_transform: bool,
+        compression_kind: Option<CompressionKind>,
         transform_passthrough: Option<(Bytes, usize)>,
         arena_threshold: usize,
         arena_cap: usize,
@@ -95,6 +98,7 @@ impl PeerTransmitSlot {
             space_available: Arc::new(StateSignal::new()),
             handshake_done: AtomicBool::new(false),
             has_transform,
+            compression_kind,
             transform_passthrough,
             #[cfg(feature = "ws")]
             is_ws,
@@ -232,6 +236,11 @@ impl PeerTransmitSlot {
 
     pub(crate) fn signal_encoded(&self) {
         self.data_signal.mark();
+    }
+
+    #[inline]
+    pub(crate) fn compression_kind(&self) -> Option<CompressionKind> {
+        self.compression_kind
     }
 
     #[inline]
@@ -450,6 +459,7 @@ mod tests {
             1,
             false,
             None,
+            None,
             omq_proto::frame_buffer::ARENA_THRESHOLD,
             omq_proto::frame_buffer::ARENA_INITIAL_CAP,
             TRANSMIT_SLOT_CAP_DEFAULT,
@@ -492,6 +502,7 @@ mod tests {
         let slot = PeerTransmitSlot::new(
             1,
             false,
+            None,
             None,
             omq_proto::frame_buffer::ARENA_THRESHOLD,
             omq_proto::frame_buffer::ARENA_INITIAL_CAP,

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -1,7 +1,7 @@
 //! omq-tokio - tokio-runtime backend for omq.
 //!
-//! Wire-compatible with libzmq. All 11 standard socket types plus 7
-//! draft types, TCP / IPC / inproc / UDP transports, NULL / CURVE /
+//! Wire-compatible with libzmq. Supports 20 socket types, TCP / IPC /
+//! inproc / UDP transports, NULL / PLAIN / CURVE mechanisms, and the
 //! lz4+tcp compression transport.
 //!
 //! The codec, message types, mechanism handshakes, and routing

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -471,9 +471,20 @@ impl FanOutSend {
         #[cfg(not(feature = "ws"))]
         let target_is_ws = false;
 
-        let lane_eligible = !target_is_ws
+        let lane_base_eligible = !target_is_ws
             && matches!(target, PeerOutbound::Wire { .. })
             && handle.transmit_slot.is_some();
+
+        let lane_eligible = lane_base_eligible && {
+            let mut g = self.inner.lock().expect("fanout inner poisoned");
+            let has_lane_peers = g.peers.values().any(|p| p.lane.is_some());
+            if has_lane_peers {
+                g.compression_kind == compression_kind
+            } else {
+                g.compression_kind = compression_kind;
+                true
+            }
+        };
 
         let lane = if !lane_eligible {
             None
@@ -486,12 +497,7 @@ impl FanOutSend {
                     any_groups,
                 },
             );
-            let mut g = self.inner.lock().expect("fanout inner poisoned");
-            if let Some(kind) = compression_kind
-                && g.compression_kind.is_none()
-            {
-                g.compression_kind = Some(kind);
-            }
+            let g = self.inner.lock().expect("fanout inner poisoned");
             if let Some(kind) = g.compression_kind {
                 let options = g.options.clone();
                 let dict = g.compression_dict.clone();

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -28,7 +28,7 @@ use omq_proto::proto::transform::CompressionKind;
 
 use super::peer_outbound::PeerOutbound;
 use super::subscription::SubscriptionSet;
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use compression::DictTraining;
 pub(crate) use filter::FanOutMode;
 use lane::{FanOutLanes, LaneDispatch, LanePeerAdd};
@@ -76,7 +76,7 @@ pub(crate) struct Submitter {
     send_count: Arc<AtomicU32>,
     xpub_nodrop: bool,
     mute_policy: FanOutMutePolicy,
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
 
@@ -92,7 +92,7 @@ impl Clone for Submitter {
             send_count: self.send_count.clone(),
             xpub_nodrop: self.xpub_nodrop,
             mute_policy: self.mute_policy,
-            #[cfg(feature = "lz4")]
+            #[cfg(any(feature = "lz4", feature = "zstd"))]
             dict_training: self.dict_training.clone(),
         }
     }
@@ -305,7 +305,7 @@ impl Submitter {
         let (forwarded, group) = filter::prepare(self.mode, msg)?;
         let msg_bytes = forwarded.byte_len();
 
-        #[cfg(feature = "lz4")]
+        #[cfg(any(feature = "lz4", feature = "zstd"))]
         compression::feed_dict_training(&self.dict_training, &self.inner, &self.lanes, &forwarded);
 
         self.dispatch_raw(&self.lanes, &forwarded, group).await?;
@@ -327,7 +327,7 @@ pub(crate) struct FanOutSend {
     mode: FanOutMode,
     xpub_nodrop: bool,
     mute_policy: FanOutMutePolicy,
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     dict_training: Arc<Mutex<Option<DictTraining>>>,
 }
 
@@ -409,7 +409,7 @@ impl FanOutSend {
             mode,
             xpub_nodrop: options.xpub_nodrop,
             mute_policy,
-            #[cfg(feature = "lz4")]
+            #[cfg(any(feature = "lz4", feature = "zstd"))]
             dict_training: Arc::new(Mutex::new(compression::new_dict_training(options))),
         }
     }
@@ -429,7 +429,7 @@ impl FanOutSend {
             send_count: Arc::new(AtomicU32::new(0)),
             xpub_nodrop: self.xpub_nodrop,
             mute_policy: self.mute_policy,
-            #[cfg(feature = "lz4")]
+            #[cfg(any(feature = "lz4", feature = "zstd"))]
             dict_training: self.dict_training.clone(),
         }
     }

--- a/omq-tokio/src/routing/fan_out.rs
+++ b/omq-tokio/src/routing/fan_out.rs
@@ -24,6 +24,7 @@ use omq_proto::error::Result;
 use omq_proto::message::Message;
 use omq_proto::options::{OnMute, Options};
 use omq_proto::proto::SocketType;
+use omq_proto::proto::transform::CompressionKind;
 
 use super::peer_outbound::PeerOutbound;
 use super::subscription::SubscriptionSet;
@@ -333,7 +334,7 @@ pub(crate) struct FanOutSend {
 struct FanOutInner {
     peers: FxHashMap<u64, FanOutPeer>,
     subscribe_all_count: usize,
-    has_compression: bool,
+    compression_kind: Option<CompressionKind>,
     compression_dict: Option<Bytes>,
     options: Options,
 }
@@ -392,7 +393,7 @@ impl FanOutSend {
         let inner = Arc::new(Mutex::new(FanOutInner {
             peers: FxHashMap::default(),
             subscribe_all_count: 0,
-            has_compression: false,
+            compression_kind: None,
             compression_dict: options.compression_dict.clone(),
             options: options.clone(),
         }));
@@ -459,10 +460,10 @@ impl FanOutSend {
         any_groups: bool,
         io_thread: usize,
     ) {
-        let has_transform = handle
+        let compression_kind = handle
             .transmit_slot
             .as_ref()
-            .is_some_and(|s| s.has_transform);
+            .and_then(|s| s.compression_kind());
         let target = PeerOutbound::from_handle(&handle);
 
         #[cfg(feature = "ws")]
@@ -486,14 +487,16 @@ impl FanOutSend {
                 },
             );
             let mut g = self.inner.lock().expect("fanout inner poisoned");
-            if has_transform {
-                g.has_compression = true;
+            if let Some(kind) = compression_kind
+                && g.compression_kind.is_none()
+            {
+                g.compression_kind = Some(kind);
             }
-            if g.has_compression {
+            if let Some(kind) = g.compression_kind {
                 let options = g.options.clone();
                 let dict = g.compression_dict.clone();
                 drop(g);
-                self.lanes.set_compression(lane, options, dict);
+                self.lanes.set_compression(lane, kind, options, dict);
             } else {
                 drop(g);
             }

--- a/omq-tokio/src/routing/fan_out/compression.rs
+++ b/omq-tokio/src/routing/fan_out/compression.rs
@@ -67,10 +67,13 @@ pub(super) fn feed_dict_training(
         return;
     }
     let dict = Bytes::from(dict_bytes);
-    let options = {
+    let (kind, options) = {
         let mut g = inner.lock().expect("fanout inner poisoned");
         g.compression_dict = Some(dict.clone());
-        g.options.clone()
+        let Some(kind) = g.compression_kind else {
+            return;
+        };
+        (kind, g.options.clone())
     };
-    lanes.set_compression_all(&options, Some(&dict));
+    lanes.set_compression_all(kind, &options, Some(&dict));
 }

--- a/omq-tokio/src/routing/fan_out/compression.rs
+++ b/omq-tokio/src/routing/fan_out/compression.rs
@@ -84,6 +84,8 @@ impl Trainer {
     }
 
     fn train(self, capacity: usize) -> Option<Bytes> {
+        #[cfg(not(feature = "zstd"))]
+        let _ = capacity;
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(trainer) => {
@@ -173,7 +175,7 @@ pub(super) fn feed_dict_training(
     }
     let mut idx = 0;
     while let Some(part) = msg.part_bytes(idx) {
-        trainer.add_sample(&part);
+        trainer.add_sample(part.as_ref());
         idx += 1;
     }
     training.msgs_left = training.msgs_left.saturating_sub(1);

--- a/omq-tokio/src/routing/fan_out/compression.rs
+++ b/omq-tokio/src/routing/fan_out/compression.rs
@@ -8,6 +8,8 @@ use bytes::Bytes;
 use omq_proto::message::Message;
 #[cfg(feature = "lz4")]
 use omq_proto::options::Options;
+#[cfg(feature = "lz4")]
+use omq_proto::proto::transform::CompressionKind;
 
 #[cfg(feature = "lz4")]
 use super::{FanOutInner, lane::FanOutLanes};
@@ -48,6 +50,14 @@ pub(super) fn feed_dict_training(
     lanes: &FanOutLanes,
     msg: &Message,
 ) {
+    if inner
+        .lock()
+        .expect("fanout inner poisoned")
+        .compression_kind
+        != Some(CompressionKind::Lz4)
+    {
+        return;
+    }
     let mut guard = dict_training.lock().expect("dict_training poisoned");
     let Some(training) = guard.as_mut() else {
         return;

--- a/omq-tokio/src/routing/fan_out/compression.rs
+++ b/omq-tokio/src/routing/fan_out/compression.rs
@@ -51,7 +51,7 @@ impl Trainer {
                 omq_proto::proto::transform::lz4::DictTrainer::new(capacity),
             )),
             #[cfg(feature = "zstd")]
-            CompressionKind::Zstd => Some(Self::Zstd(ZstdTraining::new())),
+            CompressionKind::Zstd => Some(Self::Zstd(ZstdTraining::new(capacity))),
             _ => None,
         }
     }
@@ -83,9 +83,7 @@ impl Trainer {
         }
     }
 
-    fn train(self, capacity: usize) -> Option<Bytes> {
-        #[cfg(not(feature = "zstd"))]
-        let _ = capacity;
+    fn train(self) -> Option<Bytes> {
         match self {
             #[cfg(feature = "lz4")]
             Self::Lz4(trainer) => {
@@ -93,7 +91,7 @@ impl Trainer {
                 (!dict.is_empty()).then(|| Bytes::from(dict))
             }
             #[cfg(feature = "zstd")]
-            Self::Zstd(training) => training.train(capacity),
+            Self::Zstd(training) => training.train(),
         }
     }
 }
@@ -102,6 +100,7 @@ impl Trainer {
 struct ZstdTraining {
     samples: Vec<Vec<u8>>,
     total_bytes: usize,
+    capacity: usize,
 }
 
 #[cfg(feature = "zstd")]
@@ -109,10 +108,11 @@ impl ZstdTraining {
     const MAX_BYTES: usize = 100 * 1024;
     const MAX_SAMPLE_LEN: usize = 2048;
 
-    fn new() -> Self {
+    fn new(capacity: usize) -> Self {
         Self {
             samples: Vec::with_capacity(64),
             total_bytes: 0,
+            capacity,
         }
     }
 
@@ -128,9 +128,9 @@ impl ZstdTraining {
         self.total_bytes >= Self::MAX_BYTES
     }
 
-    fn train(self, capacity: usize) -> Option<Bytes> {
+    fn train(self) -> Option<Bytes> {
         let samples: Vec<&[u8]> = self.samples.iter().map(Vec::as_slice).collect();
-        omq_proto::proto::transform::train_zdict(&samples, capacity)
+        omq_proto::proto::transform::train_zdict(&samples, self.capacity)
     }
 }
 
@@ -183,7 +183,7 @@ pub(super) fn feed_dict_training(
         return;
     }
     let training = guard.take().unwrap();
-    let Some(dict) = training.trainer.and_then(|t| t.train(training.capacity)) else {
+    let Some(dict) = training.trainer.and_then(Trainer::train) else {
         return;
     };
     let (kind, options) = {

--- a/omq-tokio/src/routing/fan_out/compression.rs
+++ b/omq-tokio/src/routing/fan_out/compression.rs
@@ -1,82 +1,189 @@
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use bytes::Bytes;
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use omq_proto::message::Message;
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use omq_proto::options::Options;
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use omq_proto::proto::transform::CompressionKind;
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 use super::{FanOutInner, lane::FanOutLanes};
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 pub(super) struct DictTraining {
-    trainer: omq_proto::proto::transform::lz4::DictTrainer,
+    trainer: Option<Trainer>,
     msgs_left: usize,
+    capacity: usize,
 }
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 impl std::fmt::Debug for DictTraining {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DictTraining")
+            .field("kind", &self.trainer.as_ref().map(Trainer::kind))
             .field("msgs_left", &self.msgs_left)
+            .field("capacity", &self.capacity)
             .finish_non_exhaustive()
     }
 }
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
+enum Trainer {
+    #[cfg(feature = "lz4")]
+    Lz4(omq_proto::proto::transform::lz4::DictTrainer),
+    #[cfg(feature = "zstd")]
+    Zstd(ZstdTraining),
+}
+
+#[cfg(any(feature = "lz4", feature = "zstd"))]
+impl Trainer {
+    fn new(kind: CompressionKind, capacity: usize) -> Option<Self> {
+        #[cfg(not(feature = "lz4"))]
+        let _ = capacity;
+        match kind {
+            #[cfg(feature = "lz4")]
+            CompressionKind::Lz4 => Some(Self::Lz4(
+                omq_proto::proto::transform::lz4::DictTrainer::new(capacity),
+            )),
+            #[cfg(feature = "zstd")]
+            CompressionKind::Zstd => Some(Self::Zstd(ZstdTraining::new())),
+            _ => None,
+        }
+    }
+
+    fn kind(&self) -> CompressionKind {
+        match self {
+            #[cfg(feature = "lz4")]
+            Self::Lz4(_) => CompressionKind::Lz4,
+            #[cfg(feature = "zstd")]
+            Self::Zstd(_) => CompressionKind::Zstd,
+        }
+    }
+
+    fn add_sample(&mut self, part: &[u8]) {
+        match self {
+            #[cfg(feature = "lz4")]
+            Self::Lz4(trainer) => trainer.add_sample(part),
+            #[cfg(feature = "zstd")]
+            Self::Zstd(training) => training.add_sample(part),
+        }
+    }
+
+    fn should_train(&self) -> bool {
+        match self {
+            #[cfg(feature = "lz4")]
+            Self::Lz4(_) => false,
+            #[cfg(feature = "zstd")]
+            Self::Zstd(training) => training.should_train(),
+        }
+    }
+
+    fn train(self, capacity: usize) -> Option<Bytes> {
+        match self {
+            #[cfg(feature = "lz4")]
+            Self::Lz4(trainer) => {
+                let dict = trainer.train();
+                (!dict.is_empty()).then(|| Bytes::from(dict))
+            }
+            #[cfg(feature = "zstd")]
+            Self::Zstd(training) => training.train(capacity),
+        }
+    }
+}
+
+#[cfg(feature = "zstd")]
+struct ZstdTraining {
+    samples: Vec<Vec<u8>>,
+    total_bytes: usize,
+}
+
+#[cfg(feature = "zstd")]
+impl ZstdTraining {
+    const MAX_BYTES: usize = 100 * 1024;
+    const MAX_SAMPLE_LEN: usize = 2048;
+
+    fn new() -> Self {
+        Self {
+            samples: Vec::with_capacity(64),
+            total_bytes: 0,
+        }
+    }
+
+    fn add_sample(&mut self, part: &[u8]) {
+        if part.len() >= Self::MAX_SAMPLE_LEN {
+            return;
+        }
+        self.samples.push(part.to_vec());
+        self.total_bytes += part.len();
+    }
+
+    fn should_train(&self) -> bool {
+        self.total_bytes >= Self::MAX_BYTES
+    }
+
+    fn train(self, capacity: usize) -> Option<Bytes> {
+        let samples: Vec<&[u8]> = self.samples.iter().map(Vec::as_slice).collect();
+        omq_proto::proto::transform::train_zdict(&samples, capacity)
+    }
+}
+
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 pub(super) fn new_dict_training(options: &Options) -> Option<DictTraining> {
     if options.compression_auto_train && options.compression_dict.is_none() {
         Some(DictTraining {
-            trainer: omq_proto::proto::transform::lz4::DictTrainer::new(
-                options.compression_dict_capacity.unwrap_or(2048),
-            ),
+            trainer: None,
             msgs_left: 100,
+            capacity: options.compression_dict_capacity.unwrap_or(2048),
         })
     } else {
         None
     }
 }
 
-#[cfg(feature = "lz4")]
+#[cfg(any(feature = "lz4", feature = "zstd"))]
 pub(super) fn feed_dict_training(
     dict_training: &Mutex<Option<DictTraining>>,
     inner: &Arc<Mutex<FanOutInner>>,
     lanes: &FanOutLanes,
     msg: &Message,
 ) {
-    if inner
+    let kind = inner
         .lock()
         .expect("fanout inner poisoned")
-        .compression_kind
-        != Some(CompressionKind::Lz4)
-    {
-        return;
-    }
+        .compression_kind;
+    let Some(kind) = kind else { return };
+
     let mut guard = dict_training.lock().expect("dict_training poisoned");
     let Some(training) = guard.as_mut() else {
         return;
     };
+    if training.trainer.is_none() {
+        training.trainer = Trainer::new(kind, training.capacity);
+    }
+    let Some(trainer) = training.trainer.as_mut() else {
+        return;
+    };
+    if trainer.kind() != kind {
+        return;
+    }
     let mut idx = 0;
     while let Some(part) = msg.part_bytes(idx) {
-        training.trainer.add_sample(&part);
+        trainer.add_sample(&part);
         idx += 1;
     }
     training.msgs_left = training.msgs_left.saturating_sub(1);
-    if training.msgs_left > 0 {
+    if training.msgs_left > 0 && !trainer.should_train() {
         return;
     }
     let training = guard.take().unwrap();
-    let dict_bytes = training.trainer.train();
-    if dict_bytes.is_empty() {
+    let Some(dict) = training.trainer.and_then(|t| t.train(training.capacity)) else {
         return;
-    }
-    let dict = Bytes::from(dict_bytes);
+    };
     let (kind, options) = {
         let mut g = inner.lock().expect("fanout inner poisoned");
         g.compression_dict = Some(dict.clone());

--- a/omq-tokio/src/routing/fan_out/fallback.rs
+++ b/omq-tokio/src/routing/fan_out/fallback.rs
@@ -239,6 +239,7 @@ mod tests {
             1,
             false,
             None,
+            None,
             omq_proto::frame_buffer::ARENA_THRESHOLD,
             omq_proto::frame_buffer::ARENA_INITIAL_CAP,
             crate::engine::transmit_slot::TRANSMIT_SLOT_CAP_DEFAULT,

--- a/omq-tokio/src/routing/fan_out/fallback.rs
+++ b/omq-tokio/src/routing/fan_out/fallback.rs
@@ -32,6 +32,17 @@ pub(super) fn dispatch_to_targets(
             _ => Ok(()),
         },
         _ => {
+            if targets.iter().any(PeerOutbound::requires_per_peer_encoding) {
+                for t in targets {
+                    if t.try_encode(msg) == TryFrameResult::Full
+                        && mute_policy == FanOutMutePolicy::DropNewest
+                    {
+                        deactivate(t);
+                    }
+                }
+                return Ok(());
+            }
+
             #[cfg(feature = "ws")]
             if targets.iter().any(PeerOutbound::is_ws) {
                 for t in targets {
@@ -221,6 +232,34 @@ mod tests {
         assert_eq!(deactivated, vec![1, 1]);
     }
 
+    #[test]
+    fn transformed_multi_target_fallback_uses_per_peer_encoding() {
+        let slot1 = test_transformed_slot(11);
+        let slot2 = test_transformed_slot(12);
+        let (inbox1, mut rx1) = tokio::sync::mpsc::channel(1);
+        let (inbox2, mut rx2) = tokio::sync::mpsc::channel(1);
+        let msg = Message::single("payload");
+        let targets = [
+            PeerOutbound::Wire {
+                slot: slot1.clone(),
+                inbox: inbox1,
+                direct: None,
+            },
+            PeerOutbound::Wire {
+                slot: slot2.clone(),
+                inbox: inbox2,
+                direct: None,
+            },
+        ];
+
+        dispatch_to_targets(&targets, &msg, FanOutMutePolicy::DropNewest, &mut |_| {}).unwrap();
+
+        assert!(slot1.is_empty());
+        assert!(slot2.is_empty());
+        assert_eq!(recv_inbox_message(&mut rx1), msg);
+        assert_eq!(recv_inbox_message(&mut rx2), msg);
+    }
+
     fn test_wire_target(
         slot: &Arc<crate::engine::transmit_slot::PeerTransmitSlot>,
     ) -> PeerOutbound {
@@ -251,6 +290,32 @@ mod tests {
         );
         slot.handshake_done.store(true, Ordering::Release);
         slot
+    }
+
+    fn test_transformed_slot(peer_id: u64) -> Arc<crate::engine::transmit_slot::PeerTransmitSlot> {
+        let slot = crate::engine::transmit_slot::PeerTransmitSlot::new(
+            peer_id,
+            true,
+            None,
+            None,
+            omq_proto::frame_buffer::ARENA_THRESHOLD,
+            omq_proto::frame_buffer::ARENA_INITIAL_CAP,
+            crate::engine::transmit_slot::TRANSMIT_SLOT_CAP_DEFAULT,
+            8,
+            #[cfg(feature = "ws")]
+            false,
+            #[cfg(feature = "ws")]
+            false,
+        );
+        slot.handshake_done.store(true, Ordering::Release);
+        slot
+    }
+
+    fn recv_inbox_message(rx: &mut tokio::sync::mpsc::Receiver<PeerDriverCommand>) -> Message {
+        match rx.try_recv().expect("inbox message") {
+            PeerDriverCommand::SendMessage(msg) => msg,
+            other => panic!("unexpected command {other:?}"),
+        }
     }
 
     fn encoded_message(body: &str) -> Bytes {

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -392,7 +392,7 @@ impl FanOutLanes {
         );
     }
 
-    #[cfg(feature = "lz4")]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
     pub(super) fn set_compression_all(
         &self,
         kind: CompressionKind,

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -780,13 +780,13 @@ impl LaneWorker {
         #[allow(unused)] options: &Options,
         #[allow(unused)] dict: Option<&Bytes>,
     ) {
-        #[cfg(feature = "lz4")]
+        #[cfg(any(feature = "lz4", feature = "zstd"))]
         if self.encoder.is_none() || dict.is_some() {
             let mut opts = options.clone().compression_auto_train(false);
             if let Some(d) = dict {
                 opts = opts.compression_dict(d.clone());
             }
-            if let Some((enc, _dec)) = MessageEncoder::for_compression_kind(kind, &opts) {
+            if let Ok(Some((enc, _dec))) = MessageEncoder::for_compression_kind(kind, &opts) {
                 self.encoder = Some(enc);
             }
         }
@@ -824,7 +824,7 @@ impl LaneWorker {
             return false;
         }
 
-        // Compress if an encoder is active (lz4+tcp:// peers present).
+        // Compress if an encoder is active.
         let mut wire_messages: SmallVec<[Message; 2]> = if let Some(ref mut enc) = self.encoder {
             match enc.encode(&dispatch.msg) {
                 Ok(transformed) => transformed,

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -17,8 +17,7 @@ use omq_proto::flow::DrainBudget;
 use omq_proto::frame_buffer::FrameBuffer;
 use omq_proto::message::Message;
 use omq_proto::options::Options;
-#[cfg(feature = "lz4")]
-use omq_proto::proto::transform::MessageEncoder;
+use omq_proto::proto::transform::{CompressionKind, MessageEncoder};
 
 use super::filter::{self, FanOutMode};
 use super::{FAN_OUT_TOTAL_COPY_BUDGET, FanOutMutePolicy};
@@ -49,6 +48,7 @@ enum LaneControl {
         group: Bytes,
     },
     SetCompression {
+        kind: CompressionKind,
         options: Box<Options>,
         dict: Option<Bytes>,
     },
@@ -158,7 +158,6 @@ struct LaneWorker {
     subscribe_all_count: usize,
     eq: FrameBuffer,
     chunks: Vec<Bytes>,
-    #[cfg(feature = "lz4")]
     encoder: Option<MessageEncoder>,
     distribution_targets: Vec<LaneDistributionTarget>,
     active_flags: Option<Arc<Vec<AtomicBool>>>,
@@ -268,7 +267,6 @@ impl FanOutLanes {
                     subscribe_all_count: 0,
                     eq: FrameBuffer::one_shot(),
                     chunks: Vec::new(),
-                    #[cfg(feature = "lz4")]
                     encoder: None,
                     distribution_targets: dist_targets,
                     active_flags: flags,
@@ -377,10 +375,17 @@ impl FanOutLanes {
         self.send_to_lane(lane, LaneControl::Leave { peer_id, group });
     }
 
-    pub(super) fn set_compression(&self, lane: usize, options: Options, dict: Option<Bytes>) {
+    pub(super) fn set_compression(
+        &self,
+        lane: usize,
+        kind: CompressionKind,
+        options: Options,
+        dict: Option<Bytes>,
+    ) {
         self.send_to_lane(
             lane,
             LaneControl::SetCompression {
+                kind,
                 options: Box::new(options),
                 dict,
             },
@@ -388,12 +393,18 @@ impl FanOutLanes {
     }
 
     #[cfg(feature = "lz4")]
-    pub(super) fn set_compression_all(&self, options: &Options, dict: Option<&Bytes>) {
+    pub(super) fn set_compression_all(
+        &self,
+        kind: CompressionKind,
+        options: &Options,
+        dict: Option<&Bytes>,
+    ) {
         let mut state = self.state.lock().expect("fanout lanes poisoned");
         for endpoint in &mut state.endpoints {
             Self::push_control(
                 endpoint,
                 LaneControl::SetCompression {
+                    kind,
                     options: Box::new(options.clone()),
                     dict: dict.cloned(),
                 },
@@ -750,8 +761,12 @@ impl LaneWorker {
                     peer.groups.remove(s);
                 }
             }
-            LaneControl::SetCompression { options, dict } => {
-                self.init_encoder(&options, dict.as_ref());
+            LaneControl::SetCompression {
+                kind,
+                options,
+                dict,
+            } => {
+                self.init_encoder(kind, &options, dict.as_ref());
             }
             LaneControl::Shutdown => return true,
         }
@@ -761,21 +776,17 @@ impl LaneWorker {
     #[allow(clippy::unused_self)]
     fn init_encoder(
         &mut self,
+        #[allow(unused)] kind: CompressionKind,
         #[allow(unused)] options: &Options,
         #[allow(unused)] dict: Option<&Bytes>,
     ) {
         #[cfg(feature = "lz4")]
         if self.encoder.is_none() || dict.is_some() {
-            use omq_proto::endpoint::{Endpoint, Host};
             let mut opts = options.clone().compression_auto_train(false);
             if let Some(d) = dict {
                 opts = opts.compression_dict(d.clone());
             }
-            let dummy = Endpoint::Lz4Tcp {
-                host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
-                port: 0,
-            };
-            if let Some((enc, _dec)) = MessageEncoder::for_endpoint(&dummy, &opts) {
+            if let Some((enc, _dec)) = MessageEncoder::for_compression_kind(kind, &opts) {
                 self.encoder = Some(enc);
             }
         }
@@ -814,8 +825,7 @@ impl LaneWorker {
         }
 
         // Compress if an encoder is active (lz4+tcp:// peers present).
-        #[cfg(feature = "lz4")]
-        let wire_messages: SmallVec<[Message; 2]> = if let Some(ref mut enc) = self.encoder {
+        let mut wire_messages: SmallVec<[Message; 2]> = if let Some(ref mut enc) = self.encoder {
             match enc.encode(&dispatch.msg) {
                 Ok(transformed) => transformed,
                 Err(_) => return false,
@@ -823,23 +833,9 @@ impl LaneWorker {
         } else {
             smallvec::smallvec![dispatch.msg.clone()]
         };
-        #[cfg(not(feature = "lz4"))]
-        let wire_messages: SmallVec<[Message; 2]> = smallvec::smallvec![dispatch.msg.clone()];
 
         // Handle dict shipment: the first transformed message may be a dict.
-        #[cfg(feature = "lz4")]
-        let (dict_msg, payload_start) = {
-            if wire_messages
-                .first()
-                .is_some_and(omq_proto::proto::transform::lz4::is_dict_shipment)
-            {
-                (Some(&wire_messages[0]), 1)
-            } else {
-                (None, 0)
-            }
-        };
-        #[cfg(not(feature = "lz4"))]
-        let (dict_msg, payload_start): (Option<&Message>, usize) = (None, 0);
+        let dict_msg = MessageEncoder::take_leading_dict_shipment(&mut wire_messages);
 
         let target_count = peer_ids.len();
         let mut eq = std::mem::replace(&mut self.eq, FrameBuffer::one_shot());
@@ -849,7 +845,7 @@ impl LaneWorker {
         // Encode dict and payload into per-peer slots. Both go through
         // push_frame_to_peer (direct FrameBuffer push) to preserve ordering.
         let has_dict = dict_msg.is_some();
-        if let Some(dict) = dict_msg {
+        if let Some(dict) = dict_msg.as_ref() {
             {
                 let frame = build_fan_out_frame(
                     &mut eq,
@@ -885,7 +881,7 @@ impl LaneWorker {
 
         if !shutdown {
             // Encode the payload messages into the FrameBuffer.
-            for wire_msg in &wire_messages[payload_start..] {
+            for wire_msg in &wire_messages {
                 encode_fan_out_message(&mut eq, wire_msg, target_count, FAN_OUT_TOTAL_COPY_BUDGET);
             }
 
@@ -946,8 +942,7 @@ impl LaneWorker {
             return;
         }
 
-        #[cfg(feature = "lz4")]
-        let wire_messages: SmallVec<[Message; 2]> = if let Some(ref mut enc) = self.encoder {
+        let mut wire_messages: SmallVec<[Message; 2]> = if let Some(ref mut enc) = self.encoder {
             match enc.encode(&dispatch.msg) {
                 Ok(transformed) => transformed,
                 Err(_) => return,
@@ -955,26 +950,12 @@ impl LaneWorker {
         } else {
             smallvec::smallvec![dispatch.msg.clone()]
         };
-        #[cfg(not(feature = "lz4"))]
-        let wire_messages: SmallVec<[Message; 2]> = smallvec::smallvec![dispatch.msg.clone()];
 
-        #[cfg(feature = "lz4")]
-        let (dict_msg, payload_start) = {
-            if wire_messages
-                .first()
-                .is_some_and(omq_proto::proto::transform::lz4::is_dict_shipment)
-            {
-                (Some(&wire_messages[0]), 1)
-            } else {
-                (None, 0)
-            }
-        };
-        #[cfg(not(feature = "lz4"))]
-        let (dict_msg, payload_start): (Option<&Message>, usize) = (None, 0);
+        let dict_msg = MessageEncoder::take_leading_dict_shipment(&mut wire_messages);
 
         let target_count = peer_ids.len();
         let has_dict = dict_msg.is_some();
-        if let Some(dict) = dict_msg {
+        if let Some(dict) = dict_msg.as_ref() {
             let frame = build_fan_out_frame(
                 &mut self.eq,
                 dict,
@@ -1000,7 +981,7 @@ impl LaneWorker {
             clear_fan_out_frame(&mut self.eq, &mut self.chunks);
         }
 
-        for wire_msg in &wire_messages[payload_start..] {
+        for wire_msg in &wire_messages {
             encode_fan_out_message(
                 &mut self.eq,
                 wire_msg,
@@ -1267,7 +1248,6 @@ mod tests {
             subscribe_all_count: 1,
             eq: FrameBuffer::one_shot(),
             chunks: Vec::new(),
-            #[cfg(feature = "lz4")]
             encoder: None,
             distribution_targets: Vec::new(),
             active_flags: None,
@@ -1316,7 +1296,6 @@ mod tests {
             subscribe_all_count: 1,
             eq: FrameBuffer::one_shot(),
             chunks: Vec::new(),
-            #[cfg(feature = "lz4")]
             encoder: None,
             distribution_targets: Vec::new(),
             active_flags: None,
@@ -1372,6 +1351,7 @@ mod tests {
         crate::engine::transmit_slot::PeerTransmitSlot::new(
             peer_id,
             false,
+            None,
             None,
             4096,
             16 * 1024,

--- a/omq-tokio/src/routing/peer_outbound.rs
+++ b/omq-tokio/src/routing/peer_outbound.rs
@@ -52,6 +52,10 @@ impl PeerOutbound {
         }
     }
 
+    pub(crate) fn requires_per_peer_encoding(&self) -> bool {
+        matches!(self, Self::Wire { slot, .. } if slot.has_transform)
+    }
+
     #[cfg(feature = "ws")]
     pub(crate) fn is_ws(&self) -> bool {
         match self {

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -56,6 +56,7 @@ pub(super) fn spawn_byte_stream_connection(
     let driver_cfg = peer_driver_config(socket);
     let workload_profile = workload_profile(socket);
     let transforms = MessageEncoder::for_endpoint(&endpoint, &socket.options);
+    let compression_kind = omq_proto::proto::transform::CompressionKind::for_endpoint(&endpoint);
     let has_transforms = transforms.is_some();
     let latency_profile = workload_profile == WorkloadProfile::Latency
         && !socket.options.mechanism.has_frame_transform();
@@ -91,6 +92,7 @@ pub(super) fn spawn_byte_stream_connection(
         socket,
         peer_id,
         has_transforms,
+        compression_kind,
         passthrough_info,
         arena,
         #[cfg(feature = "ws")]
@@ -396,6 +398,7 @@ fn build_transmit_slot(
     socket: &SocketDriver,
     peer_id: u64,
     has_transforms: bool,
+    compression_kind: Option<omq_proto::proto::transform::CompressionKind>,
     passthrough_info: Option<(bytes::Bytes, usize)>,
     arena: ArenaConfig,
     #[cfg(feature = "ws")] is_ws: bool,
@@ -413,6 +416,7 @@ fn build_transmit_slot(
     Some(crate::engine::transmit_slot::PeerTransmitSlot::new(
         peer_id,
         has_transforms,
+        compression_kind,
         passthrough_info,
         arena.threshold,
         arena.cap,

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -425,7 +425,7 @@ fn arena_config(endpoint: &Endpoint, latency_profile: bool, socket: &SocketDrive
     ArenaConfig { threshold, cap }
 }
 
-#[expect(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn build_transmit_slot(
     socket: &SocketDriver,
     peer_id: u64,

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -425,6 +425,7 @@ fn arena_config(endpoint: &Endpoint, latency_profile: bool, socket: &SocketDrive
     ArenaConfig { threshold, cap }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn build_transmit_slot(
     socket: &SocketDriver,
     peer_id: u64,

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -55,7 +55,11 @@ pub(super) fn spawn_byte_stream_connection(
     let child_cancel = socket.cancel.child_token();
     let driver_cfg = peer_driver_config(socket);
     let workload_profile = workload_profile(socket);
-    let transforms = MessageEncoder::for_endpoint(&endpoint, &socket.options);
+    let Ok(transforms) =
+        build_message_transforms(socket, &endpoint, &peer_ident, is_server, route_id)
+    else {
+        return;
+    };
     let compression_kind = omq_proto::proto::transform::CompressionKind::for_endpoint(&endpoint);
     let has_transforms = transforms.is_some();
     let latency_profile = workload_profile == WorkloadProfile::Latency
@@ -231,6 +235,33 @@ pub(super) fn spawn_inproc_peer(
     );
     if let Some(peer) = socket.peers.get_mut(&peer_id) {
         peer.task = Some(task);
+    }
+}
+
+fn build_message_transforms(
+    socket: &mut SocketDriver,
+    endpoint: &Endpoint,
+    peer_ident: &PeerIdent,
+    is_server: bool,
+    route_id: u64,
+) -> core::result::Result<Option<(MessageEncoder, omq_proto::proto::transform::MessageDecoder)>, ()>
+{
+    match MessageEncoder::for_endpoint(endpoint, &socket.options) {
+        Ok(transforms) => Ok(transforms),
+        Err(e) => {
+            socket
+                .monitor
+                .publish(omq_proto::MonitorEvent::HandshakeFailed {
+                    endpoint: endpoint.clone(),
+                    peer_ident: peer_ident.clone(),
+                    reason: e.to_string(),
+                });
+            if !is_server {
+                socket.dialers.retain(|d| d.route_id != route_id);
+                socket.send_strategy.connect_pipe_removed(route_id);
+            }
+            Err(())
+        }
     }
 }
 

--- a/omq-tokio/tests/fuzz_parsers.rs
+++ b/omq-tokio/tests/fuzz_parsers.rs
@@ -523,8 +523,9 @@ fn fuzz_compress_ws_roundtrip() {
     let opts = Options::default();
     for i in 0..iters() / 4 {
         let ep = &endpoints[rng.random_range(0..endpoints.len())];
-        let (mut enc, mut dec) =
-            MessageEncoder::for_endpoint(ep, &opts).expect("transform for compressed-ws");
+        let (mut enc, mut dec) = MessageEncoder::for_endpoint(ep, &opts)
+            .expect("transform constructor")
+            .expect("transform for compressed-ws");
         let n_parts = rng.random_range(1..=4);
         let mut parts: Vec<Bytes> = Vec::new();
         for _ in 0..n_parts {

--- a/omq-tokio/tests/lz4_pub_sub.rs
+++ b/omq-tokio/tests/lz4_pub_sub.rs
@@ -380,6 +380,54 @@ async fn pub_sub_prefix_filter() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pub_sub_mixed_tcp_then_lz4_fallback_delivers_to_all() {
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let tcp_port = test_support::bind_loopback(&publisher).await;
+    let tcp_ep = test_support::tcp_loopback(tcp_port);
+
+    let tcp_sub = Socket::new(SocketType::Sub, Options::default());
+    tcp_sub.subscribe(bytes::Bytes::new()).await.unwrap();
+    tcp_sub.connect(tcp_ep).await.unwrap();
+    publisher
+        .wait_subscribed(1, FAN_OUT_READY_TIMEOUT)
+        .await
+        .expect("tcp subscription did not arrive");
+
+    let lz4_ep = bind_lz4_loopback(&publisher).await;
+    let mut lz4_subs = Vec::new();
+    for _ in 0..2 {
+        let sub = Socket::new(SocketType::Sub, Options::default());
+        sub.subscribe(bytes::Bytes::new()).await.unwrap();
+        sub.connect(lz4_ep.clone()).await.unwrap();
+        lz4_subs.push(sub);
+    }
+    publisher
+        .wait_subscribed(3, FAN_OUT_READY_TIMEOUT)
+        .await
+        .expect("lz4 subscriptions did not arrive");
+
+    let payload = bytes::Bytes::from("quote.".repeat(2048));
+    publisher
+        .send(Message::single(payload.clone()))
+        .await
+        .unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), tcp_sub.recv())
+        .await
+        .expect("tcp subscriber did not receive message")
+        .unwrap();
+    assert_eq!(got.part_bytes(0).unwrap(), payload);
+
+    for (idx, sub) in lz4_subs.iter().enumerate() {
+        let got = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+            .await
+            .unwrap_or_else(|_| panic!("lz4 subscriber {idx} did not receive message"))
+            .unwrap();
+        assert_eq!(got.part_bytes(0).unwrap(), payload);
+    }
+}
+
 /// Fan-out to multiple subscribers: exercises the multi-target
 /// `dispatch_to_targets` path that encodes once and pushes
 /// pre-encoded compressed bytes to all peers.

--- a/omq-tokio/tests/omq_soak_compression_zstd.rs
+++ b/omq-tokio/tests/omq_soak_compression_zstd.rs
@@ -1,0 +1,153 @@
+#![cfg(all(feature = "soak", feature = "zstd"))]
+//! Soak: zstd compression transport sustained.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+const SIZES: &[usize] = &[64, 1024, 8 * 1024, 64 * 1024, 256 * 1024];
+
+fn zstd_options() -> Options {
+    soak_common::soak_options().compression_auto_train(true)
+}
+
+async fn pull_on_loopback() -> (Socket, Endpoint) {
+    let pull = Socket::new(SocketType::Pull, zstd_options());
+    let mut mon = pull.monitor();
+    pull.bind(Endpoint::ZstdTcp {
+        host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        port: 0,
+    })
+    .await
+    .unwrap();
+    let ev = tokio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let port = match ev {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::ZstdTcp { port, .. },
+        } => port,
+        other => panic!("expected ZstdTcp Listening, got {other:?}"),
+    };
+    (
+        pull,
+        Endpoint::ZstdTcp {
+            host: Host::Ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+            port,
+        },
+    )
+}
+
+fn make_payload(idx: u64, size: usize) -> Vec<u8> {
+    let mut v = vec![b'A' + (idx % 16) as u8; size];
+    let tag = format!("{{\"seq\":{idx},\"kind\":\"zstd-soak\",\"pad\":\"");
+    let tag = tag.as_bytes();
+    let n = tag.len().min(size);
+    v[..n].copy_from_slice(&tag[..n]);
+    v
+}
+
+#[test]
+fn soak_compression_zstd_sustained() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let sent = Arc::new(AtomicU64::new(0));
+    let recvd = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
+        let (pull, ep) = pull_on_loopback().await;
+        let push = Socket::new(
+            SocketType::Push,
+            zstd_options().linger(Duration::from_secs(5)),
+        );
+        push.connect(ep).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let send_sent = sent.clone();
+        let send_stop = stop.clone();
+        let push_clone = push.clone();
+        let send_task = tokio::spawn(async move {
+            let mut idx: u64 = 0;
+            while !send_stop.load(Ordering::Relaxed) {
+                let size = SIZES[idx as usize % SIZES.len()];
+                let payload = make_payload(idx, size);
+                if let Ok(Ok(())) = tokio::time::timeout(
+                    Duration::from_secs(2),
+                    push_clone.send(Message::single(payload)),
+                )
+                .await
+                {
+                    send_sent.fetch_add(1, Ordering::Relaxed);
+                }
+                idx += 1;
+            }
+        });
+
+        let recv_recvd = recvd.clone();
+        let recv_stop = stop.clone();
+        let pull_clone = pull.clone();
+        let recv_task = tokio::spawn(async move {
+            while !recv_stop.load(Ordering::Relaxed) {
+                if let Ok(Ok(m)) =
+                    tokio::time::timeout(Duration::from_secs(2), pull_clone.recv()).await
+                {
+                    let part = m.part_bytes(0).unwrap();
+                    assert!(
+                        SIZES.contains(&part.len()),
+                        "unexpected message size: {}",
+                        part.len()
+                    );
+                    recv_recvd.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+
+        let timer_stop = stop.clone();
+        let timer_sent = sent.clone();
+        let timer_recvd = recvd.clone();
+        let start = Instant::now();
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                let s = timer_sent.load(Ordering::Relaxed);
+                let r = timer_recvd.load(Ordering::Relaxed);
+                eprintln!(
+                    "[compression_zstd] {:.0}s, sent {s}, recvd {r}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+        timer_stop.store(true, Ordering::Relaxed);
+
+        let _ = send_task.await;
+        let _ = recv_task.await;
+
+        let s = sent.load(Ordering::Relaxed);
+        let r = recvd.load(Ordering::Relaxed);
+        eprintln!(
+            "[compression_zstd] done: sent {s}, recvd {r} in {:.1}s",
+            duration.as_secs_f64(),
+        );
+
+        push.close().await.unwrap();
+        pull.close().await.unwrap();
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("compression_zstd");
+}

--- a/omq-tokio/tests/omq_soak_pub_sub_zstd_dict.rs
+++ b/omq-tokio/tests/omq_soak_pub_sub_zstd_dict.rs
@@ -1,0 +1,221 @@
+#![cfg(all(feature = "soak", feature = "zstd"))]
+//! Soak: IO-lane PUB/SUB over zstd+tcp:// with fan-out dictionaries.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+
+const DECODED_SUBS: usize = 4;
+const TRAINING_MSGS: u64 = 128;
+const RAW_PAYLOAD_CHECKS: usize = 3;
+const RAW_RECV_TIMEOUT: Duration = Duration::from_secs(15);
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+const ZDICT_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
+
+fn zstd_tcp_ep(port: u16) -> Endpoint {
+    Endpoint::ZstdTcp {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+fn tcp_from_zstd(ep: &Endpoint) -> Endpoint {
+    match ep {
+        Endpoint::ZstdTcp { host, port } => Endpoint::Tcp {
+            host: host.clone(),
+            port: *port,
+        },
+        other => panic!("expected zstd+tcp endpoint, got {other:?}"),
+    }
+}
+
+fn zstd_options() -> Options {
+    soak_common::soak_options()
+        .compression_auto_train(true)
+        .send_hwm(4096)
+        .recv_hwm(4096)
+}
+
+async fn bind_zstd_pub(publisher: &Socket) -> (Endpoint, omq_tokio::MonitorStream) {
+    let mut mon = publisher.monitor();
+    publisher.bind(zstd_tcp_ep(0)).await.unwrap();
+    loop {
+        if let MonitorEvent::Listening {
+            endpoint: Endpoint::ZstdTcp { port, .. },
+        } = tokio::time::timeout(Duration::from_secs(5), mon.recv())
+            .await
+            .expect("publisher did not report listening")
+            .unwrap()
+        {
+            return (zstd_tcp_ep(port), mon);
+        }
+    }
+}
+
+async fn wait_for_subscribes(mon: &mut omq_tokio::MonitorStream, n: usize) {
+    let fut = async {
+        let mut count = 0;
+        while count < n {
+            match mon.recv().await {
+                Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed after {count}/{n} subscribes: {e:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("subscribes did not propagate");
+}
+
+fn payload(seq: u64) -> Bytes {
+    Bytes::from(format!(
+        "{{\"kind\":\"quote\",\"venue\":\"XNAS\",\"symbol\":\"OMQ\",\"seq\":{seq},\"bid\":101.25,\"ask\":101.27,\"depth\":[10125,10126,10127],\"pad\":\"{}\"}}",
+        "A".repeat(256)
+    ))
+}
+
+async fn assert_raw_dict_then_payloads(raw: &Socket) {
+    let dict = tokio::time::timeout(RAW_RECV_TIMEOUT, raw.recv())
+        .await
+        .expect("raw subscriber did not receive dictionary shipment")
+        .unwrap();
+    let dict_part = dict.part_bytes(0).unwrap();
+    assert_eq!(
+        &dict_part[..dict_part.len().min(4)],
+        &ZDICT_MAGIC[..],
+        "raw subscriber first message must be ZDICT"
+    );
+
+    for idx in 0..RAW_PAYLOAD_CHECKS {
+        let msg = tokio::time::timeout(RAW_RECV_TIMEOUT, raw.recv())
+            .await
+            .unwrap_or_else(|_| panic!("raw subscriber missed compressed payload {idx}"))
+            .unwrap();
+        let part = msg.part_bytes(0).unwrap();
+        assert_eq!(
+            &part[..part.len().min(4)],
+            &ZSTD_MAGIC[..],
+            "raw payload {idx} should be zstd-compressed"
+        );
+    }
+}
+
+#[test]
+fn soak_pub_sub_zstd_dict_io_lane_fanout() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let sent = Arc::new(AtomicU64::new(0));
+    let decoded = Arc::new(AtomicU64::new(0));
+    let raw_probes = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
+        let publisher = Socket::new(SocketType::Pub, zstd_options());
+        let (ep, mut mon) = bind_zstd_pub(&publisher).await;
+
+        let mut decoded_subs = Vec::with_capacity(DECODED_SUBS);
+        for _ in 0..DECODED_SUBS {
+            let sub = Socket::new(SocketType::Sub, zstd_options());
+            sub.connect(ep.clone()).await.unwrap();
+            sub.subscribe(Bytes::new()).await.unwrap();
+            decoded_subs.push(sub);
+        }
+        wait_for_subscribes(&mut mon, DECODED_SUBS).await;
+
+        for seq in 0..TRAINING_MSGS {
+            publisher.send(Message::single(payload(seq))).await.unwrap();
+            sent.fetch_add(1, Ordering::Relaxed);
+        }
+
+        let mut decode_tasks = Vec::with_capacity(DECODED_SUBS);
+        for sub in &decoded_subs {
+            let sub = sub.clone();
+            let decoded = decoded.clone();
+            let stop = stop.clone();
+            decode_tasks.push(tokio::spawn(async move {
+                while !stop.load(Ordering::Relaxed) {
+                    if let Ok(Ok(_msg)) =
+                        tokio::time::timeout(Duration::from_secs(2), sub.recv()).await
+                    {
+                        decoded.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+
+        let send_stop = stop.clone();
+        let send_sent = sent.clone();
+        let send_pub = publisher.clone();
+        let send_task = tokio::spawn(async move {
+            let mut seq = TRAINING_MSGS;
+            while !send_stop.load(Ordering::Relaxed) {
+                if send_pub.send(Message::single(payload(seq))).await.is_ok() {
+                    send_sent.fetch_add(1, Ordering::Relaxed);
+                }
+                seq += 1;
+            }
+        });
+
+        let start = Instant::now();
+        let mut last_probe = Instant::now().checked_sub(Duration::from_secs(1)).unwrap();
+        let mut last_log = start;
+        while start.elapsed() < duration {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if last_probe.elapsed() >= Duration::from_millis(500) {
+                last_probe = Instant::now();
+                let raw = Socket::new(SocketType::Sub, soak_common::soak_options().recv_hwm(64));
+                raw.connect(tcp_from_zstd(&ep)).await.unwrap();
+                raw.subscribe(Bytes::new()).await.unwrap();
+                assert_raw_dict_then_payloads(&raw).await;
+                raw.close().await.unwrap();
+                raw_probes.fetch_add(1, Ordering::Relaxed);
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                let s = sent.load(Ordering::Relaxed);
+                let d = decoded.load(Ordering::Relaxed);
+                let r = raw_probes.load(Ordering::Relaxed);
+                eprintln!(
+                    "[pub_sub_zstd_dict] {:.0}s, sent {s}, decoded {d}, raw_probes {r}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        let _ = send_task.await;
+        for task in decode_tasks {
+            let _ = task.await;
+        }
+
+        assert!(
+            raw_probes.load(Ordering::Relaxed) > 0,
+            "soak must attach at least one raw late subscriber"
+        );
+        assert!(
+            decoded.load(Ordering::Relaxed) > 0,
+            "decoded subscribers must receive traffic"
+        );
+
+        for sub in decoded_subs {
+            sub.close().await.unwrap();
+        }
+        publisher.close().await.unwrap();
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("pub_sub_zstd_dict");
+}

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -7,13 +7,28 @@ use std::time::Duration;
 use bytes::Bytes;
 use omq_proto::proto::transform::train_zdict;
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+use omq_tokio::{
+    Context, ContextConfig, Endpoint, Message, MonitorEvent, Options, Socket, SocketType,
+};
 use rand::Rng;
+
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+const ZDICT_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
 
 fn zstd_loopback(port: u16) -> Endpoint {
     Endpoint::ZstdTcp {
         host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
         port,
+    }
+}
+
+fn tcp_from_zstd(ep: &Endpoint) -> Endpoint {
+    match ep {
+        Endpoint::ZstdTcp { host, port } => Endpoint::Tcp {
+            host: host.clone(),
+            port: *port,
+        },
+        other => panic!("expected zstd+tcp endpoint, got {other:?}"),
     }
 }
 
@@ -257,4 +272,90 @@ async fn auto_train_survives_reconnect() {
         }
     }
     assert_eq!(got, FIRST + SECOND);
+}
+
+#[test]
+fn pub_sub_zstd_io_lane_auto_trains_dict_for_late_subscriber() {
+    let ctx = Context::with_config(ContextConfig { io_threads: 4 });
+    let opts = Options::default()
+        .compression_auto_train(true)
+        .send_hwm(2048)
+        .recv_hwm(2048);
+    let publisher = ctx.socket(SocketType::Pub, opts.clone());
+    let mut mon = publisher.monitor();
+    let decoded_subs: Vec<_> = (0..4)
+        .map(|_| ctx.socket(SocketType::Sub, opts.clone()))
+        .collect();
+    let raw = ctx.socket(SocketType::Sub, Options::default().recv_hwm(64));
+
+    ctx.block_on(async move {
+        publisher.bind(zstd_loopback(0)).await.unwrap();
+        let ep = loop {
+            if let MonitorEvent::Listening {
+                endpoint: Endpoint::ZstdTcp { port, .. },
+            } = tokio::time::timeout(Duration::from_secs(5), mon.recv())
+                .await
+                .expect("publisher did not listen")
+                .unwrap()
+            {
+                break zstd_loopback(port);
+            }
+        };
+
+        for sub in &decoded_subs {
+            sub.connect(ep.clone()).await.unwrap();
+            sub.subscribe(Bytes::new()).await.unwrap();
+        }
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut count = 0;
+            while count < decoded_subs.len() {
+                match mon.recv().await {
+                    Ok(MonitorEvent::SubscribeReceived { .. }) => count += 1,
+                    Ok(_) => {}
+                    Err(e) => panic!("monitor closed after {count} subscribes: {e:?}"),
+                }
+            }
+        })
+        .await
+        .expect("subscriptions did not arrive");
+
+        let payload = |seq: u64| {
+            Bytes::from(format!(
+                "{{\"kind\":\"quote\",\"venue\":\"XNAS\",\"symbol\":\"OMQ\",\"seq\":{seq},\"pad\":\"{}\"}}",
+                "A".repeat(256)
+            ))
+        };
+        for seq in 0..128 {
+            publisher.send(Message::single(payload(seq))).await.unwrap();
+        }
+
+        raw.connect(tcp_from_zstd(&ep)).await.unwrap();
+        raw.subscribe(Bytes::new()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        for seq in 128..132 {
+            publisher.send(Message::single(payload(seq))).await.unwrap();
+        }
+
+        let dict = tokio::time::timeout(Duration::from_secs(5), raw.recv())
+            .await
+            .expect("raw subscriber did not receive dictionary")
+            .unwrap();
+        let dict_part = dict.part_bytes(0).unwrap();
+        assert_eq!(&dict_part[..4], &ZDICT_MAGIC);
+
+        let compressed = tokio::time::timeout(Duration::from_secs(5), raw.recv())
+            .await
+            .expect("raw subscriber did not receive compressed payload")
+            .unwrap();
+        let compressed_part = compressed.part_bytes(0).unwrap();
+        assert_eq!(&compressed_part[..4], &ZSTD_MAGIC);
+
+        let decoded = tokio::time::timeout(Duration::from_secs(5), decoded_subs[0].recv())
+            .await
+            .expect("decoded subscriber did not receive payload")
+            .unwrap();
+        assert!(decoded.part_bytes(0).unwrap().starts_with(b"{\"kind\":\"quote\""));
+    });
 }

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -84,6 +84,21 @@ async fn large_compressible_roundtrip() {
 }
 
 #[tokio::test]
+async fn custom_level_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default().compression_level(1));
+    push.connect(ep).await.unwrap();
+
+    let plain = vec![b'L'; 16 * 1024];
+    push.send(Message::single(plain.clone())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().to_vec(), plain);
+}
+
+#[tokio::test]
 async fn multipart_roundtrip() {
     let (pull, ep) = pull_on_loopback().await;
     let push = Socket::new(SocketType::Push, Options::default());

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -1,0 +1,245 @@
+#![cfg(feature = "zstd")]
+
+//! End-to-end integration of `zstd+tcp://`.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use omq_proto::proto::transform::train_zdict;
+use omq_tokio::endpoint::Host;
+use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+use rand::Rng;
+
+fn zstd_loopback(port: u16) -> Endpoint {
+    Endpoint::ZstdTcp {
+        host: Host::Ip(std::net::Ipv4Addr::LOCALHOST.into()),
+        port,
+    }
+}
+
+fn make_test_dict(seed: &[u8]) -> Bytes {
+    let samples: Vec<&[u8]> = (0..200).map(|_| seed).collect();
+    train_zdict(&samples, 8 * 1024).expect("train_zdict")
+}
+
+async fn wait_for_handshake(sock: &Socket) {
+    let mut mon = sock.monitor();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::HandshakeSucceeded { .. }) => return,
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before handshake: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("handshake did not arrive within 5s");
+}
+
+async fn pull_on_loopback() -> (Socket, Endpoint) {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let mut mon = pull.monitor();
+    pull.bind(zstd_loopback(0)).await.unwrap();
+    let ev = tokio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let port = match ev {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::ZstdTcp { port, .. },
+        } => port,
+        other => panic!("expected ZstdTcp Listening, got {other:?}"),
+    };
+    (pull, zstd_loopback(port))
+}
+
+#[tokio::test]
+async fn small_plaintext_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    push.send(Message::single("hello")).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(1), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::single("hello"));
+}
+
+#[tokio::test]
+async fn large_compressible_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    let plain = vec![b'Z'; 16 * 1024];
+    push.send(Message::single(plain.clone())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().to_vec(), plain);
+}
+
+#[tokio::test]
+async fn multipart_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    let big = vec![b'q'; 4096];
+    let msg = Message::multipart::<_, Bytes>([
+        Bytes::from_static(b"hdr"),
+        Bytes::from(big.clone()),
+        Bytes::from_static(b"tail"),
+    ]);
+    push.send(msg).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.len(), 3);
+    assert_eq!(m.part_bytes(0).unwrap(), &b"hdr"[..]);
+    assert_eq!(m.part_bytes(1).unwrap().to_vec(), big);
+    assert_eq!(m.part_bytes(2).unwrap(), &b"tail"[..]);
+}
+
+#[tokio::test]
+async fn dict_roundtrip_small_payload() {
+    let dict = make_test_dict(b"omq-omq-omq-omq-omq-omq-shared-prefix\n");
+    let opts = || Options::default().compression_dict(dict.clone());
+    let pull = Socket::new(SocketType::Pull, opts());
+    let mut mon = pull.monitor();
+    pull.bind(zstd_loopback(0)).await.unwrap();
+    let port = match tokio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::ZstdTcp { port, .. },
+        } => port,
+        other => panic!("unexpected {other:?}"),
+    };
+
+    let push = Socket::new(SocketType::Push, opts());
+    push.connect(zstd_loopback(port)).await.unwrap();
+    let plain = b"omq-".repeat(20);
+    for _ in 0..3 {
+        push.send(Message::single(plain.clone())).await.unwrap();
+        let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.part_bytes(0).unwrap().to_vec(), plain);
+    }
+}
+
+#[tokio::test]
+async fn incompressible_data_roundtrip() {
+    let (pull, ep) = pull_on_loopback().await;
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(ep).await.unwrap();
+
+    let mut random = vec![0u8; 8192];
+    rand::rng().fill_bytes(&mut random);
+    push.send(Message::single(random.clone())).await.unwrap();
+    let m = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m.part_bytes(0).unwrap().to_vec(), random);
+}
+
+#[tokio::test]
+async fn req_rep_over_zstd() {
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    let mut mon = rep.monitor();
+    rep.bind(zstd_loopback(0)).await.unwrap();
+    let port = match tokio::time::timeout(Duration::from_millis(500), mon.recv())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        MonitorEvent::Listening {
+            endpoint: Endpoint::ZstdTcp { port, .. },
+        } => port,
+        other => panic!("unexpected {other:?}"),
+    };
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(zstd_loopback(port)).await.unwrap();
+    req.send(Message::single("question")).await.unwrap();
+    let q = tokio::time::timeout(Duration::from_secs(2), rep.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(q, Message::single("question"));
+
+    rep.send(Message::single("answer")).await.unwrap();
+    let a = tokio::time::timeout(Duration::from_secs(2), req.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(a, Message::single("answer"));
+}
+
+#[tokio::test]
+async fn auto_train_survives_reconnect() {
+    const FIRST: usize = 120;
+    const SECOND: usize = 20;
+
+    let (pull, ep) = pull_on_loopback().await;
+    let make_payload = |i: usize| -> Vec<u8> {
+        let prefix = format!("{i:05}|");
+        let mut v = prefix.into_bytes();
+        v.extend(
+            b"omq-zstd-auto-train-reconnect-test-payload-"
+                .iter()
+                .cycle()
+                .take(1000 - v.len()),
+        );
+        v
+    };
+
+    {
+        let push = Socket::new(
+            SocketType::Push,
+            Options::default()
+                .compression_auto_train(true)
+                .linger(Duration::from_secs(4)),
+        );
+        push.connect(ep.clone()).await.unwrap();
+        wait_for_handshake(&pull).await;
+        for i in 0..FIRST {
+            push.send(Message::single(make_payload(i))).await.unwrap();
+        }
+        push.close().await.unwrap();
+    }
+
+    {
+        let push = Socket::new(
+            SocketType::Push,
+            Options::default()
+                .compression_auto_train(true)
+                .linger(Duration::from_secs(2)),
+        );
+        push.connect(ep.clone()).await.unwrap();
+        wait_for_handshake(&pull).await;
+        for i in 0..SECOND {
+            push.send(Message::single(make_payload(i))).await.unwrap();
+        }
+        push.close().await.unwrap();
+    }
+
+    let mut got = 0;
+    while let Ok(Ok(_)) = tokio::time::timeout(Duration::from_secs(5), pull.recv()).await {
+        got += 1;
+        if got == FIRST + SECOND {
+            break;
+        }
+    }
+    assert_eq!(got, FIRST + SECOND);
+}


### PR DESCRIPTION
- Add experimental `zstd+tcp://` backed by `zrip`.
- Share compression transport helpers through `CompressionKind`.
- Keep fan-out encoders per IO lane while sharing trained dict bytes.
- Add zstd benchmarks, chart, RFC copy, regressions, and soak coverage.
- Enable pyomq `zstd`, `OMQ_COMPRESSION_LEVEL`, docs, and Python tests.