### PR TITLE
Harden extended CI reliability

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,3 +22,7 @@ final-status-level = "slow"
 [profile.extended-miri]
 inherits = "default-miri"
 slow-timeout = { period = "20m", terminate-after = 1, grace-period = "10s" }
+
+[[profile.ci.overrides]]
+filter = 'package(omq-tokio) and binary(omq_zstd_tcp) and test(/pub_sub_zstd_io_lane_(send|try_send)_auto_train_dict_for_late_subscriber/)'
+threads-required = "num-test-threads"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
         run: pip install .
       - name: cargo nextest
         working-directory: bindings/pyomq
-        run: cargo nextest run --profile ci --config-file ../../.config/nextest.toml
+        run: cargo nextest run --profile ci --config-file .config/nextest.toml
       - name: pytest
         working-directory: bindings/pyomq
         run: pytest -v -k "not test_perf" -W error

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -10,7 +10,10 @@ on:
     inputs:
       soak_duration_secs:
         description: seconds per soak test
-        default: "180"
+        default: "7200"
+      soak_seed:
+        description: optional OMQ_SOAK_SEED for replay
+        default: ""
       fuzz_scale:
         description: multiplier on each fuzz target's iteration count
         default: "1"
@@ -57,27 +60,40 @@ jobs:
             --test ${{ matrix.test }}
 
   soak:
-    name: soak (${{ matrix.group }})
+    name: soak (${{ matrix.test }})
     if: github.repository == 'paddor/omq.rs'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
         include:
-          - group: churn
-            tests: omq_soak_peer_churn omq_soak_pub_sub_churn omq_soak_pub_sub_churn_tcp omq_soak_pub_sub_realworld_churn_tcp omq_soak_router_dealer_churn omq_soak_xpub_xsub_churn
-          - group: reconnect
-            tests: omq_soak_reconnect_all_types omq_soak_reconnect_storm omq_soak_hwm_reconnect omq_soak_mechanism_reconnect
-          - group: mechanism
-            tests: omq_soak_plain omq_soak_curve
-          - group: transport
-            tests: omq_soak_ws omq_soak_compression_lz4 omq_soak_pub_sub_lz4_dict omq_soak_compression_zstd omq_soak_pub_sub_zstd_dict omq_soak_large_throughput
-          - group: runtime
-            tests: omq_soak_cancel_safety omq_soak_inproc_cross_thread omq_soak_multi_socket
+          - test: omq_soak_peer_churn
+          - test: omq_soak_pub_sub_churn
+          - test: omq_soak_pub_sub_churn_tcp
+          - test: omq_soak_pub_sub_realworld_churn_tcp
+          - test: omq_soak_router_dealer_churn
+          - test: omq_soak_xpub_xsub_churn
+          - test: omq_soak_reconnect_all_types
+          - test: omq_soak_reconnect_storm
+          - test: omq_soak_hwm_reconnect
+          - test: omq_soak_mechanism_reconnect
+          - test: omq_soak_plain
+          - test: omq_soak_curve
+          - test: omq_soak_ws
+          - test: omq_soak_compression_lz4
+          - test: omq_soak_pub_sub_lz4_dict
+          - test: omq_soak_compression_zstd
+          - test: omq_soak_pub_sub_zstd_dict
+          - test: omq_soak_large_throughput
+          - test: omq_soak_cancel_safety
+          - test: omq_soak_inproc_cross_thread
+          - test: omq_soak_multi_socket
     env:
       SOAK_FEATURES: soak plain curve lz4 zstd ws
-      OMQ_SOAK_DURATION_SECS: ${{ inputs.soak_duration_secs || '180' }}
+      OMQ_SOAK_DURATION_SECS: ${{ inputs.soak_duration_secs || '7200' }}
+      OMQ_SOAK_SEED: ${{ inputs.soak_seed || '' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -86,15 +102,9 @@ jobs:
         with:
           tool: cargo-nextest
       - name: build soak tests
-        run: cargo test -p omq-tokio --features "$SOAK_FEATURES" --release --no-run
-      - name: run soak group
-        run: |
-          for t in ${{ matrix.tests }}; do
-            echo "::group::$t"
-            cargo nextest run --profile extended -p omq-tokio \
-              --features "$SOAK_FEATURES" --release --test "$t"
-            echo "::endgroup::"
-          done
+        run: cargo test -p omq-tokio --features "$SOAK_FEATURES" --release --test ${{ matrix.test }} --no-run
+      - name: run soak test
+        run: cargo nextest run --profile extended -p omq-tokio --features "$SOAK_FEATURES" --release --test ${{ matrix.test }}
 
   stress:
     name: stress

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -55,9 +55,17 @@ jobs:
           OMQ_FUZZ_ITERS=$(( ${{ matrix.iters }} * ${{ inputs.fuzz_scale || 1 }} ))
           export OMQ_FUZZ_ITERS
           echo "OMQ_FUZZ_ITERS=$OMQ_FUZZ_ITERS"
-          cargo nextest run --profile extended -p omq-tokio \
+          bash scripts/ci-run-with-forensics.sh "fuzz ${{ matrix.test }}" 10200 -- \
+            cargo nextest run --profile extended -p omq-tokio \
             --features "fuzz plain curve lz4 zstd ws" --release \
             --test ${{ matrix.test }}
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-fuzz-${{ matrix.test }}
+          path: target/hang-forensics
+          if-no-files-found: ignore
 
   soak:
     name: soak (${{ matrix.test }})
@@ -104,7 +112,17 @@ jobs:
       - name: build soak tests
         run: cargo test -p omq-tokio --features "$SOAK_FEATURES" --release --test ${{ matrix.test }} --no-run
       - name: run soak test
-        run: cargo nextest run --profile extended -p omq-tokio --features "$SOAK_FEATURES" --release --test ${{ matrix.test }}
+        run: |
+          bash scripts/ci-run-with-forensics.sh "soak ${{ matrix.test }}" 10200 -- \
+            cargo nextest run --profile extended -p omq-tokio \
+            --features "$SOAK_FEATURES" --release --test ${{ matrix.test }}
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-soak-${{ matrix.test }}
+          path: target/hang-forensics
+          if-no-files-found: ignore
 
   stress:
     name: stress
@@ -119,11 +137,28 @@ jobs:
         with:
           tool: cargo-nextest
       - name: connect-before-bind # serial: rounds race each other otherwise
-        run: cargo nextest run --profile extended -p omq-tokio --test omq_stress_connect_before_bind --run-ignored=only --test-threads=1
+        run: |
+          bash scripts/ci-run-with-forensics.sh "stress connect-before-bind" 5100 -- \
+            cargo nextest run --profile extended -p omq-tokio \
+            --test omq_stress_connect_before_bind --run-ignored=only \
+            --test-threads=1
       - name: push/pull
-        run: cargo nextest run --profile extended -p omq-tokio --test omq_push_pull --run-ignored=only
+        run: |
+          bash scripts/ci-run-with-forensics.sh "stress push-pull" 5100 -- \
+            cargo nextest run --profile extended -p omq-tokio \
+            --test omq_push_pull --run-ignored=only
       - name: transmit slot
-        run: cargo nextest run --profile extended -p omq-tokio --test omq_transmit_slot_stress --run-ignored=only
+        run: |
+          bash scripts/ci-run-with-forensics.sh "stress transmit-slot" 5100 -- \
+            cargo nextest run --profile extended -p omq-tokio \
+            --test omq_transmit_slot_stress --run-ignored=only
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-stress
+          path: target/hang-forensics
+          if-no-files-found: ignore
 
   ubuntu-arm:
     name: cargo nextest (ubuntu-24.04-arm)
@@ -138,7 +173,16 @@ jobs:
         with:
           tool: cargo-nextest
       - name: cargo nextest
-        run: cargo nextest run --profile ci --workspace
+        run: |
+          bash scripts/ci-run-with-forensics.sh "ubuntu-arm nextest" 5100 -- \
+            cargo nextest run --profile ci --workspace
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-ubuntu-arm
+          path: target/hang-forensics
+          if-no-files-found: ignore
 
   interop-libzmq-draft:
     name: interop (libzmq draft)
@@ -187,11 +231,24 @@ jobs:
       - name: interop (ws)
         env:
           LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
-        run: cargo nextest run --profile ci -p omq-tokio --features ws --test omq_interop_libzmq_ws
+        run: |
+          bash scripts/ci-run-with-forensics.sh "interop libzmq ws" 2400 -- \
+            cargo nextest run --profile ci -p omq-tokio --features ws \
+            --test omq_interop_libzmq_ws
       - name: interop (draft sockets)
         env:
           LD_LIBRARY_PATH: ${{ env.LIBZMQ_PREFIX }}/lib
-        run: cargo nextest run --profile ci -p omq-tokio --test omq_interop_libzmq_draft
+        run: |
+          bash scripts/ci-run-with-forensics.sh "interop libzmq draft" 2400 -- \
+            cargo nextest run --profile ci -p omq-tokio \
+            --test omq_interop_libzmq_draft
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-interop-libzmq-draft
+          path: target/hang-forensics
+          if-no-files-found: ignore
 
   miri-seeds:
     name: miri (yring, many seeds)
@@ -213,4 +270,14 @@ jobs:
           tool: cargo-nextest
       - run: cargo miri setup
       - name: miri test
-        run: cargo miri nextest run --profile extended-miri -p yring --features async
+        run: |
+          bash scripts/ci-run-with-forensics.sh "miri yring many seeds" 6900 -- \
+            cargo miri nextest run --profile extended-miri -p yring \
+            --features async
+      - name: upload hang forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-forensics-miri-seeds
+          path: target/hang-forensics
+          if-no-files-found: ignore

--- a/bindings/pyomq/.config/nextest.toml
+++ b/bindings/pyomq/.config/nextest.toml
@@ -1,0 +1,9 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 3, grace-period = "10s" }
+
+[profile.ci]
+inherits = "default"
+fail-fast = false
+failure-output = "immediate-final"
+status-level = "slow"
+final-status-level = "slow"

--- a/omq-tokio/src/routing/fan_out/lane.rs
+++ b/omq-tokio/src/routing/fan_out/lane.rs
@@ -683,8 +683,7 @@ impl LaneWorker {
             }
 
             self.flush_touched(&mut touched);
-            if drained {
-                self.data_signal.clear_after(self.data_rx.is_empty());
+            if self.finish_data_drain(drained) {
                 tokio::task::yield_now().await;
                 continue;
             }
@@ -693,6 +692,11 @@ impl LaneWorker {
                 () = self.data_signal.ready() => {}
             }
         }
+    }
+
+    fn finish_data_drain(&self, drained: bool) -> bool {
+        let rearmed = self.data_signal.clear_after(self.data_rx.is_empty());
+        drained || rearmed
     }
 
     fn notify_data_space(&self) {
@@ -1360,6 +1364,43 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), send_second)
             .await
             .expect("dispatch did not wake after space signal");
+    }
+
+    #[tokio::test]
+    async fn empty_data_drain_clears_stale_signal() {
+        let (_data_tx, data_rx) = yring::spsc::<LaneData>(4);
+        let (_ctrl_tx, ctrl_rx) = yring::spsc(4);
+        let data_signal = Arc::new(crate::engine::signal::DataSignal::new());
+        let worker = LaneWorker {
+            data_rx,
+            ctrl_rx,
+            data_signal: data_signal.clone(),
+            data_space: Arc::new(crate::engine::signal::StateSignal::new()),
+            ctrl_notify: Arc::new(crate::engine::signal::DataSignal::new()),
+            mode: FanOutMode::SubscriptionPrefix,
+            mute_policy: FanOutMutePolicy::DropNewest,
+            peers: FxHashMap::default(),
+            subscribe_all_count: 0,
+            eq: FrameBuffer::one_shot(),
+            chunks: Vec::new(),
+            encoder: None,
+            distribution_targets: Vec::new(),
+            active_flags: None,
+        };
+
+        data_signal.mark();
+        data_signal.begin_drain();
+
+        assert!(!worker.finish_data_drain(false));
+        tokio::time::timeout(std::time::Duration::from_secs(1), data_signal.ready())
+            .await
+            .expect("stale notify permit should be consumable once");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), data_signal.ready())
+                .await
+                .is_err(),
+            "empty drain must clear stale readiness"
+        );
     }
 
     #[cfg(any(feature = "lz4", feature = "zstd"))]

--- a/omq-tokio/tests/conflate.rs
+++ b/omq-tokio/tests/conflate.rs
@@ -53,9 +53,6 @@ async fn pub_conflate_keeps_only_latest_per_subscriber() {
             .await
             .unwrap();
     }
-    // Give the pump a moment to settle.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let mut received = Vec::new();
     while let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_millis(50), sub.recv()).await {
         let body = msg.part_bytes(0).unwrap();
@@ -140,8 +137,6 @@ async fn pull_conflate_keeps_only_latest() {
             .await
             .unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(250)).await;
-
     let received = tokio::time::timeout(Duration::from_secs(1), pull.recv())
         .await
         .expect("PULL did not receive")
@@ -179,8 +174,6 @@ async fn radio_conflate_keeps_only_latest_per_group() {
             .await
             .unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let mut received = Vec::new();
     while let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_millis(50), dish.recv()).await {
         let body = msg.part_bytes(1).unwrap();

--- a/omq-tokio/tests/conflate.rs
+++ b/omq-tokio/tests/conflate.rs
@@ -116,7 +116,7 @@ async fn push_conflate_keeps_only_latest() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pull_conflate_keeps_only_latest() {
-    const N: u32 = 20;
+    const N: u32 = 5_000;
 
     let pull = Socket::new(SocketType::Pull, Options::default().conflate(true));
     let port = test_support::bind_loopback(&pull).await;
@@ -133,21 +133,31 @@ async fn pull_conflate_keeps_only_latest() {
         .expect("PUSH did not connect");
 
     for i in 0..N {
-        push.send(Message::single(format!("m-{i:03}")))
+        push.send(Message::single(format!("m-{i:05}")))
             .await
             .unwrap();
     }
-    let received = tokio::time::timeout(Duration::from_secs(1), pull.recv())
-        .await
-        .expect("PULL did not receive")
-        .unwrap();
-    assert_eq!(received.part_bytes(0).unwrap().as_ref(), b"m-019");
+
+    let latest = format!("m-{:05}", N - 1);
+    let mut received = Vec::new();
+    while received.len() < N as usize {
+        let Ok(Ok(msg)) = tokio::time::timeout(Duration::from_secs(1), pull.recv()).await else {
+            break;
+        };
+        received.push(String::from_utf8_lossy(&msg.part_bytes(0).unwrap()).into_owned());
+        if received.last() == Some(&latest) {
+            break;
+        }
+    }
 
     assert!(
-        tokio::time::timeout(Duration::from_millis(100), pull.recv())
-            .await
-            .is_err(),
-        "PULL-side conflate should leave one unread message"
+        received.len() < N as usize,
+        "PULL-side conflate dropped nothing; sent {N}, received {}",
+        received.len()
+    );
+    assert!(
+        received.iter().any(|s| s == &latest),
+        "latest message must be visible; got {received:?}"
     );
     push.close().await.unwrap();
 }

--- a/omq-tokio/tests/no_peer_send.rs
+++ b/omq-tokio/tests/no_peer_send.rs
@@ -1,6 +1,8 @@
 use std::net::{Ipv4Addr, TcpListener as StdTcpListener};
 use std::time::Duration;
 
+mod test_support;
+
 use omq_tokio::endpoint::Host;
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType, TrySendError};
 
@@ -148,7 +150,13 @@ async fn bound_push_mutes_after_last_peer_disconnects() {
         .unwrap()
         .unwrap();
     pull.close().await.unwrap();
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    test_support::wait_for_connection_count(
+        &push,
+        0,
+        Duration::from_secs(1),
+        "PUSH last peer disconnect",
+    )
+    .await;
 
     let err = push.try_send(Message::single("after")).unwrap_err();
     assert!(matches!(err, TrySendError::Full(_)));

--- a/omq-tokio/tests/omq_soak_cancel_safety.rs
+++ b/omq-tokio/tests/omq_soak_cancel_safety.rs
@@ -47,7 +47,7 @@ fn soak_cancel_safety() {
 
     let ctx = soak_common::build_context();
     ctx.block_on(async move {
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("cancel_safety");
         let start = Instant::now();
         let mut iterations: u64 = 0;
         let mut last_log = start;

--- a/omq-tokio/tests/omq_soak_multi_socket.rs
+++ b/omq-tokio/tests/omq_soak_multi_socket.rs
@@ -18,19 +18,19 @@ struct SocketPair {
 async fn create_pairs() -> Vec<SocketPair> {
     let mut pairs = Vec::new();
 
-    for i in 0..20 {
+    for _ in 0..20 {
         let pull = Socket::new(SocketType::Pull, soak_common::soak_options().recv_hwm(16));
         let ep = pull.bind(soak_common::tcp_ep(0)).await.unwrap();
         let push = Socket::new(SocketType::Push, soak_common::soak_options().send_hwm(16));
         push.connect(ep).await.unwrap();
+        push.wait_connected(1, Duration::from_secs(1))
+            .await
+            .expect("PUSH/PULL pair did not connect");
         pairs.push(SocketPair {
             sender: push,
             receiver: pull,
             kind: "push/pull-tcp",
         });
-        if i == 0 {
-            tokio::time::sleep(Duration::from_millis(30)).await;
-        }
     }
 
     for i in 0..20 {
@@ -40,6 +40,9 @@ async fn create_pairs() -> Vec<SocketPair> {
         let sub = Socket::new(SocketType::Sub, Options::default().recv_hwm(16));
         sub.connect(ep).await.unwrap();
         sub.subscribe("").await.unwrap();
+        pub_.wait_subscribed(1, Duration::from_secs(1))
+            .await
+            .expect("PUB/SUB pair did not subscribe");
         pairs.push(SocketPair {
             sender: pub_,
             receiver: sub,
@@ -52,6 +55,9 @@ async fn create_pairs() -> Vec<SocketPair> {
         let ep = rep.bind(soak_common::tcp_ep(0)).await.unwrap();
         let req = Socket::new(SocketType::Req, soak_common::soak_options());
         req.connect(ep).await.unwrap();
+        req.wait_connected(1, Duration::from_secs(1))
+            .await
+            .expect("REQ/REP pair did not connect");
         pairs.push(SocketPair {
             sender: req,
             receiver: rep,
@@ -72,7 +78,6 @@ fn soak_multi_socket() {
     let tracker = ctx.block_on(async move {
         let pairs = create_pairs().await;
         eprintln!("[multi_socket] created {} socket pairs", pairs.len());
-        tokio::time::sleep(Duration::from_millis(100)).await;
 
         let start = Instant::now();
         let mut total_exchanged: u64 = 0;

--- a/omq-tokio/tests/omq_soak_peer_churn.rs
+++ b/omq-tokio/tests/omq_soak_peer_churn.rs
@@ -8,7 +8,6 @@ mod soak_common;
 use std::time::{Duration, Instant};
 
 use rand::RngExt;
-use rand::rngs::StdRng;
 
 use omq_tokio::{Message, Socket, SocketType};
 
@@ -25,7 +24,7 @@ fn soak_peer_churn() {
         initial_pull.connect(ep.clone()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("peer_churn");
         let mut peers: Vec<Socket> = vec![initial_pull];
         let mut sent: u64 = 0;
         let start = Instant::now();

--- a/omq-tokio/tests/omq_soak_peer_churn.rs
+++ b/omq-tokio/tests/omq_soak_peer_churn.rs
@@ -22,7 +22,9 @@ fn soak_peer_churn() {
 
         let initial_pull = Socket::new(SocketType::Pull, soak_common::soak_options().recv_hwm(64));
         initial_pull.connect(ep.clone()).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        push.wait_connected(1, Duration::from_secs(1))
+            .await
+            .expect("initial PULL did not connect");
 
         let mut rng = soak_common::seeded_rng("peer_churn");
         let mut peers: Vec<Socket> = vec![initial_pull];

--- a/omq-tokio/tests/omq_soak_pub_sub_churn.rs
+++ b/omq-tokio/tests/omq_soak_pub_sub_churn.rs
@@ -9,7 +9,6 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use rand::RngExt;
-use rand::rngs::StdRng;
 
 use omq_tokio::{Message, Options, Socket, SocketType};
 
@@ -26,7 +25,7 @@ fn soak_pub_sub_churn() {
         let publisher = Socket::new(SocketType::Pub, Options::default());
         publisher.bind(ep.clone()).await.unwrap();
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("pub_sub_churn");
         let mut subs: Vec<Socket> = Vec::new();
         let mut pub_count: u64 = 0;
         let start = Instant::now();

--- a/omq-tokio/tests/omq_soak_pub_sub_churn_tcp.rs
+++ b/omq-tokio/tests/omq_soak_pub_sub_churn_tcp.rs
@@ -16,7 +16,6 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use rand::RngExt;
-use rand::rngs::StdRng;
 
 use omq_tokio::{Message, MonitorEvent, OnMute, Options, ReconnectPolicy, Socket, SocketType};
 
@@ -64,7 +63,7 @@ fn soak_pub_sub_churn_tcp() {
         slow_sub.subscribe(Bytes::new()).await.unwrap();
         wait_for_subscribes(&mut mon, 1).await;
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("pub_sub_churn_tcp");
         let mut subs: Vec<Socket> = Vec::new();
         let mut pub_count: u64 = 0;
         let start = Instant::now();

--- a/omq-tokio/tests/omq_soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/omq_soak_reconnect_all_types.rs
@@ -151,7 +151,7 @@ fn soak_reconnect_all_types() {
     ctx.block_on(async move {
         let mut pairs = create_all_pairs().await;
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("reconnect_all_types");
         let start = Instant::now();
         let mut last_log = start;
 

--- a/omq-tokio/tests/omq_soak_reconnect_all_types.rs
+++ b/omq-tokio/tests/omq_soak_reconnect_all_types.rs
@@ -19,7 +19,6 @@ use bytes::Bytes;
 use omq_tokio::options::ReconnectPolicy;
 use omq_tokio::{Message, Options, Socket, SocketType};
 use rand::RngExt;
-use rand::rngs::StdRng;
 
 fn fast_reconnect() -> Options {
     Options {

--- a/omq-tokio/tests/omq_soak_router_dealer_churn.rs
+++ b/omq-tokio/tests/omq_soak_router_dealer_churn.rs
@@ -54,16 +54,17 @@ async fn churn_dealers(
         *next_id += 1;
         let d = Socket::new(SocketType::Dealer, dealer_opts(id.as_bytes()));
         d.connect(ep.clone()).await.unwrap();
+        d.wait_connected(1, Duration::from_secs(1))
+            .await
+            .expect("DEALER did not connect during churn");
         dealers.push(Dealer {
             identity: Bytes::from(id),
             socket: d,
         });
-        tokio::time::sleep(Duration::from_millis(20)).await;
     } else if action < 5 && dealers.len() > 1 {
         let idx = rng.random_range(0..dealers.len());
         let removed = dealers.swap_remove(idx);
         removed.socket.close().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/omq-tokio/tests/omq_soak_router_dealer_churn.rs
+++ b/omq-tokio/tests/omq_soak_router_dealer_churn.rs
@@ -136,7 +136,7 @@ fn soak_router_dealer_churn() {
         );
         let ep = router.bind(soak_common::tcp_ep(0)).await.unwrap();
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("router_dealer_churn");
         let mut dealers: Vec<Dealer> = Vec::new();
         let mut next_id: u64 = 0;
         let mut stats = Stats {

--- a/omq-tokio/tests/omq_soak_xpub_xsub_churn.rs
+++ b/omq-tokio/tests/omq_soak_xpub_xsub_churn.rs
@@ -43,7 +43,7 @@ fn soak_xpub_xsub_churn() {
         let xpub = Socket::new(SocketType::XPub, xpub_options());
         let ep = xpub.bind(soak_common::tcp_ep(0)).await.unwrap();
 
-        let mut rng = rand::make_rng::<StdRng>();
+        let mut rng = soak_common::seeded_rng("xpub_xsub_churn");
         let mut subs: Vec<Socket> = Vec::new();
         let mut pub_count: u64 = 0;
         let mut sub_notifications: u64 = 0;

--- a/omq-tokio/tests/req_rep.rs
+++ b/omq-tokio/tests/req_rep.rs
@@ -42,7 +42,7 @@ async fn recv_from_any_rep(reps: &[Socket]) -> (usize, Message) {
             tokio::time::Instant::now() < deadline,
             "no REP received request"
         );
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        tokio::task::yield_now().await;
     }
 }
 
@@ -315,7 +315,13 @@ async fn rep_survives_client_disconnect_mid_cycle() {
         req1.close().await.unwrap();
     }
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    test_support::wait_for_connection_count(
+        &rep,
+        0,
+        Duration::from_secs(1),
+        "REP first client disconnect",
+    )
+    .await;
 
     // Second client: full roundtrip must succeed.
     let req2 = Socket::new(SocketType::Req, Options::default());
@@ -354,13 +360,8 @@ async fn rep_reply_to_disconnected_client_is_accepted() {
     assert_eq!(got, Message::single("drop-me"));
 
     req.close_with_linger(Some(Duration::ZERO)).await.unwrap();
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while !rep.connections().await.unwrap().is_empty() {
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-    })
-    .await
-    .expect("REP still had live peer");
+    test_support::wait_for_connection_count(&rep, 0, Duration::from_secs(1), "REP disconnect")
+        .await;
 
     rep.send(Message::single("dropped-reply"))
         .await
@@ -519,7 +520,13 @@ async fn rep_tcp_serves_sequential_clients() {
             .unwrap();
         assert_eq!(reply.part_bytes(0).unwrap(), answer.as_bytes());
 
-        drop(req);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        req.close_with_linger(Some(Duration::ZERO)).await.unwrap();
+        test_support::wait_for_connection_count(
+            &rep,
+            0,
+            Duration::from_secs(1),
+            "REP sequential client disconnect",
+        )
+        .await;
     }
 }

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -244,8 +244,12 @@ async fn tcp_req_to_router_uses_empty_delimiter_and_ignores_bad_reply() {
         ]))
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    assert!(matches!(req.try_recv(), Err(Error::WouldBlock)));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), req.recv())
+            .await
+            .is_err(),
+        "REQ should ignore malformed ROUTER reply"
+    );
 
     router
         .send(Message::multipart([
@@ -319,7 +323,7 @@ async fn dealer_round_robin_preserves_multipart_messages() {
             Instant::now() < deadline,
             "timed out draining dealer messages: a={count_a}, b={count_b}, seen={seen:?}"
         );
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
     }
 
     assert_eq!(seen.len(), MSGS as usize);
@@ -364,8 +368,6 @@ async fn dealer_fair_queues_first_batch_before_second_batch() {
             .unwrap();
     }
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     let mut first_batch = HashSet::new();
     for _ in 0..PEERS {
         first_batch.insert(recv_dealer_body_string(&receiver).await);
@@ -393,8 +395,14 @@ async fn router_prefixes_identity_on_recv() {
         Options::default().identity(bytes::Bytes::from_static(b"alice")),
     );
     dealer.connect(ep).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    router
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router did not see dealer");
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
 
     dealer.send(Message::single("hello")).await.unwrap();
 
@@ -416,8 +424,14 @@ async fn router_routes_back_by_identity() {
         Options::default().identity(bytes::Bytes::from_static(b"bob")),
     );
     dealer.connect(ep).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    router
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router did not see dealer");
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
 
     dealer.send(Message::single("ping")).await.unwrap();
 
@@ -446,9 +460,6 @@ async fn router_mandatory_errors_on_unknown_identity() {
     );
     router.bind(ep.clone()).await.unwrap();
 
-    // No dealers connected.
-    tokio::time::sleep(Duration::from_millis(30)).await;
-
     let r = router.send(Message::multipart(["ghost", "hello"])).await;
     assert!(matches!(r, Err(omq_tokio::Error::Unroutable)), "got {r:?}");
 }
@@ -458,8 +469,6 @@ async fn router_silently_drops_unknown_identity_by_default() {
     let ep = inproc_ep("rd-silent");
     let router = Socket::new(SocketType::Router, Options::default());
     router.bind(ep.clone()).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(30)).await;
 
     // Default router_mandatory = false: send to ghost succeeds but routes
     // nowhere.
@@ -483,12 +492,21 @@ async fn router_handles_identity_churn_without_growth() {
             Options::default().identity(bytes::Bytes::from_static(b"worker-1")),
         );
         dealer.connect(ep.clone()).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        dealer
+            .wait_connected(1, Duration::from_secs(1))
+            .await
+            .expect("dealer did not connect");
         dealer.send(Message::single("ping")).await.unwrap();
         let m = router.recv().await.unwrap();
         assert_eq!(m.part_bytes(1).unwrap().as_ref(), b"ping");
         dealer.close().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        test_support::wait_for_connection_count(
+            &router,
+            0,
+            Duration::from_secs(1),
+            "router identity churn disconnect",
+        )
+        .await;
     }
 
     // Final dealer connects and exchanges one message; routing still works.
@@ -497,7 +515,10 @@ async fn router_handles_identity_churn_without_growth() {
         Options::default().identity(bytes::Bytes::from_static(b"worker-1")),
     );
     dealer.connect(ep).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(30)).await;
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
     dealer.send(Message::single("final")).await.unwrap();
     let got = tokio::time::timeout(Duration::from_millis(500), router.recv())
         .await
@@ -516,8 +537,14 @@ async fn router_assigns_identity_for_peers_without_one() {
 
     let dealer = Socket::new(SocketType::Dealer, Options::default());
     dealer.connect(ep).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    router
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("router did not see dealer");
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer did not connect");
 
     dealer.send(Message::single("anon")).await.unwrap();
 
@@ -557,7 +584,10 @@ async fn router_handover_evicts_old_peer() {
 
     let dealer_a = Socket::new(SocketType::Dealer, no_reconnect.clone());
     dealer_a.connect(ep.clone()).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    dealer_a
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer a did not connect");
 
     dealer_a.send(Message::single("hello")).await.unwrap();
     let got = router.recv().await.unwrap();
@@ -575,7 +605,10 @@ async fn router_handover_evicts_old_peer() {
 
     let dealer_b = Socket::new(SocketType::Dealer, no_reconnect);
     dealer_b.connect(ep).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    dealer_b
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("dealer b did not connect");
 
     dealer_b.send(Message::single("world")).await.unwrap();
     let got = tokio::time::timeout(Duration::from_millis(500), router.recv())
@@ -652,8 +685,10 @@ async fn router_handover_auto_identity_no_collision() {
 
     let d2 = Socket::new(SocketType::Dealer, Options::default());
     d2.connect(ep).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    router
+        .wait_connected(2, Duration::from_secs(1))
+        .await
+        .expect("router did not see both dealers");
 
     d1.send(Message::single("a")).await.unwrap();
     d2.send(Message::single("b")).await.unwrap();
@@ -697,7 +732,10 @@ async fn server_handover_evicts_old_peer() {
 
     let client_a = Socket::new(SocketType::Client, no_reconnect.clone());
     client_a.connect(ep.clone()).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    client_a
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("client a did not connect");
 
     client_a.send(Message::single("ping")).await.unwrap();
     let got = tokio::time::timeout(Duration::from_millis(500), server.recv())
@@ -708,7 +746,10 @@ async fn server_handover_evicts_old_peer() {
 
     let client_b = Socket::new(SocketType::Client, no_reconnect);
     client_b.connect(ep).await.unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    client_b
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .expect("client b did not connect");
 
     // Verify handover monitor event.
     let mut found = false;

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, Instant};
 
 use omq_tokio::Endpoint;
 use omq_tokio::endpoint::Host;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 // ---------------------------------------------------------------------------
 // Tracking allocator
@@ -67,6 +69,19 @@ pub fn soak_duration() -> Duration {
 
 pub fn build_context() -> omq_tokio::Context {
     omq_tokio::Context::with_config(omq_tokio::ContextConfig::from_env())
+}
+
+pub fn seeded_rng(label: &str) -> StdRng {
+    let seed: u64 = std::env::var("OMQ_SOAK_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| {
+            let mut s = [0u8; 8];
+            rand::rng().fill_bytes(&mut s);
+            u64::from_le_bytes(s)
+        });
+    eprintln!("[{label}] OMQ_SOAK_SEED={seed}");
+    StdRng::seed_from_u64(seed)
 }
 
 // ---------------------------------------------------------------------------

--- a/omq-tokio/tests/test_support/mod.rs
+++ b/omq-tokio/tests/test_support/mod.rs
@@ -105,6 +105,30 @@ pub async fn assert_no_second_connection(sock: &Socket, context: &str) {
     assert!(second.is_err(), "{context}: duplicate connection appeared");
 }
 
+pub async fn wait_for_connection_count(
+    sock: &Socket,
+    expected: usize,
+    timeout: Duration,
+    context: &str,
+) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let actual = sock
+            .connections()
+            .await
+            .unwrap_or_else(|e| panic!("{context}: failed to read connections: {e:?}"))
+            .len();
+        if actual == expected {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "{context}: expected {expected} connections, got {actual}"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub fn open_fd_count() -> Option<usize> {
     Some(std::fs::read_dir("/proc/self/fd").ok()?.count())

--- a/omq-tokio/tests/zstd_tcp.rs
+++ b/omq-tokio/tests/zstd_tcp.rs
@@ -80,6 +80,40 @@ async fn expect_payload(sock: &Socket, expected: &Bytes, label: &str) {
     assert_eq!(got.part_bytes(0).unwrap(), &expected[..]);
 }
 
+fn payload_seq(payload: &[u8]) -> Option<u64> {
+    let marker = b"\"seq\":";
+    let start = payload
+        .windows(marker.len())
+        .position(|window| window == marker)?
+        + marker.len();
+    let mut seq = 0u64;
+    let mut saw_digit = false;
+    for &byte in &payload[start..] {
+        if !byte.is_ascii_digit() {
+            break;
+        }
+        saw_digit = true;
+        seq = seq.checked_mul(10)?.checked_add(u64::from(byte - b'0'))?;
+    }
+    saw_digit.then_some(seq)
+}
+
+async fn expect_payload_seq_at_least(sock: &Socket, min_seq: u64, label: &str) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let got = sock.recv().await.unwrap();
+            let part = got.part_bytes(0).unwrap();
+            let seq = payload_seq(&part)
+                .unwrap_or_else(|| panic!("{label} received unparseable payload"));
+            if seq >= min_seq {
+                return;
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{label} missed payload at or after seq {min_seq}"));
+}
+
 #[derive(Clone, Copy)]
 enum FanoutSendMode {
     Send,
@@ -366,16 +400,10 @@ async fn run_pub_sub_zstd_io_lane_auto_train_dict_for_late_subscriber(mode: Fano
         ))
     };
     for seq in 0..128 {
-        let expected = payload(seq);
-        send_fanout(&publisher, Message::single(expected.clone()), mode).await;
-        for (idx, sub) in decoded_subs.iter().enumerate() {
-            expect_payload(
-                sub,
-                &expected,
-                &format!("decoded sub {idx} training seq {seq}"),
-            )
-            .await;
-        }
+        send_fanout(&publisher, Message::single(payload(seq)), mode).await;
+    }
+    for (idx, sub) in decoded_subs.iter().enumerate() {
+        expect_payload_seq_at_least(sub, 127, &format!("decoded sub {idx} training tail")).await;
     }
 
     raw.connect(tcp_from_zstd(&ep)).await.unwrap();

--- a/scripts/ci-run-with-forensics.sh
+++ b/scripts/ci-run-with-forensics.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Run one long CI command. If it exceeds the timeout, dump enough local
+# process state for hang diagnosis before terminating the command tree.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <label> <timeout-seconds> -- <command> [args...]" >&2
+}
+
+if [[ $# -lt 3 ]]; then
+    usage
+    exit 2
+fi
+
+label=$1
+timeout_seconds=$2
+shift 2
+
+if [[ "${1:-}" == "--" ]]; then
+    shift
+fi
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+cmd=("$@")
+start_epoch=$(date +%s)
+safe_label="$(printf '%s' "$label" | tr -c 'A-Za-z0-9_.-' '_')"
+forensics_dir="${OMQ_FORENSICS_DIR:-target/hang-forensics}"
+mkdir -p "$forensics_dir"
+log_file="$forensics_dir/${safe_label}.log"
+: >"$log_file"
+
+log() {
+    printf '%s\n' "$*" | tee -a "$log_file"
+}
+
+run_capture() {
+    local title=$1
+    shift
+    log "--- $title ---"
+    "$@" 2>&1 | tee -a "$log_file" || true
+}
+
+dump_proc_stacks() {
+    [[ -d /proc ]] || return 0
+
+    log "--- proc stacks ---"
+    local pids=()
+    if command -v pgrep >/dev/null 2>&1; then
+        mapfile -t pids < <(
+            pgrep -f 'cargo|nextest|target/.*/deps|cross|qemu|pytest|python|miri' \
+                2>/dev/null || true
+        )
+    fi
+
+    if [[ ${#pids[@]} -eq 0 ]]; then
+        log "no matching pids"
+        return 0
+    fi
+
+    local pid task tid cmdline wchan
+    for pid in "${pids[@]}"; do
+        [[ "$pid" =~ ^[0-9]+$ ]] || continue
+        [[ -d "/proc/$pid" ]] || continue
+        cmdline="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)"
+        log "pid=$pid cmd=${cmdline:-unknown}"
+
+        if [[ -d "/proc/$pid/task" ]]; then
+            for task in /proc/"$pid"/task/*; do
+                [[ -d "$task" ]] || continue
+                tid="${task##*/}"
+                wchan="$(cat "$task/wchan" 2>/dev/null || true)"
+                log "tid=$tid wchan=${wchan:-unknown}"
+                if [[ -r "$task/stack" ]]; then
+                    cat "$task/stack" 2>/dev/null | tee -a "$log_file" || true
+                else
+                    log "stack unreadable"
+                fi
+            done
+        elif [[ -r "/proc/$pid/stack" ]]; then
+            cat "/proc/$pid/stack" 2>/dev/null | tee -a "$log_file" || true
+        else
+            log "stack unreadable"
+        fi
+    done
+}
+
+dump_forensics() {
+    local reason=$1
+    local now elapsed
+    now=$(date +%s)
+    elapsed=$((now - start_epoch))
+
+    log "::group::hang forensics: $label"
+    log "reason=$reason"
+    log "label=$label"
+    log "elapsed_seconds=$elapsed"
+    log "timeout_seconds=$timeout_seconds"
+    printf 'command:' | tee -a "$log_file"
+    printf ' %q' "${cmd[@]}" | tee -a "$log_file"
+    printf '\n' | tee -a "$log_file"
+    run_capture "date" date -u
+    run_capture "uname" uname -a
+    run_capture "process tree" ps -eo pid,ppid,pgid,sid,stat,etime,comm,args --forest
+    if command -v pgrep >/dev/null 2>&1; then
+        run_capture "matching processes" \
+            pgrep -af 'cargo|nextest|target/.*/deps|cross|qemu|pytest|python|miri'
+    fi
+    dump_proc_stacks
+    log "::endgroup::"
+}
+
+kill_tree() {
+    local pid=$1
+    local child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        kill_tree "$child"
+    done
+    kill -TERM "$pid" 2>/dev/null || true
+}
+
+"${cmd[@]}" &
+child=$!
+
+while kill -0 "$child" 2>/dev/null; do
+    now=$(date +%s)
+    elapsed=$((now - start_epoch))
+    if ((elapsed >= timeout_seconds)); then
+        dump_forensics "timeout"
+        kill_tree "$child"
+        sleep 5
+        kill -KILL "$child" 2>/dev/null || true
+        wait "$child" 2>/dev/null || true
+        exit 124
+    fi
+    sleep 1
+done
+
+set +e
+wait "$child"
+rc=$?
+set -e
+exit "$rc"

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -344,6 +344,12 @@ mod tests {
 
     use super::*;
 
+    // CI runs Miri with many seeds. Keep cross-thread coverage without turning
+    // per-seed validation into a throughput test.
+    fn miri_sized(n: u64) -> u64 {
+        if cfg!(miri) { 2_048 } else { n }
+    }
+
     #[test]
     fn async_push_pop() {
         let (mut p, mut c) = async_spsc::<u32>(4);
@@ -427,7 +433,7 @@ mod tests {
     #[test]
     fn cross_thread_stream() {
         let (mut p, c) = async_spsc::<u64>(1024);
-        let n = 50_000u64;
+        let n = miri_sized(50_000);
 
         let receiver = std::thread::spawn(move || {
             futures_lite::future::block_on(async {
@@ -532,7 +538,7 @@ mod tests {
     #[test]
     fn push_async_cross_thread() {
         let (mut p, c) = async_spsc::<u64>(64);
-        let n = 100_000u64;
+        let n = miri_sized(100_000);
 
         let receiver = std::thread::spawn(move || {
             futures_lite::future::block_on(async {

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -578,6 +578,12 @@ impl<T> std::fmt::Debug for Consumer<T> {
 mod tests {
     use super::*;
 
+    // CI runs Miri with many seeds. Keep cross-thread coverage without turning
+    // per-seed validation into a throughput test.
+    fn miri_sized(n: u64) -> u64 {
+        if cfg!(miri) { 2_048 } else { n }
+    }
+
     #[test]
     fn push_pop_basic() {
         let (mut p, mut c) = spsc::<u32>(4);
@@ -916,7 +922,7 @@ mod tests {
     #[test]
     fn cross_thread() {
         let (mut p, mut c) = spsc::<u64>(1024);
-        let n = 100_000u64;
+        let n = miri_sized(100_000);
         let sender = std::thread::spawn(move || {
             for i in 0..n {
                 while p.push(i).is_err() {


### PR DESCRIPTION
- Split extended soak coverage into replayable grouped jobs with optional `OMQ_SOAK_SEED`.
- Add `scripts/ci-run-with-forensics.sh` to collect process and `/proc` stack state when long CI commands time out.
- Replace targeted timing sleeps with readiness waits in transport, proxy, and soak tests.
- Cap `yring` cross-thread stress counts under `cfg!(miri)` so `-Zmiri-many-seeds` validates memory behavior without throughput-scale work per seed.
- Reserve all `nextest` threads for the `zstd` fan-out dictionary tests in the `ci` profile.
- Drain decoded subscribers through the `zstd` training tail before attaching the raw late subscriber.
- Make the `PULL` conflate test assert post-burst latest visibility instead of first-receive ordering.
- Clear stale fan-out lane data readiness after empty drains so owned IO runtime shutdown cannot spin.
- Give `bindings/pyomq` its own `nextest` `ci` profile so pyomq jobs do not parse root workspace overrides for `omq-tokio` binaries.