### PR TITLE
Harden soak reconnect stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,32 @@ jobs:
           tool: cross
       - uses: Swatinem/rust-cache@v2
       - name: compile workspace
-        run: cross check --target ${{ matrix.target }} --workspace --all-targets --all-features
+        run: |
+          if [[ "${{ matrix.target }}" == "armv7-unknown-linux-gnueabihf" ]]; then
+            # `ws` pulls in `ring`, whose debug C build passes an x86-only
+            # frame-pointer flag through this armv7 cross compiler. i686
+            # still covers 32-bit `--all-targets --all-features`.
+            features=(
+              omq-proto/plain
+              omq-proto/curve
+              omq-proto/lz4
+              omq-proto/zstd
+              omq-tokio/plain
+              omq-tokio/curve
+              omq-tokio/lz4
+              omq-tokio/zstd
+            )
+            cross check --target ${{ matrix.target }} \
+              -p yring -p omq-proto -p omq-tokio -p omq-libzmq \
+              --features "${features[*]}" \
+              --lib --bins
+          else
+            cross check --target ${{ matrix.target }} --workspace --all-targets --all-features
+          fi
       - name: yring tests
         run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p yring --all-features
       - name: tokio tcp smoke tests
+        if: matrix.target != 'armv7-unknown-linux-gnueabihf'
         run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-tokio --test omq_tcp_smoke
       - name: proto lz4 tests
         run: bash scripts/ci-cross-test-timeout.sh ${{ matrix.target }} -p omq-proto --features lz4 --lib

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +66,18 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -99,7 +120,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "crypto_secretbox",
+ "curve25519-dalek 4.1.3",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -111,7 +177,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "fiat-crypto",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -127,6 +193,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -250,6 +322,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -261,7 +345,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -269,6 +353,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "lazy_static"
@@ -385,10 +478,11 @@ name = "omq-proto"
 version = "0.25.0"
 dependencies = [
  "bytes",
+ "crypto_box",
+ "crypto_secretbox",
  "lz4rip",
  "patricia_tree",
  "rand",
- "salsabox",
  "smallvec",
  "socket2",
  "subtle",
@@ -564,8 +658,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -613,12 +716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "salsabox"
-version = "0.1.0"
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "poly1305",
- "subtle",
- "zeroize",
+ "cipher",
 ]
 
 [[package]]
@@ -1002,9 +1105,9 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek",
- "getrandom",
- "rand_core",
+ "curve25519-dalek 5.0.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,18 +56,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
+ "rand_core",
 ]
 
 [[package]]
@@ -120,52 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "crypto_box"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
-dependencies = [
- "aead",
- "crypto_secretbox",
- "curve25519-dalek 4.1.3",
- "salsa20",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto_secretbox"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
-dependencies = [
- "aead",
- "cipher",
- "generic-array",
- "poly1305",
- "salsa20",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -177,7 +111,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -193,12 +127,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -322,18 +250,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -345,7 +261,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -353,15 +269,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "lazy_static"
@@ -478,11 +385,10 @@ name = "omq-proto"
 version = "0.25.0"
 dependencies = [
  "bytes",
- "crypto_box",
- "crypto_secretbox",
  "lz4rip",
  "patricia_tree",
  "rand",
+ "salsabox",
  "smallvec",
  "socket2",
  "subtle",
@@ -658,17 +564,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -716,12 +613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+name = "salsabox"
+version = "0.1.0"
 dependencies = [
- "cipher",
+ "poly1305",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1105,9 +1002,9 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek 5.0.0",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "curve25519-dalek",
+ "getrandom",
+ "rand_core",
  "zeroize",
 ]
 

--- a/omq-tokio/src/blocking.rs
+++ b/omq-tokio/src/blocking.rs
@@ -103,6 +103,10 @@ impl Socket {
         self.inner.blocking_recv()
     }
 
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<Message> {
+        self.inner.blocking_recv_timeout(timeout)
+    }
+
     pub fn try_recv(&self) -> Result<Message> {
         self.inner.try_recv()
     }

--- a/omq-tokio/src/socket/actor/lifecycle.rs
+++ b/omq-tokio/src/socket/actor/lifecycle.rs
@@ -32,6 +32,7 @@ impl<'a> PeerLifecycle<'a> {
         }
         self.publish_disconnect(peer.as_ref(), reason);
         Self::invalidate_spsc(peer.as_ref());
+        self.driver.spsc.remove_empty_tcp_consumer(peer_id);
         self.update_send_ring();
         self.invalidate_transmit_slot(peer.as_ref());
         self.refill_recv_sink();

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -537,6 +537,57 @@ impl Socket {
         }
     }
 
+    /// Blocking receive with a timeout for sync callers.
+    pub(crate) fn blocking_recv_timeout(&self, timeout: std::time::Duration) -> Result<Message> {
+        let now = std::time::Instant::now();
+        let Some(deadline) = now.checked_add(timeout) else {
+            return self.blocking_recv();
+        };
+        match self.inner.socket_type {
+            SocketType::Req => loop {
+                let mut msg = self.inner.recv_rx.blocking_recv_until(deadline)?;
+                match msg.pop_front() {
+                    Some(delim) if delim.is_empty() => {}
+                    _ => continue,
+                }
+                self.inner
+                    .req_awaiting_reply
+                    .store(false, Ordering::Release);
+                return Ok(msg);
+            },
+            SocketType::Rep => loop {
+                let msg = self.inner.recv_rx.blocking_recv_until(deadline)?;
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(msg);
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(body);
+                }
+            },
+            _ => self.inner.recv_rx.blocking_recv_timeout(timeout),
+        }
+    }
+
     /// Non-blocking receive. Returns `Err(Error::WouldBlock)` if no message is
     /// currently queued. Does not drive the I/O engine; messages already
     /// delivered by the background driver are visible.

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -372,6 +372,26 @@ impl SpscHandles {
             conflate_slot,
         }
     }
+
+    pub(crate) fn remove_empty_tcp_consumer(&self, peer_id: u64) {
+        let mut removed = false;
+        self.tcp_consumers.write().unwrap().retain(|tc| {
+            if tc.peer_id != peer_id {
+                return true;
+            }
+            let keep = tc
+                .consumer
+                .try_lock()
+                .map_or(true, |consumer| !consumer.is_empty());
+            removed |= !keep;
+            keep
+        });
+
+        if removed {
+            self.consumer_generation.fetch_add(1, Ordering::Release);
+            self.activated.notify_changed();
+        }
+    }
 }
 
 /// Recv channel that integrates per-peer SPSC awareness. Fair-queues
@@ -1087,11 +1107,55 @@ impl SpscAwareRecv {
 #[cfg(test)]
 mod tests {
     use super::{
-        RECV_BATCH_BYTES, RECV_BATCH_MESSAGES, RecvItem, RecvSource, drain_yring, drain_yring_one,
-        drain_yring_one_into_batch, recv_source_at,
+        BlockingRecvWaker, RECV_BATCH_BYTES, RECV_BATCH_MESSAGES, RecvItem, RecvSource,
+        SpscHandles, TcpYringConsumer, drain_yring, drain_yring_one, drain_yring_one_into_batch,
+        recv_source_at,
     };
     use omq_proto::Message;
     use omq_proto::flow::DrainBudget;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn tcp_consumer(peer_id: u64) -> (yring::Producer<RecvItem>, Arc<TcpYringConsumer>) {
+        let (producer, consumer) = yring::spsc(4);
+        (
+            producer,
+            Arc::new(TcpYringConsumer {
+                consumer: std::sync::Mutex::new(consumer),
+                batch_remaining: AtomicUsize::new(0),
+                space: Arc::new(crate::engine::signal::StateSignal::new()),
+                peer_id,
+            }),
+        )
+    }
+
+    #[test]
+    fn remove_empty_tcp_consumer_drops_empty_peer_ring() {
+        let handles = SpscHandles::new(BlockingRecvWaker::new(), false);
+        let (_producer, consumer) = tcp_consumer(7);
+        handles.tcp_consumers.write().unwrap().push(consumer);
+
+        handles.remove_empty_tcp_consumer(7);
+
+        assert!(handles.tcp_consumers.read().unwrap().is_empty());
+        assert_eq!(handles.consumer_generation.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn remove_empty_tcp_consumer_keeps_unread_messages() {
+        let handles = SpscHandles::new(BlockingRecvWaker::new(), false);
+        let (mut producer, consumer) = tcp_consumer(7);
+        producer
+            .push(RecvItem::new(Message::from_slice(b"queued")))
+            .unwrap();
+        producer.flush();
+        handles.tcp_consumers.write().unwrap().push(consumer);
+
+        handles.remove_empty_tcp_consumer(7);
+
+        assert_eq!(handles.tcp_consumers.read().unwrap().len(), 1);
+        assert_eq!(handles.consumer_generation.load(Ordering::Acquire), 0);
+    }
 
     #[test]
     fn latency_drain_keeps_prefetched_batch_open() {

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -4,6 +4,7 @@
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
 use omq_proto::error::{Error, Result};
@@ -649,6 +650,51 @@ impl SpscAwareRecv {
                         continue;
                     }
                     std::thread::park();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn blocking_recv_timeout(&self, timeout: Duration) -> Result<Message> {
+        let now = Instant::now();
+        let Some(deadline) = now.checked_add(timeout) else {
+            return self.blocking_recv();
+        };
+        self.blocking_recv_until(deadline)
+    }
+
+    pub(crate) fn blocking_recv_until(&self, deadline: Instant) -> Result<Message> {
+        self.blocking_recv_waker.register(std::thread::current());
+        loop {
+            match self.try_drain() {
+                DrainResult::Message(msg) => return Ok(msg),
+                DrainResult::Closed => return Err(Error::Closed),
+                DrainResult::Empty => {}
+            }
+            self.blocking_recv_waker.prepare_sleep();
+            match self.try_drain() {
+                DrainResult::Message(msg) => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Ok(msg);
+                }
+                DrainResult::Closed => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Err(Error::Closed);
+                }
+                DrainResult::Empty => {
+                    if !self.buffered_sources_empty() {
+                        self.blocking_recv_waker.cancel_sleep();
+                        if Instant::now() >= deadline {
+                            return Err(Error::Timeout);
+                        }
+                        continue;
+                    }
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        self.blocking_recv_waker.cancel_sleep();
+                        return Err(Error::Timeout);
+                    }
+                    std::thread::park_timeout(remaining);
                 }
             }
         }

--- a/omq-tokio/tests/context.rs
+++ b/omq-tokio/tests/context.rs
@@ -6,7 +6,7 @@ mod test_support;
 use std::time::Duration;
 
 use omq_proto::endpoint::Host;
-use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType};
+use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType, error::Error};
 
 fn tcp_loopback(port: u16) -> Endpoint {
     Endpoint::Tcp {
@@ -590,6 +590,94 @@ fn blocking_socket_pub_sub() {
     }
     let m = recv_thread.join().unwrap();
     assert_eq!(m, Message::single("msg"));
+}
+
+#[test]
+fn blocking_socket_recv_timeout_empty_returns_timeout() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+
+    let start = std::time::Instant::now();
+    let result = pull.recv_timeout(Duration::from_millis(50));
+
+    assert!(matches!(result, Err(Error::Timeout)));
+    assert!(start.elapsed() >= Duration::from_millis(25));
+}
+
+#[test]
+fn blocking_socket_recv_timeout_zero_receives_queued_message() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+
+    let ep = inproc_ep("blocking-timeout-queued");
+    pull.bind(ep.clone()).unwrap();
+    push.connect(ep).unwrap();
+
+    push.send(Message::single("queued")).unwrap();
+    let m = pull.recv_timeout(Duration::ZERO).unwrap();
+
+    assert_eq!(m, Message::single("queued"));
+}
+
+#[test]
+fn blocking_socket_recv_timeout_wakes_on_late_message() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+    let push = ctx.blocking_socket(SocketType::Push, Options::default());
+
+    let ep = inproc_ep("blocking-timeout-wake");
+    pull.bind(ep.clone()).unwrap();
+    push.connect(ep).unwrap();
+
+    let receiver = pull.clone();
+    let recv_thread =
+        std::thread::spawn(move || receiver.recv_timeout(Duration::from_secs(1)).unwrap());
+    std::thread::sleep(Duration::from_millis(25));
+    push.send(Message::single("late")).unwrap();
+
+    let m = recv_thread.join().unwrap();
+    assert_eq!(m, Message::single("late"));
+}
+
+#[test]
+fn blocking_socket_recv_timeout_wakes_on_close() {
+    let ctx = Context::new();
+    let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+
+    let receiver = pull.clone();
+    let recv_thread = std::thread::spawn(move || receiver.recv_timeout(Duration::from_secs(1)));
+    std::thread::sleep(Duration::from_millis(25));
+    pull.close().unwrap();
+
+    let result = recv_thread.join().unwrap();
+    assert!(matches!(result, Err(Error::Closed)));
+}
+
+#[test]
+fn blocking_socket_req_recv_timeout_does_not_poison_socket() {
+    let ctx = Context::new();
+    let rep = ctx.blocking_socket(SocketType::Rep, Options::default());
+    let req = ctx.blocking_socket(SocketType::Req, Options::default());
+
+    let ep = inproc_ep("blocking-timeout-req");
+    rep.bind(ep.clone()).unwrap();
+    req.connect(ep).unwrap();
+
+    req.send(Message::single("question")).unwrap();
+    let timed_out = req.recv_timeout(Duration::from_millis(20));
+    assert!(matches!(timed_out, Err(Error::Timeout)));
+
+    let q = rep.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(q, Message::single("question"));
+    rep.send(Message::single("answer")).unwrap();
+
+    let a = req.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(a, Message::single("answer"));
+
+    req.send(Message::single("next")).unwrap();
+    let next = rep.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(next, Message::single("next"));
 }
 
 #[test]

--- a/omq-tokio/tests/omq_soak_pub_sub_realworld_churn_tcp.rs
+++ b/omq-tokio/tests/omq_soak_pub_sub_realworld_churn_tcp.rs
@@ -20,6 +20,7 @@ const PHASE_TARGETS: &[usize] = &[0, 1, 12, 3, 0];
 const TOPICS: &[&[u8]] = &[b"a.", b"b.", b"c.", b"d."];
 const PAYLOAD_LEN: usize = 96;
 const SEND_BATCH: usize = 256;
+const SOAK_HWM: u32 = 8_192;
 const SEND_TIMEOUT: Duration = Duration::from_secs(2);
 const PHASE_WARMUP: Duration = Duration::from_millis(300);
 const DEFAULT_PHASE_DURATION: Duration = Duration::from_secs(3);
@@ -75,15 +76,15 @@ fn reset_measurement_after_pause(
 
 fn pub_options() -> Options {
     soak_common::soak_options()
-        .send_hwm(65_536)
-        .recv_hwm(65_536)
+        .send_hwm(SOAK_HWM)
+        .recv_hwm(SOAK_HWM)
         .on_mute(OnMute::DropNewest)
 }
 
 fn sub_options() -> Options {
     Options {
         reconnect: ReconnectPolicy::Disabled,
-        ..soak_common::soak_options().recv_hwm(65_536)
+        ..soak_common::soak_options().recv_hwm(SOAK_HWM)
     }
 }
 

--- a/omq-tokio/tests/omq_soak_pub_sub_realworld_churn_tcp.rs
+++ b/omq-tokio/tests/omq_soak_pub_sub_realworld_churn_tcp.rs
@@ -27,6 +27,51 @@ const SHORT_PHASE_DURATION: Duration = Duration::from_secs(1);
 const MIN_SEND_MSGS_PER_SEC: f64 = 5_000.0;
 const MAX_GAP_RATIO: f64 = 0.01;
 const MIN_EXPECTED_FOR_GAP_CHECK: u64 = 1_000;
+const EXTERNAL_PAUSE_THRESHOLD: Duration = Duration::from_secs(10);
+
+fn active_elapsed(start: Instant, paused: Duration) -> Duration {
+    start.elapsed().saturating_sub(paused)
+}
+
+fn account_external_pause(
+    label: &str,
+    last_progress: &mut Instant,
+    run_paused: &mut Duration,
+    phase_paused: &mut Duration,
+) -> bool {
+    let now = Instant::now();
+    let idle = now.saturating_duration_since(*last_progress);
+    *last_progress = now;
+
+    if idle < EXTERNAL_PAUSE_THRESHOLD {
+        return false;
+    }
+
+    *run_paused += idle;
+    *phase_paused += idle;
+    eprintln!(
+        "[pub_sub_realworld_churn_tcp] ignored external pause during {label}: {:.1}s",
+        idle.as_secs_f64()
+    );
+    true
+}
+
+fn reset_measurement_after_pause(
+    subs: &mut [SubscriberProbe],
+    seq: u64,
+    measure_start: &mut Instant,
+    sent_at_measure_start: &mut u64,
+    recv_at_measure_start: &mut u64,
+    gaps_at_measure_start: &mut u64,
+) {
+    *measure_start = Instant::now();
+    *sent_at_measure_start = seq;
+    *recv_at_measure_start = subs.iter().map(|s| s.received).sum();
+    *gaps_at_measure_start = subs.iter().map(|s| s.gaps).sum();
+    for sub in subs {
+        sub.reset_gap_window();
+    }
+}
 
 fn pub_options() -> Options {
     soak_common::soak_options()
@@ -214,9 +259,10 @@ fn soak_pub_sub_realworld_churn_tcp() {
         let mut next_sub_id = 0usize;
         let mut phase_idx = 0usize;
         let start = Instant::now();
+        let mut run_paused = Duration::ZERO;
         let mut last_log = start;
 
-        while start.elapsed() < duration {
+        while active_elapsed(start, run_paused) < duration {
             let target = PHASE_TARGETS[phase_idx % PHASE_TARGETS.len()];
             phase_idx += 1;
 
@@ -236,8 +282,31 @@ fn soak_pub_sub_realworld_churn_tcp() {
             let mut recv_at_measure_start = 0u64;
             let mut gaps_at_measure_start = 0u64;
             let mut measure_start = phase_start;
+            let mut phase_paused = Duration::ZERO;
+            let mut last_progress = phase_start;
 
-            while phase_start.elapsed() < phase_duration && start.elapsed() < duration {
+            while active_elapsed(phase_start, phase_paused) < phase_duration
+                && active_elapsed(start, run_paused) < duration
+            {
+                if account_external_pause(
+                    "phase",
+                    &mut last_progress,
+                    &mut run_paused,
+                    &mut phase_paused,
+                ) {
+                    last_log = Instant::now();
+                    if measuring {
+                        reset_measurement_after_pause(
+                            &mut subs,
+                            seq,
+                            &mut measure_start,
+                            &mut sent_at_measure_start,
+                            &mut recv_at_measure_start,
+                            &mut gaps_at_measure_start,
+                        );
+                    }
+                }
+
                 for _ in 0..SEND_BATCH {
                     let msg = Message::single(encode(seq));
                     tokio::time::timeout(SEND_TIMEOUT, publisher.send(msg))
@@ -251,7 +320,7 @@ fn soak_pub_sub_realworld_churn_tcp() {
                     sub.drain();
                 }
 
-                if !measuring && phase_start.elapsed() >= PHASE_WARMUP {
+                if !measuring && active_elapsed(phase_start, phase_paused) >= PHASE_WARMUP {
                     measuring = true;
                     measure_start = Instant::now();
                     sent_at_measure_start = seq;
@@ -269,9 +338,28 @@ fn soak_pub_sub_realworld_churn_tcp() {
                     eprintln!(
                         "[pub_sub_realworld_churn_tcp] {:.0}s, phase_target {target}, \
                          sent {seq}, received {received}, gaps {gaps}",
-                        start.elapsed().as_secs_f64(),
+                        active_elapsed(start, run_paused).as_secs_f64(),
                     );
                     last_log = Instant::now();
+                }
+
+                if account_external_pause(
+                    "phase work",
+                    &mut last_progress,
+                    &mut run_paused,
+                    &mut phase_paused,
+                ) {
+                    last_log = Instant::now();
+                    if measuring {
+                        reset_measurement_after_pause(
+                            &mut subs,
+                            seq,
+                            &mut measure_start,
+                            &mut sent_at_measure_start,
+                            &mut recv_at_measure_start,
+                            &mut gaps_at_measure_start,
+                        );
+                    }
                 }
 
                 tokio::task::yield_now().await;

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -110,7 +110,7 @@ type Samples = (
 );
 
 const LIVE_GROWTH_WARMUP: Duration = Duration::from_secs(30);
-const LIVE_GROWTH_WINDOW: Duration = Duration::from_secs(120);
+const LIVE_GROWTH_WINDOW: Duration = Duration::from_mins(2);
 const LIVE_GROWTH_MIN_SAMPLES: usize = 30;
 const LIVE_HEAP_SLOPE_LIMIT_KIB_S: f64 = 512.0;
 const LIVE_HEAP_GROWTH_MIN_BYTES: usize = 64 * 1024 * 1024;
@@ -216,7 +216,9 @@ fn assert_live_growth_stable(
         return;
     }
 
-    let window_start = now - LIVE_GROWTH_WINDOW;
+    let Some(window_start) = now.checked_sub(LIVE_GROWTH_WINDOW) else {
+        return;
+    };
     let first = samples
         .iter()
         .position(|(t, _)| *t >= window_start)

--- a/omq-tokio/tests/soak_common/mod.rs
+++ b/omq-tokio/tests/soak_common/mod.rs
@@ -109,6 +109,14 @@ type Samples = (
     Vec<(Instant, usize)>,
 );
 
+const LIVE_GROWTH_WARMUP: Duration = Duration::from_secs(30);
+const LIVE_GROWTH_WINDOW: Duration = Duration::from_secs(120);
+const LIVE_GROWTH_MIN_SAMPLES: usize = 30;
+const LIVE_HEAP_SLOPE_LIMIT_KIB_S: f64 = 512.0;
+const LIVE_HEAP_GROWTH_MIN_BYTES: usize = 64 * 1024 * 1024;
+const LIVE_RSS_SLOPE_LIMIT_KIB_S: f64 = 1024.0;
+const LIVE_RSS_GROWTH_MIN_BYTES: usize = 128 * 1024 * 1024;
+
 pub struct ResourceMonitor {
     stop: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<Samples>>,
@@ -118,9 +126,11 @@ pub struct ResourceMonitor {
 impl ResourceMonitor {
     pub fn start() -> Self {
         let heap_baseline = alloc::LIVE_BYTES.load(std::sync::atomic::Ordering::Relaxed);
+        let label = std::thread::current().name().unwrap_or("soak").to_owned();
         let stop = Arc::new(AtomicBool::new(false));
         let stop2 = stop.clone();
         let handle = std::thread::spawn(move || {
+            let started = Instant::now();
             let mut rss_samples = Vec::new();
             let mut fd_samples = Vec::new();
             let mut heap_samples = Vec::new();
@@ -128,11 +138,27 @@ impl ResourceMonitor {
                 let now = Instant::now();
                 if let Some(rss) = read_rss_bytes() {
                     rss_samples.push((now, rss));
+                    assert_live_growth_stable(
+                        &label,
+                        "RSS",
+                        started,
+                        &rss_samples,
+                        LIVE_RSS_SLOPE_LIMIT_KIB_S,
+                        LIVE_RSS_GROWTH_MIN_BYTES,
+                    );
                 }
                 if let Some(fds) = read_fd_count() {
                     fd_samples.push((now, fds));
                 }
                 heap_samples.push((now, alloc::LIVE_BYTES.load(Ordering::Relaxed)));
+                assert_live_growth_stable(
+                    &label,
+                    "heap",
+                    started,
+                    &heap_samples,
+                    LIVE_HEAP_SLOPE_LIMIT_KIB_S,
+                    LIVE_HEAP_GROWTH_MIN_BYTES,
+                );
                 std::thread::sleep(Duration::from_secs(1));
             }
             (rss_samples, fd_samples, heap_samples)
@@ -173,6 +199,89 @@ fn read_rss_bytes() -> Option<usize> {
 
 fn read_fd_count() -> Option<usize> {
     Some(std::fs::read_dir("/proc/self/fd").ok()?.count())
+}
+
+fn assert_live_growth_stable(
+    label: &str,
+    metric: &str,
+    started: Instant,
+    samples: &[(Instant, usize)],
+    slope_limit_kib_s: f64,
+    min_growth_bytes: usize,
+) {
+    let Some((now, current)) = samples.last().copied() else {
+        return;
+    };
+    if now.duration_since(started) < LIVE_GROWTH_WARMUP + LIVE_GROWTH_WINDOW {
+        return;
+    }
+
+    let window_start = now - LIVE_GROWTH_WINDOW;
+    let first = samples
+        .iter()
+        .position(|(t, _)| *t >= window_start)
+        .unwrap_or(0);
+    let window = &samples[first..];
+    if window.len() < LIVE_GROWTH_MIN_SAMPLES {
+        return;
+    }
+
+    let window_growth = current.saturating_sub(window.first().unwrap().1);
+    if window_growth < min_growth_bytes {
+        return;
+    }
+
+    let Some(slope_bytes_per_sec) = slope_bytes_per_sec(window) else {
+        return;
+    };
+    let slope_kib_s = slope_bytes_per_sec / 1024.0;
+    if slope_kib_s <= slope_limit_kib_s {
+        return;
+    }
+
+    eprintln!(
+        "[{label}] live {metric} growth detected: slope {slope_kib_s:.1} KiB/s over {:.0}s, \
+         growth {:.1} MiB, current {:.1} MiB (limit {slope_limit_kib_s:.1} KiB/s and {:.1} MiB); \
+         failing before OOM",
+        LIVE_GROWTH_WINDOW.as_secs_f64(),
+        window_growth as f64 / 1_048_576.0,
+        current as f64 / 1_048_576.0,
+        min_growth_bytes as f64 / 1_048_576.0,
+    );
+    std::process::exit(101);
+}
+
+fn slope_bytes_per_sec(samples: &[(Instant, usize)]) -> Option<f64> {
+    let first_t = samples.first()?.0;
+    let elapsed_secs = samples.last()?.0.duration_since(first_t).as_secs_f64();
+    if elapsed_secs < 1.0 {
+        return None;
+    }
+
+    let n_f = samples.len() as f64;
+    let sum_x: f64 = samples
+        .iter()
+        .map(|(t, _)| t.duration_since(first_t).as_secs_f64())
+        .sum();
+    let sum_y: f64 = samples.iter().map(|(_, v)| *v as f64).sum();
+    let dot_xy: f64 = samples
+        .iter()
+        .map(|(t, v)| t.duration_since(first_t).as_secs_f64() * *v as f64)
+        .sum();
+    let sum_xx: f64 = samples
+        .iter()
+        .map(|(t, _)| {
+            let x = t.duration_since(first_t).as_secs_f64();
+            x * x
+        })
+        .sum();
+
+    let denom = n_f * sum_xx - sum_x * sum_x;
+    if denom == 0.0 {
+        None
+    } else {
+        Some((n_f * dot_xy - sum_x * sum_y) / denom)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -218,38 +327,13 @@ impl ResourceReport {
             return;
         }
 
-        let first_t = post_warmup.first().unwrap().0;
-        let elapsed_secs = post_warmup
-            .last()
-            .unwrap()
-            .0
-            .duration_since(first_t)
-            .as_secs_f64();
-        if elapsed_secs < 1.0 {
+        let Some(slope_bytes_per_sec) = slope_bytes_per_sec(post_warmup) else {
             return;
-        }
-
-        let n_f = post_warmup.len() as f64;
-        let sum_x: f64 = post_warmup
-            .iter()
-            .map(|(t, _)| t.duration_since(first_t).as_secs_f64())
-            .sum();
+        };
         let sum_y: f64 = post_warmup.iter().map(|(_, v)| *v as f64).sum();
-        let dot_xy: f64 = post_warmup
-            .iter()
-            .map(|(t, v)| t.duration_since(first_t).as_secs_f64() * *v as f64)
-            .sum();
-        let sum_xx: f64 = post_warmup
-            .iter()
-            .map(|(t, _)| {
-                let x = t.duration_since(first_t).as_secs_f64();
-                x * x
-            })
-            .sum();
 
-        let slope_bytes_per_sec = (n_f * dot_xy - sum_x * sum_y) / (n_f * sum_xx - sum_x * sum_x);
         let slope_kib_s = slope_bytes_per_sec / 1024.0;
-        let avg: f64 = sum_y / n_f;
+        let avg: f64 = sum_y / post_warmup.len() as f64;
 
         eprintln!(
             "[{label}] heap: avg {:.1} MiB, slope {slope_kib_s:.1} KiB/s (informational)",


### PR DESCRIPTION
- Add blocking recv timeout plumbing so soak tests can bound blocking receive waits.
- Track live allocator bytes in soak tests and account for long external pauses during pub/sub churn phases.
- Reduce real-world PUB/SUB churn soak HWM to 8,192 messages to avoid inflated per-subscriber recv ring allocation.
- Fix all-features soak clippy warnings and refresh the excluded pyomq lockfile for current CURVE deps.
- Keep armv7 CI off the `ws`/`ring` cross-build path while i686 retains full 32-bit all-features coverage.