### PR TITLE
Polish binding and benchmark docs

### DIFF
--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -1,12 +1,13 @@
 # Comparisons
 
-These charts compare OMQ with `libzmq`, `zmq.rs`, and `rzmq`. The
+These charts compare OMQ with `libzmq`, `tmq`, `zmq.rs`, and `rzmq`. The
 benchmark runner records throughput, latency, CPU time, and peer
 fairness where the pattern has multiple peers.
 
 ## Setup
 
 - `libzmq v4.3.5`
+- `tmq v0.5.0`
 - `zeromq v0.6.0`
 - `rzmq v0.5.24` in its normal and io_uring modes
 - OMQ from this repository

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 - 3 security mechanisms: NULL, PLAIN, CURVE
 - OMQ-owned background I/O threads on Linux, macOS, and Windows
 - No C compiler, no libzmq, no libsodium
-- Bindings: OMQ.rb (Ruby), [pyomq](bindings/pyomq/) (Python),
-  [OMQ.java](bindings/java/) (Java), and C API ([omq-libzmq](omq-libzmq/))
+- Bindings: [OMQ.rb](https://github.com/zeromq/omq.rb) (Ruby),
+  [pyomq](bindings/pyomq/) (Python), [OMQ.java](bindings/java/) (Java),
+  and C API ([omq-libzmq](omq-libzmq/))
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_pushpull_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
@@ -37,6 +38,8 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/pushpull/lz4_tcp.svg" alt="LZ4 PUSH/PULL throughput over TCP" width="950">
 </p>
+
+[Full compression transport benchmarks (LZ4 and Zstd)](BENCHMARKS_COMPRESSION.md)
 </details>
 
 [Full comparison charts](COMPARISONS.md)

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -10,7 +10,7 @@ small API built around `AutoCloseable`, `Duration`, `ByteBuffer`, and
 ## Highlights
 
 - Native OMQ engine shared with OMQ.rs.
-- High-throughput TCP and inproc messaging.
+- High-throughput `tcp://`, native `ipc://`, and `inproc://` messaging.
 - Compression transports: `lz4+tcp://` and `zstd+tcp://`.
 - Static compression dictionaries and auto-trained dictionaries.
 - PLAIN and CURVE security with Java auth callbacks and peer metadata.


### PR DESCRIPTION
- Links `OMQ.rb` in the top-level README to `zeromq/omq.rb`.
- Adds a near-top README link to the full compression benchmark page, which includes the Zstd PUSH/PULL chart.
- Calls out Java native `ipc://` support in the OMQ.java README highlights.
- Lists `tmq v0.5.0` in `COMPARISONS.md` so setup docs match the charted implementations.