### PR TITLE
Increase yring Miri timeout budget

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,4 +21,4 @@ final-status-level = "slow"
 
 [profile.extended-miri]
 inherits = "default-miri"
-slow-timeout = { period = "10m", terminate-after = 1, grace-period = "10s" }
+slow-timeout = { period = "20m", terminate-after = 1, grace-period = "10s" }


### PR DESCRIPTION
- `extended-miri` now allows 20 minutes before timing out a test.
- Nightly `-Zmiri-many-seeds=0..16` currently exceeds 10 minutes in large yring cross-thread tests under CI load.