### PR TITLE
Update Java perf chart warmup

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -21,11 +21,12 @@ small API built around `AutoCloseable`, `Duration`, `ByteBuffer`, and
 ## Performance
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/java/doc/charts/pushpull_tcp.svg" alt="OMQ.java vs JeroMQ PUSH/PULL TCP performance" width="850">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/java/doc/charts/pushpull_tcp.svg" alt="OMQ.java vs JeroMQ TCP throughput and latency" width="850">
 </p>
 
-2-process loopback PUSH/PULL throughput vs JeroMQ over TCP. Results are
-median local runs from `scripts/bench_pushpull_tcp.py`.
+2-process loopback PUSH/PULL throughput and REQ/REP p50 latency vs JeroMQ
+over TCP. Both panels warm the JVM before timed samples. Results are median
+local runs from `scripts/bench_pushpull_tcp.py`.
 
 ## Build, install, test
 

--- a/bindings/java/doc/charts/pushpull_tcp.svg
+++ b/bindings/java/doc/charts/pushpull_tcp.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 514" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="514" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="684" fill="white"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">JIT-warmed PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off</text>
   <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
   <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
@@ -49,66 +49,66 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,183.9 145.8,171.7 201.7,194.4 257.5,256.3 313.3,271.8 369.2,265.0 425.0,300.4 480.8,335.7 536.7,359.0 592.5,370.8 648.3,376.9 704.2,380.1 760.0,381.8" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,170.4 145.8,167.8 201.7,191.7 257.5,259.0 313.3,267.6 369.2,273.6 425.0,297.4 480.8,329.8 536.7,355.6 592.5,367.5 648.3,376.0 704.2,379.5 760.0,381.2" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,261.4 145.8,282.8 201.7,287.5 257.5,299.6 313.3,309.0 369.2,323.8 425.0,343.9 480.8,362.5 536.7,370.9 592.5,377.9 648.3,381.1 704.2,382.3 760.0,382.6" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,268.3 145.8,276.5 201.7,282.4 257.5,304.6 313.3,312.3 369.2,325.1 425.0,340.4 480.8,361.2 536.7,372.9 592.5,378.1 648.3,381.1 704.2,382.3 760.0,382.6" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,380.8 145.8,377.2 201.7,371.9 257.5,367.6 313.3,355.3 369.2,323.1 425.0,298.4 480.8,285.2 536.7,281.5 592.5,275.8 648.3,268.4 704.2,256.5 760.0,242.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="377.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="371.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="367.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="355.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="323.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="298.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="285.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="281.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="275.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="268.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="256.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="242.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,380.6 145.8,377.1 201.7,371.7 257.5,368.0 313.3,354.2 369.2,327.5 425.0,295.3 480.8,272.9 536.7,267.6 592.5,249.2 648.3,253.2 704.2,237.6 760.0,198.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="377.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="371.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="368.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="354.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="327.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="295.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="272.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="267.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="249.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="253.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="237.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="198.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.0 145.8,380.8 201.7,377.8 257.5,373.2 313.3,364.8 369.2,353.2 425.0,342.9 480.8,339.9 536.7,330.5 592.5,333.8 648.3,335.7 704.2,328.9 760.0,294.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,193.1 145.8,188.7 201.7,200.3 257.5,256.8 313.3,252.8 369.2,277.5 425.0,298.0 480.8,326.8 536.7,349.2 592.5,362.6 648.3,373.4 704.2,377.6 760.0,380.8" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,159.6 145.8,166.3 201.7,165.8 257.5,257.0 313.3,268.4 369.2,273.4 425.0,292.5 480.8,313.6 536.7,342.3 592.5,360.5 648.3,371.2 704.2,377.0 760.0,380.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,280.0 145.8,282.5 201.7,287.6 257.5,297.1 313.3,313.1 369.2,323.8 425.0,341.5 480.8,357.9 536.7,367.0 592.5,374.0 648.3,378.9 704.2,381.0 760.0,382.1" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,264.4 145.8,281.7 201.7,283.6 257.5,303.5 313.3,309.4 369.2,324.6 425.0,342.0 480.8,356.7 536.7,365.9 592.5,373.9 648.3,378.7 704.2,381.7 760.0,381.9" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.9 145.8,377.7 201.7,372.2 257.5,367.7 313.3,350.4 369.2,329.5 425.0,295.9 480.8,267.0 536.7,241.3 592.5,208.5 648.3,209.7 704.2,174.0 760.0,175.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="377.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="372.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="367.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="350.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="329.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="295.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="267.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="241.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="208.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="209.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="174.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="175.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,380.4 145.8,377.0 201.7,370.0 257.5,367.7 313.3,354.4 369.2,327.4 425.0,290.3 480.8,239.8 536.7,213.2 592.5,191.8 648.3,174.9 704.2,153.7 760.0,130.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="377.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="370.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="367.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="354.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="327.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="290.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="239.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="213.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="191.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="153.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="130.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.3 145.8,380.8 201.7,377.8 257.5,372.9 313.3,365.9 369.2,353.2 425.0,340.5 480.8,330.6 536.7,314.2 592.5,302.1 648.3,300.6 704.2,286.8 760.0,259.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="380.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="201.7" cy="377.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="373.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="364.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="372.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="365.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="369.2" cy="353.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="342.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="339.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="330.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="333.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="335.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="328.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="294.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.1 145.8,380.6 201.7,377.5 257.5,373.8 313.3,365.6 369.2,353.8 425.0,339.4 480.8,337.3 536.7,338.5 592.5,335.5 648.3,336.2 704.2,328.0 760.0,292.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="425.0" cy="340.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="330.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="314.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="302.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="300.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="286.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="259.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.1 145.8,380.7 201.7,377.6 257.5,373.7 313.3,364.9 369.2,353.6 425.0,341.0 480.8,328.1 536.7,309.8 592.5,301.4 648.3,296.8 704.2,309.2 760.0,248.7" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="380.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="373.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="365.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="353.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="339.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="337.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="338.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="335.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="336.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="328.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="292.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="380.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="377.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="373.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="364.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="353.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="341.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="328.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="309.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="301.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="296.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="309.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="248.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -122,17 +122,115 @@
   <text x="648.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
   <text x="704.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
   <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="65" y1="432" x2="79" y2="432" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="72" cy="432" r="2.5" fill="#dc2626"/>
-  <text x="85" y="436" fill="#374151" font-size="11" font-weight="500">OMQ.java</text>
-  <line x1="245" y1="432" x2="259" y2="432" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="252" cy="432" r="2.5" fill="#f97316"/>
-  <text x="265" y="436" fill="#374151" font-size="11" font-weight="500">OMQ.java receiveInto</text>
-  <line x1="425" y1="432" x2="439" y2="432" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="432" cy="432" r="2.5" fill="#2563eb"/>
-  <text x="445" y="436" fill="#374151" font-size="11" font-weight="500">JeroMQ</text>
-  <line x1="605" y1="432" x2="619" y2="432" stroke="#8b5cf6" stroke-width="2.5"/>
-  <circle cx="612" cy="432" r="2.5" fill="#8b5cf6"/>
-  <text x="625" y="436" fill="#374151" font-size="11" font-weight="500">JeroMQ recvByteBuffer</text>
-  <text x="425.0" y="454" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = GB/s (right)</text>
+  <text x="425.0" y="447" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">JIT-warmed REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90" y1="584.0" x2="760" y2="584.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="584.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
+  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
+  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
+  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
+  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
+  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
+  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="145.8" y1="464" x2="145.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="201.7" y1="464" x2="201.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="257.5" y1="464" x2="257.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="369.2" y1="464" x2="369.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="425.0" y1="464" x2="425.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="480.8" y1="464" x2="480.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="592.5" y1="464" x2="592.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="648.3" y1="464" x2="648.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="704.2" y1="464" x2="704.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
+  <polyline points="90.0,527.4 145.8,527.3 201.7,529.8 257.5,528.5 313.3,527.3 369.2,527.4 425.0,526.9 480.8,526.5 536.7,521.8 592.5,515.1 648.3,513.2 704.2,496.6 760.0,474.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="527.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="529.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="528.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="527.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="526.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="526.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="521.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="515.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="513.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="496.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="474.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,527.7 145.8,527.3 201.7,526.8 257.5,528.1 313.3,527.7 369.2,527.0 425.0,525.7 480.8,526.9 536.7,525.6 592.5,517.9 648.3,513.6 704.2,501.4 760.0,480.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="527.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="526.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="528.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="527.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="527.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="525.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="526.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="525.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="513.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="501.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="480.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,513.7 145.8,510.9 201.7,506.7 257.5,511.0 313.3,511.6 369.2,510.3 425.0,508.8 480.8,508.6 536.7,505.2 592.5,501.6 648.3,482.5 704.2,481.2 760.0,464.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="513.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="510.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="506.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="511.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="510.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="508.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="508.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="505.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="501.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="482.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="481.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="464.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,507.1 145.8,508.6 201.7,510.8 257.5,507.2 313.3,505.5 369.2,509.8 425.0,505.3 480.8,504.8 536.7,508.2 592.5,505.0 648.3,492.2 704.2,484.9 760.0,464.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="507.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="508.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="510.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="507.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="505.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="509.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="505.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="504.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="508.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="505.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="492.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="484.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="464.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
+  <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="257.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="313.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="369.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="425.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="480.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="536.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="592.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="648.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="704.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <line x1="65" y1="624" x2="79" y2="624" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="72" cy="624" r="2.5" fill="#dc2626"/>
+  <text x="85" y="628" fill="#374151" font-size="11" font-weight="500">OMQ.java</text>
+  <line x1="245" y1="624" x2="259" y2="624" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="252" cy="624" r="2.5" fill="#f97316"/>
+  <text x="265" y="628" fill="#374151" font-size="11" font-weight="500">OMQ.java receiveInto</text>
+  <line x1="425" y1="624" x2="439" y2="624" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="432" cy="624" r="2.5" fill="#2563eb"/>
+  <text x="445" y="628" fill="#374151" font-size="11" font-weight="500">JeroMQ</text>
+  <line x1="605" y1="624" x2="619" y2="624" stroke="#8b5cf6" stroke-width="2.5"/>
+  <circle cx="612" cy="624" r="2.5" fill="#8b5cf6"/>
+  <text x="625" y="628" fill="#374151" font-size="11" font-weight="500">JeroMQ recvByteBuffer</text>
+  <text x="425.0" y="646" text-anchor="middle" fill="#9ca3af" font-size="9">top dashed = msg/s (left) · top solid = GB/s (right) · bottom solid = p50 latency</text>
 </svg>

--- a/bindings/java/scripts/bench_pushpull_tcp.py
+++ b/bindings/java/scripts/bench_pushpull_tcp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Measure OMQ.java vs JeroMQ PUSH/PULL throughput over TCP loopback."""
+"""Measure OMQ.java vs JeroMQ TCP throughput and latency."""
 
 import argparse
 import datetime as dt
@@ -16,10 +16,17 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REPO = ROOT.parents[1]
-CLASS = "io.omq.perf.PushPullTcpPeer"
+PUSHPULL_CLASS = "io.omq.perf.PushPullTcpPeer"
+REQREP_CLASS = "io.omq.perf.ReqRepTcpPeer"
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [8, 128, 1024, 4096, 32768]
 DEFAULT_IMPLS = ["omq", "omq-into", "jeromq", "jeromq-into"]
+DEFAULT_THROUGHPUT_WARMUP = 50_000
+QUICK_THROUGHPUT_WARMUP = 5_000
+DEFAULT_LATENCY_WARMUP = 50_000
+DEFAULT_LATENCY_ITERS = 50_000
+QUICK_LATENCY_WARMUP = 5_000
+QUICK_LATENCY_ITERS = 5_000
 CHART_DIR = ROOT / "doc" / "charts"
 JSONL = (
     Path(os.environ.get("OMQ_JAVA_CACHE_DIR", Path.home() / ".cache" / "omq.java"))
@@ -30,6 +37,8 @@ C_OMQ = "#dc2626"
 C_OMQ_INTO = "#f97316"
 C_JEROMQ = "#2563eb"
 C_JEROMQ_INTO = "#8b5cf6"
+LATENCY_MIN_US = 20.0
+LATENCY_MAX_US = 120.0
 
 
 def parse_csv_ints(value):
@@ -125,21 +134,32 @@ def message_count(size, args):
     return max(args.min_messages, min(args.max_messages, by_bytes))
 
 
-def java_cmd(cp, impl, role, endpoint, size, messages, warmup, batch):
+def throughput_warmup_count(messages, args):
+    if args.warmup_messages is not None:
+        return args.warmup_messages
+    base = QUICK_THROUGHPUT_WARMUP if args.quick else DEFAULT_THROUGHPUT_WARMUP
+    return min(messages, max(base, messages // 20))
+
+
+def java_cmd(class_name, cp, impl, role, endpoint, size, messages, warmup, batch=None):
+    args = [
+        str(size),
+        str(messages),
+        str(warmup),
+    ]
+    if batch is not None:
+        args.append(str(batch))
     return [
         "java",
         "--enable-native-access=ALL-UNNAMED",
         "-Djava.library.path=" + str(ROOT / "native" / "target" / "release"),
         "-cp",
         cp,
-        CLASS,
+        class_name,
         impl,
         role,
         endpoint,
-        str(size),
-        str(messages),
-        str(warmup),
-        str(batch),
+        *args,
     ]
 
 
@@ -178,7 +198,7 @@ def kill(proc):
 def run_cell_once(cp, impl, size, messages, warmup, batch, timeout):
     endpoint = free_endpoint()
     pull = subprocess.Popen(
-        java_cmd(cp, impl, "pull", endpoint, size, messages, warmup, batch),
+        java_cmd(PUSHPULL_CLASS, cp, impl, "pull", endpoint, size, messages, warmup, batch),
         cwd=ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -191,7 +211,7 @@ def run_cell_once(cp, impl, size, messages, warmup, batch, timeout):
             raise RuntimeError(f"receiver did not become ready:\n{ready or ''}{out}{err}")
 
         push = subprocess.run(
-            java_cmd(cp, impl, "push", endpoint, size, messages, warmup, batch),
+            java_cmd(PUSHPULL_CLASS, cp, impl, "push", endpoint, size, messages, warmup, batch),
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -216,19 +236,82 @@ def run_cell_once(cp, impl, size, messages, warmup, batch, timeout):
 
 def run_cell(cp, impl, size, args):
     messages = message_count(size, args)
-    warmup = args.warmup_messages if args.warmup_messages is not None else max(1000, messages // 20)
+    warmup = throughput_warmup_count(messages, args)
     runs = []
     total = args.warmup_rounds + args.rounds
     for round_index in range(total):
         result = run_cell_once(cp, impl, size, messages, warmup, args.batch_size, args.timeout)
+        result["warmup_messages"] = warmup
         if round_index >= args.warmup_rounds:
             runs.append(result)
         print(
             f"  {impl:8s} size={size:6d} round={round_index + 1}/{total} "
-            f"{result['msgs_s']:12.0f} msg/s {result['gb_s']:7.3f} GB/s",
+            f"warmup={warmup:7d} {result['msgs_s']:12.0f} msg/s {result['gb_s']:7.3f} GB/s",
             flush=True,
         )
     return sorted(runs, key=lambda row: row["msgs_s"])[len(runs) // 2]
+
+
+def run_latency_cell_once(cp, impl, size, iterations, warmup, timeout):
+    endpoint = free_endpoint()
+    rep = subprocess.Popen(
+        java_cmd(REQREP_CLASS, cp, impl, "rep", endpoint, size, iterations, warmup),
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        ready = read_line_timeout(rep, 10)
+        if ready is None or not ready.startswith("READY "):
+            out, err = rep.communicate(timeout=1) if rep.poll() is not None else ("", "")
+            raise RuntimeError(f"REP did not become ready:\n{ready or ''}{out}{err}")
+
+        req = subprocess.run(
+            java_cmd(REQREP_CLASS, cp, impl, "req", endpoint, size, iterations, warmup),
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+        fail_on_noise("REQ", req.stdout, req.stderr)
+        if req.returncode != 0:
+            raise RuntimeError(f"REQ failed:\n{req.stdout}{req.stderr}")
+
+        out, err = rep.communicate(timeout=timeout)
+        out = ready + out
+        fail_on_noise("REP", out, err)
+        if rep.returncode != 0:
+            raise RuntimeError(f"REP failed:\n{out}{err}")
+        return parse_result(req.stdout)
+    except Exception:
+        kill(rep)
+        raise
+
+
+def run_latency_cell(cp, impl, size, args):
+    runs = []
+    total = args.warmup_rounds + args.rounds
+    for round_index in range(total):
+        result = run_latency_cell_once(
+            cp,
+            impl,
+            size,
+            args.latency_iterations,
+            args.latency_warmup_messages,
+            args.timeout,
+        )
+        result["warmup_messages"] = args.latency_warmup_messages
+        if round_index >= args.warmup_rounds:
+            runs.append(result)
+        print(
+            f"  {impl:8s} size={size:6d} round={round_index + 1}/{total} "
+            f"p50 {result['p50_us']:8.1f} µs p99 {result['p99_us']:8.1f} µs",
+            flush=True,
+        )
+    return sorted(runs, key=lambda row: row["p50_us"])[len(runs) // 2]
 
 
 def append_jsonl(rows):
@@ -238,12 +321,14 @@ def append_jsonl(rows):
             file.write(json.dumps(row, sort_keys=True) + "\n")
 
 
-def chart_data_from_jsonl(sizes):
+def latest_rows(kind, sizes, impls, fallback):
     latest = {}
     for row in load_jsonl():
-        if row.get("kind") != "pushpull_tcp":
+        if row.get("kind") != kind:
             continue
         impl = row.get("impl")
+        if impl not in impls:
+            continue
         size = row.get("msg_size")
         if size not in sizes:
             continue
@@ -252,8 +337,19 @@ def chart_data_from_jsonl(sizes):
         if prev is None or row.get("run_id", "") >= prev.get("run_id", ""):
             latest[key] = row
     return {
-        impl: [latest.get((impl, size), {"msgs_s": 0.0, "gb_s": 0.0}) for size in sizes]
-        for impl in DEFAULT_IMPLS
+        impl: [latest.get((impl, size), fallback.copy()) for size in sizes]
+        for impl in impls
+    }
+
+
+def chart_data_from_jsonl(sizes):
+    return {
+        "throughput": latest_rows(
+            "pushpull_tcp", sizes, DEFAULT_IMPLS, {"msgs_s": 0.0, "gb_s": 0.0}
+        ),
+        "latency": latest_rows(
+            "reqrep_tcp_latency", sizes, DEFAULT_IMPLS, {"p50_us": 0.0, "p99_us": 0.0}
+        ),
     }
 
 
@@ -287,6 +383,12 @@ def fmt_y_gbs(value):
     if value >= 1:
         return f"{value:g} GB/s"
     return f"{value * 1000:g} MB/s"
+
+
+def fmt_y_us(value):
+    if value >= 1000:
+        return f"{value / 1000:g} ms"
+    return f"{value:g} µs"
 
 
 def read_chart_hw():
@@ -347,51 +449,61 @@ def detect_hardware():
 
 def gen_chart(sizes, path):
     data = chart_data_from_jsonl(sizes)
+    throughput = data["throughput"]
+    latency = data["latency"]
     series = [
-        ("OMQ.java", C_OMQ, data["omq"]),
-        ("OMQ.java receiveInto", C_OMQ_INTO, data["omq-into"]),
-        ("JeroMQ", C_JEROMQ, data["jeromq"]),
-        ("JeroMQ recvByteBuffer", C_JEROMQ_INTO, data["jeromq-into"]),
+        ("OMQ.java", C_OMQ, "omq"),
+        ("OMQ.java receiveInto", C_OMQ_INTO, "omq-into"),
+        ("JeroMQ", C_JEROMQ, "jeromq"),
+        ("JeroMQ recvByteBuffer", C_JEROMQ_INTO, "jeromq-into"),
     ]
-    max_msgs = max((row["msgs_s"] for rows in data.values() for row in rows), default=0.0)
-    max_gbs = max((row["gb_s"] for rows in data.values() for row in rows), default=0.0)
+    max_msgs = max((row["msgs_s"] for rows in throughput.values() for row in rows), default=0.0)
+    max_gbs = max((row["gb_s"] for rows in throughput.values() for row in rows), default=0.0)
     msg_max = nice_ceil(max_msgs)
     gbs_max = nice_ceil(max_gbs)
     hw_label = detect_hardware()
     hw_offset = 14 if hw_label else 0
     svg_w = 850
-    svg_h = 500 + hw_offset
+    svg_h = 670 + hw_offset
     x_left, x_right = 90, 760
-    y_top = 35 + hw_offset
-    y_bot = 370 + hw_offset
+    t1_top = 35 + hw_offset
+    t1_bot = 370 + hw_offset
+    t1_h = t1_bot - t1_top
+    t2_top = t1_bot + 80
+    t2_bot = t2_top + 120
+    t2_h = t2_bot - t2_top
     plot_w = x_right - x_left
-    plot_h = y_bot - y_top
     mid_x = (x_left + x_right) / 2
     xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
 
     def y_msg(value):
-        return y_bot - (value / msg_max) * plot_h
+        return t1_bot - (value / msg_max) * t1_h
 
     def y_gbs(value):
-        return y_bot - (value / gbs_max) * plot_h
+        return t1_bot - (value / gbs_max) * t1_h
+
+    def y_lat(value):
+        bounded = min(max(value, LATENCY_MIN_US), LATENCY_MAX_US)
+        frac = (bounded - LATENCY_MIN_US) / (LATENCY_MAX_US - LATENCY_MIN_US)
+        return t2_bot - frac * t2_h
 
     lines = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">',
         f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
-        f'  <text x="{mid_x}" y="{y_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
         f' font-size="13" font-weight="700">'
-        "PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>",
+        "JIT-warmed PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>",
     ]
     if hw_label:
         lines.append(
-            f'  <text x="{mid_x}" y="{y_top - 3}" text-anchor="middle"'
+            f'  <text x="{mid_x}" y="{t1_top - 3}" text-anchor="middle"'
             f' fill="#9ca3af" font-size="10">{escape_svg(hw_label)}</text>'
         )
 
     for i in range(1, 11):
         frac = i / 10
-        yy = y_bot - frac * plot_h
+        yy = t1_bot - frac * t1_h
         msg_val = int(msg_max * frac)
         gbs_val = gbs_max * frac
         lines.append(
@@ -411,29 +523,30 @@ def gen_chart(sizes, path):
 
     for x in xs:
         lines.append(
-            f'  <line x1="{x:.1f}" y1="{y_top}" x2="{x:.1f}" y2="{y_bot}"'
+            f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
             f' stroke="#e5e7eb" stroke-width="1"/>'
         )
 
     lines.extend(
         [
-            f'  <line x1="{x_left}" y1="{y_top}" x2="{x_left}" y2="{y_bot}"'
+            f'  <line x1="{x_left}" y1="{t1_top}" x2="{x_left}" y2="{t1_bot}"'
             f' stroke="#9ca3af" stroke-width="1.5"/>',
-            f'  <line x1="{x_right}" y1="{y_top}" x2="{x_right}" y2="{y_bot}"'
+            f'  <line x1="{x_right}" y1="{t1_top}" x2="{x_right}" y2="{t1_bot}"'
             f' stroke="#9ca3af" stroke-width="1.5"/>',
-            f'  <line x1="{x_left}" y1="{y_bot}" x2="{x_right}" y2="{y_bot}"'
+            f'  <line x1="{x_left}" y1="{t1_bot}" x2="{x_right}" y2="{t1_bot}"'
             f' stroke="#9ca3af" stroke-width="1.5"/>',
         ]
     )
 
-    y_mid = (y_top + y_bot) / 2
+    y_mid = (t1_top + t1_bot) / 2
     lines.append(
         f'  <text x="40" y="{y_mid:.0f}" text-anchor="middle"'
         f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{y_mid:.0f})">msg/s</text>'
     )
 
-    for _, color, rows in series:
+    for _, color, impl in series:
+        rows = throughput[impl]
         points = " ".join(
             f"{xs[i]:.1f},{y_msg(row['msgs_s']):.1f}" for i, row in enumerate(rows)
         )
@@ -442,7 +555,8 @@ def gen_chart(sizes, path):
             f' stroke-width="2" stroke-dasharray="6,4"/>'
         )
 
-    for _, color, rows in series:
+    for _, color, impl in series:
+        rows = throughput[impl]
         points = " ".join(
             f"{xs[i]:.1f},{y_gbs(row['gb_s']):.1f}" for i, row in enumerate(rows)
         )
@@ -459,11 +573,73 @@ def gen_chart(sizes, path):
 
     for i, size in enumerate(sizes):
         lines.append(
-            f'  <text x="{xs[i]:.1f}" y="{y_bot + 14}" text-anchor="middle"'
+            f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
             f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
         )
 
-    legend_y = y_bot + 48
+    lines.append(
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f' font-size="13" font-weight="700">'
+        "JIT-warmed REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
+    )
+
+    for value in range(int(LATENCY_MIN_US), int(LATENCY_MAX_US) + 1, 20):
+        yy = y_lat(value)
+        lines.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+        lines.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f"{fmt_y_us(value)}</text>"
+        )
+
+    for x in xs:
+        lines.append(
+            f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+
+    lines.extend(
+        [
+            f'  <line x1="{x_left}" y1="{t2_top}" x2="{x_left}" y2="{t2_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_left}" y1="{t2_bot}" x2="{x_right}" y2="{t2_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+        ]
+    )
+
+    y_mid = (t2_top + t2_bot) / 2
+    lines.append(
+        f'  <text x="40" y="{y_mid:.0f}" text-anchor="middle"'
+        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' transform="rotate(-90,40,{y_mid:.0f})">p50 latency (µs)</text>'
+    )
+
+    for _, color, impl in series:
+        rows = latency[impl]
+        points = " ".join(
+            f"{xs[i]:.1f},{y_lat(row['p50_us']):.1f}" for i, row in enumerate(rows)
+        )
+        lines.append(
+            f'  <polyline points="{points}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for i, row in enumerate(rows):
+            yy = y_lat(row["p50_us"])
+            lines.append(
+                f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="white" stroke-width="1"/>'
+            )
+
+    for i, size in enumerate(sizes):
+        lines.append(
+            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+        )
+
+    legend_y = t2_bot + 40
     legend_items = [(label, color) for label, color, _ in series]
     item_w = 180
     total_w = len(legend_items) * item_w
@@ -484,7 +660,7 @@ def gen_chart(sizes, path):
     lines.append(
         f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
         f' fill="#9ca3af" font-size="9">'
-        f"dashed = msg/s (left) · solid = GB/s (right)</text>"
+        f"top dashed = msg/s (left) · top solid = GB/s (right) · bottom solid = p50 latency</text>"
     )
     lines.append("</svg>")
 
@@ -510,6 +686,23 @@ def print_table(rows, sizes, impls):
         print()
 
 
+def print_latency_table(rows, sizes, impls):
+    by_key = {(row["msg_size"], row["impl"]): row for row in rows}
+    print()
+    print("size  impl          p50 us    p99 us   jeromq/impl")
+    for size in sizes:
+        base = by_key.get((size, "jeromq"))
+        base_p50 = base["p50_us"] if base else 0.0
+        for impl in impls:
+            row = by_key[(size, impl)]
+            ratio = base_p50 / row["p50_us"] if base_p50 and row["p50_us"] else 0.0
+            print(
+                f"{size:5d} {impl:8s} {row['p50_us']:9.1f} "
+                f"{row['p99_us']:9.1f} {ratio:11.2f}x"
+            )
+        print()
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--quick", action="store_true")
@@ -520,13 +713,44 @@ def main():
     parser.add_argument("--target-bytes", type=int, default=256 * 1024 * 1024)
     parser.add_argument("--min-messages", type=int, default=20_000)
     parser.add_argument("--max-messages", type=int, default=1_000_000)
-    parser.add_argument("--warmup-messages", type=int)
+    parser.add_argument(
+        "--throughput-warmup",
+        "--throughput-warmup-messages",
+        "--warmup-messages",
+        dest="warmup_messages",
+        type=int,
+    )
     parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--latency-warmup", "--latency-warmup-messages", dest="latency_warmup_messages", type=int)
+    parser.add_argument("--latency-iters", "--latency-iterations", dest="latency_iterations", type=int)
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--chart-only", action="store_true")
     parser.add_argument("--no-chart", action="store_true")
+    parser.add_argument("--throughput-only", action="store_true")
+    parser.add_argument("--latency-only", action="store_true")
     args = parser.parse_args()
+
+    if args.throughput_only and args.latency_only:
+        parser.error("--throughput-only and --latency-only are mutually exclusive")
+    if args.chart_only and (args.throughput_only or args.latency_only):
+        parser.error("--chart-only cannot be combined with benchmark selection")
+    if args.rounds < 1:
+        parser.error("--rounds must be at least 1")
+    if args.warmup_rounds < 0:
+        parser.error("--warmup-rounds cannot be negative")
+    if args.warmup_messages is not None and args.warmup_messages < 0:
+        parser.error("--throughput-warmup cannot be negative")
+    if args.latency_warmup_messages is None:
+        args.latency_warmup_messages = (
+            QUICK_LATENCY_WARMUP if args.quick else DEFAULT_LATENCY_WARMUP
+        )
+    if args.latency_iterations is None:
+        args.latency_iterations = QUICK_LATENCY_ITERS if args.quick else DEFAULT_LATENCY_ITERS
+    if args.latency_warmup_messages < 0:
+        parser.error("--latency-warmup cannot be negative")
+    if args.latency_iterations < 1:
+        parser.error("--latency-iters must be at least 1")
 
     sizes = args.sizes or (QUICK_SIZES if args.quick else DEFAULT_SIZES)
     chart_path = CHART_DIR / "pushpull_tcp.svg"
@@ -538,17 +762,35 @@ def main():
     cp = classpath()
     run_id = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
     rows = []
+    throughput_rows = []
+    latency_rows = []
 
     print(f"run_id={run_id}")
-    for size in sizes:
-        for impl in args.impls:
-            row = run_cell(cp, impl, size, args)
-            row["run_id"] = run_id
-            row["kind"] = "pushpull_tcp"
-            rows.append(row)
+    if not args.latency_only:
+        print("\nPUSH/PULL throughput (TCP)...")
+        for size in sizes:
+            for impl in args.impls:
+                row = run_cell(cp, impl, size, args)
+                row["run_id"] = run_id
+                row["kind"] = "pushpull_tcp"
+                throughput_rows.append(row)
+                rows.append(row)
+
+    if not args.throughput_only:
+        print("\nREQ/REP latency (TCP)...")
+        for size in sizes:
+            for impl in args.impls:
+                row = run_latency_cell(cp, impl, size, args)
+                row["run_id"] = run_id
+                row["kind"] = "reqrep_tcp_latency"
+                latency_rows.append(row)
+                rows.append(row)
 
     append_jsonl(rows)
-    print_table(rows, sizes, args.impls)
+    if throughput_rows:
+        print_table(throughput_rows, sizes, args.impls)
+    if latency_rows:
+        print_latency_table(latency_rows, sizes, args.impls)
     print(f"appended {len(rows)} rows to {JSONL}")
     if not args.no_chart:
         gen_chart(sizes, chart_path)

--- a/bindings/java/src/test/java/io/omq/perf/ReqRepTcpPeer.java
+++ b/bindings/java/src/test/java/io/omq/perf/ReqRepTcpPeer.java
@@ -1,0 +1,306 @@
+package io.omq.perf;
+
+import io.omq.Context;
+import io.omq.OMQ;
+import io.omq.Socket;
+import io.omq.SocketType;
+import io.omq.WorkloadProfile;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Locale;
+
+/** Two-process REQ/REP TCP latency benchmark peer for OMQ.java and JeroMQ. */
+public final class ReqRepTcpPeer {
+    private static final int HWM = 1_000;
+    private static final Duration LINGER = Duration.ZERO;
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+
+    private ReqRepTcpPeer() {
+    }
+
+    /** Runs one benchmark peer process. */
+    public static void main(String[] args) {
+        if (args.length != 6) {
+            throw new IllegalArgumentException(
+                    "usage: <omq|omq-into|jeromq|jeromq-into> "
+                            + "<req|rep> <endpoint> <size> <iterations> <warmup>");
+        }
+
+        Impl impl = Impl.parse(args[0]);
+        Role role = Role.parse(args[1]);
+        String endpoint = args[2];
+        int size = Integer.parseInt(args[3]);
+        int iterations = Integer.parseInt(args[4]);
+        int warmup = Integer.parseInt(args[5]);
+        if (size < 0 || iterations <= 0 || warmup < 0) {
+            throw new IllegalArgumentException("invalid size/iterations/warmup");
+        }
+
+        if (role == Role.REP) {
+            runRep(impl, endpoint, size, iterations + warmup);
+        } else {
+            runReq(impl, endpoint, size, iterations, warmup);
+        }
+    }
+
+    private static void runRep(Impl impl, String endpoint, int size, int exchanges) {
+        switch (impl) {
+            case OMQ -> runOmqRep(endpoint, size, exchanges, false);
+            case OMQ_INTO -> runOmqRep(endpoint, size, exchanges, true);
+            case JEROMQ -> runJeroRep(endpoint, size, exchanges, false);
+            case JEROMQ_INTO -> runJeroRep(endpoint, size, exchanges, true);
+        }
+    }
+
+    private static void runReq(
+            Impl impl, String endpoint, int size, int iterations, int warmup) {
+        switch (impl) {
+            case OMQ -> runOmqReq(endpoint, size, iterations, warmup, false);
+            case OMQ_INTO -> runOmqReq(endpoint, size, iterations, warmup, true);
+            case JEROMQ -> runJeroReq(endpoint, size, iterations, warmup, false);
+            case JEROMQ_INTO -> runJeroReq(endpoint, size, iterations, warmup, true);
+        }
+    }
+
+    private static void runOmqRep(
+            String endpoint, int size, int exchanges, boolean receiveInto) {
+        byte[] payload = payload(size);
+        try (Context context = OMQ.context();
+             Socket rep = context.socket(SocketType.REP)
+                     .workloadProfile(WorkloadProfile.LATENCY)
+                     .receiveHighWaterMark(HWM)
+                     .sendHighWaterMark(HWM)
+                     .linger(LINGER)) {
+            rep.bind(endpoint);
+            ready(endpoint);
+            if (receiveInto) {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+                for (int i = 0; i < exchanges; i++) {
+                    receiveOmqInto(rep, buffer, size);
+                    rep.send(payload);
+                }
+            } else {
+                for (int i = 0; i < exchanges; i++) {
+                    receiveOmq(rep, size);
+                    rep.send(payload);
+                }
+            }
+        }
+    }
+
+    private static void runOmqReq(
+            String endpoint, int size, int iterations, int warmup, boolean receiveInto) {
+        byte[] payload = payload(size);
+        try (Context context = OMQ.context();
+             Socket req = context.socket(SocketType.REQ)
+                     .workloadProfile(WorkloadProfile.LATENCY)
+                     .receiveHighWaterMark(HWM)
+                     .sendHighWaterMark(HWM)
+                     .linger(LINGER)) {
+            req.connect(endpoint);
+            req.waitConnected(1, CONNECT_TIMEOUT);
+            if (receiveInto) {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+                for (int i = 0; i < warmup; i++) {
+                    req.send(payload);
+                    receiveOmqInto(req, buffer, size);
+                }
+                long[] rtts = new long[iterations];
+                for (int i = 0; i < iterations; i++) {
+                    long started = System.nanoTime();
+                    req.send(payload);
+                    receiveOmqInto(req, buffer, size);
+                    rtts[i] = System.nanoTime() - started;
+                }
+                result(Impl.OMQ_INTO.name, endpoint, size, iterations, rtts);
+            } else {
+                for (int i = 0; i < warmup; i++) {
+                    req.send(payload);
+                    receiveOmq(req, size);
+                }
+                long[] rtts = new long[iterations];
+                for (int i = 0; i < iterations; i++) {
+                    long started = System.nanoTime();
+                    req.send(payload);
+                    receiveOmq(req, size);
+                    rtts[i] = System.nanoTime() - started;
+                }
+                result(Impl.OMQ.name, endpoint, size, iterations, rtts);
+            }
+        }
+    }
+
+    private static void runJeroRep(
+            String endpoint, int size, int exchanges, boolean receiveInto) {
+        byte[] payload = payload(size);
+        try (org.zeromq.ZContext context = new org.zeromq.ZContext();
+             org.zeromq.ZMQ.Socket rep = context.createSocket(org.zeromq.SocketType.REP)) {
+            rep.setRcvHWM(HWM);
+            rep.setSndHWM(HWM);
+            rep.setLinger((int) LINGER.toMillis());
+            rep.bind(endpoint);
+            ready(endpoint);
+            if (receiveInto) {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+                for (int i = 0; i < exchanges; i++) {
+                    receiveJeroInto(rep, buffer, size);
+                    sendJero(rep, payload);
+                }
+            } else {
+                for (int i = 0; i < exchanges; i++) {
+                    receiveJero(rep, size);
+                    sendJero(rep, payload);
+                }
+            }
+        }
+    }
+
+    private static void runJeroReq(
+            String endpoint, int size, int iterations, int warmup, boolean receiveInto) {
+        byte[] payload = payload(size);
+        try (org.zeromq.ZContext context = new org.zeromq.ZContext();
+             org.zeromq.ZMQ.Socket req = context.createSocket(org.zeromq.SocketType.REQ)) {
+            req.setRcvHWM(HWM);
+            req.setSndHWM(HWM);
+            req.setLinger((int) LINGER.toMillis());
+            req.connect(endpoint);
+            sleep(100);
+            if (receiveInto) {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+                for (int i = 0; i < warmup; i++) {
+                    sendJero(req, payload);
+                    receiveJeroInto(req, buffer, size);
+                }
+                long[] rtts = new long[iterations];
+                for (int i = 0; i < iterations; i++) {
+                    long started = System.nanoTime();
+                    sendJero(req, payload);
+                    receiveJeroInto(req, buffer, size);
+                    rtts[i] = System.nanoTime() - started;
+                }
+                result(Impl.JEROMQ_INTO.name, endpoint, size, iterations, rtts);
+            } else {
+                for (int i = 0; i < warmup; i++) {
+                    sendJero(req, payload);
+                    receiveJero(req, size);
+                }
+                long[] rtts = new long[iterations];
+                for (int i = 0; i < iterations; i++) {
+                    long started = System.nanoTime();
+                    sendJero(req, payload);
+                    receiveJero(req, size);
+                    rtts[i] = System.nanoTime() - started;
+                }
+                result(Impl.JEROMQ.name, endpoint, size, iterations, rtts);
+            }
+        }
+    }
+
+    private static void receiveOmq(Socket socket, int size) {
+        byte[] body = socket.receiveBytes();
+        if (body.length != size) {
+            throw new IllegalStateException("expected " + size + " bytes, got " + body.length);
+        }
+    }
+
+    private static void receiveOmqInto(Socket socket, ByteBuffer buffer, int size) {
+        buffer.clear();
+        int received = socket.receiveInto(buffer);
+        if (received != size) {
+            throw new IllegalStateException("expected " + size + " bytes, got " + received);
+        }
+    }
+
+    private static void receiveJero(org.zeromq.ZMQ.Socket socket, int size) {
+        byte[] body = socket.recv(0);
+        if (body.length != size) {
+            throw new IllegalStateException("expected " + size + " bytes, got " + body.length);
+        }
+    }
+
+    private static void receiveJeroInto(
+            org.zeromq.ZMQ.Socket socket, ByteBuffer buffer, int size) {
+        buffer.clear();
+        int received = socket.recvByteBuffer(buffer, 0);
+        if (received != size) {
+            throw new IllegalStateException("expected " + size + " bytes, got " + received);
+        }
+    }
+
+    private static void sendJero(org.zeromq.ZMQ.Socket socket, byte[] payload) {
+        if (!socket.send(payload, 0)) {
+            throw new IllegalStateException("JeroMQ send failed");
+        }
+    }
+
+    private static byte[] payload(int size) {
+        byte[] payload = new byte[size];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) i;
+        }
+        return payload;
+    }
+
+    private static void ready(String endpoint) {
+        System.out.println("READY " + endpoint);
+        System.out.flush();
+    }
+
+    private static void result(
+            String impl, String endpoint, int size, int iterations, long[] rtts) {
+        Arrays.sort(rtts);
+        double p50 = rtts[iterations * 50 / 100] / 1_000.0;
+        double p99 = rtts[Math.min(iterations - 1, iterations * 99 / 100)] / 1_000.0;
+        System.out.printf(
+                Locale.ROOT,
+                "RESULT {\"impl\":\"%s\",\"endpoint\":\"%s\",\"msg_size\":%d,"
+                        + "\"iterations\":%d,\"p50_us\":%.3f,\"p99_us\":%.3f}%n",
+                impl, endpoint, size, iterations, p50, p99);
+        System.out.flush();
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(interrupted);
+        }
+    }
+
+    private enum Impl {
+        OMQ("omq"),
+        OMQ_INTO("omq-into"),
+        JEROMQ("jeromq"),
+        JEROMQ_INTO("jeromq-into");
+
+        private final String name;
+
+        Impl(String name) {
+            this.name = name;
+        }
+
+        private static Impl parse(String value) {
+            for (Impl impl : values()) {
+                if (impl.name.equals(value)) {
+                    return impl;
+                }
+            }
+            throw new IllegalArgumentException("unknown impl: " + value);
+        }
+    }
+
+    private enum Role {
+        REQ,
+        REP;
+
+        private static Role parse(String value) {
+            return switch (value) {
+                case "req" -> REQ;
+                case "rep" -> REP;
+                default -> throw new IllegalArgumentException("unknown role: " + value);
+            };
+        }
+    }
+}


### PR DESCRIPTION
- Adds Java TCP perf chart with JIT-warmed PUSH/PULL throughput and REQ/REP p50 latency panels against JeroMQ.
- Adds a two-process REQ/REP latency benchmark peer covering OMQ.java/JeroMQ and receiveInto/recvByteBuffer variants.
- Makes throughput and latency warmup explicit before timed samples, records warmup metadata, and refreshes chart data from a turbo-off local run.