### PR TITLE
Prepare OMQ.java 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,16 @@ jobs:
           java-version: "25"
           cache: maven
           cache-dependency-path: bindings/java/pom.xml
+      - uses: actions/setup-python@v6
+        id: python
+        with:
+          python-version: "3.14"
+      - name: install pyzmq
+        run: python -m pip install --upgrade pip "pyzmq>=25"
       - name: junit
+        env:
+          OMQ_INTEROP_REQUIRED: "1"
+          OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
         run: mvn -f bindings/java/pom.xml test
 
   ci-success:

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -55,6 +55,12 @@ jobs:
           java-version: "25"
           cache: maven
           cache-dependency-path: bindings/java/pom.xml
+      - uses: actions/setup-python@v6
+        id: python
+        with:
+          python-version: "3.14"
+      - name: install pyzmq
+        run: python -m pip install --upgrade pip "pyzmq>=25"
       - name: Build release native
         working-directory: bindings/java/native
         run: cargo build --release --features plain,curve,lz4,zstd
@@ -68,6 +74,9 @@ jobs:
           cp "bindings/java/native/target/release/${{ matrix.library }}" "$resource_dir/"
       - name: JUnit with release native
         shell: bash
+        env:
+          OMQ_INTEROP_REQUIRED: "1"
+          OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
         run: |
           peer_path="${GITHUB_WORKSPACE}/bindings/java/native/target/release/omq-java-peer"
           if [[ "${RUNNER_OS}" == "Windows" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ perf.data*
 /TODO
 .chart_hw
 !bindings/pyomq/.chart_hw
+!bindings/java/.chart_hw
 .perf_hw

--- a/bindings/java/.chart_hw
+++ b/bindings/java/.chart_hw
@@ -1,0 +1,2 @@
+prefix=Linux VM on a 2018 Mac Mini
+postfix=performance governor, turbo off

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -1,0 +1,17 @@
+# OMQ.java Changelog
+
+## [Unreleased]
+
+## [0.2.0]
+
+- Remove public batch send/receive APIs. Scalar receive methods still use the hidden native batch receive path.
+- Add `SocketOptions` for reusable pre-I/O option sets.
+- Add `Context.socket(SocketType, SocketOptions)`.
+- Add explicit JPMS module descriptor: `io.omq`.
+- Use native async receive for blocking receive calls made from Java virtual threads when cached ring data is empty.
+
+## [0.1.1]
+
+- First Maven Central release of OMQ.java.
+- Provide Java 25 bindings backed by native `omq-tokio`.
+- Include Linux x86_64, macOS x86_64, macOS aarch64, and Windows x86_64 native libraries in the jar.

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -10,7 +10,7 @@ Architecture detail: [`doc/architecture.md`](doc/architecture.md).
 
 ## Build, install, test
 
-Requires Java 25 or newer.
+Requires Java 25 or newer. JPMS module name: `io.omq`.
 
 Maven Central coordinates:
 
@@ -48,6 +48,7 @@ current-platform native library in the jar under `io/omq/native/...`.
 - `Context` owns native IO threads and creates sockets.
 - `Context.shareKey()` / `Context.fromShareKey(...)` explicitly share one
   native context core and `inproc://` namespace across Java handles.
+- `SocketOptions` builds reusable pre-I/O option sets for socket creation.
 - `Socket` is `AutoCloseable`; use try-with-resources.
 - `Message` is immutable and supports single-part and multipart payloads.
 - `receiveBytes` is the direct single-part hot path; use `receive` when
@@ -73,6 +74,20 @@ try (Context ctx = OMQ.context();
     push.connect(endpoint);
     push.send("hello");
     String body = pull.receive(Duration.ofSeconds(5)).orElseThrow().text();
+}
+```
+
+Reusable socket options:
+
+```java
+SocketOptions options = SocketOptions.builder()
+        .sendHighWaterMark(10_000)
+        .heartbeatInterval(Duration.ofSeconds(5))
+        .build();
+
+try (Context ctx = OMQ.context();
+     Socket push = ctx.socket(SocketType.PUSH, options)) {
+    push.connect("tcp://127.0.0.1:5555");
 }
 ```
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -12,13 +12,13 @@ Architecture detail: [`doc/architecture.md`](doc/architecture.md).
 
 Requires Java 25 or newer. JPMS module name: `io.omq`.
 
-Maven Central coordinates:
+Maven Central coordinates. Use the latest version listed on Maven Central:
 
 ```xml
 <dependency>
   <groupId>io.github.paddor</groupId>
   <artifactId>omq-java</artifactId>
-  <version>0.1.0</version>
+  <version>VERSION</version>
 </dependency>
 ```
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -55,6 +55,8 @@ current-platform native library in the jar under `io/omq/native/...`.
 - Sync receive methods transparently drain a Java 25 FFM off-heap ring filled
   from native `recv_many_into()`, so scalar `receive*` calls amortize native
   transition cost without exposing batch APIs.
+- Blocking receives on virtual threads drain cached ring data first and then
+  park through a native async receive when empty.
 - `sendAsync` and `receiveAsync` return `CompletableFuture` values backed by
   native OMQ runtime tasks, not Java worker threads. Cancel the returned
   future to abort the native task.

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,12 +1,31 @@
 # OMQ.java
 
-Modern Java bindings for OMQ backed by `omq-tokio`.
+OMQ.java brings OMQ sockets to Java with a native Rust backend.
 
-This is not a JeroMQ compatibility layer. The Java API owns a native OMQ
-context, and that context owns the background IO thread(s), matching the normal
-libzmq architecture.
+It wraps `omq-tokio`, so routing, reconnect, fair-queueing, auth, compression,
+and transport I/O run in OMQ-owned background threads while Java code gets a
+small API built around `AutoCloseable`, `Duration`, `ByteBuffer`, and
+`CompletableFuture`.
 
-Architecture detail: [`doc/architecture.md`](doc/architecture.md).
+## Highlights
+
+- Native OMQ engine shared with OMQ.rs.
+- High-throughput TCP and inproc messaging.
+- Compression transports: `lz4+tcp://` and `zstd+tcp://`.
+- Static compression dictionaries and auto-trained dictionaries.
+- PLAIN and CURVE security with Java auth callbacks and peer metadata.
+- Java 25 FFM off-heap rings hide batching behind normal scalar send/receive
+  calls.
+- Explicit native context sharing for `inproc://` across Java handles.
+
+## Performance
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/java/doc/charts/pushpull_tcp.svg" alt="OMQ.java vs JeroMQ PUSH/PULL TCP performance" width="850">
+</p>
+
+2-process loopback PUSH/PULL throughput vs JeroMQ over TCP. Results are
+median local runs from `scripts/bench_pushpull_tcp.py`.
 
 ## Build, install, test
 
@@ -43,7 +62,7 @@ mvn test
 Maven builds the Rust native library in `native/target/debug` and embeds the
 current-platform native library in the jar under `io/omq/native/...`.
 
-## Shape
+## API Shape
 
 - `Context` owns native IO threads and creates sockets.
 - `Context.shareKey()` / `Context.fromShareKey(...)` explicitly share one
@@ -63,6 +82,11 @@ current-platform native library in the jar under `io/omq/native/...`.
   future to abort the native task.
 - Sockets are synchronized on the Java side. Treat a socket as a single-thread
   object; create more sockets for more concurrent flows.
+
+OMQ.java is not a JeroMQ compatibility layer. It follows ZMQ socket semantics,
+but exposes a modern Java API instead of mirroring JeroMQ classes.
+
+Architecture detail: [`doc/architecture.md`](doc/architecture.md).
 
 Example:
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -52,7 +52,6 @@ current-platform native library in the jar under `io/omq/native/...`.
 - `Message` is immutable and supports single-part and multipart payloads.
 - `receiveBytes` is the direct single-part hot path; use `receive` when
   multipart metadata matters.
-- `sendManyBytes` sends many single-part messages in one JNI call.
 - Sync receive methods transparently drain a Java 25 FFM off-heap ring filled
   from native `recv_many_into()`, so scalar `receive*` calls amortize native
   transition cost without exposing batch APIs.

--- a/bindings/java/doc/architecture.md
+++ b/bindings/java/doc/architecture.md
@@ -64,6 +64,7 @@ ring path and use native owned storage or JNI fallback.
 - When Java's cache is empty, Rust fills descriptors and payload storage with `recv_many_into()` and reuses one internal `Vec<Message>`.
 - Java drains cached descriptors through `MemorySegment` views.
 - `receive`, `receiveBytes`, `receiveInto`, timeout variants, and try variants all use this hidden batch path.
+- On virtual threads, blocking receives drain cached ring data first; if empty, they wait through native async receive so the JVM can park the virtual thread.
 
 ## Send Path
 

--- a/bindings/java/doc/architecture.md
+++ b/bindings/java/doc/architecture.md
@@ -1,181 +1,89 @@
 # OMQ.java Architecture
 
-Maven binding for `omq-tokio`. The public API targets Java 25. Rust owns the
-OMQ context, sockets, protocol state, queues, reconnect logic, auth,
-compression, and background I/O.
+OMQ.java is a Java API over Rust `omq-tokio`.
 
-## Source layout
+- Java owns API shape, lifetime wrappers, argument validation, Java exceptions, and Java 25 FFM views of native rings.
+- Rust owns contexts, sockets, routing, queues, transports, ZMTP, reconnect, auth, compression, peer metadata, and I/O threads.
 
-```
-src/main/java/io/omq/
-  OMQ.java             static entry points and CURVE helpers
-  Context.java         native context handle, socket ownership, cleanup
-  Socket.java          synchronized socket facade and option setters
-  Message.java         immutable single-part and multipart payloads
-  Native.java          JNI declarations and packaged native library loader
-  NativeFfm.java       Java 25 FFM downcalls for fast native data paths
-  RecvRing.java        off-heap receive cache consumed from Java
-  SendRing.java        off-heap single-part send ring produced by Java
-  *Exception.java      unchecked exception hierarchy
+## Runtime
 
-native/src/
-  lib.rs              JNI and C ABI implementation over omq_tokio::blocking
-  bin/peer.rs         OMQ.rs peer used by Java interop tests
+```text
+Java caller thread
+  -> synchronized Socket method
+  -> JNI control path or FFM data path
+  -> omq_tokio::blocking::Socket
+  -> OMQ context runtime thread(s)
+  -> connection tasks and transport I/O
 ```
 
-## Threading model
+- `Context` owns a native `omq_tokio::Context`; the native context owns runtime threads, endpoint state, inproc registry, and sockets.
+- `Socket` owns one native socket handle; Java methods are `synchronized`, but socket semantics live in Rust.
+- Native handles are atomic; close is idempotent. `Cleaner` is only a leak fallback.
+- `Context.shareKey()` exposes a process-local opaque `UUID` for the native `u128` context key.
+- `Context.fromShareKey(UUID)` imports a non-owning Java handle to the same native context core.
+- Rust materializes the real blocking socket lazily on first `bind`, `connect`, `send`, `receive`, async receive, or wait.
+- Socket options are pre-materialization setup; protocol or transport setters fail after materialization.
 
-```
-Java caller thread -> synchronized Socket -> JNI/FFM -> omq_tokio::blocking::Socket
-                                                         |
-                                                         v
-                                      OMQ Context background I/O thread(s)
-                                      connection tasks, queues, ZMTP, auth,
-                                      compression, reconnect, transport I/O
-```
+## Source Map
 
-`Context(int ioThreads)` creates a native `omq_tokio::Context` with that
-I/O thread count. Java holds an opaque native handle. Closing an owning Java
-context terminates the native context and closes all Java sockets created
-from it. `Context.shareKey()` returns a process-local opaque `UUID` view of
-the native `u128` context key. `Context.fromShareKey(UUID)` imports another
-Java handle to the same native context core; closing the imported handle
-closes its Java sockets but does not terminate the owner.
+- `src/main/java/io/omq/Context.java`: context ownership and sharing
+- `src/main/java/io/omq/Socket.java`: public socket API and lifecycle
+- `src/main/java/io/omq/Native.java`: JNI declarations
+- `src/main/java/io/omq/NativeFfm.java`: FFM downcalls
+- `src/main/java/io/omq/RecvRing.java`, `SendRing.java`: Java ring views
+- `native/src/lib.rs`: JNI/FFM bridge to `omq-tokio`
 
-`Socket` holds an opaque native socket handle. The Rust side stores
-`Options` and lazily creates the actual `omq_tokio::blocking::Socket` on
-first `bind`, `connect`, `send`, `receive`, or wait operation. Option
-methods only edit the Rust `Options` value and must run before
-materialization.
+## Native Boundary
 
-Java socket methods are `synchronized`, so one Java wrapper cannot race
-itself. Native state uses an atomic handle for idempotent close and Rust
-mutexes for materialization and option mutation. `Cleaner` is a leak
-fallback, not the normal lifecycle path. Use try-with-resources.
+| Path | Role |
+| --- | --- |
+| JNI | lifecycle, endpoints, options, monitors, auth callbacks, multipart send, timeout send, async setup, error translation |
+| FFM | scalar sync receive batches, small single-part `PUSH`/`SCATTER` sends |
 
-## Data path
+The FFM ABI is Java-specific. It is not `omq-libzmq`. Java never encodes ZMTP or drives transport readiness.
 
-Java does not encode ZMTP, manage connections, or run transport threads.
-Native OMQ receives complete `Message` values and performs all socket
-semantics in Rust.
+## Ring Mechanics
 
-Synchronous receives use a Java 25 FFM fast path. Each Java socket lazily
-creates a native off-heap receive ring on first sync receive. The Rust side
-fills that ring with `recv_many_into()` using one reused `Vec<Message>`.
-Java then drains cached descriptors and payload bytes directly from
-`MemorySegment` views. Public methods stay scalar: `receive`,
-`receiveBytes`, `receiveInto`, `tryReceive`, and duration variants all use
-hidden batches when the ring is empty.
+The FFM rings are `yring`-style SPSC queues in native memory, but not the exact
+libzmq three-shared-pointer layout. Shared state is two padded atomic cursors:
+`head` and `tail`. `closed` is send-only. Each side keeps local cached cursors
+to avoid rereading the opposite atomic on every message.
 
-The receive ring mirrors `yring`/`ypipe_t` shape. Rust owns a private producer
-cursor. Java owns `head`. Rust publishes a batch by release-storing `tail`;
-Java acquires `tail`, reads descriptors with no native call per message, and
-release-stores `head` when a cached batch is drained or before refill.
-Descriptors and payload storage are native memory. Large payloads that do not
-fit the payload ring are held as native external blocks until Java advances
-`head`.
+Descriptors live in a power-of-two ring. Payload bytes live in a separate
+power-of-two arena. The producer writes payload bytes and descriptor, then
+release-stores `tail`. The consumer acquire-loads `tail`, drains descriptors,
+then release-stores `head` when slots are reusable.
 
-Single-part `PUSH` and `SCATTER` sends use a matching FFM send fast path.
-Java copies the user `byte[]` into an off-heap SPSC payload ring, writes one
-descriptor, and release-stores `tail`. A native worker thread drains
-descriptors, builds OMQ `Message` values backed by the off-heap slot, and
-submits them to the same native PUSH/SCATTER path used by JNI sends. The slot
-is released only when Rust drops the message owner. JNI send paths drain any
-queued FFM sends first, preserving call order when applications mix small
-single-part sends with multipart, timeout, async, or large-message sends.
-Large messages that do not fit the send payload ring wait for the ring to
-drain and then use the normal JNI send path. The ring remains usable for
-later small messages.
+Receive direction is Rust producer / Java consumer. Send direction is Java
+producer / Rust consumer. Large payloads that do not fit the arena leave the
+ring path and use native owned storage or JNI fallback.
 
-JNI remains the control plane for context/socket setup, options, auth
-callbacks, monitors, multipart send, non-`PUSH`/`SCATTER` send, timeout send,
-and async completion. The C ABI used by FFM is small and Java-specific; it is
-not `omq-libzmq`.
+## Receive Path
 
-`sendManyBytes` crosses JNI once with a Java `byte[][]` and sends each inner
-array as one single-part message. The Rust side copies each array into owned
-native message storage before `sendManyBytes` returns; Java buffers are never
-retained by native code.
+- Each socket lazily creates a native off-heap receive ring.
+- When Java's cache is empty, Rust fills descriptors and payload storage with `recv_many_into()` and reuses one internal `Vec<Message>`.
+- Java drains cached descriptors through `MemorySegment` views.
+- `receive`, `receiveBytes`, `receiveInto`, timeout variants, and try variants all use this hidden batch path.
 
-`inproc://` is not special-cased in Java. Each Rust context core owns its
-own inproc registry and decides whether an endpoint is local, what socket
-types are compatible, and which native queue path is legal. Separate Java
-contexts have isolated inproc namespaces. Use `Context.shareKey()` and
-`Context.fromShareKey(UUID)` when two Java handles must share one inproc
-namespace. A Java-private inproc registry would split address ownership from
-Rust and would break mixed Java/Rust endpoints inside the same process.
+## Send Path
 
-`trySend` calls native `try_send` and returns `false` when native routing
-or high-water-mark state cannot accept the message immediately. Other
-errors still raise typed exceptions. `tryReceive` and `tryRecv` return an
-empty `Optional` when no complete message is available.
+- Small single-part `PUSH` and `SCATTER` sends copy bytes into an off-heap SPSC send ring.
+- A native worker drains descriptors and submits OMQ messages on the same Rust path as JNI sends.
+- Multipart, large, timeout, async, and non-`PUSH`/`SCATTER` sends use JNI.
+- JNI sends drain queued FFM sends first, so mixed APIs preserve call order.
 
-## Async API
+## Async Path
 
-`sendAsync` and `receiveAsync` return Java `CompletableFuture` values but
-do not use Java worker threads. The Java method creates a future, JNI takes
-a global reference to it, clones the native async socket, and spawns a Rust
-future on the OMQ context runtime. JNI returns a native abort token stored
-inside the future; `cancel`, user `complete`, and user `completeExceptionally`
-drop that token and abort the native task. When the Rust future completes,
-the OMQ runtime thread attaches to the JVM as a daemon and calls `complete`
-or `completeExceptionally`.
+- `sendAsync`, `receiveAsync`, and `OMQ.receiveAny` return `CompletableFuture` without Java worker threads.
+- JNI creates a global ref, clones the native async socket, and spawns a Rust future on the OMQ runtime.
+- Completion attaches the runtime thread to the JVM as a daemon.
+- Canceling or externally completing the Java future drops a native abort token.
+- Async receive first drains any message already cached in the FFM receive ring.
 
-`receiveAsync(Duration)` wraps native `recv()` in `tokio::time::timeout`
-and completes exceptionally with `TimeoutException` on deadline. `sendAsync`
-completes after OMQ accepts the message into outbound routing buffers, same
-semantic point as synchronous `send`.
+## Inproc
 
-`OMQ.receiveAny(Socket...)` requires distinct sockets and runs one native
-task that polls nonblocking receives across them. It returns the first
-`ReceiveEvent` it consumes. It never starts loser `recv()` futures, so
-messages on other sockets remain queued. Canceling the Java future aborts
-the native poll task.
-Before spawning native receives, async receive APIs first drain any message
-already cached in the Java FFM receive ring. This preserves receive ordering
-when sync and async APIs are mixed.
+`inproc://` belongs to the Rust context core. Separate contexts have separate inproc namespaces. Handles imported with `fromShareKey` share the same native context core and therefore the same inproc namespace. Java has no private inproc registry.
 
-## Compression
+## Native Features
 
-Compression is enabled by endpoint scheme and native Cargo features.
-The Maven build enables `lz4` and `zstd`, so Java can use endpoints such
-as `lz4+tcp://127.0.0.1:5555` and `zstd+tcp://127.0.0.1:5555`.
-`compressionAutoTrain`, `compressionThreshold`, and `compressionLevel`
-map to OMQ options before socket materialization.
-
-## Security
-
-PLAIN and CURVE are enabled by the Maven native build. `OMQ.curveKeypair()`
-calls `omq_proto::CurveKeypair::generate()` in Rust and returns Z85 public
-and secret keys. `OMQ.curvePublic(secretKey)` parses a Z85 secret key in
-Rust and derives the matching Z85 public key.
-
-## Exceptions
-
-All OMQ Java exceptions are unchecked.
-
-- `TimeoutException`: timeout or would-block.
-- `ClosedException`: closed context or socket.
-- `InvalidEndpointException`: invalid endpoint or unsupported scheme.
-- `ProtocolException`: ZMTP protocol violation, bad handshake, or
-  unsupported ZMTP version.
-- `TransportException`: base for endpoint transport I/O failures. Carries
-  `operation()`, `endpoint()`, and native `detail()`.
-- `BindException`: native bind I/O failure, for example address in use.
-- `ConnectException`: native connect preflight I/O failure.
-- `NameResolutionException`: host lookup failure during bind, connect,
-  unbind, or disconnect.
-- `OMQException`: invalid configuration, message-too-large, unroutable,
-  JNI/native panic wrapper, and unexpected native errors.
-
-Java argument validation still uses standard `NullPointerException`,
-`IllegalArgumentException`, or `IllegalStateException` where appropriate.
-
-## Tests
-
-Normal CI runs the JUnit suite with the native library built by Maven. The
-soak test is opt-in and skipped unless `OMQ_JAVA_SOAK=1` or
-`-Domq.java.soak=true` is set. `bindings/java/scripts/soak.sh` runs the same
-mixed workload at 5, 10, 30, and 60 minutes by default. It exercises TCP peer
-churn, CURVE-authenticated churn, `lz4+tcp://`, `zstd+tcp://`, and shared
-context `inproc://` traffic while checking heap and RSS growth.
+Compression, PLAIN, and CURVE are native OMQ features exposed through Java options and endpoint schemes. Rust performs negotiation, key generation, authentication, compression, and peer metadata extraction.

--- a/bindings/java/doc/architecture.md
+++ b/bindings/java/doc/architecture.md
@@ -28,10 +28,12 @@ Java caller thread
 
 - `src/main/java/io/omq/Context.java`: context ownership and sharing
 - `src/main/java/io/omq/Socket.java`: public socket API and lifecycle
+- `src/main/java/io/omq/SocketOptions.java`: reusable pre-I/O option sets
 - `src/main/java/io/omq/Native.java`: JNI declarations
 - `src/main/java/io/omq/NativeFfm.java`: FFM downcalls
 - `src/main/java/io/omq/RecvRing.java`, `SendRing.java`: Java ring views
 - `native/src/lib.rs`: JNI/FFM bridge to `omq-tokio`
+- `src/main/java/module-info.java`: JPMS module descriptor
 
 ## Native Boundary
 

--- a/bindings/java/doc/charts/pushpull_tcp.svg
+++ b/bindings/java/doc/charts/pushpull_tcp.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 514" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="514" fill="white"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">7M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">9M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,183.9 145.8,171.7 201.7,194.4 257.5,256.3 313.3,271.8 369.2,265.0 425.0,300.4 480.8,335.7 536.7,359.0 592.5,370.8 648.3,376.9 704.2,380.1 760.0,381.8" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,170.4 145.8,167.8 201.7,191.7 257.5,259.0 313.3,267.6 369.2,273.6 425.0,297.4 480.8,329.8 536.7,355.6 592.5,367.5 648.3,376.0 704.2,379.5 760.0,381.2" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,261.4 145.8,282.8 201.7,287.5 257.5,299.6 313.3,309.0 369.2,323.8 425.0,343.9 480.8,362.5 536.7,370.9 592.5,377.9 648.3,381.1 704.2,382.3 760.0,382.6" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,268.3 145.8,276.5 201.7,282.4 257.5,304.6 313.3,312.3 369.2,325.1 425.0,340.4 480.8,361.2 536.7,372.9 592.5,378.1 648.3,381.1 704.2,382.3 760.0,382.6" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.8 145.8,377.2 201.7,371.9 257.5,367.6 313.3,355.3 369.2,323.1 425.0,298.4 480.8,285.2 536.7,281.5 592.5,275.8 648.3,268.4 704.2,256.5 760.0,242.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="377.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="371.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="367.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="355.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="323.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="298.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="285.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="281.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="275.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="268.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="256.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="242.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,380.6 145.8,377.1 201.7,371.7 257.5,368.0 313.3,354.2 369.2,327.5 425.0,295.3 480.8,272.9 536.7,267.6 592.5,249.2 648.3,253.2 704.2,237.6 760.0,198.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="377.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="371.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="368.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="354.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="327.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="295.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="272.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="249.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="253.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="237.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="198.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.0 145.8,380.8 201.7,377.8 257.5,373.2 313.3,364.8 369.2,353.2 425.0,342.9 480.8,339.9 536.7,330.5 592.5,333.8 648.3,335.7 704.2,328.9 760.0,294.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="380.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="377.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="373.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="364.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="353.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="342.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="339.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="330.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="333.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="335.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="328.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="294.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.1 145.8,380.6 201.7,377.5 257.5,373.8 313.3,365.6 369.2,353.8 425.0,339.4 480.8,337.3 536.7,338.5 592.5,335.5 648.3,336.2 704.2,328.0 760.0,292.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="380.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="377.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="373.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="365.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="353.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="339.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="337.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="338.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="335.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="336.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="328.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="292.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
+  <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="257.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="313.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="369.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="425.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="480.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="536.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="592.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="648.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="704.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <line x1="65" y1="432" x2="79" y2="432" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="72" cy="432" r="2.5" fill="#dc2626"/>
+  <text x="85" y="436" fill="#374151" font-size="11" font-weight="500">OMQ.java</text>
+  <line x1="245" y1="432" x2="259" y2="432" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="252" cy="432" r="2.5" fill="#f97316"/>
+  <text x="265" y="436" fill="#374151" font-size="11" font-weight="500">OMQ.java receiveInto</text>
+  <line x1="425" y1="432" x2="439" y2="432" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="432" cy="432" r="2.5" fill="#2563eb"/>
+  <text x="445" y="436" fill="#374151" font-size="11" font-weight="500">JeroMQ</text>
+  <line x1="605" y1="432" x2="619" y2="432" stroke="#8b5cf6" stroke-width="2.5"/>
+  <circle cx="612" cy="432" r="2.5" fill="#8b5cf6"/>
+  <text x="625" y="436" fill="#374151" font-size="11" font-weight="500">JeroMQ recvByteBuffer</text>
+  <text x="425.0" y="454" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = GB/s (right)</text>
+</svg>

--- a/bindings/java/native/src/bin/peer.rs
+++ b/bindings/java/native/src/bin/peer.rs
@@ -2,7 +2,9 @@ use std::env;
 use std::str::FromStr;
 use std::time::Duration;
 
-use omq_tokio::{Context, Endpoint, Message, Options, SocketType};
+use omq_tokio::{
+    Context, CurveKeypair, CurvePublicKey, CurveSecretKey, Endpoint, Message, Options, SocketType,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = env::args().skip(1);
@@ -18,10 +20,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket.connect(endpoint)?;
             socket.wait_connected(1, Duration::from_secs(5))?;
             socket.send(Message::from_slice(payload.as_bytes()))?;
+            std::thread::sleep(Duration::from_millis(100));
             socket.close()?;
         }
         "pull" => {
             let socket = ctx.blocking_socket(SocketType::Pull, Options::default());
+            let bound = socket.bind(endpoint)?;
+            println!("{bound}");
+            let message = socket.recv_timeout(Duration::from_secs(5))?;
+            let part = message.part_bytes(0).unwrap_or_default();
+            println!("{}", String::from_utf8_lossy(&part));
+            socket.close()?;
+        }
+        "curve-push" => {
+            let options = Options::default().curve_client(
+                curve_keypair_from_env("OMQ_CURVE_CLIENT_PUBLIC", "OMQ_CURVE_CLIENT_SECRET")?,
+                curve_public_from_env("OMQ_CURVE_SERVER_PUBLIC")?,
+            );
+            let socket = ctx.blocking_socket(SocketType::Push, options);
+            socket.connect(endpoint)?;
+            socket.wait_connected(1, Duration::from_secs(5))?;
+            socket.send(Message::from_slice(payload.as_bytes()))?;
+            std::thread::sleep(Duration::from_millis(100));
+            socket.close()?;
+        }
+        "curve-pull" => {
+            let options = Options::default().curve_server(curve_keypair_from_env(
+                "OMQ_CURVE_SERVER_PUBLIC",
+                "OMQ_CURVE_SERVER_SECRET",
+            )?);
+            let socket = ctx.blocking_socket(SocketType::Pull, options);
             let bound = socket.bind(endpoint)?;
             println!("{bound}");
             let message = socket.recv_timeout(Duration::from_secs(5))?;
@@ -34,4 +62,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     ctx.term();
     Ok(())
+}
+
+fn curve_keypair_from_env(
+    public_name: &str,
+    secret_name: &str,
+) -> Result<CurveKeypair, Box<dyn std::error::Error>> {
+    let public = curve_public_from_env(public_name)?;
+    let secret = CurveSecretKey::from_z85(&env::var(secret_name)?)?;
+    if public != secret.derive_public() {
+        return Err("CURVE public key does not match secret key".into());
+    }
+    Ok(CurveKeypair { public, secret })
+}
+
+fn curve_public_from_env(name: &str) -> Result<CurvePublicKey, Box<dyn std::error::Error>> {
+    Ok(CurvePublicKey::from_z85(&env::var(name)?)?)
 }

--- a/bindings/java/native/src/lib.rs
+++ b/bindings/java/native/src/lib.rs
@@ -40,7 +40,6 @@ struct JavaSocket {
     options: Mutex<Options>,
     socket: OnceLock<BlockingSocket>,
     materialize_lock: Mutex<()>,
-    recv_scratch: Mutex<Vec<Message>>,
     closed: AtomicBool,
 }
 
@@ -1742,23 +1741,6 @@ fn bytes_from_parts(env: &mut JNIEnv<'_>, parts: JObjectArray<'_>) -> Result<Vec
     Ok(out)
 }
 
-fn send_bodies(
-    env: &mut JNIEnv<'_>,
-    bodies: &JObjectArray<'_>,
-    socket: &BlockingSocket,
-) -> Result<(), Error> {
-    let len = env.get_array_length(bodies).map_err(jni_error)?;
-    for i in 0..len {
-        let body = env.get_object_array_element(bodies, i).map_err(jni_error)?;
-        if body.is_null() {
-            return Err(Error::Config(format!("message body {i} must not be null")));
-        }
-        let body = JByteArray::from(body);
-        java_send(socket, Message::single(Bytes::from(byte_array(env, body)?)))?;
-    }
-    Ok(())
-}
-
 fn java_try_send(
     socket: &BlockingSocket,
     message: Message,
@@ -1918,22 +1900,6 @@ fn message_to_java_native_ref<'local>(
         return message_part_to_java(env, message, 0).map(JObject::from);
     }
     message_to_java_parts(env, message).map(JObject::from)
-}
-
-fn messages_to_java_native_array(
-    env: &mut JNIEnv<'_>,
-    messages: &[Message],
-) -> Result<jobjectArray, Error> {
-    let object_class = env.find_class("java/lang/Object").map_err(jni_error)?;
-    let out = env
-        .new_object_array(messages.len() as jint, object_class, JObject::null())
-        .map_err(jni_error)?;
-    for (index, message) in messages.iter().enumerate() {
-        let item = message_to_java_native_ref(env, message)?;
-        env.set_object_array_element(&out, index as jint, item)
-            .map_err(jni_error)?;
-    }
-    Ok(out.into_raw())
 }
 
 fn recv_with_timeout(socket: &BlockingSocket, timeout_millis: jlong) -> Result<Message, Error> {
@@ -2190,28 +2156,6 @@ async fn receive_any_loop(
             tokio::time::sleep(Duration::from_micros(50)).await;
         }
     }
-}
-
-fn fill_java_byte_arrays(
-    env: &mut JNIEnv<'_>,
-    out: &JObjectArray<'_>,
-    offset: jint,
-    messages: &[Message],
-) -> Result<(), Error> {
-    for (index, message) in messages.iter().enumerate() {
-        if message.len() != 1 {
-            throw_java(
-                env,
-                "java/lang/IllegalStateException",
-                format!("message has {} parts", message.len()),
-            );
-            return Err(Error::Config("message is multipart".to_string()));
-        }
-        let body = message_part_to_java(env, message, 0)?;
-        env.set_object_array_element(out, offset + index as jint, body)
-            .map_err(jni_error)?;
-    }
-    Ok(())
 }
 
 fn duration_from_millis(millis: jlong) -> Result<Duration, Error> {
@@ -2671,7 +2615,6 @@ pub extern "system" fn Java_io_omq_Native_socketCreate(
             options: Mutex::new(Options::default()),
             socket: OnceLock::new(),
             materialize_lock: Mutex::new(()),
-            recv_scratch: Mutex::new(Vec::new()),
             closed: AtomicBool::new(false),
         })) as jlong
     })
@@ -2865,25 +2808,6 @@ pub extern "system" fn Java_io_omq_Native_socketSendMultipartTimeout(
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_omq_Native_socketSendMany(
-    mut env: JNIEnv<'_>,
-    _class: JClass<'_>,
-    handle: jlong,
-    messages: JObjectArray<'_>,
-) {
-    guard(&mut env, (), |env| {
-        let result = (|| {
-            let socket = socket_from_handle(handle)?.materialize()?;
-            send_bodies(env, &messages, &socket)
-        })();
-
-        if let Err(error) = result {
-            throw_omq(env, error);
-        }
-    });
-}
-
-#[unsafe(no_mangle)]
 pub extern "system" fn Java_io_omq_Native_socketTrySendMultipart(
     mut env: JNIEnv<'_>,
     _class: JClass<'_>,
@@ -2986,78 +2910,6 @@ pub extern "system" fn Java_io_omq_Native_socketRecvInto(
 
         match result {
             Ok(len) => len,
-            Err(error) => {
-                if env.exception_check().unwrap_or(false) {
-                    return 0;
-                }
-                throw_omq(env, error);
-                0
-            }
-        }
-    })
-}
-
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_io_omq_Native_socketRecvMany(
-    mut env: JNIEnv<'_>,
-    _class: JClass<'_>,
-    handle: jlong,
-    max_messages: jint,
-    timeout_millis: jlong,
-) -> jobjectArray {
-    guard(&mut env, std::ptr::null_mut(), |env| {
-        let result = (|| {
-            let java_socket = socket_from_handle(handle)?;
-            let socket = java_socket.materialize()?;
-            let mut scratch = java_socket
-                .recv_scratch
-                .lock()
-                .map_err(|_| Error::Config("recv scratch lock poisoned".to_string()))?;
-            scratch.clear();
-            recv_many_into(&socket, max_messages, timeout_millis, &mut scratch)?;
-            let out = messages_to_java_native_array(env, &scratch);
-            scratch.clear();
-            out
-        })();
-
-        match result {
-            Ok(value) => value,
-            Err(error) => {
-                throw_omq(env, error);
-                std::ptr::null_mut()
-            }
-        }
-    })
-}
-
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_io_omq_Native_socketRecvManyBytesInto(
-    mut env: JNIEnv<'_>,
-    _class: JClass<'_>,
-    handle: jlong,
-    out: JObjectArray<'_>,
-    offset: jint,
-    max_messages: jint,
-    timeout_millis: jlong,
-) -> jint {
-    guard(&mut env, 0, |env| {
-        let result = (|| {
-            let java_socket = socket_from_handle(handle)?;
-            let socket = java_socket.materialize()?;
-            let mut scratch = java_socket
-                .recv_scratch
-                .lock()
-                .map_err(|_| Error::Config("recv scratch lock poisoned".to_string()))?;
-            scratch.clear();
-            let count = recv_many_into(&socket, max_messages, timeout_millis, &mut scratch)?;
-            let fill_result = fill_java_byte_arrays(env, &out, offset, &scratch);
-            scratch.clear();
-            fill_result?;
-            Ok(count as jint)
-        })();
-
-        match result {
-            Ok(value) => value,
             Err(error) => {
                 if env.exception_check().unwrap_or(false) {
                     return 0;

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -187,6 +187,7 @@
         <version>${checkstyle.version}</version>
         <configuration>
           <configLocation>${project.basedir}/checkstyle.xml</configLocation>
+          <excludes>**/module-info.java</excludes>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
@@ -205,7 +206,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.4</version>
         <configuration>
-          <argLine>--enable-native-access=ALL-UNNAMED -Domq.java.peer=${omq.java.peer.path}</argLine>
+          <argLine>--enable-native-access=io.omq -Domq.java.peer=${omq.java.peer.path}</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>omq-java</artifactId>
   <version>${revision}</version>
   <name>OMQ.java</name>
-  <description>Java bindings for OMQ backed by omq-tokio</description>
+  <description>Java bindings for OMQ, a high-performance ZeroMQ/ZMQ-compatible messaging stack with Rust native I/O, compression, and CURVE security</description>
   <url>https://github.com/paddor/omq.rs</url>
 
   <licenses>

--- a/bindings/java/scripts/bench_pushpull_tcp.py
+++ b/bindings/java/scripts/bench_pushpull_tcp.py
@@ -4,6 +4,7 @@
 import argparse
 import datetime as dt
 import json
+import math
 import os
 import selectors
 import socket
@@ -19,10 +20,16 @@ CLASS = "io.omq.perf.PushPullTcpPeer"
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [8, 128, 1024, 4096, 32768]
 DEFAULT_IMPLS = ["omq", "omq-into", "jeromq", "jeromq-into"]
+CHART_DIR = ROOT / "doc" / "charts"
 JSONL = (
     Path(os.environ.get("OMQ_JAVA_CACHE_DIR", Path.home() / ".cache" / "omq.java"))
     / "pushpull-tcp.jsonl"
 )
+
+C_OMQ = "#dc2626"
+C_OMQ_INTO = "#f97316"
+C_JEROMQ = "#2563eb"
+C_JEROMQ_INTO = "#8b5cf6"
 
 
 def parse_csv_ints(value):
@@ -31,6 +38,19 @@ def parse_csv_ints(value):
 
 def parse_csv_strings(value):
     return [part for part in value.split(",") if part]
+
+
+def load_jsonl():
+    rows = []
+    try:
+        with JSONL.open() as file:
+            for line in file:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return rows
 
 
 def run(cmd, cwd=ROOT, timeout=None):
@@ -218,6 +238,261 @@ def append_jsonl(rows):
             file.write(json.dumps(row, sort_keys=True) + "\n")
 
 
+def chart_data_from_jsonl(sizes):
+    latest = {}
+    for row in load_jsonl():
+        if row.get("kind") != "pushpull_tcp":
+            continue
+        impl = row.get("impl")
+        size = row.get("msg_size")
+        if size not in sizes:
+            continue
+        key = (impl, size)
+        prev = latest.get(key)
+        if prev is None or row.get("run_id", "") >= prev.get("run_id", ""):
+            latest[key] = row
+    return {
+        impl: [latest.get((impl, size), {"msgs_s": 0.0, "gb_s": 0.0}) for size in sizes]
+        for impl in DEFAULT_IMPLS
+    }
+
+
+def fmt_size(size):
+    if size >= 1024:
+        return f"{size // 1024} KiB"
+    return f"{size} B"
+
+
+def nice_ceil(value):
+    if value <= 0:
+        return 1
+    exp = math.floor(math.log10(value))
+    base = 10**exp
+    for multiplier in [1, 2, 5, 10]:
+        candidate = multiplier * base
+        if candidate >= value:
+            return candidate
+    return 10 * base
+
+
+def fmt_y_rate(value):
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:g}M"
+    if value >= 1_000:
+        return f"{value / 1_000:g}k"
+    return f"{value:g}"
+
+
+def fmt_y_gbs(value):
+    if value >= 1:
+        return f"{value:g} GB/s"
+    return f"{value * 1000:g} MB/s"
+
+
+def read_chart_hw():
+    config = {}
+    path = ROOT / ".chart_hw"
+    try:
+        with path.open() as file:
+            for line in file:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, sep, value = line.partition("=")
+                if sep:
+                    config[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return config
+
+
+def escape_svg(value):
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def detect_hardware():
+    config = read_chart_hw()
+    try:
+        cpu = None
+        with open("/proc/cpuinfo") as file:
+            for line in file:
+                if line.startswith("model name"):
+                    cpu = line.split(":", 1)[1].strip()
+                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
+                    break
+        cores = os.cpu_count()
+        if cpu and cores:
+            label = f"{cpu}, {cores} cores"
+            prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
+            postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
+            extras = [item.strip() for item in postfix.split(",")] if postfix else []
+            hw_extras = os.environ.get("OMQ_HW_EXTRAS")
+            if hw_extras:
+                extras.extend(hw_extras.split(","))
+            extras = [item for item in (item.strip() for item in extras) if item]
+            if extras:
+                label += ", " + ", ".join(extras)
+            if prefix:
+                label = f"{prefix}, {label}"
+            return label
+    except OSError:
+        pass
+    return None
+
+
+def gen_chart(sizes, path):
+    data = chart_data_from_jsonl(sizes)
+    series = [
+        ("OMQ.java", C_OMQ, data["omq"]),
+        ("OMQ.java receiveInto", C_OMQ_INTO, data["omq-into"]),
+        ("JeroMQ", C_JEROMQ, data["jeromq"]),
+        ("JeroMQ recvByteBuffer", C_JEROMQ_INTO, data["jeromq-into"]),
+    ]
+    max_msgs = max((row["msgs_s"] for rows in data.values() for row in rows), default=0.0)
+    max_gbs = max((row["gb_s"] for rows in data.values() for row in rows), default=0.0)
+    msg_max = nice_ceil(max_msgs)
+    gbs_max = nice_ceil(max_gbs)
+    hw_label = detect_hardware()
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 500 + hw_offset
+    x_left, x_right = 90, 760
+    y_top = 35 + hw_offset
+    y_bot = 370 + hw_offset
+    plot_w = x_right - x_left
+    plot_h = y_bot - y_top
+    mid_x = (x_left + x_right) / 2
+    xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
+
+    def y_msg(value):
+        return y_bot - (value / msg_max) * plot_h
+
+    def y_gbs(value):
+        return y_bot - (value / gbs_max) * plot_h
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">',
+        f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
+        f'  <text x="{mid_x}" y="{y_top - 17}" text-anchor="middle" fill="#111827"'
+        f' font-size="13" font-weight="700">'
+        "PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>",
+    ]
+    if hw_label:
+        lines.append(
+            f'  <text x="{mid_x}" y="{y_top - 3}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{escape_svg(hw_label)}</text>'
+        )
+
+    for i in range(1, 11):
+        frac = i / 10
+        yy = y_bot - frac * plot_h
+        msg_val = int(msg_max * frac)
+        gbs_val = gbs_max * frac
+        lines.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+        lines.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f"{fmt_y_rate(msg_val)}</text>"
+        )
+        lines.append(
+            f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
+            f' dominant-baseline="middle" fill="#6b7280" font-size="10">'
+            f"{fmt_y_gbs(gbs_val)}</text>"
+        )
+
+    for x in xs:
+        lines.append(
+            f'  <line x1="{x:.1f}" y1="{y_top}" x2="{x:.1f}" y2="{y_bot}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+
+    lines.extend(
+        [
+            f'  <line x1="{x_left}" y1="{y_top}" x2="{x_left}" y2="{y_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_right}" y1="{y_top}" x2="{x_right}" y2="{y_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_left}" y1="{y_bot}" x2="{x_right}" y2="{y_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+        ]
+    )
+
+    y_mid = (y_top + y_bot) / 2
+    lines.append(
+        f'  <text x="40" y="{y_mid:.0f}" text-anchor="middle"'
+        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' transform="rotate(-90,40,{y_mid:.0f})">msg/s</text>'
+    )
+
+    for _, color, rows in series:
+        points = " ".join(
+            f"{xs[i]:.1f},{y_msg(row['msgs_s']):.1f}" for i, row in enumerate(rows)
+        )
+        lines.append(
+            f'  <polyline points="{points}" fill="none" stroke="{color}"'
+            f' stroke-width="2" stroke-dasharray="6,4"/>'
+        )
+
+    for _, color, rows in series:
+        points = " ".join(
+            f"{xs[i]:.1f},{y_gbs(row['gb_s']):.1f}" for i, row in enumerate(rows)
+        )
+        lines.append(
+            f'  <polyline points="{points}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for i, row in enumerate(rows):
+            yy = y_gbs(row["gb_s"])
+            lines.append(
+                f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="white" stroke-width="1"/>'
+            )
+
+    for i, size in enumerate(sizes):
+        lines.append(
+            f'  <text x="{xs[i]:.1f}" y="{y_bot + 14}" text-anchor="middle"'
+            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+        )
+
+    legend_y = y_bot + 48
+    legend_items = [(label, color) for label, color, _ in series]
+    item_w = 180
+    total_w = len(legend_items) * item_w
+    start_x = mid_x - total_w / 2
+    for idx, (label, color) in enumerate(legend_items):
+        lx = start_x + idx * item_w
+        lines.append(
+            f'  <line x1="{lx:.0f}" y1="{legend_y}" x2="{lx + 14:.0f}"'
+            f' y2="{legend_y}" stroke="{color}" stroke-width="2.5"/>'
+        )
+        lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{legend_y}" r="2.5" fill="{color}"/>')
+        lines.append(
+            f'  <text x="{lx + 20:.0f}" y="{legend_y + 4}" fill="#374151"'
+            f' font-size="11" font-weight="500">{escape_svg(label)}</text>'
+        )
+
+    footer_y = legend_y + 22
+    lines.append(
+        f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f"dashed = msg/s (left) · solid = GB/s (right)</text>"
+    )
+    lines.append("</svg>")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+    print(f"wrote {path}")
+
+
 def print_table(rows, sizes, impls):
     by_key = {(row["msg_size"], row["impl"]): row for row in rows}
     print()
@@ -249,9 +524,16 @@ def main():
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--no-build", action="store_true")
+    parser.add_argument("--chart-only", action="store_true")
+    parser.add_argument("--no-chart", action="store_true")
     args = parser.parse_args()
 
     sizes = args.sizes or (QUICK_SIZES if args.quick else DEFAULT_SIZES)
+    chart_path = CHART_DIR / "pushpull_tcp.svg"
+    if args.chart_only:
+        gen_chart(sizes, chart_path)
+        return
+
     build(args)
     cp = classpath()
     run_id = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -268,6 +550,8 @@ def main():
     append_jsonl(rows)
     print_table(rows, sizes, args.impls)
     print(f"appended {len(rows)} rows to {JSONL}")
+    if not args.no_chart:
+        gen_chart(sizes, chart_path)
 
 
 if __name__ == "__main__":

--- a/bindings/java/src/main/java/io/omq/Context.java
+++ b/bindings/java/src/main/java/io/omq/Context.java
@@ -72,6 +72,22 @@ public final class Context implements AutoCloseable {
         }
     }
 
+    /** Creates a socket and applies reusable options before first I/O. */
+    public Socket socket(SocketType type, SocketOptions options) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(options, "options");
+        synchronized (state) {
+            Socket socket = new Socket(this, state.handle(), type, sockets);
+            try {
+                options.apply(socket);
+                return socket;
+            } catch (RuntimeException | Error error) {
+                socket.close();
+                throw error;
+            }
+        }
+    }
+
     void remove(Socket.State state) {
         sockets.remove(state);
     }

--- a/bindings/java/src/main/java/io/omq/Native.java
+++ b/bindings/java/src/main/java/io/omq/Native.java
@@ -61,8 +61,6 @@ final class Native {
 
     static native int socketSendMultipartTimeout(long handle, byte[][] parts, long timeoutMillis);
 
-    static native void socketSendMany(long handle, byte[][] messages);
-
     static native int socketTrySendMultipart(long handle, byte[][] parts);
 
     static native long socketSendAsync(long handle, byte[][] parts, Object future);
@@ -70,11 +68,6 @@ final class Native {
     static native Object socketRecv(long handle, long timeoutMillis);
 
     static native int socketRecvInto(long handle, ByteBuffer destination, long timeoutMillis);
-
-    static native Object[] socketRecvMany(long handle, int maxMessages, long timeoutMillis);
-
-    static native int socketRecvManyBytesInto(
-            long handle, byte[][] out, int offset, int maxMessages, long timeoutMillis);
 
     static native long socketRecvAsync(long handle, long timeoutMillis, Object future);
 

--- a/bindings/java/src/main/java/io/omq/Socket.java
+++ b/bindings/java/src/main/java/io/omq/Socket.java
@@ -1,7 +1,9 @@
 package io.omq;
 
 import java.lang.ref.Cleaner;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -10,6 +12,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
@@ -226,17 +229,26 @@ public final class Socket implements AutoCloseable {
 
     /** Receives one message, blocking forever. */
     public synchronized Message receive() {
+        if (Thread.currentThread().isVirtual()) {
+            return receiveVirtual(FOREVER);
+        }
         return withRecvRing((ring, handle) -> ring.receive(handle, FOREVER));
     }
 
     /** Receives one single-part message body, blocking forever. */
     public synchronized byte[] receiveBytes() {
+        if (Thread.currentThread().isVirtual()) {
+            return receiveVirtual(FOREVER).bytes();
+        }
         return withRecvRing((ring, handle) -> ring.receiveBytes(handle, FOREVER));
     }
 
     /** Receives one single-part message body into {@code destination}, blocking forever. */
     public synchronized int receiveInto(ByteBuffer destination) {
         Objects.requireNonNull(destination, "destination");
+        if (Thread.currentThread().isVirtual()) {
+            return writeInto(receiveVirtual(FOREVER), destination);
+        }
         return withRecvRing((ring, handle) -> ring.receiveInto(handle, destination, FOREVER));
     }
 
@@ -245,6 +257,9 @@ public final class Socket implements AutoCloseable {
         Objects.requireNonNull(timeout, "timeout");
         long timeoutMillis = millis(timeout);
         try {
+            if (Thread.currentThread().isVirtual()) {
+                return Optional.of(receiveVirtual(timeoutMillis));
+            }
             return Optional.of(withRecvRing((ring, handle) -> ring.receive(handle, timeoutMillis)));
         } catch (TimeoutException timeoutError) {
             return Optional.empty();
@@ -256,6 +271,9 @@ public final class Socket implements AutoCloseable {
         Objects.requireNonNull(timeout, "timeout");
         long timeoutMillis = millis(timeout);
         try {
+            if (Thread.currentThread().isVirtual()) {
+                return Optional.of(receiveVirtual(timeoutMillis).bytes());
+            }
             return Optional.of(withRecvRing(
                     (ring, handle) -> ring.receiveBytes(handle, timeoutMillis)));
         } catch (TimeoutException timeoutError) {
@@ -269,6 +287,9 @@ public final class Socket implements AutoCloseable {
         Objects.requireNonNull(timeout, "timeout");
         long timeoutMillis = millis(timeout);
         try {
+            if (Thread.currentThread().isVirtual()) {
+                return OptionalInt.of(writeInto(receiveVirtual(timeoutMillis), destination));
+            }
             return OptionalInt.of(withRecvRing(
                     (ring, handle) -> ring.receiveInto(handle, destination, timeoutMillis)));
         } catch (TimeoutException timeoutError) {
@@ -983,6 +1004,47 @@ public final class Socket implements AutoCloseable {
         synchronized (state) {
             state.handle();
             return state.recvRing.tryReceiveCachedMessage();
+        }
+    }
+
+    private Message receiveVirtual(long timeoutMillis) {
+        synchronized (state) {
+            long handle = state.handle();
+            Optional<Message> cached = state.recvRing.tryReceiveCachedMessage();
+            if (cached.isPresent()) {
+                return cached.orElseThrow();
+            }
+            NativeFuture<Message> future = new NativeFuture<>();
+            long task = Native.socketRecvAsync(handle, timeoutMillis, future);
+            future.setNativeTask(task);
+            return await(future);
+        }
+    }
+
+    private static int writeInto(Message message, ByteBuffer destination) {
+        if (destination.isReadOnly()) {
+            throw new ReadOnlyBufferException();
+        }
+        byte[] bytes = message.bytes();
+        if (bytes.length > destination.remaining()) {
+            throw new BufferOverflowException();
+        }
+        destination.put(bytes);
+        return bytes.length;
+    }
+
+    private static <T> T await(CompletableFuture<T> future) {
+        try {
+            return future.join();
+        } catch (CompletionException error) {
+            Throwable cause = error.getCause();
+            if (cause instanceof RuntimeException runtime) {
+                throw runtime;
+            }
+            if (cause instanceof Error fatal) {
+                throw fatal;
+            }
+            throw error;
         }
     }
 

--- a/bindings/java/src/main/java/io/omq/Socket.java
+++ b/bindings/java/src/main/java/io/omq/Socket.java
@@ -5,8 +5,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -146,18 +144,6 @@ public final class Socket implements AutoCloseable {
             }
             return Native.socketSendMultipartTimeout(handle, parts, timeoutMillis) != 0;
         }
-    }
-
-    /** Sends each byte array as one single-part message. */
-    public synchronized Socket sendManyBytes(byte[][] bodies) {
-        Objects.requireNonNull(bodies, "bodies");
-        byte[][] messages = requireBodies(bodies);
-        synchronized (state) {
-            long handle = state.handle();
-            drainSendRingOrThrow(FOREVER);
-            Native.socketSendMany(handle, messages);
-        }
-        return this;
     }
 
     /** Attempts to send a single-part binary message without blocking. */
@@ -316,115 +302,6 @@ public final class Socket implements AutoCloseable {
                     (ring, handle) -> ring.receiveInto(handle, destination, 0)));
         } catch (TimeoutException timeoutError) {
             return OptionalInt.empty();
-        }
-    }
-
-    /** Receives up to {@code maxMessages} messages, blocking until the first message. */
-    public synchronized List<Message> receiveMany(int maxMessages) {
-        requirePositive("maxMessages", maxMessages);
-        return receiveManyFromRing(maxMessages, FOREVER);
-    }
-
-    /** Receives up to {@code maxMessages} single-part bodies, blocking until the first message. */
-    public synchronized List<byte[]> receiveManyBytes(int maxMessages) {
-        requirePositive("maxMessages", maxMessages);
-        return receiveManyBytesFromRing(maxMessages, FOREVER);
-    }
-
-    /** Receives up to {@code maxMessages} messages before the timeout, or returns an empty list. */
-    public synchronized List<Message> receiveMany(int maxMessages, Duration timeout) {
-        requirePositive("maxMessages", maxMessages);
-        Objects.requireNonNull(timeout, "timeout");
-        long timeoutMillis = millis(timeout);
-        try {
-            return receiveManyFromRing(maxMessages, timeoutMillis);
-        } catch (TimeoutException timeoutError) {
-            return List.of();
-        }
-    }
-
-    /** Receives up to {@code maxMessages} single-part bodies before the timeout, or returns an empty list. */
-    public synchronized List<byte[]> receiveManyBytes(int maxMessages, Duration timeout) {
-        requirePositive("maxMessages", maxMessages);
-        Objects.requireNonNull(timeout, "timeout");
-        long timeoutMillis = millis(timeout);
-        try {
-            return receiveManyBytesFromRing(maxMessages, timeoutMillis);
-        } catch (TimeoutException timeoutError) {
-            return List.of();
-        }
-    }
-
-    /** Fills {@code output} with single-part bodies, blocking until the first message. */
-    public synchronized int receiveManyBytesInto(byte[][] output) {
-        return receiveManyBytesInto(output, 0, outputLength(output));
-    }
-
-    /** Fills {@code output} with single-part bodies, blocking until the first message. */
-    public synchronized int receiveManyBytesInto(byte[][] output, int offset, int maxMessages) {
-        int max = checkOutputRange(output, offset, maxMessages);
-        if (max == 0) {
-            return 0;
-        }
-        return receiveManyBytesIntoFromRing(output, offset, max, FOREVER);
-    }
-
-    /** Fills {@code output} with single-part bodies before the timeout, or returns zero. */
-    public synchronized int receiveManyBytesInto(byte[][] output, Duration timeout) {
-        return receiveManyBytesInto(output, 0, outputLength(output), timeout);
-    }
-
-    /** Fills {@code output} with single-part bodies before the timeout, or returns zero. */
-    public synchronized int receiveManyBytesInto(
-            byte[][] output, int offset, int maxMessages, Duration timeout) {
-        Objects.requireNonNull(timeout, "timeout");
-        int max = checkOutputRange(output, offset, maxMessages);
-        if (max == 0) {
-            return 0;
-        }
-        long timeoutMillis = millis(timeout);
-        try {
-            return receiveManyBytesIntoFromRing(output, offset, max, timeoutMillis);
-        } catch (TimeoutException timeoutError) {
-            return 0;
-        }
-    }
-
-    /** Receives available messages up to {@code maxMessages} without blocking. */
-    public synchronized List<Message> tryReceiveMany(int maxMessages) {
-        requirePositive("maxMessages", maxMessages);
-        try {
-            return receiveManyFromRing(maxMessages, 0);
-        } catch (TimeoutException timeoutError) {
-            return List.of();
-        }
-    }
-
-    /** Receives available single-part bodies up to {@code maxMessages} without blocking. */
-    public synchronized List<byte[]> tryReceiveManyBytes(int maxMessages) {
-        requirePositive("maxMessages", maxMessages);
-        try {
-            return receiveManyBytesFromRing(maxMessages, 0);
-        } catch (TimeoutException timeoutError) {
-            return List.of();
-        }
-    }
-
-    /** Fills {@code output} with available single-part bodies without blocking. */
-    public synchronized int tryReceiveManyBytesInto(byte[][] output) {
-        return tryReceiveManyBytesInto(output, 0, outputLength(output));
-    }
-
-    /** Fills {@code output} with available single-part bodies without blocking. */
-    public synchronized int tryReceiveManyBytesInto(byte[][] output, int offset, int maxMessages) {
-        int max = checkOutputRange(output, offset, maxMessages);
-        if (max == 0) {
-            return 0;
-        }
-        try {
-            return receiveManyBytesIntoFromRing(output, offset, max, 0);
-        } catch (TimeoutException timeoutError) {
-            return 0;
         }
     }
 
@@ -1067,12 +944,6 @@ public final class Socket implements AutoCloseable {
         }
     }
 
-    private static void requirePositive(String name, int value) {
-        if (value <= 0) {
-            throw new IllegalArgumentException(name + " must be greater than zero");
-        }
-    }
-
     private static void requireNonNegative(String name, long value) {
         if (value < 0) {
             throw new IllegalArgumentException(name + " must be non-negative");
@@ -1108,81 +979,11 @@ public final class Socket implements AutoCloseable {
         }
     }
 
-    private static byte[][] requireBodies(byte[][] bodies) {
-        for (int i = 0; i < bodies.length; i++) {
-            Objects.requireNonNull(bodies[i], "body " + i);
-        }
-        return bodies;
-    }
-
-    private static int outputLength(byte[][] output) {
-        return Objects.requireNonNull(output, "output").length;
-    }
-
-    private static int checkOutputRange(byte[][] output, int offset, int maxMessages) {
-        Objects.requireNonNull(output, "output");
-        if (offset < 0) {
-            throw new IndexOutOfBoundsException("offset must be non-negative");
-        }
-        if (maxMessages < 0) {
-            throw new IllegalArgumentException("maxMessages must be non-negative");
-        }
-        if (offset > output.length || maxMessages > output.length - offset) {
-            throw new IndexOutOfBoundsException("output range exceeds array length");
-        }
-        return maxMessages;
-    }
-
     private Optional<Message> tryReceiveCachedMessage() {
         synchronized (state) {
             state.handle();
             return state.recvRing.tryReceiveCachedMessage();
         }
-    }
-
-    private List<Message> receiveManyFromRing(int maxMessages, long timeoutMillis) {
-        ArrayList<Message> out = new ArrayList<>(maxMessages);
-        out.add(withRecvRing((ring, handle) -> ring.receive(handle, timeoutMillis)));
-        while (out.size() < maxMessages) {
-            try {
-                out.add(withRecvRing((ring, handle) -> ring.receive(handle, 0)));
-            } catch (TimeoutException timeoutError) {
-                break;
-            }
-        }
-        return out;
-    }
-
-    private List<byte[]> receiveManyBytesFromRing(int maxMessages, long timeoutMillis) {
-        ArrayList<byte[]> out = new ArrayList<>(maxMessages);
-        out.add(withRecvRing((ring, handle) -> ring.receiveBytes(handle, timeoutMillis)));
-        while (out.size() < maxMessages) {
-            try {
-                out.add(withRecvRing((ring, handle) -> ring.receiveBytes(handle, 0)));
-            } catch (TimeoutException timeoutError) {
-                break;
-            }
-        }
-        return out;
-    }
-
-    private int receiveManyBytesIntoFromRing(
-            byte[][] output, int offset, int maxMessages, long timeoutMillis) {
-        int count = 0;
-        while (count < maxMessages) {
-            long timeout = count == 0 ? timeoutMillis : 0;
-            try {
-                output[offset + count] =
-                        withRecvRing((ring, handle) -> ring.receiveBytes(handle, timeout));
-                count++;
-            } catch (TimeoutException timeoutError) {
-                if (count == 0) {
-                    throw timeoutError;
-                }
-                break;
-            }
-        }
-        return count;
     }
 
     private boolean usesSendRing() {

--- a/bindings/java/src/main/java/io/omq/SocketOptions.java
+++ b/bindings/java/src/main/java/io/omq/SocketOptions.java
@@ -1,0 +1,443 @@
+package io.omq;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/** Immutable reusable socket option set. */
+public final class SocketOptions {
+    private static final int ZMTP_MAX_SHORT_STRING_BYTES = 255;
+    private static final int COMPRESSION_DICT_MAX_BYTES = 8 * 1024;
+    private static final int ZSTD_LEVEL_MIN = -8;
+    private static final int ZSTD_LEVEL_MAX = 4;
+    private static final long MAX_HEARTBEAT_TTL_MILLIS = 6_553_500;
+
+    private final List<OptionAction> actions;
+
+    private SocketOptions(List<OptionAction> actions) {
+        this.actions = List.copyOf(actions);
+    }
+
+    /** Returns a new socket option builder. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    void apply(Socket socket) {
+        for (OptionAction action : actions) {
+            action.apply(socket);
+        }
+    }
+
+    @FunctionalInterface
+    private interface OptionAction {
+        void apply(Socket socket);
+    }
+
+    /** Builder for immutable socket option sets. */
+    public static final class Builder {
+        private final ArrayList<OptionAction> actions = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        /** Builds an immutable option set. */
+        public SocketOptions build() {
+            return new SocketOptions(actions);
+        }
+
+        /** Sets linger duration for close. */
+        public Builder linger(Duration linger) {
+            Socket.millis(Objects.requireNonNull(linger, "linger"));
+            return add(socket -> socket.linger(linger));
+        }
+
+        /** Sets infinite linger. */
+        public Builder lingerForever() {
+            return add(Socket::lingerForever);
+        }
+
+        /** Sets the socket identity. */
+        public Builder identity(byte[] identity) {
+            byte[] value = copy(Objects.requireNonNull(identity, "identity"));
+            requireMaxLength("identity", value.length, ZMTP_MAX_SHORT_STRING_BYTES);
+            return add(socket -> socket.identity(copy(value)));
+        }
+
+        /** Sets send high-water mark in messages. */
+        public Builder sendHighWaterMark(int hwm) {
+            requireNonNegative("HWM", hwm);
+            return add(socket -> socket.sendHighWaterMark(hwm));
+        }
+
+        /** Sets receive high-water mark in messages. */
+        public Builder receiveHighWaterMark(int hwm) {
+            requireNonNegative("HWM", hwm);
+            return add(socket -> socket.receiveHighWaterMark(hwm));
+        }
+
+        /** Sets heartbeat interval. */
+        public Builder heartbeatInterval(Duration interval) {
+            Socket.millis(Objects.requireNonNull(interval, "interval"));
+            return add(socket -> socket.heartbeatInterval(interval));
+        }
+
+        /** Disables heartbeats. */
+        public Builder heartbeatOff() {
+            return add(Socket::heartbeatOff);
+        }
+
+        /** Sets ZMTP handshake timeout. */
+        public Builder handshakeTimeout(Duration timeout) {
+            Socket.millis(Objects.requireNonNull(timeout, "timeout"));
+            return add(socket -> socket.handshakeTimeout(timeout));
+        }
+
+        /** Sets maximum message size in bytes. */
+        public Builder maxMessageSize(long size) {
+            requireNonNegative("size", size);
+            return add(socket -> socket.maxMessageSize(size));
+        }
+
+        /** Removes the maximum message size limit. */
+        public Builder noMaxMessageSize() {
+            return add(Socket::noMaxMessageSize);
+        }
+
+        /** Enables or disables compression dictionary auto-training. */
+        public Builder compressionAutoTrain(boolean enabled) {
+            return add(socket -> socket.compressionAutoTrain(enabled));
+        }
+
+        /** Sets compression threshold in bytes. */
+        public Builder compressionThreshold(long threshold) {
+            requireNonNegative("threshold", threshold);
+            return add(socket -> socket.compressionThreshold(threshold));
+        }
+
+        /** Restores default compression threshold. */
+        public Builder compressionDefaultThreshold() {
+            return add(Socket::compressionDefaultThreshold);
+        }
+
+        /** Sets compression level. */
+        public Builder compressionLevel(int level) {
+            if (level < ZSTD_LEVEL_MIN || level > ZSTD_LEVEL_MAX) {
+                throw new IllegalArgumentException(
+                        "zstd compression level must be " + ZSTD_LEVEL_MIN + "..=" + ZSTD_LEVEL_MAX);
+            }
+            return add(socket -> socket.compressionLevel(level));
+        }
+
+        /** Restores default compression level. */
+        public Builder compressionDefaultLevel() {
+            return add(Socket::compressionDefaultLevel);
+        }
+
+        /** Configures a PLAIN server with fixed credentials. */
+        public Builder plainServer(String username, String password) {
+            Objects.requireNonNull(username, "username");
+            Objects.requireNonNull(password, "password");
+            requireZmtpShortString("username", username);
+            requireZmtpShortString("password", password);
+            return add(socket -> socket.plainServer(username, password));
+        }
+
+        /** Configures a PLAIN server with an authenticator. */
+        public Builder plainServer(Predicate<PeerInfo> authenticator) {
+            Objects.requireNonNull(authenticator, "authenticator");
+            return add(socket -> socket.plainServer(authenticator));
+        }
+
+        /** Configures a PLAIN client. */
+        public Builder plainClient(String username, String password) {
+            Objects.requireNonNull(username, "username");
+            Objects.requireNonNull(password, "password");
+            requireZmtpShortString("username", username);
+            requireZmtpShortString("password", password);
+            return add(socket -> socket.plainClient(username, password));
+        }
+
+        /** Configures a CURVE server. */
+        public Builder curveServer(CurveKeypair keypair) {
+            Objects.requireNonNull(keypair, "keypair");
+            requireMatchingCurveKeypair(keypair);
+            return add(socket -> socket.curveServer(keypair));
+        }
+
+        /** Configures a CURVE server with an authenticator. */
+        public Builder curveServer(CurveKeypair keypair, Predicate<PeerInfo> authenticator) {
+            Objects.requireNonNull(keypair, "keypair");
+            Objects.requireNonNull(authenticator, "authenticator");
+            requireMatchingCurveKeypair(keypair);
+            return add(socket -> socket.curveServer(keypair, authenticator));
+        }
+
+        /** Configures a CURVE client. */
+        public Builder curveClient(CurveKeypair keypair, String serverPublicKey) {
+            Objects.requireNonNull(keypair, "keypair");
+            Objects.requireNonNull(serverPublicKey, "serverPublicKey");
+            requireMatchingCurveKeypair(keypair);
+            CurveKeys.requireZ85Key("CURVE public key", serverPublicKey);
+            return add(socket -> socket.curveClient(keypair, serverPublicKey));
+        }
+
+        /** Selects native socket-driver scheduling. */
+        public Builder workloadProfile(WorkloadProfile profile) {
+            Objects.requireNonNull(profile, "profile");
+            return add(socket -> socket.workloadProfile(profile));
+        }
+
+        /** Restores native socket-type default scheduling. */
+        public Builder defaultWorkloadProfile() {
+            return add(Socket::defaultWorkloadProfile);
+        }
+
+        /** Disables reconnect attempts. */
+        public Builder reconnectDisabled() {
+            return add(Socket::reconnectDisabled);
+        }
+
+        /** Uses a fixed reconnect interval. */
+        public Builder reconnectInterval(Duration interval) {
+            Socket.millis(Objects.requireNonNull(interval, "interval"));
+            return add(socket -> socket.reconnectInterval(interval));
+        }
+
+        /** Uses exponential reconnect backoff. */
+        public Builder reconnectExponential(Duration min, Duration max) {
+            long minMillis = Socket.millis(Objects.requireNonNull(min, "min"));
+            long maxMillis = Socket.millis(Objects.requireNonNull(max, "max"));
+            if (maxMillis < minMillis) {
+                throw new IllegalArgumentException("max must be greater than or equal to min");
+            }
+            return add(socket -> socket.reconnectExponential(min, max));
+        }
+
+        /** Stops reconnecting after ECONNREFUSED. */
+        public Builder reconnectStopConnRefused(boolean enabled) {
+            return add(socket -> socket.reconnectStopConnRefused(enabled));
+        }
+
+        /** Sets heartbeat TTL advertised to peers. */
+        public Builder heartbeatTtl(Duration ttl) {
+            long ttlMillis = Socket.millis(Objects.requireNonNull(ttl, "ttl"));
+            if (ttlMillis > MAX_HEARTBEAT_TTL_MILLIS) {
+                throw new IllegalArgumentException("heartbeat TTL exceeds ZMTP maximum of 6553.5s");
+            }
+            return add(socket -> socket.heartbeatTtl(ttl));
+        }
+
+        /** Omits heartbeat TTL. */
+        public Builder noHeartbeatTtl() {
+            return add(Socket::noHeartbeatTtl);
+        }
+
+        /** Sets receive-idle heartbeat timeout. */
+        public Builder heartbeatTimeout(Duration timeout) {
+            Socket.millis(Objects.requireNonNull(timeout, "timeout"));
+            return add(socket -> socket.heartbeatTimeout(timeout));
+        }
+
+        /** Restores default heartbeat timeout. */
+        public Builder defaultHeartbeatTimeout() {
+            return add(Socket::defaultHeartbeatTimeout);
+        }
+
+        /** Sets maximum simultaneous pending handshakes. */
+        public Builder maxPendingHandshakes(int max) {
+            if (max <= 0) {
+                throw new IllegalArgumentException("max must be greater than zero");
+            }
+            return add(socket -> socket.maxPendingHandshakes(max));
+        }
+
+        /** Enables or disables receive-side conflation. */
+        public Builder conflate(boolean enabled) {
+            return add(socket -> socket.conflate(enabled));
+        }
+
+        /** Enables or disables ROUTER mandatory routing errors. */
+        public Builder routerMandatory(boolean enabled) {
+            return add(socket -> socket.routerMandatory(enabled));
+        }
+
+        /** Sets outbound-full behavior. */
+        public Builder onMute(OnMute mode) {
+            Objects.requireNonNull(mode, "mode");
+            return add(socket -> socket.onMute(mode));
+        }
+
+        /** Leaves TCP keepalive policy at the operating-system default. */
+        public Builder tcpKeepaliveDefault() {
+            return add(Socket::tcpKeepaliveDefault);
+        }
+
+        /** Disables TCP keepalive. */
+        public Builder tcpKeepaliveOff() {
+            return add(Socket::tcpKeepaliveOff);
+        }
+
+        /** Enables TCP keepalive. */
+        public Builder tcpKeepalive(Duration idle, Duration interval, int count) {
+            Socket.millis(Objects.requireNonNull(idle, "idle"));
+            Socket.millis(Objects.requireNonNull(interval, "interval"));
+            if (count <= 0) {
+                throw new IllegalArgumentException("count must be greater than zero");
+            }
+            return add(socket -> socket.tcpKeepalive(idle, interval, count));
+        }
+
+        /** Sets OS send buffer size. */
+        public Builder sendBufferSize(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.sendBufferSize(bytes));
+        }
+
+        /** Restores OS default send buffer size. */
+        public Builder defaultSendBufferSize() {
+            return add(Socket::defaultSendBufferSize);
+        }
+
+        /** Sets OS receive buffer size. */
+        public Builder receiveBufferSize(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.receiveBufferSize(bytes));
+        }
+
+        /** Restores OS default receive buffer size. */
+        public Builder defaultReceiveBufferSize() {
+            return add(Socket::defaultReceiveBufferSize);
+        }
+
+        /** Sets a compression dictionary. */
+        public Builder compressionDict(byte[] dict) {
+            byte[] value = copy(Objects.requireNonNull(dict, "dict"));
+            if (value.length == 0) {
+                throw new IllegalArgumentException("compression dict must not be empty");
+            }
+            requireMaxLength("compression dict", value.length, COMPRESSION_DICT_MAX_BYTES);
+            return add(socket -> socket.compressionDict(copy(value)));
+        }
+
+        /** Disables the static compression dictionary. */
+        public Builder noCompressionDict() {
+            return add(Socket::noCompressionDict);
+        }
+
+        /** Sets compression auto-trained dictionary capacity. */
+        public Builder compressionDictCapacity(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.compressionDictCapacity(bytes));
+        }
+
+        /** Restores default compression auto-trained dictionary capacity. */
+        public Builder defaultCompressionDictCapacity() {
+            return add(Socket::defaultCompressionDictCapacity);
+        }
+
+        /** Sets maximum accepted peer compression dictionary size. */
+        public Builder maxReceiveDictSize(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.maxReceiveDictSize(bytes));
+        }
+
+        /** Restores default maximum accepted peer compression dictionary size. */
+        public Builder defaultMaxReceiveDictSize() {
+            return add(Socket::defaultMaxReceiveDictSize);
+        }
+
+        /** Sets minimum size for compression offload. */
+        public Builder compressionOffloadThreshold(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.compressionOffloadThreshold(bytes));
+        }
+
+        /** Disables compression offload. */
+        public Builder noCompressionOffload() {
+            return add(Socket::noCompressionOffload);
+        }
+
+        /** Sets large-message receive threshold. */
+        public Builder largeMessageThreshold(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.largeMessageThreshold(bytes));
+        }
+
+        /** Disables the large-message receive fast path. */
+        public Builder disableLargeMessagePath() {
+            return add(Socket::disableLargeMessagePath);
+        }
+
+        /** Sets encoder arena threshold. */
+        public Builder arenaThreshold(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.arenaThreshold(bytes));
+        }
+
+        /** Restores default encoder arena threshold. */
+        public Builder defaultArenaThreshold() {
+            return add(Socket::defaultArenaThreshold);
+        }
+
+        /** Sets per-peer transmit slot capacity. */
+        public Builder transmitSlotCapacity(long bytes) {
+            requireNonNegative("bytes", bytes);
+            return add(socket -> socket.transmitSlotCapacity(bytes));
+        }
+
+        /** Restores default per-peer transmit slot capacity. */
+        public Builder defaultTransmitSlotCapacity() {
+            return add(Socket::defaultTransmitSlotCapacity);
+        }
+
+        /** Enables or disables XPUB no-drop behavior. */
+        public Builder xpubNoDrop(boolean enabled) {
+            return add(socket -> socket.xpubNoDrop(enabled));
+        }
+
+        private Builder add(OptionAction action) {
+            actions.add(action);
+            return this;
+        }
+    }
+
+    private static byte[] copy(byte[] value) {
+        return Arrays.copyOf(value, value.length);
+    }
+
+    private static void requireNonNegative(String name, long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must be non-negative");
+        }
+    }
+
+    private static void requireMaxLength(String name, int length, int max) {
+        if (length > max) {
+            throw new IllegalArgumentException(name + " length must be at most " + max + " bytes");
+        }
+    }
+
+    private static void requireZmtpShortString(String name, String value) {
+        requireMaxLength(
+                name,
+                value.getBytes(StandardCharsets.UTF_8).length,
+                ZMTP_MAX_SHORT_STRING_BYTES);
+    }
+
+    private static void requireMatchingCurveKeypair(CurveKeypair keypair) {
+        String derivedPublicKey;
+        try {
+            derivedPublicKey = OMQ.curvePublic(keypair.secretKey());
+        } catch (OMQException error) {
+            throw new IllegalArgumentException("CURVE secret key must be valid Z85", error);
+        }
+        if (!keypair.publicKey().equals(derivedPublicKey)) {
+            throw new IllegalArgumentException("CURVE public key does not match secret key");
+        }
+    }
+}

--- a/bindings/java/src/main/java/module-info.java
+++ b/bindings/java/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+/** Java bindings for OMQ. */
+module io.omq {
+    exports io.omq;
+}

--- a/bindings/java/src/test/java/io/omq/OMQInteropTest.java
+++ b/bindings/java/src/test/java/io/omq/OMQInteropTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,9 +28,9 @@ final class OMQInteropTest {
             sock.curve_server = True
             sock.curve_publickey = os.environ["SRV_PUB"].encode()
             sock.curve_secretkey = os.environ["SRV_SEC"].encode()
-            sock.bind("tcp://127.0.0.1:*")
-            endpoint = sock.getsockopt(zmq.LAST_ENDPOINT)
-            print(endpoint.decode() if isinstance(endpoint, bytes) else endpoint, flush=True)
+            endpoint = os.environ["ENDPOINT"]
+            sock.bind(endpoint)
+            print(endpoint, flush=True)
             msg = sock.recv()
             print(msg.decode(), flush=True)
             sock.close(0)
@@ -44,8 +46,8 @@ final class OMQInteropTest {
             sock.curve_serverkey = os.environ["SRV_PUB"].encode()
             sock.connect(os.environ["ENDPOINT"])
             sock.send(os.environ["PAYLOAD"].encode())
-            time.sleep(0.1)
-            sock.close(1000)
+            time.sleep(1.0)
+            sock.close(2000)
             ctx.term()
             """;
 
@@ -131,8 +133,10 @@ final class OMQInteropTest {
         assumePyzmqCurve();
         CurveKeypair serverKeypair = OMQ.curveKeypair();
         CurveKeypair clientKeypair = OMQ.curveKeypair();
+        String configuredEndpoint = freeTcpEndpoint();
         Process process = startPython(
                 Map.of(
+                        "ENDPOINT", configuredEndpoint,
                         "SRV_PUB", serverKeypair.publicKey(),
                         "SRV_SEC", serverKeypair.secretKey()),
                 PYZMQ_CURVE_PULL);
@@ -235,6 +239,12 @@ final class OMQInteropTest {
     private static String python() {
         String configured = System.getenv("OMQ_PYTHON3");
         return configured == null || configured.isBlank() ? "python3" : configured;
+    }
+
+    private static String freeTcpEndpoint() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))) {
+            return "tcp://127.0.0.1:" + socket.getLocalPort();
+        }
     }
 
     private static void assertProcessSuccess(Process process) throws InterruptedException {

--- a/bindings/java/src/test/java/io/omq/OMQInteropTest.java
+++ b/bindings/java/src/test/java/io/omq/OMQInteropTest.java
@@ -9,8 +9,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.InetAddress;
-import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,15 +19,23 @@ import org.junit.jupiter.api.Test;
 
 final class OMQInteropTest {
     private static final String PYZMQ_CURVE_PULL = """
-            import os, zmq
+            import os, random, zmq
 
             ctx = zmq.Context()
             sock = ctx.socket(zmq.PULL)
             sock.curve_server = True
             sock.curve_publickey = os.environ["SRV_PUB"].encode()
             sock.curve_secretkey = os.environ["SRV_SEC"].encode()
-            endpoint = os.environ["ENDPOINT"]
-            sock.bind(endpoint)
+            for _ in range(64):
+                endpoint = f"tcp://127.0.0.1:{random.randrange(20000, 60000)}"
+                try:
+                    sock.bind(endpoint)
+                    break
+                except zmq.ZMQError as error:
+                    if error.errno != zmq.EADDRINUSE:
+                        raise
+            else:
+                raise RuntimeError("no free TCP port")
             print(endpoint, flush=True)
             msg = sock.recv()
             print(msg.decode(), flush=True)
@@ -45,9 +51,10 @@ final class OMQInteropTest {
             sock.curve_secretkey = os.environ["CLI_SEC"].encode()
             sock.curve_serverkey = os.environ["SRV_PUB"].encode()
             sock.connect(os.environ["ENDPOINT"])
+            time.sleep(0.2)
             sock.send(os.environ["PAYLOAD"].encode())
             time.sleep(1.0)
-            sock.close(2000)
+            sock.close(5000)
             ctx.term()
             """;
 
@@ -133,10 +140,8 @@ final class OMQInteropTest {
         assumePyzmqCurve();
         CurveKeypair serverKeypair = OMQ.curveKeypair();
         CurveKeypair clientKeypair = OMQ.curveKeypair();
-        String configuredEndpoint = freeTcpEndpoint();
         Process process = startPython(
                 Map.of(
-                        "ENDPOINT", configuredEndpoint,
                         "SRV_PUB", serverKeypair.publicKey(),
                         "SRV_SEC", serverKeypair.secretKey()),
                 PYZMQ_CURVE_PULL);
@@ -239,12 +244,6 @@ final class OMQInteropTest {
     private static String python() {
         String configured = System.getenv("OMQ_PYTHON3");
         return configured == null || configured.isBlank() ? "python3" : configured;
-    }
-
-    private static String freeTcpEndpoint() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))) {
-            return "tcp://127.0.0.1:" + socket.getLocalPort();
-        }
     }
 
     private static void assertProcessSuccess(Process process) throws InterruptedException {

--- a/bindings/java/src/test/java/io/omq/OMQInteropTest.java
+++ b/bindings/java/src/test/java/io/omq/OMQInteropTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -222,6 +223,7 @@ final class OMQInteropTest {
     }
 
     private static void assumePyzmqCurve() throws IOException, InterruptedException {
+        assumeTrue(!isWindows(), "pyzmq CURVE interop is disabled on Windows");
         Process process = startPython(Map.of(), "import sys, zmq; sys.exit(0 if zmq.has('curve') else 1)");
         boolean exited = process.waitFor(10, TimeUnit.SECONDS);
         if (!exited) {
@@ -244,6 +246,10 @@ final class OMQInteropTest {
     private static String python() {
         String configured = System.getenv("OMQ_PYTHON3");
         return configured == null || configured.isBlank() ? "python3" : configured;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
     }
 
     private static void assertProcessSuccess(Process process) throws InterruptedException {

--- a/bindings/java/src/test/java/io/omq/OMQInteropTest.java
+++ b/bindings/java/src/test/java/io/omq/OMQInteropTest.java
@@ -1,8 +1,10 @@
 package io.omq;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -11,10 +13,40 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 final class OMQInteropTest {
+    private static final String PYZMQ_CURVE_PULL = """
+            import os, zmq
+
+            ctx = zmq.Context()
+            sock = ctx.socket(zmq.PULL)
+            sock.curve_server = True
+            sock.curve_publickey = os.environ["SRV_PUB"].encode()
+            sock.curve_secretkey = os.environ["SRV_SEC"].encode()
+            port = sock.bind_to_random_port("tcp://127.0.0.1")
+            print(f"tcp://127.0.0.1:{port}", flush=True)
+            msg = sock.recv()
+            print(msg.decode(), flush=True)
+            sock.close(0)
+            ctx.term()
+            """;
+    private static final String PYZMQ_CURVE_PUSH = """
+            import os, zmq
+
+            ctx = zmq.Context()
+            sock = ctx.socket(zmq.PUSH)
+            sock.curve_publickey = os.environ["CLI_PUB"].encode()
+            sock.curve_secretkey = os.environ["CLI_SEC"].encode()
+            sock.curve_serverkey = os.environ["SRV_PUB"].encode()
+            sock.connect(os.environ["ENDPOINT"])
+            sock.send(os.environ["PAYLOAD"].encode())
+            sock.close(1000)
+            ctx.term()
+            """;
+
     @Test
     void javaBindingTalksToRustOmqPeer() throws Exception {
         Process process = startPeer("pull", "tcp://127.0.0.1:0");
@@ -39,7 +71,118 @@ final class OMQInteropTest {
         }
     }
 
+    @Test
+    void javaCurveClientTalksToRustOmqPeer() throws Exception {
+        CurveKeypair serverKeypair = OMQ.curveKeypair();
+        CurveKeypair clientKeypair = OMQ.curveKeypair();
+        Process process = startPeer(
+                Map.of(
+                        "OMQ_CURVE_SERVER_PUBLIC", serverKeypair.publicKey(),
+                        "OMQ_CURVE_SERVER_SECRET", serverKeypair.secretKey()),
+                "curve-pull",
+                "tcp://127.0.0.1:0");
+        try (BufferedReader output = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+             Context context = OMQ.context();
+             Socket push = context.socket(SocketType.PUSH)
+                     .curveClient(clientKeypair, serverKeypair.publicKey())) {
+            String endpoint = output.readLine();
+            assertNotNull(endpoint);
+
+            push.connect(endpoint);
+            push.waitConnected(1, Duration.ofSeconds(5));
+            push.send("hello-rust-curve");
+
+            assertEquals("hello-rust-curve", output.readLine());
+            assertProcessSuccess(process);
+        } finally {
+            destroy(process);
+        }
+    }
+
+    @Test
+    void rustOmqCurveClientTalksToJavaServer() throws Exception {
+        CurveKeypair serverKeypair = OMQ.curveKeypair();
+        CurveKeypair clientKeypair = OMQ.curveKeypair();
+        Process process = null;
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL).curveServer(serverKeypair)) {
+            String endpoint = pull.bind("tcp://127.0.0.1:0");
+            process = startPeer(
+                    Map.of(
+                            "OMQ_CURVE_CLIENT_PUBLIC", clientKeypair.publicKey(),
+                            "OMQ_CURVE_CLIENT_SECRET", clientKeypair.secretKey(),
+                            "OMQ_CURVE_SERVER_PUBLIC", serverKeypair.publicKey()),
+                    "curve-push",
+                    endpoint,
+                    "hello-java-curve");
+
+            assertEquals("hello-java-curve", pull.receive(Duration.ofSeconds(5)).orElseThrow().text());
+            assertProcessSuccess(process);
+        } finally {
+            destroy(process);
+        }
+    }
+
+    @Test
+    void javaCurveClientTalksToPyzmqPull() throws Exception {
+        assumePyzmqCurve();
+        CurveKeypair serverKeypair = OMQ.curveKeypair();
+        CurveKeypair clientKeypair = OMQ.curveKeypair();
+        Process process = startPython(
+                Map.of(
+                        "SRV_PUB", serverKeypair.publicKey(),
+                        "SRV_SEC", serverKeypair.secretKey()),
+                PYZMQ_CURVE_PULL);
+        try (BufferedReader output = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+             Context context = OMQ.context();
+             Socket push = context.socket(SocketType.PUSH)
+                     .curveClient(clientKeypair, serverKeypair.publicKey())) {
+            String endpoint = output.readLine();
+            assertNotNull(endpoint);
+
+            push.connect(endpoint);
+            push.waitConnected(1, Duration.ofSeconds(5));
+            push.send("hello-pyzmq-curve");
+
+            assertEquals("hello-pyzmq-curve", output.readLine());
+            assertProcessSuccess(process);
+        } finally {
+            destroy(process);
+        }
+    }
+
+    @Test
+    void pyzmqCurvePushTalksToJavaServer() throws Exception {
+        assumePyzmqCurve();
+        CurveKeypair serverKeypair = OMQ.curveKeypair();
+        CurveKeypair clientKeypair = OMQ.curveKeypair();
+        Process process = null;
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL).curveServer(serverKeypair)) {
+            String endpoint = pull.bind("tcp://127.0.0.1:0");
+            process = startPython(
+                    Map.of(
+                            "ENDPOINT", endpoint,
+                            "PAYLOAD", "hello-java-from-pyzmq-curve",
+                            "CLI_PUB", clientKeypair.publicKey(),
+                            "CLI_SEC", clientKeypair.secretKey(),
+                            "SRV_PUB", serverKeypair.publicKey()),
+                    PYZMQ_CURVE_PUSH);
+
+            assertEquals("hello-java-from-pyzmq-curve", pull.receive(Duration.ofSeconds(5)).orElseThrow().text());
+            assertProcessSuccess(process);
+        } finally {
+            destroy(process);
+        }
+    }
+
     private static Process startPeer(String... args) throws IOException {
+        return startPeer(Map.of(), args);
+    }
+
+    private static Process startPeer(Map<String, String> environment, String... args) throws IOException {
         String configured = System.getProperty("omq.java.peer");
         Path peer = Path.of(configured == null || configured.isBlank()
                 ? "native/target/debug/omq-java-peer"
@@ -55,8 +198,52 @@ final class OMQInteropTest {
         String[] command = new String[args.length + 1];
         command[0] = peer.toAbsolutePath().toString();
         System.arraycopy(args, 0, command, 1, args.length);
-        return new ProcessBuilder(command)
-                .redirectErrorStream(true)
-                .start();
+        ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+        builder.environment().putAll(environment);
+        return builder.start();
+    }
+
+    private static Process startPython(Map<String, String> environment, String script) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(python(), "-c", script)
+                .redirectErrorStream(true);
+        builder.environment().putAll(environment);
+        return builder.start();
+    }
+
+    private static void assumePyzmqCurve() throws IOException, InterruptedException {
+        Process process = startPython(Map.of(), "import sys, zmq; sys.exit(0 if zmq.has('curve') else 1)");
+        boolean exited = process.waitFor(10, TimeUnit.SECONDS);
+        if (!exited) {
+            destroy(process);
+            requireOrSkip(false, "python3 + pyzmq CURVE probe timed out");
+        }
+        requireOrSkip(process.exitValue() == 0, "python3 + pyzmq with CURVE is not available");
+    }
+
+    private static void requireOrSkip(boolean condition, String message) {
+        if (condition) {
+            return;
+        }
+        if ("1".equals(System.getenv("OMQ_INTEROP_REQUIRED"))) {
+            fail(message);
+        }
+        assumeTrue(false, message);
+    }
+
+    private static String python() {
+        String configured = System.getenv("OMQ_PYTHON3");
+        return configured == null || configured.isBlank() ? "python3" : configured;
+    }
+
+    private static void assertProcessSuccess(Process process) throws InterruptedException {
+        assertNotNull(process);
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS));
+        assertEquals(0, process.exitValue());
+    }
+
+    private static void destroy(Process process) {
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
     }
 }

--- a/bindings/java/src/test/java/io/omq/OMQInteropTest.java
+++ b/bindings/java/src/test/java/io/omq/OMQInteropTest.java
@@ -26,15 +26,16 @@ final class OMQInteropTest {
             sock.curve_server = True
             sock.curve_publickey = os.environ["SRV_PUB"].encode()
             sock.curve_secretkey = os.environ["SRV_SEC"].encode()
-            port = sock.bind_to_random_port("tcp://127.0.0.1")
-            print(f"tcp://127.0.0.1:{port}", flush=True)
+            sock.bind("tcp://127.0.0.1:*")
+            endpoint = sock.getsockopt(zmq.LAST_ENDPOINT)
+            print(endpoint.decode() if isinstance(endpoint, bytes) else endpoint, flush=True)
             msg = sock.recv()
             print(msg.decode(), flush=True)
             sock.close(0)
             ctx.term()
             """;
     private static final String PYZMQ_CURVE_PUSH = """
-            import os, zmq
+            import os, time, zmq
 
             ctx = zmq.Context()
             sock = ctx.socket(zmq.PUSH)
@@ -43,6 +44,7 @@ final class OMQInteropTest {
             sock.curve_serverkey = os.environ["SRV_PUB"].encode()
             sock.connect(os.environ["ENDPOINT"])
             sock.send(os.environ["PAYLOAD"].encode())
+            time.sleep(0.1)
             sock.close(1000)
             ctx.term()
             """;

--- a/bindings/java/src/test/java/io/omq/OptionsTest.java
+++ b/bindings/java/src/test/java/io/omq/OptionsTest.java
@@ -3,7 +3,9 @@ package io.omq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 final class OptionsTest {
@@ -83,6 +85,119 @@ final class OptionsTest {
                     .defaultTransmitSlotCapacity()
                     .xpubNoDrop(false);
         }
+    }
+
+    @Test
+    void builderAppliesReusableOptionsBeforeMaterialization() {
+        SocketOptions options = SocketOptions.builder()
+                .linger(Duration.ZERO)
+                .lingerForever()
+                .workloadProfile(WorkloadProfile.LATENCY)
+                .defaultWorkloadProfile()
+                .reconnectDisabled()
+                .reconnectInterval(Duration.ofMillis(100))
+                .reconnectExponential(Duration.ofMillis(10), Duration.ofSeconds(1))
+                .reconnectStopConnRefused(true)
+                .sendHighWaterMark(10)
+                .receiveHighWaterMark(11)
+                .heartbeatInterval(Duration.ofMillis(100))
+                .heartbeatTtl(Duration.ofSeconds(3))
+                .noHeartbeatTtl()
+                .heartbeatTimeout(Duration.ofSeconds(5))
+                .defaultHeartbeatTimeout()
+                .heartbeatOff()
+                .handshakeTimeout(Duration.ofSeconds(1))
+                .maxPendingHandshakes(8)
+                .noMaxMessageSize()
+                .conflate(false)
+                .routerMandatory(false)
+                .onMute(OnMute.BLOCK)
+                .onMute(OnMute.DROP_NEWEST)
+                .onMute(OnMute.DROP_OLDEST)
+                .tcpKeepalive(Duration.ofSeconds(60), Duration.ofSeconds(10), 3)
+                .tcpKeepaliveOff()
+                .tcpKeepaliveDefault()
+                .sendBufferSize(65_536)
+                .defaultSendBufferSize()
+                .receiveBufferSize(65_536)
+                .defaultReceiveBufferSize()
+                .compressionDict("dict".getBytes(StandardCharsets.UTF_8))
+                .noCompressionDict()
+                .compressionAutoTrain(true)
+                .compressionThreshold(128)
+                .compressionDefaultThreshold()
+                .compressionLevel(1)
+                .compressionDefaultLevel()
+                .compressionDictCapacity(2_048)
+                .defaultCompressionDictCapacity()
+                .maxReceiveDictSize(8_192)
+                .defaultMaxReceiveDictSize()
+                .compressionOffloadThreshold(8_192)
+                .noCompressionOffload()
+                .largeMessageThreshold(4_096)
+                .disableLargeMessagePath()
+                .arenaThreshold(65_536)
+                .defaultArenaThreshold()
+                .transmitSlotCapacity(2 * 1024 * 1024)
+                .defaultTransmitSlotCapacity()
+                .xpubNoDrop(false)
+                .build();
+
+        try (Context context = OMQ.context();
+             Socket push = context.socket(SocketType.PUSH, options)) {
+            assertEquals(Socket.class, push.getClass());
+        }
+    }
+
+    @Test
+    void builderCopiesByteArrayOptions() {
+        byte[] identity = "before".getBytes(StandardCharsets.UTF_8);
+        SocketOptions options = SocketOptions.builder().identity(identity).build();
+        Arrays.fill(identity, (byte) 'x');
+
+        try (Context context = OMQ.context();
+             Socket router = context.socket(SocketType.ROUTER);
+             Socket dealer = context.socket(SocketType.DEALER, options)) {
+            String endpoint = router.bind(TestSupport.inprocEndpoint("builder-identity"));
+            dealer.connect(endpoint);
+            dealer.send("hello");
+
+            Message request = router.receive(Duration.ofSeconds(5)).orElseThrow();
+            assertEquals("before", new String(request.part(0), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void builderConfiguresPlainAuth() {
+        SocketOptions serverOptions = SocketOptions.builder()
+                .plainServer("alice", "secret")
+                .build();
+        SocketOptions clientOptions = SocketOptions.builder()
+                .plainClient("alice", "secret")
+                .build();
+
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL, serverOptions);
+             Socket push = context.socket(SocketType.PUSH, clientOptions)) {
+            String endpoint = pull.bind("tcp://127.0.0.1:0");
+            push.connect(endpoint);
+            push.waitConnected(1, Duration.ofSeconds(5));
+            push.send("hello over builder plain");
+
+            assertEquals("hello over builder plain", pull.receive(Duration.ofSeconds(5)).orElseThrow().text());
+        }
+    }
+
+    @Test
+    void builderRejectsInvalidOptionsEarly() {
+        assertThrows(IllegalArgumentException.class,
+                () -> SocketOptions.builder().sendHighWaterMark(-1));
+        assertThrows(IllegalArgumentException.class,
+                () -> SocketOptions.builder().compressionDict(new byte[0]));
+        assertThrows(IllegalArgumentException.class,
+                () -> SocketOptions.builder().compressionLevel(5));
+        assertThrows(IllegalArgumentException.class,
+                () -> SocketOptions.builder().heartbeatTtl(Duration.ofMillis(6_553_501)));
     }
 
     @Test

--- a/bindings/java/src/test/java/io/omq/OptionsTest.java
+++ b/bindings/java/src/test/java/io/omq/OptionsTest.java
@@ -189,6 +189,31 @@ final class OptionsTest {
     }
 
     @Test
+    void builderConfiguresCurveAuth() {
+        CurveKeypair serverKeypair = OMQ.curveKeypair();
+        CurveKeypair clientKeypair = OMQ.curveKeypair();
+        SocketOptions serverOptions = SocketOptions.builder()
+                .curveServer(
+                        serverKeypair,
+                        peer -> clientKeypair.publicKey().equals(peer.publicKey().orElse("")))
+                .build();
+        SocketOptions clientOptions = SocketOptions.builder()
+                .curveClient(clientKeypair, serverKeypair.publicKey())
+                .build();
+
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL, serverOptions);
+             Socket push = context.socket(SocketType.PUSH, clientOptions)) {
+            String endpoint = pull.bind("tcp://127.0.0.1:0");
+            push.connect(endpoint);
+            push.waitConnected(1, Duration.ofSeconds(5));
+            push.send("hello over builder curve");
+
+            assertEquals("hello over builder curve", pull.receive(Duration.ofSeconds(5)).orElseThrow().text());
+        }
+    }
+
+    @Test
     void builderRejectsInvalidOptionsEarly() {
         assertThrows(IllegalArgumentException.class,
                 () -> SocketOptions.builder().sendHighWaterMark(-1));

--- a/bindings/java/src/test/java/io/omq/SocketTest.java
+++ b/bindings/java/src/test/java/io/omq/SocketTest.java
@@ -11,8 +11,11 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 final class SocketTest {
@@ -325,6 +328,57 @@ final class SocketTest {
             assertThrows(
                     IllegalStateException.class,
                     () -> pull.receiveInto(ByteBuffer.allocate(8), Duration.ofSeconds(5)));
+        }
+    }
+
+    @Test
+    void virtualThreadReceiveWaitsThroughAsyncPath() throws Exception {
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL);
+             Socket push = context.socket(SocketType.PUSH)) {
+            String endpoint = pull.bind("inproc://virtual-receive-" + UUID.randomUUID());
+            push.connect(endpoint);
+            push.waitConnected(1, Duration.ofSeconds(5));
+
+            CompletableFuture<Message> received = new CompletableFuture<>();
+            Thread thread = Thread.ofVirtual().start(() -> {
+                try {
+                    received.complete(pull.receive());
+                } catch (Throwable error) {
+                    received.completeExceptionally(error);
+                }
+            });
+
+            try {
+                Thread.sleep(50);
+                push.send("loom");
+                assertEquals("loom", received.get(5, TimeUnit.SECONDS).text());
+            } finally {
+                thread.join(5_000);
+            }
+        }
+    }
+
+    @Test
+    void virtualThreadReceiveTimeoutReturnsEmpty() throws Exception {
+        try (Context context = OMQ.context();
+             Socket pull = context.socket(SocketType.PULL)) {
+            pull.bind("inproc://virtual-receive-timeout-" + UUID.randomUUID());
+
+            CompletableFuture<Optional<Message>> received = new CompletableFuture<>();
+            Thread thread = Thread.ofVirtual().start(() -> {
+                try {
+                    received.complete(pull.receive(Duration.ofMillis(20)));
+                } catch (Throwable error) {
+                    received.completeExceptionally(error);
+                }
+            });
+
+            try {
+                assertTrue(received.get(5, TimeUnit.SECONDS).isEmpty());
+            } finally {
+                thread.join(5_000);
+            }
         }
     }
 

--- a/bindings/java/src/test/java/io/omq/SocketTest.java
+++ b/bindings/java/src/test/java/io/omq/SocketTest.java
@@ -3,8 +3,6 @@ package io.omq;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,8 +11,6 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -333,60 +329,6 @@ final class SocketTest {
     }
 
     @Test
-    void receiveManyBytesBlocksForFirstAndDrainsAvailable() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL);
-             Socket push = context.socket(SocketType.PUSH)) {
-            String endpoint = pull.bind("inproc://batch-" + UUID.randomUUID());
-            push.connect(endpoint);
-            push.waitConnected(1, Duration.ofSeconds(5));
-
-            push.send("a");
-            push.send("bb");
-            push.send("ccc");
-
-            List<byte[]> batch = pull.receiveManyBytes(8, Duration.ofSeconds(5));
-            assertEquals(3, batch.size());
-            assertArrayEquals("a".getBytes(StandardCharsets.UTF_8), batch.get(0));
-            assertArrayEquals("bb".getBytes(StandardCharsets.UTF_8), batch.get(1));
-            assertArrayEquals("ccc".getBytes(StandardCharsets.UTF_8), batch.get(2));
-        }
-    }
-
-    @Test
-    void sendManyBytesSendsSinglePartMessages() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL);
-             Socket push = context.socket(SocketType.PUSH)) {
-            String endpoint = pull.bind("inproc://send-batch-" + UUID.randomUUID());
-            push.connect(endpoint);
-            push.waitConnected(1, Duration.ofSeconds(5));
-
-            push.sendManyBytes(new byte[][] {
-                "a".getBytes(StandardCharsets.UTF_8),
-                "bb".getBytes(StandardCharsets.UTF_8),
-                "ccc".getBytes(StandardCharsets.UTF_8),
-            });
-
-            List<byte[]> batch = pull.receiveManyBytes(8, Duration.ofSeconds(5));
-            assertEquals(3, batch.size());
-            assertArrayEquals("a".getBytes(StandardCharsets.UTF_8), batch.get(0));
-            assertArrayEquals("bb".getBytes(StandardCharsets.UTF_8), batch.get(1));
-            assertArrayEquals("ccc".getBytes(StandardCharsets.UTF_8), batch.get(2));
-        }
-    }
-
-    @Test
-    void sendManyBytesAcceptsEmptyBatch() {
-        try (Context context = OMQ.context();
-             Socket push = context.socket(SocketType.PUSH)) {
-            push.connect("inproc://empty-send-batch-" + UUID.randomUUID());
-
-            push.sendManyBytes(new byte[0][]);
-        }
-    }
-
-    @Test
     void timedSendSucceedsBeforeTimeout() {
         try (Context context = OMQ.context();
              Socket pull = context.socket(SocketType.PULL);
@@ -408,131 +350,6 @@ final class SocketTest {
             push.bind("inproc://timed-send-timeout-" + UUID.randomUUID());
 
             assertFalse(push.send("blocked", Duration.ofMillis(10)));
-        }
-    }
-
-    @Test
-    void receiveManyBytesIntoFillsReusableArrayWithOffset() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL);
-             Socket push = context.socket(SocketType.PUSH)) {
-            String endpoint = pull.bind("inproc://batch-into-" + UUID.randomUUID());
-            push.connect(endpoint);
-            push.waitConnected(1, Duration.ofSeconds(5));
-            push.sendManyBytes(new byte[][] {
-                "a".getBytes(StandardCharsets.UTF_8),
-                "bb".getBytes(StandardCharsets.UTF_8),
-                "ccc".getBytes(StandardCharsets.UTF_8),
-            });
-
-            byte[][] output = new byte[5][];
-            int count = pull.receiveManyBytesInto(output, 1, 3, Duration.ofSeconds(5));
-
-            assertEquals(3, count);
-            assertNull(output[0]);
-            assertArrayEquals("a".getBytes(StandardCharsets.UTF_8), output[1]);
-            assertArrayEquals("bb".getBytes(StandardCharsets.UTF_8), output[2]);
-            assertArrayEquals("ccc".getBytes(StandardCharsets.UTF_8), output[3]);
-            assertNull(output[4]);
-        }
-    }
-
-    @Test
-    void receiveManyBytesIntoTimeoutReturnsZeroAndKeepsOutput() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL)) {
-            pull.bind("inproc://empty-batch-timeout-" + UUID.randomUUID());
-
-            byte[] sentinel = "sentinel".getBytes(StandardCharsets.UTF_8);
-            byte[][] output = new byte[][] {sentinel};
-
-            assertEquals(0, pull.receiveManyBytesInto(output, Duration.ofMillis(10)));
-            assertSame(sentinel, output[0]);
-        }
-    }
-
-    @Test
-    void tryReceiveManyBytesIntoReturnsZeroWhenNoMessageAvailable() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL)) {
-            pull.bind("inproc://empty-batch-into-" + UUID.randomUUID());
-
-            byte[][] output = new byte[2][];
-            assertEquals(0, pull.tryReceiveManyBytesInto(output));
-            assertNull(output[0]);
-            assertNull(output[1]);
-        }
-    }
-
-    @Test
-    void receiveManyBytesIntoAcceptsZeroLengthOutput() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL)) {
-            assertEquals(0, pull.receiveManyBytesInto(new byte[0][]));
-            assertEquals(0, pull.tryReceiveManyBytesInto(new byte[0][]));
-        }
-    }
-
-    @Test
-    void receiveManyBytesIntoRejectsMultipart() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL);
-             Socket push = context.socket(SocketType.PUSH)) {
-            String endpoint = pull.bind("inproc://batch-into-multipart-" + UUID.randomUUID());
-            push.connect(endpoint);
-            push.waitConnected(1, Duration.ofSeconds(5));
-
-            push.send(Message.multipart("a".getBytes(), "b".getBytes()));
-
-            assertThrows(
-                    IllegalStateException.class,
-                    () -> pull.receiveManyBytesInto(new byte[2][], Duration.ofSeconds(5)));
-        }
-    }
-
-    @Test
-    void receiveManyReturnsMultipartMessages() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL);
-             Socket push = context.socket(SocketType.PUSH)) {
-            String endpoint = pull.bind("inproc://batch-multipart-" + UUID.randomUUID());
-            push.connect(endpoint);
-            push.waitConnected(1, Duration.ofSeconds(5));
-
-            push.send(Message.multipart("a".getBytes(), "b".getBytes()));
-            push.send("tail");
-
-            List<Message> batch = new ArrayList<>(pull.receiveMany(4, Duration.ofSeconds(5)));
-            if (batch.size() < 2) {
-                batch.addAll(pull.receiveMany(2 - batch.size(), Duration.ofSeconds(5)));
-            }
-            assertEquals(2, batch.size());
-            assertEquals(2, batch.get(0).partCount());
-            assertEquals("tail", batch.get(1).text());
-        }
-    }
-
-    @Test
-    void tryReceiveManyBytesReturnsEmptyWhenNoMessageAvailable() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL)) {
-            pull.bind("inproc://empty-batch-" + UUID.randomUUID());
-
-            assertTrue(pull.tryReceiveManyBytes(4).isEmpty());
-        }
-    }
-
-    @Test
-    void receiveManyRejectsNonPositiveLimit() {
-        try (Context context = OMQ.context();
-             Socket pull = context.socket(SocketType.PULL)) {
-            assertThrows(IllegalArgumentException.class, () -> pull.receiveMany(0));
-            assertThrows(IllegalArgumentException.class, () -> pull.tryReceiveManyBytes(0));
-            assertThrows(NullPointerException.class, () -> pull.sendManyBytes(new byte[][] {null}));
-            assertThrows(NullPointerException.class, () -> pull.receiveManyBytesInto(null));
-            assertThrows(IndexOutOfBoundsException.class, () -> pull.receiveManyBytesInto(new byte[1][], -1, 1));
-            assertThrows(IndexOutOfBoundsException.class, () -> pull.receiveManyBytesInto(new byte[1][], 1, 1));
-            assertThrows(IllegalArgumentException.class, () -> pull.receiveManyBytesInto(new byte[1][], 0, -1));
         }
     }
 


### PR DESCRIPTION
- Reworks OMQ.java `0.2.0` around a modern Java API with scalar sync/async send and receive calls, `ByteBuffer` support, and no public batch API.
- Keeps high-throughput receive batching hidden behind Java 25 FFM off-heap rings backed by native `recv_many_into()` reuse.
- Adds reusable `SocketOptions` and `Context.socket(SocketType, SocketOptions)` for pre-I/O socket setup with cleanup on failed option application.
- Adds an explicit JPMS module descriptor for `io.omq`, so module-path users can target native access at the binding module.
- Routes blocking receive calls from Java virtual threads through native async receive when the cached FFM ring is empty.
- Updates Maven Central package metadata for ZeroMQ/ZMQ searchability.
- Documents the Java binding shape, Maven Central usage, architecture, changelog, and JeroMQ TCP PUSH/PULL performance comparison.