### PR TITLE
Add shareable context core

### DIFF
--- a/bindings/pyomq/doc/architecture.md
+++ b/bindings/pyomq/doc/architecture.md
@@ -46,6 +46,20 @@ Python threads ──────────────▶ tokio thread (curre
 `omq_tokio::Socket` is `Send + Sync` and stored as `Arc<Socket>` in
 `SocketInner`. Python wrappers hold an `Arc<SocketInner>`.
 
+Each Python `Context` owns or shadows one native `omq_tokio::Context`,
+which is a handle to a shared `ContextCore`. The core owns the tokio
+runtime and its `inproc://` registry. Normal `pyomq.Context()` owns that
+core and calls native `term()` on close. Shadow contexts and
+`Context.from_share_key()` wrappers only drop their handle; they do not
+terminate the owner.
+
+`Context.share_key()` returns a process-local opaque integer backed by
+the native `u128` `ContextCore` key. `Context.from_share_key(key)` and
+`pyomq.asyncio.Context.from_share_key(key)` import another handle to the
+same core, so sync and asyncio wrappers can share `inproc://` names
+without Python-side endpoint rewriting. The native registry stores weak
+refs, so keys do not keep contexts alive.
+
 ### Why the yring relay is needed
 
 Although `omq_tokio::Socket` can be shared across threads, its
@@ -86,8 +100,8 @@ Materialization:
 
 1. Extract options from the `Overlay` into `omq_tokio::Options`.
 2. Create yring producer/consumer pairs (capacities from SNDHWM/RCVHWM).
-3. Post job to the tokio thread: build the socket, spawn send and recv
-   pump tasks.
+3. Post job to the tokio thread: build the socket from the context's
+   native `ContextCore`, spawn send and recv pump tasks.
 4. Store `Materialized { id, socket, send_prod, recv_cons, recv_ready,
    send_ready, recv_space, send_pump, recv_pump }` in the `SocketInner`.
 

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -1019,8 +1019,6 @@ class _ShadowSocket(_SocketOptionsBase):
 
 _next_ctx_id: Iterator[int] = itertools.count(1)
 
-_INPROC_PREFIX: Final[str] = "inproc://"
-
 
 class _ContextMeta(type):
     """Context metaclass with per-subclass singleton storage."""
@@ -1064,27 +1062,8 @@ class Context(metaclass=_ContextMeta):
         )
 
     def _namespace_inproc(self, endpoint: str | bytes) -> str | bytes:
-        # libzmq scopes inproc per-context; omq's registry is global. pytest
-        # holds frame references to locals (traceback capture), so __del__
-        # never fires and the old socket's registry entry stays alive. Next
-        # test's new Context tries bind("inproc://test") and gets "already
-        # bound". The entry is cleaned up eventually (Socket.close() ->
-        # SocketCommand::Close -> InprocListener::drop removes it), but not
-        # before the next test's bind(). Prefixing with context ID gives each
-        # Context its own namespace, matching libzmq's per-context scoping.
-        ns_str = f"pyomq-ctx-{self._ctx_id}/"
-        ns_bytes = ns_str.encode()
-        if isinstance(endpoint, bytes):
-            pfx = b"inproc://"
-            if endpoint.startswith(pfx) and not endpoint[len(pfx) :].startswith(
-                ns_bytes
-            ):
-                return pfx + ns_bytes + endpoint[len(pfx) :]
-        elif isinstance(endpoint, str):
-            if endpoint.startswith(_INPROC_PREFIX) and not endpoint[
-                len(_INPROC_PREFIX) :
-            ].startswith(ns_str):
-                return f"inproc://{ns_str}{endpoint[len(_INPROC_PREFIX) :]}"
+        # `inproc://` names are scoped by the native context core. Keep the
+        # user endpoint unchanged so LAST_ENDPOINT and errors match input.
         return endpoint
 
     def __class_getitem__(cls, item: Any) -> type[Context]:
@@ -1118,6 +1097,21 @@ class Context(metaclass=_ContextMeta):
         if isinstance(address, int):
             return cls(_shadow_ctx=cls.instance())
         raise TypeError(f"expected Context or int, got {type(address).__name__}")
+
+    def share_key(self) -> int:
+        """Return the opaque native context-core key for this process."""
+        return int(self._ctx.share_key())
+
+    @classmethod
+    def from_share_key(cls, key: int) -> Self:
+        """Create a Context wrapper for an existing native context core."""
+        obj = object.__new__(cls)
+        obj._ctx = _native.Context.from_share_key(key)
+        obj._is_shadow = True
+        obj._closed = False
+        obj._sockets = weakref.WeakSet()
+        obj._ctx_id = next(_next_ctx_id)
+        return cast(Self, obj)
 
     @classmethod
     def instance(cls, io_threads: int = 1) -> Self:

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -606,6 +606,7 @@ class Context(_SyncContext):
 
     _socket_class: type | None = None
     _ctx: _native.AsyncContext
+    _is_shadow: bool
     _closed: bool
     _sockets: weakref.WeakSet[Socket]
     _ctx_id: int
@@ -652,12 +653,24 @@ class Context(_SyncContext):
         self._sockets.add(s)
         return s
 
+    @classmethod
+    def from_share_key(cls, key: int) -> Context:
+        obj = object.__new__(cls)
+        obj._ctx = _native.AsyncContext.from_share_key(key)
+        obj._is_shadow = True
+        obj._closed = False
+        obj._sockets = weakref.WeakSet()
+        obj._ctx_id = next(_next_ctx_id)
+        return obj
+
     def term(self) -> None:
         self._closed = True
         for s in list(self._sockets):
             if not s.closed:
                 s.close()
         self._sockets.clear()
+        if not self._is_shadow:
+            self._ctx.term()
 
     def destroy(self, linger: int | None = None) -> None:
         for s in list(self._sockets):

--- a/bindings/pyomq/python/pyomq/testing.py
+++ b/bindings/pyomq/python/pyomq/testing.py
@@ -1,0 +1,10 @@
+"""Internal test support hooks for pyomq's own test suite."""
+
+from __future__ import annotations
+
+from . import _native
+
+
+def rust_thread_send_via_share_key(key: int, endpoint: str, payload: bytes) -> None:
+    """Start a Rust thread that imports ``key`` and sends one inproc message."""
+    _native.rust_thread_send_via_share_key(key, endpoint, payload)

--- a/bindings/pyomq/src/context.rs
+++ b/bindings/pyomq/src/context.rs
@@ -64,6 +64,17 @@ impl Context {
         }
     }
 
+    fn share_key(&self) -> PyResult<u128> {
+        self.ctx.share_key()
+    }
+
+    #[staticmethod]
+    fn from_share_key(share_key: u128) -> PyResult<Self> {
+        Ok(Context {
+            ctx: ContextInner::from_share_key(share_key)?,
+        })
+    }
+
     /// Construct a new socket of the given libzmq type code.
     #[pyo3(signature = (socket_type, /))]
     fn socket(&self, py: Python<'_>, socket_type: i32) -> PyResult<Socket> {
@@ -116,6 +127,17 @@ impl AsyncContext {
         AsyncContext {
             ctx: context.ctx.clone(),
         }
+    }
+
+    fn share_key(&self) -> PyResult<u128> {
+        self.ctx.share_key()
+    }
+
+    #[staticmethod]
+    fn from_share_key(share_key: u128) -> PyResult<Self> {
+        Ok(AsyncContext {
+            ctx: ContextInner::from_share_key(share_key)?,
+        })
     }
 
     #[pyo3(signature = (socket_type, /))]

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -17,8 +17,11 @@ mod runtime;
 mod socket;
 mod socket_async;
 
+use std::str::FromStr;
 use std::sync::Arc;
 
+use bytes::Bytes;
+use omq_proto::endpoint::Endpoint;
 use pyo3::prelude::*;
 
 /// Extractor that accepts either a sync `Socket` or an `AsyncSocket`,
@@ -57,6 +60,7 @@ fn _native(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(wait_any, m)?)?;
     m.add_function(wrap_pyfunction!(native_proxy, m)?)?;
     m.add_function(wrap_pyfunction!(has_feature, m)?)?;
+    m.add_function(wrap_pyfunction!(rust_thread_send_via_share_key, m)?)?;
     #[cfg(feature = "curve")]
     m.add_class::<peer_info::PeerInfo>()?;
     #[cfg(feature = "curve")]
@@ -65,6 +69,31 @@ fn _native(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(curve_public, m)?)?;
     }
     Ok(())
+}
+
+#[pyfunction]
+fn rust_thread_send_via_share_key(
+    py: Python<'_>,
+    share_key: u128,
+    endpoint: &str,
+    payload: &[u8],
+) -> PyResult<()> {
+    let endpoint = Endpoint::from_str(endpoint).map_err(error::map_err)?;
+    let payload = Bytes::copy_from_slice(payload);
+    py.detach(move || {
+        std::thread::spawn(move || -> omq_proto::error::Result<()> {
+            let ctx = omq_tokio::Context::from_share_key(share_key)
+                .ok_or(omq_proto::error::Error::Closed)?;
+            let push =
+                ctx.blocking_socket(omq_tokio::SocketType::Push, omq_tokio::Options::default());
+            push.connect(endpoint)?;
+            push.send(omq_tokio::Message::single(payload))
+        })
+        .join()
+        .map_err(|_| omq_proto::error::Error::Protocol("rust helper thread panicked".into()))
+        .and_then(std::convert::identity)
+    })
+    .map_err(error::map_err)
 }
 
 #[pyfunction]

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -62,6 +62,7 @@ pub(crate) struct ContextInner {
     io_threads: usize,
     state: Mutex<Option<RuntimeState>>,
     terminated: AtomicBool,
+    owns_runtime: bool,
 }
 
 impl ContextInner {
@@ -70,7 +71,31 @@ impl ContextInner {
             io_threads: io_threads.max(1),
             state: Mutex::new(None),
             terminated: AtomicBool::new(false),
+            owns_runtime: true,
         })
+    }
+
+    pub fn from_shared_context(ctx: omq_tokio::Context) -> Arc<Self> {
+        let io_threads = ctx.io_threads().max(1);
+        Arc::new(Self {
+            io_threads,
+            state: Mutex::new(Some(RuntimeState {
+                pid: std::process::id(),
+                ctx,
+            })),
+            terminated: AtomicBool::new(false),
+            owns_runtime: false,
+        })
+    }
+
+    pub fn share_key(&self) -> PyResult<u128> {
+        Ok(self.runtime_context()?.share_key())
+    }
+
+    pub fn from_share_key(share_key: u128) -> PyResult<Arc<Self>> {
+        let ctx = omq_tokio::Context::from_share_key(share_key)
+            .ok_or_else(|| crate::error::map_err(omq_proto::error::Error::Closed))?;
+        Ok(Self::from_shared_context(ctx))
     }
 
     fn ensure_runtime(&self) -> PyResult<Handle> {
@@ -82,7 +107,13 @@ impl ContextInner {
         if let Some(rt) = guard.as_ref()
             && rt.pid == pid
         {
+            if rt.ctx.is_terminated() {
+                return Err(crate::error::map_err(omq_proto::error::Error::Closed));
+            }
             return Ok(rt.ctx.handle().clone());
+        }
+        if !self.owns_runtime {
+            return Err(crate::error::map_err(omq_proto::error::Error::Closed));
         }
         let ctx = omq_tokio::Context::with_config(omq_tokio::ContextConfig {
             io_threads: self.io_threads,
@@ -105,11 +136,23 @@ impl ContextInner {
             .lock()
             .unwrap()
             .as_ref()
-            .is_some_and(|rt| rt.pid == std::process::id())
+            .is_some_and(|rt| rt.pid == std::process::id() && !rt.ctx.is_terminated())
     }
 
     pub fn runtime_handle(&self) -> PyResult<Handle> {
         self.ensure_runtime()
+    }
+
+    pub fn runtime_context(&self) -> PyResult<omq_tokio::Context> {
+        let _ = self.ensure_runtime()?;
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("runtime initialized")
+            .ctx
+            .clone())
     }
 
     /// Build a socket using omq-tokio's native blocking adapter.
@@ -118,15 +161,8 @@ impl ContextInner {
         socket_type: omq_tokio::SocketType,
         options: omq_tokio::Options,
     ) -> PyResult<(u64, omq_tokio::blocking::Socket)> {
-        let handle = self.ensure_runtime()?;
-        let ctx = self
-            .state
-            .lock()
-            .unwrap()
-            .as_ref()
-            .expect("runtime initialized")
-            .ctx
-            .clone();
+        let ctx = self.runtime_context()?;
+        let handle = ctx.handle().clone();
         let (otx, orx) = flume::bounded(1);
         handle.spawn(async move {
             let id = next_id();
@@ -165,12 +201,13 @@ impl ContextInner {
         send_ready: Arc<ReadinessSignal>,
         recv_space: Arc<omq_tokio::engine::StateSignal>,
     ) -> PyResult<(u64, Arc<InnerSocket>, JoinHandle<()>, JoinHandle<()>)> {
-        let handle = self.ensure_runtime()?;
+        let ctx = self.runtime_context()?;
+        let handle = ctx.handle().clone();
         let (otx, orx) = flume::bounded(1);
         let recv_all_signal = global_recv_signal();
         handle.spawn(async move {
             let id = next_id();
-            let sock = Arc::new(InnerSocket::new(socket_type, options));
+            let sock = Arc::new(ctx.socket(socket_type, options));
 
             const SEND_YIELD_INTERVAL: u32 = 256;
             let send_socket = sock.clone();
@@ -296,10 +333,10 @@ impl ContextInner {
         self.terminated.store(true, Ordering::Release);
         let state = self.state.lock().unwrap().take();
         if let Some(s) = state {
-            if s.pid == std::process::id() {
+            if self.owns_runtime && s.pid == std::process::id() {
                 s.ctx.term();
             } else {
-                std::mem::forget(s);
+                drop_or_forget_foreign(s);
             }
         }
     }
@@ -348,12 +385,20 @@ impl ContextInner {
 impl Drop for ContextInner {
     fn drop(&mut self) {
         if let Some(s) = self.state.get_mut().unwrap().take() {
-            if s.pid == std::process::id() {
+            if self.owns_runtime && s.pid == std::process::id() {
                 s.ctx.term();
             } else {
-                std::mem::forget(s);
+                drop_or_forget_foreign(s);
             }
         }
+    }
+}
+
+fn drop_or_forget_foreign(state: RuntimeState) {
+    if state.pid == std::process::id() {
+        drop(state);
+    } else {
+        std::mem::forget(state);
     }
 }
 

--- a/bindings/pyomq/tests/test_inproc_namespace.py
+++ b/bindings/pyomq/tests/test_inproc_namespace.py
@@ -2,6 +2,7 @@
 
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
+from pyomq.testing import rust_thread_send_via_share_key
 import pytest
 
 
@@ -76,6 +77,23 @@ def test_share_key_context_roundtrip():
         push.close()
         pull.close()
         shared.term()
+        ctx.term()
+
+
+def test_share_key_python_context_rust_thread_inproc():
+    ctx = zmq.Context()
+    try:
+        pull = ctx.socket(zmq.PULL)
+        pull.setsockopt(zmq.RCVTIMEO, 1000)
+        pull.bind("inproc://python-rust-thread")
+        rust_thread_send_via_share_key(
+            ctx.share_key(),
+            "inproc://python-rust-thread",
+            b"rust-thread",
+        )
+        assert pull.recv() == b"rust-thread"
+    finally:
+        pull.close()
         ctx.term()
 
 

--- a/bindings/pyomq/tests/test_inproc_namespace.py
+++ b/bindings/pyomq/tests/test_inproc_namespace.py
@@ -1,6 +1,8 @@
 """Context-local inproc namespace isolation."""
 
 import pyomq as zmq
+import pyomq.asyncio as zmq_async
+import pytest
 
 
 def test_two_contexts_same_inproc_name():
@@ -58,3 +60,83 @@ def test_inproc_cross_context_isolation():
             s.close()
         ctx1.term()
         ctx2.term()
+
+
+def test_share_key_context_roundtrip():
+    ctx = zmq.Context()
+    shared = zmq.Context.from_share_key(ctx.share_key())
+    try:
+        push = ctx.socket(zmq.PUSH)
+        pull = shared.socket(zmq.PULL)
+        pull.bind("inproc://shared-key")
+        push.connect("inproc://shared-key")
+        push.send(b"shared")
+        assert pull.recv() == b"shared"
+    finally:
+        push.close()
+        pull.close()
+        shared.term()
+        ctx.term()
+
+
+def test_share_key_term_does_not_destroy_owner():
+    ctx = zmq.Context()
+    shared = zmq.Context.from_share_key(ctx.share_key())
+    try:
+        shared.term()
+        push = ctx.socket(zmq.PUSH)
+        pull = ctx.socket(zmq.PULL)
+        pull.bind("inproc://owner-still-alive")
+        push.connect("inproc://owner-still-alive")
+        push.send(b"alive")
+        assert pull.recv() == b"alive"
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_imported_context_observes_owner_term():
+    ctx = zmq.Context()
+    shared = zmq.Context.from_share_key(ctx.share_key())
+    try:
+        ctx.term()
+        with pytest.raises(zmq.ContextTerminated):
+            shared.socket(zmq.PULL).bind("inproc://owner-gone")
+    finally:
+        shared.term()
+
+
+def test_imported_socket_observes_owner_term():
+    ctx = zmq.Context()
+    shared = zmq.Context.from_share_key(ctx.share_key())
+    pull = None
+    try:
+        pull = shared.socket(zmq.PULL)
+        pull.setsockopt(zmq.RCVTIMEO, 1000)
+        pull.bind("inproc://owner-gone-after-bind")
+        ctx.term()
+        with pytest.raises(zmq.ContextTerminated):
+            pull.recv()
+    finally:
+        if pull is not None:
+            pull.close()
+        shared.term()
+
+
+@pytest.mark.asyncio
+async def test_share_key_sync_async_roundtrip():
+    ctx = zmq.Context()
+    shared = zmq_async.Context.from_share_key(ctx.share_key())
+    try:
+        pull = ctx.socket(zmq.PULL)
+        push = shared.socket(zmq.PUSH)
+        pull.bind("inproc://shared-sync-async")
+        push.connect("inproc://shared-sync-async")
+        await push.send(b"async")
+        assert pull.recv() == b"async"
+    finally:
+        push.close()
+        pull.close()
+        shared.term()
+        ctx.term()

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -16,11 +16,14 @@ omq-proto core: Connection, frames, mechanisms, messages, options
 
 ## Context and runtime management
 
-`Context` owns one or more independent `current_thread` tokio runtimes,
+`Context` is a cheap handle to a shared `ContextCore`. The core owns
+one or more independent `current_thread` tokio runtimes,
 each on its own OS thread. Each runtime has its own IO reactor (epoll /
 kqueue), timer wheel, and task scheduler. There is no cross-thread work
 stealing and no shared scheduler lock. Connections assigned to one
 thread run with zero contention from connections on other threads.
+`ContextCore` also owns the `inproc://` namespace for sockets created
+through that context.
 
 - `Context::new()`: one IO thread. Default.
 - `Context::with_config(cfg)`: N IO threads. Each IO thread is a
@@ -42,6 +45,14 @@ from their own async runtime while OMQ IO stays on the context's runtime
 threads. `Context::block_on()` is a plain-`fn main()` helper that runs a
 future on the owned runtime and blocks the caller (not available on
 `Context::current()`).
+
+`Context::share_key()` returns a process-local opaque `u128` key.
+`Context::from_share_key()` turns that key back into another handle to
+the same `ContextCore`, if the owner still exists and has not been
+terminated. The registry stores weak references only, so a key cannot
+keep a context alive. C and foreign bindings pass the key as two `u64`
+words; imported binding contexts must not terminate the owner unless
+their API explicitly says they own it.
 
 ## Blocking API (background IO)
 
@@ -270,8 +281,13 @@ nonblocking send and never backpressure data forwarding.
 Inproc bypasses ZMTP framing and kernel I/O. Cross-thread peers use `yring`
 send pipes and deliver `InboundFrame::Message` through `inproc_peer_driver`.
 Same-thread paths use direct `yring::ProducerOwner` access where applicable.
-Public semantics remain the same: HWM backpressure, round-robin fairness,
-and connect-before-bind.
+Names are scoped to the owning `ContextCore`, not the process. Two
+independent contexts can bind the same `inproc://name` without seeing
+each other. Handles imported with `Context::from_share_key()` share the
+same namespace, which lets different language bindings in one process
+communicate over inproc without a process-global registry. Public
+semantics remain the same: HWM backpressure, round-robin fairness, and
+connect-before-bind.
 
 ## Drain Budgets And Signaling
 

--- a/doc/charts/pushpull/inproc.svg
+++ b/doc/charts/pushpull/inproc.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 950 418" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
 <rect x="0" y="0" width="950" height="418" opacity="1" fill="#000000" stroke="none"/>
 <text x="475" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUSH/PULL throughput: inproc</text>
-<text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 6 cores, performance governor, turbo off</text>
+<text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 12 cores, performance governor, turbo off</text>
 <text x="227" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 small messages (higher is better)
 </text>
@@ -57,97 +57,98 @@ small messages (higher is better)
 1 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="444,312 444,317 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,110 86,112 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="88,113 94,115 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="97,117 102,119 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="105,120 111,122 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="114,123 119,125 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="122,126 128,128 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="130,130 136,132 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="139,133 144,135 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="147,136 153,138 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,139 161,142 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="164,143 169,145 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="172,146 178,148 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="181,149 186,151 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="189,152 195,155 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="197,156 201,157 203,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="206,157 212,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="215,157 221,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="224,157 230,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="233,158 239,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="242,158 248,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="251,158 257,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="260,158 266,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="269,158 275,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="278,158 284,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="287,158 293,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="296,159 302,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="305,159 311,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="314,159 320,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="323,159 329,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="332,159 338,159 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="341,159 347,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="350,158 356,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="359,158 365,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="368,158 374,158 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="377,158 383,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="386,157 392,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="395,157 401,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="404,157 410,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="413,157 419,157 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="422,157 428,156 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="431,156 437,156 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="440,156 444,156 "/>
-<circle cx="80" cy="110" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="157" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="159" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,84 85,87 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="88,88 93,91 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="96,93 101,96 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="104,97 109,100 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="111,101 117,104 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="119,106 125,109 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="127,110 132,113 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="135,115 140,117 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="143,119 148,122 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,123 156,126 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="159,128 164,131 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="167,132 172,135 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="174,136 180,139 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="182,141 188,144 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="190,145 195,148 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="198,149 201,151 204,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="207,151 213,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="216,151 222,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="225,151 231,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="234,151 240,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="243,151 249,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="252,151 258,151 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="261,151 267,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="270,152 276,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="279,152 285,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="288,152 294,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="297,152 303,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="306,152 312,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="315,152 321,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="324,152 330,152 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="333,152 339,153 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="342,153 348,153 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="351,153 357,153 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="360,153 366,153 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="369,154 375,154 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="378,154 384,154 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="387,154 393,154 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="396,154 402,155 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="405,155 411,155 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="414,155 420,155 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="423,155 429,155 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="432,156 438,156 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="441,156 444,156 "/>
+<circle cx="80" cy="84" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="151" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="152" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="156" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,215 86,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,214 95,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,214 104,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,213 113,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,213 122,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,212 131,212 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,212 140,212 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="143,211 149,211 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="152,211 158,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="161,210 167,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="170,210 176,209 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="179,209 185,209 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="188,209 194,208 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="197,208 201,208 203,208 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="206,208 212,209 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="215,209 221,209 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="224,210 230,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="233,210 239,210 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="242,211 248,211 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="251,211 257,212 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="260,212 266,212 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="269,212 275,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="278,213 284,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="287,214 293,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="296,214 302,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="305,215 311,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="314,215 320,216 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="323,216 329,216 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="332,216 338,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="341,215 347,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="350,215 356,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="359,215 365,215 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="368,215 374,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="377,214 383,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="385,214 391,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="394,214 400,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="403,213 409,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="412,213 418,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="421,213 427,213 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="430,212 436,212 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="439,212 444,212 "/>
-<circle cx="80" cy="215" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="208" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="216" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="212" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,188 86,188 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,187 95,187 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,187 104,187 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,186 113,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,186 122,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,185 131,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,185 140,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="143,184 149,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="152,184 158,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="161,183 167,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="170,183 176,182 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="179,182 185,182 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="188,182 194,181 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="197,181 201,181 203,181 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="206,181 212,182 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="215,182 221,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="224,183 230,183 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="233,184 239,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="242,184 248,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="251,185 257,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="260,186 266,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="269,187 275,187 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="278,187 284,188 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="287,188 292,189 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="295,189 301,189 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="304,190 310,190 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="313,190 319,191 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="322,191 328,191 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="331,190 337,190 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="340,190 346,189 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="349,189 355,189 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="358,189 364,188 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="367,188 373,188 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="376,187 382,187 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="385,187 391,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="394,186 400,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="403,186 409,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="412,185 418,185 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="421,184 427,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="430,184 436,184 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="439,183 444,183 "/>
+<circle cx="80" cy="188" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="181" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="191" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="183" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,97 85,101 "/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="87,102 92,106 "/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="94,108 99,112 "/>
@@ -258,67 +259,67 @@ medium/large messages (higher is better)
 100 GB/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="878,56 883,56 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,211 615,159 746,109 877,57 "/>
-<circle cx="485" cy="211" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,209 615,159 746,107 877,57 "/>
+<circle cx="485" cy="209" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="615" cy="159" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="109" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="107" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="57" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,228 615,175 746,123 877,75 "/>
-<circle cx="485" cy="228" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="175" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="746" cy="123" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="75" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,220 615,166 746,116 877,67 "/>
+<circle cx="485" cy="220" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="166" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="116" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="67" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,248 615,205 746,162 877,124 "/>
 <circle cx="485" cy="248" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="615" cy="205" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="746" cy="162" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="124" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
-<text x="340" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 snd CPU%
 </text>
-<text x="430" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 rcv CPU%
 </text>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,366 92,366 "/>
 <text x="98" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 libzmq
 </text>
-<text x="230" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 UT
 </text>
-<text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 215%
 </text>
-<text x="430" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 CT
 </text>
-<text x="340" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 100%
 </text>
-<text x="430" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 UT
 </text>
-<text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 200%
 </text>
-<text x="430" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 </svg>

--- a/doc/charts/reqrep/inproc.svg
+++ b/doc/charts/reqrep/inproc.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 850 418" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
 <rect x="0" y="0" width="850" height="418" opacity="1" fill="#000000" stroke="none"/>
 <text x="425" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">REQ/REP latency: inproc</text>
-<text x="425" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 6 cores, performance governor, turbo off</text>
+<text x="425" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 12 cores, performance governor, turbo off</text>
 <text x="415" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 p50 round-trip latency (lower is better)
 </text>
@@ -87,70 +87,70 @@ p50 round-trip latency (lower is better)
 4 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="819,312 819,317 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="70,279 257,279 444,279 631,279 819,279 "/>
-<circle cx="70" cy="279" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="279" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="279" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="279" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="279" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="70,84 257,97 444,91 631,95 819,108 "/>
-<circle cx="70" cy="84" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="97" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="91" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="95" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="108" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="70,281 257,280 444,281 631,281 819,281 "/>
+<circle cx="70" cy="281" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="280" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="281" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="281" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="281" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="70,113 257,81 444,88 631,81 819,82 "/>
+<circle cx="70" cy="113" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="81" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="88" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="81" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="82" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="70,167 257,166 444,164 631,164 819,160 "/>
 <circle cx="70" cy="167" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="257" cy="166" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="164" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="631" cy="164" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="819" cy="160" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<text x="230" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
-<text x="340" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 req CPU%
 </text>
-<text x="430" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 rep CPU%
 </text>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="78,366 92,366 "/>
 <text x="98" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 libzmq
 </text>
-<text x="230" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 UT
 </text>
-<text x="340" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 115%
 </text>
-<text x="430" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 2 UT
 </text>
-<text x="340" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-113%
+<text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+110%
 </text>
-<text x="430" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 omq
 </text>
-<text x="230" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="250" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 CT
 </text>
-<text x="340" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-93%
+<text x="360" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+98%
 </text>
-<text x="430" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 0%
 </text>
 </svg>

--- a/doc/perf-verification.md
+++ b/doc/perf-verification.md
@@ -10,7 +10,9 @@ With `.perf_hw` present, the verifier measures CT REQ/REP latency at
 256B, canonical 1-IO PUSH/PULL at 16B, 1KiB, and 16KiB, and canonical
 1-IO PUB/SUB with four subscribers at 16B and 4KiB. It also checks the
 2-IO variants, a 32-subscriber 2-IO PUB/SUB 256B fan-out gate, and
-16B inproc PUSH/PULL. It uses separate OMQ contexts and loopback TCP.
+16B inproc PUSH/PULL. TCP cases use separate OMQ contexts and loopback
+TCP. The inproc case uses one shared `ContextCore`, matching scoped
+`inproc://` semantics.
 Warmup and measurement windows are bounded.
 
 Thresholds are machine-specific. Create the ignored `.perf_hw` file in the

--- a/omq-libzmq/include/zmq.h
+++ b/omq-libzmq/include/zmq.h
@@ -291,6 +291,10 @@ int   zmq_ctx_destroy (void *context_); /* deprecated */
 void *zmq_init (int io_threads_);       /* deprecated */
 int   zmq_term (void *context_);        /* deprecated */
 
+/*  OMQ extension: share/import one native ContextCore inside this process.  */
+int   omq_ctx_share_key (void *context_, uint64_t *key_hi_, uint64_t *key_lo_);
+void *omq_ctx_from_share_key (uint64_t key_hi_, uint64_t key_lo_);
+
 /*  Socket API --------------------------------------------------------------- */
 void *zmq_socket     (void *context_, int type_);
 int   zmq_close      (void *s_);

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -1,6 +1,6 @@
 //! Context: owns a tokio runtime on a background thread.
 
-use std::ffi::c_int;
+use std::ffi::{c_int, c_void};
 
 use rustc_hash::FxHashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
@@ -29,6 +29,7 @@ pub(crate) struct OmqContext {
     /// Pending inproc connect requests waiting for a bind.
     pub(crate) inproc_waiting:
         Mutex<FxHashMap<String, Vec<std::sync::Weak<crate::socket::OmqSocket>>>>,
+    owns_io_context: bool,
 }
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -55,22 +56,63 @@ impl OmqContext {
             zero_copy_recv: AtomicBool::new(true),
             inproc_binds: Mutex::new(FxHashMap::default()),
             inproc_waiting: Mutex::new(FxHashMap::default()),
+            owns_io_context: true,
         })
     }
 
+    fn from_io_context(ctx: omq_tokio::Context) -> Arc<Self> {
+        let out = Arc::new(Self {
+            ctx: OnceLock::new(),
+            configured_io_threads: AtomicI32::new(i32::try_from(ctx.io_threads()).unwrap_or(1)),
+            terminated: Arc::new(AtomicBool::new(false)),
+            socket_count: AtomicI32::new(0),
+            linger_count: AtomicI32::new(0),
+            socket_notify: (Mutex::new(()), Condvar::new()),
+            sockets: Mutex::new(Vec::new()),
+            max_sockets: AtomicI32::new(1023),
+            max_msg_size: AtomicI64::new(-1),
+            ipv6: AtomicBool::new(false),
+            blocky: AtomicBool::new(true),
+            zero_copy_recv: AtomicBool::new(true),
+            inproc_binds: Mutex::new(FxHashMap::default()),
+            inproc_waiting: Mutex::new(FxHashMap::default()),
+            owns_io_context: false,
+        });
+        out.ctx
+            .set(ctx)
+            .expect("new imported context should be empty");
+        out
+    }
+
     pub(crate) fn handle(&self) -> Option<&Handle> {
+        if self.is_effectively_terminated() {
+            return None;
+        }
         self.ctx.get().map(omq_tokio::Context::handle)
     }
 
     pub(crate) fn io_context(&self) -> Option<&omq_tokio::Context> {
+        if self.is_effectively_terminated() {
+            return None;
+        }
         let n = self.configured_io_threads.load(Ordering::Acquire);
-        (n > 0).then(|| {
-            self.ctx.get_or_init(|| {
-                omq_tokio::Context::with_config(omq_tokio::ContextConfig {
-                    io_threads: n as usize,
-                })
+        if n <= 0 {
+            return None;
+        }
+        let ctx = self.ctx.get_or_init(|| {
+            omq_tokio::Context::with_config(omq_tokio::ContextConfig {
+                io_threads: n as usize,
             })
-        })
+        });
+        (!ctx.is_terminated()).then_some(ctx)
+    }
+
+    pub(crate) fn is_effectively_terminated(&self) -> bool {
+        self.terminated.load(Ordering::Acquire)
+            || self
+                .ctx
+                .get()
+                .is_some_and(omq_tokio::Context::is_terminated)
     }
 
     pub(crate) fn zero_io_threads(&self) -> bool {
@@ -200,11 +242,49 @@ pub extern "C" fn zmq_ctx_term(ctx_ptr: *mut libc::c_void) -> c_int {
         }
     }
 
-    if let Some(ctx) = arc.ctx.get() {
+    if arc.owns_io_context
+        && let Some(ctx) = arc.ctx.get()
+    {
         ctx.term();
     }
     drop(arc);
     0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_ctx_share_key(
+    ctx_ptr: *mut c_void,
+    key_hi: *mut u64,
+    key_lo: *mut u64,
+) -> c_int {
+    if ctx_ptr.is_null() || key_hi.is_null() || key_lo.is_null() {
+        return crate::error::fail(libc::EFAULT);
+    }
+    // SAFETY: caller guarantees ctx_ptr is a valid context from this library.
+    let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
+    if ctx.is_effectively_terminated() {
+        return crate::error::fail(crate::error::ETERM);
+    }
+    let Some(io_ctx) = ctx.io_context() else {
+        return crate::error::fail(libc::ENOTSUP);
+    };
+    let key = io_ctx.share_key();
+    // SAFETY: output pointers were checked non-null above.
+    unsafe {
+        *key_hi = (key >> 64) as u64;
+        *key_lo = key as u64;
+    }
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_ctx_from_share_key(key_hi: u64, key_lo: u64) -> *mut c_void {
+    let key = (u128::from(key_hi) << 64) | u128::from(key_lo);
+    let Some(ctx) = omq_tokio::Context::from_share_key(key) else {
+        let _ = crate::error::fail(libc::EINVAL);
+        return std::ptr::null_mut();
+    };
+    Box::into_raw(Box::new(OmqContext::from_io_context(ctx))).cast()
 }
 
 #[unsafe(no_mangle)]

--- a/omq-libzmq/src/lib.rs
+++ b/omq-libzmq/src/lib.rs
@@ -39,8 +39,8 @@ mod socket;
 mod util;
 
 pub use context::{
-    zmq_ctx_destroy, zmq_ctx_get, zmq_ctx_new, zmq_ctx_set, zmq_ctx_shutdown, zmq_ctx_term,
-    zmq_init, zmq_term,
+    omq_ctx_from_share_key, omq_ctx_share_key, zmq_ctx_destroy, zmq_ctx_get, zmq_ctx_new,
+    zmq_ctx_set, zmq_ctx_shutdown, zmq_ctx_term, zmq_init, zmq_term,
 };
 pub use curve::{zmq_curve_keypair, zmq_curve_public, zmq_z85_decode, zmq_z85_encode};
 pub use error::{zmq_errno, zmq_strerror};

--- a/omq-libzmq/src/proxy.rs
+++ b/omq-libzmq/src/proxy.rs
@@ -8,7 +8,6 @@
 
 use std::ffi::c_void;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use crate::consts;
@@ -147,7 +146,7 @@ impl ProxyCtx {
                 }
             }
 
-            if self.frontend.ctx.terminated.load(Ordering::Acquire) {
+            if self.frontend.ctx.is_effectively_terminated() {
                 return crate::error::fail(crate::error::ETERM);
             }
 
@@ -327,6 +326,9 @@ impl ProxyCtx {
             std::thread::sleep(Duration::from_millis(1));
             return;
         };
+        if target.ctx.is_effectively_terminated() {
+            return;
+        }
         let Some(handle) = target.ctx.handle() else {
             std::thread::sleep(Duration::from_millis(1));
             return;

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -229,11 +229,7 @@ fn block_recv<T>(
     if rcvtimeo > 0 {
         let deadline = std::time::Instant::now() + Duration::from_millis(rcvtimeo as u64);
         loop {
-            if sock
-                .ctx
-                .terminated
-                .load(std::sync::atomic::Ordering::Acquire)
-            {
+            if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -243,11 +239,7 @@ fn block_recv<T>(
             let ms = remaining.as_millis().min(i32::MAX as u128) as c_int;
             let recv_notify = sock.notify.recv_notifier();
             let _ = recv_notify.wait_for_readable(ms);
-            if sock
-                .ctx
-                .terminated
-                .load(std::sync::atomic::Ordering::Acquire)
-            {
+            if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
             if let Some(val) = try_pop() {
@@ -256,20 +248,12 @@ fn block_recv<T>(
         }
     }
     loop {
-        if sock
-            .ctx
-            .terminated
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        if sock.ctx.is_effectively_terminated() {
             return Err(ETERM);
         }
         let recv_notify = sock.notify.recv_notifier();
-        let _ = recv_notify.wait_for_readable(-1);
-        if sock
-            .ctx
-            .terminated
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        let _ = recv_notify.wait_for_readable(100);
+        if sock.ctx.is_effectively_terminated() {
             return Err(ETERM);
         }
         if let Some(val) = try_pop() {
@@ -286,11 +270,7 @@ fn block_recv_result<T>(
     if rcvtimeo > 0 {
         let deadline = std::time::Instant::now() + Duration::from_millis(rcvtimeo as u64);
         loop {
-            if sock
-                .ctx
-                .terminated
-                .load(std::sync::atomic::Ordering::Acquire)
-            {
+            if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -300,11 +280,7 @@ fn block_recv_result<T>(
             let ms = remaining.as_millis().min(i32::MAX as u128) as c_int;
             let recv_notify = sock.notify.recv_notifier();
             let _ = recv_notify.wait_for_readable(ms);
-            if sock
-                .ctx
-                .terminated
-                .load(std::sync::atomic::Ordering::Acquire)
-            {
+            if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
             if let Some(val) = try_pop()? {
@@ -313,20 +289,12 @@ fn block_recv_result<T>(
         }
     }
     loop {
-        if sock
-            .ctx
-            .terminated
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        if sock.ctx.is_effectively_terminated() {
             return Err(ETERM);
         }
         let recv_notify = sock.notify.recv_notifier();
-        let _ = recv_notify.wait_for_readable(-1);
-        if sock
-            .ctx
-            .terminated
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
+        let _ = recv_notify.wait_for_readable(100);
+        if sock.ctx.is_effectively_terminated() {
             return Err(ETERM);
         }
         if let Some(val) = try_pop()? {
@@ -487,11 +455,7 @@ pub extern "C" fn zmq_send(
     }
     // SAFETY: sock_ptr is non-null (checked above); caller guarantees a valid socket.
     let sock = unsafe { &*(sock_ptr.cast::<Arc<OmqSocket>>()) };
-    if sock
-        .ctx
-        .terminated
-        .load(std::sync::atomic::Ordering::Acquire)
-    {
+    if sock.ctx.is_effectively_terminated() {
         return fail(ETERM);
     }
     if buf.is_null() && len > 0 {
@@ -530,11 +494,7 @@ pub extern "C" fn zmq_recv(
     }
     // SAFETY: sock_ptr is non-null (checked above); caller guarantees a valid socket.
     let sock = unsafe { &*(sock_ptr.cast::<Arc<OmqSocket>>()) };
-    if sock
-        .ctx
-        .terminated
-        .load(std::sync::atomic::Ordering::Acquire)
-    {
+    if sock.ctx.is_effectively_terminated() {
         return fail(ETERM);
     }
     if buf.is_null() && buf_len > 0 {

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -240,7 +240,7 @@ pub extern "C" fn zmq_socket(ctx_ptr: *mut c_void, type_int: c_int) -> *mut c_vo
     }
     // SAFETY: caller must pass a valid context pointer from zmq_ctx_new.
     let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
-    if ctx.terminated.load(Ordering::Acquire) {
+    if ctx.is_effectively_terminated() {
         set_errno(ETERM);
         return std::ptr::null_mut();
     }
@@ -363,16 +363,13 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) -> bool {
     // Enter the tokio runtime context so that Socket::new (which calls
     // tokio::spawn internally for its driver task) and the recv pump
     // spawn below are scheduled on the context's runtime.
-    let Some(handle) = sock.ctx.handle() else {
+    let Some(ctx) = sock.ctx.io_context().cloned() else {
         return false;
     };
+    let handle = ctx.handle().clone();
     let _guard = handle.enter();
 
-    let inner = Arc::new(omq_tokio::Socket::new_with_recv_sink_config(
-        socket_type,
-        opts,
-        recv_sink_cfg,
-    ));
+    let inner = Arc::new(ctx.socket_with_recv_sink_config(socket_type, opts, recv_sink_cfg));
 
     // Recv pump: relay from async_channel into the pump yring.
     // Handles second+ peers whose drivers push to async_channel.
@@ -459,7 +456,7 @@ unsafe fn parse_endpoint_args<'a>(
     }
     // SAFETY: caller guarantees sock_ptr is a valid socket from zmq_socket.
     let sock = unsafe { &*(sock_ptr.cast::<Arc<OmqSocket>>()) };
-    if sock.ctx.terminated.load(Ordering::Acquire) {
+    if sock.ctx.is_effectively_terminated() {
         return Err(ETERM);
     }
     // SAFETY: addr is non-null (checked above); caller guarantees a valid C string.
@@ -726,15 +723,17 @@ pub extern "C" fn zmq_socket_monitor(
     let Some(inner) = sock.inner.get() else {
         return fail(ETERM);
     };
+    let Some(monitor_ctx) = sock.ctx.io_context().cloned() else {
+        return fail(ETERM);
+    };
 
     let result = with_socket(&sock.ctx, inner, move |s| async move {
         let mut stream = s.monitor();
 
         // Create a PAIR socket for publishing events, bind it to addr.
-        let pair = std::sync::Arc::new(omq_tokio::Socket::new(
-            omq_tokio::SocketType::Pair,
-            omq_tokio::Options::default(),
-        ));
+        let pair = std::sync::Arc::new(
+            monitor_ctx.socket(omq_tokio::SocketType::Pair, omq_tokio::Options::default()),
+        );
         let ep = omq_tokio::Endpoint::from_str(&addr_str)
             .map_err(|e| omq_tokio::error::Error::InvalidEndpoint(e.to_string()))?;
         pair.bind(ep).await?;

--- a/omq-libzmq/tests/libzmq_inproc.rs
+++ b/omq-libzmq/tests/libzmq_inproc.rs
@@ -9,8 +9,8 @@ use std::mem::size_of;
 use std::time::Duration;
 
 use omq_zmq::{
-    zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_term, zmq_recv, zmq_send,
-    zmq_setsockopt, zmq_socket,
+    omq_ctx_from_share_key, omq_ctx_share_key, zmq_bind, zmq_close, zmq_connect, zmq_ctx_new,
+    zmq_ctx_term, zmq_errno, zmq_recv, zmq_send, zmq_setsockopt, zmq_socket,
 };
 
 const ZMQ_PUSH: i32 = 8;
@@ -21,6 +21,7 @@ const ZMQ_SUB: i32 = 2;
 const ZMQ_RCVTIMEO: i32 = 27;
 const ZMQ_SUBSCRIBE: i32 = 6;
 const ZMQ_SNDMORE: i32 = 2;
+const ZMQ_ETERM: i32 = 156_384_765;
 
 fn set_timeo(sock: *mut c_void, ms: i32) {
     zmq_setsockopt(
@@ -58,6 +59,130 @@ fn inproc_push_pull() {
     zmq_close(push);
     zmq_close(pull);
     zmq_ctx_term(ctx);
+}
+
+#[test]
+fn inproc_same_name_is_context_local() {
+    let ctx1 = zmq_ctx_new();
+    let ctx2 = zmq_ctx_new();
+    let push1 = zmq_socket(ctx1, ZMQ_PUSH);
+    let pull1 = zmq_socket(ctx1, ZMQ_PULL);
+    let push2 = zmq_socket(ctx2, ZMQ_PUSH);
+    let pull2 = zmq_socket(ctx2, ZMQ_PULL);
+
+    let addr = CString::new("inproc://test-context-local").unwrap();
+    assert_eq!(zmq_bind(pull1, addr.as_ptr()), 0);
+    assert_eq!(zmq_bind(pull2, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push1, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push2, addr.as_ptr()), 0);
+    std::thread::sleep(Duration::from_millis(20));
+    set_timeo(pull1, 1000);
+    set_timeo(pull2, 1000);
+
+    assert_eq!(zmq_send(push1, b"ctx1".as_ptr().cast(), 4, 0), 4);
+    assert_eq!(zmq_send(push2, b"ctx2".as_ptr().cast(), 4, 0), 4);
+
+    let mut buf = [0u8; 32];
+    assert_eq!(zmq_recv(pull1, buf.as_mut_ptr().cast(), buf.len(), 0), 4);
+    assert_eq!(&buf[..4], b"ctx1");
+    assert_eq!(zmq_recv(pull2, buf.as_mut_ptr().cast(), buf.len(), 0), 4);
+    assert_eq!(&buf[..4], b"ctx2");
+
+    zmq_close(push1);
+    zmq_close(pull1);
+    zmq_close(push2);
+    zmq_close(pull2);
+    zmq_ctx_term(ctx1);
+    zmq_ctx_term(ctx2);
+}
+
+#[test]
+fn inproc_shared_context_key_crosses_c_contexts() {
+    let ctx1 = zmq_ctx_new();
+    let mut key_hi = 0_u64;
+    let mut key_lo = 0_u64;
+    assert_eq!(omq_ctx_share_key(ctx1, &mut key_hi, &mut key_lo), 0);
+    let ctx2 = omq_ctx_from_share_key(key_hi, key_lo);
+    assert!(!ctx2.is_null());
+
+    let pull = zmq_socket(ctx1, ZMQ_PULL);
+    let push = zmq_socket(ctx2, ZMQ_PUSH);
+    let addr = CString::new("inproc://test-shared-key").unwrap();
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
+    std::thread::sleep(Duration::from_millis(20));
+    set_timeo(pull, 1000);
+
+    assert_eq!(zmq_send(push, b"shared".as_ptr().cast(), 6, 0), 6);
+    let mut buf = [0u8; 32];
+    assert_eq!(zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0), 6);
+    assert_eq!(&buf[..6], b"shared");
+
+    zmq_close(push);
+    zmq_close(pull);
+    zmq_ctx_term(ctx2);
+
+    let pull = zmq_socket(ctx1, ZMQ_PULL);
+    let push = zmq_socket(ctx1, ZMQ_PUSH);
+    let addr = CString::new("inproc://test-owner-after-import-term").unwrap();
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
+    set_timeo(pull, 1000);
+    assert_eq!(zmq_send(push, b"owner".as_ptr().cast(), 5, 0), 5);
+    assert_eq!(zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0), 5);
+    assert_eq!(&buf[..5], b"owner");
+
+    zmq_close(push);
+    zmq_close(pull);
+    zmq_ctx_term(ctx1);
+}
+
+#[test]
+fn imported_context_observes_owner_term() {
+    let ctx1 = zmq_ctx_new();
+    let mut key_hi = 0_u64;
+    let mut key_lo = 0_u64;
+    assert_eq!(omq_ctx_share_key(ctx1, &mut key_hi, &mut key_lo), 0);
+    let ctx2 = omq_ctx_from_share_key(key_hi, key_lo);
+    assert!(!ctx2.is_null());
+
+    assert_eq!(zmq_ctx_term(ctx1), 0);
+    assert!(zmq_socket(ctx2, ZMQ_PUSH).is_null());
+    assert_eq!(zmq_errno(), ZMQ_ETERM);
+    assert_eq!(omq_ctx_share_key(ctx2, &mut key_hi, &mut key_lo), -1);
+    assert_eq!(zmq_errno(), ZMQ_ETERM);
+    assert_eq!(zmq_ctx_term(ctx2), 0);
+}
+
+#[test]
+fn imported_socket_recv_wakes_after_owner_term() {
+    let ctx1 = zmq_ctx_new();
+    let mut key_hi = 0_u64;
+    let mut key_lo = 0_u64;
+    assert_eq!(omq_ctx_share_key(ctx1, &mut key_hi, &mut key_lo), 0);
+    let ctx2 = omq_ctx_from_share_key(key_hi, key_lo);
+    assert!(!ctx2.is_null());
+
+    let pull = zmq_socket(ctx2, ZMQ_PULL);
+    let addr = CString::new("inproc://test-imported-owner-term").unwrap();
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+
+    let pull_addr = pull as usize;
+    let recv_thread = std::thread::spawn(move || {
+        let pull = pull_addr as *mut c_void;
+        let mut buf = [0u8; 32];
+        let rc = zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0);
+        (rc, zmq_errno())
+    });
+
+    std::thread::sleep(Duration::from_millis(20));
+    assert_eq!(zmq_ctx_term(ctx1), 0);
+    let (rc, err) = recv_thread.join().expect("recv thread");
+    assert_eq!(rc, -1);
+    assert_eq!(err, ZMQ_ETERM);
+
+    assert_eq!(zmq_close(pull), 0);
+    assert_eq!(zmq_ctx_term(ctx2), 0);
 }
 
 #[test]

--- a/omq-tokio/src/bin/perf_verify.rs
+++ b/omq-tokio/src/bin/perf_verify.rs
@@ -170,8 +170,13 @@ async fn count_messages(sock: omq_tokio::Socket, deadline: Instant) -> u64 {
 
 async fn pushpull(size: usize, io_threads: usize, endpoint: Endpoint) -> f64 {
     tokio::task::spawn_blocking(move || {
+        let is_inproc = matches!(endpoint, Endpoint::Inproc { .. });
         let pull_ctx = Context::with_config(ContextConfig { io_threads });
-        let push_ctx = Context::with_config(ContextConfig { io_threads });
+        let push_ctx = if is_inproc {
+            pull_ctx.clone()
+        } else {
+            Context::with_config(ContextConfig { io_threads })
+        };
         let pull = pull_ctx.blocking_socket(SocketType::Pull, Options::default());
         let push = push_ctx.blocking_socket(SocketType::Push, Options::default());
         let endpoint = pull.bind(endpoint).expect("PULL bind");

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -3,9 +3,11 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, LazyLock, Mutex, Weak, mpsc};
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use rustc_hash::FxHashMap;
 use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
 
@@ -279,7 +281,7 @@ impl IoPoolHandle {
 /// ```
 #[derive(Clone, Debug)]
 pub struct Context {
-    inner: Arc<ContextInner>,
+    inner: Arc<ContextCore>,
 }
 
 enum RuntimeOwnership {
@@ -287,18 +289,25 @@ enum RuntimeOwnership {
     Borrowed { handle: Handle },
 }
 
-struct ContextInner {
+/// Shared context core.
+///
+/// A `ContextCore` owns the runtime, the per-context `inproc://`
+/// namespace, and the language-neutral share key used by bindings.
+pub struct ContextCore {
     ownership: RuntimeOwnership,
     owner_pid: u32,
     io_threads: usize,
     terminated: AtomicBool,
+    share_key: u128,
+    inproc_registry: Arc<crate::transport::inproc::InprocRegistry>,
 }
 
-impl std::fmt::Debug for ContextInner {
+impl std::fmt::Debug for ContextCore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ContextInner")
+        f.debug_struct("ContextCore")
             .field("io_threads", &self.io_threads)
             .field("owner_pid", &self.owner_pid)
+            .field("share_key", &format_args!("{:032x}", self.share_key))
             .field(
                 "owned",
                 &matches!(self.ownership, RuntimeOwnership::Owned { .. }),
@@ -308,7 +317,47 @@ impl std::fmt::Debug for ContextInner {
     }
 }
 
-impl ContextInner {
+static NEXT_CONTEXT_KEY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+static CONTEXT_KEY_PREFIX: LazyLock<u64> = LazyLock::new(|| {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos() as u64);
+    nanos ^ (u64::from(std::process::id()) << 32)
+});
+static CONTEXT_REGISTRY: LazyLock<Mutex<FxHashMap<u128, Weak<ContextCore>>>> =
+    LazyLock::new(|| Mutex::new(FxHashMap::default()));
+
+fn next_context_key() -> u128 {
+    let low = NEXT_CONTEXT_KEY.fetch_add(1, Ordering::Relaxed);
+    (u128::from(*CONTEXT_KEY_PREFIX) << 64) | u128::from(low)
+}
+
+fn register_context_core(core: &Arc<ContextCore>) {
+    let mut registry = CONTEXT_REGISTRY.lock().expect("context registry poisoned");
+    registry.retain(|_, weak| weak.strong_count() > 0);
+    registry.insert(core.share_key, Arc::downgrade(core));
+}
+
+fn unregister_context_core(share_key: u128) {
+    if let Ok(mut registry) = CONTEXT_REGISTRY.lock() {
+        registry.remove(&share_key);
+    }
+}
+
+impl ContextCore {
+    fn new(ownership: RuntimeOwnership, io_threads: usize) -> Arc<Self> {
+        let core = Arc::new(Self {
+            ownership,
+            owner_pid: std::process::id(),
+            io_threads,
+            terminated: AtomicBool::new(false),
+            share_key: next_context_key(),
+            inproc_registry: Arc::new(crate::transport::inproc::InprocRegistry::new()),
+        });
+        register_context_core(&core);
+        core
+    }
+
     fn is_owner_process(&self) -> bool {
         self.owner_pid == std::process::id()
     }
@@ -327,6 +376,12 @@ impl ContextInner {
             },
             _ => IoPoolHandle::none(),
         }
+    }
+
+    /// Language-neutral opaque key for importing this context in another
+    /// binding loaded into the same native library image.
+    pub fn share_key(&self) -> u128 {
+        self.share_key
     }
 }
 
@@ -351,12 +406,7 @@ impl Context {
         let io_threads = config.io_threads;
         let pool = IoThreadPool::new(io_threads);
         Self {
-            inner: Arc::new(ContextInner {
-                ownership: RuntimeOwnership::Owned { pool },
-                owner_pid: std::process::id(),
-                io_threads,
-                terminated: AtomicBool::new(false),
-            }),
+            inner: ContextCore::new(RuntimeOwnership::Owned { pool }, io_threads),
         }
     }
 
@@ -372,13 +422,46 @@ impl Context {
         let handle =
             Handle::try_current().expect("Context::current() called outside a tokio runtime");
         Self {
-            inner: Arc::new(ContextInner {
-                ownership: RuntimeOwnership::Borrowed { handle },
-                owner_pid: std::process::id(),
-                io_threads: 0,
-                terminated: AtomicBool::new(false),
-            }),
+            inner: ContextCore::new(RuntimeOwnership::Borrowed { handle }, 0),
         }
+    }
+
+    /// Return the opaque `u128` key for this context core.
+    ///
+    /// The key is only meaningful inside the current process and native
+    /// library image. Importing it creates another `Context` handle to the
+    /// same runtime and `inproc://` namespace.
+    pub fn share_key(&self) -> u128 {
+        self.inner.share_key()
+    }
+
+    /// Import a context by a key previously returned by [`share_key`](Self::share_key).
+    pub fn from_share_key(share_key: u128) -> Option<Self> {
+        let core = {
+            let mut registry = CONTEXT_REGISTRY.lock().ok()?;
+            let core = registry.get(&share_key).and_then(Weak::upgrade);
+            if core.is_none() {
+                registry.remove(&share_key);
+            }
+            core?
+        };
+        if !core.is_owner_process() || core.terminated.load(Ordering::Acquire) {
+            return None;
+        }
+        Some(Self { inner: core })
+    }
+
+    #[doc(hidden)]
+    pub fn core(&self) -> Arc<ContextCore> {
+        self.inner.clone()
+    }
+
+    #[doc(hidden)]
+    pub fn from_core(core: Arc<ContextCore>) -> Option<Self> {
+        if !core.is_owner_process() || core.terminated.load(Ordering::Acquire) {
+            return None;
+        }
+        Some(Self { inner: core })
     }
 
     /// Create a blocking socket on this context's runtime.
@@ -414,7 +497,38 @@ impl Context {
         );
         let _guard = self.inner.primary_handle().enter();
         let io_pool = self.inner.io_pool_handle();
-        Socket::new_with_io_pool(socket_type, options, &io_pool)
+        Socket::new_with_io_pool(
+            socket_type,
+            options,
+            &io_pool,
+            self.inner.inproc_registry.clone(),
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn socket_with_recv_sink_config(
+        &self,
+        socket_type: SocketType,
+        options: Options,
+        config: Arc<crate::engine::RecvSinkConfig>,
+    ) -> Socket {
+        assert!(
+            !self.inner.terminated.load(Ordering::Acquire),
+            "Context::socket_with_recv_sink_config() called on a terminated context"
+        );
+        assert!(
+            self.inner.is_owner_process(),
+            "Context::socket_with_recv_sink_config() called on a context inherited across fork"
+        );
+        let _guard = self.inner.primary_handle().enter();
+        let io_pool = self.inner.io_pool_handle();
+        Socket::new_with_recv_sink_config_and_io_pool(
+            socket_type,
+            options,
+            config,
+            &io_pool,
+            self.inner.inproc_registry.clone(),
+        )
     }
 
     /// Run a future on this context's runtime, blocking the calling
@@ -473,6 +587,11 @@ impl Context {
         self.inner.io_threads
     }
 
+    /// Whether this context core has been terminated.
+    pub fn is_terminated(&self) -> bool {
+        self.inner.terminated.load(Ordering::Acquire)
+    }
+
     /// Shut down this context's runtime. All spawned driver tasks are
     /// aborted and the background threads exit.
     ///
@@ -482,6 +601,7 @@ impl Context {
         if self.inner.terminated.swap(true, Ordering::AcqRel) {
             return;
         }
+        unregister_context_core(self.inner.share_key);
         if !self.inner.is_owner_process() {
             return;
         }
@@ -497,8 +617,9 @@ impl Default for Context {
     }
 }
 
-impl Drop for ContextInner {
+impl Drop for ContextCore {
     fn drop(&mut self) {
+        unregister_context_core(self.share_key);
         if !self.is_owner_process() {
             return;
         }

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -52,7 +52,7 @@ pub use omq_proto::message;
 pub use omq_proto::options;
 pub use omq_proto::proto;
 
-pub use context::{Context, ContextConfig};
+pub use context::{Context, ContextConfig, ContextCore};
 pub use proxy::{Proxy, ProxyExit};
 pub use socket::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorStream,

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -310,6 +310,7 @@ impl SocketDriver {
         reject_encrypted_inproc(&endpoint, &self.options.mechanism)?;
         let snapshot = self.inproc_snapshot();
         let bound = bind_any(
+            &self.inproc_registry,
             &endpoint,
             &snapshot,
             &self.spsc.recv_signal,
@@ -379,6 +380,7 @@ impl SocketDriver {
         let recv_signal = self.spsc.recv_signal.clone();
         let blocking_recv_waker = self.spsc.blocking_recv_waker.clone();
         let max_message_size = self.options.max_message_size;
+        let inproc_registry = self.inproc_registry.clone();
         #[cfg(feature = "ws")]
         let accept_invalid_certs = self.options.wss_tls.accept_invalid_certs;
         #[cfg(feature = "ws")]
@@ -388,6 +390,7 @@ impl SocketDriver {
             let result = dial_with_backoff(
                 || {
                     connect_any(
+                        &inproc_registry,
                         &ep_for_dial,
                         &snapshot,
                         &recv_signal,

--- a/omq-tokio/src/socket/actor/endpoints.rs
+++ b/omq-tokio/src/socket/actor/endpoints.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ws")]
+use super::WsConnectOptions;
 use super::{
     Canceled, ConnectionStatus, DialerEntry, DisconnectReason, Duration, Endpoint, Error,
     InternalEvent, ListenerEntry, MonitorEvent, PeerIdent, Result, SocketDriver, SocketType,
@@ -397,9 +399,10 @@ impl SocketDriver {
                         &blocking_recv_waker,
                         max_message_size,
                         #[cfg(feature = "ws")]
-                        accept_invalid_certs,
-                        #[cfg(feature = "ws")]
-                        &mechanism,
+                        WsConnectOptions {
+                            accept_invalid_certs,
+                            mechanism: &mechanism,
+                        },
                     )
                 },
                 policy,

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -18,6 +18,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "ws")]
+use super::dispatch::WsConnectOptions;
 use super::dispatch::{
     AnyConn, AnyStream, bind_any, connect_any, generated_identity, peer_ident_socket_addr,
     preflight_connect_endpoint_resolution,

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -238,6 +238,7 @@ pub(crate) struct SocketDriver {
     subscribe_count: Arc<AtomicU64>,
     ready_peer_count_shared: Arc<std::sync::atomic::AtomicUsize>,
     io_pool: crate::context::IoPoolHandle,
+    inproc_registry: Arc<crate::transport::inproc::InprocRegistry>,
 }
 
 impl SocketDriver {
@@ -258,6 +259,7 @@ impl SocketDriver {
         subscribe_count: Arc<AtomicU64>,
         ready_peer_count_shared: Arc<std::sync::atomic::AtomicUsize>,
         io_pool: crate::context::IoPoolHandle,
+        inproc_registry: Arc<crate::transport::inproc::InprocRegistry>,
     ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(128);
         let (peer_out_tx, peer_out_rx) = mpsc::channel(256);
@@ -296,6 +298,7 @@ impl SocketDriver {
             subscribe_count,
             ready_peer_count_shared,
             io_pool,
+            inproc_registry,
         }
     }
 

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -58,6 +58,13 @@ use crate::transport::{
     Transport as _, inproc as inproc_transport,
 };
 
+#[cfg(feature = "ws")]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WsConnectOptions<'a> {
+    pub(super) accept_invalid_certs: bool,
+    pub(super) mechanism: &'a omq_proto::MechanismSetup,
+}
+
 /// Re-register a stream with the current thread's I/O reactor. Each
 /// `current_thread` tokio runtime has its own reactor; a stream
 /// accepted on one thread must be migrated before a driver on another
@@ -520,8 +527,7 @@ pub(super) async fn connect_any(
     recv_signal: &std::sync::Arc<DataSignal>,
     blocking_recv_waker: &std::sync::Arc<crate::socket::recv::BlockingRecvWaker>,
     max_message_size: Option<usize>,
-    #[cfg(feature = "ws")] accept_invalid_certs: bool,
-    #[cfg(feature = "ws")] mechanism: &omq_proto::MechanismSetup,
+    #[cfg(feature = "ws")] ws_options: WsConnectOptions<'_>,
 ) -> Result<AnyConn> {
     if endpoint.is_tcp_family() {
         let s = TcpTransport::connect(&endpoint.underlying_tcp()).await?;
@@ -549,8 +555,8 @@ pub(super) async fn connect_any(
             port,
             path,
             matches!(plain, Endpoint::Wss { .. }),
-            accept_invalid_certs,
-            mechanism,
+            ws_options.accept_invalid_certs,
+            ws_options.mechanism,
         )
         .await?;
         let peer_ident = peer_ident_for_endpoint(endpoint);

--- a/omq-tokio/src/socket/dispatch.rs
+++ b/omq-tokio/src/socket/dispatch.rs
@@ -400,6 +400,7 @@ impl AnyListener {
 /// `lz4+tcp://` reuses the TCP listener; the per-connection
 /// transform is installed by the actor based on the endpoint scheme.
 pub(super) async fn bind_any(
+    inproc_registry: &std::sync::Arc<inproc_transport::InprocRegistry>,
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_signal: &std::sync::Arc<DataSignal>,
@@ -439,6 +440,7 @@ pub(super) async fn bind_any(
     match endpoint {
         Endpoint::Inproc { name } => {
             let listener = AnyListener::Inproc(inproc_transport::bind(
+                inproc_registry.clone(),
                 name,
                 snapshot.clone(),
                 recv_signal.clone(),
@@ -512,6 +514,7 @@ async fn preflight_connect_host(host: &Host, port: u16) -> Result<()> {
 
 /// Connect dispatch (single attempt). Used under `dial_with_backoff`.
 pub(super) async fn connect_any(
+    inproc_registry: &inproc_transport::InprocRegistry,
     endpoint: &Endpoint,
     snapshot: &InprocPeerSnapshot,
     recv_signal: &std::sync::Arc<DataSignal>,
@@ -560,6 +563,7 @@ pub(super) async fn connect_any(
     match endpoint {
         Endpoint::Inproc { name } => {
             let conn = inproc_transport::connect_with_max_message_size(
+                inproc_registry,
                 name,
                 snapshot.clone(),
                 recv_signal.clone(),
@@ -629,7 +633,9 @@ mod tests {
     async fn bind_result_for_test(endpoint: &Endpoint) -> Result<BoundListener> {
         #[cfg(feature = "ws")]
         let wss_tls = omq_proto::options::WssTls::default();
+        let inproc_registry = Arc::new(inproc_transport::InprocRegistry::new());
         bind_any(
+            &inproc_registry,
             endpoint,
             &snapshot(),
             &recv_signal(),

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -19,6 +19,7 @@ use super::actor::{CloseLinger, SocketCommand, SocketDriver, spawn_driver};
 use super::monitor::{ConnectionStatus, MonitorPublisher, MonitorStream};
 use super::recv::{SpscAwareRecv, SpscHandles, SpscPush};
 use crate::routing::{RepEnvelope, SendStrategy, SendSubmitter};
+use crate::transport::inproc::InprocRegistry;
 
 pub use omq_proto::error::TrySendError;
 
@@ -100,6 +101,7 @@ impl Socket {
             options,
             None,
             &crate::context::IoPoolHandle::none(),
+            crate::transport::inproc::standalone_registry(),
         )
     }
 
@@ -107,8 +109,9 @@ impl Socket {
         socket_type: SocketType,
         options: Options,
         io_pool: &crate::context::IoPoolHandle,
+        inproc_registry: Arc<InprocRegistry>,
     ) -> Self {
-        Self::new_inner(socket_type, options, None, io_pool)
+        Self::new_inner(socket_type, options, None, io_pool, inproc_registry)
     }
 
     /// Like [`Socket::new`], but installs a `RecvSinkConfig` that the
@@ -124,7 +127,18 @@ impl Socket {
             options,
             Some(config),
             &crate::context::IoPoolHandle::none(),
+            crate::transport::inproc::standalone_registry(),
         )
+    }
+
+    pub(crate) fn new_with_recv_sink_config_and_io_pool(
+        socket_type: SocketType,
+        options: Options,
+        config: Arc<crate::engine::RecvSinkConfig>,
+        io_pool: &crate::context::IoPoolHandle,
+        inproc_registry: Arc<InprocRegistry>,
+    ) -> Self {
+        Self::new_inner(socket_type, options, Some(config), io_pool, inproc_registry)
     }
 
     fn new_inner(
@@ -132,6 +146,7 @@ impl Socket {
         options: Options,
         recv_sink_config: Option<Arc<crate::engine::RecvSinkConfig>>,
         io_pool: &crate::context::IoPoolHandle,
+        inproc_registry: Arc<InprocRegistry>,
     ) -> Self {
         options
             .validate()
@@ -192,6 +207,7 @@ impl Socket {
             subscribe_count.clone(),
             ready_peer_count.clone(),
             io_pool.clone(),
+            inproc_registry,
         );
         let actor_task = spawn_driver(driver, io_pool);
         Self {

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -1,6 +1,6 @@
 //! In-process transport.
 //!
-//! `inproc://name` endpoints are resolved via a process-global
+//! `inproc://name` endpoints are resolved via the owning context's
 //! registry. Unlike TCP/IPC, **inproc skips the ZMTP codec
 //! entirely** - both ends are in the same process, so we exchange
 //! parsed `Message` / `Command` values directly through a pair of
@@ -13,7 +13,8 @@
 //! `Options::send_hwm` at the `SocketDriver` layer where each
 //! channel is wired up.
 
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::sync::{Condvar, Mutex as StdMutex};
 
 use rustc_hash::FxHashMap;
@@ -163,15 +164,41 @@ type InprocAck = (
     Option<Arc<InprocRx>>,
 );
 
-/// Global registry of bound inproc names → request channel.
-static REGISTRY: LazyLock<Mutex<FxHashMap<String, mpsc::Sender<InprocConnectRequest>>>> =
-    LazyLock::new(|| Mutex::new(FxHashMap::default()));
+#[derive(Debug)]
+struct InprocBinding {
+    id: u64,
+    tx: mpsc::Sender<InprocConnectRequest>,
+}
+
+/// Per-context registry of bound inproc names -> request channel.
+#[derive(Debug, Default)]
+pub struct InprocRegistry {
+    next_binding_id: AtomicU64,
+    binds: Mutex<FxHashMap<String, InprocBinding>>,
+}
+
+impl InprocRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn next_binding_id(&self) -> u64 {
+        self.next_binding_id.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+pub(crate) fn standalone_registry() -> Arc<InprocRegistry> {
+    static REGISTRY: std::sync::LazyLock<Arc<InprocRegistry>> =
+        std::sync::LazyLock::new(|| Arc::new(InprocRegistry::new()));
+    REGISTRY.clone()
+}
 
 /// Bind to `name`. The returned `InprocListener` yields one
 /// `InprocConn` per accepted connector. `snapshot` is captured
 /// here so we can hand it back to each connector synchronously
 /// during `accept`.
 pub(crate) fn bind(
+    registry: Arc<InprocRegistry>,
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_signal: Arc<DataSignal>,
@@ -179,18 +206,21 @@ pub(crate) fn bind(
     max_message_size: Option<usize>,
 ) -> Result<InprocListener> {
     let (tx, rx) = mpsc::channel(32);
+    let binding_id = registry.next_binding_id();
     {
-        let mut reg = REGISTRY.lock().expect("inproc registry poisoned");
+        let mut reg = registry.binds.lock().expect("inproc registry poisoned");
         if let Some(existing) = reg.get(name)
-            && !existing.is_closed()
+            && !existing.tx.is_closed()
         {
             return Err(Error::InvalidEndpoint(format!(
                 "inproc name already bound: {name}"
             )));
         }
-        reg.insert(name.to_string(), tx);
+        reg.insert(name.to_string(), InprocBinding { id: binding_id, tx });
     }
     Ok(InprocListener {
+        registry,
+        binding_id,
         name: name.to_string(),
         endpoint: omq_proto::endpoint::Endpoint::Inproc {
             name: name.to_string(),
@@ -204,6 +234,7 @@ pub(crate) fn bind(
 }
 
 pub(crate) async fn connect_with_max_message_size(
+    registry: &InprocRegistry,
     name: &str,
     snapshot: InprocPeerSnapshot,
     recv_signal: Arc<DataSignal>,
@@ -211,8 +242,8 @@ pub(crate) async fn connect_with_max_message_size(
     max_message_size: Option<usize>,
 ) -> Result<InprocConn> {
     let req_tx = {
-        let reg = REGISTRY.lock().expect("inproc registry poisoned");
-        reg.get(name).cloned()
+        let reg = registry.binds.lock().expect("inproc registry poisoned");
+        reg.get(name).map(|binding| binding.tx.clone())
     }
     .ok_or_else(|| Error::InvalidEndpoint(format!("no inproc binding: {name}")))?;
 
@@ -251,6 +282,8 @@ pub(crate) async fn connect_with_max_message_size(
 /// Bound inproc listener. Releases its registry slot on drop.
 #[derive(Debug)]
 pub struct InprocListener {
+    registry: Arc<InprocRegistry>,
+    binding_id: u64,
     name: String,
     endpoint: omq_proto::endpoint::Endpoint,
     snapshot: InprocPeerSnapshot,
@@ -350,7 +383,11 @@ impl InprocListener {
 
 impl Drop for InprocListener {
     fn drop(&mut self) {
-        if let Ok(mut reg) = REGISTRY.lock() {
+        if let Ok(mut reg) = self.registry.binds.lock()
+            && reg
+                .get(&self.name)
+                .is_some_and(|binding| binding.id == self.binding_id)
+        {
             reg.remove(&self.name);
         }
     }
@@ -378,6 +415,10 @@ mod tests {
         crate::socket::recv::BlockingRecvWaker::new()
     }
 
+    fn registry() -> Arc<InprocRegistry> {
+        Arc::new(InprocRegistry::new())
+    }
+
     #[test]
     fn blocking_space_rechecks_before_parking() {
         let space = BlockingSpace::new();
@@ -393,11 +434,28 @@ mod tests {
 
     #[tokio::test]
     async fn bind_connect_accept_exchange() {
-        let mut l = bind("test-bca", snap(SocketType::Pull), notify(), waker(), None).unwrap();
+        let registry = registry();
+        let mut l = bind(
+            registry.clone(),
+            "test-bca",
+            snap(SocketType::Pull),
+            notify(),
+            waker(),
+            None,
+        )
+        .unwrap();
         let n = notify();
+        let connector_registry = registry.clone();
         let connector = tokio::spawn(async move {
-            connect_with_max_message_size("test-bca", snap(SocketType::Push), n, waker(), None)
-                .await
+            connect_with_max_message_size(
+                &connector_registry,
+                "test-bca",
+                snap(SocketType::Push),
+                n,
+                waker(),
+                None,
+            )
+            .await
         });
         let server_side = l.accept().await.unwrap();
         let client_side = connector.await.unwrap().unwrap();
@@ -427,9 +485,25 @@ mod tests {
 
     #[tokio::test]
     async fn double_bind_rejected() {
-        let _l = bind("test-dup", snap(SocketType::Pair), notify(), waker(), None).unwrap();
+        let registry = registry();
+        let _l = bind(
+            registry.clone(),
+            "test-dup",
+            snap(SocketType::Pair),
+            notify(),
+            waker(),
+            None,
+        )
+        .unwrap();
         assert!(matches!(
-            bind("test-dup", snap(SocketType::Pair), notify(), waker(), None),
+            bind(
+                registry,
+                "test-dup",
+                snap(SocketType::Pair),
+                notify(),
+                waker(),
+                None
+            ),
             Err(Error::InvalidEndpoint(_))
         ));
     }
@@ -438,6 +512,7 @@ mod tests {
     async fn connect_without_bind_fails() {
         assert!(matches!(
             connect_with_max_message_size(
+                &registry(),
                 "test-unbound",
                 snap(SocketType::Push),
                 notify(),
@@ -451,9 +526,26 @@ mod tests {
 
     #[tokio::test]
     async fn listener_drop_releases_name() {
+        let registry = registry();
         {
-            let _l = bind("test-drop", snap(SocketType::Pair), notify(), waker(), None).unwrap();
+            let _l = bind(
+                registry.clone(),
+                "test-drop",
+                snap(SocketType::Pair),
+                notify(),
+                waker(),
+                None,
+            )
+            .unwrap();
         }
-        let _l2 = bind("test-drop", snap(SocketType::Pair), notify(), waker(), None).unwrap();
+        let _l2 = bind(
+            registry,
+            "test-drop",
+            snap(SocketType::Pair),
+            notify(),
+            waker(),
+            None,
+        )
+        .unwrap();
     }
 }

--- a/omq-tokio/tests/context.rs
+++ b/omq-tokio/tests/context.rs
@@ -201,6 +201,94 @@ fn multiple_contexts() {
 }
 
 #[test]
+fn contexts_have_isolated_inproc_namespaces() {
+    let ctx1 = Context::new();
+    let ctx2 = Context::new();
+    let endpoint = inproc_ep("same-name-isolated");
+
+    let pull1 = ctx1.socket(SocketType::Pull, Options::default());
+    let push1 = ctx1.socket(SocketType::Push, Options::default());
+    let pull2 = ctx2.socket(SocketType::Pull, Options::default());
+    let push2 = ctx2.socket(SocketType::Push, Options::default());
+
+    ctx1.block_on({
+        let endpoint = endpoint.clone();
+        let pull = pull1.clone();
+        let push = push1.clone();
+        async move {
+            pull.bind(endpoint.clone()).await.unwrap();
+            push.connect(endpoint).await.unwrap();
+        }
+    });
+    ctx2.block_on({
+        let endpoint = endpoint.clone();
+        let pull = pull2.clone();
+        let push = push2.clone();
+        async move {
+            pull.bind(endpoint.clone()).await.unwrap();
+            push.connect(endpoint).await.unwrap();
+        }
+    });
+
+    ctx1.block_on(async move {
+        push1.send(Message::single("ctx1")).await.unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(2), pull1.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg, Message::single("ctx1"));
+    });
+    ctx2.block_on(async move {
+        push2.send(Message::single("ctx2")).await.unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(2), pull2.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg, Message::single("ctx2"));
+    });
+}
+
+#[test]
+fn context_from_share_key_shares_inproc_namespace() {
+    let ctx = Context::new();
+    let shared = Context::from_share_key(ctx.share_key()).unwrap();
+
+    let pull = shared.socket(SocketType::Pull, Options::default());
+    let push = ctx.socket(SocketType::Push, Options::default());
+
+    ctx.block_on(async move {
+        let endpoint = inproc_ep("share-key");
+        pull.bind(endpoint.clone()).await.unwrap();
+        push.connect(endpoint).await.unwrap();
+        push.send(Message::single("shared")).await.unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg, Message::single("shared"));
+    });
+}
+
+#[test]
+fn context_share_key_does_not_keep_core_alive() {
+    let key = {
+        let ctx = Context::new();
+        ctx.share_key()
+    };
+    assert!(Context::from_share_key(key).is_none());
+}
+
+#[test]
+fn context_share_key_fails_after_term() {
+    let ctx = Context::new();
+    let key = ctx.share_key();
+    let shared = Context::from_share_key(key).unwrap();
+    ctx.term();
+    assert!(Context::from_share_key(key).is_none());
+    assert!(shared.is_terminated());
+}
+
+#[test]
 fn context_clone_shares_runtime() {
     let ctx = Context::new();
     let ctx2 = ctx.clone();


### PR DESCRIPTION
- Add `ContextCore` with a context-local `inproc://` registry and process-local `u128` share keys.
- Add C and pyomq import APIs for non-owning shared context handles.
- Preserve termination semantics for imported contexts and sockets.
- Add Rust, libzmq, and pyomq coverage for inproc isolation and shared context use.
- Refresh inproc comparison charts with turbo off.