### PR TITLE
Publish Java native classifiers

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Maven version to publish, for example 0.1.0
+        description: Maven version to publish, for example 0.3.0
         required: true
 
 permissions:
@@ -69,7 +69,7 @@ jobs:
       - name: Stage release native for tests
         shell: bash
         run: |
-          resource_dir="bindings/java/target/classes/io/omq/native/${{ matrix.platform }}"
+          resource_dir="bindings/java/target/test-classes/io/omq/native/${{ matrix.platform }}"
           mkdir -p "$resource_dir"
           cp "bindings/java/native/target/release/${{ matrix.library }}" "$resource_dir/"
       - name: JUnit with release native
@@ -130,6 +130,23 @@ jobs:
           else
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Package release artifacts
+        run: >
+          mvn -B -ntp -f bindings/java/pom.xml -Prelease
+          -Drevision=${{ steps.version.outputs.version }}
+          -DskipNative=true -DskipTests -Dgpg.skip=true
+          package
+      - name: Smoke packaged Linux classifier
+        shell: bash
+        run: |
+          jar="bindings/java/target/omq-java-${{ steps.version.outputs.version }}-linux-x86_64.jar"
+          java --enable-native-access=ALL-UNNAMED \
+            -cp "bindings/java/target/test-classes:${jar}" \
+            io.omq.smoke.PackagingSmoke
+          java --enable-native-access=io.omq \
+            --module-path "${jar}" --add-modules io.omq \
+            -cp bindings/java/target/test-classes \
+            io.omq.smoke.PackagingSmoke
       - name: Upload for validation
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Publish OMQ.java as a Java-only main jar plus platform classifier runtime jars.
 - Build and test release native libraries on CI before Maven Central upload.
 - Report the required Maven classifier when native loading fails.
+- Tighten Java soak resource checks with FD tracking, RSS/FD slope gates, and
+  post-GC heap cleanup checks.
 
 ## [0.2.0]
 

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.3.0]
+
+- Publish OMQ.java as a Java-only main jar plus platform classifier runtime jars.
+- Build and test release native libraries on CI before Maven Central upload.
+- Report the required Maven classifier when native loading fails.
+
 ## [0.2.0]
 
 - Remove public batch send/receive APIs. Scalar receive methods still use the hidden native batch receive path.

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -42,13 +42,14 @@ Maven Central coordinates. Use the latest version listed on Maven Central:
 </dependency>
 ```
 
-Synchronous receives use Java 25 FFM and require native access:
+OMQ.java loads native code and uses Java 25 FFM, so applications must enable
+native access:
 
 ```sh
 --enable-native-access=ALL-UNNAMED
 ```
 
-If the jar is used on the module path, enable only the automatic module:
+If the jar is used on the module path, enable only the named module:
 
 ```sh
 --enable-native-access=io.omq

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -39,8 +39,16 @@ Maven Central coordinates. Use the latest version listed on Maven Central:
   <groupId>io.github.paddor</groupId>
   <artifactId>omq-java</artifactId>
   <version>VERSION</version>
+  <classifier>linux-x86_64</classifier>
 </dependency>
 ```
+
+Use exactly one runtime classifier for your platform:
+
+- `linux-x86_64`
+- `macos-x86_64`
+- `macos-aarch64`
+- `windows-x86_64`
 
 OMQ.java loads native code and uses Java 25 FFM, so applications must enable
 native access:
@@ -61,8 +69,10 @@ mvn install
 mvn test
 ```
 
-Maven builds the Rust native library in `native/target/debug` and embeds the
-current-platform native library in the jar under `io/omq/native/...`.
+Maven builds the Rust native library in `native/target/debug` and places the
+current-platform native library on the test runtime path. Release builds publish
+Java-only main jars plus platform classifier jars with release native libraries
+under `io/omq/native/...`.
 
 ## API Shape
 

--- a/bindings/java/native/src/lib.rs
+++ b/bindings/java/native/src/lib.rs
@@ -169,6 +169,7 @@ const RECV_RING_STATUS_CLOSED: i32 = 2;
 const RECV_RING_STATUS_INVALID_ENDPOINT: i32 = 3;
 const RECV_RING_STATUS_PROTOCOL: i32 = 4;
 const RECV_RING_STATUS_ERROR: i32 = 5;
+const MAX_ERROR_MESSAGE_BYTES: usize = 4095;
 
 const RECV_RING_FLAG_MULTIPART: u64 = 1;
 const RECV_RING_FLAG_EXTERNAL: u64 = 2;
@@ -678,12 +679,18 @@ fn empty_cstring() -> CString {
 }
 
 fn cstring_lossy(message: &str) -> CString {
-    let bytes: Vec<u8> = message
-        .as_bytes()
-        .iter()
-        .copied()
-        .filter(|b| *b != 0)
-        .collect();
+    let mut bytes = Vec::with_capacity(message.len().min(MAX_ERROR_MESSAGE_BYTES));
+    for ch in message.chars() {
+        if ch == '\0' {
+            continue;
+        }
+        let mut encoded = [0; 4];
+        let chunk = ch.encode_utf8(&mut encoded).as_bytes();
+        if bytes.len() + chunk.len() > MAX_ERROR_MESSAGE_BYTES {
+            break;
+        }
+        bytes.extend_from_slice(chunk);
+    }
     CString::new(bytes).unwrap_or_else(|_| empty_cstring())
 }
 
@@ -3957,6 +3964,26 @@ mod recv_ring_tests {
     fn windows_dns_error_message_is_name_resolution_error() {
         let error = io::Error::other("No such host is known. (os error 11001)");
         assert!(is_name_resolution_error(&error));
+    }
+
+    #[test]
+    fn cstring_lossy_removes_nul_and_fits_java_read_window() {
+        let message = format!("a\0{}", "b".repeat(MAX_ERROR_MESSAGE_BYTES + 10));
+        let cstring = cstring_lossy(&message);
+        let bytes = cstring.to_bytes();
+
+        assert_eq!(MAX_ERROR_MESSAGE_BYTES, bytes.len());
+        assert!(!bytes.contains(&0));
+    }
+
+    #[test]
+    fn cstring_lossy_truncates_at_utf8_boundary() {
+        let message = "é".repeat(MAX_ERROR_MESSAGE_BYTES);
+        let cstring = cstring_lossy(&message);
+        let bytes = cstring.to_bytes();
+
+        assert_eq!(MAX_ERROR_MESSAGE_BYTES - 1, bytes.len());
+        assert!(std::str::from_utf8(bytes).is_ok());
     }
 
     #[test]

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -46,17 +46,21 @@
   </issueManagement>
 
   <properties>
-    <revision>0.1.0-SNAPSHOT</revision>
+    <revision>0.3.0-SNAPSHOT</revision>
     <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>5.14.1</junit.version>
     <jeromq.version>0.6.0</jeromq.version>
     <checkstyle.version>3.5.0</checkstyle.version>
     <spotless.version>2.44.0</spotless.version>
+    <antrun.version>3.2.0</antrun.version>
+    <build-helper.version>3.6.1</build-helper.version>
     <central.autoPublish>false</central.autoPublish>
     <central.waitUntil>validated</central.waitUntil>
     <native.library>libomq_java.so</native.library>
     <native.platform>linux-x86_64</native.platform>
+    <native.generated.resources>${project.build.directory}/generated-resources/native</native.generated.resources>
+    <native.classifier.classes>${project.build.directory}/native-classifiers/classes</native.classifier.classes>
     <omq.java.peer.path>${project.basedir}/native/target/debug/omq-java-peer</omq.java.peer.path>
     <skipNative>false</skipNative>
   </properties>
@@ -81,9 +85,6 @@
       <resource>
         <directory>src/main/resources</directory>
       </resource>
-      <resource>
-        <directory>${project.build.directory}/generated-resources/native</directory>
-      </resource>
     </resources>
     <plugins>
       <plugin>
@@ -93,7 +94,7 @@
         <executions>
           <execution>
             <id>cargo-build-native</id>
-            <phase>generate-resources</phase>
+            <phase>generate-test-resources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -117,13 +118,13 @@
         <executions>
           <execution>
             <id>copy-native-library</id>
-            <phase>process-resources</phase>
+            <phase>process-test-resources</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
             <configuration>
               <skip>${skipNative}</skip>
-              <outputDirectory>${project.build.outputDirectory}/io/omq/native/${native.platform}</outputDirectory>
+              <outputDirectory>${project.build.testOutputDirectory}/io/omq/native/${native.platform}</outputDirectory>
               <resources>
                 <resource>
                   <directory>${project.basedir}/native/target/debug</directory>
@@ -141,6 +142,9 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
+          <excludes>
+            <exclude>io/omq/native/**</exclude>
+          </excludes>
           <archive>
             <manifestEntries>
               <Automatic-Module-Name>io.omq</Automatic-Module-Name>
@@ -239,6 +243,151 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>${antrun.version}</version>
+            <executions>
+              <execution>
+                <id>package-native-classifier-jars</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <delete dir="${project.build.directory}/native-classifiers"/>
+                    <macrodef name="runtime-jar">
+                      <attribute name="classifier"/>
+                      <attribute name="library"/>
+                      <sequential>
+                        <mkdir dir="${native.classifier.classes}/@{classifier}"/>
+                        <copy todir="${native.classifier.classes}/@{classifier}">
+                          <fileset dir="${project.build.outputDirectory}">
+                            <exclude name="io/omq/native/**"/>
+                          </fileset>
+                        </copy>
+                        <copy file="${native.generated.resources}/io/omq/native/@{classifier}/@{library}"
+                              todir="${native.classifier.classes}/@{classifier}/io/omq/native/@{classifier}"/>
+                        <jar destfile="${project.build.directory}/${project.build.finalName}-@{classifier}.jar"
+                             basedir="${native.classifier.classes}/@{classifier}">
+                          <manifest>
+                            <attribute name="Automatic-Module-Name" value="io.omq"/>
+                          </manifest>
+                        </jar>
+                      </sequential>
+                    </macrodef>
+
+                    <runtime-jar classifier="linux-x86_64" library="libomq_java.so"/>
+                    <runtime-jar classifier="macos-x86_64" library="libomq_java.dylib"/>
+                    <runtime-jar classifier="macos-aarch64" library="libomq_java.dylib"/>
+                    <runtime-jar classifier="windows-x86_64" library="omq_java.dll"/>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>verify-native-classifier-jars</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <fail message="main jar must not contain native resources">
+                      <condition>
+                        <not>
+                          <resourcecount count="0">
+                            <zipfileset src="${project.build.directory}/${project.build.finalName}.jar"
+                                        includes="io/omq/native/**"/>
+                          </resourcecount>
+                        </not>
+                      </condition>
+                    </fail>
+
+                    <macrodef name="verify-runtime-jar">
+                      <attribute name="classifier"/>
+                      <attribute name="library"/>
+                      <sequential>
+                        <fail message="@{classifier} classifier jar must contain Java classes">
+                          <condition>
+                            <not>
+                              <resourcecount count="1">
+                                <zipfileset src="${project.build.directory}/${project.build.finalName}-@{classifier}.jar"
+                                            includes="io/omq/OMQ.class"/>
+                              </resourcecount>
+                            </not>
+                          </condition>
+                        </fail>
+                        <fail message="@{classifier} classifier jar must contain exactly its native library">
+                          <condition>
+                            <not>
+                              <resourcecount count="1">
+                                <zipfileset src="${project.build.directory}/${project.build.finalName}-@{classifier}.jar"
+                                            includes="io/omq/native/@{classifier}/@{library}"/>
+                              </resourcecount>
+                            </not>
+                          </condition>
+                        </fail>
+                        <fail message="@{classifier} classifier jar must not contain other native libraries">
+                          <condition>
+                            <not>
+                              <resourcecount count="1">
+                                <zipfileset src="${project.build.directory}/${project.build.finalName}-@{classifier}.jar"
+                                            includes="io/omq/native/**"/>
+                              </resourcecount>
+                            </not>
+                          </condition>
+                        </fail>
+                      </sequential>
+                    </macrodef>
+
+                    <verify-runtime-jar classifier="linux-x86_64" library="libomq_java.so"/>
+                    <verify-runtime-jar classifier="macos-x86_64" library="libomq_java.dylib"/>
+                    <verify-runtime-jar classifier="macos-aarch64" library="libomq_java.dylib"/>
+                    <verify-runtime-jar classifier="windows-x86_64" library="omq_java.dll"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>${build-helper.version}</version>
+            <executions>
+              <execution>
+                <id>attach-native-classifier-jars</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.build.finalName}-linux-x86_64.jar</file>
+                      <type>jar</type>
+                      <classifier>linux-x86_64</classifier>
+                    </artifact>
+                    <artifact>
+                      <file>${project.build.directory}/${project.build.finalName}-macos-x86_64.jar</file>
+                      <type>jar</type>
+                      <classifier>macos-x86_64</classifier>
+                    </artifact>
+                    <artifact>
+                      <file>${project.build.directory}/${project.build.finalName}-macos-aarch64.jar</file>
+                      <type>jar</type>
+                      <classifier>macos-aarch64</classifier>
+                    </artifact>
+                    <artifact>
+                      <file>${project.build.directory}/${project.build.finalName}-windows-x86_64.jar</file>
+                      <type>jar</type>
+                      <classifier>windows-x86_64</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/bindings/java/scripts/soak.sh
+++ b/bindings/java/scripts/soak.sh
@@ -2,13 +2,60 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cpu_count() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+  else
+    getconf _NPROCESSORS_ONLN
+  fi
+}
+
 durations="${OMQ_JAVA_SOAK_DURATIONS:-300 600 1800 3600}"
-workers="${OMQ_JAVA_SOAK_WORKERS:-$(nproc)}"
+workers="${OMQ_JAVA_SOAK_WORKERS:-$(cpu_count)}"
+cargo_cmd="${CARGO:-cargo}"
+
+case "$(uname -s)" in
+  Darwin)
+    os="macos"
+    library="libomq_java.dylib"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    os="windows"
+    library="omq_java.dll"
+    ;;
+  *)
+    os="linux"
+    library="libomq_java.so"
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    arch="x86_64"
+    ;;
+  arm64|aarch64)
+    arch="aarch64"
+    ;;
+  *)
+    arch="$(uname -m)"
+    ;;
+esac
+
+platform="${os}-${arch}"
+native_dir="${repo_root}/bindings/java/native/target/release"
+resource_dir="${repo_root}/bindings/java/target/test-classes/io/omq/native/${platform}"
+
+"${cargo_cmd}" build --release --manifest-path "${repo_root}/bindings/java/native/Cargo.toml" \
+  --features plain,curve,lz4,zstd
+
+mvn -f "${repo_root}/bindings/java/pom.xml" -DskipNative=true -DskipTests test-compile
+mkdir -p "${resource_dir}"
+cp "${native_dir}/${library}" "${resource_dir}/"
 
 for duration in ${durations}; do
   echo "== OMQ.java soak: ${duration}s, workers=${workers} =="
   OMQ_JAVA_SOAK=1 \
   OMQ_JAVA_SOAK_DURATION_SECS="${duration}" \
   OMQ_JAVA_SOAK_WORKERS="${workers}" \
-    mvn -f "${repo_root}/bindings/java/pom.xml" -Dtest=JavaSoakTest test
+    mvn -f "${repo_root}/bindings/java/pom.xml" -DskipNative=true -Dtest=JavaSoakTest test
 done

--- a/bindings/java/src/main/java/io/omq/Native.java
+++ b/bindings/java/src/main/java/io/omq/Native.java
@@ -160,23 +160,24 @@ final class Native {
 
     @SuppressWarnings("restricted")
     private static void load() {
+        String platform = platform();
         try {
             System.loadLibrary("omq_java");
             return;
         } catch (UnsatisfiedLinkError first) {
             try {
-                loadFromResource();
+                loadFromResource(platform);
                 return;
-            } catch (IOException | UnsatisfiedLinkError ignored) {
-                throw first;
+            } catch (IOException | UnsatisfiedLinkError second) {
+                throw loadError(platform, first, second);
             }
         }
     }
 
     @SuppressWarnings("restricted")
-    private static void loadFromResource() throws IOException {
+    private static void loadFromResource(String platform) throws IOException {
         String library = System.mapLibraryName("omq_java");
-        String resource = "/io/omq/native/" + platform() + "/" + library;
+        String resource = "/io/omq/native/" + platform + "/" + library;
         try (InputStream input = Native.class.getResourceAsStream(resource)) {
             if (input == null) {
                 throw new UnsatisfiedLinkError("native library resource not found: " + resource);
@@ -186,6 +187,22 @@ final class Native {
             Files.copy(input, temp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             System.load(temp.toAbsolutePath().toString());
         }
+    }
+
+    private static UnsatisfiedLinkError loadError(
+            String platform, UnsatisfiedLinkError systemError, Throwable resourceError) {
+        UnsatisfiedLinkError error = new UnsatisfiedLinkError(
+                "failed to load OMQ.java native library for "
+                        + platform
+                        + "; add dependency classifier "
+                        + platform
+                        + " for io.github.paddor:omq-java, or set java.library.path; system load failed: "
+                        + systemError.getMessage()
+                        + "; resource load failed: "
+                        + resourceError.getMessage());
+        error.addSuppressed(systemError);
+        error.addSuppressed(resourceError);
+        return error;
     }
 
     private static String platform() {

--- a/bindings/java/src/test/java/io/omq/JavaSoakTest.java
+++ b/bindings/java/src/test/java/io/omq/JavaSoakTest.java
@@ -1,5 +1,6 @@
 package io.omq;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -9,9 +10,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -20,11 +23,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 final class JavaSoakTest {
     private static final Duration RECV_TIMEOUT = Duration.ofMillis(200);
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REPORT_INTERVAL = Duration.ofSeconds(10);
+    private static final Duration RESOURCE_CHECK_DELAY = Duration.ofSeconds(20);
+    private static final Duration RESOURCE_WARMUP = Duration.ofMinutes(10);
+    private static final Duration RESOURCE_WINDOW = Duration.ofMinutes(5);
+    private static final int RESOURCE_MIN_SAMPLES = 12;
+    private static final long BYTES_PER_KIB = 1024L;
+    private static final long BYTES_PER_MIB = 1_048_576L;
     private static final byte[] ZSTD_DICT = hex(
             "37a430ecbeaadd5c811120841042664644444444244902002114c418638c21841042"
                     + "082184104208214444444444444444240900005110638c31c618630c21c418636666"
@@ -36,12 +47,9 @@ final class JavaSoakTest {
 
         long durationSeconds = longConfig("omq.java.soak.durationSeconds",
                 "OMQ_JAVA_SOAK_DURATION_SECS", 60);
-        int workers = (int) longConfig("omq.java.soak.workers",
-                "OMQ_JAVA_SOAK_WORKERS", Runtime.getRuntime().availableProcessors());
-        long heapGrowthLimit = mb(longConfig("omq.java.soak.maxHeapGrowthMb",
-                "OMQ_JAVA_SOAK_MAX_HEAP_GROWTH_MB", 384));
-        long rssGrowthLimit = mb(longConfig("omq.java.soak.maxRssGrowthMb",
-                "OMQ_JAVA_SOAK_MAX_RSS_GROWTH_MB", 768));
+        durationSeconds = Math.max(5, durationSeconds);
+        int workers = Math.max(1, (int) longConfig("omq.java.soak.workers",
+                "OMQ_JAVA_SOAK_WORKERS", Runtime.getRuntime().availableProcessors()));
 
         AtomicBoolean stop = new AtomicBoolean(false);
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -53,8 +61,16 @@ final class JavaSoakTest {
         CompletableFuture<String> curveEndpoint = new CompletableFuture<>();
         CurveKeypair curveServer = OMQ.curveKeypair();
         CurveKeypair curveClient = OMQ.curveKeypair();
+        SoakResources baseline = readSoakResources();
+        SoakResourceLimits limits = readSoakResourceLimits();
+        Instant started = Instant.now();
+        long start = System.nanoTime();
+        SoakResourceTracker resources = new SoakResourceTracker(started, baseline, limits);
+        int baseWorkloads = 5;
+        int churnWorkers = Math.max(1, workers - baseWorkloads);
+        int poolSize = Math.max(workers, baseWorkloads + churnWorkers * 2);
 
-        ExecutorService pool = Executors.newFixedThreadPool(workers);
+        ExecutorService pool = Executors.newFixedThreadPool(poolSize);
         List<Future<?>> tasks = new ArrayList<>();
         try {
             tasks.add(pool.submit(() -> tcpPull(stop, failure, tcpEndpoint, tcpMessages)));
@@ -68,7 +84,6 @@ final class JavaSoakTest {
 
             String tcp = tcpEndpoint.get(5, TimeUnit.SECONDS);
             String curve = curveEndpoint.get(5, TimeUnit.SECONDS);
-            int churnWorkers = Math.max(1, workers - tasks.size());
             for (int i = 0; i < churnWorkers; i++) {
                 int workerId = i;
                 tasks.add(pool.submit(() -> tcpChurnPush(stop, failure, tcp, workerId, tcpMessages)));
@@ -76,33 +91,25 @@ final class JavaSoakTest {
                         stop, failure, curve, curveClient, curveServer.publicKey(), workerId)));
             }
 
-            long start = System.nanoTime();
             long deadline = start + Duration.ofSeconds(durationSeconds).toNanos();
-            long baselineHeap = usedHeapBytes();
-            long baselineRss = rssBytes().orElse(usedHeapBytes());
             long nextReport = start;
             while (System.nanoTime() < deadline && failure.get() == null) {
                 Thread.sleep(1_000);
                 long now = System.nanoTime();
                 if (now >= nextReport) {
-                    long heap = usedHeapBytes();
-                    long rss = rssBytes().orElse(heap);
+                    Duration elapsed = Duration.ofNanos(now - start);
+                    SoakResources current = resources.sample(elapsed);
                     System.out.printf(
-                            "[java-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d heap=%dMB rss=%dMB%n",
-                            (now - start) / 1_000_000_000.0,
+                            "[java-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d heap=%dMB rss=%dMB fds=%d%n",
+                            elapsed.toMillis() / 1_000.0,
                             tcpMessages.sum(),
                             curveMessages.sum(),
                             compressionMessages.sum(),
                             inprocMessages.sum(),
-                            heap / 1_048_576,
-                            rss / 1_048_576);
-                    if (now - start > Duration.ofSeconds(20).toNanos()) {
-                        assertTrue(heap <= baselineHeap + heapGrowthLimit,
-                                "heap growth exceeded limit");
-                        assertTrue(rss <= baselineRss + rssGrowthLimit,
-                                "RSS growth exceeded limit");
-                    }
-                    nextReport = now + Duration.ofSeconds(10).toNanos();
+                            current.heapBytes() / BYTES_PER_MIB,
+                            current.rssBytes() / BYTES_PER_MIB,
+                            current.fdCount());
+                    nextReport = now + REPORT_INTERVAL.toNanos();
                 }
             }
         } finally {
@@ -116,6 +123,10 @@ final class JavaSoakTest {
         for (Future<?> task : tasks) {
             task.get(1, TimeUnit.SECONDS);
         }
+        System.gc();
+        Thread.sleep(200);
+        System.gc();
+        resources.assertFinal(Duration.ofNanos(System.nanoTime() - start));
         if (failure.get() != null) {
             fail(failure.get());
         }
@@ -123,6 +134,70 @@ final class JavaSoakTest {
         assertTrue(curveMessages.sum() > 0, "CURVE churn made no progress");
         assertTrue(compressionMessages.sum() > 0, "compression loop made no progress");
         assertTrue(inprocMessages.sum() > 0, "inproc loop made no progress");
+    }
+
+    @Test
+    void resourceSlopePerSecond() {
+        Instant start = Instant.EPOCH;
+        OptionalDouble slope = slopePerSecond(List.of(
+                new SoakResourceSample(start, 10),
+                new SoakResourceSample(start.plusSeconds(1), 20),
+                new SoakResourceSample(start.plusSeconds(2), 30)));
+
+        assertTrue(slope.isPresent());
+        assertEquals(10.0, slope.getAsDouble(), 0.001);
+    }
+
+    @Test
+    void resourceLiveGrowthDetectsSustainedRssGrowth() {
+        Instant start = Instant.EPOCH;
+        List<SoakResourceSample> samples = new ArrayList<>();
+        for (int seconds = 0; seconds <= 1_200; seconds += 20) {
+            samples.add(new SoakResourceSample(start.plusSeconds(seconds),
+                    seconds * BYTES_PER_MIB));
+        }
+
+        Optional<String> error = liveGrowthError("RSS", start, samples, 128, 8 * BYTES_PER_MIB);
+
+        assertTrue(error.isPresent());
+    }
+
+    @Test
+    void resourceLiveGrowthIgnoresPlateau() {
+        Instant start = Instant.EPOCH;
+        List<SoakResourceSample> samples = new ArrayList<>();
+        for (int seconds = 0; seconds <= 1_200; seconds += 20) {
+            long value = Math.min(seconds, 600) * BYTES_PER_MIB;
+            samples.add(new SoakResourceSample(start.plusSeconds(seconds), value));
+        }
+
+        Optional<String> error = liveGrowthError("RSS", start, samples, 128, 8 * BYTES_PER_MIB);
+
+        assertTrue(error.isEmpty(), error.orElse(""));
+    }
+
+    @Test
+    void resourceLiveFdGrowthDetectsSustainedGrowth() {
+        Instant start = Instant.EPOCH;
+        List<SoakResourceSample> samples = new ArrayList<>();
+        for (int seconds = 0; seconds <= 1_200; seconds += 20) {
+            samples.add(new SoakResourceSample(start.plusSeconds(seconds),
+                    10 + seconds / 2L));
+        }
+
+        Optional<String> error = liveFdGrowthError(start, samples, 0.05, 32);
+
+        assertTrue(error.isPresent());
+    }
+
+    @Test
+    void resourceLimitBaselineStartsAfterCheckDelay() {
+        SoakResources warm = new SoakResources(64 * BYTES_PER_MIB, 700 * BYTES_PER_MIB, 120);
+        SoakResources later = new SoakResources(65 * BYTES_PER_MIB, 701 * BYTES_PER_MIB, 120);
+
+        assertEquals(null, checkedResourceBaseline(Duration.ofSeconds(10), warm, null));
+        assertEquals(warm, checkedResourceBaseline(RESOURCE_CHECK_DELAY, warm, null));
+        assertEquals(warm, checkedResourceBaseline(Duration.ofSeconds(40), later, warm));
     }
 
     private static void tcpPull(
@@ -317,13 +392,85 @@ final class JavaSoakTest {
     private static long longConfig(String property, String env, long fallback) {
         String propertyValue = System.getProperty(property);
         if (propertyValue != null && !propertyValue.isBlank()) {
-            return Long.parseLong(propertyValue);
+            try {
+                return Long.parseLong(propertyValue);
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
         }
         String envValue = System.getenv(env);
         if (envValue != null && !envValue.isBlank()) {
-            return Long.parseLong(envValue);
+            try {
+                return Long.parseLong(envValue);
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
         }
         return fallback;
+    }
+
+    private static long nonNegativeLongConfig(String property, String env, long fallback) {
+        long value = longConfig(property, env, fallback);
+        if (value < 0) {
+            return fallback;
+        }
+        return value;
+    }
+
+    private static long mibConfig(String property, String env, long fallback) {
+        return nonNegativeLongConfig(property, env, fallback) * BYTES_PER_MIB;
+    }
+
+    private static double doubleConfig(String property, String env, double fallback) {
+        String propertyValue = System.getProperty(property);
+        if (propertyValue != null && !propertyValue.isBlank()) {
+            try {
+                double parsed = Double.parseDouble(propertyValue);
+                return parsed > 0 ? parsed : fallback;
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        String envValue = System.getenv(env);
+        if (envValue != null && !envValue.isBlank()) {
+            try {
+                double parsed = Double.parseDouble(envValue);
+                return parsed > 0 ? parsed : fallback;
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    private static SoakResourceLimits readSoakResourceLimits() {
+        // Java heap/RSS samples are pre-GC and include allocator high-water
+        // marks. Keep absolute caps wide enough for normal cycles and use the
+        // slope gates for sustained growth.
+        return new SoakResourceLimits(
+                mibConfig("omq.java.soak.maxHeapGrowthMb",
+                        "OMQ_JAVA_SOAK_MAX_HEAP_GROWTH_MB", 768),
+                mibConfig("omq.java.soak.maxRssGrowthMb",
+                        "OMQ_JAVA_SOAK_MAX_RSS_GROWTH_MB", 768),
+                nonNegativeLongConfig("omq.java.soak.maxFdGrowth",
+                        "OMQ_JAVA_SOAK_MAX_FD_GROWTH", 128),
+                mibConfig("omq.java.soak.maxFinalHeapGrowthMb",
+                        "OMQ_JAVA_SOAK_MAX_FINAL_HEAP_GROWTH_MB", 128),
+                nonNegativeLongConfig("omq.java.soak.maxFinalFdGrowth",
+                        "OMQ_JAVA_SOAK_MAX_FINAL_FD_GROWTH", 16),
+                doubleConfig("omq.java.soak.rssSlopeLimitKibPerSecond",
+                        "OMQ_JAVA_SOAK_RSS_SLOPE_LIMIT_KIB_S", 1_024),
+                doubleConfig("omq.java.soak.fdSlopeLimitPerSecond",
+                        "OMQ_JAVA_SOAK_FD_SLOPE_LIMIT_PER_SEC", 0.05),
+                mibConfig("omq.java.soak.rssSlopeMinGrowthMb",
+                        "OMQ_JAVA_SOAK_RSS_SLOPE_MIN_GROWTH_MB", 128),
+                nonNegativeLongConfig("omq.java.soak.fdSlopeMinGrowth",
+                        "OMQ_JAVA_SOAK_FD_SLOPE_MIN_GROWTH", 32));
+    }
+
+    private static SoakResources readSoakResources() {
+        long heap = usedHeapBytes();
+        return new SoakResources(heap, rssBytes().orElse(heap), fdCount());
     }
 
     private static long usedHeapBytes() {
@@ -345,15 +492,184 @@ final class JavaSoakTest {
         return Optional.empty();
     }
 
+    private static long fdCount() {
+        try (Stream<Path> entries = Files.list(Path.of("/proc/self/fd"))) {
+            return entries.count();
+        } catch (IOException | SecurityException ignored) {
+            return 0;
+        }
+    }
+
+    private static Optional<String> liveGrowthError(
+            String metric,
+            Instant started,
+            List<SoakResourceSample> samples,
+            double slopeLimitKibPerSecond,
+            long minGrowthBytes) {
+        Optional<List<SoakResourceSample>> window = liveGrowthWindow(started, samples);
+        if (window.isEmpty()) {
+            return Optional.empty();
+        }
+        List<SoakResourceSample> values = window.orElseThrow();
+        long current = values.getLast().value();
+        long growth = saturatingSub(current, values.getFirst().value());
+        if (growth < minGrowthBytes) {
+            return Optional.empty();
+        }
+        OptionalDouble slope = slopePerSecond(values);
+        if (slope.isEmpty()) {
+            return Optional.empty();
+        }
+        double slopeKibPerSecond = slope.getAsDouble() / BYTES_PER_KIB;
+        if (slopeKibPerSecond <= slopeLimitKibPerSecond) {
+            return Optional.empty();
+        }
+        return Optional.of(String.format(
+                "live %s growth detected: slope %.1f KiB/s over %.0fs, growth %.1f MiB, current %.1f MiB, limit %.1f KiB/s",
+                metric,
+                slopeKibPerSecond,
+                RESOURCE_WINDOW.toSeconds() * 1.0,
+                growth / (double) BYTES_PER_MIB,
+                current / (double) BYTES_PER_MIB,
+                slopeLimitKibPerSecond));
+    }
+
+    private static Optional<String> liveFdGrowthError(
+            Instant started,
+            List<SoakResourceSample> samples,
+            double slopeLimitPerSecond,
+            long minGrowth) {
+        Optional<List<SoakResourceSample>> window = liveGrowthWindow(started, samples);
+        if (window.isEmpty()) {
+            return Optional.empty();
+        }
+        List<SoakResourceSample> values = window.orElseThrow();
+        long growth = saturatingSub(values.getLast().value(), values.getFirst().value());
+        if (growth < minGrowth) {
+            return Optional.empty();
+        }
+        OptionalDouble slope = slopePerSecond(values);
+        if (slope.isEmpty() || slope.getAsDouble() <= slopeLimitPerSecond) {
+            return Optional.empty();
+        }
+        SampleRange range = sampleRange(values);
+        return Optional.of(String.format(
+                "live FD growth detected: slope %.4f FDs/s over %.0fs, range %d..%d, limit %.4f FDs/s",
+                slope.getAsDouble(),
+                RESOURCE_WINDOW.toSeconds() * 1.0,
+                range.min(),
+                range.max(),
+                slopeLimitPerSecond));
+    }
+
+    private static Optional<List<SoakResourceSample>> liveGrowthWindow(
+            Instant started,
+            List<SoakResourceSample> samples) {
+        if (samples.size() < RESOURCE_MIN_SAMPLES) {
+            return Optional.empty();
+        }
+        Instant now = samples.getLast().at();
+        if (Duration.between(started, now).compareTo(RESOURCE_WARMUP.plus(RESOURCE_WINDOW)) < 0) {
+            return Optional.empty();
+        }
+        Instant windowStart = now.minus(RESOURCE_WINDOW);
+        int first = 0;
+        for (int i = 0; i < samples.size(); i++) {
+            if (!samples.get(i).at().isBefore(windowStart)) {
+                first = i;
+                break;
+            }
+        }
+        List<SoakResourceSample> window = samples.subList(first, samples.size());
+        if (window.size() < RESOURCE_MIN_SAMPLES) {
+            return Optional.empty();
+        }
+        return Optional.of(window);
+    }
+
+    private static OptionalDouble slopePerSecond(List<SoakResourceSample> samples) {
+        if (samples.size() < 2) {
+            return OptionalDouble.empty();
+        }
+        Instant first = samples.getFirst().at();
+        double elapsed = Duration.between(first, samples.getLast().at()).toNanos()
+                / 1_000_000_000.0;
+        if (elapsed < 1) {
+            return OptionalDouble.empty();
+        }
+        double n = samples.size();
+        double sumX = 0;
+        double sumY = 0;
+        double sumXy = 0;
+        double sumXx = 0;
+        for (SoakResourceSample sample : samples) {
+            double x = Duration.between(first, sample.at()).toNanos() / 1_000_000_000.0;
+            double y = sample.value();
+            sumX += x;
+            sumY += y;
+            sumXy += x * y;
+            sumXx += x * x;
+        }
+        double denominator = n * sumXx - sumX * sumX;
+        if (denominator == 0) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of((n * sumXy - sumX * sumY) / denominator);
+    }
+
+    private static SampleRange sampleRange(List<SoakResourceSample> samples) {
+        if (samples.isEmpty()) {
+            return new SampleRange(0, 0);
+        }
+        long min = samples.getFirst().value();
+        long max = samples.getFirst().value();
+        for (SoakResourceSample sample : samples) {
+            min = Math.min(min, sample.value());
+            max = Math.max(max, sample.value());
+        }
+        return new SampleRange(min, max);
+    }
+
+    private static long saturatingSub(long value, long other) {
+        if (value < other) {
+            return 0;
+        }
+        return value - other;
+    }
+
+    private static SoakResources checkedResourceBaseline(
+            Duration elapsed,
+            SoakResources current,
+            SoakResources baseline) {
+        if (baseline != null || elapsed.compareTo(RESOURCE_CHECK_DELAY) < 0) {
+            return baseline;
+        }
+        return current;
+    }
+
+    private static void assertSoakResources(
+            SoakResources baseline,
+            SoakResources current,
+            SoakResourceLimits limits) {
+        if (current.heapBytes() > baseline.heapBytes() + limits.heapGrowthBytes()) {
+            fail(String.format("heap growth exceeded limit: baseline=%d current=%d limit=%d",
+                    baseline.heapBytes(), current.heapBytes(), limits.heapGrowthBytes()));
+        }
+        if (current.rssBytes() > baseline.rssBytes() + limits.rssGrowthBytes()) {
+            fail(String.format("RSS growth exceeded limit: baseline=%d current=%d limit=%d",
+                    baseline.rssBytes(), current.rssBytes(), limits.rssGrowthBytes()));
+        }
+        if (current.fdCount() > baseline.fdCount() + limits.fdGrowth()) {
+            fail(String.format("FD growth exceeded limit: baseline=%d current=%d limit=%d",
+                    baseline.fdCount(), current.fdCount(), limits.fdGrowth()));
+        }
+    }
+
     private static byte[] payload(String kind, int seq, int size) {
         String head = "{\"kind\":\"" + kind + "\",\"seq\":" + seq + ",\"pad\":\"";
         String tail = "\"}";
         return (head + "x".repeat(size - head.length() - tail.length()) + tail)
                 .getBytes(StandardCharsets.UTF_8);
-    }
-
-    private static long mb(long value) {
-        return value * 1_048_576L;
     }
 
     private static byte[] hex(String input) {
@@ -362,6 +678,119 @@ final class JavaSoakTest {
             out[i] = (byte) Integer.parseInt(input.substring(i * 2, i * 2 + 2), 16);
         }
         return out;
+    }
+
+    private record SoakResourceLimits(
+            long heapGrowthBytes,
+            long rssGrowthBytes,
+            long fdGrowth,
+            long finalHeapGrowthBytes,
+            long finalFdGrowth,
+            double rssSlopeKibPerSecond,
+            double fdSlopePerSecond,
+            long rssSlopeMinGrowth,
+            long fdSlopeMinGrowth) {
+    }
+
+    private record SoakResources(long heapBytes, long rssBytes, long fdCount) {
+    }
+
+    private record SoakResourceSample(Instant at, long value) {
+    }
+
+    private record SampleRange(long min, long max) {
+    }
+
+    private static final class SoakResourceTracker {
+        private final Instant started;
+        private final SoakResources startupBaseline;
+        private final SoakResourceLimits limits;
+        private final List<SoakResourceSample> heap = new ArrayList<>();
+        private final List<SoakResourceSample> rss = new ArrayList<>();
+        private final List<SoakResourceSample> fds = new ArrayList<>();
+        private SoakResources checkedBaseline;
+
+        private SoakResourceTracker(
+                Instant started,
+                SoakResources baseline,
+                SoakResourceLimits limits) {
+            this.started = started;
+            this.startupBaseline = baseline;
+            this.limits = limits;
+            appendSample(started, baseline);
+        }
+
+        private SoakResources sample(Duration elapsed) {
+            SoakResources current = readSoakResources();
+            appendSample(Instant.now(), current);
+            checkedBaseline = checkedResourceBaseline(elapsed, current, checkedBaseline);
+            if (checkedBaseline != null) {
+                assertSoakResources(checkedBaseline, current, limits);
+            }
+            liveGrowthError("RSS", started, rss,
+                            limits.rssSlopeKibPerSecond(), limits.rssSlopeMinGrowth())
+                    .ifPresent(message -> fail(message));
+            liveFdGrowthError(started, fds,
+                            limits.fdSlopePerSecond(), limits.fdSlopeMinGrowth())
+                    .ifPresent(message -> fail(message));
+            return current;
+        }
+
+        private void assertFinal(Duration elapsed) {
+            SoakResources current = sample(elapsed);
+            System.out.printf(
+                    "[java-soak] final resources heap=%dMB rss=%dMB fds=%d%n",
+                    current.heapBytes() / BYTES_PER_MIB,
+                    current.rssBytes() / BYTES_PER_MIB,
+                    current.fdCount());
+            logSlope("heap", heap, BYTES_PER_KIB, "KiB");
+            logSlope("RSS", rss, BYTES_PER_KIB, "KiB");
+            logSlope("FD", fds, 1, "FDs");
+            if (current.heapBytes() > startupBaseline.heapBytes()
+                    + limits.finalHeapGrowthBytes()) {
+                fail(String.format(
+                        "final heap growth exceeded limit: baseline=%d current=%d limit=%d",
+                        startupBaseline.heapBytes(),
+                        current.heapBytes(),
+                        limits.finalHeapGrowthBytes()));
+            }
+            if (current.fdCount() > startupBaseline.fdCount() + limits.finalFdGrowth()) {
+                fail(String.format(
+                        "final FD growth exceeded limit: baseline=%d current=%d limit=%d",
+                        startupBaseline.fdCount(), current.fdCount(), limits.finalFdGrowth()));
+            }
+        }
+
+        private void appendSample(Instant at, SoakResources resources) {
+            heap.add(new SoakResourceSample(at, resources.heapBytes()));
+            rss.add(new SoakResourceSample(at, resources.rssBytes()));
+            fds.add(new SoakResourceSample(at, resources.fdCount()));
+        }
+
+        private static void logSlope(
+                String metric,
+                List<SoakResourceSample> samples,
+                double scale,
+                String unit) {
+            if (samples.size() < 2) {
+                return;
+            }
+            int warmup = samples.size() / 5;
+            List<SoakResourceSample> postWarmup = samples.subList(warmup, samples.size());
+            OptionalDouble slope = slopePerSecond(postWarmup);
+            if (slope.isEmpty()) {
+                return;
+            }
+            SampleRange range = sampleRange(postWarmup);
+            System.out.printf(
+                    "[java-soak] %s range %.1f..%.1f %s slope %.3f %s/s%n",
+                    metric,
+                    range.min() / scale,
+                    range.max() / scale,
+                    unit,
+                    slope.getAsDouble() / scale,
+                    unit);
+        }
     }
 
     @FunctionalInterface

--- a/bindings/java/src/test/java/io/omq/smoke/PackagingSmoke.java
+++ b/bindings/java/src/test/java/io/omq/smoke/PackagingSmoke.java
@@ -1,0 +1,18 @@
+package io.omq.smoke;
+
+import io.omq.Context;
+import io.omq.OMQ;
+import io.omq.SocketType;
+
+/** Smoke entrypoint for packaged OMQ.java runtime jars. */
+public final class PackagingSmoke {
+    private PackagingSmoke() {
+    }
+
+    public static void main(String[] args) {
+        try (Context context = OMQ.context()) {
+            context.socket(SocketType.PAIR).close();
+            OMQ.curveKeypair();
+        }
+    }
+}


### PR DESCRIPTION
- Publish `omq-java` as a Java-only main jar plus platform classifier runtime jars.
- Keep debug native libraries on the test runtime path so local Maven tests still load native code.
- Build classifier jars from release native artifacts in the Java release workflow and smoke the Linux classifier before Central upload.
- Tighten Java soak coverage with release-native runs, FD tracking, RSS/FD slope gates, and post-GC heap cleanup checks.
- Bump the Java binding to `0.3.0-SNAPSHOT` and document classifier usage.