### PR TITLE
Expand native libzmq parity coverage

### DIFF
--- a/omq-libzmq/Cargo.toml
+++ b/omq-libzmq/Cargo.toml
@@ -115,6 +115,10 @@ name = "omq_libzmq_security"
 path = "tests/security.rs"
 
 [[test]]
+name = "omq_libzmq_socket_null"
+path = "tests/socket_null.rs"
+
+[[test]]
 name = "omq_libzmq_transports"
 path = "tests/transports.rs"
 

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -21,6 +21,9 @@ pub(crate) struct OmqContext {
     sockets: Mutex<Vec<Weak<crate::socket::OmqSocket>>>,
     pub max_sockets: AtomicI32,
     pub max_msg_size: AtomicI64,
+    pub ipv6: AtomicBool,
+    pub blocky: AtomicBool,
+    pub zero_copy_recv: AtomicBool,
     /// Zmq-layer inproc registry. Maps inproc name to the bound `OmqSocket`.
     pub(crate) inproc_binds: Mutex<FxHashMap<String, std::sync::Weak<crate::socket::OmqSocket>>>,
     /// Pending inproc connect requests waiting for a bind.
@@ -47,6 +50,9 @@ impl OmqContext {
             sockets: Mutex::new(Vec::new()),
             max_sockets: AtomicI32::new(1023),
             max_msg_size: AtomicI64::new(-1),
+            ipv6: AtomicBool::new(false),
+            blocky: AtomicBool::new(true),
+            zero_copy_recv: AtomicBool::new(true),
             inproc_binds: Mutex::new(FxHashMap::default()),
             inproc_waiting: Mutex::new(FxHashMap::default()),
         })
@@ -134,6 +140,8 @@ impl std::fmt::Debug for OmqContext {
             .field("linger_count", &self.linger_count.load(Ordering::Relaxed))
             .field("max_sockets", &self.max_sockets.load(Ordering::Relaxed))
             .field("max_msg_size", &self.max_msg_size.load(Ordering::Relaxed))
+            .field("ipv6", &self.ipv6.load(Ordering::Relaxed))
+            .field("blocky", &self.blocky.load(Ordering::Relaxed))
             .finish_non_exhaustive()
     }
 }
@@ -214,7 +222,9 @@ const ZMQ_MAX_SOCKETS: c_int = 2;
 const ZMQ_SOCKET_LIMIT: c_int = 3;
 const ZMQ_MAX_MSGSZ: c_int = 5;
 const ZMQ_MSG_T_SIZE: c_int = 6;
+const ZMQ_ZERO_COPY_RECV: c_int = 10;
 const ZMQ_IPV6_CTX: c_int = 42;
+const ZMQ_BLOCKY: c_int = 70;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: c_int) -> c_int {
@@ -240,7 +250,16 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
         ZMQ_MAX_MSGSZ => {
             ctx.max_msg_size.store(i64::from(value), Ordering::Relaxed);
         }
-        ZMQ_SOCKET_LIMIT | ZMQ_IPV6_CTX => {}
+        ZMQ_IPV6_CTX => {
+            ctx.ipv6.store(value != 0, Ordering::Release);
+        }
+        ZMQ_BLOCKY => {
+            ctx.blocky.store(value != 0, Ordering::Release);
+        }
+        ZMQ_ZERO_COPY_RECV => {
+            ctx.zero_copy_recv.store(value != 0, Ordering::Release);
+        }
+        ZMQ_SOCKET_LIMIT => {}
         _ => return crate::error::fail(libc::EINVAL),
     }
     0
@@ -258,7 +277,9 @@ pub extern "C" fn zmq_ctx_get(ctx_ptr: *mut libc::c_void, option: c_int) -> c_in
         ZMQ_MAX_SOCKETS | ZMQ_SOCKET_LIMIT => ctx.max_sockets.load(Ordering::Relaxed),
         ZMQ_MAX_MSGSZ => ctx.max_msg_size.load(Ordering::Relaxed) as c_int,
         ZMQ_MSG_T_SIZE => c_int::try_from(crate::msg::ZMQ_MSG_T_SIZE).unwrap_or(c_int::MAX),
-        ZMQ_IPV6_CTX => 0,
+        ZMQ_ZERO_COPY_RECV => c_int::from(ctx.zero_copy_recv.load(Ordering::Acquire)),
+        ZMQ_IPV6_CTX => c_int::from(ctx.ipv6.load(Ordering::Acquire)),
+        ZMQ_BLOCKY => c_int::from(ctx.blocky.load(Ordering::Acquire)),
         _ => crate::error::fail(libc::EINVAL),
     }
 }

--- a/omq-libzmq/src/curve.rs
+++ b/omq-libzmq/src/curve.rs
@@ -60,11 +60,13 @@ pub extern "C" fn zmq_z85_encode(
     size: usize,
 ) -> *mut libc::c_char {
     if dest.is_null() || data.is_null() || !size.is_multiple_of(4) {
+        crate::error::set_errno(libc::EINVAL);
         return std::ptr::null_mut();
     }
     // SAFETY: data is non-null (checked above) with size readable bytes.
     let slice = unsafe { std::slice::from_raw_parts(data, size) };
     let Ok(encoded) = z85::encode(slice) else {
+        crate::error::set_errno(libc::EINVAL);
         return std::ptr::null_mut();
     };
     // SAFETY: dest is non-null (checked above); caller must provide a buffer of
@@ -79,14 +81,17 @@ pub extern "C" fn zmq_z85_encode(
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_z85_decode(dest: *mut u8, string: *const libc::c_char) -> *mut u8 {
     if dest.is_null() || string.is_null() {
+        crate::error::set_errno(libc::EINVAL);
         return std::ptr::null_mut();
     }
     // SAFETY: string is non-null (checked above); caller guarantees valid C string.
     let s = unsafe { std::ffi::CStr::from_ptr(string).to_str().unwrap_or("") };
     if s.len() % 5 != 0 {
+        crate::error::set_errno(libc::EINVAL);
         return std::ptr::null_mut();
     }
     let Ok(decoded) = z85::decode(s) else {
+        crate::error::set_errno(libc::EINVAL);
         return std::ptr::null_mut();
     };
     // SAFETY: dest is non-null (checked above); caller provides a buffer of

--- a/omq-libzmq/src/msg.rs
+++ b/omq-libzmq/src/msg.rs
@@ -14,6 +14,7 @@ const KIND_EMPTY: u8 = 0;
 const KIND_HEAP: u8 = 1;
 const KIND_EXTERNAL: u8 = 2;
 const KIND_BYTES: u8 = 3;
+const KIND_HEAP_SHARED: u8 = 4;
 
 /// `zmq_msg_t` compatible repr: 64 bytes, C layout.
 ///
@@ -53,6 +54,7 @@ const OFF_HINT: usize = OFF_FREE_FN + PTR_SIZE;
 const OFF_BOXED: usize = OFF_HINT + PTR_SIZE;
 const OFF_RESERVED: usize = OFF_BOXED + PTR_SIZE;
 const RESERVED_LEN: usize = 16;
+const LARGE_MSG_SHARED_THRESHOLD: usize = 64;
 
 type FreeFn = unsafe extern "C" fn(*mut libc::c_void, *mut libc::c_void);
 
@@ -342,7 +344,7 @@ pub extern "C" fn zmq_msg_close(msg: *mut OmqMsgRepr) -> c_int {
     // SAFETY: msg is non-null (checked above).
     let r = unsafe { repr(msg) };
     match r.kind() {
-        KIND_HEAP => {
+        KIND_HEAP | KIND_HEAP_SHARED => {
             let ptr = r.ptr();
             if !ptr.is_null() {
                 // SAFETY: ptr was allocated by libc::malloc in zmq_msg_init_size.
@@ -423,7 +425,7 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
                 s.reserved_array(),
             );
         }
-        KIND_HEAP | KIND_EXTERNAL => {
+        KIND_HEAP | KIND_EXTERNAL | KIND_HEAP_SHARED => {
             // Deep copy into a new heap allocation.
             let size = s.size();
             let src_ptr = s.ptr();
@@ -444,8 +446,13 @@ pub extern "C" fn zmq_msg_copy(dst: *mut OmqMsgRepr, src: *const OmqMsgRepr) -> 
             };
             // SAFETY: dst was closed above and is ready for reinitialization.
             let d = unsafe { repr(dst) };
+            let kind = if s.kind() == KIND_EXTERNAL || size >= LARGE_MSG_SHARED_THRESHOLD {
+                KIND_HEAP_SHARED
+            } else {
+                KIND_HEAP
+            };
             d.init_fields(
-                KIND_HEAP,
+                kind,
                 s.more(),
                 size,
                 new_ptr,
@@ -471,7 +478,14 @@ pub extern "C" fn zmq_msg_get(msg: *const OmqMsgRepr, property: c_int) -> c_int 
     }
     match property {
         1 => zmq_msg_more(msg),
-        3 => 0, // ZMQ_SHARED
+        3 => {
+            // SAFETY: msg is non-null (checked above).
+            let r = unsafe { repr_ref(msg) };
+            i32::from(matches!(
+                r.kind(),
+                KIND_EXTERNAL | KIND_BYTES | KIND_HEAP_SHARED
+            ))
+        }
         5 => zmq_msg_routing_id(msg).cast_signed(),
         _ => {
             crate::error::set_errno(libc::EINVAL);

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -354,7 +354,7 @@ pub extern "C" fn zmq_setsockopt(
     optvallen: usize,
 ) -> c_int {
     if sock.is_null() {
-        return crate::error::fail(libc::EFAULT);
+        return crate::error::fail(crate::error::ENOTSOCK);
     }
     // SAFETY: caller guarantees sock is a valid socket pointer from zmq_socket.
     let sock_arc = unsafe { &*(sock.cast::<std::sync::Arc<crate::socket::OmqSocket>>()) };
@@ -837,7 +837,7 @@ pub extern "C" fn zmq_getsockopt(
     optvallen: *mut usize,
 ) -> c_int {
     if sock.is_null() {
-        return crate::error::fail(libc::EFAULT);
+        return crate::error::fail(crate::error::ENOTSOCK);
     }
     // SAFETY: caller guarantees sock is a valid socket pointer from zmq_socket.
     let sock_arc = unsafe { &*(sock.cast::<std::sync::Arc<crate::socket::OmqSocket>>()) };
@@ -1258,6 +1258,7 @@ fn write_i32(optval: *mut libc::c_void, optvallen: *mut usize, val: i32) -> c_in
     }
     // SAFETY: optval is non-null with at least 4 bytes available (checked above).
     unsafe {
+        std::ptr::write_bytes(optval.cast::<u8>(), 0, avail);
         std::ptr::write_unaligned(optval.cast::<i32>(), val);
         *optvallen = 4;
     }
@@ -1275,6 +1276,7 @@ fn write_i64(optval: *mut libc::c_void, optvallen: *mut usize, val: i64) -> c_in
     }
     // SAFETY: optval is non-null with at least 8 bytes available (checked above).
     unsafe {
+        std::ptr::write_bytes(optval.cast::<u8>(), 0, avail);
         std::ptr::write_unaligned(optval.cast::<i64>(), val);
         *optvallen = 8;
     }

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -259,11 +259,15 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
     };
     let id = next_socket_id();
 
-    let mut overlay = SocketOverlay::default();
-    overlay.ipv6 = ctx.ipv6.load(Ordering::Acquire);
-    if !ctx.blocky.load(Ordering::Acquire) {
-        overlay.linger = LingerSetting::Finite(std::time::Duration::ZERO);
-    }
+    let overlay = SocketOverlay {
+        ipv6: ctx.ipv6.load(Ordering::Acquire),
+        linger: if ctx.blocky.load(Ordering::Acquire) {
+            LingerSetting::Unset
+        } else {
+            LingerSetting::Finite(std::time::Duration::ZERO)
+        },
+        ..SocketOverlay::default()
+    };
 
     let sock = Arc::new(OmqSocket {
         id,

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -18,7 +18,7 @@ use std::os::raw::c_char;
 use crate::context::{OmqContext, next_socket_id};
 use crate::error::{ETERM, fail, map_omq_err, set_errno};
 use crate::notify::{NotifyHandle, PlatformNotifyHandle, RecvNotify};
-use crate::opts::SocketOverlay;
+use crate::opts::{LingerSetting, SocketOverlay};
 
 /// Rewrite `Host::Wildcard` to IPv6 unspecified (::) for dual-stack bind.
 fn ipv6_rewrite_wildcard(ep: Endpoint) -> Endpoint {
@@ -259,11 +259,17 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
     };
     let id = next_socket_id();
 
+    let mut overlay = SocketOverlay::default();
+    overlay.ipv6 = ctx.ipv6.load(Ordering::Acquire);
+    if !ctx.blocky.load(Ordering::Acquire) {
+        overlay.linger = LingerSetting::Finite(std::time::Duration::ZERO);
+    }
+
     let sock = Arc::new(OmqSocket {
         id,
         ctx: ctx.clone(),
         socket_type,
-        overlay: Mutex::new(SocketOverlay::default()),
+        overlay: Mutex::new(overlay),
         sndtimeo_ms: AtomicI64::new(-1),
         rcvtimeo_ms: AtomicI64::new(-1),
         send_accum: crate::local_cell::LocalCell::new(Vec::new()),
@@ -383,7 +389,7 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) -> bool {
 #[unsafe(no_mangle)]
 pub extern "C" fn zmq_close(sock_ptr: *mut c_void) -> c_int {
     if sock_ptr.is_null() {
-        return fail(libc::EFAULT);
+        return fail(crate::error::ENOTSOCK);
     }
     // SAFETY: sock_ptr came from Box::into_raw in zmq_socket; reclaiming ownership.
     let arc = unsafe { *Box::from_raw(sock_ptr.cast::<Arc<OmqSocket>>()) };
@@ -441,7 +447,10 @@ unsafe fn parse_endpoint_args<'a>(
     sock_ptr: *mut c_void,
     addr: *const c_char,
 ) -> Result<(&'a Arc<OmqSocket>, String, Endpoint), c_int> {
-    if sock_ptr.is_null() || addr.is_null() {
+    if sock_ptr.is_null() {
+        return Err(crate::error::ENOTSOCK);
+    }
+    if addr.is_null() {
         return Err(libc::EFAULT);
     }
     // SAFETY: caller guarantees sock_ptr is a valid socket from zmq_socket.
@@ -473,7 +482,10 @@ unsafe fn parse_group_args<'a>(
     sock_ptr: *mut c_void,
     cstr: *const c_char,
 ) -> Result<(&'a Arc<OmqSocket>, Bytes), c_int> {
-    if sock_ptr.is_null() || cstr.is_null() {
+    if sock_ptr.is_null() {
+        return Err(crate::error::ENOTSOCK);
+    }
+    if cstr.is_null() {
         return Err(libc::EFAULT);
     }
     // SAFETY: caller guarantees sock_ptr is a valid socket from zmq_socket.
@@ -690,7 +702,7 @@ pub extern "C" fn zmq_socket_monitor(
     events: c_int,
 ) -> c_int {
     if sock_ptr.is_null() {
-        return fail(libc::EFAULT);
+        return fail(crate::error::ENOTSOCK);
     }
     // addr == NULL means stop monitoring.
     if addr.is_null() {

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -192,7 +192,7 @@ fn ctx_ipv6_option_applies_to_new_sockets() {
     let mut v = 0i32;
     let mut sz = size_of::<i32>();
     assert_eq!(
-        zmq_getsockopt(socket, ZMQ_IPV6, (&mut v as *mut i32).cast(), &mut sz),
+        zmq_getsockopt(socket, ZMQ_IPV6, (&raw mut v).cast(), &raw mut sz),
         0
     );
     assert_eq!(sz, size_of::<i32>());
@@ -215,7 +215,7 @@ fn ctx_blocky_zero_sets_linger_zero_on_new_sockets() {
     let mut v = -1i32;
     let mut sz = size_of::<i32>();
     assert_eq!(
-        zmq_getsockopt(socket, ZMQ_LINGER, (&mut v as *mut i32).cast(), &mut sz),
+        zmq_getsockopt(socket, ZMQ_LINGER, (&raw mut v).cast(), &raw mut sz),
         0
     );
     assert_eq!(v, 0);
@@ -236,7 +236,7 @@ fn explicit_linger_overrides_ctx_blocky_default() {
         zmq_setsockopt(
             socket,
             ZMQ_LINGER,
-            (&linger as *const i32).cast(),
+            (&raw const linger).cast(),
             size_of::<i32>(),
         ),
         0
@@ -245,7 +245,7 @@ fn explicit_linger_overrides_ctx_blocky_default() {
     let mut v = 0i32;
     let mut sz = size_of::<i32>();
     assert_eq!(
-        zmq_getsockopt(socket, ZMQ_LINGER, (&mut v as *mut i32).cast(), &mut sz),
+        zmq_getsockopt(socket, ZMQ_LINGER, (&raw mut v).cast(), &raw mut sz),
         0
     );
     assert_eq!(v, linger);

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -2,17 +2,23 @@
 
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_get, zmq_ctx_new, zmq_ctx_set, zmq_ctx_shutdown,
-    zmq_ctx_term, zmq_init, zmq_recv, zmq_send, zmq_socket,
+    zmq_ctx_term, zmq_getsockopt, zmq_init, zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
+    zmq_term,
 };
 use std::ffi::CString;
 use std::ffi::c_void;
+use std::mem::size_of;
 
 const ZMQ_PUSH: i32 = 8;
 const ZMQ_PULL: i32 = 7;
 const ZMQ_IO_THREADS: i32 = 1;
 const ZMQ_MAX_SOCKETS: i32 = 2;
+const ZMQ_SOCKET_LIMIT: i32 = 3;
 const ZMQ_MAX_MSGSZ: i32 = 5;
 const ZMQ_MSG_T_SIZE: i32 = 6;
+const ZMQ_IPV6: i32 = 42;
+const ZMQ_BLOCKY: i32 = 70;
+const ZMQ_LINGER: i32 = 17;
 
 #[test]
 fn ctx_new_term() {
@@ -39,7 +45,15 @@ fn ctx_shutdown_then_term() {
 fn ctx_null_term_returns_error() {
     let rc = zmq_ctx_term(std::ptr::null_mut::<c_void>());
     assert_eq!(rc, -1);
-    assert_ne!(omq_zmq::zmq_errno(), 0);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+}
+
+#[test]
+fn ctx_null_aliases_return_efault() {
+    assert_eq!(zmq_term(std::ptr::null_mut::<c_void>()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+    assert_eq!(zmq_ctx_shutdown(std::ptr::null_mut::<c_void>()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
 }
 
 #[test]
@@ -134,6 +148,13 @@ fn ctx_get_max_sockets_default() {
 }
 
 #[test]
+fn ctx_get_socket_limit_alias() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_SOCKET_LIMIT), 1023);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn ctx_set_max_sockets() {
     let ctx = zmq_ctx_new();
     assert_eq!(zmq_ctx_set(ctx, ZMQ_MAX_SOCKETS, 512), 0);
@@ -155,6 +176,105 @@ fn ctx_set_max_msgsz() {
     let ctx = zmq_ctx_new();
     assert_eq!(zmq_ctx_set(ctx, ZMQ_MAX_MSGSZ, 65536), 0);
     assert_eq!(zmq_ctx_get(ctx, ZMQ_MAX_MSGSZ), 65536);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_ipv6_option_applies_to_new_sockets() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_IPV6), 0);
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IPV6, 1), 0);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_IPV6), 1);
+
+    let socket = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!socket.is_null());
+
+    let mut v = 0i32;
+    let mut sz = size_of::<i32>();
+    assert_eq!(
+        zmq_getsockopt(socket, ZMQ_IPV6, (&mut v as *mut i32).cast(), &mut sz),
+        0
+    );
+    assert_eq!(sz, size_of::<i32>());
+    assert_eq!(v, 1);
+
+    zmq_close(socket);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_blocky_zero_sets_linger_zero_on_new_sockets() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_BLOCKY), 1);
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_BLOCKY, 0), 0);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_BLOCKY), 0);
+
+    let socket = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!socket.is_null());
+
+    let mut v = -1i32;
+    let mut sz = size_of::<i32>();
+    assert_eq!(
+        zmq_getsockopt(socket, ZMQ_LINGER, (&mut v as *mut i32).cast(), &mut sz),
+        0
+    );
+    assert_eq!(v, 0);
+
+    zmq_close(socket);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn explicit_linger_overrides_ctx_blocky_default() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_BLOCKY, 0), 0);
+
+    let socket = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!socket.is_null());
+    let linger = 25i32;
+    assert_eq!(
+        zmq_setsockopt(
+            socket,
+            ZMQ_LINGER,
+            (&linger as *const i32).cast(),
+            size_of::<i32>(),
+        ),
+        0
+    );
+
+    let mut v = 0i32;
+    let mut sz = size_of::<i32>();
+    assert_eq!(
+        zmq_getsockopt(socket, ZMQ_LINGER, (&mut v as *mut i32).cast(), &mut sz),
+        0
+    );
+    assert_eq!(v, linger);
+
+    zmq_close(socket);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_shutdown_rejects_later_socket_creation() {
+    let ctx = zmq_ctx_new();
+    let socket = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!socket.is_null());
+    assert_eq!(zmq_close(socket), 0);
+
+    assert_eq!(zmq_ctx_shutdown(ctx), 0);
+    assert!(zmq_socket(ctx, ZMQ_PUSH).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), 156_384_765);
+
+    assert_eq!(zmq_ctx_term(ctx), 0);
+}
+
+#[test]
+fn ctx_invalid_options_return_einval() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, -1, 0), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(zmq_ctx_get(ctx, -1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
     zmq_ctx_term(ctx);
 }
 

--- a/omq-libzmq/tests/multipart.rs
+++ b/omq-libzmq/tests/multipart.rs
@@ -10,9 +10,10 @@ use std::time::Duration;
 
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_getsockopt, zmq_msg_close,
-    zmq_msg_copy, zmq_msg_data, zmq_msg_init, zmq_msg_init_buffer, zmq_msg_init_data,
-    zmq_msg_init_size, zmq_msg_more, zmq_msg_move, zmq_msg_recv, zmq_msg_send, zmq_msg_set,
-    zmq_msg_size, zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
+    zmq_msg_copy, zmq_msg_data, zmq_msg_get, zmq_msg_gets, zmq_msg_group, zmq_msg_init,
+    zmq_msg_init_buffer, zmq_msg_init_data, zmq_msg_init_size, zmq_msg_more, zmq_msg_move,
+    zmq_msg_recv, zmq_msg_send, zmq_msg_set, zmq_msg_set_group, zmq_msg_size, zmq_recv, zmq_send,
+    zmq_setsockopt, zmq_socket,
 };
 
 const ZMQ_PUSH: i32 = 8;
@@ -21,6 +22,7 @@ const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_RCVMORE: i32 = 13;
 const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_MORE: i32 = 1;
+const ZMQ_SHARED: i32 = 3;
 const ZMQ_ROUTING_ID: i32 = 5;
 
 const ZMQ_MSG_WORDS: usize = 64 / size_of::<usize>();
@@ -74,6 +76,22 @@ fn msg_init_size() {
     unsafe { std::ptr::write_bytes(data.cast::<u8>(), 0xAB, 16) };
 
     zmq_msg_close(m.0.as_mut_ptr().cast());
+}
+
+#[test]
+fn msg_init_size_zero_and_init_buffer_null_zero() {
+    let mut sized = ZmqMsg::zeroed();
+    assert_eq!(zmq_msg_init_size(sized.0.as_mut_ptr().cast(), 0), 0);
+    assert_eq!(zmq_msg_size(sized.0.as_ptr().cast()), 0);
+    assert_eq!(zmq_msg_close(sized.0.as_mut_ptr().cast()), 0);
+
+    let mut copied = ZmqMsg::zeroed();
+    assert_eq!(
+        zmq_msg_init_buffer(copied.0.as_mut_ptr().cast(), std::ptr::null(), 0),
+        0
+    );
+    assert_eq!(zmq_msg_size(copied.0.as_ptr().cast()), 0);
+    assert_eq!(zmq_msg_close(copied.0.as_mut_ptr().cast()), 0);
 }
 
 #[test]
@@ -175,6 +193,114 @@ fn msg_init_buffer() {
     zmq_msg_close(m.0.as_mut_ptr().cast());
 }
 
+#[test]
+fn msg_get_reports_shared_for_external_data_and_large_copy() {
+    let mut external = ZmqMsg::zeroed();
+    let mut payload = [0x42u8; 5];
+    assert_eq!(
+        zmq_msg_init_data(
+            external.0.as_mut_ptr().cast(),
+            payload.as_mut_ptr().cast(),
+            payload.len(),
+            None,
+            std::ptr::null_mut(),
+        ),
+        0
+    );
+    assert_eq!(zmq_msg_get(external.0.as_ptr().cast(), ZMQ_SHARED), 1);
+
+    let mut large = ZmqMsg::zeroed();
+    assert_eq!(zmq_msg_init_size(large.0.as_mut_ptr().cast(), 1024), 0);
+    assert_eq!(zmq_msg_get(large.0.as_ptr().cast(), ZMQ_SHARED), 0);
+
+    let mut copied = ZmqMsg::new();
+    assert_eq!(
+        zmq_msg_copy(copied.0.as_mut_ptr().cast(), large.0.as_ptr().cast()),
+        0
+    );
+    assert_eq!(zmq_msg_get(copied.0.as_ptr().cast(), ZMQ_SHARED), 1);
+
+    assert_eq!(zmq_msg_close(copied.0.as_mut_ptr().cast()), 0);
+    assert_eq!(zmq_msg_close(large.0.as_mut_ptr().cast()), 0);
+    assert_eq!(zmq_msg_close(external.0.as_mut_ptr().cast()), 0);
+}
+
+#[test]
+fn msg_get_and_gets_validate_properties() {
+    let mut m = ZmqMsg::new();
+    assert_eq!(zmq_msg_get(m.0.as_ptr().cast(), ZMQ_MORE), 0);
+    assert_eq!(zmq_msg_get(m.0.as_ptr().cast(), ZMQ_SHARED), 0);
+    assert_eq!(zmq_msg_get(m.0.as_ptr().cast(), ZMQ_ROUTING_ID), 0);
+
+    assert_eq!(zmq_msg_get(m.0.as_ptr().cast(), 9999), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(zmq_msg_get(std::ptr::null(), ZMQ_MORE), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    for property in [
+        c"Socket-Type".as_ptr(),
+        c"Identity".as_ptr(),
+        c"Routing-Id".as_ptr(),
+        c"Peer-Address".as_ptr(),
+    ] {
+        let value = zmq_msg_gets(m.0.as_ptr().cast(), property);
+        assert!(!value.is_null());
+        assert_eq!(unsafe { std::ffi::CStr::from_ptr(value) }.to_bytes(), b"");
+    }
+
+    assert!(zmq_msg_gets(m.0.as_ptr().cast(), c"Unknown".as_ptr()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert!(zmq_msg_gets(std::ptr::null(), c"Socket-Type".as_ptr()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert!(zmq_msg_gets(m.0.as_ptr().cast(), std::ptr::null()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    assert_eq!(zmq_msg_close(m.0.as_mut_ptr().cast()), 0);
+}
+
+#[test]
+fn msg_routing_id_and_group_roundtrip() {
+    let mut m = ZmqMsg::new();
+    assert_eq!(omq_zmq::zmq_msg_routing_id(m.0.as_ptr().cast()), 0);
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(zmq_msg_group(m.0.as_ptr().cast())) }.to_bytes(),
+        b""
+    );
+
+    assert_eq!(
+        omq_zmq::zmq_msg_set_routing_id(m.0.as_mut_ptr().cast(), 42),
+        0
+    );
+    assert_eq!(omq_zmq::zmq_msg_routing_id(m.0.as_ptr().cast()), 42);
+
+    assert_eq!(
+        zmq_msg_set_group(m.0.as_mut_ptr().cast(), c"group-a".as_ptr()),
+        0
+    );
+    let group = unsafe { std::ffi::CStr::from_ptr(zmq_msg_group(m.0.as_ptr().cast())) };
+    assert_eq!(group.to_bytes(), b"group-a");
+
+    assert_eq!(
+        zmq_msg_set_group(m.0.as_mut_ptr().cast(), c"too-long-group".as_ptr()),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(omq_zmq::zmq_msg_set_routing_id(std::ptr::null_mut(), 1), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+    assert_eq!(
+        zmq_msg_set_group(std::ptr::null_mut(), c"group".as_ptr()),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+    assert_eq!(
+        zmq_msg_set_group(m.0.as_mut_ptr().cast(), std::ptr::null()),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+
+    assert_eq!(zmq_msg_close(m.0.as_mut_ptr().cast()), 0);
+}
+
 /// `zmq_msg_init_data` with `free_fn`
 #[test]
 fn msg_init_data_with_free_fn() {
@@ -205,6 +331,56 @@ fn msg_init_data_with_free_fn() {
 
     zmq_msg_close(m.0.as_mut_ptr().cast());
     assert!(FREED.load(Ordering::SeqCst), "free_fn was not called");
+}
+
+#[test]
+fn msg_init_data_free_fn_runs_after_successful_send() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    unsafe extern "C" fn count_free(_data: *mut c_void, hint: *mut c_void) {
+        let counter = unsafe { &*hint.cast::<AtomicUsize>() };
+        counter.fetch_add(1, Ordering::SeqCst);
+    }
+
+    let ctx = zmq_ctx_new();
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+    let pull = zmq_socket(ctx, ZMQ_PULL);
+    let addr = CString::new("inproc://test-msg-free-on-send").unwrap();
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
+    std::thread::sleep(Duration::from_millis(20));
+    set_timeo(pull, ZMQ_RCVTIMEO, 1000);
+
+    let freed = AtomicUsize::new(0);
+    let mut payload = *b"external-data";
+    let mut m = ZmqMsg::zeroed();
+    assert_eq!(
+        zmq_msg_init_data(
+            m.0.as_mut_ptr().cast(),
+            payload.as_mut_ptr().cast(),
+            payload.len(),
+            Some(count_free),
+            (&freed as *const AtomicUsize).cast_mut().cast(),
+        ),
+        0
+    );
+
+    assert_eq!(
+        zmq_msg_send(m.0.as_mut_ptr().cast(), push, 0),
+        i32::try_from(payload.len()).unwrap()
+    );
+    assert_eq!(freed.load(Ordering::SeqCst), 1);
+
+    let mut buf = [0u8; 32];
+    assert_eq!(
+        zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0),
+        i32::try_from(payload.len()).unwrap()
+    );
+    assert_eq!(&buf[..payload.len()], &payload);
+
+    zmq_close(push);
+    zmq_close(pull);
+    zmq_ctx_term(ctx);
 }
 
 /// `zmq_msg_move` transfers ownership; src becomes empty

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -91,6 +91,29 @@ fn get_bytes(sock: *mut c_void, opt: i32, buf: &mut [u8]) -> usize {
 }
 
 #[test]
+fn getsockopt_i32_clears_larger_output_buffer() {
+    let ctx = zmq_ctx_new();
+    let sub = zmq_socket(ctx, ZMQ_SUB);
+
+    let mut more: i64 = -1;
+    let mut more_size = size_of::<i64>();
+    assert_eq!(
+        zmq_getsockopt(
+            sub,
+            ZMQ_RCVMORE,
+            (&mut more as *mut i64).cast(),
+            &mut more_size,
+        ),
+        0
+    );
+    assert_eq!(more_size, size_of::<i32>());
+    assert_eq!(more, 0);
+
+    zmq_close(sub);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
 fn hwm_roundtrip() {
     let ctx = zmq_ctx_new();
     let s = zmq_socket(ctx, ZMQ_PUSH);

--- a/omq-libzmq/tests/proxy.rs
+++ b/omq-libzmq/tests/proxy.rs
@@ -24,13 +24,22 @@ const ZMQ_XSUB: i32 = 10;
 const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_SUBSCRIBE: i32 = 6;
 const ZMQ_RCVMORE: i32 = 13;
+const ZMQ_LINGER: i32 = 17;
 const ZMQ_SNDHWM: i32 = 23;
 const ZMQ_RCVHWM: i32 = 24;
 const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_SNDTIMEO: i32 = 28;
 
+fn set_i32(sock: *mut c_void, opt: i32, value: i32) {
+    zmq_setsockopt(sock, opt, (&value as *const i32).cast(), size_of::<i32>());
+}
+
 fn set_timeo(sock: *mut c_void, opt: i32, ms: i32) {
-    zmq_setsockopt(sock, opt, (&ms as *const i32).cast(), size_of::<i32>());
+    set_i32(sock, opt, ms);
+}
+
+fn set_linger(sock: *mut c_void, ms: i32) {
+    set_i32(sock, ZMQ_LINGER, ms);
 }
 
 fn rcvmore(sock: *mut c_void) -> bool {
@@ -228,6 +237,8 @@ fn proxy_retries_pending_after_bypass_backpressure() {
 
 #[test]
 fn proxy_does_not_starve_reverse_direction_when_frontend_is_hot() {
+    const HOT_MESSAGES: u32 = 128;
+
     let ctx = zmq_ctx_new();
     let fe = zmq_socket(ctx, ZMQ_PAIR);
     let be = zmq_socket(ctx, ZMQ_PAIR);
@@ -235,6 +246,12 @@ fn proxy_does_not_starve_reverse_direction_when_frontend_is_hot() {
     let right = zmq_socket(ctx, ZMQ_PAIR);
     let ctrl_a = zmq_socket(ctx, ZMQ_PAIR);
     let ctrl_b = zmq_socket(ctx, ZMQ_PAIR);
+
+    // This test builds frontend-to-backend backlog before asserting reverse
+    // progress. Keep teardown independent of any late queued sends.
+    for sock in [fe, be, left, right, ctrl_a, ctrl_b] {
+        set_linger(sock, 0);
+    }
 
     let hwm = 16i32;
     zmq_setsockopt(
@@ -276,13 +293,22 @@ fn proxy_does_not_starve_reverse_direction_when_frontend_is_hot() {
         zmq_proxy_steerable(a.fe, a.be, a.cap, a.ctrl)
     });
 
-    for i in 0..512u32 {
+    let mut hot_sent = 0usize;
+    for i in 0..HOT_MESSAGES {
         let data = i.to_le_bytes();
-        let _ = zmq_send(left, data.as_ptr().cast(), data.len(), ZMQ_DONTWAIT);
+        let rc = zmq_send(left, data.as_ptr().cast(), data.len(), ZMQ_DONTWAIT);
+        if rc == i32::try_from(data.len()).expect("test payload len fits i32") {
+            hot_sent += 1;
+        }
     }
+    assert!(
+        hot_sent > hwm as usize,
+        "hot path did not build backlog (sent {hot_sent})"
+    );
 
     let payload = b"right-to-left";
-    zmq_send(right, payload.as_ptr().cast(), payload.len(), 0);
+    let rc = zmq_send(right, payload.as_ptr().cast(), payload.len(), 0);
+    assert_eq!(rc as usize, payload.len());
 
     let mut buf = [0u8; 64];
     let rc = zmq_recv(left, buf.as_mut_ptr().cast(), buf.len(), 0);
@@ -293,6 +319,18 @@ fn proxy_does_not_starve_reverse_direction_when_frontend_is_hot() {
         omq_zmq::zmq_errno()
     );
     assert_eq!(&buf[..payload.len()], payload);
+
+    set_timeo(right, ZMQ_RCVTIMEO, 5000);
+    let mut hot_buf = [0u8; 4];
+    for n in 0..hot_sent {
+        let rc = zmq_recv(right, hot_buf.as_mut_ptr().cast(), hot_buf.len(), 0);
+        assert_eq!(
+            rc,
+            4,
+            "right hot recv {n}/{hot_sent} failed (errno={})",
+            omq_zmq::zmq_errno()
+        );
+    }
 
     zmq_send(ctrl_b, b"TERMINATE".as_ptr().cast(), 9, 0);
     assert_eq!(proxy.join().unwrap(), 0);

--- a/omq-libzmq/tests/security.rs
+++ b/omq-libzmq/tests/security.rs
@@ -45,6 +45,7 @@ fn z85_encode_decode_roundtrip() {
     let mut encoded = [0u8; 11]; // 8 bytes -> 10 Z85 chars + null
     let ret = zmq_z85_encode(encoded.as_mut_ptr().cast(), data.as_ptr(), data.len());
     assert!(!ret.is_null());
+    assert_eq!(&encoded[..10], b"HelloWorld");
     let z85_str = std::str::from_utf8(&encoded[..10]).unwrap();
     assert_eq!(z85_str.len(), 10);
 
@@ -60,6 +61,33 @@ fn z85_invalid_size_returns_null() {
     let mut encoded = [0u8; 10];
     let ret = zmq_z85_encode(encoded.as_mut_ptr().cast(), data.as_ptr(), data.len());
     assert!(ret.is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+}
+
+#[test]
+fn z85_invalid_inputs_set_einval() {
+    let data = [0u8; 4];
+    let mut encoded = [0u8; 6];
+    assert!(zmq_z85_encode(std::ptr::null_mut(), data.as_ptr(), data.len()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert!(zmq_z85_encode(encoded.as_mut_ptr().cast(), std::ptr::null(), data.len()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    let mut decoded = [0u8; 8];
+    for invalid in [
+        c"0".as_ptr(),
+        c"01234567".as_ptr(),
+        c"#####".as_ptr(),
+        c"%nSc1".as_ptr(),
+    ] {
+        assert!(zmq_z85_decode(decoded.as_mut_ptr(), invalid).is_null());
+        assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    }
+
+    assert!(zmq_z85_decode(std::ptr::null_mut(), c"HelloWorld".as_ptr()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert!(zmq_z85_decode(decoded.as_mut_ptr(), std::ptr::null()).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
 }
 
 #[test]

--- a/omq-libzmq/tests/socket_null.rs
+++ b/omq-libzmq/tests/socket_null.rs
@@ -32,23 +32,13 @@ fn null_socket_ops_return_enotsock() {
     assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
 
     assert_eq!(
-        zmq_setsockopt(
-            sock,
-            ZMQ_SNDHWM,
-            (&hwm as *const i32).cast(),
-            size_of::<i32>(),
-        ),
+        zmq_setsockopt(sock, ZMQ_SNDHWM, (&raw const hwm).cast(), size_of::<i32>(),),
         -1
     );
     assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
 
     assert_eq!(
-        zmq_getsockopt(
-            sock,
-            ZMQ_SNDHWM,
-            (&mut out as *mut i32).cast(),
-            &mut out_size,
-        ),
+        zmq_getsockopt(sock, ZMQ_SNDHWM, (&raw mut out).cast(), &raw mut out_size,),
         -1
     );
     assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);

--- a/omq-libzmq/tests/socket_null.rs
+++ b/omq-libzmq/tests/socket_null.rs
@@ -1,0 +1,74 @@
+//! libzmq parity tests for null socket handles.
+
+use std::ffi::c_void;
+use std::mem::size_of;
+
+use omq_zmq::{
+    zmq_bind, zmq_close, zmq_connect, zmq_disconnect, zmq_getsockopt, zmq_join, zmq_leave,
+    zmq_setsockopt, zmq_socket, zmq_socket_monitor, zmq_unbind,
+};
+
+const ZMQ_PAIR: i32 = 0;
+const ZMQ_SNDHWM: i32 = 23;
+const ZMQ_EVENT_ALL: i32 = 0xFFFF;
+const ZMQ_ENOTSOCK: i32 = 156_384_721;
+
+#[test]
+fn socket_null_context_returns_efault() {
+    assert!(zmq_socket(std::ptr::null_mut::<c_void>(), ZMQ_PAIR).is_null());
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
+}
+
+#[test]
+fn null_socket_ops_return_enotsock() {
+    let sock = std::ptr::null_mut::<c_void>();
+    let endpoint = c"inproc://socket-null";
+    let group = c"group";
+    let hwm = 100i32;
+    let mut out = 0i32;
+    let mut out_size = size_of::<i32>();
+
+    assert_eq!(zmq_close(sock), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+
+    assert_eq!(
+        zmq_setsockopt(
+            sock,
+            ZMQ_SNDHWM,
+            (&hwm as *const i32).cast(),
+            size_of::<i32>(),
+        ),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+
+    assert_eq!(
+        zmq_getsockopt(
+            sock,
+            ZMQ_SNDHWM,
+            (&mut out as *mut i32).cast(),
+            &mut out_size,
+        ),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+
+    assert_eq!(
+        zmq_socket_monitor(sock, endpoint.as_ptr(), ZMQ_EVENT_ALL),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+
+    assert_eq!(zmq_bind(sock, endpoint.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+    assert_eq!(zmq_connect(sock, endpoint.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+    assert_eq!(zmq_unbind(sock, endpoint.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+    assert_eq!(zmq_disconnect(sock, endpoint.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+    assert_eq!(zmq_join(sock, group.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+    assert_eq!(zmq_leave(sock, group.as_ptr()), -1);
+    assert_eq!(omq_zmq::zmq_errno(), ZMQ_ENOTSOCK);
+}

--- a/omq-libzmq/tests/util.rs
+++ b/omq-libzmq/tests/util.rs
@@ -3,8 +3,8 @@
 
 use omq_zmq::{
     zmq_atomic_counter_dec, zmq_atomic_counter_destroy, zmq_atomic_counter_inc,
-    zmq_atomic_counter_new, zmq_atomic_counter_set, zmq_atomic_counter_value, zmq_has,
-    zmq_stopwatch_start, zmq_stopwatch_stop, zmq_version,
+    zmq_atomic_counter_new, zmq_atomic_counter_set, zmq_atomic_counter_value, zmq_has, zmq_sleep,
+    zmq_stopwatch_intermediate, zmq_stopwatch_start, zmq_stopwatch_stop, zmq_strerror, zmq_version,
 };
 
 #[test]
@@ -19,6 +19,13 @@ fn version_is_4_3_6() {
 }
 
 #[test]
+fn version_accepts_null_output_pointers() {
+    let mut minor = -1i32;
+    zmq_version(std::ptr::null_mut(), &mut minor, std::ptr::null_mut());
+    assert_eq!(minor, 3);
+}
+
+#[test]
 fn has_capabilities() {
     assert_eq!(zmq_has(c"tcp".as_ptr()), 1);
     assert_eq!(zmq_has(c"inproc".as_ptr()), 1);
@@ -26,7 +33,23 @@ fn has_capabilities() {
     assert_eq!(zmq_has(c"curve".as_ptr()), 1);
     assert_eq!(zmq_has(c"plain".as_ptr()), 1);
     assert_eq!(zmq_has(c"zmtp3".as_ptr()), 1);
+    assert_eq!(zmq_has(c"norm".as_ptr()), 0);
+    assert_eq!(zmq_has(c"tipc".as_ptr()), 0);
+    assert_eq!(zmq_has(c"vmci".as_ptr()), 0);
+    assert_eq!(zmq_has(c"gssapi".as_ptr()), 0);
     assert_eq!(zmq_has(c"nonexistent".as_ptr()), 0);
+    assert_eq!(zmq_has(std::ptr::null()), 0);
+}
+
+#[test]
+fn strerror_returns_messages_for_system_and_zmq_errors() {
+    let einval = zmq_strerror(libc::EINVAL);
+    assert!(!einval.is_null());
+
+    let eterm = zmq_strerror(156_384_765);
+    assert!(!eterm.is_null());
+    let text = unsafe { std::ffi::CStr::from_ptr(eterm) };
+    assert_eq!(text.to_bytes(), b"Context was terminated");
 }
 
 #[test]
@@ -34,9 +57,19 @@ fn stopwatch_elapsed() {
     let watch = zmq_stopwatch_start();
     assert!(!watch.is_null());
     std::thread::sleep(std::time::Duration::from_millis(10));
+    assert!(zmq_stopwatch_intermediate(watch) >= 5000);
     let elapsed = zmq_stopwatch_stop(watch);
     assert!(elapsed >= 5000, "expected >= 5000 µs, got {elapsed}");
     assert!(elapsed < 1_000_000, "expected < 1s, got {elapsed} µs");
+    assert_eq!(zmq_stopwatch_intermediate(std::ptr::null_mut()), 0);
+    assert_eq!(zmq_stopwatch_stop(std::ptr::null_mut()), 0);
+}
+
+#[test]
+fn sleep_zero_returns_quickly() {
+    let start = std::time::Instant::now();
+    zmq_sleep(0);
+    assert!(start.elapsed() < std::time::Duration::from_millis(50));
 }
 
 #[test]
@@ -46,23 +79,28 @@ fn atomic_counter_lifecycle() {
 
     assert_eq!(zmq_atomic_counter_value(counter), 0);
 
-    zmq_atomic_counter_set(counter, 5);
-    assert_eq!(zmq_atomic_counter_value(counter), 5);
+    assert_eq!(zmq_atomic_counter_inc(counter), 0);
+    assert_eq!(zmq_atomic_counter_inc(counter), 1);
+    assert_eq!(zmq_atomic_counter_inc(counter), 2);
+    assert_eq!(zmq_atomic_counter_value(counter), 3);
 
-    let prev = zmq_atomic_counter_inc(counter);
-    assert_eq!(prev, 5);
-    assert_eq!(zmq_atomic_counter_value(counter), 6);
+    assert_eq!(zmq_atomic_counter_dec(counter), 1);
+    assert_eq!(zmq_atomic_counter_dec(counter), 1);
+    assert_eq!(zmq_atomic_counter_dec(counter), 0);
+    assert_eq!(zmq_atomic_counter_value(counter), 0);
 
-    let still_positive = zmq_atomic_counter_dec(counter);
-    assert_eq!(still_positive, 1);
-    assert_eq!(zmq_atomic_counter_value(counter), 5);
-
-    zmq_atomic_counter_set(counter, 1);
-    let still_positive = zmq_atomic_counter_dec(counter);
-    assert_eq!(still_positive, 0);
+    zmq_atomic_counter_set(counter, 2);
+    assert_eq!(zmq_atomic_counter_dec(counter), 1);
+    assert_eq!(zmq_atomic_counter_dec(counter), 0);
     assert_eq!(zmq_atomic_counter_value(counter), 0);
 
     let mut p = counter;
     zmq_atomic_counter_destroy(&mut p);
     assert!(p.is_null());
+    zmq_atomic_counter_destroy(&mut p);
+    zmq_atomic_counter_destroy(std::ptr::null_mut());
+    zmq_atomic_counter_set(std::ptr::null_mut(), 1);
+    assert_eq!(zmq_atomic_counter_inc(std::ptr::null_mut()), 0);
+    assert_eq!(zmq_atomic_counter_dec(std::ptr::null_mut()), 0);
+    assert_eq!(zmq_atomic_counter_value(std::ptr::null_mut()), 0);
 }

--- a/omq-libzmq/tests/xpub_xsub.rs
+++ b/omq-libzmq/tests/xpub_xsub.rs
@@ -106,12 +106,13 @@ fn xpub_receives_sub_notifications() {
     set_linger_zero(xpub);
     set_linger_zero(sub);
 
-    let addr = helpers::bind_random_tcp(xpub);
+    let addr = CString::new("inproc://test-xpub-sub-notifications").unwrap();
+    zmq_bind(xpub, addr.as_ptr());
     set_timeo(xpub, 2000);
 
     zmq_setsockopt(sub, ZMQ_SUBSCRIBE, b"news".as_ptr().cast(), 4);
     zmq_connect(sub, addr.as_ptr());
-    std::thread::sleep(Duration::from_millis(200));
+    std::thread::sleep(Duration::from_millis(50));
     set_timeo(sub, 2000);
 
     // XPUB should receive a subscription notification: 0x01 + "news".

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -119,6 +119,7 @@ impl ReceiveProfile {
 pub enum RecvSink {
     Channel(Arc<crate::socket::recv::SharedRecvPipe>),
     Yring(YringSink),
+    Conflate(Arc<crate::socket::recv::ConflateRecvSlot>),
     Rep(RepRecvSink),
 }
 
@@ -217,6 +218,7 @@ impl std::fmt::Debug for RecvSink {
                 .debug_struct("Yring")
                 .field("producer", &y.producer)
                 .finish_non_exhaustive(),
+            Self::Conflate(_) => f.debug_tuple("Conflate").finish_non_exhaustive(),
             Self::Rep(_) => f.debug_tuple("Rep").finish_non_exhaustive(),
         }
     }
@@ -310,6 +312,10 @@ impl RecvSink {
                 }
                 Err(returned) => Some(returned.message),
             },
+            Self::Conflate(slot) => {
+                let _ = slot.send_latest(m);
+                None
+            }
             Self::Rep(_) => unreachable!("REP uses the blocking direct path"),
         }
     }
@@ -348,6 +354,7 @@ impl RecvSink {
                     return true;
                 }
             }
+            Self::Conflate(slot) => slot.send_latest(m),
             Self::Rep(_) => unreachable!("plain send on REP sink"),
         }
     }

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -173,7 +173,13 @@ pub(super) fn spawn_inproc_peer(
         tx,
         rx,
     } = conn;
-    let recv_sink = take_inproc_recv_sink(socket);
+    let recv_sink = take_inproc_recv_sink(socket).or_else(|| {
+        socket
+            .spsc
+            .conflate_slot
+            .as_ref()
+            .map(|slot| crate::engine::RecvSink::Conflate(slot.clone()))
+    });
     let io_thread = socket.io_pool.assign_thread();
 
     socket.peers.insert(
@@ -200,14 +206,13 @@ pub(super) fn spawn_inproc_peer(
         },
     );
 
-    let recv_direct = if can_bypass_actor_recv(socket.socket_type) {
+    let direct_recv_enabled = can_bypass_actor_recv(socket.socket_type) && recv_sink.is_none();
+    let recv_direct = if direct_recv_enabled {
         Some(socket.recv_tx.clone())
     } else {
         None
     };
-    let recv_spsc = rx
-        .clone()
-        .filter(|_| can_bypass_actor_recv(socket.socket_type));
+    let recv_spsc = rx.clone().filter(|_| direct_recv_enabled);
     if let Some(ref s) = recv_spsc {
         PeerLifecycle::new(socket).register_inproc_consumer(s, true);
     }
@@ -528,6 +533,10 @@ fn attach_yring_recv_bypass(
     peer_id: u64,
     rep_latency: bool,
 ) -> ConnectionDriver<AnyStream> {
+    if let Some(slot) = socket.spsc.conflate_slot.as_ref() {
+        return peer_driver.with_recv_sink(crate::engine::RecvSink::Conflate(slot.clone()));
+    }
+
     let sink = socket
         .recv_sink_config
         .as_ref()

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -159,7 +159,17 @@ impl Socket {
         let monitor = MonitorPublisher::new();
         let send_strategy = SendStrategy::for_socket_type(socket_type, &options, io_pool);
         let send_submitter = send_strategy.submitter();
-        let spsc = SpscHandles::new(blocking_recv_waker);
+        let conflate_recv = options.conflate
+            && matches!(
+                socket_type,
+                SocketType::Pull
+                    | SocketType::Sub
+                    | SocketType::XSub
+                    | SocketType::Dish
+                    | SocketType::Dealer
+                    | SocketType::Gather
+            );
+        let spsc = SpscHandles::new(blocking_recv_waker, conflate_recv);
         let type_state = Arc::new(Mutex::new(TypeState::new()));
         let rep_pending = Arc::new(Mutex::new(std::collections::VecDeque::new()));
         let rep_current = Arc::new(Mutex::new(None));

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -170,6 +170,62 @@ impl std::fmt::Debug for TcpYringConsumer {
 
 pub(crate) type TcpConsumers = Arc<RwLock<Vec<Arc<TcpYringConsumer>>>>;
 
+/// Receive-side conflate storage. Producers overwrite the single slot;
+/// the socket recv path observes only the latest unread message.
+pub(crate) struct ConflateRecvSlot {
+    slot: Mutex<Option<RecvItem>>,
+    notify: Arc<DataSignal>,
+    closed: AtomicBool,
+    blocking_waker: Arc<BlockingRecvWaker>,
+}
+
+impl std::fmt::Debug for ConflateRecvSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConflateRecvSlot")
+            .field("closed", &self.closed.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl ConflateRecvSlot {
+    pub(crate) fn new(
+        notify: Arc<DataSignal>,
+        blocking_waker: Arc<BlockingRecvWaker>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            slot: Mutex::new(None),
+            notify,
+            closed: AtomicBool::new(false),
+            blocking_waker,
+        })
+    }
+
+    pub(crate) fn send_latest(&self, msg: Message) -> bool {
+        if self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+        *self.slot.lock().unwrap() = Some(RecvItem::new(msg));
+        self.notify.mark();
+        self.blocking_waker.wake();
+        true
+    }
+
+    fn take(&self) -> Option<Message> {
+        self.slot.lock().unwrap().take().map(RecvItem::into_message)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.slot.lock().unwrap().is_none()
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.slot.lock().unwrap().take();
+        self.notify.wake_all();
+        self.blocking_waker.wake();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SharedRecvPipe: MPSC yring-based recv channel
 // ---------------------------------------------------------------------------
@@ -295,19 +351,24 @@ pub(crate) struct SpscHandles {
     pub activated: SpscActivated,
     pub tcp_consumers: TcpConsumers,
     pub blocking_recv_waker: Arc<BlockingRecvWaker>,
+    pub conflate_slot: Option<Arc<ConflateRecvSlot>>,
 }
 
 impl SpscHandles {
-    pub(crate) fn new(blocking_recv_waker: Arc<BlockingRecvWaker>) -> Self {
+    pub(crate) fn new(blocking_recv_waker: Arc<BlockingRecvWaker>, conflate_recv: bool) -> Self {
+        let recv_signal = Arc::new(DataSignal::new());
+        let conflate_slot = conflate_recv
+            .then(|| ConflateRecvSlot::new(recv_signal.clone(), blocking_recv_waker.clone()));
         Self {
             consumers: Arc::new(RwLock::new(Vec::new())),
             consumer_generation: Arc::new(AtomicU64::new(0)),
             send_ring: Arc::new(ArcSwapOption::empty()),
             send_ring_available: Arc::new(AtomicBool::new(false)),
-            recv_signal: Arc::new(DataSignal::new()),
+            recv_signal,
             activated: Arc::new(StateSignal::new()),
             tcp_consumers: Arc::new(RwLock::new(Vec::new())),
             blocking_recv_waker,
+            conflate_slot,
         }
     }
 }
@@ -337,6 +398,8 @@ pub(crate) struct SpscAwareRecv {
     recv_pipe_notify: Arc<DataSignal>,
     /// Space-available signal for the shared recv pipe.
     recv_pipe_space: Arc<StateSignal>,
+    /// Optional receive-side conflate slot.
+    conflate_slot: Option<Arc<ConflateRecvSlot>>,
     /// Drain state: cached consumer snapshots, message batch buffer,
     /// and the shared recv pipe consumer.
     drain_state: Mutex<DrainState>,
@@ -545,6 +608,7 @@ impl SpscAwareRecv {
             activated: handles.activated,
             send_ring: handles.send_ring,
             send_ring_available: handles.send_ring_available,
+            conflate_slot: handles.conflate_slot,
             recv_pipe_notify,
             recv_pipe_space,
             blocking_recv_waker: handles.blocking_recv_waker,
@@ -592,10 +656,14 @@ impl SpscAwareRecv {
 
     fn buffered_sources_empty(&self) -> bool {
         let guard = self.drain_state.lock().unwrap();
-        Self::state_is_empty(&guard)
+        Self::state_is_empty(&guard) && self.conflate_slot_empty()
     }
 
     fn try_drain(&self) -> DrainResult {
+        if let Some(msg) = self.take_conflate_message() {
+            return DrainResult::Message(msg);
+        }
+
         let mut guard = self.drain_state.lock().unwrap();
 
         if let Some(msg) = guard.batch.pop_front() {
@@ -606,6 +674,11 @@ impl SpscAwareRecv {
         self.recv_pipe_notify.begin_drain();
         self.refresh_snapshot(&mut guard);
 
+        if let Some(msg) = self.take_conflate_message() {
+            drop(guard);
+            return DrainResult::Message(msg);
+        }
+
         let state = &mut *guard;
         if let Some(msg) = Self::try_latency_fast_path(state) {
             drop(guard);
@@ -615,9 +688,10 @@ impl SpscAwareRecv {
         let result = latency_result.or_else(|| state.batch.pop_front());
         let pipe_disconnected = state.recv_consumer.is_disconnected();
         let has_peers = !state.inproc.is_empty() || !state.tcp.is_empty();
+        let all_empty = Self::state_is_empty(state) && self.conflate_slot_empty();
         if result.is_none()
-            && Self::state_is_empty(state)
-            && (self.recv_signal.clear_after(Self::state_is_empty(state))
+            && all_empty
+            && (self.recv_signal.clear_after(all_empty)
                 || self
                     .recv_pipe_notify
                     .clear_after(state.recv_consumer.is_empty()))
@@ -645,6 +719,16 @@ impl SpscAwareRecv {
         state.inproc.clone_from(&self.consumers.read().unwrap());
         state.tcp.clone_from(&self.tcp_consumers.read().unwrap());
         state.generation = current_gen;
+    }
+
+    fn take_conflate_message(&self) -> Option<Message> {
+        self.conflate_slot.as_ref().and_then(|slot| slot.take())
+    }
+
+    fn conflate_slot_empty(&self) -> bool {
+        self.conflate_slot
+            .as_ref()
+            .is_none_or(|slot| slot.is_empty())
     }
 
     fn try_latency_fast_path(state: &mut DrainState) -> Option<Message> {
@@ -801,7 +885,8 @@ impl SpscAwareRecv {
             tokio::pin!(pipe_ready);
             tokio::pin!(activated);
 
-            if self.consumer_generation.load(Ordering::Acquire) > 0 {
+            if self.consumer_generation.load(Ordering::Acquire) > 0 || self.conflate_slot.is_some()
+            {
                 match self.try_drain() {
                     DrainResult::Message(msg) => return Ok(msg),
                     DrainResult::Closed => return Err(Error::Closed),
@@ -852,6 +937,9 @@ impl SpscAwareRecv {
         }
         self.consumers.write().unwrap().clear();
         self.tcp_consumers.write().unwrap().clear();
+        if let Some(slot) = &self.conflate_slot {
+            slot.close();
+        }
         if let Some(pair) = self.send_ring.load_full() {
             pair.space_notify.notify_changed();
             pair.blocking_space.notify();

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -375,6 +375,12 @@ enum RecvSource {
     Shared,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrainLimit {
+    One,
+    Budget,
+}
+
 #[derive(Clone, Copy)]
 enum PeerSource<'a> {
     Inproc(&'a InprocRx),
@@ -396,6 +402,7 @@ fn drain_peer_source(
     latency: bool,
     batch: &mut VecDeque<Message>,
     budget: &mut DrainBudget,
+    limit: DrainLimit,
 ) -> SourceDrain {
     match source {
         PeerSource::Inproc(peer) => drain_peer_consumer(
@@ -404,6 +411,7 @@ fn drain_peer_source(
             latency,
             batch,
             budget,
+            limit,
             || {
                 peer.space_notify.notify_changed();
                 peer.blocking_space.notify();
@@ -415,6 +423,7 @@ fn drain_peer_source(
             latency,
             batch,
             budget,
+            limit,
             || peer.space.notify_changed(),
         ),
     }
@@ -426,6 +435,7 @@ fn drain_peer_consumer<F: FnMut()>(
     latency: bool,
     batch: &mut VecDeque<Message>,
     budget: &mut DrainBudget,
+    limit: DrainLimit,
     mut on_release: F,
 ) -> SourceDrain {
     let Ok(mut consumer) = consumer.try_lock() else {
@@ -436,8 +446,15 @@ fn drain_peer_consumer<F: FnMut()>(
         let (item, released) = drain_yring_one(&mut consumer, &mut remaining);
         (item.map(RecvItem::into_message), released)
     } else {
-        let drained = drain_yring(&mut consumer, batch, &mut remaining, budget);
-        (None, drained > 0)
+        let released = match limit {
+            DrainLimit::One => {
+                let (_, released) =
+                    drain_yring_one_into_batch(&mut consumer, batch, &mut remaining, budget);
+                released
+            }
+            DrainLimit::Budget => drain_yring(&mut consumer, batch, &mut remaining, budget) > 0,
+        };
+        (None, released)
     };
     if released {
         on_release();
@@ -447,6 +464,24 @@ fn drain_peer_consumer<F: FnMut()>(
         message,
         disconnected: consumer.is_disconnected(),
     }
+}
+
+fn drain_yring_one_into_batch(
+    consumer: &mut yring::Consumer<RecvItem>,
+    batch: &mut VecDeque<Message>,
+    batch_remaining: &mut usize,
+    budget: &mut DrainBudget,
+) -> (usize, bool) {
+    if budget.exhausted() {
+        return (0, false);
+    }
+    let (item, released) = drain_yring_one(consumer, batch_remaining);
+    let Some(item) = item else {
+        return (0, released);
+    };
+    let _ = budget.account(item.size_class.budget_bytes());
+    batch.push_back(item.message);
+    (1, released)
 }
 
 fn drain_yring(
@@ -626,6 +661,7 @@ impl SpscAwareRecv {
             true,
             &mut state.batch,
             &mut budget,
+            DrainLimit::One,
         )
         .message
     }
@@ -637,6 +673,12 @@ impl SpscAwareRecv {
         let inproc_len = state.inproc.len();
         let tcp_len = state.tcp.len();
         let source_count = inproc_len + tcp_len + 1;
+        let peer_source_count = inproc_len + tcp_len;
+        let limit = if !state.latency && peer_source_count > 1 {
+            DrainLimit::One
+        } else {
+            DrainLimit::Budget
+        };
         let start = state.recv_cursor % source_count;
 
         // One logical round-robin space covers all sources. This prevents a
@@ -653,14 +695,16 @@ impl SpscAwareRecv {
                     state.latency,
                     &mut state.batch,
                     &mut budget,
+                    limit,
                 ),
                 RecvSource::Stream(index) => drain_peer_source(
                     PeerSource::Stream(&state.tcp[index]),
                     state.latency,
                     &mut state.batch,
                     &mut budget,
+                    limit,
                 ),
-                RecvSource::Shared => self.drain_shared_source(state, &mut budget),
+                RecvSource::Shared => self.drain_shared_source(state, &mut budget, limit),
             };
             result = outcome.message;
             has_disconnected |= outcome.disconnected;
@@ -668,7 +712,12 @@ impl SpscAwareRecv {
         (result, has_disconnected)
     }
 
-    fn drain_shared_source(&self, state: &mut DrainState, budget: &mut DrainBudget) -> SourceDrain {
+    fn drain_shared_source(
+        &self,
+        state: &mut DrainState,
+        budget: &mut DrainBudget,
+        limit: DrainLimit,
+    ) -> SourceDrain {
         if state.latency {
             let (item, released) =
                 drain_yring_one(&mut state.recv_consumer, &mut state.recv_batch_remaining);
@@ -680,13 +729,26 @@ impl SpscAwareRecv {
                 disconnected: false,
             }
         } else {
-            let drained = drain_yring(
-                &mut state.recv_consumer,
-                &mut state.batch,
-                &mut state.recv_batch_remaining,
-                budget,
-            );
-            if drained > 0 {
+            let released = match limit {
+                DrainLimit::One => {
+                    let (_, released) = drain_yring_one_into_batch(
+                        &mut state.recv_consumer,
+                        &mut state.batch,
+                        &mut state.recv_batch_remaining,
+                        budget,
+                    );
+                    released
+                }
+                DrainLimit::Budget => {
+                    drain_yring(
+                        &mut state.recv_consumer,
+                        &mut state.batch,
+                        &mut state.recv_batch_remaining,
+                        budget,
+                    ) > 0
+                }
+            };
+            if released {
                 self.recv_pipe_space.notify_changed();
             }
             SourceDrain::default()
@@ -892,7 +954,7 @@ impl SpscAwareRecv {
 mod tests {
     use super::{
         RECV_BATCH_BYTES, RECV_BATCH_MESSAGES, RecvItem, RecvSource, drain_yring, drain_yring_one,
-        recv_source_at,
+        drain_yring_one_into_batch, recv_source_at,
     };
     use omq_proto::Message;
     use omq_proto::flow::DrainBudget;
@@ -1004,6 +1066,32 @@ mod tests {
 
         let next = consumer.prefetch_and_pop().unwrap();
         assert_eq!(next.message.part_bytes(0).unwrap(), &b"next"[..]);
+    }
+
+    #[test]
+    fn one_item_drain_keeps_remainder_for_next_fair_round() {
+        let (mut producer, mut consumer) = yring::spsc(8);
+        producer
+            .push(RecvItem::new(Message::from_slice(b"first")))
+            .unwrap();
+        producer
+            .push(RecvItem::new(Message::from_slice(b"second")))
+            .unwrap();
+        producer.flush();
+
+        let mut batch = std::collections::VecDeque::new();
+        let mut budget = DrainBudget::new(256, usize::MAX);
+        let mut remaining = 0;
+        assert_eq!(
+            drain_yring_one_into_batch(&mut consumer, &mut batch, &mut remaining, &mut budget),
+            (1, false)
+        );
+        assert_eq!(
+            batch.pop_front().unwrap().part_bytes(0).unwrap().as_ref(),
+            b"first"
+        );
+        assert_eq!(remaining, 1);
+        assert!(!consumer.is_empty());
     }
 
     #[test]

--- a/omq-tokio/tests/conflate.rs
+++ b/omq-tokio/tests/conflate.rs
@@ -2,6 +2,8 @@
 //! the latest message. Verifies the silent-bug fix - the option was
 //! settable but had no effect prior to this change.
 //!
+mod test_support;
+
 use std::time::Duration;
 
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
@@ -112,6 +114,46 @@ async fn push_conflate_keeps_only_latest() {
     assert!(
         received.iter().any(|s| s == "m-099"),
         "latest message must be visible; got {received:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pull_conflate_keeps_only_latest() {
+    const N: u32 = 100;
+
+    let pull = Socket::new(SocketType::Pull, Options::default().conflate(true));
+    let port = test_support::bind_loopback(&pull).await;
+
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.connect(test_support::tcp_loopback(port))
+        .await
+        .unwrap();
+    pull.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("PULL did not see PUSH");
+    push.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("PUSH did not connect");
+
+    for i in 0..N {
+        push.send(Message::single(format!("m-{i:03}")))
+            .await
+            .unwrap();
+    }
+    push.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let received = tokio::time::timeout(Duration::from_secs(1), pull.recv())
+        .await
+        .expect("PULL did not receive")
+        .unwrap();
+    assert_eq!(received.part_bytes(0).unwrap().as_ref(), b"m-099");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), pull.recv())
+            .await
+            .is_err(),
+        "PULL-side conflate should leave one unread message"
     );
 }
 

--- a/omq-tokio/tests/conflate.rs
+++ b/omq-tokio/tests/conflate.rs
@@ -119,7 +119,7 @@ async fn push_conflate_keeps_only_latest() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pull_conflate_keeps_only_latest() {
-    const N: u32 = 100;
+    const N: u32 = 20;
 
     let pull = Socket::new(SocketType::Pull, Options::default().conflate(true));
     let port = test_support::bind_loopback(&pull).await;
@@ -140,14 +140,13 @@ async fn pull_conflate_keeps_only_latest() {
             .await
             .unwrap();
     }
-    push.close().await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     let received = tokio::time::timeout(Duration::from_secs(1), pull.recv())
         .await
         .expect("PULL did not receive")
         .unwrap();
-    assert_eq!(received.part_bytes(0).unwrap().as_ref(), b"m-099");
+    assert_eq!(received.part_bytes(0).unwrap().as_ref(), b"m-019");
 
     assert!(
         tokio::time::timeout(Duration::from_millis(100), pull.recv())
@@ -155,6 +154,7 @@ async fn pull_conflate_keeps_only_latest() {
             .is_err(),
         "PULL-side conflate should leave one unread message"
     );
+    push.close().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/omq-tokio/tests/no_peer_send.rs
+++ b/omq-tokio/tests/no_peer_send.rs
@@ -39,6 +39,28 @@ async fn bound_push_without_peer_mutes() {
 }
 
 #[tokio::test]
+async fn bound_dealer_without_peer_mutes() {
+    let dealer = Socket::new(SocketType::Dealer, Options::default().send_hwm(1));
+    dealer.bind(tcp_ep(0)).await.unwrap();
+
+    let err = dealer.try_send(Message::single("x")).unwrap_err();
+    assert!(matches!(err, TrySendError::Full(_)));
+
+    let mut send = tokio::spawn({
+        let dealer = dealer.clone();
+        async move { dealer.send(Message::single("wait")).await }
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut send)
+            .await
+            .is_err(),
+        "bound no-peer DEALER send must wait for a pipe"
+    );
+    dealer.close().await.unwrap();
+    assert!(matches!(send.await.unwrap(), Err(omq_tokio::Error::Closed)));
+}
+
+#[tokio::test]
 async fn connect_side_push_queues_in_pre_ready_pipe() {
     let ep = free_tcp_ep();
     let push = Socket::new(SocketType::Push, Options::default().send_hwm(2));

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -6,7 +6,9 @@ use std::net::TcpListener as StdTcpListener;
 use std::time::Duration;
 
 use omq_tokio::options::ReconnectPolicy;
-use omq_tokio::{Endpoint, Message, OnMute, Options, Socket, SocketType};
+use omq_tokio::{
+    Endpoint, Message, MonitorEvent, MonitorStream, OnMute, Options, Socket, SocketType,
+};
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
@@ -17,6 +19,23 @@ fn free_tcp_port() -> u16 {
     let port = listener.local_addr().unwrap().port();
     drop(listener);
     port
+}
+
+async fn wait_for_unsubscribe(mon: &mut MonitorStream, prefix: &[u8]) {
+    let fut = async {
+        loop {
+            match mon.recv().await {
+                Ok(MonitorEvent::UnsubscribeReceived { prefix: got }) if got.as_ref() == prefix => {
+                    return;
+                }
+                Ok(_) => {}
+                Err(e) => panic!("monitor closed before unsubscribe: {e:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(2), fut)
+        .await
+        .expect("unsubscribe did not arrive");
 }
 
 #[tokio::test]
@@ -301,6 +320,57 @@ async fn pub_sub_unsubscribe() {
     // blueberry filtered out.
     let other = tokio::time::timeout(Duration::from_millis(100), subscriber.recv()).await;
     assert!(other.is_err());
+}
+
+#[tokio::test]
+async fn pub_sub_overlapping_unsubscribe_keeps_narrower_prefix() {
+    let publisher = Socket::new(SocketType::Pub, Options::default());
+    let mut publisher_mon = publisher.monitor();
+    let port = test_support::bind_loopback(&publisher).await;
+
+    let subscriber = Socket::new(SocketType::Sub, Options::default());
+    subscriber.subscribe("a").await.unwrap();
+    subscriber.subscribe("ab").await.unwrap();
+    subscriber
+        .connect(test_support::tcp_loopback(port))
+        .await
+        .unwrap();
+
+    publisher
+        .wait_subscribed(2, Duration::from_secs(1))
+        .await
+        .expect("subscriptions did not arrive");
+
+    publisher.send(Message::single("ab-first")).await.unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(1), subscriber.recv())
+        .await
+        .expect("subscriber did not receive first match")
+        .unwrap();
+    assert_eq!(first, Message::single("ab-first"));
+
+    subscriber.unsubscribe("a").await.unwrap();
+    wait_for_unsubscribe(&mut publisher_mon, b"a").await;
+
+    publisher.send(Message::single("a-filtered")).await.unwrap();
+    publisher.send(Message::single("ab-second")).await.unwrap();
+    let second = tokio::time::timeout(Duration::from_secs(1), subscriber.recv())
+        .await
+        .expect("subscriber did not receive narrower-prefix match")
+        .unwrap();
+    assert_eq!(second, Message::single("ab-second"));
+
+    let extra = tokio::time::timeout(Duration::from_millis(150), subscriber.recv()).await;
+    assert!(extra.is_err(), "broader unsubscribed prefix still matched");
+
+    subscriber.unsubscribe("ab").await.unwrap();
+    wait_for_unsubscribe(&mut publisher_mon, b"ab").await;
+
+    publisher.send(Message::single("ab-third")).await.unwrap();
+    let gone = tokio::time::timeout(Duration::from_millis(150), subscriber.recv()).await;
+    assert!(
+        gone.is_err(),
+        "narrower prefix still matched after unsubscribe"
+    );
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -10,6 +10,8 @@ use omq_tokio::{
     Endpoint, Message, MonitorEvent, MonitorStream, OnMute, Options, Socket, SocketType,
 };
 
+static PUB_IO_LANE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
 }
@@ -514,6 +516,7 @@ async fn xpub_nodrop_delivers_all_under_backpressure() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pub_io_lane_fanout_all_receive() {
+    let _guard = PUB_IO_LANE_TEST_LOCK.lock().await;
     let pub_ = Socket::new(SocketType::Pub, Options::default());
     let port = test_support::bind_loopback(&pub_).await;
 
@@ -552,6 +555,7 @@ async fn pub_io_lane_fanout_all_receive() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pub_io_lane_fanout_subscription_filter() {
+    let _guard = PUB_IO_LANE_TEST_LOCK.lock().await;
     let pub_ = Socket::new(SocketType::Pub, Options::default());
     let port = test_support::bind_loopback(&pub_).await;
 
@@ -619,6 +623,7 @@ async fn pub_io_lane_fanout_block_on_mute_does_not_block_slow_sub() {
     const SUBS: usize = 6;
     const MSGS: u32 = 256;
 
+    let _guard = PUB_IO_LANE_TEST_LOCK.lock().await;
     let pub_ = Socket::new(
         SocketType::Pub,
         Options::default().send_hwm(1).on_mute(OnMute::Block),
@@ -653,6 +658,7 @@ async fn pub_io_lane_fanout_two_worker_runtime_all_receive() {
     const SUBS: usize = 8;
     const MSGS: u32 = 32;
 
+    let _guard = PUB_IO_LANE_TEST_LOCK.lock().await;
     let pub_ = Socket::new(SocketType::Pub, Options::default());
     let port = test_support::bind_loopback(&pub_).await;
 

--- a/omq-tokio/tests/push_pull.rs
+++ b/omq-tokio/tests/push_pull.rs
@@ -2,6 +2,7 @@
 
 mod test_support;
 
+use std::collections::HashSet;
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -33,6 +34,14 @@ fn encode_stress_message(id: u32, payload: &[u8]) -> Message {
 fn decode_stress_message(msg: &Message) -> u32 {
     let bytes = msg.part_bytes(0).expect("frame");
     u32::from_be_bytes(bytes[0..4].try_into().unwrap())
+}
+
+async fn recv_body_string(sock: &Socket) -> String {
+    let msg = tokio::time::timeout(Duration::from_secs(1), sock.recv())
+        .await
+        .expect("recv timed out")
+        .unwrap();
+    String::from_utf8(msg.part_bytes(0).unwrap().to_vec()).unwrap()
 }
 
 #[tokio::test]
@@ -150,6 +159,87 @@ async fn push_pull_single_peer() {
     assert_eq!(m1, Message::single("a"));
     assert_eq!(m2, Message::single("b"));
     assert_eq!(m3, Message::single("c"));
+}
+
+#[tokio::test]
+async fn push_round_robin_delivers_two_rounds_to_each_pull() {
+    const PULLS: usize = 5;
+
+    let ep = inproc_ep("pp-spec-round-robin");
+    let push = Socket::new(SocketType::Push, Options::default());
+    push.bind(ep.clone()).await.unwrap();
+
+    let mut pulls = Vec::with_capacity(PULLS);
+    for _ in 0..PULLS {
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        pull.connect(ep.clone()).await.unwrap();
+        pulls.push(pull);
+    }
+    push.wait_connected(PULLS, Duration::from_secs(1))
+        .await
+        .expect("PUSH did not see all PULLs");
+
+    for _ in 0..PULLS {
+        push.send(Message::single("ABC")).await.unwrap();
+    }
+    for _ in 0..PULLS {
+        push.send(Message::single("DEF")).await.unwrap();
+    }
+
+    for pull in &pulls {
+        assert_eq!(recv_body_string(pull).await, "ABC");
+        assert_eq!(recv_body_string(pull).await, "DEF");
+    }
+}
+
+#[tokio::test]
+async fn pull_fair_queues_first_batch_before_second_batch() {
+    const PUSHES: usize = 5;
+
+    let ep = inproc_ep("pp-spec-fair-queue");
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    pull.bind(ep.clone()).await.unwrap();
+
+    let mut pushes = Vec::with_capacity(PUSHES);
+    for _ in 0..PUSHES {
+        let push = Socket::new(SocketType::Push, Options::default());
+        push.connect(ep.clone()).await.unwrap();
+        pushes.push(push);
+    }
+    pull.wait_connected(PUSHES, Duration::from_secs(1))
+        .await
+        .expect("PULL did not see all PUSHes");
+
+    for (peer, push) in pushes.iter().enumerate() {
+        push.send(Message::single(format!("first-{peer}")))
+            .await
+            .unwrap();
+        push.send(Message::single(format!("second-{peer}")))
+            .await
+            .unwrap();
+    }
+
+    let mut first_batch = HashSet::new();
+    for _ in 0..PUSHES {
+        first_batch.insert(recv_body_string(&pull).await);
+    }
+    assert_eq!(
+        first_batch,
+        (0..PUSHES)
+            .map(|peer| format!("first-{peer}"))
+            .collect::<HashSet<_>>()
+    );
+
+    let mut second_batch = HashSet::new();
+    for _ in 0..PUSHES {
+        second_batch.insert(recv_body_string(&pull).await);
+    }
+    assert_eq!(
+        second_batch,
+        (0..PUSHES)
+            .map(|peer| format!("second-{peer}"))
+            .collect::<HashSet<_>>()
+    );
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -10,6 +10,7 @@
 
 mod test_support;
 
+use std::collections::HashSet;
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
@@ -176,6 +177,51 @@ async fn req_round_robins_across_connected_reps() {
     }
 
     assert_eq!(counts, [ROUNDS; REPS]);
+}
+
+#[tokio::test]
+async fn dealer_round_robins_requests_across_reps() {
+    const REPS: usize = 5;
+
+    let ep = inproc_ep("rr-dealer-round-robin");
+    let dealer = Socket::new(SocketType::Dealer, Options::default());
+    dealer.bind(ep.clone()).await.unwrap();
+
+    let mut reps = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.connect(ep.clone()).await.unwrap();
+        reps.push(rep);
+    }
+    dealer
+        .wait_connected(REPS, Duration::from_secs(1))
+        .await
+        .expect("DEALER did not see all REPs");
+
+    for i in 0..REPS {
+        dealer
+            .send(Message::multipart([
+                bytes::Bytes::new(),
+                bytes::Bytes::from(format!("q-{i}")),
+            ]))
+            .await
+            .unwrap();
+    }
+
+    let mut counts = [0usize; REPS];
+    let mut bodies = HashSet::new();
+    for _ in 0..REPS {
+        let (idx, request) = recv_from_any_rep(&reps).await;
+        counts[idx] += 1;
+        assert!(
+            bodies.insert(String::from_utf8(request.part_bytes(0).unwrap().to_vec()).unwrap()),
+            "duplicate REP request body"
+        );
+    }
+
+    assert_eq!(counts, [1; REPS]);
+    let expected = (0..REPS).map(|i| format!("q-{i}")).collect();
+    assert_eq!(bodies, expected);
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -27,6 +27,24 @@ fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
 }
 
+async fn recv_from_any_rep(reps: &[Socket]) -> (usize, Message) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        for (idx, rep) in reps.iter().enumerate() {
+            match rep.try_recv() {
+                Ok(msg) => return (idx, msg),
+                Err(Error::WouldBlock) => {}
+                Err(e) => panic!("rep {idx} recv failed: {e:?}"),
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no REP received request"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
 #[tokio::test]
 async fn req_duplicate_tcp_connect_is_ignored() {
     let rep = Socket::new(SocketType::Rep, Options::default());
@@ -118,6 +136,49 @@ async fn req_rep_multiple_rounds() {
 }
 
 #[tokio::test]
+async fn req_round_robins_across_connected_reps() {
+    const REPS: usize = 5;
+    const ROUNDS: usize = 2;
+
+    let ep = inproc_ep("rr-req-round-robin");
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.bind(ep.clone()).await.unwrap();
+
+    let mut reps = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let rep = Socket::new(SocketType::Rep, Options::default());
+        rep.connect(ep.clone()).await.unwrap();
+        reps.push(rep);
+    }
+    req.wait_connected(REPS, Duration::from_secs(1))
+        .await
+        .expect("REQ did not see all REPs");
+
+    let mut counts = [0usize; REPS];
+    for i in 0..(REPS * ROUNDS) {
+        let question = format!("q-{i}");
+        req.send(Message::single(question.clone())).await.unwrap();
+
+        let (idx, request) = recv_from_any_rep(&reps).await;
+        assert_eq!(request.part_bytes(0).unwrap(), question.as_bytes());
+        counts[idx] += 1;
+
+        let answer = format!("a-{idx}-{i}");
+        reps[idx]
+            .send(Message::single(answer.clone()))
+            .await
+            .unwrap();
+        let reply = tokio::time::timeout(Duration::from_secs(1), req.recv())
+            .await
+            .expect("REQ did not receive reply")
+            .unwrap();
+        assert_eq!(reply.part_bytes(0).unwrap(), answer.as_bytes());
+    }
+
+    assert_eq!(counts, [ROUNDS; REPS]);
+}
+
+#[tokio::test]
 async fn dealer_to_rep_envelope() {
     // DEALER sends [empty, body]; REP saves envelope + empty delim and
     // returns just the body to the user. Reply goes back through the
@@ -151,6 +212,37 @@ async fn dealer_to_rep_envelope() {
     assert_eq!(reply.len(), 2);
     assert!(reply.part_bytes(0).unwrap().is_empty());
     assert_eq!(reply.part_bytes(1).unwrap(), &b"world"[..]);
+}
+
+#[tokio::test]
+async fn dealer_to_rep_preserves_large_envelope_on_reply() {
+    let ep = inproc_ep("rr-dealer-rep-big-envelope");
+    let rep = Socket::new(SocketType::Rep, Options::default());
+    rep.bind(ep.clone()).await.unwrap();
+
+    let dealer = Socket::new(SocketType::Dealer, Options::default());
+    dealer.connect(ep).await.unwrap();
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
+
+    dealer
+        .send(Message::multipart(["X", "Y", "", "request"]))
+        .await
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), rep.recv())
+        .await
+        .expect("REP did not receive dealer request")
+        .unwrap();
+    assert_eq!(got, Message::single("request"));
+
+    rep.send(Message::single("reply")).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), dealer.recv())
+        .await
+        .expect("DEALER did not receive REP reply")
+        .unwrap();
+    assert_eq!(reply, Message::multipart(["X", "Y", "", "reply"]));
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -19,7 +19,7 @@ fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
 }
 
-fn record_dealer_round_robin_msg(msg: Message, seen: &mut HashSet<u32>) {
+fn record_dealer_round_robin_msg(msg: &Message, seen: &mut HashSet<u32>) {
     assert_eq!(msg.len(), 3);
     assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"dealer-id");
 
@@ -41,7 +41,7 @@ fn drain_dealer_round_robin_msgs(router: &Socket, seen: &mut HashSet<u32>) -> us
     loop {
         match router.try_recv() {
             Ok(msg) => {
-                record_dealer_round_robin_msg(msg, seen);
+                record_dealer_round_robin_msg(&msg, seen);
                 count += 1;
             }
             Err(Error::WouldBlock) => return count,

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -7,14 +7,47 @@
 
 mod test_support;
 
-use std::time::Duration;
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
 
 use omq_tokio::{
-    DisconnectReason, Endpoint, Message, MonitorEvent, Options, ReconnectPolicy, Socket, SocketType,
+    DisconnectReason, Endpoint, Error, Message, MonitorEvent, Options, ReconnectPolicy, Socket,
+    SocketType,
 };
 
 fn inproc_ep(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
+}
+
+fn record_dealer_round_robin_msg(msg: Message, seen: &mut HashSet<u32>) {
+    assert_eq!(msg.len(), 3);
+    assert_eq!(msg.part_bytes(0).unwrap().as_ref(), b"dealer-id");
+
+    let header = msg.part_bytes(1).unwrap();
+    let header = std::str::from_utf8(&header).unwrap();
+    let seq = header
+        .strip_prefix("head-")
+        .expect("header prefix")
+        .parse::<u32>()
+        .expect("header sequence");
+
+    let body = msg.part_bytes(2).unwrap();
+    assert_eq!(body.as_ref(), format!("body-{seq}").as_bytes());
+    assert!(seen.insert(seq), "duplicate dealer message {seq}");
+}
+
+fn drain_dealer_round_robin_msgs(router: &Socket, seen: &mut HashSet<u32>) -> usize {
+    let mut count = 0;
+    loop {
+        match router.try_recv() {
+            Ok(msg) => {
+                record_dealer_round_robin_msg(msg, seen);
+                count += 1;
+            }
+            Err(Error::WouldBlock) => return count,
+            Err(e) => panic!("router recv failed: {e:?}"),
+        }
+    }
 }
 
 #[tokio::test]
@@ -164,6 +197,125 @@ async fn tcp_router_routes_two_initial_dealer_identities() {
         .unwrap();
     assert_eq!(reply_a, Message::single("reply-a"));
     assert_eq!(reply_b, Message::single("reply-b"));
+}
+
+#[tokio::test]
+async fn tcp_req_to_router_uses_empty_delimiter_and_ignores_bad_reply() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = test_support::bind_loopback(&router).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let req = Socket::new(SocketType::Req, Options::default());
+    req.connect(ep).await.unwrap();
+
+    router
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router did not see req");
+    req.wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("req did not connect");
+
+    req.send(Message::multipart(["A", "B"])).await.unwrap();
+    let request = tokio::time::timeout(Duration::from_secs(1), router.recv())
+        .await
+        .expect("router did not receive req")
+        .unwrap();
+    assert_eq!(request.len(), 4);
+    let identity = request.part_bytes(0).unwrap();
+    assert!(!identity.is_empty());
+    assert!(request.part_bytes(1).unwrap().is_empty());
+    assert_eq!(request.part_bytes(2).unwrap().as_ref(), b"A");
+    assert_eq!(request.part_bytes(3).unwrap().as_ref(), b"B");
+
+    router
+        .send(Message::multipart([
+            identity.clone(),
+            bytes::Bytes::from_static(b"bad"),
+        ]))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(matches!(req.try_recv(), Err(Error::WouldBlock)));
+
+    router
+        .send(Message::multipart([
+            identity,
+            bytes::Bytes::new(),
+            bytes::Bytes::from_static(b"good"),
+        ]))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), req.recv())
+        .await
+        .expect("req did not receive good reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("good"));
+}
+
+#[tokio::test]
+async fn dealer_round_robin_preserves_multipart_messages() {
+    const MSGS: u32 = 12;
+
+    let router_a = Socket::new(SocketType::Router, Options::default());
+    let port_a = test_support::bind_loopback(&router_a).await;
+
+    let router_b = Socket::new(SocketType::Router, Options::default());
+    let port_b = test_support::bind_loopback(&router_b).await;
+
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        Options::default().identity(bytes::Bytes::from_static(b"dealer-id")),
+    );
+    dealer
+        .connect(test_support::tcp_loopback(port_a))
+        .await
+        .unwrap();
+    dealer
+        .connect(test_support::tcp_loopback(port_b))
+        .await
+        .unwrap();
+
+    router_a
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router a did not see dealer");
+    router_b
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router b did not see dealer");
+    dealer
+        .wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect both routers");
+
+    for i in 0..MSGS {
+        dealer
+            .send(Message::multipart([
+                format!("head-{i}"),
+                format!("body-{i}"),
+            ]))
+            .await
+            .unwrap();
+    }
+
+    let mut seen = HashSet::new();
+    let mut count_a = 0;
+    let mut count_b = 0;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while seen.len() < MSGS as usize {
+        count_a += drain_dealer_round_robin_msgs(&router_a, &mut seen);
+        count_b += drain_dealer_round_robin_msgs(&router_b, &mut seen);
+        assert!(
+            Instant::now() < deadline,
+            "timed out draining dealer messages: a={count_a}, b={count_b}, seen={seen:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(seen.len(), MSGS as usize);
+    assert!(count_a > 0, "router a received no messages");
+    assert!(count_b > 0, "router b received no messages");
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -50,6 +50,15 @@ fn drain_dealer_round_robin_msgs(router: &Socket, seen: &mut HashSet<u32>) -> us
     }
 }
 
+async fn recv_dealer_body_string(dealer: &Socket) -> String {
+    let msg = tokio::time::timeout(Duration::from_secs(1), dealer.recv())
+        .await
+        .expect("DEALER did not receive")
+        .unwrap();
+    assert_eq!(msg.len(), 1);
+    String::from_utf8(msg.part_bytes(0).unwrap().to_vec()).unwrap()
+}
+
 #[tokio::test]
 async fn dealer_duplicate_tcp_connect_is_ignored() {
     let router = Socket::new(SocketType::Router, Options::default());
@@ -316,6 +325,60 @@ async fn dealer_round_robin_preserves_multipart_messages() {
     assert_eq!(seen.len(), MSGS as usize);
     assert!(count_a > 0, "router a received no messages");
     assert!(count_b > 0, "router b received no messages");
+}
+
+#[tokio::test]
+async fn dealer_fair_queues_first_batch_before_second_batch() {
+    const PEERS: usize = 5;
+
+    let ep = inproc_ep("rd-dealer-fair-queue");
+    let receiver = Socket::new(SocketType::Dealer, Options::default());
+    receiver.bind(ep.clone()).await.unwrap();
+
+    let mut senders = Vec::with_capacity(PEERS);
+    for _ in 0..PEERS {
+        let sender = Socket::new(SocketType::Dealer, Options::default());
+        sender.connect(ep.clone()).await.unwrap();
+        senders.push(sender);
+    }
+    receiver
+        .wait_connected(PEERS, Duration::from_secs(1))
+        .await
+        .expect("receiver did not see all DEALER peers");
+
+    senders[0].send(Message::single("warm-a")).await.unwrap();
+    assert_eq!(recv_dealer_body_string(&receiver).await, "warm-a");
+    senders[0].send(Message::single("warm-b")).await.unwrap();
+    assert_eq!(recv_dealer_body_string(&receiver).await, "warm-b");
+
+    for (idx, sender) in senders.iter().enumerate() {
+        sender
+            .send(Message::single(format!("first-{idx}")))
+            .await
+            .unwrap();
+    }
+    for (idx, sender) in senders.iter().enumerate() {
+        sender
+            .send(Message::single(format!("second-{idx}")))
+            .await
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut first_batch = HashSet::new();
+    for _ in 0..PEERS {
+        first_batch.insert(recv_dealer_body_string(&receiver).await);
+    }
+    let expected_first = (0..PEERS).map(|idx| format!("first-{idx}")).collect();
+    assert_eq!(first_batch, expected_first);
+
+    let mut second_batch = HashSet::new();
+    for _ in 0..PEERS {
+        second_batch.insert(recv_dealer_body_string(&receiver).await);
+    }
+    let expected_second = (0..PEERS).map(|idx| format!("second-{idx}")).collect();
+    assert_eq!(second_batch, expected_second);
 }
 
 #[tokio::test]

--- a/omq-tokio/tests/stream.rs
+++ b/omq-tokio/tests/stream.rs
@@ -80,6 +80,59 @@ async fn stream_basic_roundtrip() {
 }
 
 #[tokio::test]
+async fn stream_large_raw_payload_roundtrip() {
+    let stream = Socket::new(SocketType::Stream, Options::default());
+    let ep = stream.bind(tcp_ep(0)).await.unwrap();
+    let addr = resolved_addr(&ep);
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+
+    let connect_msg = tokio::time::timeout(Duration::from_secs(2), stream.recv())
+        .await
+        .expect("timed out waiting for connect notification")
+        .unwrap();
+    let identity = connect_msg.part_bytes(0).unwrap();
+    assert!(!identity.is_empty(), "identity should be non-empty");
+    assert!(connect_msg.part_bytes(1).unwrap().is_empty());
+
+    let payload: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
+    client.write_all(&payload).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(3), async {
+        let mut received = Vec::with_capacity(payload.len());
+        while received.len() < payload.len() {
+            let msg = stream.recv().await.unwrap();
+            assert_eq!(msg.len(), 2);
+            assert_eq!(msg.part_bytes(0).unwrap(), identity);
+
+            let chunk = msg.part_bytes(1).unwrap();
+            assert!(!chunk.is_empty(), "unexpected empty STREAM notification");
+            received.extend_from_slice(&chunk);
+        }
+        received
+    })
+    .await
+    .expect("timed out receiving large raw payload");
+    assert_eq!(received, payload);
+
+    let reply: Vec<u8> = payload.iter().map(|b| b ^ 0xA5).collect();
+    stream
+        .send(Message::multipart([
+            identity,
+            Bytes::copy_from_slice(&reply),
+        ]))
+        .await
+        .unwrap();
+
+    let mut got_reply = vec![0u8; reply.len()];
+    tokio::time::timeout(Duration::from_secs(3), client.read_exact(&mut got_reply))
+        .await
+        .expect("timed out waiting for large STREAM reply")
+        .unwrap();
+    assert_eq!(got_reply, reply);
+}
+
+#[tokio::test]
 async fn stream_peer_disconnect() {
     let stream = Socket::new(SocketType::Stream, Options::default());
     let ep = stream.bind(tcp_ep(0)).await.unwrap();

--- a/omq-tokio/tests/tcp_smoke.rs
+++ b/omq-tokio/tests/tcp_smoke.rs
@@ -49,3 +49,28 @@ async fn req_rep_tcp_smoke() {
         .unwrap();
     assert_eq!(reply, Message::single("tcp-reply"));
 }
+
+#[tokio::test]
+async fn pair_tcp_connect_by_localhost_name() {
+    let server = Socket::new(SocketType::Pair, Options::default());
+    let port = test_support::bind_loopback(&server).await;
+    let ep = format!("tcp://localhost:{port}").parse().unwrap();
+
+    let client = Socket::new(SocketType::Pair, Options::default());
+    client.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&client).await;
+
+    client.send(Message::single("HELLO")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), server.recv())
+        .await
+        .expect("server did not receive PAIR message")
+        .unwrap();
+    assert_eq!(got, Message::single("HELLO"));
+
+    server.send(Message::single("WORLD")).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), client.recv())
+        .await
+        .expect("client did not receive PAIR reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("WORLD"));
+}

--- a/omq-tokio/tests/xpub_xsub.rs
+++ b/omq-tokio/tests/xpub_xsub.rs
@@ -99,6 +99,31 @@ async fn xpub_surfaces_subscribe_messages() {
 }
 
 #[tokio::test]
+async fn xpub_surfaces_sub_unsubscribe_messages() {
+    let xpub = Socket::new(SocketType::XPub, Options::default());
+    let endpoint: Endpoint = "inproc://xpub-sub-unsubscribe".parse().unwrap();
+    xpub.bind(endpoint.clone()).await.unwrap();
+
+    let sub = Socket::new(SocketType::Sub, Options::default());
+    sub.connect(endpoint).await.unwrap();
+    sub.subscribe("news").await.unwrap();
+
+    let subscribe = tokio::time::timeout(Duration::from_secs(2), xpub.recv())
+        .await
+        .expect("XPUB subscribe notification timed out")
+        .unwrap();
+    assert_eq!(subscribe.part_bytes(0).unwrap().as_ref(), b"\x01news");
+
+    sub.unsubscribe("news").await.unwrap();
+
+    let unsubscribe = tokio::time::timeout(Duration::from_secs(2), xpub.recv())
+        .await
+        .expect("XPUB unsubscribe notification timed out")
+        .unwrap();
+    assert_eq!(unsubscribe.part_bytes(0).unwrap().as_ref(), b"\x00news");
+}
+
+#[tokio::test]
 async fn xsub_subscribe_filters_messages_from_xpub() {
     // XSUB.subscribe() sends a ZMTP SUBSCRIBE command to connected XPUB.
     // XPUB should then only forward matching messages to the XSUB.

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -316,8 +316,12 @@ async fn auto_train_survives_reconnect() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn pub_sub_zstd_io_lane_send_and_try_send_auto_train_dict_for_late_subscriber() {
+async fn pub_sub_zstd_io_lane_send_auto_train_dict_for_late_subscriber() {
     run_pub_sub_zstd_io_lane_auto_train_dict_for_late_subscriber(FanoutSendMode::Send).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pub_sub_zstd_io_lane_try_send_auto_train_dict_for_late_subscriber() {
     run_pub_sub_zstd_io_lane_auto_train_dict_for_late_subscriber(FanoutSendMode::TrySend).await;
 }
 


### PR DESCRIPTION
- Add libzmq-derived parity tests for native `omq-tokio` behavior: `ROUTER`/`DEALER` routing, `PUB`/`SUB` filtering and fanout, `REQ`/`REP` state and envelopes, `PAIR` TCP name resolution, `STREAM` large payloads, no-peer sends, conflate, and fair recv ordering.
- Expand `omq-libzmq` edge-case tests for context, message, option, util, null socket, and security behavior used while translating cases.
- Fix native behavior exposed by new tests: receive-side conflate keeps newest queued message, fair-queue recv preserves peer order, and `PUB` IO-lane fanout stress cases run serially to avoid harness contention.
- Stabilize `omq-libzmq` proxy starvation teardown by draining hot-path backlog and using zero linger before context termination.
- Stabilize `omq-libzmq` XPUB notification parity coverage by using inproc transport for subscription semantics.
- Split zstd `send`/`try_send` IO-lane fanout coverage into separate tests so each mode gets a fresh nextest process.