### PR TITLE
Restore medium-large direct recv throughput

### DIFF
--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 950 482" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
 <rect x="0" y="0" width="950" height="482" opacity="1" fill="#000000" stroke="none"/>
 <text x="475" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUSH/PULL throughput, TCP loopback, 2-process</text>
-<text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 6 cores, performance governor, turbo off</text>
+<text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 12 cores, performance governor, turbo off</text>
 <text x="227" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 small messages (higher is better)
 </text>
@@ -13,54 +13,49 @@ small messages (higher is better)
 <line opacity="1" stroke="#374151" stroke-width="1" x1="383" y1="311" x2="383" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="444" y1="311" x2="444" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="311" x2="444" y2="311"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="283" x2="444" y2="283"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="255" x2="444" y2="255"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="226" x2="444" y2="226"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="198" x2="444" y2="198"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="170" x2="444" y2="170"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="141" x2="444" y2="141"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="113" x2="444" y2="113"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="85" x2="444" y2="85"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="280" x2="444" y2="280"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="248" x2="444" y2="248"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="216" x2="444" y2="216"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="184" x2="444" y2="184"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="152" x2="444" y2="152"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="120" x2="444" y2="120"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="88" x2="444" y2="88"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="56" x2="444" y2="56"/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,56 79,311 "/>
 <text x="70" y="311" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 0/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,311 79,311 "/>
-<text x="70" y="283" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<text x="70" y="280" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,283 79,283 "/>
-<text x="70" y="255" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,280 79,280 "/>
+<text x="70" y="248" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,255 79,255 "/>
-<text x="70" y="226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,248 79,248 "/>
+<text x="70" y="216" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,226 79,226 "/>
-<text x="70" y="198" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,216 79,216 "/>
+<text x="70" y="184" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,198 79,198 "/>
-<text x="70" y="170" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,184 79,184 "/>
+<text x="70" y="152" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,170 79,170 "/>
-<text x="70" y="141" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,152 79,152 "/>
+<text x="70" y="120" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,141 79,141 "/>
-<text x="70" y="113" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,120 79,120 "/>
+<text x="70" y="88" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,113 79,113 "/>
-<text x="70" y="85" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16M/s
-</text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,85 79,85 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,88 79,88 "/>
 <text x="70" y="56" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18M/s
+16M/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,56 79,56 "/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,312 444,312 "/>
@@ -92,119 +87,119 @@ small messages (higher is better)
 1 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="444,312 444,317 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,265 86,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,265 95,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,264 104,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,264 113,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,264 122,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,264 131,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,263 140,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,263 149,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,264 158,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,264 167,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,264 176,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,265 185,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,265 194,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,266 201,266 203,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,266 212,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,267 221,268 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,268 230,268 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,269 239,269 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,269 248,270 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,270 257,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,271 262,271 266,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,271 275,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,271 284,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,271 293,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,272 302,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,272 311,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,272 320,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,272 329,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="332,271 338,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="341,271 347,270 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="350,270 356,270 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="359,270 365,269 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="368,269 374,269 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="377,268 383,268 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="386,268 391,270 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,270 400,271 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,272 409,273 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,273 418,274 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="421,275 427,276 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="430,276 436,278 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="439,278 444,279 "/>
-<circle cx="80" cy="265" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="263" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="266" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="271" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="272" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="268" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="279" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,294 86,293 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,293 95,292 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,292 104,291 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,291 113,290 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,290 122,289 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,289 131,288 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="134,288 140,287 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="143,287 149,287 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="152,287 158,286 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="161,286 167,286 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="170,286 176,286 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="179,286 185,286 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="188,285 194,285 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="197,285 201,285 203,285 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="206,284 211,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,283 220,282 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,281 229,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,280 238,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="241,278 247,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="250,277 256,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="259,276 262,275 265,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="268,275 274,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="277,275 283,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="286,276 292,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="295,276 301,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="304,276 310,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="313,277 319,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="322,277 322,277 328,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="331,277 337,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="340,278 346,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="349,278 355,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="358,279 364,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="367,279 373,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="376,280 382,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="385,280 391,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="394,281 400,281 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="403,281 409,282 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="412,282 418,282 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="421,282 427,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="430,283 436,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="439,284 444,284 "/>
-<circle cx="80" cy="294" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="287" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="285" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="275" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="277" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="280" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="284" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,307 86,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,307 95,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,307 104,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,307 113,307 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,259 86,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,259 95,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,258 104,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,258 113,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,258 122,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,258 131,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,257 140,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,257 149,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,258 158,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,258 167,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,259 176,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,260 185,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,260 194,261 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,261 201,261 203,261 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,261 212,262 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,262 221,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,263 230,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,264 239,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,264 248,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,265 257,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,266 262,266 266,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,266 275,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,266 284,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,266 293,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,267 302,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,267 311,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,267 320,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,267 329,267 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="332,266 338,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="341,266 347,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="350,265 356,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="359,265 365,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="368,264 374,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="377,263 382,263 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="385,263 391,265 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,265 400,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,267 409,268 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,269 418,270 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="421,270 427,272 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="430,272 435,273 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="438,274 444,275 "/>
+<circle cx="80" cy="259" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="257" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="261" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="266" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="267" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="263" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="275" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,292 86,291 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,291 95,290 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,290 104,289 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,288 113,288 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,287 122,286 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,286 131,285 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="134,285 139,284 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="142,284 148,284 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="151,284 157,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="160,283 166,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="169,283 175,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="178,283 184,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="187,282 193,282 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="196,282 201,282 202,282 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="205,281 211,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,279 220,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,278 229,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,276 238,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="241,274 247,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="250,272 255,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="258,271 262,270 264,270 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="267,270 273,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="276,271 282,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="285,271 291,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="294,272 300,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="303,272 309,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="312,273 318,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="321,273 322,273 327,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="330,273 336,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="339,274 345,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="348,274 354,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="357,275 363,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="366,275 372,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="375,276 381,276 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="384,276 390,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="393,277 399,277 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="402,278 408,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="411,278 417,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="420,279 426,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="429,280 435,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="438,281 444,281 "/>
+<circle cx="80" cy="292" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="284" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="282" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="270" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="273" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="276" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="281" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,306 86,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,306 95,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,306 104,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,306 113,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,307 122,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,307 131,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,307 140,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,307 149,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,307 158,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,307 167,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,307 176,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="179,308 185,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="188,308 194,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="197,308 201,308 203,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,308 212,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,308 221,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="224,308 230,308 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,307 176,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="179,307 185,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="188,307 194,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="197,307 201,307 203,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,307 212,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,307 221,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="224,307 230,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,308 239,308 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,308 248,308 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,308 257,308 "/>
@@ -229,218 +224,218 @@ small messages (higher is better)
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,308 428,308 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="431,308 437,308 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="440,308 444,308 "/>
-<circle cx="80" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="80" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="140" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="262" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="383" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,296 86,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,296 95,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,296 104,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="107,296 113,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="116,297 122,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="125,297 131,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="134,297 140,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="143,297 149,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="152,297 158,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="161,297 167,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="170,297 176,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="179,298 185,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="188,298 194,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="197,298 201,298 203,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="206,298 212,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="215,298 221,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="224,299 230,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="233,299 239,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="242,299 248,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="251,300 257,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="260,300 262,300 266,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="269,300 275,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="278,300 284,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="287,300 293,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="296,299 302,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="305,299 311,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="314,299 320,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="323,299 329,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="332,299 338,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="341,299 347,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="350,299 356,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="359,300 365,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="368,300 374,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="377,300 383,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="386,300 392,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="395,300 401,301 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="404,301 410,301 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="413,301 419,301 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="422,301 428,301 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="431,302 437,302 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="440,302 444,302 "/>
-<circle cx="80" cy="296" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="297" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="298" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="300" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="299" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="300" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="302" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,172 86,174 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="88,175 94,178 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="97,179 102,181 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="105,182 110,185 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="113,186 119,188 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="122,189 127,192 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="130,193 135,195 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="138,196 140,197 143,199 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="146,201 150,205 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="153,207 157,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="160,212 165,216 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="167,218 172,221 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="174,223 179,227 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="181,229 186,232 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="188,234 193,238 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="195,240 200,243 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="203,244 209,245 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="212,245 218,245 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="221,246 227,246 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="230,246 236,247 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="239,247 245,248 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="248,248 254,248 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="257,249 262,249 263,249 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="266,249 272,250 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="275,250 281,251 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="284,251 290,251 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="293,252 299,252 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="302,252 308,253 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="311,253 317,254 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="320,254 322,254 325,255 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="328,255 334,257 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="337,257 343,259 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="346,259 352,261 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="355,262 361,263 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="364,264 369,265 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="372,266 378,267 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="381,268 383,268 387,269 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="390,269 396,270 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="399,270 405,271 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="408,271 414,272 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="417,272 423,273 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="426,274 432,274 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="435,275 441,276 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="443,276 444,276 "/>
-<circle cx="80" cy="172" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="197" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="244" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="249" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="254" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="268" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="276" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,80 85,83 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="87,85 92,88 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="95,90 100,93 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="102,95 107,98 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="110,100 115,103 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="117,105 122,108 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="125,110 130,113 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="132,115 137,118 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="140,120 140,120 143,125 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="145,127 149,132 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,134 154,139 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,142 159,147 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="161,149 165,154 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="167,156 170,161 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="172,163 175,168 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="177,171 181,176 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="183,178 186,183 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="188,185 191,190 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="193,192 197,197 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="199,200 201,203 203,203 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="206,202 212,201 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="215,200 220,199 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="223,198 229,197 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="232,196 238,195 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="241,194 247,193 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="250,192 255,190 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="258,190 262,189 264,190 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="267,191 273,193 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="275,194 281,196 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="284,197 289,199 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="292,201 298,203 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="301,204 306,206 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="309,207 315,209 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="317,210 322,212 323,213 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="325,214 331,217 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="333,219 338,222 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="341,223 346,226 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="349,228 354,231 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="356,232 362,235 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="364,237 369,240 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="372,241 377,245 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="380,246 383,248 385,249 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="388,250 393,252 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="396,253 402,255 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="405,256 410,259 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="413,260 419,262 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="421,263 427,265 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="430,266 435,269 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="438,270 444,272 "/>
-<circle cx="80" cy="80" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="120" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="203" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="189" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="212" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="248" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="272" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,212 86,213 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,213 95,214 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,214 104,215 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,216 113,216 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,217 122,218 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="125,218 131,219 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="134,219 139,220 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,221 148,224 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="150,225 156,228 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="158,229 164,231 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="167,233 172,235 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="175,237 180,239 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="183,240 188,243 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="191,244 196,247 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="199,248 201,249 205,251 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="207,252 213,255 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="215,256 221,259 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="223,260 229,263 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="231,264 237,267 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="239,268 245,271 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="247,273 253,275 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="255,277 261,279 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="263,280 269,280 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="272,281 278,281 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="281,281 287,281 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="290,281 296,282 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="299,282 305,282 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="308,282 314,283 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="317,283 322,283 323,283 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="326,284 332,284 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="335,285 341,286 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="344,286 350,287 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="353,287 359,288 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="362,288 368,289 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="371,289 377,290 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="380,291 383,291 386,291 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="389,292 395,293 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="398,293 404,294 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="407,294 413,295 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="416,295 422,296 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="425,296 430,297 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="433,298 439,298 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="442,299 444,299 "/>
-<circle cx="80" cy="212" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="220" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="249" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="280" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="283" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="291" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="299" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,294 86,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,294 95,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,294 104,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="107,294 113,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="116,295 122,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="125,295 131,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="134,295 140,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="143,295 149,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="152,295 158,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="161,295 167,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="170,295 176,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="179,296 185,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="188,296 194,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="197,296 201,296 203,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="206,296 212,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="215,296 221,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="224,297 230,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="233,297 239,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="242,297 248,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="251,298 257,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="260,298 262,298 266,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="269,298 275,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="278,298 284,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="287,298 293,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="296,298 302,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="305,298 311,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="314,298 320,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="323,298 329,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="332,298 338,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="341,298 347,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="350,298 356,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="359,299 365,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="368,299 374,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="377,299 383,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="386,299 392,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="395,299 401,300 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="404,300 410,300 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="413,300 419,300 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="422,300 428,300 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="431,301 437,301 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="440,301 444,301 "/>
+<circle cx="80" cy="294" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="295" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="296" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="298" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="298" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="299" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="301" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,183 86,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,183 95,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,184 104,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,184 113,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,184 122,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,184 131,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,185 140,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="142,187 147,191 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="149,193 154,196 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="156,198 161,202 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="163,204 168,208 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="170,210 175,214 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="177,215 182,219 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="184,221 189,225 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="191,227 196,231 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="198,233 201,235 203,235 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="206,235 212,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="215,236 221,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="224,236 230,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="233,237 239,237 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="242,237 248,237 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="251,237 257,238 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="260,238 262,238 266,239 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="269,239 275,240 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="278,240 284,241 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="287,242 293,243 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="296,243 302,244 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="305,244 310,245 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="313,246 319,247 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="322,247 328,248 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="331,249 337,250 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="340,251 346,252 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="349,253 355,254 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="357,255 363,256 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="366,257 372,258 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="375,259 381,260 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="384,261 390,262 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="393,263 398,264 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="401,265 407,266 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="410,266 416,268 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="419,268 425,269 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="428,270 434,271 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="437,272 443,273 "/>
+<circle cx="80" cy="183" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="185" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="235" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="238" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="247" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="261" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="273" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,81 86,81 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="89,82 95,82 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="98,82 104,83 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="107,83 113,83 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="116,83 122,84 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="125,84 131,84 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="134,85 140,85 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="142,87 145,93 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="146,95 149,100 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,103 154,108 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,110 159,116 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="160,118 164,123 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="165,126 168,131 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="170,133 173,139 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="175,141 178,146 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="179,149 182,154 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="184,156 187,162 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="189,164 192,169 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="193,172 197,177 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="198,179 201,184 202,184 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="205,183 210,182 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="213,182 219,181 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="222,181 228,180 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="231,179 237,178 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="240,178 246,177 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="249,176 255,175 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="258,175 262,174 264,175 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="266,176 272,178 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="275,179 280,182 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="283,183 288,185 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="291,187 297,189 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="299,190 305,193 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="308,194 313,196 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="316,197 321,200 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="324,201 329,205 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="331,206 336,210 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="339,211 344,215 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="346,216 351,220 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="354,221 359,225 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="361,226 366,230 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="369,231 374,235 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="376,236 381,240 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="384,241 389,244 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="392,245 398,247 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="400,248 406,251 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="409,252 414,254 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="417,255 422,258 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="425,259 431,261 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="433,263 439,265 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="442,266 444,267 "/>
+<circle cx="80" cy="81" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="85" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="184" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="174" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="200" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="241" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="267" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,200 86,201 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,201 95,202 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,202 104,203 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,204 113,204 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,205 122,206 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="125,206 131,207 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="134,207 139,208 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,209 147,212 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="150,214 155,217 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="158,218 163,221 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="166,222 171,225 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,227 179,230 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="181,231 187,234 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="189,235 195,238 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="197,240 201,242 202,243 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="205,244 210,247 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="213,249 218,252 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="221,253 226,256 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="229,257 234,260 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="236,262 242,265 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="244,266 250,269 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="252,271 257,273 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="260,275 262,276 266,276 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="269,276 275,277 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="278,277 284,277 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="287,277 293,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="296,278 302,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="305,278 311,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="314,279 320,279 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="323,279 329,280 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="332,280 338,281 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="341,282 346,283 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,283 355,284 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,284 364,285 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,286 373,287 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,287 382,288 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,288 391,289 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,290 400,291 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,291 409,292 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,293 418,294 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,294 426,295 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="429,296 435,297 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="438,297 444,298 "/>
+<circle cx="80" cy="200" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="208" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="242" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="276" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="288" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="298" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <text x="712" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 medium/large messages (higher is better)
 </text>
@@ -584,30 +579,30 @@ medium/large messages (higher is better)
 <circle cx="798" cy="111" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="837" cy="120" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="128" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,267 524,245 563,204 602,176 641,140 681,113 720,107 759,96 798,67 837,85 877,99 "/>
-<circle cx="485" cy="267" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="524" cy="245" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="563" cy="204" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="602" cy="176" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="641" cy="140" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="681" cy="113" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="720" cy="107" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="759" cy="96" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="798" cy="67" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="837" cy="85" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="99" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,235 524,214 563,191 602,165 641,144 681,118 720,99 759,103 798,69 837,81 877,103 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,268 524,242 563,207 602,173 641,142 681,117 720,104 759,95 798,72 837,66 877,76 "/>
+<circle cx="485" cy="268" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="242" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="207" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="173" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="142" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="117" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="104" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="95" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="72" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="66" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="76" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,235 524,216 563,190 602,168 641,144 681,120 720,108 759,105 798,68 837,68 877,88 "/>
 <circle cx="485" cy="235" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="524" cy="214" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="563" cy="191" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="602" cy="165" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="216" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="190" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="168" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="641" cy="144" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="681" cy="118" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="720" cy="99" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="759" cy="103" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="798" cy="69" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="837" cy="81" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="103" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="120" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="108" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="105" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="68" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="68" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="88" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,289 524,279 563,274 602,267 641,263 681,262 720,261 759,231 798,149 837,139 877,143 "/>
 <circle cx="485" cy="289" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="524" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
@@ -650,10 +645,10 @@ omq
 1 IO
 </text>
 <text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-126%
+128%
 </text>
 <text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-192%
+191%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -663,7 +658,7 @@ omq
 CT
 </text>
 <text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-96%
+88%
 </text>
 <text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 89%
@@ -686,7 +681,7 @@ tmq v0.5.0
 zmq.rs v0.6.0
 </text>
 <text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
+12 MT
 </text>
 <text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 92%
@@ -699,7 +694,7 @@ zmq.rs v0.6.0
 rzmq v0.5.24
 </text>
 <text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
+12 MT
 </text>
 <text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 102%
@@ -712,7 +707,7 @@ rzmq v0.5.24
 rzmq-iouring v0.5.24
 </text>
 <text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
+12 MT
 </text>
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 149%

--- a/omq-proto/src/options.rs
+++ b/omq-proto/src/options.rs
@@ -208,9 +208,11 @@ pub struct Options {
     /// Switch the recv path to a sized one-shot read for any inbound
     /// frame whose wire payload is at least this many bytes.
     ///
-    /// On `omq-tokio` this threshold triggers a `read_exact` fast
-    /// path that reads large payloads into a single pre-sized buffer
-    /// instead of accumulating fixed-size reads through the codec.
+    /// On `omq-tokio` this threshold triggers a fast path that reads
+    /// large payloads into a single pre-sized buffer instead of
+    /// accumulating fixed-size reads through the codec. Medium-large
+    /// payloads may use bounded pooled buffers; larger payloads use
+    /// one-shot owned buffers.
     pub large_message_threshold: Option<usize>,
 
     /// Payload size at which the encoder switches from contiguous arena

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Large direct receives now reuse bounded pooled buffers for medium-large
+  frames and avoid zero-filling frames above the pool cap.
+
 ## [0.21.1] - 2026-08-08
 
 ### Added

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use smallvec::SmallVec;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
@@ -36,6 +36,8 @@ const RECV_MEDIUM_BYTES: usize = 1024 * 1024;
 const RECV_LARGE_BYTES: usize = 1024 * 1024;
 const RECV_MEDIUM_TIME: Duration = Duration::from_micros(200);
 const RECV_LARGE_TIME: Duration = Duration::from_micros(200);
+const RECV_POOL_MAX_BUFFER_BYTES: usize = 1024 * 1024;
+const RECV_POOL_MAX_RETAINED_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReceiveProfile {
@@ -479,8 +481,8 @@ pub struct PeerDriverConfig {
     pub heartbeat_timeout: Option<Duration>,
     /// `TTL` field of outgoing PING (peer-hint for when to assume dead).
     pub heartbeat_ttl: Option<Duration>,
-    /// Recv frames whose payload exceeds this threshold via a single
-    /// `read_exact` into a pre-sized buffer, bypassing the fixed
+    /// Recv frames whose payload exceeds this threshold directly into
+    /// a pre-sized owned buffer, bypassing the fixed
     /// `read_buf` -> `Connection` buffering path. `0` disables.
     pub large_message_threshold: usize,
 }
@@ -868,6 +870,7 @@ where
         };
         let mut read_buf_full_reads = 0usize;
         let mut read_buf = BytesMut::with_capacity(read_buf_target);
+        let recv_pool = RecvBufPool::new();
         let mut eq = FrameBuffer::with_config_lazy(arena_threshold, arena_cap);
         let mut drain_buf: Vec<Bytes> = Vec::new();
         let mut arena_buf: Vec<u8> = Vec::new();
@@ -929,6 +932,7 @@ where
                         &mut read_buf_full_reads,
                         &config,
                         &mut last_input,
+                        &recv_pool,
                         &peer_out,
                         peer_id,
                     ).await?;
@@ -1038,6 +1042,7 @@ where
                         &mut read_buf_full_reads,
                         &config,
                         &mut last_input,
+                        &recv_pool,
                         &peer_out,
                         peer_id,
                     ).await?;
@@ -1256,6 +1261,7 @@ async fn read_stream_input<R: AsyncRead + Unpin>(
     read_buf_full_reads: &mut usize,
     config: &PeerDriverConfig,
     last_input: &mut Instant,
+    recv_pool: &Arc<RecvBufPool>,
     peer_out: &mpsc::Sender<(u64, PeerEvent)>,
     peer_id: u64,
 ) -> Result<()> {
@@ -1276,7 +1282,7 @@ async fn read_stream_input<R: AsyncRead + Unpin>(
         emit_connection_events_best_effort(connection, peer_out, peer_id).await;
         return Err(e);
     }
-    handle_large_messages(connection, reader, config, last_input).await
+    handle_large_messages(connection, reader, config, last_input, recv_pool).await
 }
 
 fn handle_pre_activation_inbox_command(
@@ -1484,13 +1490,77 @@ async fn drain_send_pipe_batch<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// Read large frames directly into owned buffers (bypasses the fixed
+#[derive(Debug)]
+struct RecvBufPool {
+    inner: std::sync::Mutex<RecvBufPoolInner>,
+}
+
+#[derive(Debug, Default)]
+struct RecvBufPoolInner {
+    buffers: Vec<Vec<u8>>,
+    retained_bytes: usize,
+}
+
+impl RecvBufPool {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: std::sync::Mutex::new(RecvBufPoolInner::default()),
+        })
+    }
+
+    fn take(&self, capacity: usize) -> Vec<u8> {
+        let mut pool = self.inner.lock().expect("recv buf pool");
+        if let Some(mut buf) = pool.buffers.pop() {
+            pool.retained_bytes = pool.retained_bytes.saturating_sub(buf.capacity());
+            if buf.capacity() < capacity {
+                buf.reserve(capacity - buf.capacity());
+            }
+            buf.clear();
+            return buf;
+        }
+        Vec::with_capacity(capacity)
+    }
+
+    fn give(&self, mut buf: Vec<u8>) {
+        let capacity = buf.capacity();
+        if capacity > RECV_POOL_MAX_BUFFER_BYTES {
+            return;
+        }
+        buf.clear();
+        let mut pool = self.inner.lock().expect("recv buf pool");
+        if pool.retained_bytes.saturating_add(capacity) <= RECV_POOL_MAX_RETAINED_BYTES {
+            pool.retained_bytes += capacity;
+            pool.buffers.push(buf);
+        }
+    }
+}
+
+struct PooledRecvBuf {
+    buf: Vec<u8>,
+    pool: Arc<RecvBufPool>,
+}
+
+impl AsRef<[u8]> for PooledRecvBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
+impl Drop for PooledRecvBuf {
+    fn drop(&mut self) {
+        let buf = std::mem::take(&mut self.buf);
+        self.pool.give(buf);
+    }
+}
+
+/// Read large frames directly into pooled owned buffers (bypasses the fixed
 /// `read_buf` -> `Connection` buffering path).
 async fn handle_large_messages<R: AsyncRead + Unpin>(
     connection: &mut Connection,
     reader: &mut R,
     config: &PeerDriverConfig,
     last_input: &mut Instant,
+    recv_pool: &Arc<RecvBufPool>,
 ) -> Result<()> {
     #[cfg(feature = "ws")]
     let skip_large = connection.is_ws();
@@ -1506,13 +1576,45 @@ async fn handle_large_messages<R: AsyncRead + Unpin>(
         let Some((plen, prefix)) = connection.begin_supplied_payload_with_prefix() else {
             break;
         };
-        let mut buf = BytesMut::zeroed(plen);
-        buf[..prefix.len()].copy_from_slice(prefix.as_slice());
-        if prefix.len() < plen {
-            reader.read_exact(&mut buf[prefix.len()..plen]).await?;
-        }
+        let payload = if plen <= RECV_POOL_MAX_BUFFER_BYTES {
+            let mut buf = recv_pool.take(plen);
+            buf.extend_from_slice(prefix.as_slice());
+            if buf.len() < plen {
+                let filled = buf.len();
+                buf.resize(plen, 0);
+                reader.read_exact(&mut buf[filled..plen]).await?;
+            }
+            debug_assert_eq!(buf.len(), plen);
+            Bytes::from_owner(PooledRecvBuf {
+                buf,
+                pool: Arc::clone(recv_pool),
+            })
+        } else {
+            let mut buf = BytesMut::with_capacity(plen);
+            buf.extend_from_slice(prefix.as_slice());
+            if buf.len() < plen {
+                read_exact_buf(reader, &mut buf, plen).await?;
+            }
+            debug_assert_eq!(buf.len(), plen);
+            buf.freeze()
+        };
         *last_input = Instant::now();
-        connection.supply_payload(buf.freeze())?;
+        connection.supply_payload(payload)?;
+    }
+    Ok(())
+}
+
+async fn read_exact_buf<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut BytesMut,
+    target_len: usize,
+) -> io::Result<()> {
+    while buf.len() < target_len {
+        let remaining = target_len - buf.len();
+        let mut limited = (&mut *buf).limit(remaining);
+        if reader.read_buf(&mut limited).await? == 0 {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+        }
     }
     Ok(())
 }
@@ -1974,6 +2076,45 @@ mod tests {
         assert_eq!(signals.load(Ordering::Relaxed), 2);
     }
 
+    #[test]
+    fn recv_buf_pool_reuses_bounded_buffers() {
+        let pool = RecvBufPool::new();
+        let mut buf = pool.take(256 * 1024);
+        buf.extend_from_slice(&[7; 1024]);
+        let capacity = buf.capacity();
+        pool.give(buf);
+
+        assert_eq!(pool.inner.lock().unwrap().buffers.len(), 1);
+        let reused = pool.take(128 * 1024);
+        assert_eq!(reused.len(), 0);
+        assert!(reused.capacity() >= capacity);
+        assert_eq!(pool.inner.lock().unwrap().retained_bytes, 0);
+    }
+
+    #[test]
+    fn recv_buf_pool_does_not_retain_huge_buffers() {
+        let pool = RecvBufPool::new();
+        pool.give(Vec::with_capacity(RECV_POOL_MAX_BUFFER_BYTES + 1));
+        let guard = pool.inner.lock().unwrap();
+        assert_eq!(guard.buffers.len(), 0);
+        assert_eq!(guard.retained_bytes, 0);
+    }
+
+    #[test]
+    fn recv_buf_pool_caps_total_retained_bytes() {
+        let pool = RecvBufPool::new();
+        let buffer_count = (RECV_POOL_MAX_RETAINED_BYTES / RECV_POOL_MAX_BUFFER_BYTES) + 2;
+        for _ in 0..buffer_count {
+            pool.give(Vec::with_capacity(RECV_POOL_MAX_BUFFER_BYTES));
+        }
+        let guard = pool.inner.lock().unwrap();
+        assert!(guard.retained_bytes <= RECV_POOL_MAX_RETAINED_BYTES);
+        assert_eq!(
+            guard.buffers.len(),
+            RECV_POOL_MAX_RETAINED_BYTES / RECV_POOL_MAX_BUFFER_BYTES
+        );
+    }
+
     #[derive(Debug)]
     struct PartialVectoredWriter {
         out: Vec<u8>,
@@ -2144,6 +2285,25 @@ mod tests {
             buf.put_slice(&self.data[self.pos..end]);
             self.pos = end;
             Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Debug)]
+    struct UninitProbeReader {
+        inner: ScriptedReader,
+    }
+
+    impl tokio::io::AsyncRead for UninitProbeReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            assert!(
+                buf.initialized().is_empty(),
+                "large recv path must fill uninitialized spare capacity"
+            );
+            Pin::new(&mut self.inner).poll_read(cx, buf)
         }
     }
 
@@ -2400,7 +2560,7 @@ mod tests {
         };
         let mut last_input = Instant::now();
 
-        handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+        handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
             .await
             .unwrap();
 
@@ -2436,7 +2596,7 @@ mod tests {
         };
         let mut last_input = Instant::now();
 
-        handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+        handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
             .await
             .unwrap();
 
@@ -2474,13 +2634,74 @@ mod tests {
         };
         let mut last_input = Instant::now();
 
-        handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+        handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
             .await
             .unwrap();
 
         let msg = pull.poll_message().expect("large message decoded");
         assert_eq!(msg.part_bytes(0).unwrap().as_ref(), payload.as_slice());
         assert_eq!(reader.pos, reader.data.len());
+    }
+
+    #[tokio::test]
+    async fn large_message_direct_read_uses_uninitialized_spare_capacity() {
+        const MSG_SIZE: usize = RECV_POOL_MAX_BUFFER_BYTES + 1024;
+        const PREFIX_PAYLOAD_BYTES: usize = 64;
+
+        let (mut push, mut pull) = ready_push_pull_connections();
+        let payload = patterned_payload(MSG_SIZE, 45);
+        push.send_message(&Message::single(Bytes::from(payload.clone())))
+            .unwrap();
+        let wire = Bytes::from(drain_transmit(&mut push));
+        let prefix_wire_bytes = 9 + PREFIX_PAYLOAD_BYTES;
+
+        pull.handle_input(wire.slice(..prefix_wire_bytes)).unwrap();
+        let mut reader = UninitProbeReader {
+            inner: ScriptedReader::new(wire.slice(prefix_wire_bytes..), [128, 4093, 65_537]),
+        };
+        let config = PeerDriverConfig {
+            large_message_threshold: 128 * 1024,
+            ..PeerDriverConfig::default()
+        };
+        let mut last_input = Instant::now();
+
+        handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
+            .await
+            .unwrap();
+
+        let msg = pull.poll_message().expect("large message decoded");
+        assert_eq!(msg.part_bytes(0).unwrap().as_ref(), payload.as_slice());
+    }
+
+    #[tokio::test]
+    async fn large_message_direct_read_returns_unexpected_eof_on_short_payload() {
+        const MSG_SIZE: usize = 1024 * 1024;
+        const PREFIX_PAYLOAD_BYTES: usize = 64;
+
+        let (mut push, mut pull) = ready_push_pull_connections();
+        let payload = patterned_payload(MSG_SIZE, 44);
+        push.send_message(&Message::single(Bytes::from(payload)))
+            .unwrap();
+        let wire = Bytes::from(drain_transmit(&mut push));
+        let prefix_wire_bytes = 9 + PREFIX_PAYLOAD_BYTES;
+
+        pull.handle_input(wire.slice(..prefix_wire_bytes)).unwrap();
+        let short_end = prefix_wire_bytes + 1024;
+        let mut reader = ScriptedReader::new(wire.slice(prefix_wire_bytes..short_end), [128]);
+        let config = PeerDriverConfig {
+            large_message_threshold: 128 * 1024,
+            ..PeerDriverConfig::default()
+        };
+        let mut last_input = Instant::now();
+
+        let err = handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
+            .await
+            .expect_err("short payload must fail");
+
+        assert!(matches!(
+            err,
+            Error::Io(ref e) if e.kind() == io::ErrorKind::UnexpectedEof
+        ));
     }
 
     #[tokio::test]
@@ -2507,7 +2728,7 @@ mod tests {
                 wire.slice(prefix_wire_bytes..),
                 [3, 1, 65_537, 8_191, 262_147],
             );
-            handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+            handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
                 .await
                 .unwrap();
 
@@ -2537,7 +2758,7 @@ mod tests {
 
             feed_fragmented_input(&mut pull, &wire, prefix_wire_bytes);
             let mut reader = ScriptedReader::new(wire.slice(prefix_wire_bytes..), [1, 7, 31, 257]);
-            handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+            handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
                 .await
                 .unwrap();
 
@@ -2593,7 +2814,7 @@ mod tests {
                 [1 + (seq % 7), 3, 31, 4093, 65_537, 131_071, 262_147],
             );
 
-            handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+            handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
                 .await
                 .unwrap();
 
@@ -2664,7 +2885,7 @@ mod tests {
                     262_147,
                 ];
                 let mut reader = ScriptedReader::new(wire.slice(cursor..), read_caps);
-                handle_large_messages(&mut pull, &mut reader, &config, &mut last_input)
+                handle_large_messages_test(&mut pull, &mut reader, &config, &mut last_input)
                     .await
                     .unwrap();
                 cursor += reader.pos;
@@ -3183,6 +3404,16 @@ mod tests {
         if start < end {
             connection.handle_input(wire.slice(start..end)).unwrap();
         }
+    }
+
+    async fn handle_large_messages_test<R: AsyncRead + Unpin>(
+        connection: &mut Connection,
+        reader: &mut R,
+        config: &PeerDriverConfig,
+        last_input: &mut Instant,
+    ) -> Result<()> {
+        let recv_pool = RecvBufPool::new();
+        handle_large_messages(connection, reader, config, last_input, &recv_pool).await
     }
 
     fn feed_input_in_chunks(


### PR DESCRIPTION
- Reuse bounded direct-receive buffers for payloads up to 1MiB.
- Keep larger frames on the no-zero `BytesMut` path to avoid huge zero-fill cost.
- Refresh the main PUSH/PULL TCP chart with the longer median-run results.