### PR TITLE
Add OMQ.go binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,23 @@ jobs:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
         run: cargo nextest run --profile ci -p omq-tokio --features curve --test omq_interop_pyzmq_curve
 
+  cppzmq:
+    name: cppzmq
+    needs: [changes, linux-gate]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: install cppzmq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppzmq-dev
+      - name: cppzmq tests
+        run: ./scripts/test-cppzmq.sh
+
   loom:
     name: loom (yring)
     needs: [changes, linux-gate]
@@ -508,6 +525,7 @@ jobs:
         encryption,
         compression,
         interop,
+        cppzmq,
         loom,
         miri,
         fuzz-smoke,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,6 +25,7 @@ cargo test -p omq-tokio
 cargo test -p omq-proto
 cargo test -p yring
 cargo test -p omq-tokio --test omq_req_rep -- some_test_name
+./scripts/test-cppzmq.sh
 ```
 
 Feature-gated tests:
@@ -91,6 +92,7 @@ runs, on Linux only:
 | job | what |
 |-----|------|
 | `interop` | pyzmq NULL/STREAM + PLAIN + CURVE |
+| `cppzmq` | `cppzmq` API tests against `libomq_zmq` |
 | `loom` | `yring` loom suite under `--cfg loom`, release |
 | `miri` | `cargo miri test -p yring --features async`, nightly |
 | `fuzz-smoke` | parsers at 1M iters, socket actions at 200 |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,6 +157,14 @@ maturin develop --release
 OMQ_SOAK_DURATION_SECS=120 python3 -m pytest tests/soak/ -v --tb=short
 ```
 
+### OMQ.go Soak Tests
+
+```sh
+bindings/go/scripts/soak.sh
+OMQ_GO_SOAK_DURATIONS="300 600 1800 3600" OMQ_GO_SOAK_WORKERS=12 \
+  bindings/go/scripts/soak.sh
+```
+
 ## Stress Tests
 
 ```sh

--- a/bindings/go/DEVELOPMENT.md
+++ b/bindings/go/DEVELOPMENT.md
@@ -1,0 +1,195 @@
+# OMQ.go Development
+
+Run commands from the repository root unless shown otherwise.
+
+## Prerequisites
+
+- Go 1.25 or newer.
+- cgo enabled.
+- Rust toolchain with Cargo.
+- `python3` for performance chart generation.
+- libzmq development files when generating `zmq4` comparison rows.
+
+## Normal Test Pass
+
+Build the native library and run the Go tests:
+
+```sh
+./scripts/test-go.sh
+```
+
+Include the Go race detector:
+
+```sh
+OMQ_GO_RACE=1 ./scripts/test-go.sh
+```
+
+Manual equivalent:
+
+```sh
+cargo build --release --manifest-path bindings/go/native/Cargo.toml
+export LD_LIBRARY_PATH="$PWD/bindings/go/native/target/release:$PWD/bindings/go/native/target/debug:${LD_LIBRARY_PATH:-}"
+(cd bindings/go && go test -count=1 ./...)
+```
+
+On macOS, set `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH`.
+
+## Soak Tests
+
+Use the soak wrapper:
+
+```sh
+bindings/go/scripts/soak.sh
+```
+
+Defaults:
+
+- durations: `300 600 1800 3600` seconds
+- workers: `nproc`
+- `GOMAXPROCS`: same as workers
+
+Run one 10 minute pass on all CPUs:
+
+```sh
+OMQ_GO_SOAK_DURATIONS=600 bindings/go/scripts/soak.sh
+```
+
+Run 10m, 30m, and 2h with 12 workers:
+
+```sh
+OMQ_GO_SOAK_DURATIONS="600 1800 7200" OMQ_GO_SOAK_WORKERS=12 bindings/go/scripts/soak.sh
+```
+
+Run one scenario:
+
+```sh
+OMQ_GO_SOAK_DURATIONS=1800 \
+OMQ_GO_SOAK_SCENARIOS=context-churn \
+bindings/go/scripts/soak.sh
+```
+
+Skip scenarios:
+
+```sh
+OMQ_GO_SOAK_SKIP_SCENARIOS=curve,compression bindings/go/scripts/soak.sh
+```
+
+Scenarios:
+
+- `tcp`: TCP PUSH/PULL churn against a shared receiver.
+- `curve`: CURVE TCP PUSH/PULL churn.
+- `compression`: `lz4+tcp` and `zstd+tcp`, including dictionary use.
+- `inproc`: inproc REQ/REP loop.
+- `poller`: inproc fan-in through `Poller`.
+- `pubsub`: TCP PUB/SUB subscriber churn.
+- `context-churn`: repeated context/socket create, use, close cycles.
+
+Soak logs include progress counters, Go heap, RSS, smaps rollup, FD count,
+goroutine count, OS thread count, cgo calls, native wrapper live counters, and
+scenario create/close counters.
+
+Useful leak-check knobs:
+
+- `OMQ_GO_SOAK_MAX_FD_GROWTH`
+- `OMQ_GO_SOAK_MAX_FINAL_FD_GROWTH`
+- `OMQ_GO_SOAK_HEAP_SLOPE_LIMIT_KIB_S`
+- `OMQ_GO_SOAK_RSS_SLOPE_LIMIT_KIB_S`
+- `OMQ_GO_SOAK_FD_SLOPE_LIMIT_PER_SEC`
+- `OMQ_GO_SOAK_RSS_TAIL_GROWTH_PERCENT`
+- `OMQ_GO_SOAK_HEAP_SLOPE_MIN_GROWTH_MB`
+- `OMQ_GO_SOAK_RSS_SLOPE_MIN_GROWTH_MB`
+- `OMQ_GO_SOAK_FD_SLOPE_MIN_GROWTH`
+- `OMQ_GO_SOAK_HEAP_RESIDUAL_FLOOR_MB`
+- `OMQ_GO_SOAK_RSS_TAIL_GROWTH_MIN_MB`
+
+The native live counters must return to their baseline after shutdown.
+
+## Benchmarks
+
+Run perf work on an otherwise quiet machine. Do not run benchmark or profiler
+jobs in parallel.
+
+Build native first, then run Go microbenchmarks:
+
+```sh
+cargo build --release --manifest-path bindings/go/native/Cargo.toml
+export LD_LIBRARY_PATH="$PWD/bindings/go/native/target/release:$PWD/bindings/go/native/target/debug:${LD_LIBRARY_PATH:-}"
+(cd bindings/go && go test -run '^$' -bench=. -benchmem -count=5)
+```
+
+Run selected hot-path benchmarks:
+
+```sh
+(cd bindings/go && go test -run '^$' -bench='InprocPushPull.*128B' -benchmem -count=10)
+```
+
+The two-process TCP benchmarks use an internal peer mode driven by the test
+binary. Do not set `OMQ_GO_BENCH_PEER` manually.
+
+## Performance Chart
+
+The chart script runs two-process TCP PUSH/PULL throughput and REQ/REP latency,
+then appends rows to:
+
+```text
+~/.cache/omq.go/bindings.jsonl
+```
+
+Override the cache root:
+
+```sh
+OMQ_GO_CACHE_DIR=/tmp/omq-go-cache bindings/go/scripts/update_perf.py
+```
+
+Quick local run:
+
+```sh
+bindings/go/scripts/update_perf.py --quick
+```
+
+Full default run:
+
+```sh
+bindings/go/scripts/update_perf.py
+```
+
+Default sizes are:
+
+```text
+16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
+```
+
+Run specific sizes:
+
+```sh
+bindings/go/scripts/update_perf.py --sizes 16,128,1k,8k,32k
+```
+
+Regenerate only the SVG from cached rows:
+
+```sh
+bindings/go/scripts/update_perf.py --chart-only
+```
+
+Output chart:
+
+```text
+bindings/go/doc/charts/bindings.svg
+```
+
+Useful chart script flags:
+
+- `--throughput-only`
+- `--latency-only`
+- `--rounds N`
+- `--warmup-rounds N`
+- `--target-bytes N`
+- `--latency-iters N`
+- `--no-save`
+- `--no-chart`
+- `--no-build`
+- `--no-harness-build`
+
+`--chart-only` uses the latest cached row for each implementation, benchmark
+kind, and message size. The cache is append-only; remove or archive the JSONL
+file when old rows should no longer be considered.

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,30 +1,125 @@
-# OMQ Go Binding
+# OMQ.go
 
-Idiomatic Go binding over `omq-tokio`. Rust owns OMQ contexts, sockets,
-protocol state, compression, reconnect, and IO threads. Go exposes scalar
-context-aware calls plus optional channel adapters.
+Modern Go binding for OMQ backed by `omq-tokio`.
 
-Build native library first:
+The Go API owns a native OMQ context, and that context owns background IO
+thread(s), matching the normal libzmq architecture. Public socket calls are
+goroutine-safe and context-cancelable. Hot loops can bind directly to the
+socket owner goroutine.
+
+![OMQ.go performance](doc/charts/bindings.svg)
+
+## Build, install, test
+
+Requires Go 1.22 or newer, cgo, and a Rust toolchain.
+
+Module path:
 
 ```sh
-../../scripts/test-go.sh
+go get github.com/paddor/omq.rs/bindings/go
 ```
 
-Minimal use:
+The Go package links against the native library built from `native/`:
+
+```sh
+cargo build --release --manifest-path native/Cargo.toml
+go test ./...
+```
+
+From the repository root, the full binding check builds the native library and
+runs the Go tests with the right library path:
+
+```sh
+./scripts/test-go.sh
+```
+
+## API Shape
+
+- `Context` owns native IO threads and creates sockets.
+- `Context.ShareKey()` / `OpenShared(...)` explicitly share one native context
+  core and `inproc://` namespace across Go handles.
+- `Socket` serializes native access through an owner goroutine, so public calls
+  are race-free across goroutines.
+- `Message` supports single-part and multipart payloads and copies input on
+  construction.
+- `RecvInto` is the direct single-part receive path when the caller owns the
+  destination buffer.
+- `Socket.Run(ctx, fn)` executes `fn` on the socket owner goroutine. Its
+  `BoundSocket` methods use private native send/receive rings to amortize cgo
+  cost without exposing public batch APIs.
+- `Send`, `Recv`, and `RecvInto` take `context.Context`; `Try*` and timeout
+  variants cover nonblocking and deadline-style code.
+- `Socket.Channels(ctx, opts)` adapts one socket to Go channels at the edge.
+  It is not the core hot path.
+- `Monitor` exposes native socket events.
+- Socket options cover HWM, linger, identity, pub/sub controls, routing
+  controls, and compression transport settings.
+
+Architecture detail: [`doc/architecture.md`](doc/architecture.md).
+
+Example:
 
 ```go
-ctx, _ := omq.Open(omq.Config{IOThreads: 2})
-defer ctx.Close()
+func example() error {
+	ctx, err := omq.Open(omq.Config{IOThreads: 1})
+	if err != nil {
+		return err
+	}
+	defer ctx.Close()
 
-pull, _ := ctx.Socket(omq.Pull)
-push, _ := ctx.Socket(omq.Push)
-endpoint, _ := pull.Bind("inproc://example")
-_ = push.Connect(endpoint)
+	pull, err := ctx.Socket(omq.Pull, omq.Linger(0))
+	if err != nil {
+		return err
+	}
+	defer pull.Close(context.Background())
 
-_ = push.Send(context.Background(), omq.String("hello"))
-msg, _ := pull.Recv(context.Background())
-fmt.Println(msg.String())
+	push, err := ctx.Socket(omq.Push, omq.Linger(0))
+	if err != nil {
+		return err
+	}
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		return err
+	}
+	if err := push.Connect(endpoint); err != nil {
+		return err
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := push.Send(runCtx, omq.String("hello")); err != nil {
+		return err
+	}
+	msg, err := pull.Recv(runCtx)
+	if err != nil {
+		return err
+	}
+	fmt.Println(msg.String())
+	return nil
+}
 ```
 
-Public calls are scalar. Native receive refills use OMQ batch APIs behind
-the cgo boundary. Go does not expose public send or receive batch methods.
+Channel adapter:
+
+```go
+func receiveOne(runCtx context.Context, pull *omq.Socket) error {
+	channels, err := pull.Channels(runCtx, omq.ChannelOptions{Capacity: 1024})
+	if err != nil {
+		return err
+	}
+	defer channels.Close()
+
+	select {
+	case msg := <-channels.Rx:
+		fmt.Println(msg.String())
+		return nil
+	case err := <-channels.Errors:
+		return err
+	case <-runCtx.Done():
+		return runCtx.Err()
+	}
+}
+```

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,30 @@
+# OMQ Go Binding
+
+Idiomatic Go binding over `omq-tokio`. Rust owns OMQ contexts, sockets,
+protocol state, compression, reconnect, and IO threads. Go exposes scalar
+context-aware calls plus optional channel adapters.
+
+Build native library first:
+
+```sh
+../../scripts/test-go.sh
+```
+
+Minimal use:
+
+```go
+ctx, _ := omq.Open(omq.Config{IOThreads: 2})
+defer ctx.Close()
+
+pull, _ := ctx.Socket(omq.Pull)
+push, _ := ctx.Socket(omq.Push)
+endpoint, _ := pull.Bind("inproc://example")
+_ = push.Connect(endpoint)
+
+_ = push.Send(context.Background(), omq.String("hello"))
+msg, _ := pull.Recv(context.Background())
+fmt.Println(msg.String())
+```
+
+Public calls are scalar. Native receive refills use OMQ batch APIs behind
+the cgo boundary. Go does not expose public send or receive batch methods.

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -11,7 +11,7 @@ socket owner goroutine.
 
 ## Build, install, test
 
-Requires Go 1.22 or newer, cgo, and a Rust toolchain.
+Requires Go 1.25 or newer, cgo, and a Rust toolchain.
 
 Module path:
 

--- a/bindings/go/api_test.go
+++ b/bindings/go/api_test.go
@@ -1,0 +1,253 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCurveKeyHelpers(t *testing.T) {
+	keypair, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keypair.Public) != 40 || len(keypair.Secret) != 40 {
+		t.Fatalf("CURVE key lengths = %d/%d, want 40/40", len(keypair.Public), len(keypair.Secret))
+	}
+	public, err := CurvePublic(keypair.Secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if public != keypair.Public {
+		t.Fatalf("derived public = %q, want %q", public, keypair.Public)
+	}
+}
+
+func TestPlainTCP(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull, err := ctx.Socket(Pull, PlainServer("alice", "secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, PlainClient("alice", "secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("plain"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "plain" {
+		t.Fatalf("message = %q, want plain", got)
+	}
+}
+
+func TestCurveTCP(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	serverKeypair, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientKeypair, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pull, err := ctx.Socket(Pull, CurveServer(serverKeypair))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, CurveClient(clientKeypair, serverKeypair.Public))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("curve"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "curve" {
+		t.Fatalf("message = %q, want curve", got)
+	}
+}
+
+func TestWaitSubscribed(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pub := newTestSocket(t, ctx, Pub)
+	defer closeSocket(t, pub)
+	sub := newTestSocket(t, ctx, Sub)
+	defer closeSocket(t, sub)
+
+	bound, err := pub.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.SubscribeString("topic/"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pub.WaitSubscribedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := pub.SendTimeout(String("topic/value"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := sub.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "topic/value" {
+		t.Fatalf("message = %q, want topic/value", got)
+	}
+}
+
+func TestReceiveAny(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull1 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull1)
+	pull2 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull2)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull2.Bind("inproc://go-receive-any")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := TryReceiveAny(pull1, pull2); !errors.Is(err, ErrAgain) {
+		t.Fatalf("TryReceiveAny err = %v, want ErrAgain", err)
+	}
+	if err := push.SendTimeout(String("either"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	event, err := ReceiveAnyTimeout(time.Second, pull1, pull2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Socket != pull2 {
+		t.Fatal("ReceiveAny returned wrong socket")
+	}
+	if got := event.Message.String(); got != "either" {
+		t.Fatalf("message = %q, want either", got)
+	}
+}
+
+func TestProxyPushPull(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	frontend := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, frontend)
+	backend := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, backend)
+	source := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, source)
+	sink := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, sink)
+
+	frontendEndpoint, err := frontend.Bind("inproc://go-proxy-fe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendEndpoint, err := sink.Bind("inproc://go-proxy-be")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Connect(frontendEndpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Connect(backendEndpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	proxyCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Proxy(proxyCtx, frontend, backend, ProxyOptions{})
+	}()
+
+	if err := source.SendTimeout(String("proxied"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := sink.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "proxied" {
+		t.Fatalf("message = %q, want proxied", got)
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrCanceled) {
+			t.Fatalf("Proxy err = %v, want ErrCanceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not stop")
+	}
+}
+
+func TestMessageCopiesPublicBytes(t *testing.T) {
+	input := []byte("abc")
+	msg := Bytes(input)
+	input[0] = 'x'
+	if got := msg.String(); got != "abc" {
+		t.Fatalf("message = %q, want abc", got)
+	}
+	out := msg.Bytes()
+	out[1] = 'y'
+	if got := msg.String(); got != "abc" {
+		t.Fatalf("message after Bytes mutation = %q, want abc", got)
+	}
+	if part := msg.Part(0); string(part) != "abc" {
+		t.Fatalf("part = %q, want abc", part)
+	}
+	if msg.ByteLen() != 3 || msg.IsMultipart() {
+		t.Fatalf("message metadata wrong")
+	}
+}

--- a/bindings/go/auth.go
+++ b/bindings/go/auth.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 )
 
+// Authenticator decides whether to accept a peer handshake.
 type Authenticator func(PeerInfo) bool
 
 var (

--- a/bindings/go/auth.go
+++ b/bindings/go/auth.go
@@ -1,0 +1,38 @@
+package omq
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type Authenticator func(PeerInfo) bool
+
+var (
+	nextAuthCallbackID atomic.Uint64
+	authCallbacksMu    sync.RWMutex
+	authCallbacks      = make(map[uint64]Authenticator)
+)
+
+func registerAuthCallback(callback Authenticator) uint64 {
+	id := nextAuthCallbackID.Add(1)
+	authCallbacksMu.Lock()
+	authCallbacks[id] = callback
+	authCallbacksMu.Unlock()
+	return id
+}
+
+func unregisterAuthCallback(id uint64) {
+	authCallbacksMu.Lock()
+	delete(authCallbacks, id)
+	authCallbacksMu.Unlock()
+}
+
+func callAuthCallback(id uint64, peer PeerInfo) bool {
+	authCallbacksMu.RLock()
+	callback := authCallbacks[id]
+	authCallbacksMu.RUnlock()
+	if callback == nil {
+		return false
+	}
+	return callback(peer)
+}

--- a/bindings/go/auth_test.go
+++ b/bindings/go/auth_test.go
@@ -1,0 +1,125 @@
+package omq
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPlainServerAuthCallbackTCP(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	seen := make(chan PeerInfo, 4)
+	pull, err := ctx.Socket(Pull, PlainServerAuth(func(peer PeerInfo) bool {
+		select {
+		case seen <- peer:
+		default:
+		}
+		return peer.Mechanism == "PLAIN" && peer.Username == "alice" && peer.Password == "secret"
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, PlainClient("alice", "secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("plain-callback"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "plain-callback" {
+		t.Fatalf("message = %q, want plain-callback", got)
+	}
+	assertAuthPeer(t, seen, "PLAIN", "", "alice", "secret")
+}
+
+func TestCurveServerAuthCallbackTCP(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	serverKeypair, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientKeypair, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := make(chan PeerInfo, 4)
+	pull, err := ctx.Socket(Pull, CurveServerAuth(serverKeypair, func(peer PeerInfo) bool {
+		select {
+		case seen <- peer:
+		default:
+		}
+		return peer.Mechanism == "CURVE" && peer.PublicKey == clientKeypair.Public
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, CurveClient(clientKeypair, serverKeypair.Public))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("curve-callback"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "curve-callback" {
+		t.Fatalf("message = %q, want curve-callback", got)
+	}
+	assertAuthPeer(t, seen, "CURVE", clientKeypair.Public, "", "")
+}
+
+func assertAuthPeer(
+	t *testing.T,
+	seen <-chan PeerInfo,
+	mechanism string,
+	publicKey string,
+	username string,
+	password string,
+) {
+	t.Helper()
+	select {
+	case peer := <-seen:
+		if peer.Mechanism != mechanism || peer.PublicKey != publicKey ||
+			peer.Username != username || peer.Password != password {
+			t.Fatalf("peer = %#v", peer)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("auth callback was not called")
+	}
+}

--- a/bindings/go/bench_test.go
+++ b/bindings/go/bench_test.go
@@ -1,0 +1,205 @@
+package omq
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const benchPayloadSize = 128
+
+func TestMain(m *testing.M) {
+	if os.Getenv("OMQ_GO_BENCH_PEER") == "push" {
+		os.Exit(runBenchPushPeer())
+	}
+	os.Exit(m.Run())
+}
+
+func BenchmarkInprocPushPull128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		for i := 0; i < b.N; i++ {
+			if err := push.Send(runCtx, msg); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		errCh <- nil
+	}()
+	for i := 0; i < b.N; i++ {
+		if _, err := pull.Recv(runCtx); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkTCPPushPull128BTwoProcesses(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	monitor, err := pull.Monitor()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer monitor.Close()
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		b.Fatal(err)
+	}
+	cmd := exec.Command(exe, "-test.run=^$")
+	cmd.Env = append(os.Environ(),
+		"OMQ_GO_BENCH_PEER=push",
+		"OMQ_GO_BENCH_ENDPOINT="+endpoint,
+		"OMQ_GO_BENCH_COUNT="+strconv.Itoa(b.N),
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		b.Fatal(err)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		b.Fatal(err)
+	}
+	waitBenchHandshake(b, monitor)
+
+	payload := make([]byte, benchPayloadSize)
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := stdin.Write([]byte{1}); err != nil {
+		b.Fatal(err)
+	}
+	if err := stdin.Close(); err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg, err := pull.Recv(runCtx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(msg.Bytes()) != len(payload) {
+			b.Fatalf("payload len = %d", len(msg.Bytes()))
+		}
+	}
+	b.StopTimer()
+	if err := cmd.Wait(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func runBenchPushPeer() int {
+	endpoint := os.Getenv("OMQ_GO_BENCH_ENDPOINT")
+	count, err := strconv.Atoi(os.Getenv("OMQ_GO_BENCH_COUNT"))
+	if err != nil || endpoint == "" {
+		fmt.Fprintln(os.Stderr, "invalid bench peer env")
+		return 2
+	}
+	ctx, err := Open(Config{IOThreads: 2})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer ctx.Close()
+	push, err := ctx.Socket(Push)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer push.Close(context.Background())
+	if err := push.Connect(endpoint); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if _, err := io.ReadFull(os.Stdin, make([]byte, 1)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for i := 0; i < count; i++ {
+		if err := push.Send(runCtx, msg); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	}
+	return 0
+}
+
+func waitBenchHandshake(b *testing.B, monitor *Monitor) {
+	b.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		event, err := monitor.Recv(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if event.Kind == "HANDSHAKE_SUCCEEDED" {
+			return
+		}
+	}
+}
+
+func openBenchContext(b *testing.B) *Context {
+	b.Helper()
+	ctx, err := Open(Config{IOThreads: 2})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return ctx
+}
+
+func openBenchSocket(b *testing.B, ctx *Context, socketType SocketType) *Socket {
+	b.Helper()
+	socket, err := ctx.Socket(socketType)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return socket
+}

--- a/bindings/go/bench_test.go
+++ b/bindings/go/bench_test.go
@@ -335,14 +335,18 @@ func BenchmarkInprocPushPullRunTryRecvView128B(b *testing.B) {
 			return nil
 		})
 	}()
+	expectedLen := len(payload)
+	checkPayload := func(view []byte) error {
+		if len(view) != expectedLen {
+			return fmt.Errorf("payload len = %d", len(view))
+		}
+		return nil
+	}
 	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
 		for i := 0; i < b.N; i++ {
 			for {
-				view, err := socket.TryRecvView()
+				err := socket.TryRecvView(checkPayload)
 				if err == nil {
-					if view.Len() != len(payload) {
-						return fmt.Errorf("payload len = %d", view.Len())
-					}
 					break
 				}
 				if !errors.Is(err, ErrAgain) {

--- a/bindings/go/bench_test.go
+++ b/bindings/go/bench_test.go
@@ -2,6 +2,7 @@ package omq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,8 @@ import (
 const benchPayloadSize = 128
 
 func TestMain(m *testing.M) {
-	if os.Getenv("OMQ_GO_BENCH_PEER") == "push" {
+	switch os.Getenv("OMQ_GO_BENCH_PEER") {
+	case "push", "push-run":
 		os.Exit(runBenchPushPeer())
 	}
 	os.Exit(m.Run())
@@ -65,7 +67,308 @@ func BenchmarkInprocPushPull128B(b *testing.B) {
 	}
 }
 
+func BenchmarkInprocPushPullRecvInto128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc-into")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	dst := make([]byte, benchPayloadSize)
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		for i := 0; i < b.N; i++ {
+			if err := push.Send(runCtx, msg); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		errCh <- nil
+	}()
+	for i := 0; i < b.N; i++ {
+		n, err := pull.RecvInto(runCtx, dst)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if n != len(payload) {
+			b.Fatalf("payload len = %d", n)
+		}
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkInprocPushPullRunRecvInto128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc-run")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	dst := make([]byte, benchPayloadSize)
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
+			for i := 0; i < b.N; i++ {
+				if err := socket.Send(runCtx, msg); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}()
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
+		for i := 0; i < b.N; i++ {
+			n, err := socket.RecvInto(runCtx, dst)
+			if err != nil {
+				return err
+			}
+			if n != len(payload) {
+				return fmt.Errorf("payload len = %d", n)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkInprocPushPullRunBlockingRecvInto128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc-run-blocking")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	dst := make([]byte, benchPayloadSize)
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+			for i := 0; i < b.N; i++ {
+				if err := socket.SendBlocking(msg); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}()
+	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+		for i := 0; i < b.N; i++ {
+			n, err := socket.RecvIntoBlocking(dst)
+			if err != nil {
+				return err
+			}
+			if n != len(payload) {
+				return fmt.Errorf("payload len = %d", n)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkInprocPushPullRunTryRecvInto128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc-run-try")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+	dst := make([]byte, benchPayloadSize)
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+			for i := 0; i < b.N; i++ {
+				for {
+					err := socket.TrySend(msg)
+					if err == nil {
+						break
+					}
+					if !errors.Is(err, ErrAgain) {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	}()
+	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+		for i := 0; i < b.N; i++ {
+			for {
+				n, err := socket.TryRecvInto(dst)
+				if err == nil {
+					if n != len(payload) {
+						return fmt.Errorf("payload len = %d", n)
+					}
+					break
+				}
+				if !errors.Is(err, ErrAgain) {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkInprocPushPullRunTryRecvView128B(b *testing.B) {
+	ctx := openBenchContext(b)
+	defer ctx.Close()
+
+	pull := openBenchSocket(b, ctx, Pull)
+	defer pull.Close(context.Background())
+	push := openBenchSocket(b, ctx, Push)
+	defer push.Close(context.Background())
+
+	endpoint, err := pull.Bind("inproc://bench-inproc-run-view")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, benchPayloadSize)
+	msg := Bytes(payload)
+
+	b.SetBytes(benchPayloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+			for i := 0; i < b.N; i++ {
+				for {
+					err := socket.TrySend(msg)
+					if err == nil {
+						break
+					}
+					if !errors.Is(err, ErrAgain) {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	}()
+	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+		for i := 0; i < b.N; i++ {
+			for {
+				view, err := socket.TryRecvView()
+				if err == nil {
+					if view.Len() != len(payload) {
+						return fmt.Errorf("payload len = %d", view.Len())
+					}
+					break
+				}
+				if !errors.Is(err, ErrAgain) {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		b.Fatal(err)
+	}
+}
+
 func BenchmarkTCPPushPull128BTwoProcesses(b *testing.B) {
+	benchmarkTCPPushPullTwoProcesses(b, false)
+}
+
+func BenchmarkTCPPushPullRunRecvInto128BTwoProcesses(b *testing.B) {
+	benchmarkTCPPushPullTwoProcesses(b, true)
+}
+
+func benchmarkTCPPushPullTwoProcesses(b *testing.B, runFastPath bool) {
 	ctx := openBenchContext(b)
 	defer ctx.Close()
 
@@ -87,8 +390,12 @@ func BenchmarkTCPPushPull128BTwoProcesses(b *testing.B) {
 		b.Fatal(err)
 	}
 	cmd := exec.Command(exe, "-test.run=^$")
+	peer := "push"
+	if runFastPath {
+		peer = "push-run"
+	}
 	cmd.Env = append(os.Environ(),
-		"OMQ_GO_BENCH_PEER=push",
+		"OMQ_GO_BENCH_PEER="+peer,
 		"OMQ_GO_BENCH_ENDPOINT="+endpoint,
 		"OMQ_GO_BENCH_COUNT="+strconv.Itoa(b.N),
 	)
@@ -115,13 +422,32 @@ func BenchmarkTCPPushPull128BTwoProcesses(b *testing.B) {
 	b.SetBytes(benchPayloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		msg, err := pull.Recv(runCtx)
+	if runFastPath {
+		dst := make([]byte, benchPayloadSize)
+		err = pull.Run(runCtx, func(socket *BoundSocket) error {
+			for i := 0; i < b.N; i++ {
+				n, err := socket.RecvIntoBlocking(dst)
+				if err != nil {
+					return err
+				}
+				if n != len(payload) {
+					return fmt.Errorf("payload len = %d", n)
+				}
+			}
+			return nil
+		})
 		if err != nil {
 			b.Fatal(err)
 		}
-		if len(msg.Bytes()) != len(payload) {
-			b.Fatalf("payload len = %d", len(msg.Bytes()))
+	} else {
+		for i := 0; i < b.N; i++ {
+			msg, err := pull.Recv(runCtx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(msg.Bytes()) != len(payload) {
+				b.Fatalf("payload len = %d", len(msg.Bytes()))
+			}
 		}
 	}
 	b.StopTimer()
@@ -137,7 +463,7 @@ func runBenchPushPeer() int {
 		fmt.Fprintln(os.Stderr, "invalid bench peer env")
 		return 2
 	}
-	ctx, err := Open(Config{IOThreads: 2})
+	ctx, err := Open(Config{IOThreads: 1})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -162,6 +488,21 @@ func runBenchPushPeer() int {
 	msg := Bytes(payload)
 	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	if os.Getenv("OMQ_GO_BENCH_PEER") == "push-run" {
+		err := push.Run(runCtx, func(socket *BoundSocket) error {
+			for i := 0; i < count; i++ {
+				if err := socket.SendBlocking(msg); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		return 0
+	}
 	for i := 0; i < count; i++ {
 		if err := push.Send(runCtx, msg); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -188,7 +529,7 @@ func waitBenchHandshake(b *testing.B, monitor *Monitor) {
 
 func openBenchContext(b *testing.B) *Context {
 	b.Helper()
-	ctx, err := Open(Config{IOThreads: 2})
+	ctx, err := Open(Config{IOThreads: 1})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/bindings/go/bench_test.go
+++ b/bindings/go/bench_test.go
@@ -14,6 +14,11 @@ import (
 
 const benchPayloadSize = 128
 
+// These paired throughput benchmarks intentionally use b.N instead of B.Loop.
+// Sender and receiver, sometimes in different processes, must agree on the
+// exact message count before timed work starts. B.Loop exposes final b.N only
+// after the benchmark loop exits.
+
 func TestMain(m *testing.M) {
 	switch os.Getenv("OMQ_GO_BENCH_PEER") {
 	case "push", "push-run":
@@ -41,7 +46,7 @@ func BenchmarkInprocPushPull128B(b *testing.B) {
 
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
-	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
 	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
@@ -87,7 +92,7 @@ func BenchmarkInprocPushPullRecvInto128B(b *testing.B) {
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
 	dst := make([]byte, benchPayloadSize)
-	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
 	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
@@ -137,7 +142,7 @@ func BenchmarkInprocPushPullRunRecvInto128B(b *testing.B) {
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
 	dst := make([]byte, benchPayloadSize)
-	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
 	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
@@ -194,13 +199,15 @@ func BenchmarkInprocPushPullRunBlockingRecvInto128B(b *testing.B) {
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
 	dst := make([]byte, benchPayloadSize)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
+	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
 			for i := 0; i < b.N; i++ {
 				if err := socket.SendBlocking(msg); err != nil {
 					return err
@@ -209,7 +216,7 @@ func BenchmarkInprocPushPullRunBlockingRecvInto128B(b *testing.B) {
 			return nil
 		})
 	}()
-	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
 		for i := 0; i < b.N; i++ {
 			n, err := socket.RecvIntoBlocking(dst)
 			if err != nil {
@@ -249,13 +256,15 @@ func BenchmarkInprocPushPullRunTryRecvInto128B(b *testing.B) {
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
 	dst := make([]byte, benchPayloadSize)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
+	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
 			for i := 0; i < b.N; i++ {
 				for {
 					err := socket.TrySend(msg)
@@ -270,7 +279,7 @@ func BenchmarkInprocPushPullRunTryRecvInto128B(b *testing.B) {
 			return nil
 		})
 	}()
-	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
 		for i := 0; i < b.N; i++ {
 			for {
 				n, err := socket.TryRecvInto(dst)
@@ -314,13 +323,15 @@ func BenchmarkInprocPushPullRunTryRecvView128B(b *testing.B) {
 
 	payload := make([]byte, benchPayloadSize)
 	msg := Bytes(payload)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
+	defer cancel()
 
 	b.SetBytes(benchPayloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- push.Run(context.Background(), func(socket *BoundSocket) error {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
 			for i := 0; i < b.N; i++ {
 				for {
 					err := socket.TrySend(msg)
@@ -342,7 +353,7 @@ func BenchmarkInprocPushPullRunTryRecvView128B(b *testing.B) {
 		}
 		return nil
 	}
-	err = pull.Run(context.Background(), func(socket *BoundSocket) error {
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
 		for i := 0; i < b.N; i++ {
 			for {
 				err := socket.TryRecvView(checkPayload)
@@ -415,7 +426,7 @@ func benchmarkTCPPushPullTwoProcesses(b *testing.B, runFastPath bool) {
 	waitBenchHandshake(b, monitor)
 
 	payload := make([]byte, benchPayloadSize)
-	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	runCtx, cancel := context.WithTimeout(b.Context(), 30*time.Second)
 	defer cancel()
 	if _, err := stdin.Write([]byte{1}); err != nil {
 		b.Fatal(err)

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,6 +3,7 @@ package omq
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -204,6 +205,9 @@ func TestRunRecvViewReturnsCallbackErrAgain(t *testing.T) {
 	if err := push.Connect(bound); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := push.WaitConnectedTimeout(1, time.Second); err != nil {
+		t.Fatal(err)
+	}
 	if err := push.SendTimeout(String("first"), time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +225,7 @@ func TestRunRecvViewReturnsCallbackErrAgain(t *testing.T) {
 		err := socket.RecvViewBlocking(func(payload []byte) error {
 			calls++
 			if got := string(payload); got != "first" {
-				t.Fatalf("message = %q, want first", got)
+				return fmt.Errorf("message = %q, want first", got)
 			}
 			return ErrAgain
 		})
@@ -236,7 +240,7 @@ func TestRunRecvViewReturnsCallbackErrAgain(t *testing.T) {
 		err = socket.RecvView(runCtx, func(payload []byte) error {
 			calls++
 			if got := string(payload); got != "second" {
-				t.Fatalf("message = %q, want second", got)
+				return fmt.Errorf("message = %q, want second", got)
 			}
 			return ErrAgain
 		})

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -1,0 +1,253 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInprocPushPull(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint := "inproc://go-push-pull"
+	bound, err := pull.Bind(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	sendCtx, cancelSend := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelSend()
+	if err := push.Send(sendCtx, String("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := pull.RecvTimeout(2 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "hello" {
+		t.Fatalf("message = %q, want hello", got)
+	}
+}
+
+func TestMultipart(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	want := Multipart([]byte("a"), []byte("b"), []byte("c"))
+	if err := push.SendTimeout(want, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := pull.RecvTimeout(2 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := got.Parts()
+	if len(parts) != 3 || string(parts[0]) != "a" || string(parts[1]) != "b" || string(parts[2]) != "c" {
+		t.Fatalf("parts = %#v", parts)
+	}
+}
+
+func TestTimeoutsAndTry(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	if _, err := pull.Bind("inproc://go-timeouts"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := pull.TryRecv(); !errors.Is(err, ErrAgain) {
+		t.Fatalf("TryRecv err = %v, want ErrAgain", err)
+	}
+	if _, err := pull.RecvTimeout(5 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestChannels(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-channels")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pullCh, err := pull.Channels(runCtx, ChannelOptions{Capacity: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pullCh.Close()
+	pushCh, err := push.Channels(runCtx, ChannelOptions{Capacity: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pushCh.Close()
+
+	if pullCh.Tx != nil {
+		t.Fatal("PULL Tx is not nil")
+	}
+	if pushCh.Rx != nil {
+		t.Fatal("PUSH Rx is not nil")
+	}
+
+	select {
+	case pushCh.Tx <- String("via-channel"):
+	case <-runCtx.Done():
+		t.Fatal(runCtx.Err())
+	}
+
+	select {
+	case msg := <-pullCh.Rx:
+		if got := msg.String(); got != "via-channel" {
+			t.Fatalf("message = %q, want via-channel", got)
+		}
+	case err := <-pullCh.Errors:
+		t.Fatal(err)
+	case <-runCtx.Done():
+		t.Fatal(runCtx.Err())
+	}
+}
+
+func TestMonitorListening(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	monitor, err := pull.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer monitor.Close()
+
+	if _, err := pull.Bind("inproc://go-monitor"); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	for {
+		event, err := monitor.Recv(runCtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if event.Kind == "LISTENING" {
+			return
+		}
+	}
+}
+
+func TestSocketTypeCreation(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	types := []SocketType{
+		Pair, Pub, Sub, Req, Rep, Dealer, Router, Pull, Push, XPub,
+		XSub, Stream, Server, Client, Radio, Dish, Gather, Scatter, Peer, Channel,
+	}
+	for _, socketType := range types {
+		socket := newTestSocket(t, ctx, socketType)
+		closeSocket(t, socket)
+	}
+}
+
+func TestLZ4TCP(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("lz4+tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("compressed"), 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(2 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "compressed" {
+		t.Fatalf("message = %q, want compressed", got)
+	}
+}
+
+func openTestContext(t *testing.T) *Context {
+	t.Helper()
+	ctx, err := Open(Config{IOThreads: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx
+}
+
+func newTestSocket(t *testing.T, ctx *Context, socketType SocketType) *Socket {
+	t.Helper()
+	socket, err := ctx.Socket(socketType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return socket
+}
+
+func closeSocket(t *testing.T, socket *Socket) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := socket.Close(ctx); err != nil && !errors.Is(err, ErrClosed) {
+		t.Fatal(err)
+	}
+}
+
+func closeContext(t *testing.T, ctx *Context) {
+	t.Helper()
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := ctx.CloseContext(closeCtx); err != nil && !errors.Is(err, ErrClosed) {
+		t.Fatal(err)
+	}
+}

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -162,25 +162,102 @@ func TestRunRecvViewReleasesSendRingSlot(t *testing.T) {
 	}()
 
 	err = pull.Run(runCtx, func(socket *BoundSocket) error {
-		view, err := socket.TryRecvView()
-		for errors.Is(err, ErrAgain) {
+		for {
+			err := socket.TryRecvView(func(payload []byte) error {
+				if got := string(payload); got != "view" {
+					t.Fatalf("message = %q, want view", got)
+				}
+				return nil
+			})
+			if err == nil {
+				return nil
+			}
+			if !errors.Is(err, ErrAgain) {
+				return err
+			}
 			if err := runCtx.Err(); err != nil {
 				return err
 			}
-			view, err = socket.TryRecvView()
 		}
-		if err != nil {
-			return err
-		}
-		if got := string(view.Bytes()); got != "view" {
-			t.Fatalf("message = %q, want view", got)
-		}
-		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunRecvViewReturnsCallbackErrAgain(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-run-recv-view-callback-again")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("first"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("second"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("third"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
+		calls := 0
+		err := socket.RecvViewBlocking(func(payload []byte) error {
+			calls++
+			if got := string(payload); got != "first" {
+				t.Fatalf("message = %q, want first", got)
+			}
+			return ErrAgain
+		})
+		if !errors.Is(err, ErrAgain) {
+			t.Fatalf("RecvViewBlocking err = %v, want ErrAgain", err)
+		}
+		if calls != 1 {
+			t.Fatalf("callback calls = %d, want 1", calls)
+		}
+
+		calls = 0
+		err = socket.RecvView(runCtx, func(payload []byte) error {
+			calls++
+			if got := string(payload); got != "second" {
+				t.Fatalf("message = %q, want second", got)
+			}
+			return ErrAgain
+		})
+		if !errors.Is(err, ErrAgain) {
+			t.Fatalf("RecvView err = %v, want ErrAgain", err)
+		}
+		if calls != 1 {
+			t.Fatalf("callback calls = %d, want 1", calls)
+		}
+
+		buf := make([]byte, 16)
+		n, err := socket.RecvIntoBlocking(buf)
+		if err != nil {
+			return err
+		}
+		if got := string(buf[:n]); got != "third" {
+			t.Fatalf("message = %q, want third", got)
+		}
+		return nil
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -90,6 +90,101 @@ func TestTimeoutsAndTry(t *testing.T) {
 	}
 }
 
+func TestRunRecvInto(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-run-recv-into")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
+			return socket.SendBlocking(Bytes([]byte("ring")))
+		})
+	}()
+
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
+		buf := make([]byte, 16)
+		n, err := socket.RecvIntoBlocking(buf)
+		if err != nil {
+			return err
+		}
+		if got := string(buf[:n]); got != "ring" {
+			t.Fatalf("message = %q, want ring", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunRecvViewReleasesSendRingSlot(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-run-recv-view")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- push.Run(runCtx, func(socket *BoundSocket) error {
+			return socket.SendBlocking(Bytes([]byte("view")))
+		})
+	}()
+
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
+		view, err := socket.TryRecvView()
+		for errors.Is(err, ErrAgain) {
+			if err := runCtx.Err(); err != nil {
+				return err
+			}
+			view, err = socket.TryRecvView()
+		}
+		if err != nil {
+			return err
+		}
+		if got := string(view.Bytes()); got != "view" {
+			t.Fatalf("message = %q, want view", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestChannels(t *testing.T) {
 	ctx := openTestContext(t)
 	defer closeContext(t, ctx)

--- a/bindings/go/channels.go
+++ b/bindings/go/channels.go
@@ -25,6 +25,10 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	policy := opts.OverrunPolicy
+	if policy == OverrunBlock {
+		policy = s.overrun
+	}
 	capacity := opts.Capacity
 	if capacity <= 0 {
 		capacity = 1024
@@ -52,7 +56,11 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 					}
 					return
 				}
-				if !sendRx(ctx, rx, msg, opts.OverrunPolicy) {
+				ok, err := sendRx(ctx, rx, msg, policy)
+				if err != nil {
+					reportError(ctx, errorsCh, err)
+				}
+				if !ok {
 					return
 				}
 			}
@@ -108,6 +116,7 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 
 	go func() {
 		wg.Wait()
+		close(errorsCh)
 		close(done)
 	}()
 
@@ -137,18 +146,18 @@ func reportError(ctx context.Context, errorsCh chan<- error, err error) {
 	}
 }
 
-func sendRx(ctx context.Context, rx chan Message, msg Message, policy OverrunPolicy) bool {
+func sendRx(ctx context.Context, rx chan Message, msg Message, policy OverrunPolicy) (bool, error) {
 	switch policy {
 	case OverrunDropNewest:
 		select {
 		case rx <- msg:
 		default:
 		}
-		return true
+		return true, nil
 	case OverrunDropOldest:
 		select {
 		case rx <- msg:
-			return true
+			return true, nil
 		default:
 		}
 		select {
@@ -158,22 +167,22 @@ func sendRx(ctx context.Context, rx chan Message, msg Message, policy OverrunPol
 		select {
 		case rx <- msg:
 		case <-ctx.Done():
-			return false
+			return false, nil
 		}
-		return true
+		return true, nil
 	case OverrunReturnError:
 		select {
 		case rx <- msg:
-			return true
+			return true, nil
 		default:
-			return false
+			return false, &Error{Err: "receive channel overrun"}
 		}
 	default:
 		select {
 		case rx <- msg:
-			return true
+			return true, nil
 		case <-ctx.Done():
-			return false
+			return false, nil
 		}
 	}
 }

--- a/bindings/go/channels.go
+++ b/bindings/go/channels.go
@@ -53,10 +53,8 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 
 	if s.socketType.canRecv() {
 		rx = make(chan Message, capacity)
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			defer close(rx)
-			defer wg.Done()
 			for {
 				msg, err := s.Recv(ctx)
 				if err != nil {
@@ -73,14 +71,12 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	if s.socketType.canSend() {
 		tx = make(chan Message, capacity)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-ctx.Done():
@@ -94,16 +90,14 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	monitor, err := s.Monitor()
 	if err == nil {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			defer monitor.Close()
 			defer close(eventsCh)
-			defer wg.Done()
 			for {
 				event, err := monitor.Recv(ctx)
 				if err != nil {
@@ -118,7 +112,7 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 					return
 				}
 			}
-		}()
+		})
 	} else {
 		close(eventsCh)
 	}

--- a/bindings/go/channels.go
+++ b/bindings/go/channels.go
@@ -198,10 +198,16 @@ func sendRx(ctx context.Context, rx chan Message, msg Message, policy OverrunPol
 }
 
 func sendChannelBatch(ctx context.Context, socket *Socket, tx <-chan Message, first Message, errorsCh chan<- error) bool {
+	if errFromContext(ctx) != nil {
+		return false
+	}
 	batch := make([]Message, 0, 64)
 	batch = append(batch, first)
 drain:
 	for len(batch) < cap(batch) {
+		if errFromContext(ctx) != nil {
+			return false
+		}
 		select {
 		case msg, ok := <-tx:
 			if !ok {
@@ -214,6 +220,9 @@ drain:
 	}
 
 	for len(batch) > 0 {
+		if errFromContext(ctx) != nil {
+			return false
+		}
 		sent, err := socket.trySendBatch(batch)
 		if sent > 0 {
 			batch = batch[sent:]

--- a/bindings/go/channels.go
+++ b/bindings/go/channels.go
@@ -1,0 +1,222 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type ChannelOptions struct {
+	Capacity      int
+	OverrunPolicy OverrunPolicy
+}
+
+type SocketChannels struct {
+	Rx     <-chan Message
+	Tx     chan<- Message
+	Events <-chan MonitorEvent
+	Errors <-chan error
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChannels, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	capacity := opts.Capacity
+	if capacity <= 0 {
+		capacity = 1024
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	errorsCh := make(chan error, capacity)
+	eventsCh := make(chan MonitorEvent, capacity)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	var rx chan Message
+	var tx chan Message
+
+	if s.socketType.canRecv() {
+		rx = make(chan Message, capacity)
+		wg.Add(1)
+		go func() {
+			defer close(rx)
+			defer wg.Done()
+			for {
+				msg, err := s.Recv(ctx)
+				if err != nil {
+					if !errors.Is(err, ErrCanceled) && !errors.Is(err, ErrClosed) {
+						reportError(ctx, errorsCh, err)
+					}
+					return
+				}
+				if !sendRx(ctx, rx, msg, opts.OverrunPolicy) {
+					return
+				}
+			}
+		}()
+	}
+
+	if s.socketType.canSend() {
+		tx = make(chan Message, capacity)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg, ok := <-tx:
+					if !ok {
+						return
+					}
+					if !sendChannelBatch(ctx, s, tx, msg, errorsCh) {
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	monitor, err := s.Monitor()
+	if err == nil {
+		wg.Add(1)
+		go func() {
+			defer monitor.Close()
+			defer close(eventsCh)
+			defer wg.Done()
+			for {
+				event, err := monitor.Recv(ctx)
+				if err != nil {
+					if !errors.Is(err, ErrCanceled) && !errors.Is(err, ErrClosed) {
+						reportError(ctx, errorsCh, err)
+					}
+					return
+				}
+				select {
+				case eventsCh <- event:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	} else {
+		close(eventsCh)
+	}
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	return &SocketChannels{
+		Rx:     rx,
+		Tx:     tx,
+		Events: eventsCh,
+		Errors: errorsCh,
+		cancel: cancel,
+		done:   done,
+	}, nil
+}
+
+func (c *SocketChannels) Close() {
+	if c == nil {
+		return
+	}
+	c.cancel()
+	<-c.done
+}
+
+func reportError(ctx context.Context, errorsCh chan<- error, err error) {
+	select {
+	case errorsCh <- err:
+	case <-ctx.Done():
+	default:
+	}
+}
+
+func sendRx(ctx context.Context, rx chan Message, msg Message, policy OverrunPolicy) bool {
+	switch policy {
+	case OverrunDropNewest:
+		select {
+		case rx <- msg:
+		default:
+		}
+		return true
+	case OverrunDropOldest:
+		select {
+		case rx <- msg:
+			return true
+		default:
+		}
+		select {
+		case <-rx:
+		default:
+		}
+		select {
+		case rx <- msg:
+		case <-ctx.Done():
+			return false
+		}
+		return true
+	case OverrunReturnError:
+		select {
+		case rx <- msg:
+			return true
+		default:
+			return false
+		}
+	default:
+		select {
+		case rx <- msg:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
+func sendChannelBatch(ctx context.Context, socket *Socket, tx <-chan Message, first Message, errorsCh chan<- error) bool {
+	batch := make([]Message, 0, 64)
+	batch = append(batch, first)
+drain:
+	for len(batch) < cap(batch) {
+		select {
+		case msg, ok := <-tx:
+			if !ok {
+				break drain
+			}
+			batch = append(batch, msg)
+		default:
+			break drain
+		}
+	}
+
+	for len(batch) > 0 {
+		sent, err := socket.trySendBatch(batch)
+		if sent > 0 {
+			batch = batch[sent:]
+			continue
+		}
+		if err == nil {
+			return true
+		}
+		if errors.Is(err, ErrAgain) {
+			if err := socket.Send(ctx, batch[0]); err != nil {
+				if !errors.Is(err, ErrCanceled) && !errors.Is(err, ErrClosed) {
+					reportError(ctx, errorsCh, err)
+				}
+				return false
+			}
+			batch = batch[1:]
+			continue
+		}
+		if !errors.Is(err, ErrCanceled) && !errors.Is(err, ErrClosed) {
+			reportError(ctx, errorsCh, err)
+		}
+		return false
+	}
+	return true
+}

--- a/bindings/go/channels.go
+++ b/bindings/go/channels.go
@@ -6,21 +6,30 @@ import (
 	"sync"
 )
 
+// ChannelOptions configures Socket.Channels.
 type ChannelOptions struct {
-	Capacity      int
+	// Capacity sets Go channel capacity.
+	Capacity int
+	// OverrunPolicy controls receive channel overrun behavior.
 	OverrunPolicy OverrunPolicy
 }
 
+// SocketChannels exposes a socket through Go channels.
 type SocketChannels struct {
-	Rx     <-chan Message
-	Tx     chan<- Message
+	// Rx receives socket messages when the socket can receive.
+	Rx <-chan Message
+	// Tx sends socket messages when the socket can send.
+	Tx chan<- Message
+	// Events receives monitor events when monitoring is available.
 	Events <-chan MonitorEvent
+	// Errors receives worker errors.
 	Errors <-chan error
 
 	cancel context.CancelFunc
 	done   chan struct{}
 }
 
+// Channels adapts a socket to Go channels.
 func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChannels, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -130,6 +139,7 @@ func (s *Socket) Channels(ctx context.Context, opts ChannelOptions) (*SocketChan
 	}, nil
 }
 
+// Close stops channel workers.
 func (c *SocketChannels) Close() {
 	if c == nil {
 		return

--- a/bindings/go/channels_test.go
+++ b/bindings/go/channels_test.go
@@ -78,3 +78,50 @@ func TestChannelsCloseClosesErrors(t *testing.T) {
 		t.Fatal("Errors not closed")
 	}
 }
+
+func TestSendChannelBatchStopsBeforeDrainWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tx := make(chan Message, 1)
+	tx <- String("queued")
+	errorsCh := make(chan error, 1)
+
+	if sendChannelBatch(ctx, nil, tx, String("first"), errorsCh) {
+		t.Fatal("sendChannelBatch reported success after cancel")
+	}
+	if got := len(tx); got != 1 {
+		t.Fatalf("queued messages drained after cancel = %d, want 1", got)
+	}
+}
+
+func TestChannelsCloseStopsBusyTxWorker(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	channels, err := push.Channels(runCtx, ChannelOptions{Capacity: 128})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer channels.Close()
+
+	for i := 0; i < 128; i++ {
+		channels.Tx <- String("queued")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		channels.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Channels.Close did not stop busy Tx worker")
+	}
+}

--- a/bindings/go/channels_test.go
+++ b/bindings/go/channels_test.go
@@ -1,0 +1,80 @@
+package omq
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestChannelsReportReceiveOverrun(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-channel-overrun")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	channels, err := pull.Channels(runCtx, ChannelOptions{
+		Capacity:      1,
+		OverrunPolicy: OverrunReturnError,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer channels.Close()
+
+	if err := push.SendTimeout(String("one"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("two"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err, ok := <-channels.Errors:
+		if !ok {
+			t.Fatal("Errors closed before overrun")
+		}
+		if err == nil {
+			t.Fatal("overrun error is nil")
+		}
+	case <-runCtx.Done():
+		t.Fatal(runCtx.Err())
+	}
+}
+
+func TestChannelsCloseClosesErrors(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	channels, err := pull.Channels(runCtx, ChannelOptions{Capacity: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels.Close()
+
+	select {
+	case _, ok := <-channels.Errors:
+		if ok {
+			t.Fatal("Errors still open")
+		}
+	default:
+		t.Fatal("Errors not closed")
+	}
+}

--- a/bindings/go/channels_test.go
+++ b/bindings/go/channels_test.go
@@ -3,6 +3,7 @@ package omq
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -93,6 +94,42 @@ func TestSendChannelBatchStopsBeforeDrainWhenCanceled(t *testing.T) {
 	if got := len(tx); got != 1 {
 		t.Fatalf("queued messages drained after cancel = %d, want 1", got)
 	}
+}
+
+func TestSendRxBlockCancelSynctest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		rx := make(chan Message)
+		done := make(chan struct{})
+		var ok bool
+		var err error
+
+		go func() {
+			ok, err = sendRx(ctx, rx, String("blocked"), OverrunBlock)
+			close(done)
+		}()
+
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("sendRx returned before cancellation")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("sendRx did not return after cancellation")
+		}
+		if ok {
+			t.Fatal("sendRx reported success after cancellation")
+		}
+		if err != nil {
+			t.Fatalf("sendRx err = %v", err)
+		}
+	})
 }
 
 func TestChannelsCloseStopsBusyTxWorker(t *testing.T) {

--- a/bindings/go/compression_test.go
+++ b/bindings/go/compression_test.go
@@ -1,0 +1,184 @@
+package omq
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var zstdTestDict = mustHex("37a430ecbeaadd5c811120841042664644444444244902002114c418638c21841042" +
+	"082184104208214444444444444444240900005110638c31c618630c21c418636666" +
+	"864692040080000000c000000000010000")
+var lz4TestDict = []byte("omq-quote-symbol-price-volume-json-shared-prefix")
+
+func TestCompressionTransports(t *testing.T) {
+	for _, transport := range []string{"lz4+tcp", "zstd+tcp"} {
+		t.Run(transport, func(t *testing.T) {
+			compressionRoundTrip(t, transport+"://127.0.0.1:*")
+		})
+	}
+}
+
+func TestCompressionStaticDict(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoint  string
+		dict      []byte
+		threshold int
+	}{
+		{name: "lz4", endpoint: "lz4+tcp://127.0.0.1:*", dict: lz4TestDict, threshold: 32},
+		{name: "zstd", endpoint: "zstd+tcp://127.0.0.1:*", dict: zstdTestDict, threshold: 32},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := openTestContext(t)
+			defer closeContext(t, ctx)
+
+			pull := newTestSocket(t, ctx, Pull)
+			defer closeSocket(t, pull)
+			push, err := ctx.Socket(Push,
+				CompressionDict(test.dict),
+				CompressionThreshold(test.threshold),
+				CompressionLevel(1),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closeSocket(t, push)
+
+			endpoint, err := pull.Bind(test.endpoint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := push.Connect(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+				t.Fatal(err)
+			}
+			payload := compressionPayload(7, 512)
+			if err := push.SendTimeout(Bytes(payload), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			msg, err := pull.RecvTimeout(time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(msg.Bytes(), payload) {
+				t.Fatalf("payload mismatch")
+			}
+		})
+	}
+}
+
+func TestCompressionAutoTrainAndMultipart(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull, err := ctx.Socket(Pull, CompressionAutoTrain(true), CompressionDictCapacity(4096))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push,
+		CompressionAutoTrain(true),
+		CompressionDictCapacity(4096),
+		CompressionThreshold(32),
+		CompressionLevel(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("lz4+tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 140; i++ {
+		if err := push.SendTimeout(Bytes(compressionPayload(i, 768)), time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wantMulti := Multipart([]byte("meta"), []byte("payload"))
+	if err := push.SendTimeout(wantMulti, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 140; i++ {
+		msg, err := pull.RecvTimeout(time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(msg.Bytes(), compressionPayload(i, 768)) {
+			t.Fatalf("payload %d mismatch", i)
+		}
+	}
+	gotMulti, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMulti.Len() != 2 || string(gotMulti.Part(0)) != "meta" || string(gotMulti.Part(1)) != "payload" {
+		t.Fatalf("multipart = %#v", gotMulti.Parts())
+	}
+}
+
+func compressionRoundTrip(t *testing.T, endpoint string) {
+	t.Helper()
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull, err := ctx.Socket(Pull, CompressionAutoTrain(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, CompressionAutoTrain(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String(`{"kind":"json","value":42}`), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != `{"kind":"json","value":42}` {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func compressionPayload(seq, size int) []byte {
+	head := fmt.Sprintf(`{"kind":"quote","symbol":"OMQ","seq":%d,"pad":"`, seq)
+	tail := `"}`
+	return []byte(head + strings.Repeat("A", size-len(head)-len(tail)) + tail)
+}
+
+func mustHex(input string) []byte {
+	out, err := hex.DecodeString(input)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/bindings/go/connect_before_bind_test.go
+++ b/bindings/go/connect_before_bind_test.go
@@ -1,0 +1,140 @@
+package omq
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestConnectBeforeBindPushPullTCP(t *testing.T) {
+	for _, delay := range []time.Duration{0, 50 * time.Millisecond, 250 * time.Millisecond} {
+		t.Run(delay.String(), func(t *testing.T) {
+			ctx := openTestContext(t)
+			defer closeContext(t, ctx)
+
+			push := newTestSocket(t, ctx, Push)
+			defer closeSocket(t, push)
+			pull := newTestSocket(t, ctx, Pull)
+			defer closeSocket(t, pull)
+
+			endpoint := freeTCPEndpoint(t)
+			if err := push.Connect(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(delay)
+			if _, err := pull.Bind(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			if err := push.SendTimeout(String("late"), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			msg, err := pull.RecvTimeout(5 * time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := msg.String(); got != "late" {
+				t.Fatalf("message = %q, want late", got)
+			}
+		})
+	}
+}
+
+func TestConnectBeforeBindReqRepTCP(t *testing.T) {
+	for _, delay := range []time.Duration{0, 50 * time.Millisecond, 250 * time.Millisecond} {
+		t.Run(delay.String(), func(t *testing.T) {
+			ctx := openTestContext(t)
+			defer closeContext(t, ctx)
+
+			req := newTestSocket(t, ctx, Req)
+			defer closeSocket(t, req)
+			rep := newTestSocket(t, ctx, Rep)
+			defer closeSocket(t, rep)
+
+			endpoint := freeTCPEndpoint(t)
+			if err := req.Connect(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(delay)
+			if _, err := rep.Bind(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			if err := req.SendTimeout(String("q"), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			query, err := rep.RecvTimeout(5 * time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := query.String(); got != "q" {
+				t.Fatalf("query = %q, want q", got)
+			}
+			if err := rep.SendTimeout(String("a"), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			answer, err := req.RecvTimeout(5 * time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := answer.String(); got != "a" {
+				t.Fatalf("answer = %q, want a", got)
+			}
+		})
+	}
+}
+
+func TestConnectBeforeBindPairInproc(t *testing.T) {
+	for _, delay := range []time.Duration{0, 50 * time.Millisecond, 250 * time.Millisecond} {
+		t.Run(delay.String(), func(t *testing.T) {
+			ctx := openTestContext(t)
+			defer closeContext(t, ctx)
+
+			a := newTestSocket(t, ctx, Pair)
+			defer closeSocket(t, a)
+			b := newTestSocket(t, ctx, Pair)
+			defer closeSocket(t, b)
+
+			endpoint := "inproc://go-cbb-pair-" + delay.String()
+			if err := a.Connect(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(delay)
+			if _, err := b.Bind(endpoint); err != nil {
+				t.Fatal(err)
+			}
+			if err := a.SendTimeout(String("from-a"), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			msg, err := b.RecvTimeout(5 * time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := msg.String(); got != "from-a" {
+				t.Fatalf("message = %q, want from-a", got)
+			}
+			if err := b.SendTimeout(String("from-b"), time.Second); err != nil {
+				t.Fatal(err)
+			}
+			msg, err = a.RecvTimeout(5 * time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := msg.String(); got != "from-b" {
+				t.Fatalf("message = %q, want from-b", got)
+			}
+		})
+	}
+}
+
+func freeTCPEndpoint(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("tcp://127.0.0.1:%d", port)
+}

--- a/bindings/go/context.go
+++ b/bindings/go/context.go
@@ -3,6 +3,7 @@ package omq
 import (
 	"context"
 	"runtime"
+	"sync"
 	"sync/atomic"
 )
 
@@ -13,8 +14,14 @@ type Config struct {
 }
 
 type Context struct {
-	handle *nativeContext
-	closed atomic.Bool
+	handle    *nativeContext
+	ringSize  int
+	overrun   OverrunPolicy
+	mu        sync.Mutex
+	sockets   map[*Socket]struct{}
+	closed    atomic.Bool
+	closeOnce sync.Once
+	closeDone chan struct{}
 }
 
 func Open(config Config) (*Context, error) {
@@ -22,11 +29,23 @@ func Open(config Config) (*Context, error) {
 	if ioThreads == 0 {
 		ioThreads = 1
 	}
+	if ioThreads < 0 {
+		return nil, &ConfigError{Err: "io_threads must be greater than zero"}
+	}
+	if config.RingSize < 0 {
+		return nil, &ConfigError{Err: "ring size must be non-negative"}
+	}
 	handle, err := contextOpenNative(ioThreads)
 	if err != nil {
 		return nil, err
 	}
-	ctx := &Context{handle: handle}
+	ctx := &Context{
+		handle:    handle,
+		ringSize:  config.RingSize,
+		overrun:   config.OverrunPolicy,
+		sockets:   make(map[*Socket]struct{}),
+		closeDone: make(chan struct{}),
+	}
 	runtime.SetFinalizer(ctx, (*Context).free)
 	return ctx, nil
 }
@@ -36,7 +55,11 @@ func OpenShared(key ShareKey) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx := &Context{handle: handle}
+	ctx := &Context{
+		handle:    handle,
+		sockets:   make(map[*Socket]struct{}),
+		closeDone: make(chan struct{}),
+	}
 	runtime.SetFinalizer(ctx, (*Context).free)
 	return ctx, nil
 }
@@ -54,12 +77,20 @@ func (c *Context) Socket(socketType SocketType, opts ...SocketOption) (*Socket, 
 	if c == nil || c.handle == nil || c.closed.Load() {
 		return nil, ErrClosed
 	}
+	c.mu.Lock()
+	if c.closed.Load() {
+		c.mu.Unlock()
+		return nil, ErrClosed
+	}
 	handle, err := socketNewNative(c.handle, socketType)
 	if err != nil {
+		c.mu.Unlock()
 		return nil, err
 	}
-	socket := newSocket(handle, socketType)
+	socket := newSocket(handle, socketType, c, c.ringSize, c.overrun)
 	runtime.SetFinalizer(socket, (*Socket).free)
+	c.sockets[socket] = struct{}{}
+	c.mu.Unlock()
 	for _, opt := range opts {
 		if err := opt(socket); err != nil {
 			socket.free()
@@ -75,19 +106,18 @@ func (c *Context) Close() error {
 }
 
 func (c *Context) CloseContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if c == nil || c.handle == nil {
 		return nil
 	}
-	if c.closed.Swap(true) {
-		return nil
-	}
-	done := make(chan struct{})
-	go func() {
-		contextCloseNative(c.handle)
-		close(done)
-	}()
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		go c.closeAll()
+	})
 	select {
-	case <-done:
+	case <-c.closeDone:
 		keepAlive(c)
 		return nil
 	case <-ctx.Done():
@@ -99,6 +129,40 @@ func (c *Context) free() {
 	if c == nil || c.handle == nil {
 		return
 	}
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		go c.closeAll()
+	})
+	<-c.closeDone
 	contextFreeNative(c.handle)
 	c.handle = nil
+}
+
+func (c *Context) removeSocket(socket *Socket) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.sockets, socket)
+}
+
+func (c *Context) closeAll() {
+	sockets := c.detachSockets()
+	for _, socket := range sockets {
+		_ = socket.Close(context.Background())
+	}
+	contextCloseNative(c.handle)
+	close(c.closeDone)
+}
+
+func (c *Context) detachSockets() []*Socket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.sockets) == 0 {
+		return nil
+	}
+	sockets := make([]*Socket, 0, len(c.sockets))
+	for socket := range c.sockets {
+		sockets = append(sockets, socket)
+	}
+	c.sockets = make(map[*Socket]struct{})
+	return sockets
 }

--- a/bindings/go/context.go
+++ b/bindings/go/context.go
@@ -21,6 +21,7 @@ type Context struct {
 	sockets   map[*Socket]struct{}
 	closed    atomic.Bool
 	closeOnce sync.Once
+	freeOnce  sync.Once
 	closeDone chan struct{}
 }
 
@@ -131,11 +132,9 @@ func (c *Context) free() {
 	}
 	c.closeOnce.Do(func() {
 		c.closed.Store(true)
-		go c.closeAll()
+		c.closeAll()
 	})
 	<-c.closeDone
-	contextFreeNative(c.handle)
-	c.handle = nil
 }
 
 func (c *Context) removeSocket(socket *Socket) {
@@ -145,12 +144,15 @@ func (c *Context) removeSocket(socket *Socket) {
 }
 
 func (c *Context) closeAll() {
+	defer close(c.closeDone)
 	sockets := c.detachSockets()
 	for _, socket := range sockets {
 		_ = socket.Close(context.Background())
 	}
-	contextCloseNative(c.handle)
-	close(c.closeDone)
+	c.freeOnce.Do(func() {
+		contextFreeNative(c.handle)
+	})
+	runtime.SetFinalizer(c, nil)
 }
 
 func (c *Context) detachSockets() []*Socket {

--- a/bindings/go/context.go
+++ b/bindings/go/context.go
@@ -7,12 +7,17 @@ import (
 	"sync/atomic"
 )
 
+// Config controls native context and Go ring defaults.
 type Config struct {
-	IOThreads     int
-	RingSize      int
+	// IOThreads sets native OMQ I/O thread count.
+	IOThreads int
+	// RingSize sets private Go/native ring descriptor capacity.
+	RingSize int
+	// OverrunPolicy sets default channel overrun behavior.
 	OverrunPolicy OverrunPolicy
 }
 
+// Context owns a native OMQ context and its sockets.
 type Context struct {
 	handle    *nativeContext
 	ringSize  int
@@ -25,6 +30,7 @@ type Context struct {
 	closeDone chan struct{}
 }
 
+// Open creates a native OMQ context.
 func Open(config Config) (*Context, error) {
 	ioThreads := config.IOThreads
 	if ioThreads == 0 {
@@ -51,6 +57,7 @@ func Open(config Config) (*Context, error) {
 	return ctx, nil
 }
 
+// OpenShared imports a process-local shared native context.
 func OpenShared(key ShareKey) (*Context, error) {
 	handle, err := contextFromShareKeyNative(key)
 	if err != nil {
@@ -65,6 +72,7 @@ func OpenShared(key ShareKey) (*Context, error) {
 	return ctx, nil
 }
 
+// ShareKey returns a process-local key for sharing this context.
 func (c *Context) ShareKey() (ShareKey, error) {
 	if c == nil || c.handle == nil || c.closed.Load() {
 		return ShareKey{}, ErrClosed
@@ -74,6 +82,7 @@ func (c *Context) ShareKey() (ShareKey, error) {
 	return key, err
 }
 
+// Socket creates a socket and applies pre-I/O options.
 func (c *Context) Socket(socketType SocketType, opts ...SocketOption) (*Socket, error) {
 	if c == nil || c.handle == nil || c.closed.Load() {
 		return nil, ErrClosed
@@ -102,10 +111,12 @@ func (c *Context) Socket(socketType SocketType, opts ...SocketOption) (*Socket, 
 	return socket, nil
 }
 
+// Close closes all owned sockets and terminates the context.
 func (c *Context) Close() error {
 	return c.CloseContext(context.Background())
 }
 
+// CloseContext closes the context, bounded by ctx.
 func (c *Context) CloseContext(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()

--- a/bindings/go/context.go
+++ b/bindings/go/context.go
@@ -1,0 +1,104 @@
+package omq
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+)
+
+type Config struct {
+	IOThreads     int
+	RingSize      int
+	OverrunPolicy OverrunPolicy
+}
+
+type Context struct {
+	handle *nativeContext
+	closed atomic.Bool
+}
+
+func Open(config Config) (*Context, error) {
+	ioThreads := config.IOThreads
+	if ioThreads == 0 {
+		ioThreads = 1
+	}
+	handle, err := contextOpenNative(ioThreads)
+	if err != nil {
+		return nil, err
+	}
+	ctx := &Context{handle: handle}
+	runtime.SetFinalizer(ctx, (*Context).free)
+	return ctx, nil
+}
+
+func OpenShared(key ShareKey) (*Context, error) {
+	handle, err := contextFromShareKeyNative(key)
+	if err != nil {
+		return nil, err
+	}
+	ctx := &Context{handle: handle}
+	runtime.SetFinalizer(ctx, (*Context).free)
+	return ctx, nil
+}
+
+func (c *Context) ShareKey() (ShareKey, error) {
+	if c == nil || c.handle == nil || c.closed.Load() {
+		return ShareKey{}, ErrClosed
+	}
+	key, err := contextShareKeyNative(c.handle)
+	keepAlive(c)
+	return key, err
+}
+
+func (c *Context) Socket(socketType SocketType, opts ...SocketOption) (*Socket, error) {
+	if c == nil || c.handle == nil || c.closed.Load() {
+		return nil, ErrClosed
+	}
+	handle, err := socketNewNative(c.handle, socketType)
+	if err != nil {
+		return nil, err
+	}
+	socket := newSocket(handle, socketType)
+	runtime.SetFinalizer(socket, (*Socket).free)
+	for _, opt := range opts {
+		if err := opt(socket); err != nil {
+			socket.free()
+			return nil, err
+		}
+	}
+	keepAlive(c)
+	return socket, nil
+}
+
+func (c *Context) Close() error {
+	return c.CloseContext(context.Background())
+}
+
+func (c *Context) CloseContext(ctx context.Context) error {
+	if c == nil || c.handle == nil {
+		return nil
+	}
+	if c.closed.Swap(true) {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		contextCloseNative(c.handle)
+		close(done)
+	}()
+	select {
+	case <-done:
+		keepAlive(c)
+		return nil
+	case <-ctx.Done():
+		return errFromContext(ctx)
+	}
+}
+
+func (c *Context) free() {
+	if c == nil || c.handle == nil {
+		return
+	}
+	contextFreeNative(c.handle)
+	c.handle = nil
+}

--- a/bindings/go/context.go
+++ b/bindings/go/context.go
@@ -19,11 +19,16 @@ type Config struct {
 
 // Context owns a native OMQ context and its sockets.
 type Context struct {
+	state   *contextState
+	cleanup runtime.Cleanup
+}
+
+type contextState struct {
 	handle    *nativeContext
 	ringSize  int
 	overrun   OverrunPolicy
 	mu        sync.Mutex
-	sockets   map[*Socket]struct{}
+	sockets   map[*socketState]struct{}
 	closed    atomic.Bool
 	closeOnce sync.Once
 	freeOnce  sync.Once
@@ -46,14 +51,15 @@ func Open(config Config) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx := &Context{
+	state := &contextState{
 		handle:    handle,
 		ringSize:  config.RingSize,
 		overrun:   config.OverrunPolicy,
-		sockets:   make(map[*Socket]struct{}),
+		sockets:   make(map[*socketState]struct{}),
 		closeDone: make(chan struct{}),
 	}
-	runtime.SetFinalizer(ctx, (*Context).free)
+	ctx := &Context{state: state}
+	ctx.cleanup = runtime.AddCleanup(ctx, cleanupContextState, state)
 	return ctx, nil
 }
 
@@ -63,47 +69,54 @@ func OpenShared(key ShareKey) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx := &Context{
+	state := &contextState{
 		handle:    handle,
-		sockets:   make(map[*Socket]struct{}),
+		sockets:   make(map[*socketState]struct{}),
 		closeDone: make(chan struct{}),
 	}
-	runtime.SetFinalizer(ctx, (*Context).free)
+	ctx := &Context{state: state}
+	ctx.cleanup = runtime.AddCleanup(ctx, cleanupContextState, state)
 	return ctx, nil
 }
 
 // ShareKey returns a process-local key for sharing this context.
 func (c *Context) ShareKey() (ShareKey, error) {
-	if c == nil || c.handle == nil || c.closed.Load() {
+	state := c.stateOrNil()
+	if state == nil || state.closed.Load() {
 		return ShareKey{}, ErrClosed
 	}
-	key, err := contextShareKeyNative(c.handle)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.closed.Load() || state.handle == nil {
+		return ShareKey{}, ErrClosed
+	}
+	key, err := contextShareKeyNative(state.handle)
 	keepAlive(c)
 	return key, err
 }
 
 // Socket creates a socket and applies pre-I/O options.
 func (c *Context) Socket(socketType SocketType, opts ...SocketOption) (*Socket, error) {
-	if c == nil || c.handle == nil || c.closed.Load() {
+	state := c.stateOrNil()
+	if state == nil || state.closed.Load() {
 		return nil, ErrClosed
 	}
-	c.mu.Lock()
-	if c.closed.Load() {
-		c.mu.Unlock()
+	state.mu.Lock()
+	if state.closed.Load() || state.handle == nil {
+		state.mu.Unlock()
 		return nil, ErrClosed
 	}
-	handle, err := socketNewNative(c.handle, socketType)
+	handle, err := socketNewNative(state.handle, socketType)
 	if err != nil {
-		c.mu.Unlock()
+		state.mu.Unlock()
 		return nil, err
 	}
-	socket := newSocket(handle, socketType, c, c.ringSize, c.overrun)
-	runtime.SetFinalizer(socket, (*Socket).free)
-	c.sockets[socket] = struct{}{}
-	c.mu.Unlock()
+	socket := newSocket(handle, socketType, c, state, state.ringSize, state.overrun)
+	state.sockets[socket.state] = struct{}{}
+	state.mu.Unlock()
 	for _, opt := range opts {
 		if err := opt(socket); err != nil {
-			socket.free()
+			_ = socket.Close(context.Background())
 			return nil, err
 		}
 	}
@@ -121,61 +134,82 @@ func (c *Context) CloseContext(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if c == nil || c.handle == nil {
+	state := c.stateOrNil()
+	if state == nil {
 		return nil
 	}
-	c.closeOnce.Do(func() {
-		c.closed.Store(true)
-		go c.closeAll()
-	})
+	state.startClose()
 	select {
-	case <-c.closeDone:
+	case <-state.closeDone:
+		c.cleanup.Stop()
 		keepAlive(c)
 		return nil
 	case <-ctx.Done():
+		keepAlive(c)
 		return errFromContext(ctx)
 	}
 }
 
-func (c *Context) free() {
-	if c == nil || c.handle == nil {
+func cleanupContextState(state *contextState) {
+	if state == nil {
 		return
 	}
-	c.closeOnce.Do(func() {
-		c.closed.Store(true)
-		c.closeAll()
-	})
-	<-c.closeDone
+	go state.closeBackground()
 }
 
-func (c *Context) removeSocket(socket *Socket) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.sockets, socket)
-}
-
-func (c *Context) closeAll() {
-	defer close(c.closeDone)
-	sockets := c.detachSockets()
-	for _, socket := range sockets {
-		_ = socket.Close(context.Background())
-	}
-	c.freeOnce.Do(func() {
-		contextFreeNative(c.handle)
-	})
-	runtime.SetFinalizer(c, nil)
-}
-
-func (c *Context) detachSockets() []*Socket {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if len(c.sockets) == 0 {
+func (c *Context) stateOrNil() *contextState {
+	if c == nil {
 		return nil
 	}
-	sockets := make([]*Socket, 0, len(c.sockets))
-	for socket := range c.sockets {
+	return c.state
+}
+
+func (state *contextState) startClose() {
+	state.closeOnce.Do(func() {
+		state.closed.Store(true)
+		go state.closeAll()
+	})
+}
+
+func (state *contextState) closeBackground() {
+	state.closeOnce.Do(func() {
+		state.closed.Store(true)
+		state.closeAll()
+	})
+}
+
+func (state *contextState) removeSocket(socket *socketState) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	delete(state.sockets, socket)
+}
+
+func (state *contextState) closeAll() {
+	defer close(state.closeDone)
+	sockets := state.detachSockets()
+	for _, socket := range sockets {
+		_ = socket.close(context.Background(), socketOp{kind: socketOpClose, useConfigured: true})
+	}
+	state.freeOnce.Do(func() {
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		if state.handle != nil {
+			contextFreeNative(state.handle)
+			state.handle = nil
+		}
+	})
+}
+
+func (state *contextState) detachSockets() []*socketState {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sockets) == 0 {
+		return nil
+	}
+	sockets := make([]*socketState, 0, len(state.sockets))
+	for socket := range state.sockets {
 		sockets = append(sockets, socket)
 	}
-	c.sockets = make(map[*Socket]struct{})
+	state.sockets = make(map[*socketState]struct{})
 	return sockets
 }

--- a/bindings/go/context_test.go
+++ b/bindings/go/context_test.go
@@ -1,0 +1,90 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestOpenRejectsInvalidConfig(t *testing.T) {
+	if _, err := Open(Config{IOThreads: -1}); err == nil {
+		t.Fatal("Open with negative IOThreads succeeded")
+	}
+	if _, err := Open(Config{RingSize: -1}); err == nil {
+		t.Fatal("Open with negative RingSize succeeded")
+	}
+}
+
+func TestContextCloseClosesOwnedSockets(t *testing.T) {
+	ctx := openTestContext(t)
+	pull := newTestSocket(t, ctx, Pull)
+
+	closeContext(t, ctx)
+
+	if _, err := pull.TryRecv(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("TryRecv err = %v, want ErrClosed", err)
+	}
+	if _, err := ctx.Socket(Push); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Socket after close err = %v, want ErrClosed", err)
+	}
+}
+
+func TestSharedContextCloseDoesNotTerminateOwner(t *testing.T) {
+	owner := openTestContext(t)
+	defer closeContext(t, owner)
+
+	key, err := owner.ShareKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, err := OpenShared(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeContext(t, shared)
+
+	socket := newTestSocket(t, owner, Pull)
+	defer closeSocket(t, socket)
+}
+
+func TestContextCloseContextCanTimeOutWhileCloseContinues(t *testing.T) {
+	ctx := openTestContext(t)
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	runStarted := make(chan struct{})
+	releaseRun := make(chan struct{})
+	go func() {
+		_ = pull.Run(context.Background(), func(socket *BoundSocket) error {
+			close(runStarted)
+			<-releaseRun
+			return nil
+		})
+	}()
+	select {
+	case <-runStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := ctx.CloseContext(closeCtx); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("CloseContext err = %v, want ErrTimeout", err)
+	}
+	close(releaseRun)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ctx.Close()
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("context close did not finish")
+	}
+}

--- a/bindings/go/context_test.go
+++ b/bindings/go/context_test.go
@@ -16,6 +16,45 @@ func TestOpenRejectsInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestNativeStatsTrackContextAndSocket(t *testing.T) {
+	baseline := nativeStatsNative()
+	ctx, err := Open(Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterOpen := nativeStatsNative()
+	if afterOpen.contextsCreated != baseline.contextsCreated+1 {
+		t.Fatalf("contextsCreated = %d, want %d", afterOpen.contextsCreated, baseline.contextsCreated+1)
+	}
+	if afterOpen.contextsLive != baseline.contextsLive+1 {
+		t.Fatalf("contextsLive = %d, want %d", afterOpen.contextsLive, baseline.contextsLive+1)
+	}
+
+	socket, err := ctx.Socket(Pull, Linger(0))
+	if err != nil {
+		_ = ctx.Close()
+		t.Fatal(err)
+	}
+	afterSocket := nativeStatsNative()
+	if afterSocket.socketsCreated != baseline.socketsCreated+1 {
+		t.Fatalf("socketsCreated = %d, want %d", afterSocket.socketsCreated, baseline.socketsCreated+1)
+	}
+	if afterSocket.socketsLive != baseline.socketsLive+1 {
+		t.Fatalf("socketsLive = %d, want %d", afterSocket.socketsLive, baseline.socketsLive+1)
+	}
+
+	if err := socket.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	final := nativeStatsNative()
+	if leak := final.liveGrowthSince(baseline); leak != "" {
+		t.Fatalf("native live growth after close: %s", leak)
+	}
+}
+
 func TestContextCloseClosesOwnedSockets(t *testing.T) {
 	ctx := openTestContext(t)
 	pull := newTestSocket(t, ctx, Pull)

--- a/bindings/go/doc/architecture.md
+++ b/bindings/go/doc/architecture.md
@@ -1,0 +1,58 @@
+# OMQ Go Architecture
+
+The Go binding is an idiomatic package over a small C ABI implemented by
+`bindings/go/native`. The native crate uses `omq-tokio`, not `omq-libzmq`.
+
+## Threading
+
+`Open(Config{IOThreads: n})` creates an OMQ context with `n` owned IO
+threads. Go caller goroutines never own transport, reconnect, compression,
+or ZMTP state.
+
+The public API is goroutine-safe. Socket close marks native state closed and
+wakes later operations through typed errors. Native handles are kept alive
+until Go finalizers release the small handle object, so close does not race
+with an in-flight cgo call by freeing memory underneath it.
+
+## Calls
+
+Public send and receive APIs are scalar:
+
+- `Send(ctx, Message)`
+- `Recv(ctx)`
+- `SendTimeout(Message, time.Duration)`
+- `RecvTimeout(time.Duration)`
+- `TrySend(Message)`
+- `TryRecv()`
+
+Timeout helpers are convenience wrappers around context-aware loops:
+
+- `timeout == 0`: nonblocking
+- `timeout < 0`: wait forever
+- `timeout > 0`: deadline
+
+Go cancellation is handled before entering cgo and between nonblocking
+native attempts. User goroutines do not need to close a socket from another
+goroutine to interrupt a blocked receive.
+
+## Data Path
+
+Go copies outbound message parts into C-owned memory before calling native
+code. Native never stores Go pointers. Inbound message parts are allocated
+by Rust and copied into Go-owned `[]byte` before the native message is freed.
+
+Receive uses hidden batching. When the native receive cache is empty,
+Rust calls `try_recv_many_into`, `recv_many_into`, or
+`recv_many_timeout_into` with a reused scratch vector, then returns one
+message to Go. No public batch API is exposed.
+
+## Channels
+
+`Socket.Channels(ctx, opts)` is an edge adapter over the scalar API.
+Tx-only sockets expose nil `Rx`; Rx-only sockets expose nil `Tx`.
+The adapter supports bounded buffers and explicit overrun policy for
+receive delivery.
+
+The channel API is Go-friendly, but Go channels are not marketed as pure
+lock-free primitives. The hot native receive refill path avoids per-message
+cgo calls by batching internally.

--- a/bindings/go/doc/architecture.md
+++ b/bindings/go/doc/architecture.md
@@ -20,10 +20,12 @@ Public send and receive APIs are scalar:
 
 - `Send(ctx, Message)`
 - `Recv(ctx)`
+- `RecvInto(ctx, []byte)`
 - `SendTimeout(Message, time.Duration)`
 - `RecvTimeout(time.Duration)`
 - `TrySend(Message)`
 - `TryRecv()`
+- `TryRecvInto([]byte)`
 
 Timeout helpers are convenience wrappers around context-aware loops:
 
@@ -35,16 +37,31 @@ Go cancellation is handled before entering cgo and between nonblocking
 native attempts. User goroutines do not need to close a socket from another
 goroutine to interrupt a blocked receive.
 
+`Socket.Run(ctx, fn)` executes `fn` on the socket owner goroutine, pinned to
+one OS thread. It is the low-latency path for tight loops. `BoundSocket`
+keeps scalar methods, but skips the per-call owner-channel handoff while
+preserving the one-native-thread-per-socket rule.
+
 ## Data Path
 
 Go copies outbound message parts into C-owned memory before calling native
 code. Native never stores Go pointers. Inbound message parts are allocated
 by Rust and copied into Go-owned `[]byte` before the native message is freed.
 
-Receive uses hidden batching. When the native receive cache is empty,
-Rust calls `try_recv_many_into`, `recv_many_into`, or
-`recv_many_timeout_into` with a reused scratch vector, then returns one
-message to Go. No public batch API is exposed.
+Hot `BoundSocket` sends for single-part `PUSH` and `SCATTER` copy the Go
+payload into a native SPSC send ring. A native worker drains descriptors in
+batches and submits them with OMQ's private `try_send_many` path. Native
+keeps each ring slot alive until the OMQ `Message` drops, so Go buffers are
+never retained by Rust.
+
+Hot `BoundSocket` receives use a native SPSC receive ring. Rust refills the
+ring with `try_recv_many_into`, `recv_many_into`, or `recv_many_timeout_into`
+and Go drains scalar `RecvInto` calls from ring descriptors. No public batch
+API is exposed.
+
+The general scalar API remains context-aware and goroutine-safe. It pays the
+owner-channel and cgo transition costs on each operation. Use `Socket.Run`
+when a socket is on a hot path.
 
 ## Channels
 

--- a/bindings/go/doc/architecture.md
+++ b/bindings/go/doc/architecture.md
@@ -59,6 +59,15 @@ ring with `try_recv_many_into`, `recv_many_into`, or `recv_many_timeout_into`
 and Go drains scalar `RecvInto` calls from ring descriptors. No public batch
 API is exposed.
 
+OPTIMIZE: the current hot path still copies payload bytes at the Go/native
+boundary. Single-part sends copy into the native send ring. Single-part
+receives copy from OMQ `Message` into the native receive ring and then into
+the caller's `RecvInto` buffer. This keeps cgo pointer ownership simple, but
+large payload throughput is limited by memory bandwidth. Future work should
+measure owned native send buffers that Go fills before transfer to OMQ, plus
+a direct native `RecvInto` path that decodes single-part messages into the
+caller buffer when batching would not be harmed.
+
 The general scalar API remains context-aware and goroutine-safe. It pays the
 owner-channel and cgo transition costs on each operation. Use `Socket.Run`
 when a socket is on a hot path.

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -144,32 +144,32 @@
   <circle cx="638.2" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,550.3 150.9,549.9 211.8,552.6 272.7,552.0 333.6,549.0 394.5,547.8 455.5,550.5 516.4,547.7 577.3,547.3 638.2,542.5 699.1,530.6 760.0,519.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="550.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="549.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="552.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="552.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="549.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="547.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="550.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="547.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="547.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="542.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="530.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="519.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,549.1 150.9,546.3 211.8,549.0 272.7,546.7 333.6,544.4 394.5,547.9 455.5,548.2 516.4,545.4 577.3,545.9 638.2,536.2 699.1,533.9 760.0,521.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="549.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="549.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="546.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="544.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="547.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="545.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="545.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="536.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="533.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="521.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,549.4 150.9,552.5 211.8,551.5 272.7,554.2 333.6,549.4 394.5,551.0 455.5,552.0 516.4,547.8 577.3,541.5 638.2,541.0 699.1,524.5 760.0,519.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="549.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="552.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="551.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="554.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="549.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="551.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="552.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="547.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="541.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="541.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="524.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="519.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,547.7 150.9,543.3 211.8,544.2 272.7,547.8 333.6,548.0 394.5,548.6 455.5,547.0 516.4,546.1 577.3,546.3 638.2,535.4 699.1,528.6 760.0,524.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="547.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="543.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="544.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="547.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="548.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="547.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="546.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="535.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="528.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="524.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -131,45 +131,45 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,510.1 150.9,510.7 211.8,511.2 272.7,510.6 333.6,507.1 394.5,509.3 455.5,507.9 516.4,503.8 577.3,496.8 638.2,489.0 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="510.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="510.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="511.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="510.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="509.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="507.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="503.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="496.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,507.1 150.9,505.1 211.8,505.8 272.7,509.9 333.6,509.0 394.5,511.4 455.5,506.9 516.4,502.6 577.3,500.5 638.2,495.0 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="505.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="505.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="509.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="509.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="511.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="506.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="502.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="500.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="495.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,549.4 150.9,552.5 211.8,551.5 272.7,554.2 333.6,549.4 394.5,551.0 455.5,552.0 516.4,547.8 577.3,541.5 638.2,541.0 699.1,524.5 760.0,519.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="549.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="552.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="551.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="554.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="549.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="551.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="552.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="547.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="541.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="541.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="524.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="519.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,547.7 150.9,543.3 211.8,544.2 272.7,547.8 333.6,548.0 394.5,548.6 455.5,547.0 516.4,546.1 577.3,546.3 638.2,535.4 699.1,528.6 760.0,524.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="547.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="543.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="544.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="547.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="548.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="547.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="546.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="535.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="528.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="524.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,569.7 150.9,569.8 211.8,569.9 272.7,569.2 333.6,568.8 394.5,568.3 455.5,568.3 516.4,567.9 577.3,563.8 638.2,560.4 699.1,555.4 760.0,545.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="569.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="569.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="569.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="569.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="568.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="568.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="568.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="567.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="563.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="560.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="555.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="545.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,550.6 150.9,544.5 211.8,545.6 272.7,546.6 333.6,546.6 394.5,547.7 455.5,546.0 516.4,546.3 577.3,545.1 638.2,536.2 699.1,532.9 760.0,526.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="550.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="544.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="545.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="546.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="546.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="547.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="546.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="545.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="536.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="532.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="526.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -48,34 +48,34 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,149.6 150.9,141.1 211.8,289.9 272.7,288.4 333.6,291.9 394.5,319.5 455.5,341.4 516.4,346.8 577.3,368.3 638.2,373.3 699.1,378.3 760.0,380.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,331.4 150.9,331.7 211.8,334.8 272.7,345.9 333.6,349.5 394.5,358.1 455.5,367.1 516.4,373.8 577.3,377.9 638.2,380.6 699.1,381.9 760.0,382.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,376.5 150.9,368.5 211.8,372.0 272.7,359.5 333.6,336.8 394.5,318.0 455.5,296.8 516.4,231.7 577.3,255.5 638.2,209.4 699.1,195.7 760.0,174.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="376.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="368.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="372.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="359.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="336.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="318.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="296.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="231.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="255.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="209.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="195.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.3 150.9,380.7 211.8,377.7 272.7,374.2 333.6,366.3 394.5,357.4 455.5,349.3 516.4,342.4 577.3,333.9 638.2,328.3 699.1,316.6 760.0,272.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,189.1 150.9,185.8 211.8,279.7 272.7,277.5 333.6,285.0 394.5,321.8 455.5,325.5 516.4,352.8 577.3,359.0 638.2,374.6 699.1,378.9 760.0,381.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,330.7 150.9,333.0 211.8,335.0 272.7,347.5 333.6,348.4 394.5,356.1 455.5,367.5 516.4,373.0 577.3,378.0 638.2,380.9 699.1,381.9 760.0,382.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,377.8 150.9,371.3 211.8,370.7 272.7,356.7 333.6,333.3 394.5,320.3 455.5,264.1 516.4,256.1 577.3,178.9 638.2,229.7 699.1,216.2 760.0,227.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="377.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="371.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="370.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="356.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="333.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="320.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="264.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="256.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="178.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="229.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="216.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="227.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.3 150.9,380.7 211.8,377.7 272.7,374.7 333.6,365.8 394.5,355.4 455.5,350.2 516.4,338.9 577.3,335.2 638.2,332.5 699.1,314.8 760.0,276.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="150.9" cy="380.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="211.8" cy="377.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="374.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="366.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="357.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="349.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="342.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="333.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="328.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="316.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="272.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="374.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="365.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="355.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="350.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="338.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="335.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="332.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="314.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="276.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
@@ -131,45 +131,45 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,507.3 150.9,513.4 211.8,510.4 272.7,509.6 333.6,507.2 394.5,507.2 455.5,506.9 516.4,505.0 577.3,501.2 638.2,494.8 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="507.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="513.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="510.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="509.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="506.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,506.9 150.9,504.9 211.8,508.8 272.7,507.2 333.6,505.9 394.5,506.9 455.5,507.2 516.4,505.0 577.3,497.7 638.2,491.8 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="506.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="504.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="508.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="505.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="506.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="516.4" cy="505.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="501.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="494.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="497.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="491.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,569.7 150.9,568.4 211.8,567.8 272.7,566.8 333.6,567.6 394.5,567.6 455.5,567.4 516.4,566.7 577.3,562.6 638.2,561.5 699.1,554.8 760.0,545.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="569.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="568.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="567.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="566.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="567.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="567.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="567.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="566.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="562.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="561.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="554.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="545.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,548.6 150.9,546.4 211.8,548.2 272.7,548.2 333.6,548.8 394.5,548.2 455.5,548.7 516.4,547.0 577.3,547.6 638.2,535.8 699.1,532.6 760.0,523.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="546.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,568.2 150.9,567.2 211.8,568.5 272.7,567.5 333.6,567.7 394.5,567.5 455.5,567.3 516.4,565.0 577.3,562.9 638.2,559.8 699.1,553.8 760.0,545.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="568.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="567.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="568.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="567.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="567.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="567.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="567.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="565.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="562.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="559.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="553.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="545.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,548.3 150.9,544.5 211.8,548.3 272.7,548.2 333.6,548.5 394.5,545.4 455.5,546.5 516.4,545.8 577.3,545.7 638.2,536.0 699.1,529.8 760.0,522.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="548.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="544.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="548.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="272.7" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="548.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="548.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="547.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="547.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="535.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="532.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="523.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="548.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="545.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="546.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="545.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="545.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="536.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="529.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="522.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -3,34 +3,34 @@
   <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback</text>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 12 cores</text>
   <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
   <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
   <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
   <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
   <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
   <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
   <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
   <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
   <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
   <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
   <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
   <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
   <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">7M</text>
   <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
   <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
   <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
   <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">9M</text>
   <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
   <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
   <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
   <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#e5e7eb" stroke-width="1"/>
@@ -48,34 +48,34 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,215.5 150.9,251.6 211.8,314.5 272.7,324.6 333.6,338.4 394.5,327.6 455.5,355.5 516.4,368.5 577.3,373.2 638.2,376.8 699.1,380.3 760.0,382.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,348.7 150.9,350.8 211.8,351.9 272.7,357.7 333.6,362.5 394.5,367.1 455.5,374.1 516.4,378.5 577.3,380.0 638.2,381.9 699.1,382.6 760.0,383.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,373.2 150.9,367.1 211.8,366.2 272.7,353.6 333.6,337.3 394.5,268.5 455.5,267.2 516.4,256.8 577.3,207.6 638.2,147.7 699.1,144.4 760.0,143.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="373.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="367.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="366.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="353.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="337.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="268.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="267.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="256.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="207.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="144.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="143.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,381.7 150.9,379.8 211.8,375.8 272.7,370.5 333.6,362.0 394.5,349.4 455.5,343.5 516.4,339.3 577.3,318.6 638.2,315.0 699.1,295.2 760.0,258.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="381.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="379.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="375.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="370.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="362.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="349.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="343.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="339.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="318.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="315.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="295.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="258.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,149.6 150.9,141.1 211.8,289.9 272.7,288.4 333.6,291.9 394.5,319.5 455.5,341.4 516.4,346.8 577.3,368.3 638.2,373.3 699.1,378.3 760.0,380.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,331.4 150.9,331.7 211.8,334.8 272.7,345.9 333.6,349.5 394.5,358.1 455.5,367.1 516.4,373.8 577.3,377.9 638.2,380.6 699.1,381.9 760.0,382.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,376.5 150.9,368.5 211.8,372.0 272.7,359.5 333.6,336.8 394.5,318.0 455.5,296.8 516.4,231.7 577.3,255.5 638.2,209.4 699.1,195.7 760.0,174.9" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="376.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="368.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="372.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="359.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="336.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="318.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="296.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="231.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="255.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="209.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="195.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,382.3 150.9,380.7 211.8,377.7 272.7,374.2 333.6,366.3 394.5,357.4 455.5,349.3 516.4,342.4 577.3,333.9 638.2,328.3 699.1,316.6 760.0,272.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="380.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="377.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="374.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="366.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="357.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="349.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="342.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="333.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="328.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="316.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="272.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
@@ -131,45 +131,45 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,526.2 150.9,524.5 211.8,522.1 272.7,519.1 333.6,514.4 394.5,513.6 455.5,514.2 516.4,512.7 577.3,506.8 638.2,507.1 699.1,500.4 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="526.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="524.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="522.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="519.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="514.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="513.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="514.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="512.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="506.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="500.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,510.1 150.9,510.7 211.8,511.2 272.7,510.6 333.6,507.1 394.5,509.3 455.5,507.9 516.4,503.8 577.3,496.8 638.2,489.0 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="510.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="510.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="511.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="510.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="509.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="507.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="503.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="496.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,578.6 150.9,576.8 211.8,573.4 272.7,574.1 333.6,570.8 394.5,568.5 455.5,571.8 516.4,573.5 577.3,570.2 638.2,563.9 699.1,562.0 760.0,550.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="578.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="576.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="573.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="574.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="570.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="568.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="571.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="573.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="570.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="563.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="562.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="550.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,563.3 150.9,563.0 211.8,556.3 272.7,559.0 333.6,557.1 394.5,555.9 455.5,552.5 516.4,559.3 577.3,556.1 638.2,547.1 699.1,545.3 760.0,534.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="563.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="563.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="556.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="559.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="557.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="555.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="552.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="559.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="556.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="547.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="545.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="534.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,550.3 150.9,549.9 211.8,552.6 272.7,552.0 333.6,549.0 394.5,547.8 455.5,550.5 516.4,547.7 577.3,547.3 638.2,542.5 699.1,530.6 760.0,519.3" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="550.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="549.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="552.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="552.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="549.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="547.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="550.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="547.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="547.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="542.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="530.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="519.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,549.1 150.9,546.3 211.8,549.0 272.7,546.7 333.6,544.4 394.5,547.9 455.5,548.2 516.4,545.4 577.3,545.9 638.2,536.2 699.1,533.9 760.0,521.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="549.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="549.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="546.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="544.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="547.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="545.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="545.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="536.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="533.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="521.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -1,0 +1,194 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="684" fill="white"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 12 cores</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">12M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">14M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">16M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">18M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="211.8" y1="49" x2="211.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="272.7" y1="49" x2="272.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="333.6" y1="49" x2="333.6" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="394.5" y1="49" x2="394.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="455.5" y1="49" x2="455.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="516.4" y1="49" x2="516.4" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="577.3" y1="49" x2="577.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="638.2" y1="49" x2="638.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="699.1" y1="49" x2="699.1" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,215.5 150.9,251.6 211.8,314.5 272.7,324.6 333.6,338.4 394.5,327.6 455.5,355.5 516.4,368.5 577.3,373.2 638.2,376.8 699.1,380.3 760.0,382.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,348.7 150.9,350.8 211.8,351.9 272.7,357.7 333.6,362.5 394.5,367.1 455.5,374.1 516.4,378.5 577.3,380.0 638.2,381.9 699.1,382.6 760.0,383.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,373.2 150.9,367.1 211.8,366.2 272.7,353.6 333.6,337.3 394.5,268.5 455.5,267.2 516.4,256.8 577.3,207.6 638.2,147.7 699.1,144.4 760.0,143.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="373.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="367.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="366.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="353.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="337.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="268.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="267.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="256.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="207.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="147.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="144.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="143.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,381.7 150.9,379.8 211.8,375.8 272.7,370.5 333.6,362.0 394.5,349.4 455.5,343.5 516.4,339.3 577.3,318.6 638.2,315.0 699.1,295.2 760.0,258.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="379.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="375.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="370.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="362.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="349.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="343.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="339.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="318.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="315.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="295.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="258.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="150.9" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="211.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="272.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="333.6" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="394.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="455.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="516.4" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="577.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="638.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="699.1" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <line x1="255" y1="424" x2="269" y2="424" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="262" cy="424" r="2.5" fill="#f97316"/>
+  <text x="275" y="428" fill="#374151" font-size="11" font-weight="500">OMQ.go hot path</text>
+  <line x1="425" y1="424" x2="439" y2="424" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="432" cy="424" r="2.5" fill="#2563eb"/>
+  <text x="445" y="428" fill="#374151" font-size="11" font-weight="500">zmq4</text>
+  <text x="425.0" y="442" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left), solid = throughput (right)</text>
+  <text x="425.0" y="472" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 us</text>
+  <line x1="90" y1="597.0" x2="760" y2="597.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="597.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 us</text>
+  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 us</text>
+  <line x1="90" y1="573.0" x2="760" y2="573.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="573.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 us</text>
+  <line x1="90" y1="561.0" x2="760" y2="561.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="561.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 us</text>
+  <line x1="90" y1="549.0" x2="760" y2="549.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 us</text>
+  <line x1="90" y1="537.0" x2="760" y2="537.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="537.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 us</text>
+  <line x1="90" y1="525.0" x2="760" y2="525.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="525.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 us</text>
+  <line x1="90" y1="513.0" x2="760" y2="513.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="513.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 us</text>
+  <line x1="90" y1="501.0" x2="760" y2="501.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="501.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 us</text>
+  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 us</text>
+  <line x1="90.0" y1="489" x2="90.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="150.9" y1="489" x2="150.9" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="211.8" y1="489" x2="211.8" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="272.7" y1="489" x2="272.7" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="333.6" y1="489" x2="333.6" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="394.5" y1="489" x2="394.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="455.5" y1="489" x2="455.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="516.4" y1="489" x2="516.4" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="577.3" y1="489" x2="577.3" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="638.2" y1="489" x2="638.2" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="699.1" y1="489" x2="699.1" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="760.0" y1="489" x2="760.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
+  <polyline points="90.0,526.2 150.9,524.5 211.8,522.1 272.7,519.1 333.6,514.4 394.5,513.6 455.5,514.2 516.4,512.7 577.3,506.8 638.2,507.1 699.1,500.4 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="526.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="524.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="522.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="519.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="514.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="513.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="514.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="512.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="506.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="500.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,578.6 150.9,576.8 211.8,573.4 272.7,574.1 333.6,570.8 394.5,568.5 455.5,571.8 516.4,573.5 577.3,570.2 638.2,563.9 699.1,562.0 760.0,550.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="578.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="576.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="573.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="574.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="570.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="568.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="571.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="573.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="570.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="563.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="562.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="550.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,563.3 150.9,563.0 211.8,556.3 272.7,559.0 333.6,557.1 394.5,555.9 455.5,552.5 516.4,559.3 577.3,556.1 638.2,547.1 699.1,545.3 760.0,534.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="563.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="563.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="556.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="559.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="557.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="555.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="552.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="559.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="556.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="547.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="545.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="534.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
+  <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
+  <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
+  <text x="272.7" y="623" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
+  <text x="333.6" y="623" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
+  <text x="394.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
+  <text x="455.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
+  <text x="516.4" y="623" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
+  <text x="577.3" y="623" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
+  <text x="638.2" y="623" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
+  <text x="699.1" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
+  <line x1="170" y1="649" x2="184" y2="649" stroke="#dc2626" stroke-width="2.5"/>
+  <circle cx="177" cy="649" r="2.5" fill="#dc2626"/>
+  <text x="190" y="653" fill="#374151" font-size="11" font-weight="500">OMQ.go scalar</text>
+  <line x1="340" y1="649" x2="354" y2="649" stroke="#f97316" stroke-width="2.5"/>
+  <circle cx="347" cy="649" r="2.5" fill="#f97316"/>
+  <text x="360" y="653" fill="#374151" font-size="11" font-weight="500">OMQ.go Socket.Run</text>
+  <line x1="510" y1="649" x2="524" y2="649" stroke="#2563eb" stroke-width="2.5"/>
+  <circle cx="517" cy="649" r="2.5" fill="#2563eb"/>
+  <text x="530" y="653" fill="#374151" font-size="11" font-weight="500">zmq4</text>
+</svg>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -131,45 +131,45 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,507.1 150.9,505.1 211.8,505.8 272.7,509.9 333.6,509.0 394.5,511.4 455.5,506.9 516.4,502.6 577.3,500.5 638.2,495.0 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="507.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="505.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="505.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="509.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="509.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="511.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,507.3 150.9,513.4 211.8,510.4 272.7,509.6 333.6,507.2 394.5,507.2 455.5,506.9 516.4,505.0 577.3,501.2 638.2,494.8 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="507.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="513.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="510.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="509.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="507.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="455.5" cy="506.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="502.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="500.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="495.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="505.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="501.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="494.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,569.7 150.9,569.8 211.8,569.9 272.7,569.2 333.6,568.8 394.5,568.3 455.5,568.3 516.4,567.9 577.3,563.8 638.2,560.4 699.1,555.4 760.0,545.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,569.7 150.9,568.4 211.8,567.8 272.7,566.8 333.6,567.6 394.5,567.6 455.5,567.4 516.4,566.7 577.3,562.6 638.2,561.5 699.1,554.8 760.0,545.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="569.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="569.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="569.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="569.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="568.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="568.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="568.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="567.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="563.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="560.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="555.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="545.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,550.6 150.9,544.5 211.8,545.6 272.7,546.6 333.6,546.6 394.5,547.7 455.5,546.0 516.4,546.3 577.3,545.1 638.2,536.2 699.1,532.9 760.0,526.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="550.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="544.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="545.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="546.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="546.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="547.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="546.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="546.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="545.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="536.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="532.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="526.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="568.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="567.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="566.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="567.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="567.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="567.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="566.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="562.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="561.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="554.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="545.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,548.6 150.9,546.4 211.8,548.2 272.7,548.2 333.6,548.8 394.5,548.2 455.5,548.7 516.4,547.0 577.3,547.6 638.2,535.8 699.1,532.6 760.0,523.5" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="150.9" cy="546.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="211.8" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="272.7" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="333.6" cy="548.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="394.5" cy="548.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="455.5" cy="548.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="516.4" cy="547.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="577.3" cy="547.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="638.2" cy="535.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="699.1" cy="532.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="523.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
   <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>

--- a/bindings/go/errors.go
+++ b/bindings/go/errors.go
@@ -1,0 +1,60 @@
+package omq
+
+import "errors"
+
+var (
+	ErrAgain      = errors.New("omq: operation would block")
+	ErrClosed     = errors.New("omq: closed")
+	ErrTimeout    = errors.New("omq: operation timed out")
+	ErrCanceled   = errors.New("omq: operation canceled")
+	ErrUnroutable = errors.New("omq: no route to peer")
+)
+
+type Error struct {
+	Err string
+}
+
+func (e *Error) Error() string {
+	return "omq: " + e.Err
+}
+
+type EndpointError struct {
+	Op  string
+	Err string
+}
+
+func (e *EndpointError) Error() string {
+	return "omq: " + e.Op + ": " + e.Err
+}
+
+type ProtocolError struct {
+	Err string
+}
+
+func (e *ProtocolError) Error() string {
+	return "omq: protocol: " + e.Err
+}
+
+type ConfigError struct {
+	Err string
+}
+
+func (e *ConfigError) Error() string {
+	return "omq: config: " + e.Err
+}
+
+type TransportError struct {
+	Err string
+}
+
+func (e *TransportError) Error() string {
+	return "omq: transport: " + e.Err
+}
+
+type MessageTooLargeError struct {
+	Err string
+}
+
+func (e *MessageTooLargeError) Error() string {
+	return "omq: message too large: " + e.Err
+}

--- a/bindings/go/errors.go
+++ b/bindings/go/errors.go
@@ -2,6 +2,7 @@ package omq
 
 import "errors"
 
+// ErrAgain reports that a nonblocking operation would block.
 var (
 	ErrAgain      = errors.New("omq: operation would block")
 	ErrClosed     = errors.New("omq: closed")
@@ -10,7 +11,9 @@ var (
 	ErrUnroutable = errors.New("omq: no route to peer")
 )
 
+// Error is a generic OMQ error.
 type Error struct {
+	// Err is the native error detail.
 	Err string
 }
 
@@ -18,8 +21,11 @@ func (e *Error) Error() string {
 	return "omq: " + e.Err
 }
 
+// EndpointError reports endpoint parsing or scheme errors.
 type EndpointError struct {
-	Op  string
+	// Op is the endpoint operation.
+	Op string
+	// Err is the endpoint error detail.
 	Err string
 }
 
@@ -27,7 +33,9 @@ func (e *EndpointError) Error() string {
 	return "omq: " + e.Op + ": " + e.Err
 }
 
+// ProtocolError reports socket type or ZMTP protocol violations.
 type ProtocolError struct {
+	// Err is the protocol error detail.
 	Err string
 }
 
@@ -35,7 +43,9 @@ func (e *ProtocolError) Error() string {
 	return "omq: protocol: " + e.Err
 }
 
+// ConfigError reports invalid configuration.
 type ConfigError struct {
+	// Err is the config error detail.
 	Err string
 }
 
@@ -43,7 +53,9 @@ func (e *ConfigError) Error() string {
 	return "omq: config: " + e.Err
 }
 
+// TransportError reports transport I/O errors.
 type TransportError struct {
+	// Err is the transport error detail.
 	Err string
 }
 
@@ -51,7 +63,9 @@ func (e *TransportError) Error() string {
 	return "omq: transport: " + e.Err
 }
 
+// MessageTooLargeError reports a message size limit violation.
 type MessageTooLargeError struct {
+	// Err is the message size error detail.
 	Err string
 }
 

--- a/bindings/go/exceptions_test.go
+++ b/bindings/go/exceptions_test.go
@@ -1,0 +1,68 @@
+package omq
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEndpointErrorsAreTyped(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	if _, err := pull.Bind("not-an-endpoint"); !isEndpointError(err) {
+		t.Fatalf("Bind err = %v, want EndpointError", err)
+	}
+	if err := pull.Connect("nosuch://host"); !isEndpointError(err) {
+		t.Fatalf("Connect err = %v, want EndpointError", err)
+	}
+}
+
+func TestClosedSocketReturnsTypedError(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	closeSocket(t, pull)
+	if _, err := pull.RecvTimeout(time.Millisecond); !errors.Is(err, ErrClosed) {
+		t.Fatalf("RecvTimeout err = %v, want ErrClosed", err)
+	}
+}
+
+func TestMaxMessageSizeDropsOversizedReceive(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull, err := ctx.Socket(Pull, MaxMessageSize(8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("too-large-message"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pull.RecvTimeout(200 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+}
+
+func isEndpointError(err error) bool {
+	var endpoint *EndpointError
+	return errors.As(err, &endpoint)
+}

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/paddor/omq.rs/bindings/go
+
+go 1.22

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/paddor/omq.rs/bindings/go
 
-go 1.22
+go 1.25

--- a/bindings/go/inproc_test.go
+++ b/bindings/go/inproc_test.go
@@ -1,0 +1,62 @@
+package omq
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInprocNamesAreContextLocal(t *testing.T) {
+	endpoint := "inproc://go-isolated"
+	a := openTestContext(t)
+	defer closeContext(t, a)
+	b := openTestContext(t)
+	defer closeContext(t, b)
+
+	pull := newTestSocket(t, a, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, b, Push)
+	defer closeSocket(t, push)
+
+	if _, err := pull.Bind(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	_ = push.SendTimeout(String("hidden"), 50*time.Millisecond)
+	if _, err := pull.RecvTimeout(100 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestInprocWorksAcrossSharedContexts(t *testing.T) {
+	owner := openTestContext(t)
+	defer closeContext(t, owner)
+	key, err := owner.ShareKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, err := OpenShared(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeContext(t, shared)
+
+	pull := newTestSocket(t, owner, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, shared, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-shared-contexts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("visible"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	assertRecvString(t, pull, "visible")
+}

--- a/bindings/go/message.go
+++ b/bindings/go/message.go
@@ -24,6 +24,17 @@ func Multipart(parts ...[]byte) Message {
 	return NewMessage(parts...)
 }
 
+func Group(group string, body []byte) Message {
+	return Multipart([]byte(group), body)
+}
+
+func Route(identity []byte, body Message) Message {
+	parts := make([][]byte, 0, len(body.parts)+1)
+	parts = append(parts, identity)
+	parts = append(parts, body.parts...)
+	return NewMessage(parts...)
+}
+
 func (m Message) Parts() [][]byte {
 	out := make([][]byte, len(m.parts))
 	for i, part := range m.parts {
@@ -37,18 +48,38 @@ func (m Message) partsView() [][]byte {
 }
 
 func (m Message) Bytes() []byte {
+	part := m.Part(0)
+	return part
+}
+
+func (m Message) Part(index int) []byte {
 	if len(m.parts) == 0 {
 		return nil
 	}
-	return m.parts[0]
+	return append([]byte(nil), m.parts[index]...)
 }
 
 func (m Message) String() string {
-	return string(m.Bytes())
+	if len(m.parts) == 0 {
+		return ""
+	}
+	return string(m.parts[0])
 }
 
 func (m Message) Len() int {
 	return len(m.parts)
+}
+
+func (m Message) IsMultipart() bool {
+	return len(m.parts) > 1
+}
+
+func (m Message) ByteLen() int {
+	var total int
+	for _, part := range m.parts {
+		total += len(part)
+	}
+	return total
 }
 
 func (m Message) Empty() bool {

--- a/bindings/go/message.go
+++ b/bindings/go/message.go
@@ -1,0 +1,52 @@
+package omq
+
+type Message struct {
+	parts [][]byte
+}
+
+func NewMessage(parts ...[]byte) Message {
+	out := Message{parts: make([][]byte, len(parts))}
+	for i, part := range parts {
+		out.parts[i] = append([]byte(nil), part...)
+	}
+	return out
+}
+
+func Bytes(data []byte) Message {
+	return NewMessage(data)
+}
+
+func String(data string) Message {
+	return NewMessage([]byte(data))
+}
+
+func Multipart(parts ...[]byte) Message {
+	return NewMessage(parts...)
+}
+
+func (m Message) Parts() [][]byte {
+	out := make([][]byte, len(m.parts))
+	for i, part := range m.parts {
+		out[i] = append([]byte(nil), part...)
+	}
+	return out
+}
+
+func (m Message) Bytes() []byte {
+	if len(m.parts) == 0 {
+		return nil
+	}
+	return append([]byte(nil), m.parts[0]...)
+}
+
+func (m Message) String() string {
+	return string(m.Bytes())
+}
+
+func (m Message) Len() int {
+	return len(m.parts)
+}
+
+func (m Message) Empty() bool {
+	return len(m.parts) == 0
+}

--- a/bindings/go/message.go
+++ b/bindings/go/message.go
@@ -52,11 +52,26 @@ func (m Message) Bytes() []byte {
 	return part
 }
 
+func (m Message) BytesOK() ([]byte, bool) {
+	if len(m.parts) != 1 {
+		return nil, false
+	}
+	return append([]byte(nil), m.parts[0]...), true
+}
+
 func (m Message) Part(index int) []byte {
-	if len(m.parts) == 0 {
+	part, ok := m.PartOK(index)
+	if !ok {
 		return nil
 	}
-	return append([]byte(nil), m.parts[index]...)
+	return part
+}
+
+func (m Message) PartOK(index int) ([]byte, bool) {
+	if index < 0 || index >= len(m.parts) {
+		return nil, false
+	}
+	return append([]byte(nil), m.parts[index]...), true
 }
 
 func (m Message) String() string {
@@ -84,4 +99,47 @@ func (m Message) ByteLen() int {
 
 func (m Message) Empty() bool {
 	return len(m.parts) == 0
+}
+
+func (m Message) Route() []byte {
+	return m.Part(0)
+}
+
+func (m Message) RouteOK() ([]byte, bool) {
+	return m.PartOK(0)
+}
+
+func (m Message) Group() string {
+	group, ok := m.GroupOK()
+	if !ok {
+		return ""
+	}
+	return group
+}
+
+func (m Message) GroupOK() (string, bool) {
+	part, ok := m.PartOK(0)
+	if !ok {
+		return "", false
+	}
+	return string(part), true
+}
+
+func (m Message) Body() Message {
+	if len(m.parts) <= 1 {
+		return Message{}
+	}
+	return NewMessage(m.parts[1:]...)
+}
+
+func (m Message) Equal(other Message) bool {
+	if len(m.parts) != len(other.parts) {
+		return false
+	}
+	for i, part := range m.parts {
+		if string(part) != string(other.parts[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/bindings/go/message.go
+++ b/bindings/go/message.go
@@ -32,11 +32,15 @@ func (m Message) Parts() [][]byte {
 	return out
 }
 
+func (m Message) partsView() [][]byte {
+	return m.parts
+}
+
 func (m Message) Bytes() []byte {
 	if len(m.parts) == 0 {
 		return nil
 	}
-	return append([]byte(nil), m.parts[0]...)
+	return m.parts[0]
 }
 
 func (m Message) String() string {

--- a/bindings/go/message.go
+++ b/bindings/go/message.go
@@ -1,9 +1,11 @@
 package omq
 
+// Message is an immutable OMQ message with zero or more parts.
 type Message struct {
 	parts [][]byte
 }
 
+// NewMessage copies parts into a message.
 func NewMessage(parts ...[]byte) Message {
 	out := Message{parts: make([][]byte, len(parts))}
 	for i, part := range parts {
@@ -12,22 +14,27 @@ func NewMessage(parts ...[]byte) Message {
 	return out
 }
 
+// Bytes creates a single-part binary message.
 func Bytes(data []byte) Message {
 	return NewMessage(data)
 }
 
+// String creates a single-part UTF-8 message.
 func String(data string) Message {
 	return NewMessage([]byte(data))
 }
 
+// Multipart creates a multipart message.
 func Multipart(parts ...[]byte) Message {
 	return NewMessage(parts...)
 }
 
+// Group creates a RADIO/DISH group message.
 func Group(group string, body []byte) Message {
 	return Multipart([]byte(group), body)
 }
 
+// Route prefixes a message with a routing identity.
 func Route(identity []byte, body Message) Message {
 	parts := make([][]byte, 0, len(body.parts)+1)
 	parts = append(parts, identity)
@@ -35,6 +42,7 @@ func Route(identity []byte, body Message) Message {
 	return NewMessage(parts...)
 }
 
+// Parts returns copies of all message parts.
 func (m Message) Parts() [][]byte {
 	out := make([][]byte, len(m.parts))
 	for i, part := range m.parts {
@@ -47,11 +55,13 @@ func (m Message) partsView() [][]byte {
 	return m.parts
 }
 
+// Bytes returns a copy of the first part.
 func (m Message) Bytes() []byte {
 	part := m.Part(0)
 	return part
 }
 
+// BytesOK returns the single part when the message has exactly one part.
 func (m Message) BytesOK() ([]byte, bool) {
 	if len(m.parts) != 1 {
 		return nil, false
@@ -59,6 +69,7 @@ func (m Message) BytesOK() ([]byte, bool) {
 	return append([]byte(nil), m.parts[0]...), true
 }
 
+// Part returns a copy of one part or nil when index is out of range.
 func (m Message) Part(index int) []byte {
 	part, ok := m.PartOK(index)
 	if !ok {
@@ -67,6 +78,7 @@ func (m Message) Part(index int) []byte {
 	return part
 }
 
+// PartOK returns a copy of one part and whether it exists.
 func (m Message) PartOK(index int) ([]byte, bool) {
 	if index < 0 || index >= len(m.parts) {
 		return nil, false
@@ -74,6 +86,7 @@ func (m Message) PartOK(index int) ([]byte, bool) {
 	return append([]byte(nil), m.parts[index]...), true
 }
 
+// String decodes the first part as UTF-8 text.
 func (m Message) String() string {
 	if len(m.parts) == 0 {
 		return ""
@@ -81,14 +94,17 @@ func (m Message) String() string {
 	return string(m.parts[0])
 }
 
+// Len returns the number of parts.
 func (m Message) Len() int {
 	return len(m.parts)
 }
 
+// IsMultipart reports whether the message has more than one part.
 func (m Message) IsMultipart() bool {
 	return len(m.parts) > 1
 }
 
+// ByteLen returns the total bytes across all parts.
 func (m Message) ByteLen() int {
 	var total int
 	for _, part := range m.parts {
@@ -97,18 +113,22 @@ func (m Message) ByteLen() int {
 	return total
 }
 
+// Empty reports whether the message has no parts.
 func (m Message) Empty() bool {
 	return len(m.parts) == 0
 }
 
+// Route returns the first part as a routing identity.
 func (m Message) Route() []byte {
 	return m.Part(0)
 }
 
+// RouteOK returns the routing identity and whether it exists.
 func (m Message) RouteOK() ([]byte, bool) {
 	return m.PartOK(0)
 }
 
+// Group returns the first part as a group name.
 func (m Message) Group() string {
 	group, ok := m.GroupOK()
 	if !ok {
@@ -117,6 +137,7 @@ func (m Message) Group() string {
 	return group
 }
 
+// GroupOK returns the group name and whether it exists.
 func (m Message) GroupOK() (string, bool) {
 	part, ok := m.PartOK(0)
 	if !ok {
@@ -125,6 +146,7 @@ func (m Message) GroupOK() (string, bool) {
 	return string(part), true
 }
 
+// Body returns all parts after the first part.
 func (m Message) Body() Message {
 	if len(m.parts) <= 1 {
 		return Message{}
@@ -132,6 +154,7 @@ func (m Message) Body() Message {
 	return NewMessage(m.parts[1:]...)
 }
 
+// Equal reports whether two messages have identical parts.
 func (m Message) Equal(other Message) bool {
 	if len(m.parts) != len(other.parts) {
 		return false

--- a/bindings/go/message_test.go
+++ b/bindings/go/message_test.go
@@ -1,0 +1,57 @@
+package omq
+
+import "testing"
+
+func TestMessageAccessorsAreBoundsSafe(t *testing.T) {
+	msg := Multipart([]byte("route"), []byte("body"))
+
+	if part, ok := msg.PartOK(-1); ok || part != nil {
+		t.Fatalf("PartOK(-1) = %q/%v, want nil/false", part, ok)
+	}
+	if part, ok := msg.PartOK(2); ok || part != nil {
+		t.Fatalf("PartOK(2) = %q/%v, want nil/false", part, ok)
+	}
+	if part := msg.Part(2); part != nil {
+		t.Fatalf("Part(2) = %q, want nil", part)
+	}
+	if _, ok := msg.BytesOK(); ok {
+		t.Fatal("BytesOK succeeded for multipart message")
+	}
+}
+
+func TestMessageRouteGroupBodyAndEquality(t *testing.T) {
+	body := Multipart([]byte("a"), []byte("b"))
+	routed := Route([]byte("worker-1"), body)
+
+	route, ok := routed.RouteOK()
+	if !ok || string(route) != "worker-1" {
+		t.Fatalf("route = %q/%v, want worker-1/true", route, ok)
+	}
+	if !routed.Body().Equal(body) {
+		t.Fatalf("body = %#v, want %#v", routed.Body().Parts(), body.Parts())
+	}
+
+	grouped := Group("weather", []byte("rain"))
+	group, ok := grouped.GroupOK()
+	if !ok || group != "weather" {
+		t.Fatalf("group = %q/%v, want weather/true", group, ok)
+	}
+	if grouped.Group() != "weather" {
+		t.Fatalf("Group = %q, want weather", grouped.Group())
+	}
+	if got := grouped.Body().String(); got != "rain" {
+		t.Fatalf("body = %q, want rain", got)
+	}
+}
+
+func TestMessageSinglePartBytesOKCopies(t *testing.T) {
+	msg := String("copy")
+	bytes, ok := msg.BytesOK()
+	if !ok || string(bytes) != "copy" {
+		t.Fatalf("BytesOK = %q/%v, want copy/true", bytes, ok)
+	}
+	bytes[0] = 'x'
+	if got := msg.String(); got != "copy" {
+		t.Fatalf("message = %q, want copy", got)
+	}
+}

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -1,0 +1,92 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+type Monitor struct {
+	handle *nativeMonitor
+	closed atomic.Bool
+}
+
+type MonitorEvent struct {
+	Kind         string
+	Endpoint     string
+	PeerIdent    string
+	Reason       string
+	CommandName  string
+	Data         []byte
+	ConnectionID uint64
+	Retry        time.Duration
+	Attempt      uint32
+}
+
+func (s *Socket) Monitor() (*Monitor, error) {
+	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return monitorNewNative(handle)
+	})
+	if err != nil {
+		return nil, err
+	}
+	monitor := &Monitor{handle: value.(*nativeMonitor)}
+	runtime.SetFinalizer(monitor, (*Monitor).free)
+	keepAlive(s)
+	return monitor, nil
+}
+
+func (m *Monitor) Recv(ctx context.Context) (MonitorEvent, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return MonitorEvent{}, err
+		}
+		event, err := m.TryRecv()
+		if err == nil {
+			return event, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return MonitorEvent{}, err
+		}
+		timer := time.NewTimer(retryDelay(i))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return MonitorEvent{}, errFromContext(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+func (m *Monitor) TryRecv() (MonitorEvent, error) {
+	if m == nil || m.handle == nil || m.closed.Load() {
+		return MonitorEvent{}, ErrClosed
+	}
+	event, err := monitorRecvNative(m.handle)
+	keepAlive(m)
+	return event, err
+}
+
+func (m *Monitor) Close() {
+	if m == nil || m.handle == nil {
+		return
+	}
+	if m.closed.Swap(true) {
+		return
+	}
+	monitorCloseNative(m.handle)
+	keepAlive(m)
+}
+
+func (m *Monitor) free() {
+	if m == nil || m.handle == nil {
+		return
+	}
+	monitorFreeNative(m.handle)
+	m.handle = nil
+}

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -17,6 +17,8 @@ type MonitorEvent struct {
 	Kind         string
 	Endpoint     string
 	PeerIdent    string
+	Peer         PeerInfo
+	HasPeer      bool
 	Reason       string
 	CommandName  string
 	Data         []byte

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -53,14 +53,22 @@ func (m *Monitor) Recv(ctx context.Context) (MonitorEvent, error) {
 		if !errors.Is(err, ErrAgain) {
 			return MonitorEvent{}, err
 		}
-		timer := time.NewTimer(retryDelay(i))
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return MonitorEvent{}, errFromContext(ctx)
-		case <-timer.C:
+		if err := waitRetry(ctx, i); err != nil {
+			return MonitorEvent{}, err
 		}
 	}
+}
+
+func (m *Monitor) RecvTimeout(timeout time.Duration) (MonitorEvent, error) {
+	if timeout == 0 {
+		return m.TryRecv()
+	}
+	if timeout < 0 {
+		return m.Recv(context.Background())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return m.Recv(ctx)
 }
 
 func (m *Monitor) TryRecv() (MonitorEvent, error) {

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -11,6 +11,11 @@ import (
 
 // Monitor receives native socket monitor events.
 type Monitor struct {
+	state   *monitorState
+	cleanup runtime.Cleanup
+}
+
+type monitorState struct {
 	handle *nativeMonitor
 	mu     sync.Mutex
 	closed atomic.Bool
@@ -50,8 +55,9 @@ func (s *Socket) Monitor() (*Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	monitor := &Monitor{handle: value.(*nativeMonitor)}
-	runtime.SetFinalizer(monitor, (*Monitor).free)
+	state := &monitorState{handle: value.(*nativeMonitor)}
+	monitor := &Monitor{state: state}
+	monitor.cleanup = runtime.AddCleanup(monitor, cleanupMonitorState, state)
 	keepAlive(s)
 	return monitor, nil
 }
@@ -93,37 +99,52 @@ func (m *Monitor) RecvTimeout(timeout time.Duration) (MonitorEvent, error) {
 
 // TryRecv receives a monitor event without waiting.
 func (m *Monitor) TryRecv() (MonitorEvent, error) {
-	if m == nil {
+	state := m.stateOrNil()
+	if state == nil {
 		return MonitorEvent{}, ErrClosed
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.handle == nil || m.closed.Load() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.handle == nil || state.closed.Load() {
 		return MonitorEvent{}, ErrClosed
 	}
-	event, err := monitorRecvNative(m.handle)
+	event, err := monitorRecvNative(state.handle)
 	keepAlive(m)
 	return event, err
 }
 
 // Close closes the monitor stream.
 func (m *Monitor) Close() {
-	if m == nil {
+	state := m.stateOrNil()
+	if state == nil {
 		return
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed.Swap(true) {
-		return
-	}
-	if m.handle != nil {
-		monitorFreeNative(m.handle)
-		m.handle = nil
-	}
-	runtime.SetFinalizer(m, nil)
+	state.close()
+	m.cleanup.Stop()
 	keepAlive(m)
 }
 
-func (m *Monitor) free() {
-	m.Close()
+func (m *Monitor) stateOrNil() *monitorState {
+	if m == nil {
+		return nil
+	}
+	return m.state
+}
+
+func cleanupMonitorState(state *monitorState) {
+	if state != nil {
+		state.close()
+	}
+}
+
+func (state *monitorState) close() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.closed.Swap(true) {
+		return
+	}
+	if state.handle != nil {
+		monitorFreeNative(state.handle)
+		state.handle = nil
+	}
 }

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -8,25 +8,39 @@ import (
 	"time"
 )
 
+// Monitor receives native socket monitor events.
 type Monitor struct {
 	handle *nativeMonitor
 	closed atomic.Bool
 }
 
+// MonitorEvent describes one native monitor event.
 type MonitorEvent struct {
-	Kind         string
-	Endpoint     string
-	PeerIdent    string
-	Peer         PeerInfo
-	HasPeer      bool
-	Reason       string
-	CommandName  string
-	Data         []byte
+	// Kind is the native monitor event name.
+	Kind string
+	// Endpoint is the endpoint associated with the event.
+	Endpoint string
+	// PeerIdent is the native peer identifier when present.
+	PeerIdent string
+	// Peer is peer metadata when HasPeer is true.
+	Peer PeerInfo
+	// HasPeer reports whether Peer is populated.
+	HasPeer bool
+	// Reason is error or disconnect detail when present.
+	Reason string
+	// CommandName is the peer command name when present.
+	CommandName string
+	// Data is event payload bytes when present.
+	Data []byte
+	// ConnectionID is the native connection id when present.
 	ConnectionID uint64
-	Retry        time.Duration
-	Attempt      uint32
+	// Retry is reconnect delay when present.
+	Retry time.Duration
+	// Attempt is reconnect attempt count when present.
+	Attempt uint32
 }
 
+// Monitor opens a monitor stream for this socket.
 func (s *Socket) Monitor() (*Monitor, error) {
 	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
 		return monitorNewNative(handle)
@@ -40,6 +54,7 @@ func (s *Socket) Monitor() (*Monitor, error) {
 	return monitor, nil
 }
 
+// Recv receives the next monitor event.
 func (m *Monitor) Recv(ctx context.Context) (MonitorEvent, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -61,6 +76,7 @@ func (m *Monitor) Recv(ctx context.Context) (MonitorEvent, error) {
 	}
 }
 
+// RecvTimeout receives a monitor event with timeout semantics.
 func (m *Monitor) RecvTimeout(timeout time.Duration) (MonitorEvent, error) {
 	if timeout == 0 {
 		return m.TryRecv()
@@ -73,6 +89,7 @@ func (m *Monitor) RecvTimeout(timeout time.Duration) (MonitorEvent, error) {
 	return m.Recv(ctx)
 }
 
+// TryRecv receives a monitor event without waiting.
 func (m *Monitor) TryRecv() (MonitorEvent, error) {
 	if m == nil || m.handle == nil || m.closed.Load() {
 		return MonitorEvent{}, ErrClosed
@@ -82,6 +99,7 @@ func (m *Monitor) TryRecv() (MonitorEvent, error) {
 	return event, err
 }
 
+// Close closes the monitor stream.
 func (m *Monitor) Close() {
 	if m == nil || m.handle == nil {
 		return

--- a/bindings/go/monitor.go
+++ b/bindings/go/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -11,6 +12,7 @@ import (
 // Monitor receives native socket monitor events.
 type Monitor struct {
 	handle *nativeMonitor
+	mu     sync.Mutex
 	closed atomic.Bool
 }
 
@@ -91,7 +93,12 @@ func (m *Monitor) RecvTimeout(timeout time.Duration) (MonitorEvent, error) {
 
 // TryRecv receives a monitor event without waiting.
 func (m *Monitor) TryRecv() (MonitorEvent, error) {
-	if m == nil || m.handle == nil || m.closed.Load() {
+	if m == nil {
+		return MonitorEvent{}, ErrClosed
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.handle == nil || m.closed.Load() {
 		return MonitorEvent{}, ErrClosed
 	}
 	event, err := monitorRecvNative(m.handle)
@@ -101,20 +108,22 @@ func (m *Monitor) TryRecv() (MonitorEvent, error) {
 
 // Close closes the monitor stream.
 func (m *Monitor) Close() {
-	if m == nil || m.handle == nil {
+	if m == nil {
 		return
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.closed.Swap(true) {
 		return
 	}
-	monitorCloseNative(m.handle)
+	if m.handle != nil {
+		monitorFreeNative(m.handle)
+		m.handle = nil
+	}
+	runtime.SetFinalizer(m, nil)
 	keepAlive(m)
 }
 
 func (m *Monitor) free() {
-	if m == nil || m.handle == nil {
-		return
-	}
-	monitorFreeNative(m.handle)
-	m.handle = nil
+	m.Close()
 }

--- a/bindings/go/monitor_test.go
+++ b/bindings/go/monitor_test.go
@@ -38,6 +38,18 @@ func TestMonitorHandshakeEvent(t *testing.T) {
 	if event.Endpoint != endpoint {
 		t.Fatalf("event endpoint = %q, want %q", event.Endpoint, endpoint)
 	}
+	if !event.HasPeer {
+		t.Fatal("monitor event has no peer info")
+	}
+	if event.Peer.SocketType != "PUSH" {
+		t.Fatalf("peer socket type = %q, want PUSH", event.Peer.SocketType)
+	}
+	if string(event.Peer.Identity) != "push-id" {
+		t.Fatalf("peer identity = %q, want push-id", event.Peer.Identity)
+	}
+	if event.Peer.ZMTPMajor != 3 || event.Peer.ZMTPMinor == 0 {
+		t.Fatalf("ZMTP version = %d.%d, want 3.x", event.Peer.ZMTPMajor, event.Peer.ZMTPMinor)
+	}
 }
 
 func TestMonitorTimeoutAndClose(t *testing.T) {

--- a/bindings/go/monitor_test.go
+++ b/bindings/go/monitor_test.go
@@ -1,0 +1,82 @@
+package omq
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMonitorHandshakeEvent(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push, err := ctx.Socket(Push, Identity([]byte("push-id")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+	monitor, err := pull.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer monitor.Close()
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	event := receiveMonitorKind(t, monitor, "HANDSHAKE_SUCCEEDED")
+	if event.Endpoint != endpoint {
+		t.Fatalf("event endpoint = %q, want %q", event.Endpoint, endpoint)
+	}
+}
+
+func TestMonitorTimeoutAndClose(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	monitor, err := pull.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := monitor.TryRecv(); !errors.Is(err, ErrAgain) {
+		t.Fatalf("TryRecv err = %v, want ErrAgain", err)
+	}
+	if _, err := monitor.RecvTimeout(time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+	monitor.Close()
+	if _, err := monitor.TryRecv(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("TryRecv after close err = %v, want ErrClosed", err)
+	}
+}
+
+func receiveMonitorKind(t *testing.T, monitor *Monitor, kind string) MonitorEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		event, err := monitor.RecvTimeout(200 * time.Millisecond)
+		if errors.Is(err, ErrTimeout) || errors.Is(err, ErrAgain) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if event.Kind == kind {
+			return event
+		}
+	}
+	t.Fatalf("timed out waiting for monitor event %s", kind)
+	return MonitorEvent{}
+}

--- a/bindings/go/monitor_test.go
+++ b/bindings/go/monitor_test.go
@@ -1,6 +1,7 @@
 package omq
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -71,6 +72,35 @@ func TestMonitorTimeoutAndClose(t *testing.T) {
 	monitor.Close()
 	if _, err := monitor.TryRecv(); !errors.Is(err, ErrClosed) {
 		t.Fatalf("TryRecv after close err = %v, want ErrClosed", err)
+	}
+	monitor.Close()
+}
+
+func TestMonitorConcurrentCloseAndRecv(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	monitor, err := pull.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := monitor.Recv(context.Background())
+		errCh <- err
+	}()
+	time.Sleep(time.Millisecond)
+	monitor.Close()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("Monitor Recv err = %v, want ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Monitor Recv did not unblock after close")
 	}
 }
 

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -744,11 +744,22 @@ func eventFromC(raw C.OmqGoEvent) MonitorEvent {
 		Kind:         goString(raw.kind),
 		Endpoint:     goString(raw.endpoint),
 		PeerIdent:    goString(raw.peer_ident),
+		HasPeer:      raw.has_peer != 0,
 		Reason:       goString(raw.reason),
 		CommandName:  goString(raw.command_name),
 		ConnectionID: uint64(raw.connection_id),
 		Retry:        time.Duration(uint64(raw.retry_millis)) * time.Millisecond,
 		Attempt:      uint32(raw.attempt),
+	}
+	if ev.HasPeer {
+		ev.Peer = PeerInfo{
+			Identity:     copyFromCPtr(raw.peer_identity, raw.peer_identity_len),
+			ConnectionID: uint64(raw.connection_id),
+			PeerAddress:  goString(raw.peer_address),
+			SocketType:   goString(raw.peer_socket_type),
+			ZMTPMajor:    uint8(raw.zmtp_major),
+			ZMTPMinor:    uint8(raw.zmtp_minor),
+		}
 	}
 	if raw.data != nil && raw.data_len > 0 {
 		ev.Data = copyFromCPtr(raw.data, raw.data_len)

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -1,0 +1,429 @@
+package omq
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/native/include
+#cgo linux LDFLAGS: -L${SRCDIR}/native/target/release -L${SRCDIR}/native/target/debug -lomq_go -Wl,-rpath,${SRCDIR}/native/target/release -Wl,-rpath,${SRCDIR}/native/target/debug
+#cgo darwin LDFLAGS: -L${SRCDIR}/native/target/release -L${SRCDIR}/native/target/debug -lomq_go -Wl,-rpath,${SRCDIR}/native/target/release -Wl,-rpath,${SRCDIR}/native/target/debug
+#include "omq_go.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+type nativeContext = C.OmqGoContext
+type nativeSocket = C.OmqGoSocket
+type nativeMonitor = C.OmqGoMonitor
+
+func statusErr(status C.OmqGoStatus) error {
+	if status.code == C.OMQ_GO_OK {
+		return nil
+	}
+	msg := "omq error"
+	if status.message != nil {
+		msg = C.GoString(status.message)
+		C.omq_go_string_free(status.message)
+	}
+	switch status.code {
+	case C.OMQ_GO_AGAIN:
+		return ErrAgain
+	case C.OMQ_GO_CLOSED:
+		return ErrClosed
+	case C.OMQ_GO_TIMEOUT:
+		return ErrTimeout
+	case C.OMQ_GO_CANCELED:
+		return ErrCanceled
+	case C.OMQ_GO_INVALID_ENDPOINT:
+		return &EndpointError{Op: "endpoint", Err: msg}
+	case C.OMQ_GO_UNSUPPORTED_SCHEME:
+		return &EndpointError{Op: "scheme", Err: msg}
+	case C.OMQ_GO_PROTOCOL:
+		return &ProtocolError{Err: msg}
+	case C.OMQ_GO_CONFIG:
+		return &ConfigError{Err: msg}
+	case C.OMQ_GO_IO:
+		return &TransportError{Err: msg}
+	case C.OMQ_GO_UNROUTABLE:
+		return ErrUnroutable
+	case C.OMQ_GO_MESSAGE_TOO_LARGE:
+		return &MessageTooLargeError{Err: msg}
+	default:
+		return &Error{Err: msg}
+	}
+}
+
+func contextOpenNative(ioThreads int) (*nativeContext, error) {
+	var out *C.OmqGoContext
+	err := statusErr(C.omq_go_context_open(C.size_t(ioThreads), &out))
+	if err != nil {
+		return nil, err
+	}
+	return (*nativeContext)(out), nil
+}
+
+func contextFromShareKeyNative(key ShareKey) (*nativeContext, error) {
+	var out *C.OmqGoContext
+	err := statusErr(C.omq_go_context_from_share_key(C.uint64_t(key.High), C.uint64_t(key.Low), &out))
+	if err != nil {
+		return nil, err
+	}
+	return (*nativeContext)(out), nil
+}
+
+func contextShareKeyNative(ctx *nativeContext) (ShareKey, error) {
+	var high C.uint64_t
+	var low C.uint64_t
+	err := statusErr(C.omq_go_context_share_key((*C.OmqGoContext)(ctx), &high, &low))
+	if err != nil {
+		return ShareKey{}, err
+	}
+	return ShareKey{High: uint64(high), Low: uint64(low)}, nil
+}
+
+func contextCloseNative(ctx *nativeContext) {
+	C.omq_go_context_close((*C.OmqGoContext)(ctx))
+}
+
+func contextFreeNative(ctx *nativeContext) {
+	C.omq_go_context_free((*C.OmqGoContext)(ctx))
+}
+
+func socketNewNative(ctx *nativeContext, socketType SocketType) (*nativeSocket, error) {
+	var out *C.OmqGoSocket
+	err := statusErr(C.omq_go_socket_new((*C.OmqGoContext)(ctx), C.int32_t(socketType), &out))
+	if err != nil {
+		return nil, err
+	}
+	return (*nativeSocket)(out), nil
+}
+
+func socketBindNative(socket *nativeSocket, endpoint string) (string, error) {
+	cEndpoint := C.CString(endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	var bound *C.char
+	err := statusErr(C.omq_go_socket_bind((*C.OmqGoSocket)(socket), cEndpoint, &bound))
+	if err != nil {
+		return "", err
+	}
+	if bound == nil {
+		return endpoint, nil
+	}
+	defer C.omq_go_string_free(bound)
+	return C.GoString(bound), nil
+}
+
+func socketConnectNative(socket *nativeSocket, endpoint string) error {
+	cEndpoint := C.CString(endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	return statusErr(C.omq_go_socket_connect((*C.OmqGoSocket)(socket), cEndpoint))
+}
+
+func socketUnbindNative(socket *nativeSocket, endpoint string) error {
+	cEndpoint := C.CString(endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	return statusErr(C.omq_go_socket_unbind((*C.OmqGoSocket)(socket), cEndpoint))
+}
+
+func socketDisconnectNative(socket *nativeSocket, endpoint string) error {
+	cEndpoint := C.CString(endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	return statusErr(C.omq_go_socket_disconnect((*C.OmqGoSocket)(socket), cEndpoint))
+}
+
+func socketMessageSendNative(socket *nativeSocket, msg Message) error {
+	parts, count, free := messageToC(msg)
+	defer free()
+	return statusErr(C.omq_go_socket_send((*C.OmqGoSocket)(socket), parts, count, 0))
+}
+
+func socketMessagesTrySendNative(socket *nativeSocket, messages []Message) (int, error) {
+	if len(messages) == 0 {
+		return 0, nil
+	}
+	size := C.size_t(len(messages)) * C.size_t(unsafe.Sizeof(C.OmqGoWireMessage{}))
+	ptr := C.malloc(size)
+	wire := unsafe.Slice((*C.OmqGoWireMessage)(ptr), len(messages))
+	freeFns := make([]func(), 0, len(messages))
+	for i, msg := range messages {
+		parts, count, free := messageToC(msg)
+		freeFns = append(freeFns, free)
+		wire[i].parts = parts
+		wire[i].part_count = count
+	}
+	defer func() {
+		for _, free := range freeFns {
+			free()
+		}
+		C.free(ptr)
+	}()
+	var sent C.size_t
+	err := statusErr(C.omq_go_socket_try_send_batch((*C.OmqGoSocket)(socket), (*C.OmqGoWireMessage)(ptr), C.size_t(len(messages)), &sent))
+	return int(sent), err
+}
+
+func socketMessageRecvNative(socket *nativeSocket) (Message, error) {
+	var out C.OmqGoMessage
+	err := statusErr(C.omq_go_socket_recv((*C.OmqGoSocket)(socket), 0, &out))
+	if err != nil {
+		return Message{}, err
+	}
+	defer C.omq_go_message_free(out)
+	return messageFromC(out), nil
+}
+
+func socketSubscribeNative(socket *nativeSocket, data []byte) error {
+	if len(data) == 0 {
+		return statusErr(C.omq_go_socket_subscribe((*C.OmqGoSocket)(socket), nil, 0))
+	}
+	ptr := C.CBytes(data)
+	defer C.free(ptr)
+	return statusErr(C.omq_go_socket_subscribe((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(data))))
+}
+
+func socketUnsubscribeNative(socket *nativeSocket, data []byte) error {
+	if len(data) == 0 {
+		return statusErr(C.omq_go_socket_unsubscribe((*C.OmqGoSocket)(socket), nil, 0))
+	}
+	ptr := C.CBytes(data)
+	defer C.free(ptr)
+	return statusErr(C.omq_go_socket_unsubscribe((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(data))))
+}
+
+func socketJoinNative(socket *nativeSocket, data []byte) error {
+	if len(data) == 0 {
+		return statusErr(C.omq_go_socket_join((*C.OmqGoSocket)(socket), nil, 0))
+	}
+	ptr := C.CBytes(data)
+	defer C.free(ptr)
+	return statusErr(C.omq_go_socket_join((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(data))))
+}
+
+func socketLeaveNative(socket *nativeSocket, data []byte) error {
+	if len(data) == 0 {
+		return statusErr(C.omq_go_socket_leave((*C.OmqGoSocket)(socket), nil, 0))
+	}
+	ptr := C.CBytes(data)
+	defer C.free(ptr)
+	return statusErr(C.omq_go_socket_leave((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(data))))
+}
+
+func socketCloseNative(socket *nativeSocket, linger time.Duration, useConfigured bool) error {
+	millis := int64(-2)
+	if !useConfigured {
+		millis = durationMillis(linger)
+	}
+	return statusErr(C.omq_go_socket_close((*C.OmqGoSocket)(socket), C.int64_t(millis)))
+}
+
+func socketFreeNative(socket *nativeSocket) {
+	C.omq_go_socket_free((*C.OmqGoSocket)(socket))
+}
+
+func setSendHWMNative(socket *nativeSocket, value uint32) error {
+	return statusErr(C.omq_go_socket_set_send_hwm((*C.OmqGoSocket)(socket), C.uint32_t(value)))
+}
+
+func setRecvHWMNative(socket *nativeSocket, value uint32) error {
+	return statusErr(C.omq_go_socket_set_recv_hwm((*C.OmqGoSocket)(socket), C.uint32_t(value)))
+}
+
+func setLingerNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_linger((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setIdentityNative(socket *nativeSocket, value []byte) error {
+	return socketSetBytesNative(socket, value, func(s *C.OmqGoSocket, p *C.uint8_t, n C.size_t) C.OmqGoStatus {
+		return C.omq_go_socket_set_identity(s, p, n)
+	})
+}
+
+func setConflateNative(socket *nativeSocket, value bool) error {
+	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
+		return C.omq_go_socket_set_conflate(s, enabled)
+	})
+}
+
+func setRouterMandatoryNative(socket *nativeSocket, value bool) error {
+	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
+		return C.omq_go_socket_set_router_mandatory(s, enabled)
+	})
+}
+
+func setXPubNoDropNative(socket *nativeSocket, value bool) error {
+	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
+		return C.omq_go_socket_set_xpub_nodrop(s, enabled)
+	})
+}
+
+func setCompressionAutoTrainNative(socket *nativeSocket, value bool) error {
+	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
+		return C.omq_go_socket_set_compression_auto_train(s, enabled)
+	})
+}
+
+func setCompressionThresholdNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_compression_threshold((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setCompressionLevelNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_compression_level((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setCompressionDictNative(socket *nativeSocket, value []byte) error {
+	return socketSetBytesNative(socket, value, func(s *C.OmqGoSocket, p *C.uint8_t, n C.size_t) C.OmqGoStatus {
+		return C.omq_go_socket_set_compression_dict(s, p, n)
+	})
+}
+
+func socketSetBoolNative(socket *nativeSocket, value bool, op func(*C.OmqGoSocket, C.int) C.OmqGoStatus) error {
+	enabled := C.int(0)
+	if value {
+		enabled = 1
+	}
+	return statusErr(op((*C.OmqGoSocket)(socket), enabled))
+}
+
+func socketSetBytesNative(socket *nativeSocket, value []byte, op func(*C.OmqGoSocket, *C.uint8_t, C.size_t) C.OmqGoStatus) error {
+	if len(value) == 0 {
+		return statusErr(op((*C.OmqGoSocket)(socket), nil, 0))
+	}
+	ptr := C.CBytes(value)
+	defer C.free(ptr)
+	return statusErr(op((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(value))))
+}
+
+func monitorNewNative(socket *nativeSocket) (*nativeMonitor, error) {
+	var out *C.OmqGoMonitor
+	err := statusErr(C.omq_go_socket_monitor((*C.OmqGoSocket)(socket), &out))
+	if err != nil {
+		return nil, err
+	}
+	return (*nativeMonitor)(out), nil
+}
+
+func monitorRecvNative(monitor *nativeMonitor) (MonitorEvent, error) {
+	var out C.OmqGoEvent
+	err := statusErr(C.omq_go_monitor_recv((*C.OmqGoMonitor)(monitor), 0, &out))
+	if err != nil {
+		return MonitorEvent{}, err
+	}
+	defer C.omq_go_event_free(out)
+	return eventFromC(out), nil
+}
+
+func monitorCloseNative(monitor *nativeMonitor) {
+	C.omq_go_monitor_close((*C.OmqGoMonitor)(monitor))
+}
+
+func monitorFreeNative(monitor *nativeMonitor) {
+	C.omq_go_monitor_free((*C.OmqGoMonitor)(monitor))
+}
+
+func messageToC(msg Message) (*C.OmqGoPart, C.size_t, func()) {
+	parts := msg.Parts()
+	if len(parts) == 0 {
+		return nil, 0, func() {}
+	}
+	size := C.size_t(len(parts)) * C.size_t(unsafe.Sizeof(C.OmqGoPart{}))
+	ptr := C.malloc(size)
+	arr := unsafe.Slice((*C.OmqGoPart)(ptr), len(parts))
+	for i, part := range parts {
+		if len(part) == 0 {
+			arr[i].data = nil
+			arr[i].len = 0
+			continue
+		}
+		data := C.CBytes(part)
+		arr[i].data = (*C.uint8_t)(data)
+		arr[i].len = C.size_t(len(part))
+	}
+	free := func() {
+		for _, part := range arr {
+			if part.data != nil {
+				C.free(unsafe.Pointer(part.data))
+			}
+		}
+		C.free(ptr)
+	}
+	return (*C.OmqGoPart)(ptr), C.size_t(len(parts)), free
+}
+
+func messageFromC(raw C.OmqGoMessage) Message {
+	if raw.parts == nil || raw.part_count == 0 {
+		return Message{}
+	}
+	parts := unsafe.Slice(raw.parts, int(raw.part_count))
+	out := make([][]byte, len(parts))
+	for i, part := range parts {
+		if part.data == nil || part.len == 0 {
+			out[i] = []byte{}
+			continue
+		}
+		out[i] = C.GoBytes(unsafe.Pointer(part.data), C.int(part.len))
+	}
+	return NewMessage(out...)
+}
+
+func eventFromC(raw C.OmqGoEvent) MonitorEvent {
+	ev := MonitorEvent{
+		Kind:         goString(raw.kind),
+		Endpoint:     goString(raw.endpoint),
+		PeerIdent:    goString(raw.peer_ident),
+		Reason:       goString(raw.reason),
+		CommandName:  goString(raw.command_name),
+		ConnectionID: uint64(raw.connection_id),
+		Retry:        time.Duration(uint64(raw.retry_millis)) * time.Millisecond,
+		Attempt:      uint32(raw.attempt),
+	}
+	if raw.data != nil && raw.data_len > 0 {
+		ev.Data = C.GoBytes(unsafe.Pointer(raw.data), C.int(raw.data_len))
+	}
+	return ev
+}
+
+func goString(value *C.char) string {
+	if value == nil {
+		return ""
+	}
+	return C.GoString(value)
+}
+
+func durationMillis(value time.Duration) int64 {
+	if value < 0 {
+		return -1
+	}
+	return int64(value / time.Millisecond)
+}
+
+func retryDelay(iteration int) time.Duration {
+	if iteration < 10 {
+		return 50 * time.Microsecond
+	}
+	if iteration < 100 {
+		return 250 * time.Microsecond
+	}
+	return time.Millisecond
+}
+
+func errFromContext(ctx context.Context) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrTimeout
+	}
+	return ErrCanceled
+}
+
+func keepAlive(values ...any) {
+	for _, value := range values {
+		runtime.KeepAlive(value)
+	}
+}

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -520,7 +520,7 @@ func messageFromC(raw C.OmqGoMessage) Message {
 			out[i] = []byte{}
 			continue
 		}
-		out[i] = C.GoBytes(unsafe.Pointer(part.data), C.int(part.len))
+		out[i] = copyFromCPtr(part.data, part.len)
 	}
 	return Message{parts: out}
 }
@@ -537,9 +537,19 @@ func eventFromC(raw C.OmqGoEvent) MonitorEvent {
 		Attempt:      uint32(raw.attempt),
 	}
 	if raw.data != nil && raw.data_len > 0 {
-		ev.Data = C.GoBytes(unsafe.Pointer(raw.data), C.int(raw.data_len))
+		ev.Data = copyFromCPtr(raw.data, raw.data_len)
 	}
 	return ev
+}
+
+func copyFromCPtr(data *C.uint8_t, length C.size_t) []byte {
+	n := int(length)
+	if C.size_t(n) != length {
+		panic("omq: native message exceeds Go slice capacity")
+	}
+	out := make([]byte, n)
+	copy(out, unsafe.Slice((*byte)(unsafe.Pointer(data)), n))
+	return out
 }
 
 func goString(value *C.char) string {
@@ -553,7 +563,11 @@ func durationMillis(value time.Duration) int64 {
 	if value < 0 {
 		return -1
 	}
-	return int64(value / time.Millisecond)
+	millis := value / time.Millisecond
+	if value%time.Millisecond != 0 {
+		millis++
+	}
+	return int64(millis)
 }
 
 func retryDelay(iteration int) time.Duration {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -245,6 +245,47 @@ func socketMessagesTrySendNative(socket *nativeSocket, messages []Message) (int,
 	return int(sent), err
 }
 
+func receiveAnyNative(sockets []*Socket, timeoutMillis int64) (ReceiveEvent, error) {
+	if len(sockets) == 0 {
+		return ReceiveEvent{}, &ConfigError{Err: "receive-any requires at least one socket"}
+	}
+	size := C.size_t(len(sockets)) * C.size_t(unsafe.Sizeof(uintptr(0)))
+	ptr := C.malloc(size)
+	if ptr == nil {
+		return ReceiveEvent{}, &Error{Err: "receive-any allocation failed"}
+	}
+	defer C.free(ptr)
+
+	handles := unsafe.Slice((**C.OmqGoSocket)(ptr), len(sockets))
+	for i, socket := range sockets {
+		handle, err := socket.nativeHandle()
+		if err != nil {
+			return ReceiveEvent{}, err
+		}
+		handles[i] = (*C.OmqGoSocket)(handle)
+	}
+
+	var index C.size_t
+	var out C.OmqGoMessage
+	err := statusErr(C.omq_go_receive_any(
+		(**C.OmqGoSocket)(ptr),
+		C.size_t(len(sockets)),
+		C.int64_t(timeoutMillis),
+		&index,
+		&out,
+	))
+	if err != nil {
+		return ReceiveEvent{}, err
+	}
+	defer C.omq_go_message_free(out)
+	goIndex := int(index)
+	if goIndex < 0 || goIndex >= len(sockets) {
+		return ReceiveEvent{}, &Error{Err: "native receive-any returned invalid socket index"}
+	}
+	keepAlive(sockets)
+	return ReceiveEvent{Socket: sockets[goIndex], Message: messageFromC(out)}, nil
+}
+
 func socketMessageRecvNative(socket *nativeSocket) (Message, error) {
 	var out C.OmqGoMessage
 	err := statusErr(C.omq_go_socket_recv((*C.OmqGoSocket)(socket), 0, &out))

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -325,21 +325,6 @@ func socketMessageRecvIntoNativeTimeout(socket *nativeSocket, dst []byte, timeou
 	return int(written), nil
 }
 
-func socketMessageRecvViewNative(socket *nativeSocket) (RecvView, error) {
-	raw := C.omq_go_socket_recv_one_view((*C.OmqGoSocket)(socket), 0)
-	if err := statusErr(raw.status); err != nil {
-		return RecvView{}, err
-	}
-	if raw.data == nil || raw.len == 0 {
-		return RecvView{}, nil
-	}
-	return RecvView{data: unsafe.Slice((*byte)(unsafe.Pointer(raw.data)), int(raw.len))}, nil
-}
-
-func socketRecvViewClearNative(socket *nativeSocket) error {
-	return statusErr(C.omq_go_socket_clear_recv_view((*C.OmqGoSocket)(socket)))
-}
-
 func sendRingCreateNative(socket *nativeSocket, descCapacity, payloadCapacity int) (*nativeSendRing, sendRingMemory, error) {
 	var out *C.OmqGoSendRing
 	err := statusErr(C.omq_go_send_ring_create(

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -25,6 +25,27 @@ type nativeSendRing = C.OmqGoSendRing
 type nativeRecvRing = C.OmqGoRecvRing
 type nativeCancel = C.OmqGoCancel
 
+type nativeStats struct {
+	contextsCreated  uint64
+	contextsFreed    uint64
+	contextsLive     uint64
+	socketsCreated   uint64
+	socketsFreed     uint64
+	socketsLive      uint64
+	monitorsCreated  uint64
+	monitorsFreed    uint64
+	monitorsLive     uint64
+	sendRingsCreated uint64
+	sendRingsFreed   uint64
+	sendRingsLive    uint64
+	recvRingsCreated uint64
+	recvRingsFreed   uint64
+	recvRingsLive    uint64
+	cancelsCreated   uint64
+	cancelsFreed     uint64
+	cancelsLive      uint64
+}
+
 type sendRingMemory struct {
 	control         unsafe.Pointer
 	descriptors     unsafe.Pointer
@@ -85,6 +106,31 @@ func contextOpenNative(ioThreads int) (*nativeContext, error) {
 		return nil, err
 	}
 	return (*nativeContext)(out), nil
+}
+
+func nativeStatsNative() nativeStats {
+	var out C.OmqGoNativeStats
+	C.omq_go_native_stats(&out)
+	return nativeStats{
+		contextsCreated:  uint64(out.contexts_created),
+		contextsFreed:    uint64(out.contexts_freed),
+		contextsLive:     uint64(out.contexts_live),
+		socketsCreated:   uint64(out.sockets_created),
+		socketsFreed:     uint64(out.sockets_freed),
+		socketsLive:      uint64(out.sockets_live),
+		monitorsCreated:  uint64(out.monitors_created),
+		monitorsFreed:    uint64(out.monitors_freed),
+		monitorsLive:     uint64(out.monitors_live),
+		sendRingsCreated: uint64(out.send_rings_created),
+		sendRingsFreed:   uint64(out.send_rings_freed),
+		sendRingsLive:    uint64(out.send_rings_live),
+		recvRingsCreated: uint64(out.recv_rings_created),
+		recvRingsFreed:   uint64(out.recv_rings_freed),
+		recvRingsLive:    uint64(out.recv_rings_live),
+		cancelsCreated:   uint64(out.cancels_created),
+		cancelsFreed:     uint64(out.cancels_freed),
+		cancelsLive:      uint64(out.cancels_live),
+	}
 }
 
 func contextFromShareKeyNative(key ShareKey) (*nativeContext, error) {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -139,6 +139,17 @@ func curvePublicNative(secretKey string) (string, error) {
 	return C.GoString(publicKey), nil
 }
 
+//export omqGoAuthCallback
+func omqGoAuthCallback(id C.uint64_t, peer *C.OmqGoAuthPeer) C.int {
+	if peer == nil {
+		return 0
+	}
+	if callAuthCallback(uint64(id), peerInfoFromC(peer)) {
+		return 1
+	}
+	return 0
+}
+
 func socketNewNative(ctx *nativeContext, socketType SocketType) (*nativeSocket, error) {
 	var out *C.OmqGoSocket
 	err := statusErr(C.omq_go_socket_new((*C.OmqGoContext)(ctx), C.int32_t(socketType), &out))
@@ -470,6 +481,13 @@ func setPlainServerNative(socket *nativeSocket, username, password string) error
 	return statusErr(C.omq_go_socket_set_plain_server((*C.OmqGoSocket)(socket), cUsername, cPassword))
 }
 
+func setPlainServerAuthNative(socket *nativeSocket, callbackID uint64) error {
+	return statusErr(C.omq_go_socket_set_plain_server_callback(
+		(*C.OmqGoSocket)(socket),
+		C.uint64_t(callbackID),
+	))
+}
+
 func setPlainClientNative(socket *nativeSocket, username, password string) error {
 	cUsername := C.CString(username)
 	defer C.free(unsafe.Pointer(cUsername))
@@ -484,6 +502,19 @@ func setCurveServerNative(socket *nativeSocket, keypair CurveKeypair) error {
 	cSecret := C.CString(keypair.Secret)
 	defer C.free(unsafe.Pointer(cSecret))
 	return statusErr(C.omq_go_socket_set_curve_server((*C.OmqGoSocket)(socket), cPublic, cSecret))
+}
+
+func setCurveServerAuthNative(socket *nativeSocket, keypair CurveKeypair, callbackID uint64) error {
+	cPublic := C.CString(keypair.Public)
+	defer C.free(unsafe.Pointer(cPublic))
+	cSecret := C.CString(keypair.Secret)
+	defer C.free(unsafe.Pointer(cSecret))
+	return statusErr(C.omq_go_socket_set_curve_server_callback(
+		(*C.OmqGoSocket)(socket),
+		cPublic,
+		cSecret,
+		C.uint64_t(callbackID),
+	))
 }
 
 func setCurveClientNative(socket *nativeSocket, keypair CurveKeypair, serverPublicKey string) error {
@@ -723,6 +754,30 @@ func eventFromC(raw C.OmqGoEvent) MonitorEvent {
 		ev.Data = copyFromCPtr(raw.data, raw.data_len)
 	}
 	return ev
+}
+
+func peerInfoFromC(raw *C.OmqGoAuthPeer) PeerInfo {
+	return PeerInfo{
+		Mechanism: stringFromCBytes(raw.mechanism_data, raw.mechanism_len),
+		PublicKey: stringFromCBytes(raw.public_key_data, raw.public_key_len),
+		Identity:  bytesFromCBytes(raw.identity_data, raw.identity_len),
+		Username:  stringFromCBytes(raw.username_data, raw.username_len),
+		Password:  stringFromCBytes(raw.password_data, raw.password_len),
+	}
+}
+
+func stringFromCBytes(data *C.uint8_t, length C.size_t) string {
+	if data == nil || length == 0 {
+		return ""
+	}
+	return string(unsafe.Slice((*byte)(unsafe.Pointer(data)), int(length)))
+}
+
+func bytesFromCBytes(data *C.uint8_t, length C.size_t) []byte {
+	if data == nil || length == 0 {
+		return nil
+	}
+	return append([]byte(nil), unsafe.Slice((*byte)(unsafe.Pointer(data)), int(length))...)
 }
 
 func copyFromCPtr(data *C.uint8_t, length C.size_t) []byte {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -112,6 +112,33 @@ func contextFreeNative(ctx *nativeContext) {
 	C.omq_go_context_free((*C.OmqGoContext)(ctx))
 }
 
+func curveKeypairNative() (CurveKeypair, error) {
+	var publicKey *C.char
+	var secretKey *C.char
+	err := statusErr(C.omq_go_curve_keypair(&publicKey, &secretKey))
+	if err != nil {
+		return CurveKeypair{}, err
+	}
+	defer C.omq_go_string_free(publicKey)
+	defer C.omq_go_string_free(secretKey)
+	return CurveKeypair{
+		Public: C.GoString(publicKey),
+		Secret: C.GoString(secretKey),
+	}, nil
+}
+
+func curvePublicNative(secretKey string) (string, error) {
+	cSecret := C.CString(secretKey)
+	defer C.free(unsafe.Pointer(cSecret))
+	var publicKey *C.char
+	err := statusErr(C.omq_go_curve_public(cSecret, &publicKey))
+	if err != nil {
+		return "", err
+	}
+	defer C.omq_go_string_free(publicKey)
+	return C.GoString(publicKey), nil
+}
+
 func socketNewNative(ctx *nativeContext, socketType SocketType) (*nativeSocket, error) {
 	var out *C.OmqGoSocket
 	err := statusErr(C.omq_go_socket_new((*C.OmqGoContext)(ctx), C.int32_t(socketType), &out))
@@ -368,6 +395,31 @@ func socketLeaveNative(socket *nativeSocket, data []byte) error {
 	return statusErr(C.omq_go_socket_leave((*C.OmqGoSocket)(socket), (*C.uint8_t)(ptr), C.size_t(len(data))))
 }
 
+func socketWaitConnectedNative(socket *nativeSocket, minPeers int, timeout time.Duration) (int, error) {
+	if minPeers < 0 {
+		return 0, &ConfigError{Err: "min peers must be non-negative"}
+	}
+	var out C.size_t
+	err := statusErr(C.omq_go_socket_wait_connected(
+		(*C.OmqGoSocket)(socket),
+		C.size_t(minPeers),
+		C.int64_t(durationMillis(timeout)),
+		&out,
+	))
+	return int(out), err
+}
+
+func socketWaitSubscribedNative(socket *nativeSocket, minSubscriptions uint64, timeout time.Duration) (uint64, error) {
+	var out C.uint64_t
+	err := statusErr(C.omq_go_socket_wait_subscribed(
+		(*C.OmqGoSocket)(socket),
+		C.uint64_t(minSubscriptions),
+		C.int64_t(durationMillis(timeout)),
+		&out,
+	))
+	return uint64(out), err
+}
+
 func socketCloseNative(socket *nativeSocket, linger time.Duration, useConfigured bool) error {
 	millis := int64(-2)
 	if !useConfigured {
@@ -398,6 +450,91 @@ func setIdentityNative(socket *nativeSocket, value []byte) error {
 	})
 }
 
+func setHeartbeatIntervalNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_heartbeat_interval((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setHandshakeTimeoutNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_handshake_timeout((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setMaxMessageSizeNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_max_message_size((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setPlainServerNative(socket *nativeSocket, username, password string) error {
+	cUsername := C.CString(username)
+	defer C.free(unsafe.Pointer(cUsername))
+	cPassword := C.CString(password)
+	defer C.free(unsafe.Pointer(cPassword))
+	return statusErr(C.omq_go_socket_set_plain_server((*C.OmqGoSocket)(socket), cUsername, cPassword))
+}
+
+func setPlainClientNative(socket *nativeSocket, username, password string) error {
+	cUsername := C.CString(username)
+	defer C.free(unsafe.Pointer(cUsername))
+	cPassword := C.CString(password)
+	defer C.free(unsafe.Pointer(cPassword))
+	return statusErr(C.omq_go_socket_set_plain_client((*C.OmqGoSocket)(socket), cUsername, cPassword))
+}
+
+func setCurveServerNative(socket *nativeSocket, keypair CurveKeypair) error {
+	cPublic := C.CString(keypair.Public)
+	defer C.free(unsafe.Pointer(cPublic))
+	cSecret := C.CString(keypair.Secret)
+	defer C.free(unsafe.Pointer(cSecret))
+	return statusErr(C.omq_go_socket_set_curve_server((*C.OmqGoSocket)(socket), cPublic, cSecret))
+}
+
+func setCurveClientNative(socket *nativeSocket, keypair CurveKeypair, serverPublicKey string) error {
+	cPublic := C.CString(keypair.Public)
+	defer C.free(unsafe.Pointer(cPublic))
+	cSecret := C.CString(keypair.Secret)
+	defer C.free(unsafe.Pointer(cSecret))
+	cServerPublic := C.CString(serverPublicKey)
+	defer C.free(unsafe.Pointer(cServerPublic))
+	return statusErr(C.omq_go_socket_set_curve_client(
+		(*C.OmqGoSocket)(socket),
+		cPublic,
+		cSecret,
+		cServerPublic,
+	))
+}
+
+func setWorkloadProfileNative(socket *nativeSocket, value int32) error {
+	return statusErr(C.omq_go_socket_set_workload_profile((*C.OmqGoSocket)(socket), C.int32_t(value)))
+}
+
+func setReconnectNative(socket *nativeSocket, mode int32, minMillis, maxMillis int64) error {
+	return statusErr(C.omq_go_socket_set_reconnect(
+		(*C.OmqGoSocket)(socket),
+		C.int32_t(mode),
+		C.int64_t(minMillis),
+		C.int64_t(maxMillis),
+	))
+}
+
+func setReconnectStopConnRefusedNative(socket *nativeSocket, enabled bool) error {
+	return socketSetBoolNative(socket, enabled, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
+		return C.omq_go_socket_set_reconnect_stop_conn_refused(s, enabled)
+	})
+}
+
+func setHeartbeatTTLNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_heartbeat_ttl((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setHeartbeatTimeoutNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_heartbeat_timeout((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setMaxPendingHandshakesNative(socket *nativeSocket, value int) error {
+	if value <= 0 {
+		return &ConfigError{Err: "max pending handshakes must be greater than zero"}
+	}
+	return statusErr(C.omq_go_socket_set_max_pending_handshakes((*C.OmqGoSocket)(socket), C.size_t(value)))
+}
+
 func setConflateNative(socket *nativeSocket, value bool) error {
 	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
 		return C.omq_go_socket_set_conflate(s, enabled)
@@ -408,6 +545,28 @@ func setRouterMandatoryNative(socket *nativeSocket, value bool) error {
 	return socketSetBoolNative(socket, value, func(s *C.OmqGoSocket, enabled C.int) C.OmqGoStatus {
 		return C.omq_go_socket_set_router_mandatory(s, enabled)
 	})
+}
+
+func setOnMuteNative(socket *nativeSocket, mode int32) error {
+	return statusErr(C.omq_go_socket_set_on_mute((*C.OmqGoSocket)(socket), C.int32_t(mode)))
+}
+
+func setTCPKeepaliveNative(socket *nativeSocket, mode int32, idleMillis, intervalMillis int64, count uint32) error {
+	return statusErr(C.omq_go_socket_set_tcp_keepalive(
+		(*C.OmqGoSocket)(socket),
+		C.int32_t(mode),
+		C.int64_t(idleMillis),
+		C.int64_t(intervalMillis),
+		C.uint32_t(count),
+	))
+}
+
+func setSendBufferSizeNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_send_buffer_size((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setRecvBufferSizeNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_recv_buffer_size((*C.OmqGoSocket)(socket), C.int64_t(value)))
 }
 
 func setXPubNoDropNative(socket *nativeSocket, value bool) error {
@@ -434,6 +593,30 @@ func setCompressionDictNative(socket *nativeSocket, value []byte) error {
 	return socketSetBytesNative(socket, value, func(s *C.OmqGoSocket, p *C.uint8_t, n C.size_t) C.OmqGoStatus {
 		return C.omq_go_socket_set_compression_dict(s, p, n)
 	})
+}
+
+func setCompressionDictCapacityNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_compression_dict_capacity((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setMaxRecvDictSizeNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_max_recv_dict_size((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setCompressionOffloadThresholdNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_compression_offload_threshold((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setLargeMessageThresholdNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_large_message_threshold((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setArenaThresholdNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_arena_threshold((*C.OmqGoSocket)(socket), C.int64_t(value)))
+}
+
+func setTransmitSlotCapacityNative(socket *nativeSocket, value int64) error {
+	return statusErr(C.omq_go_socket_set_transmit_slot_cap((*C.OmqGoSocket)(socket), C.int64_t(value)))
 }
 
 func socketSetBoolNative(socket *nativeSocket, value bool, op func(*C.OmqGoSocket, C.int) C.OmqGoStatus) error {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -20,6 +20,24 @@ import (
 type nativeContext = C.OmqGoContext
 type nativeSocket = C.OmqGoSocket
 type nativeMonitor = C.OmqGoMonitor
+type nativeSendRing = C.OmqGoSendRing
+type nativeRecvRing = C.OmqGoRecvRing
+
+type sendRingMemory struct {
+	control         unsafe.Pointer
+	descriptors     unsafe.Pointer
+	payload         unsafe.Pointer
+	descCapacity    int
+	payloadCapacity int
+}
+
+type recvRingMemory struct {
+	control         unsafe.Pointer
+	descriptors     unsafe.Pointer
+	payload         unsafe.Pointer
+	descCapacity    int
+	payloadCapacity int
+}
 
 func statusErr(status C.OmqGoStatus) error {
 	if status.code == C.OMQ_GO_OK {
@@ -137,9 +155,31 @@ func socketDisconnectNative(socket *nativeSocket, endpoint string) error {
 }
 
 func socketMessageSendNative(socket *nativeSocket, msg Message) error {
+	return socketMessageSendNativeTimeout(socket, msg, 0)
+}
+
+func socketMessageSendWaitNative(socket *nativeSocket, msg Message) error {
+	return socketMessageSendNativeTimeout(socket, msg, -1)
+}
+
+func socketMessageSendNativeTimeout(socket *nativeSocket, msg Message, timeoutMillis int64) error {
+	if parts := msg.partsView(); len(parts) == 1 {
+		part := parts[0]
+		if len(part) == 0 {
+			return statusErr(C.omq_go_socket_send_one((*C.OmqGoSocket)(socket), nil, 0, C.int64_t(timeoutMillis)))
+		}
+		status := C.omq_go_socket_send_one(
+			(*C.OmqGoSocket)(socket),
+			(*C.uint8_t)(unsafe.Pointer(&part[0])),
+			C.size_t(len(part)),
+			C.int64_t(timeoutMillis),
+		)
+		runtime.KeepAlive(part)
+		return statusErr(status)
+	}
 	parts, count, free := messageToC(msg)
 	defer free()
-	return statusErr(C.omq_go_socket_send((*C.OmqGoSocket)(socket), parts, count, 0))
+	return statusErr(C.omq_go_socket_send((*C.OmqGoSocket)(socket), parts, count, C.int64_t(timeoutMillis)))
 }
 
 func socketMessagesTrySendNative(socket *nativeSocket, messages []Message) (int, error) {
@@ -175,6 +215,121 @@ func socketMessageRecvNative(socket *nativeSocket) (Message, error) {
 	}
 	defer C.omq_go_message_free(out)
 	return messageFromC(out), nil
+}
+
+func socketMessageRecvIntoNative(socket *nativeSocket, dst []byte) (int, error) {
+	return socketMessageRecvIntoNativeTimeout(socket, dst, 0)
+}
+
+func socketMessageRecvIntoWaitNative(socket *nativeSocket, dst []byte) (int, error) {
+	return socketMessageRecvIntoNativeTimeout(socket, dst, -1)
+}
+
+func socketMessageRecvIntoNativeTimeout(socket *nativeSocket, dst []byte, timeoutMillis int64) (int, error) {
+	var written C.size_t
+	var data *C.uint8_t
+	if len(dst) > 0 {
+		data = (*C.uint8_t)(unsafe.Pointer(&dst[0]))
+	}
+	err := statusErr(C.omq_go_socket_recv_one_into(
+		(*C.OmqGoSocket)(socket),
+		C.int64_t(timeoutMillis),
+		data,
+		C.size_t(len(dst)),
+		&written,
+	))
+	runtime.KeepAlive(dst)
+	if err != nil {
+		return 0, err
+	}
+	return int(written), nil
+}
+
+func socketMessageRecvViewNative(socket *nativeSocket) (RecvView, error) {
+	raw := C.omq_go_socket_recv_one_view((*C.OmqGoSocket)(socket), 0)
+	if err := statusErr(raw.status); err != nil {
+		return RecvView{}, err
+	}
+	if raw.data == nil || raw.len == 0 {
+		return RecvView{}, nil
+	}
+	return RecvView{data: unsafe.Slice((*byte)(unsafe.Pointer(raw.data)), int(raw.len))}, nil
+}
+
+func socketRecvViewClearNative(socket *nativeSocket) error {
+	return statusErr(C.omq_go_socket_clear_recv_view((*C.OmqGoSocket)(socket)))
+}
+
+func sendRingCreateNative(socket *nativeSocket, descCapacity, payloadCapacity int) (*nativeSendRing, sendRingMemory, error) {
+	var out *C.OmqGoSendRing
+	err := statusErr(C.omq_go_send_ring_create(
+		(*C.OmqGoSocket)(socket),
+		C.size_t(descCapacity),
+		C.size_t(payloadCapacity),
+		&out,
+	))
+	if err != nil {
+		return nil, sendRingMemory{}, err
+	}
+	var memory C.OmqGoSendRingMemory
+	err = statusErr(C.omq_go_send_ring_memory(out, &memory))
+	if err != nil {
+		C.omq_go_send_ring_close(out)
+		return nil, sendRingMemory{}, err
+	}
+	return (*nativeSendRing)(out), sendRingMemory{
+		control:         unsafe.Pointer(memory.control),
+		descriptors:     unsafe.Pointer(memory.descriptors),
+		payload:         unsafe.Pointer(memory.payload),
+		descCapacity:    int(memory.desc_capacity),
+		payloadCapacity: int(memory.payload_capacity),
+	}, nil
+}
+
+func sendRingErrorNative(ring *nativeSendRing) error {
+	return statusErr(C.omq_go_send_ring_error((*C.OmqGoSendRing)(ring)))
+}
+
+func sendRingCloseNative(ring *nativeSendRing) {
+	C.omq_go_send_ring_close((*C.OmqGoSendRing)(ring))
+}
+
+func recvRingCreateNative(socket *nativeSocket, descCapacity, payloadCapacity int) (*nativeRecvRing, recvRingMemory, error) {
+	var out *C.OmqGoRecvRing
+	err := statusErr(C.omq_go_recv_ring_create(
+		(*C.OmqGoSocket)(socket),
+		C.size_t(descCapacity),
+		C.size_t(payloadCapacity),
+		&out,
+	))
+	if err != nil {
+		return nil, recvRingMemory{}, err
+	}
+	var memory C.OmqGoRecvRingMemory
+	err = statusErr(C.omq_go_recv_ring_memory(out, &memory))
+	if err != nil {
+		C.omq_go_recv_ring_close(out)
+		return nil, recvRingMemory{}, err
+	}
+	return (*nativeRecvRing)(out), recvRingMemory{
+		control:         unsafe.Pointer(memory.control),
+		descriptors:     unsafe.Pointer(memory.descriptors),
+		payload:         unsafe.Pointer(memory.payload),
+		descCapacity:    int(memory.desc_capacity),
+		payloadCapacity: int(memory.payload_capacity),
+	}, nil
+}
+
+func recvRingFillNative(ring *nativeRecvRing, timeoutMillis int64, maxMessages int) error {
+	return statusErr(C.omq_go_recv_ring_fill(
+		(*C.OmqGoRecvRing)(ring),
+		C.int64_t(timeoutMillis),
+		C.size_t(maxMessages),
+	))
+}
+
+func recvRingCloseNative(ring *nativeRecvRing) {
+	C.omq_go_recv_ring_close((*C.OmqGoRecvRing)(ring))
 }
 
 func socketSubscribeNative(socket *nativeSocket, data []byte) error {
@@ -326,7 +481,7 @@ func monitorFreeNative(monitor *nativeMonitor) {
 }
 
 func messageToC(msg Message) (*C.OmqGoPart, C.size_t, func()) {
-	parts := msg.Parts()
+	parts := msg.partsView()
 	if len(parts) == 0 {
 		return nil, 0, func() {}
 	}
@@ -367,7 +522,7 @@ func messageFromC(raw C.OmqGoMessage) Message {
 		}
 		out[i] = C.GoBytes(unsafe.Pointer(part.data), C.int(part.len))
 	}
-	return NewMessage(out...)
+	return Message{parts: out}
 }
 
 func eventFromC(raw C.OmqGoEvent) MonitorEvent {
@@ -409,6 +564,24 @@ func retryDelay(iteration int) time.Duration {
 		return 250 * time.Microsecond
 	}
 	return time.Millisecond
+}
+
+func waitRetry(ctx context.Context, iteration int) error {
+	if iteration < 8 {
+		return nil
+	}
+	if iteration < 256 {
+		runtime.Gosched()
+		return nil
+	}
+	timer := time.NewTimer(retryDelay(iteration))
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return errFromContext(ctx)
+	case <-timer.C:
+		return nil
+	}
 }
 
 func errFromContext(ctx context.Context) error {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -296,7 +296,7 @@ func lockNativeSockets(sockets []*Socket) ([]*nativeSocket, func(), error) {
 		return uintptr(unsafe.Pointer(order[i])) < uintptr(unsafe.Pointer(order[j]))
 	})
 
-	locked := make([]*Socket, 0, len(order))
+	locked := make([]*socketState, 0, len(order))
 	unlock := func() {
 		for i := len(locked) - 1; i >= 0; i-- {
 			locked[i].handleMu.RUnlock()
@@ -307,18 +307,23 @@ func lockNativeSockets(sockets []*Socket) ([]*nativeSocket, func(), error) {
 			unlock()
 			return nil, nil, &ConfigError{Err: "receive-any socket is nil"}
 		}
-		socket.handleMu.RLock()
-		if socket.closed.Load() || socket.handle == nil {
-			socket.handleMu.RUnlock()
+		state := socket.stateOrNil()
+		if state == nil {
 			unlock()
 			return nil, nil, ErrClosed
 		}
-		locked = append(locked, socket)
+		state.handleMu.RLock()
+		if state.closed.Load() || state.handle == nil {
+			state.handleMu.RUnlock()
+			unlock()
+			return nil, nil, ErrClosed
+		}
+		locked = append(locked, state)
 	}
 
 	handles := make([]*nativeSocket, len(sockets))
 	for i, socket := range sockets {
-		handles[i] = socket.handle
+		handles[i] = socket.state.handle
 	}
 	return handles, unlock, nil
 }

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -22,6 +22,7 @@ type nativeSocket = C.OmqGoSocket
 type nativeMonitor = C.OmqGoMonitor
 type nativeSendRing = C.OmqGoSendRing
 type nativeRecvRing = C.OmqGoRecvRing
+type nativeCancel = C.OmqGoCancel
 
 type sendRingMemory struct {
 	control         unsafe.Pointer
@@ -407,8 +408,32 @@ func recvRingFillNative(ring *nativeRecvRing, timeoutMillis int64, maxMessages i
 	))
 }
 
+func recvRingFillCancelableNative(ring *nativeRecvRing, cancel *nativeCancel, maxMessages int) error {
+	return statusErr(C.omq_go_recv_ring_fill_cancelable(
+		(*C.OmqGoRecvRing)(ring),
+		(*C.OmqGoCancel)(cancel),
+		C.size_t(maxMessages),
+	))
+}
+
 func recvRingCloseNative(ring *nativeRecvRing) {
 	C.omq_go_recv_ring_close((*C.OmqGoRecvRing)(ring))
+}
+
+func cancelNewNative() *nativeCancel {
+	return (*nativeCancel)(C.omq_go_cancel_new())
+}
+
+func cancelNative(cancel *nativeCancel) {
+	C.omq_go_cancel((*C.OmqGoCancel)(cancel))
+}
+
+func cancelRegisterCurrentNative(cancel *nativeCancel) {
+	C.omq_go_cancel_register_current((*C.OmqGoCancel)(cancel))
+}
+
+func cancelFreeNative(cancel *nativeCancel) {
+	C.omq_go_cancel_free((*C.OmqGoCancel)(cancel))
 }
 
 func socketSubscribeNative(socket *nativeSocket, data []byte) error {

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"sort"
 	"time"
 	"unsafe"
 )
@@ -250,6 +251,12 @@ func receiveAnyNative(sockets []*Socket, timeoutMillis int64) (ReceiveEvent, err
 	if len(sockets) == 0 {
 		return ReceiveEvent{}, &ConfigError{Err: "receive-any requires at least one socket"}
 	}
+	nativeHandles, unlock, err := lockNativeSockets(sockets)
+	if err != nil {
+		return ReceiveEvent{}, err
+	}
+	defer unlock()
+
 	size := C.size_t(len(sockets)) * C.size_t(unsafe.Sizeof(uintptr(0)))
 	ptr := C.malloc(size)
 	if ptr == nil {
@@ -258,17 +265,13 @@ func receiveAnyNative(sockets []*Socket, timeoutMillis int64) (ReceiveEvent, err
 	defer C.free(ptr)
 
 	handles := unsafe.Slice((**C.OmqGoSocket)(ptr), len(sockets))
-	for i, socket := range sockets {
-		handle, err := socket.nativeHandle()
-		if err != nil {
-			return ReceiveEvent{}, err
-		}
+	for i, handle := range nativeHandles {
 		handles[i] = (*C.OmqGoSocket)(handle)
 	}
 
 	var index C.size_t
 	var out C.OmqGoMessage
-	err := statusErr(C.omq_go_receive_any(
+	err = statusErr(C.omq_go_receive_any(
 		(**C.OmqGoSocket)(ptr),
 		C.size_t(len(sockets)),
 		C.int64_t(timeoutMillis),
@@ -285,6 +288,39 @@ func receiveAnyNative(sockets []*Socket, timeoutMillis int64) (ReceiveEvent, err
 	}
 	keepAlive(sockets)
 	return ReceiveEvent{Socket: sockets[goIndex], Message: messageFromC(out)}, nil
+}
+
+func lockNativeSockets(sockets []*Socket) ([]*nativeSocket, func(), error) {
+	order := append([]*Socket(nil), sockets...)
+	sort.Slice(order, func(i, j int) bool {
+		return uintptr(unsafe.Pointer(order[i])) < uintptr(unsafe.Pointer(order[j]))
+	})
+
+	locked := make([]*Socket, 0, len(order))
+	unlock := func() {
+		for i := len(locked) - 1; i >= 0; i-- {
+			locked[i].handleMu.RUnlock()
+		}
+	}
+	for _, socket := range order {
+		if socket == nil {
+			unlock()
+			return nil, nil, &ConfigError{Err: "receive-any socket is nil"}
+		}
+		socket.handleMu.RLock()
+		if socket.closed.Load() || socket.handle == nil {
+			socket.handleMu.RUnlock()
+			unlock()
+			return nil, nil, ErrClosed
+		}
+		locked = append(locked, socket)
+	}
+
+	handles := make([]*nativeSocket, len(sockets))
+	for i, socket := range sockets {
+		handles[i] = socket.handle
+	}
+	return handles, unlock, nil
 }
 
 func socketMessageRecvNative(socket *nativeSocket) (Message, error) {

--- a/bindings/go/native/Cargo.toml
+++ b/bindings/go/native/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "omq-go-native"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.93"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "omq_go"
+crate-type = ["cdylib"]
+
+[features]
+default = ["plain", "curve", "lz4", "zstd", "ws"]
+plain = ["omq-proto/plain", "omq-tokio/plain"]
+curve = ["omq-proto/curve", "omq-tokio/curve"]
+lz4 = ["omq-proto/lz4", "omq-tokio/lz4"]
+zstd = ["omq-proto/zstd", "omq-tokio/zstd"]
+ws = ["omq-proto/ws", "omq-tokio/ws"]
+
+[dependencies]
+bytes = "1.12.0"
+omq-proto = { path = "../../../omq-proto", default-features = false }
+omq-tokio = { path = "../../../omq-tokio", default-features = false }
+tokio = { version = "1.52.0", features = ["time"] }

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -69,12 +69,6 @@ typedef struct {
 } OmqGoAuthPeer;
 
 typedef struct {
-  OmqGoStatus status;
-  const uint8_t *data;
-  size_t len;
-} OmqGoRecvView;
-
-typedef struct {
   void *control;
   void *descriptors;
   void *payload;
@@ -126,9 +120,6 @@ OmqGoStatus omq_go_socket_try_send_batch(OmqGoSocket *socket, const OmqGoWireMes
 OmqGoStatus omq_go_receive_any(OmqGoSocket **sockets, size_t socket_count, int64_t timeout_millis, size_t *index, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv(OmqGoSocket *socket, int64_t timeout_millis, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv_one_into(OmqGoSocket *socket, int64_t timeout_millis, uint8_t *data, size_t capacity, size_t *written);
-OmqGoStatus omq_go_socket_recv_one_borrow(OmqGoSocket *socket, int64_t timeout_millis, size_t capacity, const uint8_t **data, size_t *written);
-OmqGoRecvView omq_go_socket_recv_one_view(OmqGoSocket *socket, int64_t timeout_millis);
-OmqGoStatus omq_go_socket_clear_recv_view(OmqGoSocket *socket);
 OmqGoStatus omq_go_socket_subscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_unsubscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_join(OmqGoSocket *socket, const uint8_t *data, size_t len);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -1,0 +1,110 @@
+#ifndef OMQ_GO_H
+#define OMQ_GO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct OmqGoContext OmqGoContext;
+typedef struct OmqGoSocket OmqGoSocket;
+typedef struct OmqGoMonitor OmqGoMonitor;
+
+typedef struct {
+  int32_t code;
+  char *message;
+} OmqGoStatus;
+
+typedef struct {
+  uint8_t *data;
+  size_t len;
+} OmqGoPart;
+
+typedef struct {
+  OmqGoPart *parts;
+  size_t part_count;
+} OmqGoMessage;
+
+typedef struct {
+  const OmqGoPart *parts;
+  size_t part_count;
+} OmqGoWireMessage;
+
+typedef struct {
+  char *kind;
+  char *endpoint;
+  char *peer_ident;
+  char *reason;
+  char *command_name;
+  uint8_t *data;
+  size_t data_len;
+  uint64_t connection_id;
+  uint64_t retry_millis;
+  uint32_t attempt;
+} OmqGoEvent;
+
+enum {
+  OMQ_GO_OK = 0,
+  OMQ_GO_AGAIN = 1,
+  OMQ_GO_CLOSED = 2,
+  OMQ_GO_TIMEOUT = 3,
+  OMQ_GO_CANCELED = 4,
+  OMQ_GO_INVALID_ENDPOINT = 5,
+  OMQ_GO_UNSUPPORTED_SCHEME = 6,
+  OMQ_GO_PROTOCOL = 7,
+  OMQ_GO_CONFIG = 8,
+  OMQ_GO_IO = 9,
+  OMQ_GO_UNROUTABLE = 10,
+  OMQ_GO_MESSAGE_TOO_LARGE = 11,
+  OMQ_GO_ERROR = 99
+};
+
+OmqGoStatus omq_go_context_open(size_t io_threads, OmqGoContext **out);
+OmqGoStatus omq_go_context_from_share_key(uint64_t high, uint64_t low, OmqGoContext **out);
+OmqGoStatus omq_go_context_share_key(OmqGoContext *ctx, uint64_t *high, uint64_t *low);
+void omq_go_context_close(OmqGoContext *ctx);
+void omq_go_context_free(OmqGoContext *ctx);
+
+OmqGoStatus omq_go_socket_new(OmqGoContext *ctx, int32_t socket_type, OmqGoSocket **out);
+OmqGoStatus omq_go_socket_bind(OmqGoSocket *socket, const char *endpoint, char **bound_endpoint);
+OmqGoStatus omq_go_socket_connect(OmqGoSocket *socket, const char *endpoint);
+OmqGoStatus omq_go_socket_unbind(OmqGoSocket *socket, const char *endpoint);
+OmqGoStatus omq_go_socket_disconnect(OmqGoSocket *socket, const char *endpoint);
+OmqGoStatus omq_go_socket_send(OmqGoSocket *socket, const OmqGoPart *parts, size_t part_count, int64_t timeout_millis);
+OmqGoStatus omq_go_socket_try_send_batch(OmqGoSocket *socket, const OmqGoWireMessage *messages, size_t message_count, size_t *sent);
+OmqGoStatus omq_go_socket_recv(OmqGoSocket *socket, int64_t timeout_millis, OmqGoMessage *out);
+OmqGoStatus omq_go_socket_subscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_unsubscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_join(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_leave(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_close(OmqGoSocket *socket, int64_t linger_millis);
+void omq_go_socket_free(OmqGoSocket *socket);
+
+OmqGoStatus omq_go_socket_set_send_hwm(OmqGoSocket *socket, uint32_t value);
+OmqGoStatus omq_go_socket_set_recv_hwm(OmqGoSocket *socket, uint32_t value);
+OmqGoStatus omq_go_socket_set_linger(OmqGoSocket *socket, int64_t millis);
+OmqGoStatus omq_go_socket_set_identity(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_set_conflate(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_router_mandatory(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_xpub_nodrop(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_compression_auto_train(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_compression_threshold(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_compression_level(OmqGoSocket *socket, int64_t level);
+OmqGoStatus omq_go_socket_set_compression_dict(OmqGoSocket *socket, const uint8_t *data, size_t len);
+
+OmqGoStatus omq_go_socket_monitor(OmqGoSocket *socket, OmqGoMonitor **out);
+OmqGoStatus omq_go_monitor_recv(OmqGoMonitor *monitor, int64_t timeout_millis, OmqGoEvent *out);
+void omq_go_monitor_close(OmqGoMonitor *monitor);
+void omq_go_monitor_free(OmqGoMonitor *monitor);
+
+void omq_go_message_free(OmqGoMessage message);
+void omq_go_event_free(OmqGoEvent event);
+void omq_go_string_free(char *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -38,13 +38,20 @@ typedef struct {
   char *kind;
   char *endpoint;
   char *peer_ident;
+  char *peer_address;
+  char *peer_socket_type;
   char *reason;
   char *command_name;
   uint8_t *data;
   size_t data_len;
+  uint8_t *peer_identity;
+  size_t peer_identity_len;
   uint64_t connection_id;
   uint64_t retry_millis;
   uint32_t attempt;
+  uint32_t zmtp_major;
+  uint32_t zmtp_minor;
+  int has_peer;
 } OmqGoEvent;
 
 typedef struct {

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -11,6 +11,8 @@ extern "C" {
 typedef struct OmqGoContext OmqGoContext;
 typedef struct OmqGoSocket OmqGoSocket;
 typedef struct OmqGoMonitor OmqGoMonitor;
+typedef struct OmqGoSendRing OmqGoSendRing;
+typedef struct OmqGoRecvRing OmqGoRecvRing;
 
 typedef struct {
   int32_t code;
@@ -45,6 +47,28 @@ typedef struct {
   uint32_t attempt;
 } OmqGoEvent;
 
+typedef struct {
+  OmqGoStatus status;
+  const uint8_t *data;
+  size_t len;
+} OmqGoRecvView;
+
+typedef struct {
+  void *control;
+  void *descriptors;
+  void *payload;
+  size_t desc_capacity;
+  size_t payload_capacity;
+} OmqGoSendRingMemory;
+
+typedef struct {
+  void *control;
+  void *descriptors;
+  void *payload;
+  size_t desc_capacity;
+  size_t payload_capacity;
+} OmqGoRecvRingMemory;
+
 enum {
   OMQ_GO_OK = 0,
   OMQ_GO_AGAIN = 1,
@@ -73,8 +97,13 @@ OmqGoStatus omq_go_socket_connect(OmqGoSocket *socket, const char *endpoint);
 OmqGoStatus omq_go_socket_unbind(OmqGoSocket *socket, const char *endpoint);
 OmqGoStatus omq_go_socket_disconnect(OmqGoSocket *socket, const char *endpoint);
 OmqGoStatus omq_go_socket_send(OmqGoSocket *socket, const OmqGoPart *parts, size_t part_count, int64_t timeout_millis);
+OmqGoStatus omq_go_socket_send_one(OmqGoSocket *socket, const uint8_t *data, size_t len, int64_t timeout_millis);
 OmqGoStatus omq_go_socket_try_send_batch(OmqGoSocket *socket, const OmqGoWireMessage *messages, size_t message_count, size_t *sent);
 OmqGoStatus omq_go_socket_recv(OmqGoSocket *socket, int64_t timeout_millis, OmqGoMessage *out);
+OmqGoStatus omq_go_socket_recv_one_into(OmqGoSocket *socket, int64_t timeout_millis, uint8_t *data, size_t capacity, size_t *written);
+OmqGoStatus omq_go_socket_recv_one_borrow(OmqGoSocket *socket, int64_t timeout_millis, size_t capacity, const uint8_t **data, size_t *written);
+OmqGoRecvView omq_go_socket_recv_one_view(OmqGoSocket *socket, int64_t timeout_millis);
+OmqGoStatus omq_go_socket_clear_recv_view(OmqGoSocket *socket);
 OmqGoStatus omq_go_socket_subscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_unsubscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_join(OmqGoSocket *socket, const uint8_t *data, size_t len);
@@ -98,6 +127,16 @@ OmqGoStatus omq_go_socket_monitor(OmqGoSocket *socket, OmqGoMonitor **out);
 OmqGoStatus omq_go_monitor_recv(OmqGoMonitor *monitor, int64_t timeout_millis, OmqGoEvent *out);
 void omq_go_monitor_close(OmqGoMonitor *monitor);
 void omq_go_monitor_free(OmqGoMonitor *monitor);
+
+OmqGoStatus omq_go_send_ring_create(OmqGoSocket *socket, size_t desc_capacity, size_t payload_capacity, OmqGoSendRing **out);
+OmqGoStatus omq_go_send_ring_memory(OmqGoSendRing *ring, OmqGoSendRingMemory *out);
+OmqGoStatus omq_go_send_ring_error(OmqGoSendRing *ring);
+void omq_go_send_ring_close(OmqGoSendRing *ring);
+
+OmqGoStatus omq_go_recv_ring_create(OmqGoSocket *socket, size_t desc_capacity, size_t payload_capacity, OmqGoRecvRing **out);
+OmqGoStatus omq_go_recv_ring_memory(OmqGoRecvRing *ring, OmqGoRecvRingMemory *out);
+OmqGoStatus omq_go_recv_ring_fill(OmqGoRecvRing *ring, int64_t timeout_millis, size_t max_messages);
+void omq_go_recv_ring_close(OmqGoRecvRing *ring);
 
 void omq_go_message_free(OmqGoMessage message);
 void omq_go_event_free(OmqGoEvent event);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -48,6 +48,19 @@ typedef struct {
 } OmqGoEvent;
 
 typedef struct {
+  const uint8_t *mechanism_data;
+  size_t mechanism_len;
+  const uint8_t *public_key_data;
+  size_t public_key_len;
+  const uint8_t *identity_data;
+  size_t identity_len;
+  const uint8_t *username_data;
+  size_t username_len;
+  const uint8_t *password_data;
+  size_t password_len;
+} OmqGoAuthPeer;
+
+typedef struct {
   OmqGoStatus status;
   const uint8_t *data;
   size_t len;
@@ -124,8 +137,10 @@ OmqGoStatus omq_go_socket_set_heartbeat_interval(OmqGoSocket *socket, int64_t mi
 OmqGoStatus omq_go_socket_set_handshake_timeout(OmqGoSocket *socket, int64_t millis);
 OmqGoStatus omq_go_socket_set_max_message_size(OmqGoSocket *socket, int64_t bytes);
 OmqGoStatus omq_go_socket_set_plain_server(OmqGoSocket *socket, const char *username, const char *password);
+OmqGoStatus omq_go_socket_set_plain_server_callback(OmqGoSocket *socket, uint64_t callback_id);
 OmqGoStatus omq_go_socket_set_plain_client(OmqGoSocket *socket, const char *username, const char *password);
 OmqGoStatus omq_go_socket_set_curve_server(OmqGoSocket *socket, const char *public_key, const char *secret_key);
+OmqGoStatus omq_go_socket_set_curve_server_callback(OmqGoSocket *socket, const char *public_key, const char *secret_key, uint64_t callback_id);
 OmqGoStatus omq_go_socket_set_curve_client(OmqGoSocket *socket, const char *public_key, const char *secret_key, const char *server_public_key);
 OmqGoStatus omq_go_socket_set_workload_profile(OmqGoSocket *socket, int32_t profile);
 OmqGoStatus omq_go_socket_set_reconnect(OmqGoSocket *socket, int32_t mode, int64_t min_millis, int64_t max_millis);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -91,6 +91,9 @@ OmqGoStatus omq_go_context_share_key(OmqGoContext *ctx, uint64_t *high, uint64_t
 void omq_go_context_close(OmqGoContext *ctx);
 void omq_go_context_free(OmqGoContext *ctx);
 
+OmqGoStatus omq_go_curve_keypair(char **public_key, char **secret_key);
+OmqGoStatus omq_go_curve_public(const char *secret_key, char **public_key);
+
 OmqGoStatus omq_go_socket_new(OmqGoContext *ctx, int32_t socket_type, OmqGoSocket **out);
 OmqGoStatus omq_go_socket_bind(OmqGoSocket *socket, const char *endpoint, char **bound_endpoint);
 OmqGoStatus omq_go_socket_connect(OmqGoSocket *socket, const char *endpoint);
@@ -108,6 +111,8 @@ OmqGoStatus omq_go_socket_subscribe(OmqGoSocket *socket, const uint8_t *data, si
 OmqGoStatus omq_go_socket_unsubscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_join(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_leave(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_wait_connected(OmqGoSocket *socket, size_t min_peers, int64_t timeout_millis, size_t *out);
+OmqGoStatus omq_go_socket_wait_subscribed(OmqGoSocket *socket, uint64_t min_subscriptions, int64_t timeout_millis, uint64_t *out);
 OmqGoStatus omq_go_socket_close(OmqGoSocket *socket, int64_t linger_millis);
 void omq_go_socket_free(OmqGoSocket *socket);
 
@@ -115,13 +120,36 @@ OmqGoStatus omq_go_socket_set_send_hwm(OmqGoSocket *socket, uint32_t value);
 OmqGoStatus omq_go_socket_set_recv_hwm(OmqGoSocket *socket, uint32_t value);
 OmqGoStatus omq_go_socket_set_linger(OmqGoSocket *socket, int64_t millis);
 OmqGoStatus omq_go_socket_set_identity(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_set_heartbeat_interval(OmqGoSocket *socket, int64_t millis);
+OmqGoStatus omq_go_socket_set_handshake_timeout(OmqGoSocket *socket, int64_t millis);
+OmqGoStatus omq_go_socket_set_max_message_size(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_plain_server(OmqGoSocket *socket, const char *username, const char *password);
+OmqGoStatus omq_go_socket_set_plain_client(OmqGoSocket *socket, const char *username, const char *password);
+OmqGoStatus omq_go_socket_set_curve_server(OmqGoSocket *socket, const char *public_key, const char *secret_key);
+OmqGoStatus omq_go_socket_set_curve_client(OmqGoSocket *socket, const char *public_key, const char *secret_key, const char *server_public_key);
+OmqGoStatus omq_go_socket_set_workload_profile(OmqGoSocket *socket, int32_t profile);
+OmqGoStatus omq_go_socket_set_reconnect(OmqGoSocket *socket, int32_t mode, int64_t min_millis, int64_t max_millis);
+OmqGoStatus omq_go_socket_set_reconnect_stop_conn_refused(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_heartbeat_ttl(OmqGoSocket *socket, int64_t millis);
+OmqGoStatus omq_go_socket_set_heartbeat_timeout(OmqGoSocket *socket, int64_t millis);
+OmqGoStatus omq_go_socket_set_max_pending_handshakes(OmqGoSocket *socket, size_t max);
 OmqGoStatus omq_go_socket_set_conflate(OmqGoSocket *socket, int enabled);
 OmqGoStatus omq_go_socket_set_router_mandatory(OmqGoSocket *socket, int enabled);
+OmqGoStatus omq_go_socket_set_on_mute(OmqGoSocket *socket, int32_t mode);
+OmqGoStatus omq_go_socket_set_tcp_keepalive(OmqGoSocket *socket, int32_t mode, int64_t idle_millis, int64_t interval_millis, uint32_t count);
+OmqGoStatus omq_go_socket_set_send_buffer_size(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_recv_buffer_size(OmqGoSocket *socket, int64_t bytes);
 OmqGoStatus omq_go_socket_set_xpub_nodrop(OmqGoSocket *socket, int enabled);
 OmqGoStatus omq_go_socket_set_compression_auto_train(OmqGoSocket *socket, int enabled);
 OmqGoStatus omq_go_socket_set_compression_threshold(OmqGoSocket *socket, int64_t bytes);
 OmqGoStatus omq_go_socket_set_compression_level(OmqGoSocket *socket, int64_t level);
 OmqGoStatus omq_go_socket_set_compression_dict(OmqGoSocket *socket, const uint8_t *data, size_t len);
+OmqGoStatus omq_go_socket_set_compression_dict_capacity(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_max_recv_dict_size(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_compression_offload_threshold(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_large_message_threshold(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_arena_threshold(OmqGoSocket *socket, int64_t bytes);
+OmqGoStatus omq_go_socket_set_transmit_slot_cap(OmqGoSocket *socket, int64_t bytes);
 
 OmqGoStatus omq_go_socket_monitor(OmqGoSocket *socket, OmqGoMonitor **out);
 OmqGoStatus omq_go_monitor_recv(OmqGoMonitor *monitor, int64_t timeout_millis, OmqGoEvent *out);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -13,6 +13,7 @@ typedef struct OmqGoSocket OmqGoSocket;
 typedef struct OmqGoMonitor OmqGoMonitor;
 typedef struct OmqGoSendRing OmqGoSendRing;
 typedef struct OmqGoRecvRing OmqGoRecvRing;
+typedef struct OmqGoCancel OmqGoCancel;
 
 typedef struct {
   int32_t code;
@@ -187,7 +188,13 @@ void omq_go_send_ring_close(OmqGoSendRing *ring);
 OmqGoStatus omq_go_recv_ring_create(OmqGoSocket *socket, size_t desc_capacity, size_t payload_capacity, OmqGoRecvRing **out);
 OmqGoStatus omq_go_recv_ring_memory(OmqGoRecvRing *ring, OmqGoRecvRingMemory *out);
 OmqGoStatus omq_go_recv_ring_fill(OmqGoRecvRing *ring, int64_t timeout_millis, size_t max_messages);
+OmqGoStatus omq_go_recv_ring_fill_cancelable(OmqGoRecvRing *ring, const OmqGoCancel *cancel, size_t max_messages);
 void omq_go_recv_ring_close(OmqGoRecvRing *ring);
+
+OmqGoCancel *omq_go_cancel_new(void);
+void omq_go_cancel(const OmqGoCancel *cancel);
+void omq_go_cancel_register_current(const OmqGoCancel *cancel);
+void omq_go_cancel_free(OmqGoCancel *cancel);
 
 void omq_go_message_free(OmqGoMessage message);
 void omq_go_event_free(OmqGoEvent event);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -122,6 +122,7 @@ OmqGoStatus omq_go_socket_disconnect(OmqGoSocket *socket, const char *endpoint);
 OmqGoStatus omq_go_socket_send(OmqGoSocket *socket, const OmqGoPart *parts, size_t part_count, int64_t timeout_millis);
 OmqGoStatus omq_go_socket_send_one(OmqGoSocket *socket, const uint8_t *data, size_t len, int64_t timeout_millis);
 OmqGoStatus omq_go_socket_try_send_batch(OmqGoSocket *socket, const OmqGoWireMessage *messages, size_t message_count, size_t *sent);
+OmqGoStatus omq_go_receive_any(OmqGoSocket **sockets, size_t socket_count, int64_t timeout_millis, size_t *index, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv(OmqGoSocket *socket, int64_t timeout_millis, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv_one_into(OmqGoSocket *socket, int64_t timeout_millis, uint8_t *data, size_t capacity, size_t *written);
 OmqGoStatus omq_go_socket_recv_one_borrow(OmqGoSocket *socket, int64_t timeout_millis, size_t capacity, const uint8_t **data, size_t *written);

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -84,6 +84,27 @@ typedef struct {
   size_t payload_capacity;
 } OmqGoRecvRingMemory;
 
+typedef struct {
+  uint64_t contexts_created;
+  uint64_t contexts_freed;
+  uint64_t contexts_live;
+  uint64_t sockets_created;
+  uint64_t sockets_freed;
+  uint64_t sockets_live;
+  uint64_t monitors_created;
+  uint64_t monitors_freed;
+  uint64_t monitors_live;
+  uint64_t send_rings_created;
+  uint64_t send_rings_freed;
+  uint64_t send_rings_live;
+  uint64_t recv_rings_created;
+  uint64_t recv_rings_freed;
+  uint64_t recv_rings_live;
+  uint64_t cancels_created;
+  uint64_t cancels_freed;
+  uint64_t cancels_live;
+} OmqGoNativeStats;
+
 enum {
   OMQ_GO_OK = 0,
   OMQ_GO_AGAIN = 1,
@@ -190,6 +211,7 @@ void omq_go_cancel_free(OmqGoCancel *cancel);
 void omq_go_message_free(OmqGoMessage message);
 void omq_go_event_free(OmqGoEvent event);
 void omq_go_string_free(char *value);
+void omq_go_native_stats(OmqGoNativeStats *out);
 
 #ifdef __cplusplus
 }

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -16,12 +16,17 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use omq_proto::TrySendError;
+#[cfg(feature = "plain")]
+use omq_tokio::Authenticator;
 use omq_tokio::blocking::Socket as BlockingSocket;
+use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{
-    Context, ContextConfig, DisconnectReason, Endpoint, Error, Message,
+    Context, ContextConfig, DisconnectReason, Endpoint, Error, MechanismSetup, Message,
     MonitorEvent as NativeMonitorEvent, MonitorRecvError, MonitorStream, MonitorTryRecvError,
     Options, PeerCommandKind, SocketType,
 };
+#[cfg(feature = "curve")]
+use omq_tokio::{CurveKeypair, CurvePublicKey, CurveSecretKey, CurveServerOptions};
 
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("OMQ Go native binding requires a 64-bit target");
@@ -862,12 +867,44 @@ fn duration_from_timeout_millis(timeout_millis: i64) -> Option<Duration> {
     }
 }
 
+fn duration_from_millis(millis: i64) -> Result<Duration, Error> {
+    if millis < 0 {
+        return Err(Error::Config("duration must be non-negative".to_string()));
+    }
+    Ok(Duration::from_millis(millis as u64))
+}
+
+fn optional_duration_from_millis(millis: i64) -> Result<Option<Duration>, Error> {
+    if millis < 0 {
+        Ok(None)
+    } else {
+        duration_from_millis(millis).map(Some)
+    }
+}
+
+fn optional_usize_from_i64(name: &str, value: i64) -> Result<Option<usize>, Error> {
+    if value < 0 {
+        Ok(None)
+    } else {
+        usize::try_from(value)
+            .map(Some)
+            .map_err(|_| Error::Config(format!("{name} exceeds usize")))
+    }
+}
+
 fn linger_from_millis(millis: i64) -> Option<Duration> {
     if millis < 0 {
         None
     } else {
         Some(Duration::from_millis(millis as u64))
     }
+}
+
+#[cfg(feature = "curve")]
+fn curve_keypair_from_z85(public_key: &str, secret_key: &str) -> Result<CurveKeypair, Error> {
+    let public = CurvePublicKey::from_z85(public_key)?;
+    let secret = CurveSecretKey::from_z85(secret_key)?;
+    Ok(CurveKeypair { public, secret })
 }
 
 fn message_from_c(parts: *const OmqGoPart, part_count: usize) -> Result<Message, Error> {
@@ -1435,6 +1472,60 @@ pub extern "C" fn omq_go_context_free(ctx: *mut OmqGoContext) {
 }
 
 #[unsafe(no_mangle)]
+#[cfg(feature = "curve")]
+pub extern "C" fn omq_go_curve_keypair(
+    public_key: *mut *mut c_char,
+    secret_key: *mut *mut c_char,
+) -> OmqGoStatus {
+    if public_key.is_null() || secret_key.is_null() {
+        return OmqGoStatus::err(CONFIG, "null CURVE key output pointer");
+    }
+    let keypair = CurveKeypair::generate();
+    unsafe {
+        *public_key = string_to_raw(keypair.public.to_z85());
+        *secret_key = string_to_raw(keypair.secret.to_z85());
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "curve"))]
+pub extern "C" fn omq_go_curve_keypair(
+    _public_key: *mut *mut c_char,
+    _secret_key: *mut *mut c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "CURVE support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "curve")]
+pub extern "C" fn omq_go_curve_public(
+    secret_key: *const c_char,
+    public_key: *mut *mut c_char,
+) -> OmqGoStatus {
+    if public_key.is_null() {
+        return OmqGoStatus::err(CONFIG, "null CURVE public key output pointer");
+    }
+    let result = (|| {
+        let secret = CurveSecretKey::from_z85(str_from_c(secret_key)?)?;
+        unsafe {
+            *public_key = string_to_raw(secret.derive_public().to_z85());
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "curve"))]
+pub extern "C" fn omq_go_curve_public(
+    _secret_key: *const c_char,
+    _public_key: *mut *mut c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "CURVE support not enabled")
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn omq_go_socket_new(
     ctx: *mut OmqGoContext,
     socket_type: i32,
@@ -1812,6 +1903,52 @@ pub extern "C" fn omq_go_socket_leave(
     })
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_wait_connected(
+    socket: *mut OmqGoSocket,
+    min_peers: usize,
+    timeout_millis: i64,
+    out: *mut usize,
+) -> OmqGoStatus {
+    if socket.is_null() || out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null wait_connected pointer");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let timeout = duration_from_millis(timeout_millis)?;
+        let count = socket.materialize()?.wait_connected(min_peers, timeout)?;
+        unsafe {
+            *out = count;
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_wait_subscribed(
+    socket: *mut OmqGoSocket,
+    min_subscriptions: u64,
+    timeout_millis: i64,
+    out: *mut u64,
+) -> OmqGoStatus {
+    if socket.is_null() || out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null wait_subscribed pointer");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let timeout = duration_from_millis(timeout_millis)?;
+        let count = socket
+            .materialize()?
+            .wait_subscribed(min_subscriptions, timeout)?;
+        unsafe {
+            *out = count;
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
 fn socket_bytes_op<F>(socket: *mut OmqGoSocket, data: *const u8, len: usize, op: F) -> OmqGoStatus
 where
     F: FnOnce(BlockingSocket, &[u8]) -> Result<(), Error>,
@@ -1894,6 +2031,268 @@ pub extern "C" fn omq_go_socket_set_identity(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_heartbeat_interval(
+    socket: *mut OmqGoSocket,
+    millis: i64,
+) -> OmqGoStatus {
+    let interval = match optional_duration_from_millis(millis) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.heartbeat_interval = interval)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_handshake_timeout(
+    socket: *mut OmqGoSocket,
+    millis: i64,
+) -> OmqGoStatus {
+    let timeout = match optional_duration_from_millis(millis) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.handshake_timeout = timeout)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_max_message_size(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let max = match optional_usize_from_i64("max message size", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.max_message_size = max)
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "plain")]
+pub extern "C" fn omq_go_socket_set_plain_server(
+    socket: *mut OmqGoSocket,
+    username: *const c_char,
+    password: *const c_char,
+) -> OmqGoStatus {
+    let result = (|| {
+        let expected_username = str_from_c(username)?.to_string();
+        let expected_password = str_from_c(password)?.to_string();
+        Ok(set_socket_option(socket, move |options| {
+            options.mechanism = MechanismSetup::PlainServer {
+                authenticator: Authenticator::new(move |peer| {
+                    peer.username.as_deref() == Some(expected_username.as_str())
+                        && peer.password.as_deref() == Some(expected_password.as_str())
+                }),
+            };
+        }))
+    })();
+    match result {
+        Ok(status) => status,
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "plain"))]
+pub extern "C" fn omq_go_socket_set_plain_server(
+    _socket: *mut OmqGoSocket,
+    _username: *const c_char,
+    _password: *const c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "PLAIN support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "plain")]
+pub extern "C" fn omq_go_socket_set_plain_client(
+    socket: *mut OmqGoSocket,
+    username: *const c_char,
+    password: *const c_char,
+) -> OmqGoStatus {
+    let result = (|| {
+        let username = str_from_c(username)?.to_string();
+        let password = str_from_c(password)?.to_string();
+        Ok(set_socket_option(socket, move |options| {
+            options.mechanism = MechanismSetup::PlainClient { username, password };
+        }))
+    })();
+    match result {
+        Ok(status) => status,
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "plain"))]
+pub extern "C" fn omq_go_socket_set_plain_client(
+    _socket: *mut OmqGoSocket,
+    _username: *const c_char,
+    _password: *const c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "PLAIN support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "curve")]
+pub extern "C" fn omq_go_socket_set_curve_server(
+    socket: *mut OmqGoSocket,
+    public_key: *const c_char,
+    secret_key: *const c_char,
+) -> OmqGoStatus {
+    let result = (|| {
+        let keypair = curve_keypair_from_z85(str_from_c(public_key)?, str_from_c(secret_key)?)?;
+        Ok(set_socket_option(socket, move |options| {
+            options.mechanism = MechanismSetup::CurveServer {
+                our_keypair: keypair,
+                options: CurveServerOptions::default(),
+            };
+        }))
+    })();
+    match result {
+        Ok(status) => status,
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "curve"))]
+pub extern "C" fn omq_go_socket_set_curve_server(
+    _socket: *mut OmqGoSocket,
+    _public_key: *const c_char,
+    _secret_key: *const c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "CURVE support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "curve")]
+pub extern "C" fn omq_go_socket_set_curve_client(
+    socket: *mut OmqGoSocket,
+    public_key: *const c_char,
+    secret_key: *const c_char,
+    server_public_key: *const c_char,
+) -> OmqGoStatus {
+    let result = (|| {
+        let keypair = curve_keypair_from_z85(str_from_c(public_key)?, str_from_c(secret_key)?)?;
+        let server_public = CurvePublicKey::from_z85(str_from_c(server_public_key)?)?;
+        Ok(set_socket_option(socket, move |options| {
+            options.mechanism = MechanismSetup::CurveClient {
+                our_keypair: keypair,
+                server_public,
+            };
+        }))
+    })();
+    match result {
+        Ok(status) => status,
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "curve"))]
+pub extern "C" fn omq_go_socket_set_curve_client(
+    _socket: *mut OmqGoSocket,
+    _public_key: *const c_char,
+    _secret_key: *const c_char,
+    _server_public_key: *const c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "CURVE support not enabled")
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_workload_profile(
+    socket: *mut OmqGoSocket,
+    profile: i32,
+) -> OmqGoStatus {
+    let profile = match profile {
+        -1 => None,
+        0 => Some(WorkloadProfile::Throughput),
+        1 => Some(WorkloadProfile::Latency),
+        other => return OmqGoStatus::err(CONFIG, format!("unknown workload profile {other}")),
+    };
+    set_socket_option(socket, move |options| options.workload_profile = profile)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_reconnect(
+    socket: *mut OmqGoSocket,
+    mode: i32,
+    min_millis: i64,
+    max_millis: i64,
+) -> OmqGoStatus {
+    let reconnect = match mode {
+        0 => ReconnectPolicy::Disabled,
+        1 => match duration_from_millis(min_millis) {
+            Ok(min) => ReconnectPolicy::Fixed(min),
+            Err(error) => return OmqGoStatus::from_error(error),
+        },
+        2 => {
+            let min = match duration_from_millis(min_millis) {
+                Ok(min) => min,
+                Err(error) => return OmqGoStatus::from_error(error),
+            };
+            let max = match duration_from_millis(max_millis) {
+                Ok(max) => max,
+                Err(error) => return OmqGoStatus::from_error(error),
+            };
+            if max < min {
+                return OmqGoStatus::err(
+                    CONFIG,
+                    "reconnect max must be greater than or equal to min",
+                );
+            }
+            ReconnectPolicy::Exponential { min, max }
+        }
+        other => return OmqGoStatus::err(CONFIG, format!("unknown reconnect mode {other}")),
+    };
+    set_socket_option(socket, move |options| options.reconnect = reconnect)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_reconnect_stop_conn_refused(
+    socket: *mut OmqGoSocket,
+    enabled: i32,
+) -> OmqGoStatus {
+    set_socket_option(socket, move |options| {
+        options.reconnect_stop_conn_refused = enabled != 0
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_heartbeat_ttl(
+    socket: *mut OmqGoSocket,
+    millis: i64,
+) -> OmqGoStatus {
+    let ttl = match optional_duration_from_millis(millis) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.heartbeat_ttl = ttl)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_heartbeat_timeout(
+    socket: *mut OmqGoSocket,
+    millis: i64,
+) -> OmqGoStatus {
+    let timeout = match optional_duration_from_millis(millis) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.heartbeat_timeout = timeout)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_max_pending_handshakes(
+    socket: *mut OmqGoSocket,
+    max: usize,
+) -> OmqGoStatus {
+    if max == 0 {
+        return OmqGoStatus::err(CONFIG, "max pending handshakes must be greater than zero");
+    }
+    set_socket_option(socket, move |options| options.max_pending_handshakes = max)
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn omq_go_socket_set_conflate(
     socket: *mut OmqGoSocket,
     enabled: i32,
@@ -1907,6 +2306,75 @@ pub extern "C" fn omq_go_socket_set_router_mandatory(
     enabled: i32,
 ) -> OmqGoStatus {
     set_socket_option(socket, |options| options.router_mandatory = enabled != 0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_on_mute(socket: *mut OmqGoSocket, mode: i32) -> OmqGoStatus {
+    let on_mute = match mode {
+        0 => OnMute::Block,
+        1 => OnMute::DropNewest,
+        2 => OnMute::DropOldest,
+        other => return OmqGoStatus::err(CONFIG, format!("unknown on-mute mode {other}")),
+    };
+    set_socket_option(socket, move |options| options.on_mute = on_mute)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_tcp_keepalive(
+    socket: *mut OmqGoSocket,
+    mode: i32,
+    idle_millis: i64,
+    interval_millis: i64,
+    count: u32,
+) -> OmqGoStatus {
+    let keepalive = match mode {
+        0 => KeepAlive::Default,
+        1 => KeepAlive::Disabled,
+        2 => {
+            if count == 0 {
+                return OmqGoStatus::err(CONFIG, "TCP keepalive count must be greater than zero");
+            }
+            let idle = match duration_from_millis(idle_millis) {
+                Ok(idle) => idle,
+                Err(error) => return OmqGoStatus::from_error(error),
+            };
+            let intvl = match duration_from_millis(interval_millis) {
+                Ok(intvl) => intvl,
+                Err(error) => return OmqGoStatus::from_error(error),
+            };
+            KeepAlive::Enabled {
+                idle,
+                intvl,
+                cnt: count,
+            }
+        }
+        other => return OmqGoStatus::err(CONFIG, format!("unknown TCP keepalive mode {other}")),
+    };
+    set_socket_option(socket, move |options| options.tcp_keepalive = keepalive)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_send_buffer_size(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("send buffer size", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.send_buffer_size = bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_recv_buffer_size(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("receive buffer size", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.recv_buffer_size = bytes)
 }
 
 #[unsafe(no_mangle)]
@@ -1968,6 +2436,84 @@ pub extern "C" fn omq_go_socket_set_compression_dict(
         }
     };
     set_socket_option(socket, |options| options.compression_dict = value)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_dict_capacity(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("compression dictionary capacity", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| {
+        options.compression_dict_capacity = bytes
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_max_recv_dict_size(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("max receive dictionary size", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.max_recv_dict_size = bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_offload_threshold(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("compression offload threshold", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| {
+        options.compression_offload_threshold = bytes
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_large_message_threshold(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("large message threshold", bytes) {
+        Ok(value) => value.filter(|bytes| *bytes != 0),
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| {
+        options.large_message_threshold = bytes
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_arena_threshold(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("arena threshold", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.arena_threshold = bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_transmit_slot_cap(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let bytes = match optional_usize_from_i64("transmit slot capacity", bytes) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, move |options| options.transmit_slot_cap = bytes)
 }
 
 fn set_socket_option<F>(socket: *mut OmqGoSocket, f: F) -> OmqGoStatus

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -115,13 +115,6 @@ unsafe extern "C" {
 }
 
 #[repr(C)]
-pub struct OmqGoRecvView {
-    status: OmqGoStatus,
-    data: *const u8,
-    len: usize,
-}
-
-#[repr(C)]
 pub struct OmqGoSendRingMemory {
     control: *mut c_void,
     descriptors: *mut c_void,
@@ -278,8 +271,6 @@ pub struct OmqGoSocket {
     materialize_lock: Mutex<()>,
     recv_cache: Mutex<VecDeque<Message>>,
     recv_scratch: Mutex<Vec<Message>>,
-    recv_into_scratch: Mutex<Vec<u8>>,
-    recv_view_message: Mutex<Option<Message>>,
     closed: AtomicBool,
 }
 
@@ -1249,46 +1240,6 @@ fn copy_message_into(message: &Message, destination: &mut [u8]) -> Result<usize,
     Ok(part.len())
 }
 
-fn copy_message_to_scratch(
-    message: &Message,
-    capacity: usize,
-    scratch: &mut Vec<u8>,
-) -> Result<usize, Error> {
-    if message.len() != 1 {
-        return Err(Error::Config(
-            "RecvInto requires a single-part message".to_string(),
-        ));
-    }
-    let part = message
-        .part_slice(0)
-        .ok_or_else(|| Error::Config("missing message part".to_string()))?;
-    if part.len() > capacity {
-        return Err(Error::MessageTooLarge {
-            size: part.len(),
-            max: capacity,
-        });
-    }
-    scratch.clear();
-    scratch.extend_from_slice(part);
-    Ok(part.len())
-}
-
-fn message_part_view(message: &Message) -> Result<(*const u8, usize), Error> {
-    if message.len() != 1 {
-        return Err(Error::Config(
-            "RecvView requires a single-part message".to_string(),
-        ));
-    }
-    let part = message
-        .part_slice(0)
-        .ok_or_else(|| Error::Config("missing message part".to_string()))?;
-    if part.is_empty() {
-        Ok((ptr::null(), 0))
-    } else {
-        Ok((part.as_ptr(), part.len()))
-    }
-}
-
 fn try_send_with_timeout(
     native: &BlockingSocket,
     mut message: Message,
@@ -1800,8 +1751,6 @@ pub extern "C" fn omq_go_socket_new(
             materialize_lock: Mutex::new(()),
             recv_cache: Mutex::new(VecDeque::new()),
             recv_scratch: Mutex::new(Vec::with_capacity(RECV_BATCH)),
-            recv_into_scratch: Mutex::new(Vec::new()),
-            recv_view_message: Mutex::new(None),
             closed: AtomicBool::new(false),
         }));
     }
@@ -2072,100 +2021,6 @@ pub extern "C" fn omq_go_socket_recv_one_into(
         }
         Ok(())
     })();
-    status_from_result(result)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn omq_go_socket_recv_one_borrow(
-    socket: *mut OmqGoSocket,
-    timeout_millis: i64,
-    capacity: usize,
-    data: *mut *const u8,
-    written: *mut usize,
-) -> OmqGoStatus {
-    if socket.is_null() {
-        return OmqGoStatus::err(CLOSED, "socket closed");
-    }
-    if data.is_null() || written.is_null() {
-        return OmqGoStatus::err(CONFIG, "null receive borrow pointer");
-    }
-    unsafe {
-        *data = ptr::null();
-        *written = 0;
-    }
-    let socket = unsafe { &*socket };
-    let result = (|| {
-        let message = recv_one(socket, timeout_millis)?;
-        let mut scratch = socket
-            .recv_into_scratch
-            .lock()
-            .map_err(|_| Error::Config("receive-into scratch lock poisoned".to_string()))?;
-        let copied = copy_message_to_scratch(&message, capacity, &mut scratch)?;
-        unsafe {
-            *written = copied;
-            *data = if copied == 0 {
-                ptr::null()
-            } else {
-                scratch.as_ptr()
-            };
-        }
-        Ok(())
-    })();
-    status_from_result(result)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn omq_go_socket_recv_one_view(
-    socket: *mut OmqGoSocket,
-    timeout_millis: i64,
-) -> OmqGoRecvView {
-    if socket.is_null() {
-        return OmqGoRecvView {
-            status: OmqGoStatus::err(CLOSED, "socket closed"),
-            data: ptr::null(),
-            len: 0,
-        };
-    }
-    let socket = unsafe { &*socket };
-    let result = (|| {
-        let message = recv_one(socket, timeout_millis)?;
-        let mut guard = socket
-            .recv_view_message
-            .lock()
-            .map_err(|_| Error::Config("receive view lock poisoned".to_string()))?;
-        *guard = Some(message);
-        let message = guard
-            .as_ref()
-            .ok_or_else(|| Error::Config("receive view missing message".to_string()))?;
-        message_part_view(message)
-    })();
-    match result {
-        Ok((data, len)) => OmqGoRecvView {
-            status: OmqGoStatus::ok(),
-            data,
-            len,
-        },
-        Err(error) => OmqGoRecvView {
-            status: OmqGoStatus::from_error(error),
-            data: ptr::null(),
-            len: 0,
-        },
-    }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn omq_go_socket_clear_recv_view(socket: *mut OmqGoSocket) -> OmqGoStatus {
-    if socket.is_null() {
-        return OmqGoStatus::err(CLOSED, "socket closed");
-    }
-    let socket = unsafe { &*socket };
-    let result = socket
-        .recv_view_message
-        .lock()
-        .map_err(|_| Error::Config("receive view lock poisoned".to_string()))
-        .map(|mut guard| {
-            guard.take();
-        });
     status_from_result(result)
 }
 

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -4,7 +4,7 @@
 )]
 
 use std::collections::VecDeque;
-use std::ffi::{CStr, CString, c_char, c_void};
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
 use std::ptr;
 use std::slice;
 use std::str::FromStr;
@@ -16,8 +16,10 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use omq_proto::TrySendError;
-#[cfg(feature = "plain")]
+#[cfg(any(feature = "plain", feature = "curve"))]
 use omq_tokio::Authenticator;
+#[cfg(any(feature = "plain", feature = "curve"))]
+use omq_tokio::MechanismPeerInfo;
 use omq_tokio::blocking::Socket as BlockingSocket;
 use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{
@@ -83,6 +85,25 @@ pub struct OmqGoEvent {
     connection_id: u64,
     retry_millis: u64,
     attempt: u32,
+}
+
+#[repr(C)]
+pub struct OmqGoAuthPeer {
+    mechanism_data: *const u8,
+    mechanism_len: usize,
+    public_key_data: *const u8,
+    public_key_len: usize,
+    identity_data: *const u8,
+    identity_len: usize,
+    username_data: *const u8,
+    username_len: usize,
+    password_data: *const u8,
+    password_len: usize,
+}
+
+#[cfg(any(feature = "plain", feature = "curve"))]
+unsafe extern "C" {
+    fn omqGoAuthCallback(callback_id: u64, peer: *const OmqGoAuthPeer) -> c_int;
 }
 
 #[repr(C)]
@@ -1252,6 +1273,71 @@ fn bytes_to_event_data(bytes: Bytes) -> (*mut u8, usize) {
     raw_bytes(&bytes)
 }
 
+#[cfg(any(feature = "plain", feature = "curve"))]
+fn go_authenticator(callback_id: u64) -> Authenticator {
+    Authenticator::new(move |peer| go_authenticate(callback_id, peer))
+}
+
+#[cfg(any(feature = "plain", feature = "curve"))]
+fn go_authenticate(callback_id: u64, peer: &MechanismPeerInfo) -> bool {
+    let mechanism = peer.mechanism.as_str().unwrap_or("");
+    let public_key = peer_public_key_z85(peer);
+
+    let (mechanism_data, mechanism_len) = str_view(mechanism);
+    let (public_key_data, public_key_len) = str_view(&public_key);
+    let (identity_data, identity_len) = optional_bytes_view(peer.identity.as_deref());
+    let (username_data, username_len) = optional_str_view(peer.username.as_deref());
+    let (password_data, password_len) = optional_str_view(peer.password.as_deref());
+
+    let c_peer = OmqGoAuthPeer {
+        mechanism_data,
+        mechanism_len,
+        public_key_data,
+        public_key_len,
+        identity_data,
+        identity_len,
+        username_data,
+        username_len,
+        password_data,
+        password_len,
+    };
+    unsafe { omqGoAuthCallback(callback_id, &c_peer) != 0 }
+}
+
+#[cfg(feature = "curve")]
+fn peer_public_key_z85(peer: &MechanismPeerInfo) -> String {
+    if peer.mechanism == omq_proto::proto::MechanismName::CURVE {
+        return CurvePublicKey::from_bytes(peer.public_key).to_z85();
+    }
+    String::new()
+}
+
+#[cfg(not(feature = "curve"))]
+fn peer_public_key_z85(_peer: &MechanismPeerInfo) -> String {
+    String::new()
+}
+
+#[cfg(any(feature = "plain", feature = "curve"))]
+fn str_view(value: &str) -> (*const u8, usize) {
+    if value.is_empty() {
+        return (ptr::null(), 0);
+    }
+    (value.as_ptr(), value.len())
+}
+
+#[cfg(any(feature = "plain", feature = "curve"))]
+fn optional_str_view(value: Option<&str>) -> (*const u8, usize) {
+    value.map_or((ptr::null(), 0), str_view)
+}
+
+#[cfg(any(feature = "plain", feature = "curve"))]
+fn optional_bytes_view(value: Option<&[u8]>) -> (*const u8, usize) {
+    match value {
+        Some(bytes) if !bytes.is_empty() => (bytes.as_ptr(), bytes.len()),
+        _ => (ptr::null(), 0),
+    }
+}
+
 fn event_to_c(event: NativeMonitorEvent) -> OmqGoEvent {
     let mut out = OmqGoEvent {
         kind: ptr::null_mut(),
@@ -2103,6 +2189,31 @@ pub extern "C" fn omq_go_socket_set_plain_server(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "plain")]
+pub extern "C" fn omq_go_socket_set_plain_server_callback(
+    socket: *mut OmqGoSocket,
+    callback_id: u64,
+) -> OmqGoStatus {
+    if callback_id == 0 {
+        return OmqGoStatus::err(CONFIG, "invalid auth callback id");
+    }
+    set_socket_option(socket, move |options| {
+        options.mechanism = MechanismSetup::PlainServer {
+            authenticator: go_authenticator(callback_id),
+        };
+    })
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "plain"))]
+pub extern "C" fn omq_go_socket_set_plain_server_callback(
+    _socket: *mut OmqGoSocket,
+    _callback_id: u64,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "PLAIN support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "plain")]
 pub extern "C" fn omq_go_socket_set_plain_client(
     socket: *mut OmqGoSocket,
     username: *const c_char,
@@ -2159,6 +2270,45 @@ pub extern "C" fn omq_go_socket_set_curve_server(
     _socket: *mut OmqGoSocket,
     _public_key: *const c_char,
     _secret_key: *const c_char,
+) -> OmqGoStatus {
+    OmqGoStatus::err(CONFIG, "CURVE support not enabled")
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "curve")]
+pub extern "C" fn omq_go_socket_set_curve_server_callback(
+    socket: *mut OmqGoSocket,
+    public_key: *const c_char,
+    secret_key: *const c_char,
+    callback_id: u64,
+) -> OmqGoStatus {
+    if callback_id == 0 {
+        return OmqGoStatus::err(CONFIG, "invalid auth callback id");
+    }
+    let result = (|| {
+        let keypair = curve_keypair_from_z85(str_from_c(public_key)?, str_from_c(secret_key)?)?;
+        Ok(set_socket_option(socket, move |options| {
+            let mut curve_options = CurveServerOptions::default();
+            curve_options.authenticator = Some(go_authenticator(callback_id));
+            options.mechanism = MechanismSetup::CurveServer {
+                our_keypair: keypair,
+                options: curve_options,
+            };
+        }))
+    })();
+    match result {
+        Ok(status) => status,
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "curve"))]
+pub extern "C" fn omq_go_socket_set_curve_server_callback(
+    _socket: *mut OmqGoSocket,
+    _public_key: *const c_char,
+    _secret_key: *const c_char,
+    _callback_id: u64,
 ) -> OmqGoStatus {
     OmqGoStatus::err(CONFIG, "CURVE support not enabled")
 }

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -9,7 +9,7 @@ use std::ptr;
 use std::slice;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -49,6 +49,19 @@ const ERROR: i32 = 99;
 
 const RECV_BATCH: usize = 64;
 const RING_BATCH: usize = 512;
+
+static CONTEXTS_CREATED: AtomicU64 = AtomicU64::new(0);
+static CONTEXTS_FREED: AtomicU64 = AtomicU64::new(0);
+static SOCKETS_CREATED: AtomicU64 = AtomicU64::new(0);
+static SOCKETS_FREED: AtomicU64 = AtomicU64::new(0);
+static MONITORS_CREATED: AtomicU64 = AtomicU64::new(0);
+static MONITORS_FREED: AtomicU64 = AtomicU64::new(0);
+static SEND_RINGS_CREATED: AtomicU64 = AtomicU64::new(0);
+static SEND_RINGS_FREED: AtomicU64 = AtomicU64::new(0);
+static RECV_RINGS_CREATED: AtomicU64 = AtomicU64::new(0);
+static RECV_RINGS_FREED: AtomicU64 = AtomicU64::new(0);
+static CANCELS_CREATED: AtomicU64 = AtomicU64::new(0);
+static CANCELS_FREED: AtomicU64 = AtomicU64::new(0);
 
 #[repr(C)]
 pub struct OmqGoStatus {
@@ -130,6 +143,29 @@ pub struct OmqGoRecvRingMemory {
     payload: *mut c_void,
     desc_capacity: usize,
     payload_capacity: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct OmqGoNativeStats {
+    contexts_created: u64,
+    contexts_freed: u64,
+    contexts_live: u64,
+    sockets_created: u64,
+    sockets_freed: u64,
+    sockets_live: u64,
+    monitors_created: u64,
+    monitors_freed: u64,
+    monitors_live: u64,
+    send_rings_created: u64,
+    send_rings_freed: u64,
+    send_rings_live: u64,
+    recv_rings_created: u64,
+    recv_rings_freed: u64,
+    recv_rings_live: u64,
+    cancels_created: u64,
+    cancels_freed: u64,
+    cancels_live: u64,
 }
 
 #[repr(C, align(128))]
@@ -327,6 +363,16 @@ impl OmqGoStatus {
             TrySendError::Error(error) => Self::from_error(error),
         }
     }
+}
+
+fn bump(counter: &AtomicU64) {
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+fn snapshot_counter(created: &AtomicU64, freed: &AtomicU64) -> (u64, u64, u64) {
+    let created = created.load(Ordering::Relaxed);
+    let freed = freed.load(Ordering::Relaxed);
+    (created, freed, created.saturating_sub(freed))
 }
 
 fn status_code_from_error(error: &Error) -> i32 {
@@ -1601,6 +1647,7 @@ pub extern "C" fn omq_go_context_open(
             closed: AtomicBool::new(false),
         }));
     }
+    bump(&CONTEXTS_CREATED);
     OmqGoStatus::ok()
 }
 
@@ -1624,6 +1671,7 @@ pub extern "C" fn omq_go_context_from_share_key(
             closed: AtomicBool::new(false),
         }));
     }
+    bump(&CONTEXTS_CREATED);
     OmqGoStatus::ok()
 }
 
@@ -1666,6 +1714,7 @@ pub extern "C" fn omq_go_context_free(ctx: *mut OmqGoContext) {
         return;
     }
     omq_go_context_close(ctx);
+    bump(&CONTEXTS_FREED);
     unsafe {
         drop(Box::from_raw(ctx));
     }
@@ -1754,6 +1803,7 @@ pub extern "C" fn omq_go_socket_new(
             closed: AtomicBool::new(false),
         }));
     }
+    bump(&SOCKETS_CREATED);
     OmqGoStatus::ok()
 }
 
@@ -2160,6 +2210,7 @@ pub extern "C" fn omq_go_socket_free(socket: *mut OmqGoSocket) {
         return;
     }
     let _ = omq_go_socket_close(socket, -2);
+    bump(&SOCKETS_FREED);
     unsafe {
         drop(Box::from_raw(socket));
     }
@@ -2773,6 +2824,7 @@ pub extern "C" fn omq_go_socket_monitor(
                     closed: AtomicBool::new(false),
                 }));
             }
+            bump(&MONITORS_CREATED);
             OmqGoStatus::ok()
         }
         Err(error) => OmqGoStatus::from_error(error),
@@ -2828,6 +2880,7 @@ pub extern "C" fn omq_go_monitor_free(monitor: *mut OmqGoMonitor) {
         return;
     }
     omq_go_monitor_close(monitor);
+    bump(&MONITORS_FREED);
     unsafe {
         drop(Box::from_raw(monitor));
     }
@@ -2863,6 +2916,7 @@ pub extern "C" fn omq_go_send_ring_create(
             unsafe {
                 *out = Box::into_raw(Box::new(ring));
             }
+            bump(&SEND_RINGS_CREATED);
             OmqGoStatus::ok()
         }
         Err(error) => OmqGoStatus::from_error(error),
@@ -2899,6 +2953,7 @@ pub extern "C" fn omq_go_send_ring_close(ring: *mut OmqGoSendRing) {
     if ring.is_null() {
         return;
     }
+    bump(&SEND_RINGS_FREED);
     unsafe {
         drop(Box::from_raw(ring));
     }
@@ -2934,6 +2989,7 @@ pub extern "C" fn omq_go_recv_ring_create(
             unsafe {
                 *out = Box::into_raw(Box::new(ring));
             }
+            bump(&RECV_RINGS_CREATED);
             OmqGoStatus::ok()
         }
         Err(error) => OmqGoStatus::from_error(error),
@@ -2999,6 +3055,7 @@ pub extern "C" fn omq_go_recv_ring_close(ring: *mut OmqGoRecvRing) {
     if ring.is_null() {
         return;
     }
+    bump(&RECV_RINGS_FREED);
     unsafe {
         drop(Box::from_raw(ring));
     }
@@ -3006,9 +3063,11 @@ pub extern "C" fn omq_go_recv_ring_close(ring: *mut OmqGoRecvRing) {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn omq_go_cancel_new() -> *mut OmqGoCancel {
-    Box::into_raw(Box::new(OmqGoCancel {
+    let cancel = Box::into_raw(Box::new(OmqGoCancel {
         inner: BlockingRecvCancel::new(),
-    }))
+    }));
+    bump(&CANCELS_CREATED);
+    cancel
 }
 
 #[unsafe(no_mangle)]
@@ -3036,6 +3095,7 @@ pub extern "C" fn omq_go_cancel_free(cancel: *mut OmqGoCancel) {
     if cancel.is_null() {
         return;
     }
+    bump(&CANCELS_FREED);
     unsafe {
         drop(Box::from_raw(cancel));
     }
@@ -3098,5 +3158,48 @@ pub extern "C" fn omq_go_string_free(value: *mut c_char) {
     }
     unsafe {
         drop(CString::from_raw(value));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_native_stats(out: *mut OmqGoNativeStats) {
+    if out.is_null() {
+        return;
+    }
+
+    let (contexts_created, contexts_freed, contexts_live) =
+        snapshot_counter(&CONTEXTS_CREATED, &CONTEXTS_FREED);
+    let (sockets_created, sockets_freed, sockets_live) =
+        snapshot_counter(&SOCKETS_CREATED, &SOCKETS_FREED);
+    let (monitors_created, monitors_freed, monitors_live) =
+        snapshot_counter(&MONITORS_CREATED, &MONITORS_FREED);
+    let (send_rings_created, send_rings_freed, send_rings_live) =
+        snapshot_counter(&SEND_RINGS_CREATED, &SEND_RINGS_FREED);
+    let (recv_rings_created, recv_rings_freed, recv_rings_live) =
+        snapshot_counter(&RECV_RINGS_CREATED, &RECV_RINGS_FREED);
+    let (cancels_created, cancels_freed, cancels_live) =
+        snapshot_counter(&CANCELS_CREATED, &CANCELS_FREED);
+
+    unsafe {
+        *out = OmqGoNativeStats {
+            contexts_created,
+            contexts_freed,
+            contexts_live,
+            sockets_created,
+            sockets_freed,
+            sockets_live,
+            monitors_created,
+            monitors_freed,
+            monitors_live,
+            send_rings_created,
+            send_rings_freed,
+            send_rings_live,
+            recv_rings_created,
+            recv_rings_freed,
+            recv_rings_live,
+            cancels_created,
+            cancels_freed,
+            cancels_live,
+        };
     }
 }

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -1099,6 +1099,64 @@ fn recv_one(socket: &OmqGoSocket, timeout_millis: i64) -> Result<Message, Error>
         .ok_or(Error::WouldBlock)
 }
 
+struct ReceiveAnyEntry<'a> {
+    index: usize,
+    socket: &'a OmqGoSocket,
+    native: BlockingSocket,
+}
+
+fn try_receive_any_entry(
+    entries: &[ReceiveAnyEntry<'_>],
+) -> Result<Option<(usize, Message)>, Error> {
+    for entry in entries {
+        if entry.socket.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        if let Some(message) = entry
+            .socket
+            .recv_cache
+            .lock()
+            .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?
+            .pop_front()
+        {
+            return Ok(Some((entry.index, message)));
+        }
+        match entry.native.try_recv() {
+            Ok(message) => return Ok(Some((entry.index, message))),
+            Err(Error::WouldBlock | Error::Timeout) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(None)
+}
+
+async fn receive_any_loop(
+    entries: Vec<ReceiveAnyEntry<'_>>,
+    timeout: Option<Duration>,
+) -> Result<Option<(usize, Message)>, Error> {
+    let deadline = timeout.and_then(|timeout| Instant::now().checked_add(timeout));
+    let mut spins = 0u32;
+
+    loop {
+        if let Some(event) = try_receive_any_entry(&entries)? {
+            return Ok(Some(event));
+        }
+
+        if let Some(deadline) = deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            tokio::time::sleep(remaining.min(Duration::from_micros(50))).await;
+        } else if spins < 256 {
+            spins += 1;
+            tokio::task::yield_now().await;
+        } else {
+            tokio::time::sleep(Duration::from_micros(50)).await;
+        }
+    }
+}
+
 fn copy_message_into(message: &Message, destination: &mut [u8]) -> Result<usize, Error> {
     if message.len() != 1 {
         return Err(Error::Config(
@@ -1827,6 +1885,67 @@ pub extern "C" fn omq_go_socket_try_send_batch(
         }
     })();
     status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_receive_any(
+    sockets: *const *mut OmqGoSocket,
+    socket_count: usize,
+    timeout_millis: i64,
+    index: *mut usize,
+    out: *mut OmqGoMessage,
+) -> OmqGoStatus {
+    if socket_count == 0 {
+        return OmqGoStatus::err(CONFIG, "receive-any requires at least one socket");
+    }
+    if sockets.is_null() || index.is_null() || out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive-any pointer");
+    }
+    unsafe {
+        *index = 0;
+        *out = OmqGoMessage {
+            parts: ptr::null_mut(),
+            part_count: 0,
+        };
+    }
+
+    let raw_sockets = unsafe { slice::from_raw_parts(sockets, socket_count) };
+    let mut entries = Vec::with_capacity(socket_count);
+    for (entry_index, socket) in raw_sockets.iter().copied().enumerate() {
+        if socket.is_null() {
+            return OmqGoStatus::err(CONFIG, "receive-any socket is null");
+        }
+        let socket = unsafe { &*socket };
+        if socket.closed.load(Ordering::Acquire) {
+            return OmqGoStatus::err(CLOSED, "socket closed");
+        }
+        match socket.materialize() {
+            Ok(native) => entries.push(ReceiveAnyEntry {
+                index: entry_index,
+                socket,
+                native,
+            }),
+            Err(error) => return OmqGoStatus::from_error(error),
+        }
+    }
+
+    let timeout = duration_from_timeout_millis(timeout_millis);
+    let ctx = entries[0].socket.ctx.clone();
+    match ctx.block_on(receive_any_loop(entries, timeout)) {
+        Ok(Some((event_index, message))) => unsafe {
+            *index = event_index;
+            *out = message_to_c(message);
+            OmqGoStatus::ok()
+        },
+        Ok(None) => {
+            if timeout_millis == 0 {
+                OmqGoStatus::err(AGAIN, "operation would block")
+            } else {
+                OmqGoStatus::err(TIMEOUT, "operation timed out")
+            }
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -4,13 +4,14 @@
 )]
 
 use std::collections::VecDeque;
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, CString, c_char, c_void};
 use std::ptr;
 use std::slice;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 use std::sync::{Mutex, OnceLock};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
@@ -39,6 +40,7 @@ const MESSAGE_TOO_LARGE: i32 = 11;
 const ERROR: i32 = 99;
 
 const RECV_BATCH: usize = 64;
+const RING_BATCH: usize = 512;
 
 #[repr(C)]
 pub struct OmqGoStatus {
@@ -78,6 +80,152 @@ pub struct OmqGoEvent {
     attempt: u32,
 }
 
+#[repr(C)]
+pub struct OmqGoRecvView {
+    status: OmqGoStatus,
+    data: *const u8,
+    len: usize,
+}
+
+#[repr(C)]
+pub struct OmqGoSendRingMemory {
+    control: *mut c_void,
+    descriptors: *mut c_void,
+    payload: *mut c_void,
+    desc_capacity: usize,
+    payload_capacity: usize,
+}
+
+#[repr(C)]
+pub struct OmqGoRecvRingMemory {
+    control: *mut c_void,
+    descriptors: *mut c_void,
+    payload: *mut c_void,
+    desc_capacity: usize,
+    payload_capacity: usize,
+}
+
+#[repr(C, align(128))]
+struct RecvRingControl {
+    head: AtomicUsize,
+    _pad0: [u8; 120],
+    tail: AtomicUsize,
+    _pad1: [u8; 120],
+}
+
+impl RecvRingControl {
+    fn new() -> Self {
+        Self {
+            head: AtomicUsize::new(0),
+            _pad0: [0; 120],
+            tail: AtomicUsize::new(0),
+            _pad1: [0; 120],
+        }
+    }
+}
+
+#[repr(C, align(64))]
+#[derive(Clone, Copy, Default)]
+struct RecvRingDesc {
+    payload: u64,
+    payload_len: u64,
+    total_len: u64,
+    part_count: u64,
+    flags: u64,
+    payload_end: u64,
+    _reserved0: u64,
+    _reserved1: u64,
+}
+
+#[repr(C, align(128))]
+struct SendRingControl {
+    head: AtomicUsize,
+    _pad0: [u8; 120],
+    tail: AtomicUsize,
+    _pad1: [u8; 120],
+    closed: AtomicUsize,
+    _pad2: [u8; 120],
+}
+
+impl SendRingControl {
+    fn new() -> Self {
+        Self {
+            head: AtomicUsize::new(0),
+            _pad0: [0; 120],
+            tail: AtomicUsize::new(0),
+            _pad1: [0; 120],
+            closed: AtomicUsize::new(0),
+            _pad2: [0; 120],
+        }
+    }
+}
+
+#[repr(C, align(64))]
+#[derive(Clone, Copy, Default)]
+struct SendRingDesc {
+    payload: u64,
+    payload_len: u64,
+    payload_end: u64,
+    _reserved0: u64,
+    _reserved1: u64,
+    _reserved2: u64,
+    _reserved3: u64,
+    _reserved4: u64,
+}
+
+pub struct OmqGoSendRing {
+    shared: Arc<OmqGoSendRingShared>,
+    worker: Option<JoinHandle<()>>,
+}
+
+struct OmqGoSendRingShared {
+    socket: BlockingSocket,
+    control: Box<SendRingControl>,
+    desc: Box<[SendRingDesc]>,
+    payload: Box<[u8]>,
+    done: Box<[AtomicBool]>,
+    desc_mask: usize,
+    last_error_code: AtomicI32,
+    last_error_message: Mutex<CString>,
+    reclaim: Mutex<SendRingReclaim>,
+}
+
+struct SendRingReclaim {
+    cursor: usize,
+}
+
+struct SendSlotOwner {
+    shared: Arc<OmqGoSendRingShared>,
+    cursor: usize,
+    offset: usize,
+    len: usize,
+}
+
+struct RecvExternalBlock {
+    cursor: usize,
+    _bytes: Box<[u8]>,
+}
+
+pub struct OmqGoRecvRing {
+    socket: BlockingSocket,
+    control: Box<RecvRingControl>,
+    desc: Box<[RecvRingDesc]>,
+    payload: Box<[u8]>,
+    desc_mask: usize,
+    payload_mask: usize,
+    cursor: usize,
+    cached_head: usize,
+    reclaimed_head: usize,
+    payload_cursor: usize,
+    payload_head: usize,
+    pending: VecDeque<Message>,
+    scratch: Vec<Message>,
+    external: VecDeque<RecvExternalBlock>,
+}
+
+const RECV_RING_FLAG_MULTIPART: u64 = 1;
+const RECV_RING_FLAG_EXTERNAL: u64 = 2;
+
 pub struct OmqGoContext {
     ctx: Context,
     owner: bool,
@@ -92,6 +240,8 @@ pub struct OmqGoSocket {
     materialize_lock: Mutex<()>,
     recv_cache: Mutex<VecDeque<Message>>,
     recv_scratch: Mutex<Vec<Message>>,
+    recv_into_scratch: Mutex<Vec<u8>>,
+    recv_view_message: Mutex<Option<Message>>,
     closed: AtomicBool,
 }
 
@@ -147,6 +297,24 @@ impl OmqGoStatus {
             TrySendError::Closed => Self::err(CLOSED, "socket closed"),
             TrySendError::Error(error) => Self::from_error(error),
         }
+    }
+}
+
+fn status_code_from_error(error: &Error) -> i32 {
+    match error {
+        Error::InvalidEndpoint(_) => INVALID_ENDPOINT,
+        Error::UnsupportedScheme(_) => UNSUPPORTED_SCHEME,
+        Error::UnsupportedZmtpVersion { .. } | Error::Protocol(_) | Error::HandshakeFailed(_) => {
+            PROTOCOL
+        }
+        Error::Closed => CLOSED,
+        Error::Timeout => TIMEOUT,
+        Error::MessageTooLarge { .. } => MESSAGE_TOO_LARGE,
+        Error::Unroutable => UNROUTABLE,
+        Error::WouldBlock => AGAIN,
+        Error::Config(_) => CONFIG,
+        Error::Io(_) => IO,
+        _ => ERROR,
     }
 }
 
@@ -209,11 +377,416 @@ impl OmqGoSocket {
     }
 }
 
+impl OmqGoRecvRing {
+    fn new(socket: BlockingSocket, desc_capacity: usize, payload_capacity: usize) -> Self {
+        let desc_capacity = desc_capacity.max(1).next_power_of_two();
+        let payload_capacity = payload_capacity.max(1).next_power_of_two();
+        Self {
+            socket,
+            control: Box::new(RecvRingControl::new()),
+            desc: vec![RecvRingDesc::default(); desc_capacity].into_boxed_slice(),
+            payload: vec![0; payload_capacity].into_boxed_slice(),
+            desc_mask: desc_capacity - 1,
+            payload_mask: payload_capacity - 1,
+            cursor: 0,
+            cached_head: 0,
+            reclaimed_head: 0,
+            payload_cursor: 0,
+            payload_head: 0,
+            pending: VecDeque::new(),
+            scratch: Vec::with_capacity(desc_capacity.min(RING_BATCH)),
+            external: VecDeque::new(),
+        }
+    }
+
+    fn memory(&self) -> OmqGoRecvRingMemory {
+        OmqGoRecvRingMemory {
+            control: self.control.as_ref() as *const RecvRingControl as *mut c_void,
+            descriptors: self.desc.as_ptr() as *mut c_void,
+            payload: self.payload.as_ptr() as *mut c_void,
+            desc_capacity: self.desc.len(),
+            payload_capacity: self.payload.len(),
+        }
+    }
+
+    fn reclaim_consumed(&mut self) {
+        let head = self.control.head.load(Ordering::Acquire);
+        while self.reclaimed_head != head {
+            let index = self.reclaimed_head & self.desc_mask;
+            let desc = self.desc[index];
+            if desc.flags & RECV_RING_FLAG_EXTERNAL != 0 {
+                if self
+                    .external
+                    .front()
+                    .is_some_and(|block| block.cursor == self.reclaimed_head)
+                {
+                    self.external.pop_front();
+                }
+            } else {
+                self.payload_head = desc.payload_end as usize;
+            }
+            self.reclaimed_head = self.reclaimed_head.wrapping_add(1);
+        }
+        self.cached_head = head;
+    }
+
+    fn desc_is_full(&mut self) -> bool {
+        if self.cursor.wrapping_sub(self.cached_head) < self.desc.len() {
+            return false;
+        }
+        self.cached_head = self.control.head.load(Ordering::Acquire);
+        self.cursor.wrapping_sub(self.cached_head) >= self.desc.len()
+    }
+
+    fn reserve_payload(&mut self, len: usize) -> Option<(usize, usize)> {
+        if len == 0 {
+            return Some((0, self.payload_cursor));
+        }
+        if len > self.payload.len() {
+            return None;
+        }
+
+        let mut cursor = self.payload_cursor;
+        let mut offset = cursor & self.payload_mask;
+        let mut needed = len;
+        if offset + len > self.payload.len() {
+            let pad = self.payload.len() - offset;
+            cursor = cursor.wrapping_add(pad);
+            needed = needed.wrapping_add(pad);
+            offset = 0;
+        }
+
+        if cursor.wrapping_add(len).wrapping_sub(self.payload_head) > self.payload.len() {
+            return None;
+        }
+
+        self.payload_cursor = self.payload_cursor.wrapping_add(needed);
+        Some((offset, cursor.wrapping_add(len)))
+    }
+
+    fn publish(&mut self, message: &Message) -> bool {
+        if self.desc_is_full() {
+            return false;
+        }
+
+        let part_count = message.len();
+        let total_len = message.byte_len();
+        let encoded_len = encoded_message_len(message);
+        let cursor = self.cursor;
+        let index = cursor & self.desc_mask;
+        let flags = if part_count > 1 {
+            RECV_RING_FLAG_MULTIPART
+        } else {
+            0
+        };
+
+        if let Some((offset, payload_end)) = self.reserve_payload(encoded_len) {
+            write_message_encoded(message, &mut self.payload[offset..offset + encoded_len]);
+            self.desc[index] = RecvRingDesc {
+                payload: offset as u64,
+                payload_len: encoded_len as u64,
+                total_len: total_len as u64,
+                part_count: part_count as u64,
+                flags,
+                payload_end: payload_end as u64,
+                _reserved0: 0,
+                _reserved1: 0,
+            };
+        } else {
+            let bytes = encode_message(message).into_boxed_slice();
+            let addr = bytes.as_ptr() as u64;
+            self.external.push_back(RecvExternalBlock {
+                cursor,
+                _bytes: bytes,
+            });
+            self.desc[index] = RecvRingDesc {
+                payload: addr,
+                payload_len: encoded_len as u64,
+                total_len: total_len as u64,
+                part_count: part_count as u64,
+                flags: flags | RECV_RING_FLAG_EXTERNAL,
+                payload_end: self.payload_cursor as u64,
+                _reserved0: 0,
+                _reserved1: 0,
+            };
+        }
+
+        self.cursor = self.cursor.wrapping_add(1);
+        true
+    }
+
+    fn flush(&self, old_cursor: usize) -> usize {
+        if self.cursor == old_cursor {
+            return 0;
+        }
+        self.control.tail.store(self.cursor, Ordering::Release);
+        self.cursor.wrapping_sub(old_cursor)
+    }
+
+    fn fill(&mut self, timeout_millis: i64, max_messages: usize) -> Result<usize, Error> {
+        if max_messages == 0 {
+            return Err(Error::Config(
+                "max messages must be greater than zero".to_string(),
+            ));
+        }
+
+        self.reclaim_consumed();
+        let start_cursor = self.cursor;
+
+        while self.cursor.wrapping_sub(start_cursor) < max_messages {
+            if let Some(message) = self.pending.pop_front() {
+                if self.publish(&message) {
+                    continue;
+                }
+                self.pending.push_front(message);
+                break;
+            }
+
+            if self.desc_is_full() {
+                break;
+            }
+
+            let remaining = max_messages - self.cursor.wrapping_sub(start_cursor);
+            let desc_space = self.desc.len() - self.cursor.wrapping_sub(self.cached_head);
+            let batch_max = remaining.min(desc_space).min(RING_BATCH);
+            self.scratch.clear();
+            recv_many_into(&self.socket, batch_max, timeout_millis, &mut self.scratch)?;
+
+            let mut blocked = false;
+            let mut batch = Vec::new();
+            std::mem::swap(&mut batch, &mut self.scratch);
+            let mut drained = batch.drain(..);
+            while let Some(message) = drained.next() {
+                if self.publish(&message) {
+                    continue;
+                }
+                self.pending.push_back(message);
+                self.pending.extend(&mut drained);
+                blocked = true;
+                break;
+            }
+            drop(drained);
+            batch.clear();
+            std::mem::swap(&mut batch, &mut self.scratch);
+            if blocked {
+                break;
+            }
+            break;
+        }
+
+        let filled = self.flush(start_cursor);
+        if filled == 0 {
+            return Err(Error::WouldBlock);
+        }
+        Ok(filled)
+    }
+}
+
+impl OmqGoSendRing {
+    fn new(socket: BlockingSocket, desc_capacity: usize, payload_capacity: usize) -> Self {
+        let desc_capacity = desc_capacity.max(1).next_power_of_two();
+        let payload_capacity = payload_capacity.max(1).next_power_of_two();
+        let shared = Arc::new(OmqGoSendRingShared {
+            socket,
+            control: Box::new(SendRingControl::new()),
+            desc: vec![SendRingDesc::default(); desc_capacity].into_boxed_slice(),
+            payload: vec![0; payload_capacity].into_boxed_slice(),
+            done: (0..desc_capacity).map(|_| AtomicBool::new(false)).collect(),
+            desc_mask: desc_capacity - 1,
+            last_error_code: AtomicI32::new(OK),
+            last_error_message: Mutex::new(empty_cstring()),
+            reclaim: Mutex::new(SendRingReclaim { cursor: 0 }),
+        });
+        let worker_shared = Arc::clone(&shared);
+        let worker = thread::spawn(move || send_ring_worker(worker_shared));
+        Self {
+            shared,
+            worker: Some(worker),
+        }
+    }
+
+    fn memory(&self) -> OmqGoSendRingMemory {
+        OmqGoSendRingMemory {
+            control: self.shared.control.as_ref() as *const SendRingControl as *mut c_void,
+            descriptors: self.shared.desc.as_ptr() as *mut c_void,
+            payload: self.shared.payload.as_ptr() as *mut c_void,
+            desc_capacity: self.shared.desc.len(),
+            payload_capacity: self.shared.payload.len(),
+        }
+    }
+
+    fn status(&self) -> OmqGoStatus {
+        let code = self.shared.last_error_code.load(Ordering::Acquire);
+        if code == OK {
+            if self.shared.closed() {
+                return OmqGoStatus::err(CLOSED, "send ring closed");
+            }
+            return OmqGoStatus::ok();
+        }
+        let message = self
+            .shared
+            .last_error_message
+            .lock()
+            .map(|message| message.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| "send ring error".to_string());
+        OmqGoStatus::err(code, message)
+    }
+
+    fn close(&mut self) {
+        self.shared.control.closed.store(1, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for OmqGoSendRing {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl AsRef<[u8]> for SendSlotOwner {
+    fn as_ref(&self) -> &[u8] {
+        &self.shared.payload[self.offset..self.offset + self.len]
+    }
+}
+
+impl Drop for SendSlotOwner {
+    fn drop(&mut self) {
+        self.shared.release_slot(self.cursor);
+    }
+}
+
+impl OmqGoSendRingShared {
+    fn set_error(&self, code: i32, message: impl AsRef<str>) {
+        self.last_error_code.store(code, Ordering::Release);
+        if let Ok(mut slot) = self.last_error_message.lock() {
+            *slot = cstring_lossy(message.as_ref());
+        }
+        self.control.closed.store(1, Ordering::Release);
+    }
+
+    fn closed(&self) -> bool {
+        self.control.closed.load(Ordering::Acquire) != 0
+    }
+
+    fn message_at(self: &Arc<Self>, cursor: usize) -> Message {
+        let desc = self.desc[cursor & self.desc_mask];
+        Message::single(Bytes::from_owner(SendSlotOwner {
+            shared: Arc::clone(self),
+            cursor,
+            offset: desc.payload as usize,
+            len: desc.payload_len as usize,
+        }))
+    }
+
+    fn release_slot(&self, cursor: usize) {
+        self.done[cursor & self.desc_mask].store(true, Ordering::Release);
+        let Ok(mut reclaim) = self.reclaim.lock() else {
+            return;
+        };
+        loop {
+            let index = reclaim.cursor & self.desc_mask;
+            if !self.done[index].swap(false, Ordering::AcqRel) {
+                break;
+            }
+            reclaim.cursor = reclaim.cursor.wrapping_add(1);
+            self.control.head.store(reclaim.cursor, Ordering::Release);
+        }
+    }
+}
+
+fn send_ring_worker(shared: Arc<OmqGoSendRingShared>) {
+    let mut head = 0usize;
+    let mut cached_tail = 0usize;
+    let mut batch = VecDeque::with_capacity(RING_BATCH);
+    let mut spins = 0u32;
+
+    loop {
+        while batch.len() < RING_BATCH {
+            let cursor = head.wrapping_add(batch.len());
+            if cursor == cached_tail {
+                cached_tail = shared.control.tail.load(Ordering::Acquire);
+                if cursor == cached_tail {
+                    break;
+                }
+            }
+            batch.push_back(shared.message_at(cursor));
+        }
+
+        if batch.is_empty() {
+            if shared.closed() {
+                break;
+            }
+            send_ring_backoff(&mut spins);
+            continue;
+        }
+
+        match shared.socket.try_send_many(&mut batch, RING_BATCH) {
+            Ok(sent) => {
+                if sent == 0 {
+                    if shared.closed() {
+                        break;
+                    }
+                    send_ring_backoff(&mut spins);
+                    continue;
+                }
+                head = head.wrapping_add(sent);
+                spins = 0;
+            }
+            Err(TrySendError::Full(returned)) => {
+                batch.push_front(returned);
+                if shared.closed() {
+                    break;
+                }
+                send_ring_backoff(&mut spins);
+            }
+            Err(TrySendError::Closed) => {
+                shared.set_error(CLOSED, "socket closed");
+                break;
+            }
+            Err(TrySendError::Error(error)) => {
+                shared.set_error(status_code_from_error(&error), error.to_string());
+                break;
+            }
+        }
+    }
+
+    shared.control.closed.store(1, Ordering::Release);
+}
+
+fn send_ring_backoff(spins: &mut u32) {
+    if *spins < 256 {
+        std::hint::spin_loop();
+        *spins += 1;
+    } else if *spins < 512 {
+        thread::yield_now();
+        *spins += 1;
+    } else {
+        thread::sleep(Duration::from_micros(50));
+    }
+}
+
 fn status_from_result(result: Result<(), Error>) -> OmqGoStatus {
     match result {
         Ok(()) => OmqGoStatus::ok(),
         Err(error) => OmqGoStatus::from_error(error),
     }
+}
+
+fn empty_cstring() -> CString {
+    CString::new("").expect("empty string contains no NUL")
+}
+
+fn cstring_lossy(message: &str) -> CString {
+    let bytes: Vec<u8> = message
+        .as_bytes()
+        .iter()
+        .copied()
+        .filter(|byte| *byte != 0)
+        .collect();
+    CString::new(bytes).unwrap_or_else(|_| empty_cstring())
 }
 
 fn string_to_raw(value: String) -> *mut c_char {
@@ -239,6 +812,16 @@ fn bytes_from_c<'a>(ptr: *const u8, len: usize) -> Result<&'a [u8], Error> {
         return Err(Error::Config("null byte pointer".to_string()));
     }
     Ok(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+fn bytes_from_c_mut<'a>(ptr: *mut u8, len: usize) -> Result<&'a mut [u8], Error> {
+    if len == 0 {
+        return Ok(&mut []);
+    }
+    if ptr.is_null() {
+        return Err(Error::Config("null byte pointer".to_string()));
+    }
+    Ok(unsafe { slice::from_raw_parts_mut(ptr, len) })
 }
 
 fn endpoint_from_c(ptr: *const c_char) -> Result<Endpoint, Error> {
@@ -325,6 +908,38 @@ fn messages_from_c(
     Ok(out)
 }
 
+fn encoded_message_len(message: &Message) -> usize {
+    if message.len() == 1 {
+        return message.part_slice(0).unwrap_or_default().len();
+    }
+    4 + 4 * message.len() + message.byte_len()
+}
+
+fn encode_message(message: &Message) -> Vec<u8> {
+    let mut out = vec![0; encoded_message_len(message)];
+    write_message_encoded(message, &mut out);
+    out
+}
+
+fn write_message_encoded(message: &Message, out: &mut [u8]) {
+    if message.len() == 1 {
+        let body = message.part_slice(0).unwrap_or_default();
+        out.copy_from_slice(body);
+        return;
+    }
+
+    let part_count = message.len() as u32;
+    out[..4].copy_from_slice(&part_count.to_ne_bytes());
+    let mut offset = 4 + 4 * message.len();
+    for index in 0..message.len() {
+        let part = message.part_slice(index).unwrap_or_default();
+        let len_offset = 4 + 4 * index;
+        out[len_offset..len_offset + 4].copy_from_slice(&(part.len() as u32).to_ne_bytes());
+        out[offset..offset + part.len()].copy_from_slice(part);
+        offset += part.len();
+    }
+}
+
 fn raw_bytes(bytes: &[u8]) -> (*mut u8, usize) {
     if bytes.is_empty() {
         return (ptr::null_mut(), 0);
@@ -361,6 +976,19 @@ fn message_to_c(message: Message) -> OmqGoMessage {
     }
 }
 
+fn recv_many_into(
+    native: &BlockingSocket,
+    max: usize,
+    timeout_millis: i64,
+    out: &mut Vec<Message>,
+) -> Result<usize, Error> {
+    match timeout_millis {
+        i64::MIN..=-1 => native.recv_many_into(max, out),
+        0 => native.try_recv_many_into(max, out),
+        _ => native.recv_many_timeout_into(max, Duration::from_millis(timeout_millis as u64), out),
+    }
+}
+
 fn refill_recv_cache(socket: &OmqGoSocket, timeout_millis: i64) -> Result<(), Error> {
     let native = socket.materialize()?;
     let mut scratch = socket
@@ -369,15 +997,7 @@ fn refill_recv_cache(socket: &OmqGoSocket, timeout_millis: i64) -> Result<(), Er
         .map_err(|_| Error::Config("receive scratch lock poisoned".to_string()))?;
     scratch.clear();
 
-    let received = match timeout_millis {
-        i64::MIN..=-1 => native.recv_many_into(RECV_BATCH, &mut scratch),
-        0 => native.try_recv_many_into(RECV_BATCH, &mut scratch),
-        _ => native.recv_many_timeout_into(
-            RECV_BATCH,
-            Duration::from_millis(timeout_millis as u64),
-            &mut scratch,
-        ),
-    }?;
+    let received = recv_many_into(&native, RECV_BATCH, timeout_millis, &mut scratch)?;
 
     if received == 0 {
         return Err(Error::WouldBlock);
@@ -412,6 +1032,65 @@ fn recv_one(socket: &OmqGoSocket, timeout_millis: i64) -> Result<Message, Error>
         .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?
         .pop_front()
         .ok_or(Error::WouldBlock)
+}
+
+fn copy_message_into(message: &Message, destination: &mut [u8]) -> Result<usize, Error> {
+    if message.len() != 1 {
+        return Err(Error::Config(
+            "RecvInto requires a single-part message".to_string(),
+        ));
+    }
+    let part = message
+        .part_slice(0)
+        .ok_or_else(|| Error::Config("missing message part".to_string()))?;
+    if part.len() > destination.len() {
+        return Err(Error::MessageTooLarge {
+            size: part.len(),
+            max: destination.len(),
+        });
+    }
+    destination[..part.len()].copy_from_slice(part);
+    Ok(part.len())
+}
+
+fn copy_message_to_scratch(
+    message: &Message,
+    capacity: usize,
+    scratch: &mut Vec<u8>,
+) -> Result<usize, Error> {
+    if message.len() != 1 {
+        return Err(Error::Config(
+            "RecvInto requires a single-part message".to_string(),
+        ));
+    }
+    let part = message
+        .part_slice(0)
+        .ok_or_else(|| Error::Config("missing message part".to_string()))?;
+    if part.len() > capacity {
+        return Err(Error::MessageTooLarge {
+            size: part.len(),
+            max: capacity,
+        });
+    }
+    scratch.clear();
+    scratch.extend_from_slice(part);
+    Ok(part.len())
+}
+
+fn message_part_view(message: &Message) -> Result<(*const u8, usize), Error> {
+    if message.len() != 1 {
+        return Err(Error::Config(
+            "RecvView requires a single-part message".to_string(),
+        ));
+    }
+    let part = message
+        .part_slice(0)
+        .ok_or_else(|| Error::Config("missing message part".to_string()))?;
+    if part.is_empty() {
+        Ok((ptr::null(), 0))
+    } else {
+        Ok((part.as_ptr(), part.len()))
+    }
 }
 
 fn try_send_with_timeout(
@@ -781,6 +1460,8 @@ pub extern "C" fn omq_go_socket_new(
             materialize_lock: Mutex::new(()),
             recv_cache: Mutex::new(VecDeque::new()),
             recv_scratch: Mutex::new(Vec::with_capacity(RECV_BATCH)),
+            recv_into_scratch: Mutex::new(Vec::new()),
+            recv_view_message: Mutex::new(None),
             closed: AtomicBool::new(false),
         }));
     }
@@ -875,6 +1556,31 @@ pub extern "C" fn omq_go_socket_send(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_send_one(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+    timeout_millis: i64,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        if socket.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        let native = socket.materialize()?;
+        let message = Message::from_slice(bytes_from_c(data, len)?);
+        Ok((native, message))
+    })();
+    match result {
+        Ok((native, message)) => try_send_with_timeout(&native, message, timeout_millis),
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn omq_go_socket_try_send_batch(
     socket: *mut OmqGoSocket,
     messages: *const OmqGoWireMessage,
@@ -936,6 +1642,130 @@ pub extern "C" fn omq_go_socket_recv(
         }
         Err(error) => OmqGoStatus::from_error(error),
     }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv_one_into(
+    socket: *mut OmqGoSocket,
+    timeout_millis: i64,
+    data: *mut u8,
+    capacity: usize,
+    written: *mut usize,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if written.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive length pointer");
+    }
+    unsafe {
+        *written = 0;
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let destination = bytes_from_c_mut(data, capacity)?;
+        let message = recv_one(socket, timeout_millis)?;
+        let copied = copy_message_into(&message, destination)?;
+        unsafe {
+            *written = copied;
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv_one_borrow(
+    socket: *mut OmqGoSocket,
+    timeout_millis: i64,
+    capacity: usize,
+    data: *mut *const u8,
+    written: *mut usize,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if data.is_null() || written.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive borrow pointer");
+    }
+    unsafe {
+        *data = ptr::null();
+        *written = 0;
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let message = recv_one(socket, timeout_millis)?;
+        let mut scratch = socket
+            .recv_into_scratch
+            .lock()
+            .map_err(|_| Error::Config("receive-into scratch lock poisoned".to_string()))?;
+        let copied = copy_message_to_scratch(&message, capacity, &mut scratch)?;
+        unsafe {
+            *written = copied;
+            *data = if copied == 0 {
+                ptr::null()
+            } else {
+                scratch.as_ptr()
+            };
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv_one_view(
+    socket: *mut OmqGoSocket,
+    timeout_millis: i64,
+) -> OmqGoRecvView {
+    if socket.is_null() {
+        return OmqGoRecvView {
+            status: OmqGoStatus::err(CLOSED, "socket closed"),
+            data: ptr::null(),
+            len: 0,
+        };
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let message = recv_one(socket, timeout_millis)?;
+        let mut guard = socket
+            .recv_view_message
+            .lock()
+            .map_err(|_| Error::Config("receive view lock poisoned".to_string()))?;
+        *guard = Some(message);
+        let message = guard
+            .as_ref()
+            .ok_or_else(|| Error::Config("receive view missing message".to_string()))?;
+        message_part_view(message)
+    })();
+    match result {
+        Ok((data, len)) => OmqGoRecvView {
+            status: OmqGoStatus::ok(),
+            data,
+            len,
+        },
+        Err(error) => OmqGoRecvView {
+            status: OmqGoStatus::from_error(error),
+            data: ptr::null(),
+            len: 0,
+        },
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_clear_recv_view(socket: *mut OmqGoSocket) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = socket
+        .recv_view_message
+        .lock()
+        .map_err(|_| Error::Config("receive view lock poisoned".to_string()))
+        .map(|mut guard| {
+            guard.take();
+        });
+    status_from_result(result)
 }
 
 #[unsafe(no_mangle)]
@@ -1225,6 +2055,156 @@ pub extern "C" fn omq_go_monitor_free(monitor: *mut OmqGoMonitor) {
     omq_go_monitor_close(monitor);
     unsafe {
         drop(Box::from_raw(monitor));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_send_ring_create(
+    socket: *mut OmqGoSocket,
+    desc_capacity: usize,
+    payload_capacity: usize,
+    out: *mut *mut OmqGoSendRing,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null send ring output pointer");
+    }
+    unsafe {
+        *out = ptr::null_mut();
+    }
+    if desc_capacity == 0 {
+        return OmqGoStatus::err(CONFIG, "send ring descriptor capacity must be positive");
+    }
+    if payload_capacity == 0 {
+        return OmqGoStatus::err(CONFIG, "send ring payload capacity must be positive");
+    }
+
+    let socket = unsafe { &*socket };
+    match socket.materialize() {
+        Ok(native) => {
+            let ring = OmqGoSendRing::new(native, desc_capacity, payload_capacity);
+            unsafe {
+                *out = Box::into_raw(Box::new(ring));
+            }
+            OmqGoStatus::ok()
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_send_ring_memory(
+    ring: *mut OmqGoSendRing,
+    out: *mut OmqGoSendRingMemory,
+) -> OmqGoStatus {
+    if ring.is_null() {
+        return OmqGoStatus::err(CLOSED, "send ring closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null send ring memory pointer");
+    }
+    unsafe {
+        *out = (&*ring).memory();
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_send_ring_error(ring: *mut OmqGoSendRing) -> OmqGoStatus {
+    if ring.is_null() {
+        return OmqGoStatus::err(CLOSED, "send ring closed");
+    }
+    unsafe { (&*ring).status() }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_send_ring_close(ring: *mut OmqGoSendRing) {
+    if ring.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ring));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_recv_ring_create(
+    socket: *mut OmqGoSocket,
+    desc_capacity: usize,
+    payload_capacity: usize,
+    out: *mut *mut OmqGoRecvRing,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive ring output pointer");
+    }
+    unsafe {
+        *out = ptr::null_mut();
+    }
+    if desc_capacity == 0 {
+        return OmqGoStatus::err(CONFIG, "receive ring descriptor capacity must be positive");
+    }
+    if payload_capacity == 0 {
+        return OmqGoStatus::err(CONFIG, "receive ring payload capacity must be positive");
+    }
+
+    let socket = unsafe { &*socket };
+    match socket.materialize() {
+        Ok(native) => {
+            let ring = OmqGoRecvRing::new(native, desc_capacity, payload_capacity);
+            unsafe {
+                *out = Box::into_raw(Box::new(ring));
+            }
+            OmqGoStatus::ok()
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_recv_ring_memory(
+    ring: *mut OmqGoRecvRing,
+    out: *mut OmqGoRecvRingMemory,
+) -> OmqGoStatus {
+    if ring.is_null() {
+        return OmqGoStatus::err(CLOSED, "receive ring closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive ring memory pointer");
+    }
+    unsafe {
+        *out = (&*ring).memory();
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_recv_ring_fill(
+    ring: *mut OmqGoRecvRing,
+    timeout_millis: i64,
+    max_messages: usize,
+) -> OmqGoStatus {
+    if ring.is_null() {
+        return OmqGoStatus::err(CLOSED, "receive ring closed");
+    }
+    let ring = unsafe { &mut *ring };
+    match ring.fill(timeout_millis, max_messages) {
+        Ok(_) => OmqGoStatus::ok(),
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_recv_ring_close(ring: *mut OmqGoRecvRing) {
+    if ring.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(ring));
     }
 }
 

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -20,7 +20,7 @@ use omq_proto::TrySendError;
 use omq_tokio::Authenticator;
 #[cfg(any(feature = "plain", feature = "curve"))]
 use omq_tokio::MechanismPeerInfo;
-use omq_tokio::blocking::Socket as BlockingSocket;
+use omq_tokio::blocking::{BlockingRecvCancel, Socket as BlockingSocket};
 use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{
     Context, ContextConfig, DisconnectReason, Endpoint, Error, MechanismSetup, Message,
@@ -37,6 +37,7 @@ const OK: i32 = 0;
 const AGAIN: i32 = 1;
 const CLOSED: i32 = 2;
 const TIMEOUT: i32 = 3;
+const CANCELED: i32 = 4;
 const INVALID_ENDPOINT: i32 = 5;
 const UNSUPPORTED_SCHEME: i32 = 6;
 const PROTOCOL: i32 = 7;
@@ -254,6 +255,10 @@ pub struct OmqGoRecvRing {
     pending: VecDeque<Message>,
     scratch: Vec<Message>,
     external: VecDeque<RecvExternalBlock>,
+}
+
+pub struct OmqGoCancel {
+    inner: BlockingRecvCancel,
 }
 
 const RECV_RING_FLAG_MULTIPART: u64 = 1;
@@ -612,6 +617,74 @@ impl OmqGoRecvRing {
             return Err(Error::WouldBlock);
         }
         Ok(filled)
+    }
+
+    fn fill_cancelable(
+        &mut self,
+        cancel: &BlockingRecvCancel,
+        max_messages: usize,
+    ) -> Result<Option<usize>, Error> {
+        if max_messages == 0 {
+            return Err(Error::Config(
+                "max messages must be greater than zero".to_string(),
+            ));
+        }
+        self.reclaim_consumed();
+        let start_cursor = self.cursor;
+
+        while self.cursor.wrapping_sub(start_cursor) < max_messages {
+            if let Some(message) = self.pending.pop_front() {
+                if self.publish(&message) {
+                    continue;
+                }
+                self.pending.push_front(message);
+                break;
+            }
+
+            if self.desc_is_full() {
+                break;
+            }
+
+            let remaining = max_messages - self.cursor.wrapping_sub(start_cursor);
+            let desc_space = self.desc.len() - self.cursor.wrapping_sub(self.cached_head);
+            let batch_max = remaining.min(desc_space).min(RING_BATCH);
+            self.scratch.clear();
+            let Some(_) = self.socket.recv_many_registered_cancelable_into(
+                batch_max,
+                cancel,
+                &mut self.scratch,
+            )?
+            else {
+                return Ok(None);
+            };
+
+            let mut blocked = false;
+            let mut batch = Vec::new();
+            std::mem::swap(&mut batch, &mut self.scratch);
+            let mut drained = batch.drain(..);
+            while let Some(message) = drained.next() {
+                if self.publish(&message) {
+                    continue;
+                }
+                self.pending.push_back(message);
+                self.pending.extend(&mut drained);
+                blocked = true;
+                break;
+            }
+            drop(drained);
+            batch.clear();
+            std::mem::swap(&mut batch, &mut self.scratch);
+            if blocked {
+                break;
+            }
+            break;
+        }
+
+        let filled = self.flush(start_cursor);
+        if filled == 0 {
+            return Err(Error::WouldBlock);
+        }
+        Ok(Some(filled))
     }
 }
 
@@ -3046,12 +3119,70 @@ pub extern "C" fn omq_go_recv_ring_fill(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn omq_go_recv_ring_fill_cancelable(
+    ring: *mut OmqGoRecvRing,
+    cancel: *const OmqGoCancel,
+    max_messages: usize,
+) -> OmqGoStatus {
+    if ring.is_null() {
+        return OmqGoStatus::err(CLOSED, "receive ring closed");
+    }
+    if cancel.is_null() {
+        return OmqGoStatus::err(CONFIG, "receive cancel handle is null");
+    }
+    let ring = unsafe { &mut *ring };
+    let cancel = unsafe { &*cancel };
+    match ring.fill_cancelable(&cancel.inner, max_messages) {
+        Ok(Some(_)) => OmqGoStatus::ok(),
+        Ok(None) => OmqGoStatus::err(CANCELED, "operation canceled"),
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn omq_go_recv_ring_close(ring: *mut OmqGoRecvRing) {
     if ring.is_null() {
         return;
     }
     unsafe {
         drop(Box::from_raw(ring));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_cancel_new() -> *mut OmqGoCancel {
+    Box::into_raw(Box::new(OmqGoCancel {
+        inner: BlockingRecvCancel::new(),
+    }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_cancel(cancel: *const OmqGoCancel) {
+    if cancel.is_null() {
+        return;
+    }
+    unsafe {
+        (*cancel).inner.cancel();
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_cancel_register_current(cancel: *const OmqGoCancel) {
+    if cancel.is_null() {
+        return;
+    }
+    unsafe {
+        (*cancel).inner.register_current_thread_once();
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_cancel_free(cancel: *mut OmqGoCancel) {
+    if cancel.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(cancel));
     }
 }
 

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -25,7 +25,7 @@ use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{
     Context, ContextConfig, DisconnectReason, Endpoint, Error, MechanismSetup, Message,
     MonitorEvent as NativeMonitorEvent, MonitorRecvError, MonitorStream, MonitorTryRecvError,
-    Options, PeerCommandKind, SocketType,
+    Options, PeerCommandKind, PeerInfo as NativePeerInfo, SocketType,
 };
 #[cfg(feature = "curve")]
 use omq_tokio::{CurveKeypair, CurvePublicKey, CurveSecretKey, CurveServerOptions};
@@ -78,13 +78,20 @@ pub struct OmqGoEvent {
     kind: *mut c_char,
     endpoint: *mut c_char,
     peer_ident: *mut c_char,
+    peer_address: *mut c_char,
+    peer_socket_type: *mut c_char,
     reason: *mut c_char,
     command_name: *mut c_char,
     data: *mut u8,
     data_len: usize,
+    peer_identity: *mut u8,
+    peer_identity_len: usize,
     connection_id: u64,
     retry_millis: u64,
     attempt: u32,
+    zmtp_major: u32,
+    zmtp_minor: u32,
+    has_peer: c_int,
 }
 
 #[repr(C)]
@@ -1273,6 +1280,24 @@ fn bytes_to_event_data(bytes: Bytes) -> (*mut u8, usize) {
     raw_bytes(&bytes)
 }
 
+fn fill_monitor_peer(out: &mut OmqGoEvent, peer: NativePeerInfo) {
+    out.has_peer = 1;
+    out.connection_id = peer.connection_id;
+    out.zmtp_major = u32::from(peer.zmtp_version.0);
+    out.zmtp_minor = u32::from(peer.zmtp_version.1);
+    if let Some(identity) = peer.peer_identity {
+        let (data, len) = bytes_to_event_data(identity);
+        out.peer_identity = data;
+        out.peer_identity_len = len;
+    }
+    if let Some(address) = peer.peer_address {
+        out.peer_address = string_to_raw(address.to_string());
+    }
+    if let Some(socket_type) = peer.peer_properties.socket_type {
+        out.peer_socket_type = string_to_raw(format!("{socket_type:?}").to_ascii_uppercase());
+    }
+}
+
 #[cfg(any(feature = "plain", feature = "curve"))]
 fn go_authenticator(callback_id: u64) -> Authenticator {
     Authenticator::new(move |peer| go_authenticate(callback_id, peer))
@@ -1343,13 +1368,20 @@ fn event_to_c(event: NativeMonitorEvent) -> OmqGoEvent {
         kind: ptr::null_mut(),
         endpoint: ptr::null_mut(),
         peer_ident: ptr::null_mut(),
+        peer_address: ptr::null_mut(),
+        peer_socket_type: ptr::null_mut(),
         reason: ptr::null_mut(),
         command_name: ptr::null_mut(),
         data: ptr::null_mut(),
         data_len: 0,
+        peer_identity: ptr::null_mut(),
+        peer_identity_len: 0,
         connection_id: 0,
         retry_millis: 0,
         attempt: 0,
+        zmtp_major: 0,
+        zmtp_minor: 0,
+        has_peer: 0,
     };
 
     match event {
@@ -1380,7 +1412,7 @@ fn event_to_c(event: NativeMonitorEvent) -> OmqGoEvent {
         NativeMonitorEvent::HandshakeSucceeded { endpoint, peer } => {
             out.kind = string_to_raw("HANDSHAKE_SUCCEEDED".to_string());
             out.endpoint = string_to_raw(endpoint.to_string());
-            out.connection_id = peer.connection_id;
+            fill_monitor_peer(&mut out, peer);
         }
         NativeMonitorEvent::HandshakeFailed {
             endpoint,
@@ -1409,7 +1441,7 @@ fn event_to_c(event: NativeMonitorEvent) -> OmqGoEvent {
         } => {
             out.kind = string_to_raw("DISCONNECTED".to_string());
             out.endpoint = string_to_raw(endpoint.to_string());
-            out.connection_id = peer.connection_id;
+            fill_monitor_peer(&mut out, peer);
             out.reason = string_to_raw(disconnect_reason(reason));
         }
         NativeMonitorEvent::SubscribeReceived { prefix } => {
@@ -2932,6 +2964,8 @@ pub extern "C" fn omq_go_event_free(event: OmqGoEvent) {
     omq_go_string_free(event.kind);
     omq_go_string_free(event.endpoint);
     omq_go_string_free(event.peer_ident);
+    omq_go_string_free(event.peer_address);
+    omq_go_string_free(event.peer_socket_type);
     omq_go_string_free(event.reason);
     omq_go_string_free(event.command_name);
     if !event.data.is_null() && event.data_len > 0 {
@@ -2939,6 +2973,14 @@ pub extern "C" fn omq_go_event_free(event: OmqGoEvent) {
             drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
                 event.data,
                 event.data_len,
+            )));
+        }
+    }
+    if !event.peer_identity.is_null() && event.peer_identity_len > 0 {
+        unsafe {
+            drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
+                event.peer_identity,
+                event.peer_identity_len,
             )));
         }
     }

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -1,0 +1,1279 @@
+#![expect(
+    clippy::not_unsafe_ptr_arg_deref,
+    reason = "C ABI entrypoints validate raw pointers and report status codes"
+)]
+
+use std::collections::VecDeque;
+use std::ffi::{CStr, CString, c_char};
+use std::ptr;
+use std::slice;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_proto::TrySendError;
+use omq_tokio::blocking::Socket as BlockingSocket;
+use omq_tokio::{
+    Context, ContextConfig, DisconnectReason, Endpoint, Error, Message,
+    MonitorEvent as NativeMonitorEvent, MonitorRecvError, MonitorStream, MonitorTryRecvError,
+    Options, PeerCommandKind, SocketType,
+};
+
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("OMQ Go native binding requires a 64-bit target");
+
+const OK: i32 = 0;
+const AGAIN: i32 = 1;
+const CLOSED: i32 = 2;
+const TIMEOUT: i32 = 3;
+const INVALID_ENDPOINT: i32 = 5;
+const UNSUPPORTED_SCHEME: i32 = 6;
+const PROTOCOL: i32 = 7;
+const CONFIG: i32 = 8;
+const IO: i32 = 9;
+const UNROUTABLE: i32 = 10;
+const MESSAGE_TOO_LARGE: i32 = 11;
+const ERROR: i32 = 99;
+
+const RECV_BATCH: usize = 64;
+
+#[repr(C)]
+pub struct OmqGoStatus {
+    code: i32,
+    message: *mut c_char,
+}
+
+#[repr(C)]
+pub struct OmqGoPart {
+    data: *mut u8,
+    len: usize,
+}
+
+#[repr(C)]
+pub struct OmqGoMessage {
+    parts: *mut OmqGoPart,
+    part_count: usize,
+}
+
+#[repr(C)]
+pub struct OmqGoWireMessage {
+    parts: *const OmqGoPart,
+    part_count: usize,
+}
+
+#[repr(C)]
+pub struct OmqGoEvent {
+    kind: *mut c_char,
+    endpoint: *mut c_char,
+    peer_ident: *mut c_char,
+    reason: *mut c_char,
+    command_name: *mut c_char,
+    data: *mut u8,
+    data_len: usize,
+    connection_id: u64,
+    retry_millis: u64,
+    attempt: u32,
+}
+
+pub struct OmqGoContext {
+    ctx: Context,
+    owner: bool,
+    closed: AtomicBool,
+}
+
+pub struct OmqGoSocket {
+    ctx: Context,
+    socket_type: SocketType,
+    options: Mutex<Options>,
+    socket: OnceLock<BlockingSocket>,
+    materialize_lock: Mutex<()>,
+    recv_cache: Mutex<VecDeque<Message>>,
+    recv_scratch: Mutex<Vec<Message>>,
+    closed: AtomicBool,
+}
+
+pub struct OmqGoMonitor {
+    ctx: Context,
+    stream: Mutex<Option<MonitorStream>>,
+    closed: AtomicBool,
+}
+
+impl OmqGoStatus {
+    fn ok() -> Self {
+        Self {
+            code: OK,
+            message: ptr::null_mut(),
+        }
+    }
+
+    fn err(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: string_to_raw(message.into()),
+        }
+    }
+
+    fn from_error(error: Error) -> Self {
+        match error {
+            Error::InvalidEndpoint(message) => Self::err(INVALID_ENDPOINT, message),
+            Error::UnsupportedScheme(message) => Self::err(UNSUPPORTED_SCHEME, message),
+            Error::UnsupportedZmtpVersion { major, minor } => Self::err(
+                PROTOCOL,
+                format!("unsupported ZMTP version: {major}.{minor}"),
+            ),
+            Error::Protocol(message) | Error::HandshakeFailed(message) => {
+                Self::err(PROTOCOL, message)
+            }
+            Error::Closed => Self::err(CLOSED, "socket closed"),
+            Error::Timeout => Self::err(TIMEOUT, "operation timed out"),
+            Error::MessageTooLarge { size, max } => Self::err(
+                MESSAGE_TOO_LARGE,
+                format!("message too large: {size} bytes exceeds max {max}"),
+            ),
+            Error::Unroutable => Self::err(UNROUTABLE, "no route to peer"),
+            Error::WouldBlock => Self::err(AGAIN, "operation would block"),
+            Error::Config(message) => Self::err(CONFIG, message),
+            Error::Io(error) => Self::err(IO, error.to_string()),
+            _ => Self::err(ERROR, error.to_string()),
+        }
+    }
+
+    fn from_try_send(error: TrySendError) -> Self {
+        match error {
+            TrySendError::Full(_) => Self::err(AGAIN, "send queue full"),
+            TrySendError::Closed => Self::err(CLOSED, "socket closed"),
+            TrySendError::Error(error) => Self::from_error(error),
+        }
+    }
+}
+
+impl OmqGoSocket {
+    fn materialize(&self) -> Result<BlockingSocket, Error> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        if let Some(socket) = self.socket.get() {
+            return Ok(socket.clone());
+        }
+
+        let _guard = self
+            .materialize_lock
+            .lock()
+            .map_err(|_| Error::Config("materialize lock poisoned".to_string()))?;
+        if let Some(socket) = self.socket.get() {
+            return Ok(socket.clone());
+        }
+
+        let options = self
+            .options
+            .lock()
+            .map_err(|_| Error::Config("options lock poisoned".to_string()))?
+            .clone();
+        options.validate()?;
+        let socket = self.ctx.blocking_socket(self.socket_type, options);
+        self.socket
+            .set(socket.clone())
+            .map_err(|_| Error::Config("socket materialized concurrently".to_string()))?;
+        Ok(socket)
+    }
+
+    fn set_option<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut Options),
+    {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        if self.socket.get().is_some() {
+            return Err(Error::Config(
+                "socket options must be set before bind, connect, send, or recv".to_string(),
+            ));
+        }
+        let mut options = self
+            .options
+            .lock()
+            .map_err(|_| Error::Config("options lock poisoned".to_string()))?;
+        f(&mut options);
+        Ok(())
+    }
+
+    fn configured_linger(&self) -> Result<Option<Duration>, Error> {
+        Ok(self
+            .options
+            .lock()
+            .map_err(|_| Error::Config("options lock poisoned".to_string()))?
+            .linger)
+    }
+}
+
+fn status_from_result(result: Result<(), Error>) -> OmqGoStatus {
+    match result {
+        Ok(()) => OmqGoStatus::ok(),
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+fn string_to_raw(value: String) -> *mut c_char {
+    let value = value.replace('\0', "\\0");
+    CString::new(value).expect("nul removed").into_raw()
+}
+
+fn str_from_c(ptr: *const c_char) -> Result<&'static str, Error> {
+    if ptr.is_null() {
+        return Err(Error::Config("null string pointer".to_string()));
+    }
+    let value = unsafe { CStr::from_ptr(ptr) };
+    value
+        .to_str()
+        .map_err(|error| Error::Config(format!("invalid UTF-8 string: {error}")))
+}
+
+fn bytes_from_c<'a>(ptr: *const u8, len: usize) -> Result<&'a [u8], Error> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(Error::Config("null byte pointer".to_string()));
+    }
+    Ok(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+fn endpoint_from_c(ptr: *const c_char) -> Result<Endpoint, Error> {
+    Endpoint::from_str(str_from_c(ptr)?)
+}
+
+fn socket_type_from_i32(value: i32) -> Result<SocketType, Error> {
+    match value {
+        1 => Ok(SocketType::Pair),
+        2 => Ok(SocketType::Pub),
+        3 => Ok(SocketType::Sub),
+        4 => Ok(SocketType::Req),
+        5 => Ok(SocketType::Rep),
+        6 => Ok(SocketType::Dealer),
+        7 => Ok(SocketType::Router),
+        8 => Ok(SocketType::Pull),
+        9 => Ok(SocketType::Push),
+        10 => Ok(SocketType::XPub),
+        11 => Ok(SocketType::XSub),
+        12 => Ok(SocketType::Stream),
+        13 => Ok(SocketType::Server),
+        14 => Ok(SocketType::Client),
+        15 => Ok(SocketType::Radio),
+        16 => Ok(SocketType::Dish),
+        17 => Ok(SocketType::Gather),
+        18 => Ok(SocketType::Scatter),
+        19 => Ok(SocketType::Peer),
+        20 => Ok(SocketType::Channel),
+        _ => Err(Error::Config(format!("unknown socket type {value}"))),
+    }
+}
+
+fn duration_from_timeout_millis(timeout_millis: i64) -> Option<Duration> {
+    if timeout_millis < 0 {
+        None
+    } else {
+        Some(Duration::from_millis(timeout_millis as u64))
+    }
+}
+
+fn linger_from_millis(millis: i64) -> Option<Duration> {
+    if millis < 0 {
+        None
+    } else {
+        Some(Duration::from_millis(millis as u64))
+    }
+}
+
+fn message_from_c(parts: *const OmqGoPart, part_count: usize) -> Result<Message, Error> {
+    if part_count == 0 {
+        return Ok(Message::new());
+    }
+    if parts.is_null() {
+        return Err(Error::Config("null message parts pointer".to_string()));
+    }
+    let parts = unsafe { slice::from_raw_parts(parts, part_count) };
+    if part_count == 1 {
+        let part = &parts[0];
+        return Ok(Message::from_slice(bytes_from_c(part.data, part.len)?));
+    }
+
+    let mut copied = Vec::with_capacity(part_count);
+    for part in parts {
+        copied.push(Bytes::copy_from_slice(bytes_from_c(part.data, part.len)?));
+    }
+    Ok(Message::multipart(copied))
+}
+
+fn messages_from_c(
+    messages: *const OmqGoWireMessage,
+    message_count: usize,
+) -> Result<VecDeque<Message>, Error> {
+    if message_count == 0 {
+        return Ok(VecDeque::new());
+    }
+    if messages.is_null() {
+        return Err(Error::Config("null message batch pointer".to_string()));
+    }
+    let messages = unsafe { slice::from_raw_parts(messages, message_count) };
+    let mut out = VecDeque::with_capacity(message_count);
+    for message in messages {
+        out.push_back(message_from_c(message.parts, message.part_count)?);
+    }
+    Ok(out)
+}
+
+fn raw_bytes(bytes: &[u8]) -> (*mut u8, usize) {
+    if bytes.is_empty() {
+        return (ptr::null_mut(), 0);
+    }
+    let mut boxed = bytes.to_vec().into_boxed_slice();
+    let len = boxed.len();
+    let data = boxed.as_mut_ptr();
+    std::mem::forget(boxed);
+    (data, len)
+}
+
+fn message_to_c(message: Message) -> OmqGoMessage {
+    let part_count = message.len();
+    if part_count == 0 {
+        return OmqGoMessage {
+            parts: ptr::null_mut(),
+            part_count: 0,
+        };
+    }
+
+    let mut parts = Vec::with_capacity(part_count);
+    for index in 0..part_count {
+        let bytes = message.part_bytes(index).unwrap_or_default();
+        let (data, len) = raw_bytes(&bytes);
+        parts.push(OmqGoPart { data, len });
+    }
+    let mut boxed = parts.into_boxed_slice();
+    let ptr = boxed.as_mut_ptr();
+    let len = boxed.len();
+    std::mem::forget(boxed);
+    OmqGoMessage {
+        parts: ptr,
+        part_count: len,
+    }
+}
+
+fn refill_recv_cache(socket: &OmqGoSocket, timeout_millis: i64) -> Result<(), Error> {
+    let native = socket.materialize()?;
+    let mut scratch = socket
+        .recv_scratch
+        .lock()
+        .map_err(|_| Error::Config("receive scratch lock poisoned".to_string()))?;
+    scratch.clear();
+
+    let received = match timeout_millis {
+        i64::MIN..=-1 => native.recv_many_into(RECV_BATCH, &mut scratch),
+        0 => native.try_recv_many_into(RECV_BATCH, &mut scratch),
+        _ => native.recv_many_timeout_into(
+            RECV_BATCH,
+            Duration::from_millis(timeout_millis as u64),
+            &mut scratch,
+        ),
+    }?;
+
+    if received == 0 {
+        return Err(Error::WouldBlock);
+    }
+
+    let mut cache = socket
+        .recv_cache
+        .lock()
+        .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?;
+    cache.extend(scratch.drain(..));
+    Ok(())
+}
+
+fn recv_one(socket: &OmqGoSocket, timeout_millis: i64) -> Result<Message, Error> {
+    if socket.closed.load(Ordering::Acquire) {
+        return Err(Error::Closed);
+    }
+
+    if let Some(message) = socket
+        .recv_cache
+        .lock()
+        .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?
+        .pop_front()
+    {
+        return Ok(message);
+    }
+
+    refill_recv_cache(socket, timeout_millis)?;
+    socket
+        .recv_cache
+        .lock()
+        .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?
+        .pop_front()
+        .ok_or(Error::WouldBlock)
+}
+
+fn try_send_with_timeout(
+    native: &BlockingSocket,
+    mut message: Message,
+    timeout_millis: i64,
+) -> OmqGoStatus {
+    if timeout_millis == 0 {
+        return match native.try_send(message) {
+            Ok(()) => OmqGoStatus::ok(),
+            Err(error) => OmqGoStatus::from_try_send(error),
+        };
+    }
+
+    if timeout_millis < 0 {
+        return status_from_result(native.send(message));
+    }
+
+    let deadline = Instant::now() + Duration::from_millis(timeout_millis as u64);
+    loop {
+        match native.try_send(message) {
+            Ok(()) => return OmqGoStatus::ok(),
+            Err(TrySendError::Full(returned)) => {
+                if Instant::now() >= deadline {
+                    return OmqGoStatus::err(TIMEOUT, "operation timed out");
+                }
+                message = returned;
+                thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => return OmqGoStatus::from_try_send(error),
+        }
+    }
+}
+
+fn monitor_recv_error(error: MonitorRecvError) -> Error {
+    match error {
+        MonitorRecvError::Closed => Error::Closed,
+        MonitorRecvError::Lagged(count) => {
+            Error::Config(format!("monitor lagged behind; missed {count} events"))
+        }
+        _ => Error::Config("unknown monitor receive error".to_string()),
+    }
+}
+
+fn monitor_try_recv_error(error: MonitorTryRecvError) -> Result<Option<NativeMonitorEvent>, Error> {
+    match error {
+        MonitorTryRecvError::Empty => Ok(None),
+        MonitorTryRecvError::Closed => Err(Error::Closed),
+        MonitorTryRecvError::Lagged(count) => Err(Error::Config(format!(
+            "monitor lagged behind; missed {count} events"
+        ))),
+        _ => Err(Error::Config("unknown monitor receive error".to_string())),
+    }
+}
+
+fn monitor_recv_with_timeout(
+    monitor: &OmqGoMonitor,
+    timeout_millis: i64,
+) -> Result<Option<NativeMonitorEvent>, Error> {
+    if monitor.closed.load(Ordering::Acquire) {
+        return Err(Error::Closed);
+    }
+
+    let mut stream = {
+        let mut guard = monitor
+            .stream
+            .lock()
+            .map_err(|_| Error::Config("monitor lock poisoned".to_string()))?;
+        guard
+            .take()
+            .ok_or_else(|| Error::Config("monitor receive already in progress".to_string()))?
+    };
+
+    let result = if timeout_millis == 0 {
+        monitor_try_recv_error(match stream.try_recv() {
+            Ok(event) => {
+                let mut guard = monitor
+                    .stream
+                    .lock()
+                    .map_err(|_| Error::Config("monitor lock poisoned".to_string()))?;
+                *guard = Some(stream);
+                return Ok(Some(event));
+            }
+            Err(error) => error,
+        })
+    } else {
+        let timeout = duration_from_timeout_millis(timeout_millis);
+        let (returned, result) = monitor.ctx.block_on(async move {
+            let result = match timeout {
+                Some(timeout) => match tokio::time::timeout(timeout, stream.recv()).await {
+                    Ok(Ok(event)) => Ok(Some(event)),
+                    Ok(Err(error)) => Err(monitor_recv_error(error)),
+                    Err(_) => Ok(None),
+                },
+                None => stream.recv().await.map(Some).map_err(monitor_recv_error),
+            };
+            (stream, result)
+        });
+        stream = returned;
+        result
+    };
+
+    let mut guard = monitor
+        .stream
+        .lock()
+        .map_err(|_| Error::Config("monitor lock poisoned".to_string()))?;
+    *guard = Some(stream);
+    result
+}
+
+fn disconnect_reason(reason: DisconnectReason) -> String {
+    match reason {
+        DisconnectReason::PeerClosed => "peer closed".to_string(),
+        DisconnectReason::LocalClose => "local close".to_string(),
+        DisconnectReason::Error(error) => error,
+        DisconnectReason::Handover => "handover".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn bytes_to_event_data(bytes: Bytes) -> (*mut u8, usize) {
+    raw_bytes(&bytes)
+}
+
+fn event_to_c(event: NativeMonitorEvent) -> OmqGoEvent {
+    let mut out = OmqGoEvent {
+        kind: ptr::null_mut(),
+        endpoint: ptr::null_mut(),
+        peer_ident: ptr::null_mut(),
+        reason: ptr::null_mut(),
+        command_name: ptr::null_mut(),
+        data: ptr::null_mut(),
+        data_len: 0,
+        connection_id: 0,
+        retry_millis: 0,
+        attempt: 0,
+    };
+
+    match event {
+        NativeMonitorEvent::Listening { endpoint } => {
+            out.kind = string_to_raw("LISTENING".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+        }
+        NativeMonitorEvent::Accepted {
+            endpoint,
+            peer_ident,
+            connection_id,
+        } => {
+            out.kind = string_to_raw("ACCEPTED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.peer_ident = string_to_raw(peer_ident.to_string());
+            out.connection_id = connection_id;
+        }
+        NativeMonitorEvent::Connected {
+            endpoint,
+            peer_ident,
+            connection_id,
+        } => {
+            out.kind = string_to_raw("CONNECTED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.peer_ident = string_to_raw(peer_ident.to_string());
+            out.connection_id = connection_id;
+        }
+        NativeMonitorEvent::HandshakeSucceeded { endpoint, peer } => {
+            out.kind = string_to_raw("HANDSHAKE_SUCCEEDED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.connection_id = peer.connection_id;
+        }
+        NativeMonitorEvent::HandshakeFailed {
+            endpoint,
+            peer_ident,
+            reason,
+        } => {
+            out.kind = string_to_raw("HANDSHAKE_FAILED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.peer_ident = string_to_raw(peer_ident.to_string());
+            out.reason = string_to_raw(reason);
+        }
+        NativeMonitorEvent::ConnectDelayed {
+            endpoint,
+            retry_in,
+            attempt,
+        } => {
+            out.kind = string_to_raw("CONNECT_DELAYED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.retry_millis = retry_in.as_millis() as u64;
+            out.attempt = attempt;
+        }
+        NativeMonitorEvent::Disconnected {
+            endpoint,
+            peer,
+            reason,
+        } => {
+            out.kind = string_to_raw("DISCONNECTED".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            out.connection_id = peer.connection_id;
+            out.reason = string_to_raw(disconnect_reason(reason));
+        }
+        NativeMonitorEvent::SubscribeReceived { prefix } => {
+            out.kind = string_to_raw("SUBSCRIBE_RECEIVED".to_string());
+            let (data, len) = bytes_to_event_data(prefix);
+            out.data = data;
+            out.data_len = len;
+        }
+        NativeMonitorEvent::UnsubscribeReceived { prefix } => {
+            out.kind = string_to_raw("UNSUBSCRIBE_RECEIVED".to_string());
+            let (data, len) = bytes_to_event_data(prefix);
+            out.data = data;
+            out.data_len = len;
+        }
+        NativeMonitorEvent::JoinReceived { group } => {
+            out.kind = string_to_raw("JOIN_RECEIVED".to_string());
+            let (data, len) = bytes_to_event_data(group);
+            out.data = data;
+            out.data_len = len;
+        }
+        NativeMonitorEvent::LeaveReceived { group } => {
+            out.kind = string_to_raw("LEAVE_RECEIVED".to_string());
+            let (data, len) = bytes_to_event_data(group);
+            out.data = data;
+            out.data_len = len;
+        }
+        NativeMonitorEvent::PeerCommand {
+            endpoint, command, ..
+        } => {
+            out.kind = string_to_raw("PEER_COMMAND".to_string());
+            out.endpoint = string_to_raw(endpoint.to_string());
+            match command {
+                PeerCommandKind::Error { reason } => {
+                    out.command_name = string_to_raw("ERROR".to_string());
+                    out.reason = string_to_raw(reason);
+                }
+                PeerCommandKind::Unknown { name, body } => {
+                    out.command_name = string_to_raw(String::from_utf8_lossy(&name).into_owned());
+                    let (data, len) = bytes_to_event_data(body);
+                    out.data = data;
+                    out.data_len = len;
+                }
+                _ => {
+                    out.reason = string_to_raw("unknown peer command".to_string());
+                }
+            }
+        }
+        NativeMonitorEvent::Closed => {
+            out.kind = string_to_raw("CLOSED".to_string());
+        }
+        _ => {
+            out.kind = string_to_raw("UNKNOWN".to_string());
+        }
+    }
+    out
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_context_open(
+    io_threads: usize,
+    out: *mut *mut OmqGoContext,
+) -> OmqGoStatus {
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null context output pointer");
+    }
+    if io_threads == 0 {
+        return OmqGoStatus::err(CONFIG, "io_threads must be greater than zero");
+    }
+
+    let ctx = Context::with_config(ContextConfig { io_threads });
+    unsafe {
+        *out = Box::into_raw(Box::new(OmqGoContext {
+            ctx,
+            owner: true,
+            closed: AtomicBool::new(false),
+        }));
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_context_from_share_key(
+    high: u64,
+    low: u64,
+    out: *mut *mut OmqGoContext,
+) -> OmqGoStatus {
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null context output pointer");
+    }
+    let key = ((high as u128) << 64) | low as u128;
+    let Some(ctx) = Context::from_share_key(key) else {
+        return OmqGoStatus::err(CLOSED, "shared context not found");
+    };
+    unsafe {
+        *out = Box::into_raw(Box::new(OmqGoContext {
+            ctx,
+            owner: false,
+            closed: AtomicBool::new(false),
+        }));
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_context_share_key(
+    ctx: *mut OmqGoContext,
+    high: *mut u64,
+    low: *mut u64,
+) -> OmqGoStatus {
+    if ctx.is_null() || high.is_null() || low.is_null() {
+        return OmqGoStatus::err(CONFIG, "null context share key pointer");
+    }
+    let ctx = unsafe { &*ctx };
+    if ctx.closed.load(Ordering::Acquire) {
+        return OmqGoStatus::err(CLOSED, "context closed");
+    }
+    let key = ctx.ctx.share_key();
+    unsafe {
+        *high = (key >> 64) as u64;
+        *low = key as u64;
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_context_close(ctx: *mut OmqGoContext) {
+    if ctx.is_null() {
+        return;
+    }
+    let ctx = unsafe { &*ctx };
+    let was_open = !ctx.closed.swap(true, Ordering::AcqRel);
+    if was_open && ctx.owner {
+        ctx.ctx.term();
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_context_free(ctx: *mut OmqGoContext) {
+    if ctx.is_null() {
+        return;
+    }
+    omq_go_context_close(ctx);
+    unsafe {
+        drop(Box::from_raw(ctx));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_new(
+    ctx: *mut OmqGoContext,
+    socket_type: i32,
+    out: *mut *mut OmqGoSocket,
+) -> OmqGoStatus {
+    if ctx.is_null() || out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null socket creation pointer");
+    }
+    let ctx = unsafe { &*ctx };
+    if ctx.closed.load(Ordering::Acquire) {
+        return OmqGoStatus::err(CLOSED, "context closed");
+    }
+    let socket_type = match socket_type_from_i32(socket_type) {
+        Ok(value) => value,
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    unsafe {
+        *out = Box::into_raw(Box::new(OmqGoSocket {
+            ctx: ctx.ctx.clone(),
+            socket_type,
+            options: Mutex::new(Options::default()),
+            socket: OnceLock::new(),
+            materialize_lock: Mutex::new(()),
+            recv_cache: Mutex::new(VecDeque::new()),
+            recv_scratch: Mutex::new(Vec::with_capacity(RECV_BATCH)),
+            closed: AtomicBool::new(false),
+        }));
+    }
+    OmqGoStatus::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_bind(
+    socket: *mut OmqGoSocket,
+    endpoint: *const c_char,
+    bound_endpoint: *mut *mut c_char,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let endpoint = endpoint_from_c(endpoint)?;
+        let bound = socket.materialize()?.bind(endpoint)?;
+        if !bound_endpoint.is_null() {
+            unsafe {
+                *bound_endpoint = string_to_raw(bound.to_string());
+            }
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_connect(
+    socket: *mut OmqGoSocket,
+    endpoint: *const c_char,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| socket.materialize()?.connect(endpoint_from_c(endpoint)?))();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_unbind(
+    socket: *mut OmqGoSocket,
+    endpoint: *const c_char,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| socket.materialize()?.unbind(endpoint_from_c(endpoint)?))();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_disconnect(
+    socket: *mut OmqGoSocket,
+    endpoint: *const c_char,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| socket.materialize()?.disconnect(endpoint_from_c(endpoint)?))();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_send(
+    socket: *mut OmqGoSocket,
+    parts: *const OmqGoPart,
+    part_count: usize,
+    timeout_millis: i64,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        if socket.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        let native = socket.materialize()?;
+        let message = message_from_c(parts, part_count)?;
+        Ok((native, message))
+    })();
+    match result {
+        Ok((native, message)) => try_send_with_timeout(&native, message, timeout_millis),
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_try_send_batch(
+    socket: *mut OmqGoSocket,
+    messages: *const OmqGoWireMessage,
+    message_count: usize,
+    sent: *mut usize,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if sent.is_null() {
+        return OmqGoStatus::err(CONFIG, "null sent output pointer");
+    }
+    unsafe {
+        *sent = 0;
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        if socket.closed.load(Ordering::Acquire) {
+            return Err(Error::Closed);
+        }
+        let native = socket.materialize()?;
+        let mut queue = messages_from_c(messages, message_count)?;
+        match native.try_send_many(&mut queue, message_count) {
+            Ok(count) => {
+                unsafe {
+                    *sent = count;
+                }
+                Ok(())
+            }
+            Err(error) => Err(match error {
+                TrySendError::Full(_) => Error::WouldBlock,
+                TrySendError::Closed => Error::Closed,
+                TrySendError::Error(error) => error,
+            }),
+        }
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv(
+    socket: *mut OmqGoSocket,
+    timeout_millis: i64,
+    out: *mut OmqGoMessage,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive output pointer");
+    }
+    let socket = unsafe { &*socket };
+    match recv_one(socket, timeout_millis) {
+        Ok(message) => {
+            unsafe {
+                *out = message_to_c(message);
+            }
+            OmqGoStatus::ok()
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_subscribe(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    socket_bytes_op(socket, data, len, |socket, bytes| {
+        socket.subscribe(Bytes::copy_from_slice(bytes))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_unsubscribe(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    socket_bytes_op(socket, data, len, |socket, bytes| {
+        socket.unsubscribe(Bytes::copy_from_slice(bytes))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_join(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    socket_bytes_op(socket, data, len, |socket, bytes| {
+        socket.join(Bytes::copy_from_slice(bytes))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_leave(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    socket_bytes_op(socket, data, len, |socket, bytes| {
+        socket.leave(Bytes::copy_from_slice(bytes))
+    })
+}
+
+fn socket_bytes_op<F>(socket: *mut OmqGoSocket, data: *const u8, len: usize, op: F) -> OmqGoStatus
+where
+    F: FnOnce(BlockingSocket, &[u8]) -> Result<(), Error>,
+{
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let data = bytes_from_c(data, len)?;
+        op(socket.materialize()?, data)
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_close(socket: *mut OmqGoSocket, linger_millis: i64) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::ok();
+    }
+    let socket = unsafe { &*socket };
+    let was_open = !socket.closed.swap(true, Ordering::AcqRel);
+    if !was_open {
+        return OmqGoStatus::ok();
+    }
+
+    let Some(native) = socket.socket.get() else {
+        return OmqGoStatus::ok();
+    };
+    let linger = if linger_millis == -2 {
+        match socket.configured_linger() {
+            Ok(value) => value,
+            Err(error) => return OmqGoStatus::from_error(error),
+        }
+    } else {
+        linger_from_millis(linger_millis)
+    };
+    status_from_result(native.clone().close_with_linger(linger))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_free(socket: *mut OmqGoSocket) {
+    if socket.is_null() {
+        return;
+    }
+    let _ = omq_go_socket_close(socket, -2);
+    unsafe {
+        drop(Box::from_raw(socket));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_send_hwm(socket: *mut OmqGoSocket, value: u32) -> OmqGoStatus {
+    set_socket_option(socket, |options| options.send_hwm = value)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_recv_hwm(socket: *mut OmqGoSocket, value: u32) -> OmqGoStatus {
+    set_socket_option(socket, |options| options.recv_hwm = value)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_linger(socket: *mut OmqGoSocket, millis: i64) -> OmqGoStatus {
+    set_socket_option(socket, |options| {
+        options.linger = linger_from_millis(millis)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_identity(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    let bytes = match bytes_from_c(data, len) {
+        Ok(bytes) => Bytes::copy_from_slice(bytes),
+        Err(error) => return OmqGoStatus::from_error(error),
+    };
+    set_socket_option(socket, |options| options.identity = bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_conflate(
+    socket: *mut OmqGoSocket,
+    enabled: i32,
+) -> OmqGoStatus {
+    set_socket_option(socket, |options| options.conflate = enabled != 0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_router_mandatory(
+    socket: *mut OmqGoSocket,
+    enabled: i32,
+) -> OmqGoStatus {
+    set_socket_option(socket, |options| options.router_mandatory = enabled != 0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_xpub_nodrop(
+    socket: *mut OmqGoSocket,
+    enabled: i32,
+) -> OmqGoStatus {
+    set_socket_option(socket, |options| options.xpub_nodrop = enabled != 0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_auto_train(
+    socket: *mut OmqGoSocket,
+    enabled: i32,
+) -> OmqGoStatus {
+    set_socket_option(socket, |options| {
+        options.compression_auto_train = enabled != 0
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_threshold(
+    socket: *mut OmqGoSocket,
+    bytes: i64,
+) -> OmqGoStatus {
+    let value = if bytes < 0 {
+        None
+    } else {
+        Some(bytes as usize)
+    };
+    set_socket_option(socket, |options| options.compression_threshold = value)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_level(
+    socket: *mut OmqGoSocket,
+    level: i64,
+) -> OmqGoStatus {
+    let value = if level == i64::MIN {
+        None
+    } else {
+        Some(level as i32)
+    };
+    set_socket_option(socket, |options| options.compression_level = value)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_set_compression_dict(
+    socket: *mut OmqGoSocket,
+    data: *const u8,
+    len: usize,
+) -> OmqGoStatus {
+    let value = if len == 0 {
+        None
+    } else {
+        match bytes_from_c(data, len) {
+            Ok(bytes) => Some(Bytes::copy_from_slice(bytes)),
+            Err(error) => return OmqGoStatus::from_error(error),
+        }
+    };
+    set_socket_option(socket, |options| options.compression_dict = value)
+}
+
+fn set_socket_option<F>(socket: *mut OmqGoSocket, f: F) -> OmqGoStatus
+where
+    F: FnOnce(&mut Options),
+{
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    status_from_result(unsafe { &*socket }.set_option(f))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_monitor(
+    socket: *mut OmqGoSocket,
+    out: *mut *mut OmqGoMonitor,
+) -> OmqGoStatus {
+    if socket.is_null() || out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null monitor pointer");
+    }
+    let socket = unsafe { &*socket };
+    match socket.materialize() {
+        Ok(native) => {
+            unsafe {
+                *out = Box::into_raw(Box::new(OmqGoMonitor {
+                    ctx: socket.ctx.clone(),
+                    stream: Mutex::new(Some(native.monitor())),
+                    closed: AtomicBool::new(false),
+                }));
+            }
+            OmqGoStatus::ok()
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_monitor_recv(
+    monitor: *mut OmqGoMonitor,
+    timeout_millis: i64,
+    out: *mut OmqGoEvent,
+) -> OmqGoStatus {
+    if monitor.is_null() {
+        return OmqGoStatus::err(CLOSED, "monitor closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null monitor event output pointer");
+    }
+    let monitor = unsafe { &*monitor };
+    match monitor_recv_with_timeout(monitor, timeout_millis) {
+        Ok(Some(event)) => {
+            unsafe {
+                *out = event_to_c(event);
+            }
+            OmqGoStatus::ok()
+        }
+        Ok(None) => {
+            if timeout_millis == 0 {
+                OmqGoStatus::err(AGAIN, "operation would block")
+            } else {
+                OmqGoStatus::err(TIMEOUT, "operation timed out")
+            }
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_monitor_close(monitor: *mut OmqGoMonitor) {
+    if monitor.is_null() {
+        return;
+    }
+    let monitor = unsafe { &*monitor };
+    monitor.closed.store(true, Ordering::Release);
+    if let Ok(mut guard) = monitor.stream.lock() {
+        guard.take();
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_monitor_free(monitor: *mut OmqGoMonitor) {
+    if monitor.is_null() {
+        return;
+    }
+    omq_go_monitor_close(monitor);
+    unsafe {
+        drop(Box::from_raw(monitor));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_message_free(message: OmqGoMessage) {
+    if message.parts.is_null() || message.part_count == 0 {
+        return;
+    }
+    let parts = unsafe { slice::from_raw_parts_mut(message.parts, message.part_count) };
+    for part in parts {
+        if !part.data.is_null() && part.len > 0 {
+            unsafe {
+                drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
+                    part.data, part.len,
+                )));
+            }
+        }
+    }
+    unsafe {
+        drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
+            message.parts,
+            message.part_count,
+        )));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_event_free(event: OmqGoEvent) {
+    omq_go_string_free(event.kind);
+    omq_go_string_free(event.endpoint);
+    omq_go_string_free(event.peer_ident);
+    omq_go_string_free(event.reason);
+    omq_go_string_free(event.command_name);
+    if !event.data.is_null() && event.data_len > 0 {
+        unsafe {
+            drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
+                event.data,
+                event.data_len,
+            )));
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_string_free(value: *mut c_char) {
+    if value.is_null() {
+        return;
+    }
+    unsafe {
+        drop(CString::from_raw(value));
+    }
+}

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -5,6 +5,13 @@ import "time"
 type SocketOption func(*Socket) error
 
 const defaultCompressionLevel = int64(-1 << 63)
+const (
+	zmtpMaxShortStringBytes = 255
+	compressionDictMaxBytes = 8 * 1024
+	zstdLevelMin            = -8
+	zstdLevelMax            = 4
+	maxHeartbeatTTLMillis   = 6_553_500
+)
 
 func nativeOption(op func(*nativeSocket) error) SocketOption {
 	return func(s *Socket) error {
@@ -28,9 +35,7 @@ func RecvHWM(value uint32) SocketOption {
 }
 
 func Linger(value time.Duration) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setLingerNative(handle, durationMillis(value))
-	})
+	return durationOption(value, setLingerNative)
 }
 
 func LingerForever() SocketOption {
@@ -41,6 +46,9 @@ func LingerForever() SocketOption {
 
 func Identity(value []byte) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if len(value) > zmtpMaxShortStringBytes {
+			return &ConfigError{Err: "identity length must be at most 255 bytes"}
+		}
 		return setIdentityNative(handle, value)
 	})
 }
@@ -56,7 +64,16 @@ func HeartbeatOff() SocketOption {
 }
 
 func HeartbeatTTL(value time.Duration) SocketOption {
-	return durationOption(value, setHeartbeatTTLNative)
+	return nativeOption(func(handle *nativeSocket) error {
+		millis, err := nonNegativeMillis("heartbeat TTL", value)
+		if err != nil {
+			return err
+		}
+		if millis > maxHeartbeatTTLMillis {
+			return &ConfigError{Err: "heartbeat TTL exceeds ZMTP maximum of 6553.5s"}
+		}
+		return setHeartbeatTTLNative(handle, millis)
+	})
 }
 
 func NoHeartbeatTTL() SocketOption {
@@ -97,24 +114,42 @@ func NoMaxMessageSize() SocketOption {
 
 func PlainServer(username, password string) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if err := validateZmtpShortString("PLAIN username", username); err != nil {
+			return err
+		}
+		if err := validateZmtpShortString("PLAIN password", password); err != nil {
+			return err
+		}
 		return setPlainServerNative(handle, username, password)
 	})
 }
 
 func PlainClient(username, password string) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if err := validateZmtpShortString("PLAIN username", username); err != nil {
+			return err
+		}
+		if err := validateZmtpShortString("PLAIN password", password); err != nil {
+			return err
+		}
 		return setPlainClientNative(handle, username, password)
 	})
 }
 
 func CurveServer(keypair CurveKeypair) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if err := validateCurveKeypair(keypair); err != nil {
+			return err
+		}
 		return setCurveServerNative(handle, keypair)
 	})
 }
 
 func CurveClient(keypair CurveKeypair, serverPublicKey string) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if err := validateCurveKeypair(keypair); err != nil {
+			return err
+		}
 		return setCurveClientNative(handle, keypair, serverPublicKey)
 	})
 }
@@ -267,6 +302,9 @@ func CompressionDefaultThreshold() SocketOption {
 
 func CompressionLevel(level int) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if level < zstdLevelMin || level > zstdLevelMax {
+			return &ConfigError{Err: "zstd compression level must be -8..=4"}
+		}
 		return setCompressionLevelNative(handle, int64(level))
 	})
 }
@@ -279,6 +317,12 @@ func CompressionDefaultLevel() SocketOption {
 
 func CompressionDict(value []byte) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
+		if len(value) == 0 {
+			return &ConfigError{Err: "compression dict must not be empty"}
+		}
+		if len(value) > compressionDictMaxBytes {
+			return &ConfigError{Err: "compression dict length must be at most 8192 bytes"}
+		}
 		return setCompressionDictNative(handle, value)
 	})
 }
@@ -373,4 +417,22 @@ func nonNegativeInt64Option(name string, value int64, set func(*nativeSocket, in
 		}
 		return set(handle, value)
 	})
+}
+
+func validateZmtpShortString(name, value string) error {
+	if len([]byte(value)) > zmtpMaxShortStringBytes {
+		return &ConfigError{Err: name + " length must be at most 255 bytes"}
+	}
+	return nil
+}
+
+func validateCurveKeypair(keypair CurveKeypair) error {
+	public, err := CurvePublic(keypair.Secret)
+	if err != nil {
+		return err
+	}
+	if public != keypair.Public {
+		return &ConfigError{Err: "CURVE public key does not match secret key"}
+	}
+	return nil
 }

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -1,0 +1,104 @@
+package omq
+
+import "time"
+
+type SocketOption func(*Socket) error
+
+func SendHWM(value uint32) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setSendHWMNative(handle, value)
+		})
+		return err
+	}
+}
+
+func RecvHWM(value uint32) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setRecvHWMNative(handle, value)
+		})
+		return err
+	}
+}
+
+func Linger(value time.Duration) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setLingerNative(handle, durationMillis(value))
+		})
+		return err
+	}
+}
+
+func Identity(value []byte) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setIdentityNative(handle, value)
+		})
+		return err
+	}
+}
+
+func Conflate(enabled bool) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setConflateNative(handle, enabled)
+		})
+		return err
+	}
+}
+
+func RouterMandatory(enabled bool) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setRouterMandatoryNative(handle, enabled)
+		})
+		return err
+	}
+}
+
+func XPubNoDrop(enabled bool) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setXPubNoDropNative(handle, enabled)
+		})
+		return err
+	}
+}
+
+func CompressionAutoTrain(enabled bool) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setCompressionAutoTrainNative(handle, enabled)
+		})
+		return err
+	}
+}
+
+func CompressionThreshold(bytes int) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setCompressionThresholdNative(handle, int64(bytes))
+		})
+		return err
+	}
+}
+
+func CompressionLevel(level int) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setCompressionLevelNative(handle, int64(level))
+		})
+		return err
+	}
+}
+
+func CompressionDict(value []byte) SocketOption {
+	return func(s *Socket) error {
+		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
+			return nil, setCompressionDictNative(handle, value)
+		})
+		return err
+	}
+}

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -232,10 +232,10 @@ func LingerForever() SocketOption {
 func Identity(value []byte) SocketOption {
 	copied := append([]byte(nil), value...)
 	return trackedOption(func(handle *nativeSocket) error {
-		if len(value) > zmtpMaxShortStringBytes {
+		if len(copied) > zmtpMaxShortStringBytes {
 			return &ConfigError{Err: "identity length must be at most 255 bytes"}
 		}
-		return setIdentityNative(handle, value)
+		return setIdentityNative(handle, copied)
 	}, func(options *SocketOptions) {
 		options.Identity = OptionValue[[]byte]{Value: append([]byte(nil), copied...), Set: true}
 	})
@@ -699,13 +699,13 @@ func CompressionDefaultLevel() SocketOption {
 func CompressionDict(value []byte) SocketOption {
 	copied := append([]byte(nil), value...)
 	return trackedOption(func(handle *nativeSocket) error {
-		if len(value) == 0 {
+		if len(copied) == 0 {
 			return &ConfigError{Err: "compression dict must not be empty"}
 		}
-		if len(value) > compressionDictMaxBytes {
+		if len(copied) > compressionDictMaxBytes {
 			return &ConfigError{Err: "compression dict length must be at most 8192 bytes"}
 		}
-		return setCompressionDictNative(handle, value)
+		return setCompressionDictNative(handle, copied)
 	}, func(options *SocketOptions) {
 		options.CompressionDict = OptionValue[[]byte]{Value: append([]byte(nil), copied...), Set: true}
 		options.NoCompressionDict = false

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -124,6 +124,14 @@ func PlainServer(username, password string) SocketOption {
 	})
 }
 
+func PlainServerAuth(auth Authenticator) SocketOption {
+	return authOption(auth, func(id uint64) SocketOption {
+		return nativeOption(func(handle *nativeSocket) error {
+			return setPlainServerAuthNative(handle, id)
+		})
+	})
+}
+
 func PlainClient(username, password string) SocketOption {
 	return nativeOption(func(handle *nativeSocket) error {
 		if err := validateZmtpShortString("PLAIN username", username); err != nil {
@@ -142,6 +150,17 @@ func CurveServer(keypair CurveKeypair) SocketOption {
 			return err
 		}
 		return setCurveServerNative(handle, keypair)
+	})
+}
+
+func CurveServerAuth(keypair CurveKeypair, auth Authenticator) SocketOption {
+	return authOption(auth, func(id uint64) SocketOption {
+		return nativeOption(func(handle *nativeSocket) error {
+			if err := validateCurveKeypair(keypair); err != nil {
+				return err
+			}
+			return setCurveServerAuthNative(handle, keypair, id)
+		})
 	})
 }
 
@@ -424,6 +443,24 @@ func validateZmtpShortString(name, value string) error {
 		return &ConfigError{Err: name + " length must be at most 255 bytes"}
 	}
 	return nil
+}
+
+func authOption(auth Authenticator, option func(uint64) SocketOption) SocketOption {
+	return func(s *Socket) error {
+		if auth == nil {
+			return &ConfigError{Err: "authenticator must not be nil"}
+		}
+		if s == nil {
+			return ErrClosed
+		}
+		id := registerAuthCallback(auth)
+		if err := option(id)(s); err != nil {
+			unregisterAuthCallback(id)
+			return err
+		}
+		s.addAuthCallback(id)
+		return nil
+	}
 }
 
 func validateCurveKeypair(keypair CurveKeypair) error {

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -4,101 +4,373 @@ import "time"
 
 type SocketOption func(*Socket) error
 
-func SendHWM(value uint32) SocketOption {
+const defaultCompressionLevel = int64(-1 << 63)
+
+func nativeOption(op func(*nativeSocket) error) SocketOption {
 	return func(s *Socket) error {
 		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setSendHWMNative(handle, value)
+			return nil, op(handle)
 		})
 		return err
 	}
+}
+
+func SendHWM(value uint32) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setSendHWMNative(handle, value)
+	})
 }
 
 func RecvHWM(value uint32) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setRecvHWMNative(handle, value)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setRecvHWMNative(handle, value)
+	})
 }
 
 func Linger(value time.Duration) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setLingerNative(handle, durationMillis(value))
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setLingerNative(handle, durationMillis(value))
+	})
+}
+
+func LingerForever() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setLingerNative(handle, -1)
+	})
 }
 
 func Identity(value []byte) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setIdentityNative(handle, value)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setIdentityNative(handle, value)
+	})
+}
+
+func HeartbeatInterval(value time.Duration) SocketOption {
+	return durationOption(value, setHeartbeatIntervalNative)
+}
+
+func HeartbeatOff() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setHeartbeatIntervalNative(handle, -1)
+	})
+}
+
+func HeartbeatTTL(value time.Duration) SocketOption {
+	return durationOption(value, setHeartbeatTTLNative)
+}
+
+func NoHeartbeatTTL() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setHeartbeatTTLNative(handle, -1)
+	})
+}
+
+func HeartbeatTimeout(value time.Duration) SocketOption {
+	return durationOption(value, setHeartbeatTimeoutNative)
+}
+
+func DefaultHeartbeatTimeout() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setHeartbeatTimeoutNative(handle, -1)
+	})
+}
+
+func HandshakeTimeout(value time.Duration) SocketOption {
+	return durationOption(value, setHandshakeTimeoutNative)
+}
+
+func NoHandshakeTimeout() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setHandshakeTimeoutNative(handle, -1)
+	})
+}
+
+func MaxMessageSize(bytes int64) SocketOption {
+	return nonNegativeInt64Option("max message size", bytes, setMaxMessageSizeNative)
+}
+
+func NoMaxMessageSize() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setMaxMessageSizeNative(handle, -1)
+	})
+}
+
+func PlainServer(username, password string) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setPlainServerNative(handle, username, password)
+	})
+}
+
+func PlainClient(username, password string) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setPlainClientNative(handle, username, password)
+	})
+}
+
+func CurveServer(keypair CurveKeypair) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCurveServerNative(handle, keypair)
+	})
+}
+
+func CurveClient(keypair CurveKeypair, serverPublicKey string) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCurveClientNative(handle, keypair, serverPublicKey)
+	})
+}
+
+func Workload(profile WorkloadProfile) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setWorkloadProfileNative(handle, int32(profile))
+	})
+}
+
+func DefaultWorkload() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setWorkloadProfileNative(handle, -1)
+	})
+}
+
+func ReconnectDisabled() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setReconnectNative(handle, 0, 0, 0)
+	})
+}
+
+func ReconnectInterval(value time.Duration) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		millis, err := nonNegativeMillis("reconnect interval", value)
+		if err != nil {
+			return err
+		}
+		return setReconnectNative(handle, 1, millis, 0)
+	})
+}
+
+func ReconnectExponential(min, max time.Duration) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		minMillis, err := nonNegativeMillis("reconnect min", min)
+		if err != nil {
+			return err
+		}
+		maxMillis, err := nonNegativeMillis("reconnect max", max)
+		if err != nil {
+			return err
+		}
+		if maxMillis < minMillis {
+			return &ConfigError{Err: "reconnect max must be greater than or equal to min"}
+		}
+		return setReconnectNative(handle, 2, minMillis, maxMillis)
+	})
+}
+
+func ReconnectStopConnRefused(enabled bool) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setReconnectStopConnRefusedNative(handle, enabled)
+	})
+}
+
+func MaxPendingHandshakes(value int) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setMaxPendingHandshakesNative(handle, value)
+	})
 }
 
 func Conflate(enabled bool) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setConflateNative(handle, enabled)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setConflateNative(handle, enabled)
+	})
 }
 
 func RouterMandatory(enabled bool) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setRouterMandatoryNative(handle, enabled)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setRouterMandatoryNative(handle, enabled)
+	})
+}
+
+func OnMutePolicy(mode OnMute) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setOnMuteNative(handle, int32(mode))
+	})
+}
+
+func TCPKeepaliveDefault() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setTCPKeepaliveNative(handle, 0, 0, 0, 0)
+	})
+}
+
+func TCPKeepaliveOff() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setTCPKeepaliveNative(handle, 1, 0, 0, 0)
+	})
+}
+
+func TCPKeepalive(idle, interval time.Duration, count uint32) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		if count == 0 {
+			return &ConfigError{Err: "TCP keepalive count must be greater than zero"}
+		}
+		idleMillis, err := nonNegativeMillis("TCP keepalive idle", idle)
+		if err != nil {
+			return err
+		}
+		intervalMillis, err := nonNegativeMillis("TCP keepalive interval", interval)
+		if err != nil {
+			return err
+		}
+		return setTCPKeepaliveNative(handle, 2, idleMillis, intervalMillis, count)
+	})
+}
+
+func SendBufferSize(bytes int64) SocketOption {
+	return nonNegativeInt64Option("send buffer size", bytes, setSendBufferSizeNative)
+}
+
+func DefaultSendBufferSize() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setSendBufferSizeNative(handle, -1)
+	})
+}
+
+func RecvBufferSize(bytes int64) SocketOption {
+	return nonNegativeInt64Option("receive buffer size", bytes, setRecvBufferSizeNative)
+}
+
+func DefaultRecvBufferSize() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setRecvBufferSizeNative(handle, -1)
+	})
 }
 
 func XPubNoDrop(enabled bool) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setXPubNoDropNative(handle, enabled)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setXPubNoDropNative(handle, enabled)
+	})
 }
 
 func CompressionAutoTrain(enabled bool) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setCompressionAutoTrainNative(handle, enabled)
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionAutoTrainNative(handle, enabled)
+	})
 }
 
 func CompressionThreshold(bytes int) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setCompressionThresholdNative(handle, int64(bytes))
-		})
-		return err
-	}
+	return nonNegativeInt64Option("compression threshold", int64(bytes), setCompressionThresholdNative)
+}
+
+func CompressionDefaultThreshold() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionThresholdNative(handle, -1)
+	})
 }
 
 func CompressionLevel(level int) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setCompressionLevelNative(handle, int64(level))
-		})
-		return err
-	}
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionLevelNative(handle, int64(level))
+	})
+}
+
+func CompressionDefaultLevel() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionLevelNative(handle, defaultCompressionLevel)
+	})
 }
 
 func CompressionDict(value []byte) SocketOption {
-	return func(s *Socket) error {
-		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
-			return nil, setCompressionDictNative(handle, value)
-		})
-		return err
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionDictNative(handle, value)
+	})
+}
+
+func NoCompressionDict() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionDictNative(handle, nil)
+	})
+}
+
+func CompressionDictCapacity(bytes int64) SocketOption {
+	return nonNegativeInt64Option("compression dictionary capacity", bytes, setCompressionDictCapacityNative)
+}
+
+func DefaultCompressionDictCapacity() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionDictCapacityNative(handle, -1)
+	})
+}
+
+func MaxRecvDictSize(bytes int64) SocketOption {
+	return nonNegativeInt64Option("max receive dictionary size", bytes, setMaxRecvDictSizeNative)
+}
+
+func DefaultMaxRecvDictSize() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setMaxRecvDictSizeNative(handle, -1)
+	})
+}
+
+func CompressionOffloadThreshold(bytes int64) SocketOption {
+	return nonNegativeInt64Option("compression offload threshold", bytes, setCompressionOffloadThresholdNative)
+}
+
+func NoCompressionOffload() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setCompressionOffloadThresholdNative(handle, -1)
+	})
+}
+
+func LargeMessageThreshold(bytes int64) SocketOption {
+	return nonNegativeInt64Option("large message threshold", bytes, setLargeMessageThresholdNative)
+}
+
+func DisableLargeMessagePath() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setLargeMessageThresholdNative(handle, -1)
+	})
+}
+
+func ArenaThreshold(bytes int64) SocketOption {
+	return nonNegativeInt64Option("arena threshold", bytes, setArenaThresholdNative)
+}
+
+func DefaultArenaThreshold() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setArenaThresholdNative(handle, -1)
+	})
+}
+
+func TransmitSlotCapacity(bytes int64) SocketOption {
+	return nonNegativeInt64Option("transmit slot capacity", bytes, setTransmitSlotCapacityNative)
+}
+
+func DefaultTransmitSlotCapacity() SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		return setTransmitSlotCapacityNative(handle, -1)
+	})
+}
+
+func durationOption(value time.Duration, set func(*nativeSocket, int64) error) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		millis, err := nonNegativeMillis("duration", value)
+		if err != nil {
+			return err
+		}
+		return set(handle, millis)
+	})
+}
+
+func nonNegativeMillis(name string, value time.Duration) (int64, error) {
+	if value < 0 {
+		return 0, &ConfigError{Err: name + " must be non-negative"}
 	}
+	return durationMillis(value), nil
+}
+
+func nonNegativeInt64Option(name string, value int64, set func(*nativeSocket, int64) error) SocketOption {
+	return nativeOption(func(handle *nativeSocket) error {
+		if value < 0 {
+			return &ConfigError{Err: name + " must be non-negative"}
+		}
+		return set(handle, value)
+	})
 }

--- a/bindings/go/options.go
+++ b/bindings/go/options.go
@@ -2,7 +2,170 @@ package omq
 
 import "time"
 
+// SocketOption configures a socket before its first bind, connect, or I/O.
 type SocketOption func(*Socket) error
+
+// OptionValue stores an optional configured value in a socket option snapshot.
+type OptionValue[T any] struct {
+	// Value is the configured value.
+	Value T
+	// Set reports whether Value is configured.
+	Set bool
+}
+
+// SocketOptions reports options configured through OMQ.go.
+type SocketOptions struct {
+	// SendHWM is the configured outbound high-water mark.
+	SendHWM OptionValue[uint32]
+	// RecvHWM is the configured inbound high-water mark.
+	RecvHWM OptionValue[uint32]
+	// Linger is the configured close linger.
+	Linger OptionValue[time.Duration]
+	// LingerNever reports linger-forever configuration.
+	LingerNever bool
+	// Identity is the configured ZMTP identity.
+	Identity OptionValue[[]byte]
+
+	// HeartbeatInterval is the configured heartbeat interval.
+	HeartbeatInterval OptionValue[time.Duration]
+	// HeartbeatOff reports disabled heartbeats.
+	HeartbeatOff bool
+	// HeartbeatTTL is the configured heartbeat TTL.
+	HeartbeatTTL OptionValue[time.Duration]
+	// NoHeartbeatTTL reports disabled heartbeat TTL.
+	NoHeartbeatTTL bool
+	// HeartbeatTimeout is the configured heartbeat timeout.
+	HeartbeatTimeout OptionValue[time.Duration]
+	// DefaultHeartbeatTimeout reports default heartbeat timeout.
+	DefaultHeartbeatTimeout bool
+	// HandshakeTimeout is the configured handshake timeout.
+	HandshakeTimeout OptionValue[time.Duration]
+	// NoHandshakeTimeout reports disabled handshake timeout.
+	NoHandshakeTimeout bool
+	// MaxMessageSize is the configured receive size limit.
+	MaxMessageSize OptionValue[int64]
+	// NoMaxMessageSize reports disabled receive size limit.
+	NoMaxMessageSize bool
+
+	// PlainServer is fixed PLAIN server credentials.
+	PlainServer OptionValue[PlainCredentials]
+	// PlainServerAuth reports a PLAIN server callback.
+	PlainServerAuth bool
+	// PlainClient is PLAIN client credentials.
+	PlainClient OptionValue[PlainCredentials]
+	// CurveServer is CURVE server key material.
+	CurveServer OptionValue[CurveKeypair]
+	// CurveServerAuth reports a CURVE server callback.
+	CurveServerAuth bool
+	// CurveClient is CURVE client key material.
+	CurveClient OptionValue[CurveClientConfig]
+
+	// Workload is native workload tuning.
+	Workload OptionValue[WorkloadProfile]
+	// DefaultWorkload reports default workload tuning.
+	DefaultWorkload bool
+	// Reconnect is configured reconnect behavior.
+	Reconnect OptionValue[ReconnectConfig]
+	// ReconnectStopConnRefused is stop-on-refused behavior.
+	ReconnectStopConnRefused OptionValue[bool]
+	// MaxPendingHandshakes is the configured handshake cap.
+	MaxPendingHandshakes OptionValue[int]
+	// Conflate is configured conflate behavior.
+	Conflate OptionValue[bool]
+	// RouterMandatory is configured ROUTER mandatory behavior.
+	RouterMandatory OptionValue[bool]
+	// OnMute is configured mute behavior.
+	OnMute OptionValue[OnMute]
+	// TCPKeepalive is configured TCP keepalive behavior.
+	TCPKeepalive OptionValue[TCPKeepaliveConfig]
+	// SendBufferSize is configured OS send buffer size.
+	SendBufferSize OptionValue[int64]
+	// DefaultSendBufferSize reports default OS send buffer size.
+	DefaultSendBufferSize bool
+	// RecvBufferSize is configured OS receive buffer size.
+	RecvBufferSize OptionValue[int64]
+	// DefaultRecvBufferSize reports default OS receive buffer size.
+	DefaultRecvBufferSize bool
+	// XPubNoDrop is configured XPUB no-drop behavior.
+	XPubNoDrop OptionValue[bool]
+
+	// CompressionAutoTrain is configured dictionary auto-training.
+	CompressionAutoTrain OptionValue[bool]
+	// CompressionThreshold is configured compression threshold.
+	CompressionThreshold OptionValue[int64]
+	// CompressionDefaultThreshold reports default compression threshold.
+	CompressionDefaultThreshold bool
+	// CompressionLevel is configured zstd compression level.
+	CompressionLevel OptionValue[int]
+	// CompressionDefaultLevel reports default compression level.
+	CompressionDefaultLevel bool
+	// CompressionDict is the static compression dictionary.
+	CompressionDict OptionValue[[]byte]
+	// NoCompressionDict reports cleared static compression dictionary.
+	NoCompressionDict bool
+	// CompressionDictCapacity is configured dictionary capacity.
+	CompressionDictCapacity OptionValue[int64]
+	// DefaultCompressionDictCapacity reports default dictionary capacity.
+	DefaultCompressionDictCapacity bool
+	// MaxRecvDictSize is configured max received dictionary size.
+	MaxRecvDictSize OptionValue[int64]
+	// DefaultMaxRecvDictSize reports default max received dictionary size.
+	DefaultMaxRecvDictSize bool
+	// CompressionOffloadThreshold is configured compression offload threshold.
+	CompressionOffloadThreshold OptionValue[int64]
+	// NoCompressionOffload reports disabled compression offload.
+	NoCompressionOffload bool
+	// LargeMessageThreshold is configured large-message threshold.
+	LargeMessageThreshold OptionValue[int64]
+	// DisableLargeMessagePath reports disabled large-message path.
+	DisableLargeMessagePath bool
+	// ArenaThreshold is configured frame arena threshold.
+	ArenaThreshold OptionValue[int64]
+	// DefaultArenaThreshold reports default arena threshold.
+	DefaultArenaThreshold bool
+	// TransmitSlotCapacity is configured transmit slot capacity.
+	TransmitSlotCapacity OptionValue[int64]
+	// DefaultTransmitSlotCapacity reports default transmit slot capacity.
+	DefaultTransmitSlotCapacity bool
+}
+
+// PlainCredentials stores configured PLAIN username and password.
+type PlainCredentials struct {
+	// Username is the PLAIN username.
+	Username string
+	// Password is the PLAIN password.
+	Password string
+}
+
+// CurveClientConfig stores configured CURVE client keys.
+type CurveClientConfig struct {
+	// Keypair is the client keypair.
+	Keypair CurveKeypair
+	// ServerPublicKey is the expected server public key.
+	ServerPublicKey string
+}
+
+// ReconnectConfig stores configured reconnect behavior.
+type ReconnectConfig struct {
+	// Mode is disabled, fixed, or exponential.
+	Mode string
+	// Min is the fixed interval or exponential lower bound.
+	Min time.Duration
+	// Max is the exponential upper bound.
+	Max time.Duration
+}
+
+// TCPKeepaliveConfig stores configured TCP keepalive behavior.
+type TCPKeepaliveConfig struct {
+	// Mode is default, off, or enabled.
+	Mode string
+	// Idle is TCP keepalive idle time.
+	Idle time.Duration
+	// Interval is TCP keepalive probe interval.
+	Interval time.Duration
+	// Count is TCP keepalive probe count.
+	Count uint32
+}
 
 const defaultCompressionLevel = int64(-1 << 63)
 const (
@@ -14,57 +177,91 @@ const (
 )
 
 func nativeOption(op func(*nativeSocket) error) SocketOption {
+	return trackedOption(op, nil)
+}
+
+func trackedOption(op func(*nativeSocket) error, record func(*SocketOptions)) SocketOption {
 	return func(s *Socket) error {
 		_, err := s.call(nil, false, func(handle *nativeSocket) (any, error) {
 			return nil, op(handle)
 		})
+		if err == nil {
+			s.recordOption(record)
+		}
 		return err
 	}
 }
 
+// SendHWM sets the outbound high-water mark.
 func SendHWM(value uint32) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setSendHWMNative(handle, value)
+	}, func(options *SocketOptions) {
+		options.SendHWM = OptionValue[uint32]{Value: value, Set: true}
 	})
 }
 
+// RecvHWM sets the inbound high-water mark.
 func RecvHWM(value uint32) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setRecvHWMNative(handle, value)
+	}, func(options *SocketOptions) {
+		options.RecvHWM = OptionValue[uint32]{Value: value, Set: true}
 	})
 }
 
+// Linger sets socket close linger.
 func Linger(value time.Duration) SocketOption {
-	return durationOption(value, setLingerNative)
-}
-
-func LingerForever() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setLingerNative(handle, -1)
+	return trackedDurationOption(value, setLingerNative, func(options *SocketOptions, value time.Duration) {
+		options.Linger = OptionValue[time.Duration]{Value: value, Set: true}
+		options.LingerNever = false
 	})
 }
 
+// LingerForever keeps pending messages until delivered on close.
+func LingerForever() SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
+		return setLingerNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.Linger = OptionValue[time.Duration]{}
+		options.LingerNever = true
+	})
+}
+
+// Identity sets the ZMTP routing identity.
 func Identity(value []byte) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	copied := append([]byte(nil), value...)
+	return trackedOption(func(handle *nativeSocket) error {
 		if len(value) > zmtpMaxShortStringBytes {
 			return &ConfigError{Err: "identity length must be at most 255 bytes"}
 		}
 		return setIdentityNative(handle, value)
+	}, func(options *SocketOptions) {
+		options.Identity = OptionValue[[]byte]{Value: append([]byte(nil), copied...), Set: true}
 	})
 }
 
+// HeartbeatInterval sets ZMTP heartbeat interval.
 func HeartbeatInterval(value time.Duration) SocketOption {
-	return durationOption(value, setHeartbeatIntervalNative)
-}
-
-func HeartbeatOff() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setHeartbeatIntervalNative(handle, -1)
+	return trackedDurationOption(value, setHeartbeatIntervalNative, func(options *SocketOptions, value time.Duration) {
+		options.HeartbeatInterval = OptionValue[time.Duration]{Value: value, Set: true}
+		options.HeartbeatOff = false
 	})
 }
 
+// HeartbeatOff disables heartbeats.
+func HeartbeatOff() SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
+		return setHeartbeatIntervalNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.HeartbeatInterval = OptionValue[time.Duration]{}
+		options.HeartbeatOff = true
+	})
+}
+
+// HeartbeatTTL sets ZMTP heartbeat TTL.
 func HeartbeatTTL(value time.Duration) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		millis, err := nonNegativeMillis("heartbeat TTL", value)
 		if err != nil {
 			return err
@@ -73,47 +270,79 @@ func HeartbeatTTL(value time.Duration) SocketOption {
 			return &ConfigError{Err: "heartbeat TTL exceeds ZMTP maximum of 6553.5s"}
 		}
 		return setHeartbeatTTLNative(handle, millis)
+	}, func(options *SocketOptions) {
+		options.HeartbeatTTL = OptionValue[time.Duration]{Value: value, Set: true}
+		options.NoHeartbeatTTL = false
 	})
 }
 
+// NoHeartbeatTTL disables heartbeat TTL.
 func NoHeartbeatTTL() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setHeartbeatTTLNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.HeartbeatTTL = OptionValue[time.Duration]{}
+		options.NoHeartbeatTTL = true
 	})
 }
 
+// HeartbeatTimeout sets missing-heartbeat timeout.
 func HeartbeatTimeout(value time.Duration) SocketOption {
-	return durationOption(value, setHeartbeatTimeoutNative)
+	return trackedDurationOption(value, setHeartbeatTimeoutNative, func(options *SocketOptions, value time.Duration) {
+		options.HeartbeatTimeout = OptionValue[time.Duration]{Value: value, Set: true}
+		options.DefaultHeartbeatTimeout = false
+	})
 }
 
+// DefaultHeartbeatTimeout restores native heartbeat timeout default.
 func DefaultHeartbeatTimeout() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setHeartbeatTimeoutNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.HeartbeatTimeout = OptionValue[time.Duration]{}
+		options.DefaultHeartbeatTimeout = true
 	})
 }
 
+// HandshakeTimeout sets ZMTP handshake timeout.
 func HandshakeTimeout(value time.Duration) SocketOption {
-	return durationOption(value, setHandshakeTimeoutNative)
+	return trackedDurationOption(value, setHandshakeTimeoutNative, func(options *SocketOptions, value time.Duration) {
+		options.HandshakeTimeout = OptionValue[time.Duration]{Value: value, Set: true}
+		options.NoHandshakeTimeout = false
+	})
 }
 
+// NoHandshakeTimeout disables handshake timeout.
 func NoHandshakeTimeout() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setHandshakeTimeoutNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.HandshakeTimeout = OptionValue[time.Duration]{}
+		options.NoHandshakeTimeout = true
 	})
 }
 
+// MaxMessageSize sets max receive message size in bytes.
 func MaxMessageSize(bytes int64) SocketOption {
-	return nonNegativeInt64Option("max message size", bytes, setMaxMessageSizeNative)
-}
-
-func NoMaxMessageSize() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setMaxMessageSizeNative(handle, -1)
+	return trackedNonNegativeInt64Option("max message size", bytes, setMaxMessageSizeNative, func(options *SocketOptions, value int64) {
+		options.MaxMessageSize = OptionValue[int64]{Value: value, Set: true}
+		options.NoMaxMessageSize = false
 	})
 }
 
+// NoMaxMessageSize removes max receive message size.
+func NoMaxMessageSize() SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
+		return setMaxMessageSizeNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.MaxMessageSize = OptionValue[int64]{}
+		options.NoMaxMessageSize = true
+	})
+}
+
+// PlainServer configures fixed PLAIN server credentials.
 func PlainServer(username, password string) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if err := validateZmtpShortString("PLAIN username", username); err != nil {
 			return err
 		}
@@ -121,19 +350,30 @@ func PlainServer(username, password string) SocketOption {
 			return err
 		}
 		return setPlainServerNative(handle, username, password)
+	}, func(options *SocketOptions) {
+		options.PlainServer = OptionValue[PlainCredentials]{
+			Value: PlainCredentials{Username: username, Password: password},
+			Set:   true,
+		}
+		options.PlainServerAuth = false
 	})
 }
 
+// PlainServerAuth configures a PLAIN server authenticator.
 func PlainServerAuth(auth Authenticator) SocketOption {
 	return authOption(auth, func(id uint64) SocketOption {
 		return nativeOption(func(handle *nativeSocket) error {
 			return setPlainServerAuthNative(handle, id)
 		})
+	}, func(options *SocketOptions) {
+		options.PlainServer = OptionValue[PlainCredentials]{}
+		options.PlainServerAuth = true
 	})
 }
 
+// PlainClient configures PLAIN client credentials.
 func PlainClient(username, password string) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if err := validateZmtpShortString("PLAIN username", username); err != nil {
 			return err
 		}
@@ -141,18 +381,28 @@ func PlainClient(username, password string) SocketOption {
 			return err
 		}
 		return setPlainClientNative(handle, username, password)
+	}, func(options *SocketOptions) {
+		options.PlainClient = OptionValue[PlainCredentials]{
+			Value: PlainCredentials{Username: username, Password: password},
+			Set:   true,
+		}
 	})
 }
 
+// CurveServer configures a CURVE server.
 func CurveServer(keypair CurveKeypair) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if err := validateCurveKeypair(keypair); err != nil {
 			return err
 		}
 		return setCurveServerNative(handle, keypair)
+	}, func(options *SocketOptions) {
+		options.CurveServer = OptionValue[CurveKeypair]{Value: keypair, Set: true}
+		options.CurveServerAuth = false
 	})
 }
 
+// CurveServerAuth configures a CURVE server authenticator.
 func CurveServerAuth(keypair CurveKeypair, auth Authenticator) SocketOption {
 	return authOption(auth, func(id uint64) SocketOption {
 		return nativeOption(func(handle *nativeSocket) error {
@@ -161,48 +411,78 @@ func CurveServerAuth(keypair CurveKeypair, auth Authenticator) SocketOption {
 			}
 			return setCurveServerAuthNative(handle, keypair, id)
 		})
+	}, func(options *SocketOptions) {
+		options.CurveServer = OptionValue[CurveKeypair]{Value: keypair, Set: true}
+		options.CurveServerAuth = true
 	})
 }
 
+// CurveClient configures a CURVE client.
 func CurveClient(keypair CurveKeypair, serverPublicKey string) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if err := validateCurveKeypair(keypair); err != nil {
 			return err
 		}
 		return setCurveClientNative(handle, keypair, serverPublicKey)
+	}, func(options *SocketOptions) {
+		options.CurveClient = OptionValue[CurveClientConfig]{
+			Value: CurveClientConfig{Keypair: keypair, ServerPublicKey: serverPublicKey},
+			Set:   true,
+		}
 	})
 }
 
+// Workload sets native workload tuning.
 func Workload(profile WorkloadProfile) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setWorkloadProfileNative(handle, int32(profile))
+	}, func(options *SocketOptions) {
+		options.Workload = OptionValue[WorkloadProfile]{Value: profile, Set: true}
+		options.DefaultWorkload = false
 	})
 }
 
+// DefaultWorkload restores native workload tuning.
 func DefaultWorkload() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setWorkloadProfileNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.Workload = OptionValue[WorkloadProfile]{}
+		options.DefaultWorkload = true
 	})
 }
 
+// ReconnectDisabled disables automatic reconnect.
 func ReconnectDisabled() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setReconnectNative(handle, 0, 0, 0)
+	}, func(options *SocketOptions) {
+		options.Reconnect = OptionValue[ReconnectConfig]{
+			Value: ReconnectConfig{Mode: "disabled"},
+			Set:   true,
+		}
 	})
 }
 
+// ReconnectInterval sets fixed reconnect interval.
 func ReconnectInterval(value time.Duration) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		millis, err := nonNegativeMillis("reconnect interval", value)
 		if err != nil {
 			return err
 		}
 		return setReconnectNative(handle, 1, millis, 0)
+	}, func(options *SocketOptions) {
+		options.Reconnect = OptionValue[ReconnectConfig]{
+			Value: ReconnectConfig{Mode: "fixed", Min: value},
+			Set:   true,
+		}
 	})
 }
 
+// ReconnectExponential sets exponential reconnect bounds.
 func ReconnectExponential(min, max time.Duration) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		minMillis, err := nonNegativeMillis("reconnect min", min)
 		if err != nil {
 			return err
@@ -215,53 +495,86 @@ func ReconnectExponential(min, max time.Duration) SocketOption {
 			return &ConfigError{Err: "reconnect max must be greater than or equal to min"}
 		}
 		return setReconnectNative(handle, 2, minMillis, maxMillis)
+	}, func(options *SocketOptions) {
+		options.Reconnect = OptionValue[ReconnectConfig]{
+			Value: ReconnectConfig{Mode: "exponential", Min: min, Max: max},
+			Set:   true,
+		}
 	})
 }
 
+// ReconnectStopConnRefused toggles stop-on-ECONNREFUSED reconnect behavior.
 func ReconnectStopConnRefused(enabled bool) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setReconnectStopConnRefusedNative(handle, enabled)
+	}, func(options *SocketOptions) {
+		options.ReconnectStopConnRefused = OptionValue[bool]{Value: enabled, Set: true}
 	})
 }
 
+// MaxPendingHandshakes limits concurrent pending handshakes.
 func MaxPendingHandshakes(value int) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setMaxPendingHandshakesNative(handle, value)
+	}, func(options *SocketOptions) {
+		options.MaxPendingHandshakes = OptionValue[int]{Value: value, Set: true}
 	})
 }
 
+// Conflate keeps only the latest queued message.
 func Conflate(enabled bool) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setConflateNative(handle, enabled)
+	}, func(options *SocketOptions) {
+		options.Conflate = OptionValue[bool]{Value: enabled, Set: true}
 	})
 }
 
+// RouterMandatory toggles ROUTER unroutable send errors.
 func RouterMandatory(enabled bool) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setRouterMandatoryNative(handle, enabled)
+	}, func(options *SocketOptions) {
+		options.RouterMandatory = OptionValue[bool]{Value: enabled, Set: true}
 	})
 }
 
+// OnMutePolicy sets behavior when native outbound queues are full.
 func OnMutePolicy(mode OnMute) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setOnMuteNative(handle, int32(mode))
+	}, func(options *SocketOptions) {
+		options.OnMute = OptionValue[OnMute]{Value: mode, Set: true}
 	})
 }
 
+// TCPKeepaliveDefault restores platform TCP keepalive defaults.
 func TCPKeepaliveDefault() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setTCPKeepaliveNative(handle, 0, 0, 0, 0)
+	}, func(options *SocketOptions) {
+		options.TCPKeepalive = OptionValue[TCPKeepaliveConfig]{
+			Value: TCPKeepaliveConfig{Mode: "default"},
+			Set:   true,
+		}
 	})
 }
 
+// TCPKeepaliveOff disables TCP keepalive.
 func TCPKeepaliveOff() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setTCPKeepaliveNative(handle, 1, 0, 0, 0)
+	}, func(options *SocketOptions) {
+		options.TCPKeepalive = OptionValue[TCPKeepaliveConfig]{
+			Value: TCPKeepaliveConfig{Mode: "off"},
+			Set:   true,
+		}
 	})
 }
 
+// TCPKeepalive enables TCP keepalive with idle, interval, and probe count.
 func TCPKeepalive(idle, interval time.Duration, count uint32) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if count == 0 {
 			return &ConfigError{Err: "TCP keepalive count must be greater than zero"}
 		}
@@ -274,68 +587,118 @@ func TCPKeepalive(idle, interval time.Duration, count uint32) SocketOption {
 			return err
 		}
 		return setTCPKeepaliveNative(handle, 2, idleMillis, intervalMillis, count)
+	}, func(options *SocketOptions) {
+		options.TCPKeepalive = OptionValue[TCPKeepaliveConfig]{
+			Value: TCPKeepaliveConfig{
+				Mode:     "enabled",
+				Idle:     idle,
+				Interval: interval,
+				Count:    count,
+			},
+			Set: true,
+		}
 	})
 }
 
+// SendBufferSize sets OS send buffer size.
 func SendBufferSize(bytes int64) SocketOption {
-	return nonNegativeInt64Option("send buffer size", bytes, setSendBufferSizeNative)
+	return trackedNonNegativeInt64Option("send buffer size", bytes, setSendBufferSizeNative, func(options *SocketOptions, value int64) {
+		options.SendBufferSize = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultSendBufferSize = false
+	})
 }
 
+// DefaultSendBufferSize restores OS send buffer default.
 func DefaultSendBufferSize() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setSendBufferSizeNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.SendBufferSize = OptionValue[int64]{}
+		options.DefaultSendBufferSize = true
 	})
 }
 
+// RecvBufferSize sets OS receive buffer size.
 func RecvBufferSize(bytes int64) SocketOption {
-	return nonNegativeInt64Option("receive buffer size", bytes, setRecvBufferSizeNative)
+	return trackedNonNegativeInt64Option("receive buffer size", bytes, setRecvBufferSizeNative, func(options *SocketOptions, value int64) {
+		options.RecvBufferSize = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultRecvBufferSize = false
+	})
 }
 
+// DefaultRecvBufferSize restores OS receive buffer default.
 func DefaultRecvBufferSize() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setRecvBufferSizeNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.RecvBufferSize = OptionValue[int64]{}
+		options.DefaultRecvBufferSize = true
 	})
 }
 
+// XPubNoDrop toggles XPUB no-drop behavior.
 func XPubNoDrop(enabled bool) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setXPubNoDropNative(handle, enabled)
+	}, func(options *SocketOptions) {
+		options.XPubNoDrop = OptionValue[bool]{Value: enabled, Set: true}
 	})
 }
 
+// CompressionAutoTrain toggles compression dictionary auto-training.
 func CompressionAutoTrain(enabled bool) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setCompressionAutoTrainNative(handle, enabled)
+	}, func(options *SocketOptions) {
+		options.CompressionAutoTrain = OptionValue[bool]{Value: enabled, Set: true}
 	})
 }
 
+// CompressionThreshold sets minimum bytes before compression.
 func CompressionThreshold(bytes int) SocketOption {
-	return nonNegativeInt64Option("compression threshold", int64(bytes), setCompressionThresholdNative)
-}
-
-func CompressionDefaultThreshold() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setCompressionThresholdNative(handle, -1)
+	return trackedNonNegativeInt64Option("compression threshold", int64(bytes), setCompressionThresholdNative, func(options *SocketOptions, value int64) {
+		options.CompressionThreshold = OptionValue[int64]{Value: value, Set: true}
+		options.CompressionDefaultThreshold = false
 	})
 }
 
+// CompressionDefaultThreshold restores native compression threshold.
+func CompressionDefaultThreshold() SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
+		return setCompressionThresholdNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.CompressionThreshold = OptionValue[int64]{}
+		options.CompressionDefaultThreshold = true
+	})
+}
+
+// CompressionLevel sets zstd compression level.
 func CompressionLevel(level int) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		if level < zstdLevelMin || level > zstdLevelMax {
 			return &ConfigError{Err: "zstd compression level must be -8..=4"}
 		}
 		return setCompressionLevelNative(handle, int64(level))
+	}, func(options *SocketOptions) {
+		options.CompressionLevel = OptionValue[int]{Value: level, Set: true}
+		options.CompressionDefaultLevel = false
 	})
 }
 
+// CompressionDefaultLevel restores native compression level.
 func CompressionDefaultLevel() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setCompressionLevelNative(handle, defaultCompressionLevel)
+	}, func(options *SocketOptions) {
+		options.CompressionLevel = OptionValue[int]{}
+		options.CompressionDefaultLevel = true
 	})
 }
 
+// CompressionDict sets a static compression dictionary.
 func CompressionDict(value []byte) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	copied := append([]byte(nil), value...)
+	return trackedOption(func(handle *nativeSocket) error {
 		if len(value) == 0 {
 			return &ConfigError{Err: "compression dict must not be empty"}
 		}
@@ -343,82 +706,149 @@ func CompressionDict(value []byte) SocketOption {
 			return &ConfigError{Err: "compression dict length must be at most 8192 bytes"}
 		}
 		return setCompressionDictNative(handle, value)
+	}, func(options *SocketOptions) {
+		options.CompressionDict = OptionValue[[]byte]{Value: append([]byte(nil), copied...), Set: true}
+		options.NoCompressionDict = false
 	})
 }
 
+// NoCompressionDict clears the static compression dictionary.
 func NoCompressionDict() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setCompressionDictNative(handle, nil)
+	}, func(options *SocketOptions) {
+		options.CompressionDict = OptionValue[[]byte]{}
+		options.NoCompressionDict = true
 	})
 }
 
+// CompressionDictCapacity sets compression dictionary capacity.
 func CompressionDictCapacity(bytes int64) SocketOption {
-	return nonNegativeInt64Option("compression dictionary capacity", bytes, setCompressionDictCapacityNative)
+	return trackedNonNegativeInt64Option("compression dictionary capacity", bytes, setCompressionDictCapacityNative, func(options *SocketOptions, value int64) {
+		options.CompressionDictCapacity = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultCompressionDictCapacity = false
+	})
 }
 
+// DefaultCompressionDictCapacity restores native dictionary capacity.
 func DefaultCompressionDictCapacity() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setCompressionDictCapacityNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.CompressionDictCapacity = OptionValue[int64]{}
+		options.DefaultCompressionDictCapacity = true
 	})
 }
 
+// MaxRecvDictSize sets max received dictionary size.
 func MaxRecvDictSize(bytes int64) SocketOption {
-	return nonNegativeInt64Option("max receive dictionary size", bytes, setMaxRecvDictSizeNative)
+	return trackedNonNegativeInt64Option("max receive dictionary size", bytes, setMaxRecvDictSizeNative, func(options *SocketOptions, value int64) {
+		options.MaxRecvDictSize = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultMaxRecvDictSize = false
+	})
 }
 
+// DefaultMaxRecvDictSize restores native received dictionary size.
 func DefaultMaxRecvDictSize() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setMaxRecvDictSizeNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.MaxRecvDictSize = OptionValue[int64]{}
+		options.DefaultMaxRecvDictSize = true
 	})
 }
 
+// CompressionOffloadThreshold sets compression offload threshold.
 func CompressionOffloadThreshold(bytes int64) SocketOption {
-	return nonNegativeInt64Option("compression offload threshold", bytes, setCompressionOffloadThresholdNative)
+	return trackedNonNegativeInt64Option("compression offload threshold", bytes, setCompressionOffloadThresholdNative, func(options *SocketOptions, value int64) {
+		options.CompressionOffloadThreshold = OptionValue[int64]{Value: value, Set: true}
+		options.NoCompressionOffload = false
+	})
 }
 
+// NoCompressionOffload disables compression offload.
 func NoCompressionOffload() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setCompressionOffloadThresholdNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.CompressionOffloadThreshold = OptionValue[int64]{}
+		options.NoCompressionOffload = true
 	})
 }
 
+// LargeMessageThreshold sets large-message path threshold.
 func LargeMessageThreshold(bytes int64) SocketOption {
-	return nonNegativeInt64Option("large message threshold", bytes, setLargeMessageThresholdNative)
+	return trackedNonNegativeInt64Option("large message threshold", bytes, setLargeMessageThresholdNative, func(options *SocketOptions, value int64) {
+		options.LargeMessageThreshold = OptionValue[int64]{Value: value, Set: true}
+		options.DisableLargeMessagePath = false
+	})
 }
 
+// DisableLargeMessagePath disables the large-message path.
 func DisableLargeMessagePath() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setLargeMessageThresholdNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.LargeMessageThreshold = OptionValue[int64]{}
+		options.DisableLargeMessagePath = true
 	})
 }
 
+// ArenaThreshold sets native frame arena threshold.
 func ArenaThreshold(bytes int64) SocketOption {
-	return nonNegativeInt64Option("arena threshold", bytes, setArenaThresholdNative)
-}
-
-func DefaultArenaThreshold() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
-		return setArenaThresholdNative(handle, -1)
+	return trackedNonNegativeInt64Option("arena threshold", bytes, setArenaThresholdNative, func(options *SocketOptions, value int64) {
+		options.ArenaThreshold = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultArenaThreshold = false
 	})
 }
 
-func TransmitSlotCapacity(bytes int64) SocketOption {
-	return nonNegativeInt64Option("transmit slot capacity", bytes, setTransmitSlotCapacityNative)
+// DefaultArenaThreshold restores native arena threshold.
+func DefaultArenaThreshold() SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
+		return setArenaThresholdNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.ArenaThreshold = OptionValue[int64]{}
+		options.DefaultArenaThreshold = true
+	})
 }
 
+// TransmitSlotCapacity sets native transmit slot capacity.
+func TransmitSlotCapacity(bytes int64) SocketOption {
+	return trackedNonNegativeInt64Option("transmit slot capacity", bytes, setTransmitSlotCapacityNative, func(options *SocketOptions, value int64) {
+		options.TransmitSlotCapacity = OptionValue[int64]{Value: value, Set: true}
+		options.DefaultTransmitSlotCapacity = false
+	})
+}
+
+// DefaultTransmitSlotCapacity restores native transmit slot capacity.
 func DefaultTransmitSlotCapacity() SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedOption(func(handle *nativeSocket) error {
 		return setTransmitSlotCapacityNative(handle, -1)
+	}, func(options *SocketOptions) {
+		options.TransmitSlotCapacity = OptionValue[int64]{}
+		options.DefaultTransmitSlotCapacity = true
 	})
 }
 
 func durationOption(value time.Duration, set func(*nativeSocket, int64) error) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedDurationOption(value, set, nil)
+}
+
+func trackedDurationOption(
+	value time.Duration,
+	set func(*nativeSocket, int64) error,
+	record func(*SocketOptions, time.Duration),
+) SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
 		millis, err := nonNegativeMillis("duration", value)
 		if err != nil {
 			return err
 		}
 		return set(handle, millis)
+	}, func(options *SocketOptions) {
+		if record != nil {
+			record(options, value)
+		}
 	})
 }
 
@@ -430,11 +860,24 @@ func nonNegativeMillis(name string, value time.Duration) (int64, error) {
 }
 
 func nonNegativeInt64Option(name string, value int64, set func(*nativeSocket, int64) error) SocketOption {
-	return nativeOption(func(handle *nativeSocket) error {
+	return trackedNonNegativeInt64Option(name, value, set, nil)
+}
+
+func trackedNonNegativeInt64Option(
+	name string,
+	value int64,
+	set func(*nativeSocket, int64) error,
+	record func(*SocketOptions, int64),
+) SocketOption {
+	return trackedOption(func(handle *nativeSocket) error {
 		if value < 0 {
 			return &ConfigError{Err: name + " must be non-negative"}
 		}
 		return set(handle, value)
+	}, func(options *SocketOptions) {
+		if record != nil {
+			record(options, value)
+		}
 	})
 }
 
@@ -445,7 +888,11 @@ func validateZmtpShortString(name, value string) error {
 	return nil
 }
 
-func authOption(auth Authenticator, option func(uint64) SocketOption) SocketOption {
+func authOption(
+	auth Authenticator,
+	option func(uint64) SocketOption,
+	record func(*SocketOptions),
+) SocketOption {
 	return func(s *Socket) error {
 		if auth == nil {
 			return &ConfigError{Err: "authenticator must not be nil"}
@@ -459,6 +906,7 @@ func authOption(auth Authenticator, option func(uint64) SocketOption) SocketOpti
 			return err
 		}
 		s.addAuthCallback(id)
+		s.recordOption(record)
 		return nil
 	}
 }

--- a/bindings/go/options_test.go
+++ b/bindings/go/options_test.go
@@ -154,6 +154,8 @@ func TestOptionsRejectInvalidValues(t *testing.T) {
 		Identity(make([]byte, zmtpMaxShortStringBytes+1)),
 		PlainServer(string(make([]byte, zmtpMaxShortStringBytes+1)), "secret"),
 		PlainClient("alice", string(make([]byte, zmtpMaxShortStringBytes+1))),
+		PlainServerAuth(nil),
+		CurveServerAuth(CurveKeypair{}, nil),
 	}
 	for _, option := range invalid {
 		if err := option(pull); !isConfigError(err) {

--- a/bindings/go/options_test.go
+++ b/bindings/go/options_test.go
@@ -1,0 +1,180 @@
+package omq
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestOptionsAcceptBeforeMaterialization(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	options := []SocketOption{
+		Linger(0),
+		LingerForever(),
+		Workload(WorkloadLatency),
+		DefaultWorkload(),
+		ReconnectDisabled(),
+		ReconnectInterval(100 * time.Millisecond),
+		ReconnectExponential(10*time.Millisecond, time.Second),
+		ReconnectStopConnRefused(true),
+		SendHWM(10),
+		RecvHWM(11),
+		HeartbeatInterval(100 * time.Millisecond),
+		HeartbeatTTL(3 * time.Second),
+		NoHeartbeatTTL(),
+		HeartbeatTimeout(5 * time.Second),
+		DefaultHeartbeatTimeout(),
+		HeartbeatOff(),
+		HandshakeTimeout(time.Second),
+		MaxPendingHandshakes(8),
+		NoMaxMessageSize(),
+		Conflate(false),
+		RouterMandatory(false),
+		OnMutePolicy(OnMuteBlock),
+		OnMutePolicy(OnMuteDropNewest),
+		OnMutePolicy(OnMuteDropOldest),
+		TCPKeepalive(time.Minute, 10*time.Second, 3),
+		TCPKeepaliveOff(),
+		TCPKeepaliveDefault(),
+		SendBufferSize(65_536),
+		DefaultSendBufferSize(),
+		RecvBufferSize(65_536),
+		DefaultRecvBufferSize(),
+		CompressionDict([]byte("dict")),
+		NoCompressionDict(),
+		CompressionAutoTrain(true),
+		CompressionThreshold(128),
+		CompressionDefaultThreshold(),
+		CompressionLevel(1),
+		CompressionDefaultLevel(),
+		CompressionDictCapacity(2_048),
+		DefaultCompressionDictCapacity(),
+		MaxRecvDictSize(8_192),
+		DefaultMaxRecvDictSize(),
+		CompressionOffloadThreshold(8_192),
+		NoCompressionOffload(),
+		LargeMessageThreshold(4_096),
+		DisableLargeMessagePath(),
+		ArenaThreshold(65_536),
+		DefaultArenaThreshold(),
+		TransmitSlotCapacity(2 * 1024 * 1024),
+		DefaultTransmitSlotCapacity(),
+		XPubNoDrop(false),
+	}
+	for _, option := range options {
+		if err := option(push); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestOptionsCopyByteSlices(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	identity := []byte("before")
+	dealer, err := ctx.Socket(Dealer, Identity(identity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, dealer)
+	identity[0] = 'x'
+	router := newTestSocket(t, ctx, Router)
+	defer closeSocket(t, router)
+
+	endpoint, err := router.Bind("inproc://go-options-copy-identity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dealer.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := dealer.SendTimeout(String("hello"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	request, err := router.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(request.Part(0)); got != "before" {
+		t.Fatalf("identity = %q, want before", got)
+	}
+}
+
+func TestOptionsCannotChangeAfterMaterialization(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+	if err := push.Connect("tcp://127.0.0.1:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Linger(0)(push); !isConfigError(err) {
+		t.Fatalf("Linger after connect err = %v, want ConfigError", err)
+	}
+	if err := RouterMandatory(true)(push); !isConfigError(err) {
+		t.Fatalf("RouterMandatory after connect err = %v, want ConfigError", err)
+	}
+}
+
+func TestOptionsRejectInvalidValues(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	invalid := []SocketOption{
+		Linger(-time.Millisecond),
+		HeartbeatInterval(-time.Millisecond),
+		HeartbeatTTL(time.Duration(maxHeartbeatTTLMillis+1) * time.Millisecond),
+		HandshakeTimeout(-time.Millisecond),
+		MaxMessageSize(-1),
+		ReconnectExponential(time.Second, time.Millisecond),
+		MaxPendingHandshakes(0),
+		TCPKeepalive(time.Second, time.Second, 0),
+		SendBufferSize(-1),
+		RecvBufferSize(-1),
+		CompressionDict(nil),
+		CompressionDict(make([]byte, compressionDictMaxBytes+1)),
+		CompressionLevel(zstdLevelMax + 1),
+		CompressionThreshold(-1),
+		CompressionDictCapacity(-1),
+		MaxRecvDictSize(-1),
+		CompressionOffloadThreshold(-1),
+		LargeMessageThreshold(-1),
+		ArenaThreshold(-1),
+		TransmitSlotCapacity(-1),
+		Identity(make([]byte, zmtpMaxShortStringBytes+1)),
+		PlainServer(string(make([]byte, zmtpMaxShortStringBytes+1)), "secret"),
+		PlainClient("alice", string(make([]byte, zmtpMaxShortStringBytes+1))),
+	}
+	for _, option := range invalid {
+		if err := option(pull); !isConfigError(err) {
+			t.Fatalf("option err = %v, want ConfigError", err)
+		}
+	}
+
+	first, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CurveServer(CurveKeypair{Public: first.Public, Secret: second.Secret})(pull); !isConfigError(err) {
+		t.Fatalf("CurveServer mismatched keypair err = %v, want ConfigError", err)
+	}
+}
+
+func isConfigError(err error) bool {
+	var config *ConfigError
+	return errors.As(err, &config)
+}

--- a/bindings/go/options_test.go
+++ b/bindings/go/options_test.go
@@ -78,12 +78,13 @@ func TestOptionsCopyByteSlices(t *testing.T) {
 	defer closeContext(t, ctx)
 
 	identity := []byte("before")
-	dealer, err := ctx.Socket(Dealer, Identity(identity))
+	identityOption := Identity(identity)
+	identity[0] = 'x'
+	dealer, err := ctx.Socket(Dealer, identityOption)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer closeSocket(t, dealer)
-	identity[0] = 'x'
 	router := newTestSocket(t, ctx, Router)
 	defer closeSocket(t, router)
 
@@ -113,6 +114,24 @@ func TestOptionsCopyByteSlices(t *testing.T) {
 	again := dealer.Options()
 	if string(again.Identity.Value) != "before" {
 		t.Fatalf("identity option mutated = %q, want before", again.Identity.Value)
+	}
+
+	dict := []byte("abcd")
+	dictOption := CompressionDict(dict)
+	dict[0] = 'z'
+	push, err := ctx.Socket(Push, dictOption)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, push)
+	pushOptions := push.Options()
+	if !pushOptions.CompressionDict.Set || string(pushOptions.CompressionDict.Value) != "abcd" {
+		t.Fatalf("compression dict option = %q/%v, want abcd/true", pushOptions.CompressionDict.Value, pushOptions.CompressionDict.Set)
+	}
+	pushOptions.CompressionDict.Value[0] = 'y'
+	pushAgain := push.Options()
+	if string(pushAgain.CompressionDict.Value) != "abcd" {
+		t.Fatalf("compression dict option mutated = %q, want abcd", pushAgain.CompressionDict.Value)
 	}
 }
 

--- a/bindings/go/options_test.go
+++ b/bindings/go/options_test.go
@@ -104,6 +104,119 @@ func TestOptionsCopyByteSlices(t *testing.T) {
 	if got := string(request.Part(0)); got != "before" {
 		t.Fatalf("identity = %q, want before", got)
 	}
+
+	options := dealer.Options()
+	if !options.Identity.Set || string(options.Identity.Value) != "before" {
+		t.Fatalf("identity option = %q/%v, want before/true", options.Identity.Value, options.Identity.Set)
+	}
+	options.Identity.Value[0] = 'z'
+	again := dealer.Options()
+	if string(again.Identity.Value) != "before" {
+		t.Fatalf("identity option mutated = %q, want before", again.Identity.Value)
+	}
+}
+
+func TestOptionsSnapshotReportsConfiguredValues(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	socket, err := ctx.Socket(Push,
+		SendHWM(7),
+		RecvHWM(8),
+		Linger(2*time.Millisecond),
+		HeartbeatOff(),
+		NoHeartbeatTTL(),
+		DefaultHeartbeatTimeout(),
+		NoHandshakeTimeout(),
+		NoMaxMessageSize(),
+		PlainClient("alice", "secret"),
+		Workload(WorkloadLatency),
+		ReconnectExponential(time.Millisecond, 10*time.Millisecond),
+		ReconnectStopConnRefused(true),
+		MaxPendingHandshakes(4),
+		Conflate(true),
+		RouterMandatory(true),
+		OnMutePolicy(OnMuteDropNewest),
+		TCPKeepalive(time.Second, time.Second, 2),
+		SendBufferSize(1024),
+		RecvBufferSize(2048),
+		XPubNoDrop(true),
+		CompressionAutoTrain(true),
+		CompressionThreshold(64),
+		CompressionLevel(1),
+		CompressionDict([]byte("abcd")),
+		CompressionDictCapacity(4096),
+		MaxRecvDictSize(8192),
+		CompressionOffloadThreshold(16384),
+		LargeMessageThreshold(32768),
+		ArenaThreshold(65536),
+		TransmitSlotCapacity(131072),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, socket)
+
+	options := socket.Options()
+	if !options.SendHWM.Set || options.SendHWM.Value != 7 {
+		t.Fatalf("SendHWM = %#v", options.SendHWM)
+	}
+	if !options.RecvHWM.Set || options.RecvHWM.Value != 8 {
+		t.Fatalf("RecvHWM = %#v", options.RecvHWM)
+	}
+	if !options.Linger.Set || options.Linger.Value != 2*time.Millisecond {
+		t.Fatalf("Linger = %#v", options.Linger)
+	}
+	if !options.HeartbeatOff || !options.NoHeartbeatTTL || !options.DefaultHeartbeatTimeout ||
+		!options.NoHandshakeTimeout || !options.NoMaxMessageSize {
+		t.Fatalf("duration sentinel options = %#v", options)
+	}
+	if !options.PlainClient.Set || options.PlainClient.Value.Username != "alice" ||
+		options.PlainClient.Value.Password != "secret" {
+		t.Fatalf("PlainClient = %#v", options.PlainClient)
+	}
+	if !options.Workload.Set || options.Workload.Value != WorkloadLatency {
+		t.Fatalf("Workload = %#v", options.Workload)
+	}
+	if !options.Reconnect.Set || options.Reconnect.Value.Mode != "exponential" {
+		t.Fatalf("Reconnect = %#v", options.Reconnect)
+	}
+	if !options.ReconnectStopConnRefused.Set || !options.ReconnectStopConnRefused.Value {
+		t.Fatalf("ReconnectStopConnRefused = %#v", options.ReconnectStopConnRefused)
+	}
+	if !options.MaxPendingHandshakes.Set || options.MaxPendingHandshakes.Value != 4 {
+		t.Fatalf("MaxPendingHandshakes = %#v", options.MaxPendingHandshakes)
+	}
+	if !options.Conflate.Set || !options.Conflate.Value ||
+		!options.RouterMandatory.Set || !options.RouterMandatory.Value ||
+		!options.XPubNoDrop.Set || !options.XPubNoDrop.Value {
+		t.Fatalf("bool options = %#v", options)
+	}
+	if !options.OnMute.Set || options.OnMute.Value != OnMuteDropNewest {
+		t.Fatalf("OnMute = %#v", options.OnMute)
+	}
+	if !options.TCPKeepalive.Set || options.TCPKeepalive.Value.Mode != "enabled" ||
+		options.TCPKeepalive.Value.Count != 2 {
+		t.Fatalf("TCPKeepalive = %#v", options.TCPKeepalive)
+	}
+	if !options.SendBufferSize.Set || options.SendBufferSize.Value != 1024 ||
+		!options.RecvBufferSize.Set || options.RecvBufferSize.Value != 2048 {
+		t.Fatalf("buffer sizes = %#v/%#v", options.SendBufferSize, options.RecvBufferSize)
+	}
+	if !options.CompressionAutoTrain.Set || !options.CompressionAutoTrain.Value ||
+		!options.CompressionThreshold.Set || options.CompressionThreshold.Value != 64 ||
+		!options.CompressionLevel.Set || options.CompressionLevel.Value != 1 ||
+		!options.CompressionDict.Set || string(options.CompressionDict.Value) != "abcd" {
+		t.Fatalf("compression basics = %#v", options)
+	}
+	if !options.CompressionDictCapacity.Set || options.CompressionDictCapacity.Value != 4096 ||
+		!options.MaxRecvDictSize.Set || options.MaxRecvDictSize.Value != 8192 ||
+		!options.CompressionOffloadThreshold.Set || options.CompressionOffloadThreshold.Value != 16384 ||
+		!options.LargeMessageThreshold.Set || options.LargeMessageThreshold.Value != 32768 ||
+		!options.ArenaThreshold.Set || options.ArenaThreshold.Value != 65536 ||
+		!options.TransmitSlotCapacity.Set || options.TransmitSlotCapacity.Value != 131072 {
+		t.Fatalf("compression/perf sizes = %#v", options)
+	}
 }
 
 func TestOptionsCannotChangeAfterMaterialization(t *testing.T) {

--- a/bindings/go/poll.go
+++ b/bindings/go/poll.go
@@ -6,11 +6,15 @@ import (
 	"time"
 )
 
+// ReceiveEvent identifies the socket that produced a message.
 type ReceiveEvent struct {
-	Socket  *Socket
+	// Socket is the socket that produced Message.
+	Socket *Socket
+	// Message is the received message.
 	Message Message
 }
 
+// TryReceiveAny receives from the first ready socket without waiting.
 func TryReceiveAny(sockets ...*Socket) (ReceiveEvent, error) {
 	if err := validateReceiveAnySockets(sockets); err != nil {
 		return ReceiveEvent{}, err
@@ -27,6 +31,7 @@ func TryReceiveAny(sockets ...*Socket) (ReceiveEvent, error) {
 	return ReceiveEvent{}, ErrAgain
 }
 
+// ReceiveAny receives from any supplied socket until ctx is done.
 func ReceiveAny(ctx context.Context, sockets ...*Socket) (ReceiveEvent, error) {
 	if err := validateReceiveAnySockets(sockets); err != nil {
 		return ReceiveEvent{}, err
@@ -51,6 +56,7 @@ func ReceiveAny(ctx context.Context, sockets ...*Socket) (ReceiveEvent, error) {
 	}
 }
 
+// ReceiveAnyTimeout receives from any socket with libzmq-style timeout semantics.
 func ReceiveAnyTimeout(timeout time.Duration, sockets ...*Socket) (ReceiveEvent, error) {
 	if timeout == 0 {
 		return TryReceiveAny(sockets...)

--- a/bindings/go/poll.go
+++ b/bindings/go/poll.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const receiveAnyContextPoll = time.Millisecond
+
 // ReceiveEvent identifies the socket that produced a message.
 type ReceiveEvent struct {
 	// Socket is the socket that produced Message.
@@ -19,16 +21,7 @@ func TryReceiveAny(sockets ...*Socket) (ReceiveEvent, error) {
 	if err := validateReceiveAnySockets(sockets); err != nil {
 		return ReceiveEvent{}, err
 	}
-	for _, socket := range sockets {
-		msg, err := socket.TryRecv()
-		if err == nil {
-			return ReceiveEvent{Socket: socket, Message: msg}, nil
-		}
-		if !errors.Is(err, ErrAgain) {
-			return ReceiveEvent{}, err
-		}
-	}
-	return ReceiveEvent{}, ErrAgain
+	return receiveAnyNative(sockets, 0)
 }
 
 // ReceiveAny receives from any supplied socket until ctx is done.
@@ -39,18 +32,15 @@ func ReceiveAny(ctx context.Context, sockets ...*Socket) (ReceiveEvent, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	for i := 0; ; i++ {
+	for {
 		if err := errFromContext(ctx); err != nil {
 			return ReceiveEvent{}, err
 		}
-		event, err := TryReceiveAny(sockets...)
+		event, err := receiveAnyNative(sockets, receiveAnyTimeoutMillis(ctx))
 		if err == nil {
 			return event, nil
 		}
-		if !errors.Is(err, ErrAgain) {
-			return ReceiveEvent{}, err
-		}
-		if err := waitRetry(ctx, i); err != nil {
+		if !errors.Is(err, ErrAgain) && !errors.Is(err, ErrTimeout) {
 			return ReceiveEvent{}, err
 		}
 	}
@@ -62,11 +52,15 @@ func ReceiveAnyTimeout(timeout time.Duration, sockets ...*Socket) (ReceiveEvent,
 		return TryReceiveAny(sockets...)
 	}
 	if timeout < 0 {
-		return ReceiveAny(context.Background(), sockets...)
+		if err := validateReceiveAnySockets(sockets); err != nil {
+			return ReceiveEvent{}, err
+		}
+		return receiveAnyNative(sockets, -1)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return ReceiveAny(ctx, sockets...)
+	if err := validateReceiveAnySockets(sockets); err != nil {
+		return ReceiveEvent{}, err
+	}
+	return receiveAnyNative(sockets, durationMillis(timeout))
 }
 
 func validateReceiveAnySockets(sockets []*Socket) error {
@@ -84,4 +78,63 @@ func validateReceiveAnySockets(sockets []*Socket) error {
 		seen[socket] = struct{}{}
 	}
 	return nil
+}
+
+func receiveAnyTimeoutMillis(ctx context.Context) int64 {
+	timeout := receiveAnyContextPoll
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return 0
+		}
+		if remaining < timeout {
+			timeout = remaining
+		}
+	}
+	return durationMillis(timeout)
+}
+
+// Poller receives from a stable set of sockets.
+type Poller struct {
+	sockets []*Socket
+}
+
+// NewPoller creates a poller for distinct sockets.
+func NewPoller(sockets ...*Socket) (*Poller, error) {
+	if err := validateReceiveAnySockets(sockets); err != nil {
+		return nil, err
+	}
+	return &Poller{sockets: append([]*Socket(nil), sockets...)}, nil
+}
+
+// Sockets returns a copy of this poller's sockets.
+func (p *Poller) Sockets() []*Socket {
+	if p == nil {
+		return nil
+	}
+	return append([]*Socket(nil), p.sockets...)
+}
+
+// TryRecv receives from the first ready poller socket without waiting.
+func (p *Poller) TryRecv() (ReceiveEvent, error) {
+	if p == nil {
+		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
+	}
+	return TryReceiveAny(p.sockets...)
+}
+
+// Recv receives from any poller socket until ctx is done.
+func (p *Poller) Recv(ctx context.Context) (ReceiveEvent, error) {
+	if p == nil {
+		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
+	}
+	return ReceiveAny(ctx, p.sockets...)
+}
+
+// RecvTimeout receives from any poller socket with timeout semantics.
+func (p *Poller) RecvTimeout(timeout time.Duration) (ReceiveEvent, error) {
+	if p == nil {
+		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
+	}
+	return ReceiveAnyTimeout(timeout, p.sockets...)
 }

--- a/bindings/go/poll.go
+++ b/bindings/go/poll.go
@@ -3,6 +3,7 @@ package omq
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 )
 
@@ -96,7 +97,9 @@ func receiveAnyTimeoutMillis(ctx context.Context) int64 {
 
 // Poller receives from a stable set of sockets.
 type Poller struct {
+	mu      sync.Mutex
 	sockets []*Socket
+	next    int
 }
 
 // NewPoller creates a poller for distinct sockets.
@@ -112,6 +115,8 @@ func (p *Poller) Sockets() []*Socket {
 	if p == nil {
 		return nil
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return append([]*Socket(nil), p.sockets...)
 }
 
@@ -120,7 +125,12 @@ func (p *Poller) TryRecv() (ReceiveEvent, error) {
 	if p == nil {
 		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
 	}
-	return TryReceiveAny(p.sockets...)
+	sockets := p.orderedSockets()
+	event, err := TryReceiveAny(sockets...)
+	if err == nil {
+		p.advance(event.Socket)
+	}
+	return event, err
 }
 
 // Recv receives from any poller socket until ctx is done.
@@ -128,7 +138,12 @@ func (p *Poller) Recv(ctx context.Context) (ReceiveEvent, error) {
 	if p == nil {
 		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
 	}
-	return ReceiveAny(ctx, p.sockets...)
+	sockets := p.orderedSockets()
+	event, err := ReceiveAny(ctx, sockets...)
+	if err == nil {
+		p.advance(event.Socket)
+	}
+	return event, err
 }
 
 // RecvTimeout receives from any poller socket with timeout semantics.
@@ -136,5 +151,35 @@ func (p *Poller) RecvTimeout(timeout time.Duration) (ReceiveEvent, error) {
 	if p == nil {
 		return ReceiveEvent{}, &ConfigError{Err: "poller is nil"}
 	}
-	return ReceiveAnyTimeout(timeout, p.sockets...)
+	sockets := p.orderedSockets()
+	event, err := ReceiveAnyTimeout(timeout, sockets...)
+	if err == nil {
+		p.advance(event.Socket)
+	}
+	return event, err
+}
+
+func (p *Poller) orderedSockets() []*Socket {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := len(p.sockets)
+	if n == 0 {
+		return nil
+	}
+	out := make([]*Socket, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, p.sockets[(p.next+i)%n])
+	}
+	return out
+}
+
+func (p *Poller) advance(socket *Socket) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, candidate := range p.sockets {
+		if candidate == socket {
+			p.next = (i + 1) % len(p.sockets)
+			return
+		}
+	}
 }

--- a/bindings/go/poll.go
+++ b/bindings/go/poll.go
@@ -1,0 +1,81 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type ReceiveEvent struct {
+	Socket  *Socket
+	Message Message
+}
+
+func TryReceiveAny(sockets ...*Socket) (ReceiveEvent, error) {
+	if err := validateReceiveAnySockets(sockets); err != nil {
+		return ReceiveEvent{}, err
+	}
+	for _, socket := range sockets {
+		msg, err := socket.TryRecv()
+		if err == nil {
+			return ReceiveEvent{Socket: socket, Message: msg}, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return ReceiveEvent{}, err
+		}
+	}
+	return ReceiveEvent{}, ErrAgain
+}
+
+func ReceiveAny(ctx context.Context, sockets ...*Socket) (ReceiveEvent, error) {
+	if err := validateReceiveAnySockets(sockets); err != nil {
+		return ReceiveEvent{}, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return ReceiveEvent{}, err
+		}
+		event, err := TryReceiveAny(sockets...)
+		if err == nil {
+			return event, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return ReceiveEvent{}, err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return ReceiveEvent{}, err
+		}
+	}
+}
+
+func ReceiveAnyTimeout(timeout time.Duration, sockets ...*Socket) (ReceiveEvent, error) {
+	if timeout == 0 {
+		return TryReceiveAny(sockets...)
+	}
+	if timeout < 0 {
+		return ReceiveAny(context.Background(), sockets...)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return ReceiveAny(ctx, sockets...)
+}
+
+func validateReceiveAnySockets(sockets []*Socket) error {
+	if len(sockets) == 0 {
+		return &ConfigError{Err: "receive-any requires at least one socket"}
+	}
+	seen := make(map[*Socket]struct{}, len(sockets))
+	for _, socket := range sockets {
+		if socket == nil {
+			return &ConfigError{Err: "receive-any socket is nil"}
+		}
+		if _, ok := seen[socket]; ok {
+			return &ConfigError{Err: "receive-any sockets must be unique"}
+		}
+		seen[socket] = struct{}{}
+	}
+	return nil
+}

--- a/bindings/go/poll_test.go
+++ b/bindings/go/poll_test.go
@@ -92,6 +92,63 @@ func TestReceiveAnyDoesNotConsumeLosingSocket(t *testing.T) {
 	}
 }
 
+func TestPollerRotatesReadySockets(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull1 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull1)
+	pull2 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull2)
+	push1 := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push1)
+	push2 := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push2)
+
+	endpoint1, err := pull1.Bind("inproc://go-poller-rotate-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint2, err := pull2.Bind("inproc://go-poller-rotate-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push1.Connect(endpoint1); err != nil {
+		t.Fatal(err)
+	}
+	if err := push2.Connect(endpoint2); err != nil {
+		t.Fatal(err)
+	}
+	if err := push1.SendTimeout(String("one"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push1.SendTimeout(String("one-again"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push2.SendTimeout(String("two"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := NewPoller(pull1, pull2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := poller.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := poller.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Socket != pull1 || first.Message.String() != "one" {
+		t.Fatalf("first event = %#v", first)
+	}
+	if second.Socket != pull2 || second.Message.String() != "two" {
+		t.Fatalf("second event = %#v", second)
+	}
+}
+
 func TestReceiveAnyContextCancellation(t *testing.T) {
 	ctx := openTestContext(t)
 	defer closeContext(t, ctx)

--- a/bindings/go/poll_test.go
+++ b/bindings/go/poll_test.go
@@ -1,0 +1,125 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPollerReceivesFromMultipleSockets(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull1 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull1)
+	pull2 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull2)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull2.Bind("inproc://go-poller")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	poller, err := NewPoller(pull1, pull2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("poller"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	event, err := poller.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Socket != pull2 || event.Message.String() != "poller" {
+		t.Fatalf("event = %#v", event)
+	}
+}
+
+func TestReceiveAnyDoesNotConsumeLosingSocket(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull1 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull1)
+	pull2 := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull2)
+	push1 := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push1)
+	push2 := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push2)
+
+	endpoint1, err := pull1.Bind("inproc://go-receive-any-loser-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint2, err := pull2.Bind("inproc://go-receive-any-loser-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push1.Connect(endpoint1); err != nil {
+		t.Fatal(err)
+	}
+	if err := push2.Connect(endpoint2); err != nil {
+		t.Fatal(err)
+	}
+	if err := push1.SendTimeout(String("first"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push2.SendTimeout(String("second"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	event, err := ReceiveAnyTimeout(time.Second, pull1, pull2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Socket != pull1 || event.Message.String() != "first" {
+		t.Fatalf("first event = %#v", event)
+	}
+	msg, err := pull2.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "second" {
+		t.Fatalf("losing socket message = %q, want second", got)
+	}
+}
+
+func TestReceiveAnyContextCancellation(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	if _, err := pull.Bind("inproc://go-receive-any-cancel"); err != nil {
+		t.Fatal(err)
+	}
+
+	recvCtx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if _, err := ReceiveAny(recvCtx, pull); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("ReceiveAny err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestPollerRejectsInvalidSockets(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	if _, err := NewPoller(); !isConfigError(err) {
+		t.Fatalf("NewPoller empty err = %v, want ConfigError", err)
+	}
+	if _, err := NewPoller(pull, pull); !isConfigError(err) {
+		t.Fatalf("NewPoller duplicate err = %v, want ConfigError", err)
+	}
+}

--- a/bindings/go/poll_test.go
+++ b/bindings/go/poll_test.go
@@ -166,6 +166,34 @@ func TestReceiveAnyContextCancellation(t *testing.T) {
 	}
 }
 
+func TestReceiveAnyConcurrentClose(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	if _, err := pull.Bind("inproc://go-receive-any-close"); err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := ReceiveAny(context.Background(), pull)
+		errCh <- err
+	}()
+	time.Sleep(time.Millisecond)
+	if err := pull.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("ReceiveAny err = %v, want ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ReceiveAny did not unblock after close")
+	}
+}
+
 func TestPollerRejectsInvalidSockets(t *testing.T) {
 	ctx := openTestContext(t)
 	defer closeContext(t, ctx)

--- a/bindings/go/proxy.go
+++ b/bindings/go/proxy.go
@@ -1,0 +1,136 @@
+package omq
+
+import (
+	"bytes"
+	"context"
+	"errors"
+)
+
+type ProxyOptions struct {
+	Capture   *Socket
+	Control   *Socket
+	BurstSize int
+}
+
+func Proxy(ctx context.Context, frontend, backend *Socket, opts ProxyOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if frontend == nil || backend == nil {
+		return &ConfigError{Err: "proxy sockets must not be nil"}
+	}
+	burst := opts.BurstSize
+	if burst <= 0 {
+		burst = 64
+	}
+	paused := false
+	for {
+		if err := errFromContext(ctx); err != nil {
+			return err
+		}
+		if opts.Control != nil {
+			done, err := proxyHandleControl(ctx, opts.Control, &paused)
+			if done || err != nil {
+				return err
+			}
+		}
+		if paused {
+			if opts.Control == nil {
+				return &ConfigError{Err: "proxy paused without control socket"}
+			}
+			event, err := ReceiveAny(ctx, opts.Control)
+			if err != nil {
+				return err
+			}
+			done, err := proxyApplyControl(ctx, opts.Control, event.Message, &paused)
+			if done || err != nil {
+				return err
+			}
+			continue
+		}
+		var event ReceiveEvent
+		var err error
+		if opts.Control != nil {
+			event, err = ReceiveAny(ctx, opts.Control, frontend, backend)
+		} else {
+			event, err = ReceiveAny(ctx, frontend, backend)
+		}
+		if err != nil {
+			return err
+		}
+		if event.Socket == opts.Control {
+			done, err := proxyApplyControl(ctx, opts.Control, event.Message, &paused)
+			if done || err != nil {
+				return err
+			}
+		} else if event.Socket == frontend {
+			if err := proxyForwardBurst(ctx, frontend, backend, opts.Capture, event.Message, burst); err != nil {
+				return err
+			}
+		} else if err := proxyForwardBurst(ctx, backend, frontend, opts.Capture, event.Message, burst); err != nil {
+			return err
+		}
+	}
+}
+
+func proxyForwardBurst(
+	ctx context.Context,
+	source *Socket,
+	target *Socket,
+	capture *Socket,
+	first Message,
+	burst int,
+) error {
+	if err := proxyForward(ctx, target, capture, first); err != nil {
+		return err
+	}
+	for i := 1; i < burst; i++ {
+		msg, err := source.TryRecv()
+		if errors.Is(err, ErrAgain) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := proxyForward(ctx, target, capture, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func proxyForward(ctx context.Context, target *Socket, capture *Socket, msg Message) error {
+	if capture != nil {
+		_ = capture.TrySend(msg)
+	}
+	return target.Send(ctx, msg)
+}
+
+func proxyHandleControl(ctx context.Context, control *Socket, paused *bool) (bool, error) {
+	msg, err := control.TryRecv()
+	if errors.Is(err, ErrAgain) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return proxyApplyControl(ctx, control, msg, paused)
+}
+
+func proxyApplyControl(ctx context.Context, control *Socket, msg Message, paused *bool) (bool, error) {
+	command := msg.Bytes()
+	switch {
+	case bytes.Equal(command, []byte("PAUSE")):
+		*paused = true
+	case bytes.Equal(command, []byte("RESUME")):
+		*paused = false
+	case bytes.Equal(command, []byte("TERMINATE")), bytes.Equal(command, []byte("KILL")):
+		return true, nil
+	}
+	if control.socketType == Rep {
+		if err := control.Send(ctx, Bytes(nil)); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}

--- a/bindings/go/proxy.go
+++ b/bindings/go/proxy.go
@@ -6,12 +6,17 @@ import (
 	"errors"
 )
 
+// ProxyOptions configures Proxy.
 type ProxyOptions struct {
-	Capture   *Socket
-	Control   *Socket
+	// Capture receives best-effort copies of forwarded messages.
+	Capture *Socket
+	// Control receives PAUSE, RESUME, TERMINATE, and KILL commands.
+	Control *Socket
+	// BurstSize limits messages forwarded from one side per turn.
 	BurstSize int
 }
 
+// Proxy forwards messages between frontend and backend.
 func Proxy(ctx context.Context, frontend, backend *Socket, opts ProxyOptions) error {
 	if ctx == nil {
 		ctx = context.Background()

--- a/bindings/go/proxy_test.go
+++ b/bindings/go/proxy_test.go
@@ -1,0 +1,102 @@
+package omq
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestProxyCapturePauseResumeAndTerminate(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	frontend := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, frontend)
+	backend := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, backend)
+	source := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, source)
+	sink := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, sink)
+	capture := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, capture)
+	captureSink := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, captureSink)
+	controlProxy := newTestSocket(t, ctx, Rep)
+	defer closeSocket(t, controlProxy)
+	controlClient := newTestSocket(t, ctx, Req)
+	defer closeSocket(t, controlClient)
+
+	frontendEndpoint, err := frontend.Bind("inproc://go-proxy-control-fe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendEndpoint, err := sink.Bind("inproc://go-proxy-control-be")
+	if err != nil {
+		t.Fatal(err)
+	}
+	captureEndpoint, err := captureSink.Bind("inproc://go-proxy-control-capture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlEndpoint, err := controlProxy.Bind("inproc://go-proxy-control")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Connect(frontendEndpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Connect(backendEndpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := capture.Connect(captureEndpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := controlClient.Connect(controlEndpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	proxyCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyErr := make(chan error, 1)
+	go func() {
+		proxyErr <- Proxy(proxyCtx, frontend, backend, ProxyOptions{
+			Capture: capture,
+			Control: controlProxy,
+		})
+	}()
+
+	sendProxyCommand(t, controlClient, "PAUSE", true)
+	if err := source.SendTimeout(String("held"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sink.RecvTimeout(100 * time.Millisecond); err == nil {
+		t.Fatal("proxy forwarded while paused")
+	}
+	sendProxyCommand(t, controlClient, "RESUME", true)
+	assertRecvString(t, sink, "held")
+	assertRecvString(t, captureSink, "held")
+
+	sendProxyCommand(t, controlClient, "TERMINATE", false)
+	select {
+	case err := <-proxyErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not terminate")
+	}
+}
+
+func sendProxyCommand(t *testing.T, control *Socket, command string, expectReply bool) {
+	t.Helper()
+	if err := control.SendTimeout(String(command), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if !expectReply {
+		return
+	}
+	if _, err := control.RecvTimeout(time.Second); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/bindings/go/pubsub_test.go
+++ b/bindings/go/pubsub_test.go
@@ -1,0 +1,129 @@
+package omq
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPubSubPrefixFilter(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pub := newTestSocket(t, ctx, Pub)
+	defer closeSocket(t, pub)
+	sub := newTestSocket(t, ctx, Sub)
+	defer closeSocket(t, sub)
+
+	endpoint, err := pub.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.SubscribeString("weather/"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pub.WaitSubscribedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pub.SendTimeout(String("sports/score-12"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := pub.SendTimeout(String("weather/sunny"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := pub.SendTimeout(String("weather/rain"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	assertRecvString(t, sub, "weather/sunny")
+	assertRecvString(t, sub, "weather/rain")
+	if _, err := sub.TryRecv(); !errors.Is(err, ErrAgain) {
+		t.Fatalf("TryRecv err = %v, want ErrAgain", err)
+	}
+}
+
+func TestPubSubUnsubscribeDropsTopic(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pub := newTestSocket(t, ctx, Pub)
+	defer closeSocket(t, pub)
+	sub := newTestSocket(t, ctx, Sub)
+	defer closeSocket(t, sub)
+
+	endpoint, err := pub.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.SubscribeString("a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.SubscribeString("b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pub.WaitSubscribedTimeout(2, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.UnsubscribeString("a"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if err := pub.SendTimeout(String("a-one"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := pub.SendTimeout(String("b-two"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	assertRecvString(t, sub, "b-two")
+	if _, err := sub.TryRecv(); !errors.Is(err, ErrAgain) {
+		t.Fatalf("TryRecv err = %v, want ErrAgain", err)
+	}
+}
+
+func TestXPubReceivesSubscriptionFrame(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	xpub := newTestSocket(t, ctx, XPub)
+	defer closeSocket(t, xpub)
+	xsub := newTestSocket(t, ctx, XSub)
+	defer closeSocket(t, xsub)
+
+	endpoint, err := xpub.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := xsub.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := xsub.Subscribe(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	subscription, err := xpub.RecvTimeout(5 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame, ok := subscription.BytesOK()
+	if !ok || len(frame) != 1 || frame[0] != 1 {
+		t.Fatalf("subscription frame = %v/%v, want [1]/true", frame, ok)
+	}
+}
+
+func assertRecvString(t *testing.T, socket *Socket, want string) {
+	t.Helper()
+	msg, err := socket.RecvTimeout(5 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+}

--- a/bindings/go/race_test.go
+++ b/bindings/go/race_test.go
@@ -29,9 +29,7 @@ func TestConcurrentSendReceive(t *testing.T) {
 	const perGoroutine = 64
 	var wg sync.WaitGroup
 	for worker := 0; worker < goroutines; worker++ {
-		wg.Add(1)
-		go func(worker int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := 0; i < perGoroutine; i++ {
 				sendCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 				err := push.Send(sendCtx, String("msg"))
@@ -41,7 +39,7 @@ func TestConcurrentSendReceive(t *testing.T) {
 					return
 				}
 			}
-		}(worker)
+		})
 	}
 
 	for i := 0; i < goroutines*perGoroutine; i++ {

--- a/bindings/go/race_test.go
+++ b/bindings/go/race_test.go
@@ -1,0 +1,85 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConcurrentSendReceive(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-concurrent-send-recv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 4
+	const perGoroutine = 64
+	var wg sync.WaitGroup
+	for worker := 0; worker < goroutines; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				sendCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+				err := push.Send(sendCtx, String("msg"))
+				cancel()
+				if err != nil {
+					t.Errorf("worker %d send %d: %v", worker, i, err)
+					return
+				}
+			}
+		}(worker)
+	}
+
+	for i := 0; i < goroutines*perGoroutine; i++ {
+		msg, err := pull.RecvTimeout(time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := msg.String(); got != "msg" {
+			t.Fatalf("message = %q, want msg", got)
+		}
+	}
+	wg.Wait()
+}
+
+func TestConcurrentCloseAndReceive(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	if _, err := pull.Bind("inproc://go-close-recv-race"); err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := pull.Recv(context.Background())
+		errCh <- err
+	}()
+	time.Sleep(time.Millisecond)
+	if err := pull.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("Recv err = %v, want ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("receive did not unblock after close")
+	}
+}

--- a/bindings/go/recv_ring.go
+++ b/bindings/go/recv_ring.go
@@ -1,0 +1,199 @@
+package omq
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	defaultRecvRingDescCapacity    = 1024
+	defaultRecvRingPayloadCapacity = 4 * 1024 * 1024
+	recvRingFillBatch              = 512
+
+	recvRingControlHead = 0
+	recvRingControlTail = 128
+
+	recvRingFlagMultipart = 1
+	recvRingFlagExternal  = 2
+)
+
+type recvRingDesc struct {
+	payload    uint64
+	payloadLen uint64
+	totalLen   uint64
+	partCount  uint64
+	flags      uint64
+	payloadEnd uint64
+	_          [2]uint64
+}
+
+type recvRing struct {
+	handle       *nativeRecvRing
+	control      unsafe.Pointer
+	descriptors  []recvRingDesc
+	payload      []byte
+	descMask     uint64
+	head         uint64
+	releasedHead uint64
+	cachedTail   uint64
+	viewActive   bool
+}
+
+func newRecvRing(socket *nativeSocket) (*recvRing, error) {
+	handle, memory, err := recvRingCreateNative(
+		socket,
+		defaultRecvRingDescCapacity,
+		defaultRecvRingPayloadCapacity,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if memory.control == nil || memory.descriptors == nil || memory.payload == nil ||
+		memory.descCapacity <= 0 || memory.payloadCapacity <= 0 ||
+		!isPowerOfTwo(uint64(memory.descCapacity)) ||
+		!isPowerOfTwo(uint64(memory.payloadCapacity)) {
+		recvRingCloseNative(handle)
+		return nil, &ConfigError{Err: "native receive ring returned invalid memory"}
+	}
+	return &recvRing{
+		handle:      handle,
+		control:     memory.control,
+		descriptors: unsafe.Slice((*recvRingDesc)(memory.descriptors), memory.descCapacity),
+		payload:     unsafe.Slice((*byte)(memory.payload), memory.payloadCapacity),
+		descMask:    uint64(memory.descCapacity - 1),
+	}, nil
+}
+
+func (r *recvRing) tryRecvView() (RecvView, error) {
+	if r == nil || r.handle == nil {
+		return RecvView{}, ErrClosed
+	}
+	r.releaseActiveView()
+	if err := r.fillIfEmpty(0); err != nil {
+		return RecvView{}, err
+	}
+	desc := r.current()
+	if desc.partCount != 1 {
+		r.advance()
+		return RecvView{}, &ConfigError{Err: "RecvView requires a single-part message"}
+	}
+	if desc.flags&recvRingFlagExternal != 0 {
+		r.advance()
+		return RecvView{}, &ConfigError{Err: "RecvView payload exceeds receive ring capacity"}
+	}
+	r.viewActive = true
+	return RecvView{data: r.source(desc)}, nil
+}
+
+func (r *recvRing) tryRecvInto(dst []byte) (int, error) {
+	return r.recvInto(dst, 0)
+}
+
+func (r *recvRing) recvIntoBlocking(dst []byte) (int, error) {
+	return r.recvInto(dst, -1)
+}
+
+func (r *recvRing) recvInto(dst []byte, timeoutMillis int64) (int, error) {
+	if r == nil || r.handle == nil {
+		return 0, ErrClosed
+	}
+	r.releaseActiveView()
+	if err := r.fillIfEmpty(timeoutMillis); err != nil {
+		return 0, err
+	}
+	desc := r.current()
+	defer r.advance()
+	if desc.partCount != 1 {
+		return 0, &ConfigError{Err: "RecvInto requires a single-part message"}
+	}
+	if desc.flags&recvRingFlagExternal != 0 {
+		return 0, &ConfigError{Err: "RecvInto payload exceeds receive ring capacity"}
+	}
+	if desc.payloadLen > uint64(len(dst)) {
+		return 0, &MessageTooLargeError{Err: "destination buffer too small"}
+	}
+	body := r.source(desc)
+	copy(dst, body)
+	return len(body), nil
+}
+
+func (r *recvRing) close() {
+	if r == nil || r.handle == nil {
+		return
+	}
+	r.releaseActiveView()
+	r.releaseConsumed()
+	recvRingCloseNative(r.handle)
+	r.handle = nil
+	r.control = nil
+	r.descriptors = nil
+	r.payload = nil
+}
+
+func (r *recvRing) fillIfEmpty(timeoutMillis int64) error {
+	if r.hasCached() {
+		return nil
+	}
+	r.releaseConsumed()
+	if err := recvRingFillNative(r.handle, timeoutMillis, recvRingFillBatch); err != nil {
+		return err
+	}
+	r.cachedTail = r.tailAcquire()
+	if !r.hasCached() {
+		return ErrAgain
+	}
+	return nil
+}
+
+func (r *recvRing) hasCached() bool {
+	if r.head != r.cachedTail {
+		return true
+	}
+	r.cachedTail = r.tailAcquire()
+	return r.head != r.cachedTail
+}
+
+func (r *recvRing) current() recvRingDesc {
+	return r.descriptors[r.head&r.descMask]
+}
+
+func (r *recvRing) source(desc recvRingDesc) []byte {
+	if desc.payloadLen == 0 {
+		return nil
+	}
+	return r.payload[desc.payload : desc.payload+desc.payloadLen]
+}
+
+func (r *recvRing) releaseActiveView() {
+	if r.viewActive {
+		r.advance()
+		r.viewActive = false
+	}
+}
+
+func (r *recvRing) advance() {
+	r.head++
+	if r.head == r.cachedTail {
+		r.releaseConsumed()
+	}
+}
+
+func (r *recvRing) releaseConsumed() {
+	if r.releasedHead == r.head {
+		return
+	}
+	atomic.StoreUint64(r.headPtr(), r.head)
+	r.releasedHead = r.head
+}
+
+func (r *recvRing) tailAcquire() uint64 {
+	return atomic.LoadUint64(r.tailPtr())
+}
+
+func (r *recvRing) headPtr() *uint64 {
+	return (*uint64)(unsafe.Add(r.control, recvRingControlHead))
+}
+
+func (r *recvRing) tailPtr() *uint64 {
+	return (*uint64)(unsafe.Add(r.control, recvRingControlTail))
+}

--- a/bindings/go/recv_ring.go
+++ b/bindings/go/recv_ring.go
@@ -39,10 +39,14 @@ type recvRing struct {
 	viewActive   bool
 }
 
-func newRecvRing(socket *nativeSocket) (*recvRing, error) {
+func newRecvRing(socket *nativeSocket, ringSize int) (*recvRing, error) {
+	descCapacity := defaultRecvRingDescCapacity
+	if ringSize > 0 {
+		descCapacity = ringSize
+	}
 	handle, memory, err := recvRingCreateNative(
 		socket,
-		defaultRecvRingDescCapacity,
+		descCapacity,
 		defaultRecvRingPayloadCapacity,
 	)
 	if err != nil {

--- a/bindings/go/recv_ring.go
+++ b/bindings/go/recv_ring.go
@@ -97,6 +97,30 @@ func (r *recvRing) recvIntoBlocking(dst []byte) (int, error) {
 	return r.recvInto(dst, -1)
 }
 
+func (r *recvRing) recvIntoCancelable(dst []byte, cancel *nativeCancel) (int, error) {
+	if r == nil || r.handle == nil {
+		return 0, ErrClosed
+	}
+	r.releaseActiveView()
+	if err := r.fillIfEmptyCancelable(cancel); err != nil {
+		return 0, err
+	}
+	desc := r.current()
+	defer r.advance()
+	if desc.partCount != 1 {
+		return 0, &ConfigError{Err: "RecvInto requires a single-part message"}
+	}
+	if desc.flags&recvRingFlagExternal != 0 {
+		return 0, &ConfigError{Err: "RecvInto payload exceeds receive ring capacity"}
+	}
+	if desc.payloadLen > uint64(len(dst)) {
+		return 0, &MessageTooLargeError{Err: "destination buffer too small"}
+	}
+	body := r.source(desc)
+	copy(dst, body)
+	return len(body), nil
+}
+
 func (r *recvRing) recvInto(dst []byte, timeoutMillis int64) (int, error) {
 	if r == nil || r.handle == nil {
 		return 0, ErrClosed
@@ -140,6 +164,21 @@ func (r *recvRing) fillIfEmpty(timeoutMillis int64) error {
 	}
 	r.releaseConsumed()
 	if err := recvRingFillNative(r.handle, timeoutMillis, recvRingFillBatch); err != nil {
+		return err
+	}
+	r.cachedTail = r.tailAcquire()
+	if !r.hasCached() {
+		return ErrAgain
+	}
+	return nil
+}
+
+func (r *recvRing) fillIfEmptyCancelable(cancel *nativeCancel) error {
+	if r.hasCached() {
+		return nil
+	}
+	r.releaseConsumed()
+	if err := recvRingFillCancelableNative(r.handle, cancel, recvRingFillBatch); err != nil {
 		return err
 	}
 	r.cachedTail = r.tailAcquire()

--- a/bindings/go/recv_ring.go
+++ b/bindings/go/recv_ring.go
@@ -36,7 +36,6 @@ type recvRing struct {
 	head         uint64
 	releasedHead uint64
 	cachedTail   uint64
-	viewActive   bool
 }
 
 func newRecvRing(socket *nativeSocket, ringSize int) (*recvRing, error) {
@@ -68,25 +67,40 @@ func newRecvRing(socket *nativeSocket, ringSize int) (*recvRing, error) {
 	}, nil
 }
 
-func (r *recvRing) tryRecvView() (RecvView, error) {
+func (r *recvRing) tryRecvView(fn func([]byte) error) (bool, error) {
 	if r == nil || r.handle == nil {
-		return RecvView{}, ErrClosed
+		return false, ErrClosed
 	}
-	r.releaseActiveView()
 	if err := r.fillIfEmpty(0); err != nil {
-		return RecvView{}, err
+		return false, err
 	}
 	desc := r.current()
+	defer r.advance()
 	if desc.partCount != 1 {
-		r.advance()
-		return RecvView{}, &ConfigError{Err: "RecvView requires a single-part message"}
+		return true, &ConfigError{Err: "RecvView requires a single-part message"}
 	}
 	if desc.flags&recvRingFlagExternal != 0 {
-		r.advance()
-		return RecvView{}, &ConfigError{Err: "RecvView payload exceeds receive ring capacity"}
+		return true, &ConfigError{Err: "RecvView payload exceeds receive ring capacity"}
 	}
-	r.viewActive = true
-	return RecvView{data: r.source(desc)}, nil
+	return true, fn(r.source(desc))
+}
+
+func (r *recvRing) recvViewCancelable(cancel *nativeCancel, fn func([]byte) error) (bool, error) {
+	if r == nil || r.handle == nil {
+		return false, ErrClosed
+	}
+	if err := r.fillIfEmptyCancelable(cancel); err != nil {
+		return false, err
+	}
+	desc := r.current()
+	defer r.advance()
+	if desc.partCount != 1 {
+		return true, &ConfigError{Err: "RecvView requires a single-part message"}
+	}
+	if desc.flags&recvRingFlagExternal != 0 {
+		return true, &ConfigError{Err: "RecvView payload exceeds receive ring capacity"}
+	}
+	return true, fn(r.source(desc))
 }
 
 func (r *recvRing) tryRecvInto(dst []byte) (int, error) {
@@ -101,7 +115,6 @@ func (r *recvRing) recvIntoCancelable(dst []byte, cancel *nativeCancel) (int, er
 	if r == nil || r.handle == nil {
 		return 0, ErrClosed
 	}
-	r.releaseActiveView()
 	if err := r.fillIfEmptyCancelable(cancel); err != nil {
 		return 0, err
 	}
@@ -125,7 +138,6 @@ func (r *recvRing) recvInto(dst []byte, timeoutMillis int64) (int, error) {
 	if r == nil || r.handle == nil {
 		return 0, ErrClosed
 	}
-	r.releaseActiveView()
 	if err := r.fillIfEmpty(timeoutMillis); err != nil {
 		return 0, err
 	}
@@ -149,7 +161,6 @@ func (r *recvRing) close() {
 	if r == nil || r.handle == nil {
 		return
 	}
-	r.releaseActiveView()
 	r.releaseConsumed()
 	recvRingCloseNative(r.handle)
 	r.handle = nil
@@ -205,13 +216,6 @@ func (r *recvRing) source(desc recvRingDesc) []byte {
 		return nil
 	}
 	return r.payload[desc.payload : desc.payload+desc.payloadLen]
-}
-
-func (r *recvRing) releaseActiveView() {
-	if r.viewActive {
-		r.advance()
-		r.viewActive = false
-	}
 }
 
 func (r *recvRing) advance() {

--- a/bindings/go/run_test.go
+++ b/bindings/go/run_test.go
@@ -66,3 +66,45 @@ func TestBoundRecvIntoUsesContextAndRing(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCloseContextReturnsWhileRunCallbackIsActive(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = pull.Run(context.Background(), func(socket *BoundSocket) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := pull.Close(closeCtx); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Close err = %v, want ErrTimeout", err)
+	}
+	close(release)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pull.Close(context.Background())
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("socket close did not finish")
+	}
+}

--- a/bindings/go/run_test.go
+++ b/bindings/go/run_test.go
@@ -250,3 +250,26 @@ func TestBoundSocketRejectsUseAfterRun(t *testing.T) {
 		t.Fatalf("TryRecvView err = %v, want ErrClosed", err)
 	}
 }
+
+func TestRunSendRingCloseDoesNotHangWithoutPeer(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- push.Run(context.Background(), func(socket *BoundSocket) error {
+			return socket.SendBlocking(String("queued"))
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after send ring close")
+	}
+}

--- a/bindings/go/run_test.go
+++ b/bindings/go/run_test.go
@@ -211,3 +211,42 @@ func TestQueuedRecvDoesNotRunAfterContextCancel(t *testing.T) {
 		t.Fatalf("message = %q, want kept", got)
 	}
 }
+
+func TestBoundSocketRejectsUseAfterRun(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+
+	var boundPush *BoundSocket
+	if err := push.Run(context.Background(), func(socket *BoundSocket) error {
+		boundPush = socket
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := boundPush.TrySend(String("late")); !errors.Is(err, ErrClosed) {
+		t.Fatalf("TrySend err = %v, want ErrClosed", err)
+	}
+	if err := boundPush.SendBlocking(String("late")); !errors.Is(err, ErrClosed) {
+		t.Fatalf("SendBlocking err = %v, want ErrClosed", err)
+	}
+
+	var boundPull *BoundSocket
+	if err := pull.Run(context.Background(), func(socket *BoundSocket) error {
+		boundPull = socket
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	if _, err := boundPull.TryRecvInto(buf); !errors.Is(err, ErrClosed) {
+		t.Fatalf("TryRecvInto err = %v, want ErrClosed", err)
+	}
+	if err := boundPull.TryRecvView(func([]byte) error { return nil }); !errors.Is(err, ErrClosed) {
+		t.Fatalf("TryRecvView err = %v, want ErrClosed", err)
+	}
+}

--- a/bindings/go/run_test.go
+++ b/bindings/go/run_test.go
@@ -1,0 +1,68 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunBlockingReceiveHonorsContext(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	if _, err := pull.Bind("inproc://go-run-cancel"); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	err := pull.Run(runCtx, func(socket *BoundSocket) error {
+		buf := make([]byte, 16)
+		_, err := socket.RecvIntoBlocking(buf)
+		return err
+	})
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Run err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestBoundRecvIntoUsesContextAndRing(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	bound, err := pull.Bind("inproc://go-bound-recv-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("ring-context"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = pull.Run(runCtx, func(socket *BoundSocket) error {
+		buf := make([]byte, 32)
+		n, err := socket.RecvInto(runCtx, buf)
+		if err != nil {
+			return err
+		}
+		if got := string(buf[:n]); got != "ring-context" {
+			t.Fatalf("message = %q, want ring-context", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/bindings/go/run_test.go
+++ b/bindings/go/run_test.go
@@ -108,3 +108,106 @@ func TestCloseContextReturnsWhileRunCallbackIsActive(t *testing.T) {
 		t.Fatal("socket close did not finish")
 	}
 }
+
+func TestQueuedSendDoesNotRunAfterContextCancel(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-run-canceled-send")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- push.Run(context.Background(), func(socket *BoundSocket) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	sendCtx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	err = push.Send(sendCtx, String("late"))
+	cancel()
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Send err = %v, want ErrTimeout", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pull.RecvTimeout(20 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestQueuedRecvDoesNotRunAfterContextCancel(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-run-canceled-recv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("kept"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- pull.Run(context.Background(), func(socket *BoundSocket) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start")
+	}
+
+	recvCtx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	_, err = pull.Recv(recvCtx)
+	cancel()
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Recv err = %v, want ErrTimeout", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	msg, err := pull.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "kept" {
+		t.Fatalf("message = %q, want kept", got)
+	}
+}

--- a/bindings/go/scripts/soak.sh
+++ b/bindings/go/scripts/soak.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+durations="${OMQ_GO_SOAK_DURATIONS:-300 600 1800 3600}"
+workers="${OMQ_GO_SOAK_WORKERS:-$(nproc)}"
+cargo_cmd="${CARGO:-cargo}"
+
+"${cargo_cmd}" build --release --manifest-path "${repo_root}/bindings/go/native/Cargo.toml"
+
+case "$(uname -s)" in
+    Darwin)
+        export DYLD_LIBRARY_PATH="${repo_root}/bindings/go/native/target/release:${repo_root}/bindings/go/native/target/debug:${DYLD_LIBRARY_PATH:-}"
+        ;;
+    *)
+        export LD_LIBRARY_PATH="${repo_root}/bindings/go/native/target/release:${repo_root}/bindings/go/native/target/debug:${LD_LIBRARY_PATH:-}"
+        ;;
+esac
+
+for duration in ${durations}; do
+    echo "== OMQ.go soak: ${duration}s, workers=${workers} =="
+    (
+        cd "${repo_root}/bindings/go"
+        OMQ_GO_SOAK=1 \
+        OMQ_GO_SOAK_DURATION_SECS="${duration}" \
+        OMQ_GO_SOAK_WORKERS="${workers}" \
+        GOMAXPROCS="${workers}" \
+            go test -count=1 -run '^TestSoak' -parallel="${workers}" -timeout "$((duration + 120))s"
+    )
+done

--- a/bindings/go/scripts/soak.sh
+++ b/bindings/go/scripts/soak.sh
@@ -25,6 +25,6 @@ for duration in ${durations}; do
         OMQ_GO_SOAK_DURATION_SECS="${duration}" \
         OMQ_GO_SOAK_WORKERS="${workers}" \
         GOMAXPROCS="${workers}" \
-            go test -count=1 -run '^TestSoak' -parallel="${workers}" -timeout "$((duration + 120))s"
+            go test -v -count=1 -run '^TestSoak' -parallel="${workers}" -timeout "$((duration + 120))s"
     )
 done

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -1,0 +1,1346 @@
+#!/usr/bin/env python3
+"""Measure OMQ Go vs pebbe/zmq4 over 2-process TCP loopback.
+
+Adapted from bindings/pyomq/scripts/update_perf.py. Benchmark rows are
+append-only in ~/.cache/omq.go/bindings.jsonl by default. The chart is
+regenerated from the latest cached row per implementation, kind, and size.
+"""
+
+import argparse
+import datetime as dt
+import html
+import json
+import math
+import os
+import selectors
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parents[1]
+CACHE_DIR = Path(
+    os.environ.get(
+        "OMQ_GO_CACHE_DIR",
+        Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omq.go",
+    )
+)
+JSONL = CACHE_DIR / "bindings.jsonl"
+HARNESS_DIR = CACHE_DIR / "pushpull_tcp_peer"
+HARNESS_BIN = HARNESS_DIR / "perf-peer"
+CHART_DIR = ROOT / "doc" / "charts"
+CHART = CHART_DIR / "bindings.svg"
+
+DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+QUICK_SIZES = [16, 128, 1024, 4096, 32768]
+DEFAULT_IMPLS = ["omq-run-into", "zmq4"]
+DEFAULT_LATENCY_IMPLS = ["omq", "omq-run", "zmq4"]
+IMPL_LABELS = {
+    "omq": "OMQ.go scalar",
+    "omq-run": "OMQ.go Socket.Run",
+    "omq-run-into": "OMQ.go hot path",
+    "zmq4": "zmq4",
+}
+COLORS = {
+    "omq": "#dc2626",
+    "omq-run": "#f97316",
+    "omq-run-into": "#f97316",
+    "zmq4": "#2563eb",
+}
+
+GO_PEER = r'''
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	omq "github.com/paddor/omq.rs/bindings/go"
+	zmq4 "github.com/pebbe/zmq4"
+)
+
+const hwm = 1_000_000
+const linger = 5 * time.Second
+const timeout = 120 * time.Second
+
+type result struct {
+	Impl     string  `json:"impl"`
+	Endpoint string  `json:"endpoint"`
+	MsgSize  int     `json:"msg_size"`
+	Messages int     `json:"messages"`
+	Seconds  float64 `json:"seconds,omitempty"`
+	MsgsS    float64 `json:"msgs_s,omitempty"`
+	GBS      float64 `json:"gb_s,omitempty"`
+	P50US    float64 `json:"p50_us,omitempty"`
+	P99US    float64 `json:"p99_us,omitempty"`
+}
+
+func main() {
+	if len(os.Args) != 8 {
+		die("usage: perf-peer <pushpull|reqrep> <omq|omq-run|omq-run-into|zmq4> <push|pull|req|rep> <endpoint> <size> <messages> <warmup>")
+	}
+	bench := os.Args[1]
+	impl := os.Args[2]
+	role := os.Args[3]
+	endpoint := os.Args[4]
+	size := parseInt(os.Args[5], "size")
+	messages := parseInt(os.Args[6], "messages")
+	warmup := parseInt(os.Args[7], "warmup")
+	if size < 0 || messages <= 0 || warmup < 0 {
+		die("invalid size/messages/warmup")
+	}
+
+	switch bench {
+	case "pushpull":
+		switch role {
+		case "pull":
+			runPull(impl, endpoint, size, messages, warmup)
+		case "push":
+			runPush(impl, endpoint, size, messages, warmup)
+		default:
+			die("bad pushpull role: " + role)
+		}
+	case "reqrep":
+		switch role {
+		case "rep":
+			runRep(impl, endpoint, size, messages, warmup)
+		case "req":
+			runReq(impl, endpoint, size, messages, warmup)
+		default:
+			die("bad reqrep role: " + role)
+		}
+	default:
+		die("bad bench: " + bench)
+	}
+}
+
+func parseInt(value string, name string) int {
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		die("invalid " + name + ": " + value)
+	}
+	return parsed
+}
+
+func die(message string) {
+	fmt.Fprintln(os.Stderr, message)
+	os.Exit(1)
+}
+
+func ready(endpoint string) {
+	fmt.Println("READY " + endpoint)
+}
+
+func printResult(row result) {
+	data, err := json.Marshal(row)
+	if err != nil {
+		die(err.Error())
+	}
+	fmt.Printf("RESULT %s\n", data)
+}
+
+func makePayload(size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}
+
+func benchContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func runPull(impl string, endpoint string, size int, messages int, warmup int) {
+	switch impl {
+	case "omq":
+		runOMQPull(endpoint, size, messages, warmup, false)
+	case "omq-run-into":
+		runOMQPull(endpoint, size, messages, warmup, true)
+	case "zmq4":
+		runZMQPull(endpoint, size, messages, warmup)
+	default:
+		die("bad impl: " + impl)
+	}
+}
+
+func runPush(impl string, endpoint string, size int, messages int, warmup int) {
+	switch impl {
+	case "omq":
+		runOMQPush(endpoint, size, messages, warmup, false)
+	case "omq-run-into":
+		runOMQPush(endpoint, size, messages, warmup, true)
+	case "zmq4":
+		runZMQPush(endpoint, size, messages, warmup)
+	default:
+		die("bad impl: " + impl)
+	}
+}
+
+func openOMQSocket(socketType omq.SocketType, sender bool) (*omq.Context, *omq.Socket) {
+	ctx, err := omq.Open(omq.Config{IOThreads: 1})
+	if err != nil {
+		die(err.Error())
+	}
+	options := []omq.SocketOption{omq.Linger(linger)}
+	if sender {
+		options = append(options, omq.SendHWM(hwm))
+	} else {
+		options = append(options, omq.RecvHWM(hwm))
+	}
+	socket, err := ctx.Socket(socketType, options...)
+	if err != nil {
+		_ = ctx.Close()
+		die(err.Error())
+	}
+	return ctx, socket
+}
+
+func runOMQPull(endpoint string, size int, messages int, warmup int, into bool) {
+	ctx, pull := openOMQSocket(omq.Pull, false)
+	defer ctx.Close()
+	defer pull.Close(context.Background())
+	if _, err := pull.Bind(endpoint); err != nil {
+		die(err.Error())
+	}
+	ready(endpoint)
+
+	runCtx, cancel := benchContext()
+	defer cancel()
+	if into {
+		buffer := make([]byte, size)
+		var started time.Time
+		var ended time.Time
+		err := pull.Run(runCtx, func(socket *omq.BoundSocket) error {
+			recvOMQInto(socket, buffer, size, warmup)
+			started = time.Now()
+			recvOMQInto(socket, buffer, size, messages)
+			ended = time.Now()
+			return nil
+		})
+		if err != nil {
+			die(err.Error())
+		}
+		printThroughput("omq-run-into", endpoint, size, messages, started, ended)
+		return
+	}
+
+	recvOMQ(pull, runCtx, size, warmup)
+	started := time.Now()
+	recvOMQ(pull, runCtx, size, messages)
+	printThroughput("omq", endpoint, size, messages, started, time.Now())
+}
+
+func runOMQPush(endpoint string, size int, messages int, warmup int, run bool) {
+	ctx, push := openOMQSocket(omq.Push, true)
+	defer ctx.Close()
+	defer push.Close(context.Background())
+	if err := push.Connect(endpoint); err != nil {
+		die(err.Error())
+	}
+	payload := makePayload(size)
+	msg := omq.Bytes(payload)
+	total := messages + warmup
+	runCtx, cancel := benchContext()
+	defer cancel()
+	if run {
+		err := push.Run(runCtx, func(socket *omq.BoundSocket) error {
+			for i := 0; i < total; i++ {
+				if err := socket.SendBlocking(msg); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			die(err.Error())
+		}
+		return
+	}
+	for i := 0; i < total; i++ {
+		if err := push.Send(runCtx, msg); err != nil {
+			die(err.Error())
+		}
+	}
+}
+
+func recvOMQ(pull *omq.Socket, ctx context.Context, size int, count int) {
+	for i := 0; i < count; i++ {
+		msg, err := pull.Recv(ctx)
+		if err != nil {
+			die(err.Error())
+		}
+		if len(msg.Bytes()) != size {
+			die(fmt.Sprintf("expected %d bytes, got %d", size, len(msg.Bytes())))
+		}
+	}
+}
+
+func recvOMQInto(pull *omq.BoundSocket, buffer []byte, size int, count int) {
+	for i := 0; i < count; i++ {
+		n, err := pull.RecvIntoBlocking(buffer)
+		if err != nil {
+			die(err.Error())
+		}
+		if n != size {
+			die(fmt.Sprintf("expected %d bytes, got %d", size, n))
+		}
+	}
+}
+
+func openZMQSocket(socketType zmq4.Type, sender bool) (*zmq4.Context, *zmq4.Socket) {
+	ctx, err := zmq4.NewContext()
+	if err != nil {
+		die(err.Error())
+	}
+	if err := ctx.SetIoThreads(1); err != nil {
+		_ = ctx.Term()
+		die(err.Error())
+	}
+	socket, err := ctx.NewSocket(socketType)
+	if err != nil {
+		_ = ctx.Term()
+		die(err.Error())
+	}
+	if sender {
+		if err := socket.SetSndhwm(hwm); err != nil {
+			die(err.Error())
+		}
+	} else {
+		if err := socket.SetRcvhwm(hwm); err != nil {
+			die(err.Error())
+		}
+	}
+	if err := socket.SetLinger(linger); err != nil {
+		die(err.Error())
+	}
+	return ctx, socket
+}
+
+func runZMQPull(endpoint string, size int, messages int, warmup int) {
+	ctx, pull := openZMQSocket(zmq4.PULL, false)
+	defer ctx.Term()
+	defer pull.Close()
+	if err := pull.Bind(endpoint); err != nil {
+		die(err.Error())
+	}
+	ready(endpoint)
+	recvZMQ(pull, size, warmup)
+	started := time.Now()
+	recvZMQ(pull, size, messages)
+	printThroughput("zmq4", endpoint, size, messages, started, time.Now())
+}
+
+func runZMQPush(endpoint string, size int, messages int, warmup int) {
+	ctx, push := openZMQSocket(zmq4.PUSH, true)
+	defer ctx.Term()
+	defer push.Close()
+	if err := push.Connect(endpoint); err != nil {
+		die(err.Error())
+	}
+	payload := makePayload(size)
+	total := messages + warmup
+	for i := 0; i < total; i++ {
+		if _, err := push.SendBytes(payload, 0); err != nil {
+			die(err.Error())
+		}
+	}
+}
+
+func recvZMQ(pull *zmq4.Socket, size int, count int) {
+	for i := 0; i < count; i++ {
+		msg, err := pull.RecvBytes(0)
+		if err != nil {
+			die(err.Error())
+		}
+		if len(msg) != size {
+			die(fmt.Sprintf("expected %d bytes, got %d", size, len(msg)))
+		}
+	}
+}
+
+func printThroughput(impl string, endpoint string, size int, messages int, start time.Time, end time.Time) {
+	seconds := end.Sub(start).Seconds()
+	msgsS := float64(messages) / seconds
+	printResult(result{
+		Impl:     impl,
+		Endpoint: endpoint,
+		MsgSize:  size,
+		Messages: messages,
+		Seconds:  seconds,
+		MsgsS:    msgsS,
+		GBS:      msgsS * float64(size) / 1_000_000_000.0,
+	})
+}
+
+func runRep(impl string, endpoint string, size int, messages int, warmup int) {
+	switch impl {
+	case "omq":
+		runOMQRep(endpoint, messages+warmup)
+	case "omq-run":
+		runOMQRepRun(endpoint, size, messages+warmup)
+	case "zmq4":
+		runZMQRep(endpoint, messages+warmup)
+	default:
+		die("latency unsupported for impl: " + impl)
+	}
+}
+
+func runReq(impl string, endpoint string, size int, messages int, warmup int) {
+	switch impl {
+	case "omq":
+		runOMQReq(endpoint, size, messages, warmup)
+	case "omq-run":
+		runOMQReqRun(endpoint, size, messages, warmup)
+	case "zmq4":
+		runZMQReq(endpoint, size, messages, warmup)
+	default:
+		die("latency unsupported for impl: " + impl)
+	}
+}
+
+func runOMQRep(endpoint string, count int) {
+	ctx, rep := openOMQSocket(omq.Rep, false)
+	defer ctx.Close()
+	defer rep.Close(context.Background())
+	if _, err := rep.Bind(endpoint); err != nil {
+		die(err.Error())
+	}
+	ready(endpoint)
+	runCtx, cancel := benchContext()
+	defer cancel()
+	for i := 0; i < count; i++ {
+		msg, err := rep.Recv(runCtx)
+		if err != nil {
+			die(err.Error())
+		}
+		if err := rep.Send(runCtx, msg); err != nil {
+			die(err.Error())
+		}
+	}
+}
+
+func runOMQRepRun(endpoint string, size int, count int) {
+	ctx, rep := openOMQSocket(omq.Rep, false)
+	defer ctx.Close()
+	defer rep.Close(context.Background())
+	if _, err := rep.Bind(endpoint); err != nil {
+		die(err.Error())
+	}
+	ready(endpoint)
+	runCtx, cancel := benchContext()
+	defer cancel()
+	buffer := make([]byte, size)
+	reply := omq.Bytes(makePayload(size))
+	err := rep.Run(runCtx, func(socket *omq.BoundSocket) error {
+		for i := 0; i < count; i++ {
+			n, err := socket.RecvIntoBlocking(buffer)
+			if err != nil {
+				return err
+			}
+			if n != size {
+				return fmt.Errorf("expected %d bytes, got %d", size, n)
+			}
+			if err := socket.SendBlocking(reply); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		die(err.Error())
+	}
+}
+
+func runOMQReq(endpoint string, size int, messages int, warmup int) {
+	ctx, req := openOMQSocket(omq.Req, true)
+	defer ctx.Close()
+	defer req.Close(context.Background())
+	if err := req.Connect(endpoint); err != nil {
+		die(err.Error())
+	}
+	payload := makePayload(size)
+	msg := omq.Bytes(payload)
+	runCtx, cancel := benchContext()
+	defer cancel()
+	for i := 0; i < warmup; i++ {
+		omqRoundTrip(req, runCtx, msg, size)
+	}
+	durations := make([]float64, messages)
+	for i := 0; i < messages; i++ {
+		started := time.Now()
+		omqRoundTrip(req, runCtx, msg, size)
+		durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+	}
+	printLatency("omq", endpoint, size, messages, durations)
+}
+
+func runOMQReqRun(endpoint string, size int, messages int, warmup int) {
+	ctx, req := openOMQSocket(omq.Req, true)
+	defer ctx.Close()
+	defer req.Close(context.Background())
+	if err := req.Connect(endpoint); err != nil {
+		die(err.Error())
+	}
+	payload := makePayload(size)
+	msg := omq.Bytes(payload)
+	buffer := make([]byte, size)
+	durations := make([]float64, messages)
+	runCtx, cancel := benchContext()
+	defer cancel()
+	err := req.Run(runCtx, func(socket *omq.BoundSocket) error {
+		for i := 0; i < warmup; i++ {
+			if err := omqRoundTripRun(socket, msg, buffer, size); err != nil {
+				return err
+			}
+		}
+		for i := 0; i < messages; i++ {
+			started := time.Now()
+			if err := omqRoundTripRun(socket, msg, buffer, size); err != nil {
+				return err
+			}
+			durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+		}
+		return nil
+	})
+	if err != nil {
+		die(err.Error())
+	}
+	printLatency("omq-run", endpoint, size, messages, durations)
+}
+
+func omqRoundTrip(req *omq.Socket, ctx context.Context, msg omq.Message, size int) {
+	if err := req.Send(ctx, msg); err != nil {
+		die(err.Error())
+	}
+	reply, err := req.Recv(ctx)
+	if err != nil {
+		die(err.Error())
+	}
+	if len(reply.Bytes()) != size {
+		die(fmt.Sprintf("expected %d bytes, got %d", size, len(reply.Bytes())))
+	}
+}
+
+func omqRoundTripRun(req *omq.BoundSocket, msg omq.Message, buffer []byte, size int) error {
+	if err := req.SendBlocking(msg); err != nil {
+		return err
+	}
+	n, err := req.RecvIntoBlocking(buffer)
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return fmt.Errorf("expected %d bytes, got %d", size, n)
+	}
+	return nil
+}
+
+func runZMQRep(endpoint string, count int) {
+	ctx, rep := openZMQSocket(zmq4.REP, false)
+	defer ctx.Term()
+	defer rep.Close()
+	if err := rep.Bind(endpoint); err != nil {
+		die(err.Error())
+	}
+	ready(endpoint)
+	for i := 0; i < count; i++ {
+		msg, err := rep.RecvBytes(0)
+		if err != nil {
+			die(err.Error())
+		}
+		if _, err := rep.SendBytes(msg, 0); err != nil {
+			die(err.Error())
+		}
+	}
+}
+
+func runZMQReq(endpoint string, size int, messages int, warmup int) {
+	ctx, req := openZMQSocket(zmq4.REQ, true)
+	defer ctx.Term()
+	defer req.Close()
+	if err := req.Connect(endpoint); err != nil {
+		die(err.Error())
+	}
+	payload := makePayload(size)
+	for i := 0; i < warmup; i++ {
+		zmqRoundTrip(req, payload, size)
+	}
+	durations := make([]float64, messages)
+	for i := 0; i < messages; i++ {
+		started := time.Now()
+		zmqRoundTrip(req, payload, size)
+		durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+	}
+	printLatency("zmq4", endpoint, size, messages, durations)
+}
+
+func zmqRoundTrip(req *zmq4.Socket, payload []byte, size int) {
+	if _, err := req.SendBytes(payload, 0); err != nil {
+		die(err.Error())
+	}
+	reply, err := req.RecvBytes(0)
+	if err != nil {
+		die(err.Error())
+	}
+	if len(reply) != size {
+		die(fmt.Sprintf("expected %d bytes, got %d", size, len(reply)))
+	}
+}
+
+func printLatency(impl string, endpoint string, size int, messages int, durations []float64) {
+	sort.Float64s(durations)
+	p50 := durations[len(durations)*50/100]
+	p99 := durations[len(durations)*99/100]
+	printResult(result{
+		Impl:     impl,
+		Endpoint: endpoint,
+		MsgSize:  size,
+		Messages: messages,
+		P50US:    p50,
+		P99US:    p99,
+	})
+}
+'''
+
+
+def parse_csv_ints(value):
+    sizes = []
+    for raw in value.split(","):
+        raw = raw.strip().lower()
+        if not raw:
+            continue
+        multiplier = 1
+        if raw.endswith("kib"):
+            multiplier = 1024
+            raw = raw[:-3]
+        elif raw.endswith("kb"):
+            multiplier = 1000
+            raw = raw[:-2]
+        elif raw.endswith("k"):
+            multiplier = 1024
+            raw = raw[:-1]
+        size = int(raw) * multiplier
+        if size <= 0:
+            raise argparse.ArgumentTypeError("sizes must be positive")
+        sizes.append(size)
+    if not sizes:
+        raise argparse.ArgumentTypeError("at least one size is required")
+    return sizes
+
+
+def parse_csv_strings(value):
+    return [part for part in value.split(",") if part]
+
+
+def run(cmd, cwd=ROOT, timeout=None, fail_on_warning=True):
+    print("+ " + " ".join(str(part) for part in cmd), flush=True)
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+    if fail_on_warning and has_noise(result.stdout):
+        raise RuntimeError("command printed warning/timeout")
+
+
+def has_noise(text):
+    lowered = (text or "").lower()
+    return "warning" in lowered or "timeout" in lowered
+
+
+def build_native(args):
+    if args.no_build:
+        return
+    run(
+        [
+            "cargo",
+            "build",
+            "--release",
+            "--features",
+            "plain,curve,lz4,zstd",
+            "--manifest-path",
+            str(ROOT / "native" / "Cargo.toml"),
+        ],
+        cwd=REPO,
+    )
+
+
+def write_harness():
+    HARNESS_DIR.mkdir(parents=True, exist_ok=True)
+    (HARNESS_DIR / "go.mod").write_text(
+        textwrap.dedent(
+            f"""\
+            module omq-go-perf
+
+            go 1.22
+
+            require (
+            \tgithub.com/paddor/omq.rs/bindings/go v0.0.0
+            \tgithub.com/pebbe/zmq4 v1.4.0
+            )
+
+            replace github.com/paddor/omq.rs/bindings/go => {ROOT}
+            """
+        )
+    )
+    (HARNESS_DIR / "main.go").write_text(GO_PEER.lstrip())
+
+
+def build_harness(args):
+    write_harness()
+    run(["go", "mod", "tidy"], cwd=HARNESS_DIR, fail_on_warning=False)
+    if args.no_harness_build and HARNESS_BIN.exists():
+        return
+    run(["go", "build", "-o", str(HARNESS_BIN), "."], cwd=HARNESS_DIR)
+
+
+def env_with_native_lib():
+    env = os.environ.copy()
+    release = ROOT / "native" / "target" / "release"
+    debug = ROOT / "native" / "target" / "debug"
+    key = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+    env[key] = os.pathsep.join(
+        [str(release), str(debug), env[key]] if key in env else [str(release), str(debug)]
+    )
+    return env
+
+
+def free_endpoint():
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    finally:
+        sock.close()
+    return f"tcp://127.0.0.1:{port}"
+
+
+def message_count(size, args):
+    by_bytes = args.target_bytes // max(size, 1)
+    return max(args.min_messages, min(args.max_messages, by_bytes))
+
+
+def read_line_timeout(proc, seconds):
+    selector = selectors.DefaultSelector()
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    try:
+        events = selector.select(seconds)
+        if not events:
+            return None
+        return proc.stdout.readline()
+    finally:
+        selector.close()
+
+
+def peer_cmd(bench, impl, role, endpoint, size, messages, warmup):
+    return [
+        str(HARNESS_BIN),
+        bench,
+        impl,
+        role,
+        endpoint,
+        str(size),
+        str(messages),
+        str(warmup),
+    ]
+
+
+def parse_result(output):
+    for line in output.splitlines():
+        if line.startswith("RESULT "):
+            return json.loads(line[len("RESULT ") :])
+    raise RuntimeError("missing RESULT line:\n" + output)
+
+
+def fail_on_noise(name, stdout, stderr):
+    text = (stdout or "") + "\n" + (stderr or "")
+    if has_noise(text):
+        raise RuntimeError(f"{name} printed warning/timeout:\n{text}")
+
+
+def kill(proc):
+    if proc.poll() is not None:
+        return
+    proc.kill()
+    proc.communicate(timeout=5)
+
+
+def run_pair_once(bench, impl, receiver_role, sender_role, size, messages, warmup, timeout):
+    endpoint = free_endpoint()
+    env = env_with_native_lib()
+    receiver = subprocess.Popen(
+        peer_cmd(bench, impl, receiver_role, endpoint, size, messages, warmup),
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        ready = read_line_timeout(receiver, 10)
+        if ready is None or not ready.startswith("READY "):
+            out, err = receiver.communicate(timeout=1) if receiver.poll() is not None else ("", "")
+            raise RuntimeError(f"receiver did not become ready:\n{ready or ''}{out}{err}")
+
+        sender = subprocess.run(
+            peer_cmd(bench, impl, sender_role, endpoint, size, messages, warmup),
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+        fail_on_noise("sender", sender.stdout, sender.stderr)
+        if sender.returncode != 0:
+            raise RuntimeError(f"sender failed:\n{sender.stdout}{sender.stderr}")
+
+        out, err = receiver.communicate(timeout=timeout)
+        out = ready + out
+        fail_on_noise("receiver", out, err)
+        if receiver.returncode != 0:
+            raise RuntimeError(f"receiver failed:\n{out}{err}")
+        if bench == "reqrep":
+            return parse_result(sender.stdout)
+        return parse_result(out)
+    except Exception:
+        kill(receiver)
+        raise
+
+
+def run_throughput_cell(impl, size, args):
+    messages = message_count(size, args)
+    warmup = args.warmup_messages if args.warmup_messages is not None else max(1000, messages // 20)
+    runs = []
+    total = args.warmup_rounds + args.rounds
+    for round_index in range(total):
+        row = run_pair_once("pushpull", impl, "pull", "push", size, messages, warmup, args.timeout)
+        if round_index >= args.warmup_rounds:
+            runs.append(row)
+        print(
+            f"  {impl:12s} size={size:6d} round={round_index + 1}/{total} "
+            f"{row['msgs_s']:12.0f} msg/s {row['gb_s']:7.3f} GB/s",
+            flush=True,
+        )
+    return sorted(runs, key=lambda row: row["msgs_s"])[len(runs) // 2]
+
+
+def run_latency_cell(impl, size, args):
+    messages = args.latency_iters
+    warmup = args.latency_warmup
+    runs = []
+    total = args.warmup_rounds + args.rounds
+    for round_index in range(total):
+        row = run_pair_once("reqrep", impl, "rep", "req", size, messages, warmup, args.timeout)
+        if round_index >= args.warmup_rounds:
+            runs.append(row)
+        print(
+            f"  {impl:12s} size={size:6d} round={round_index + 1}/{total} "
+            f"p50 {row['p50_us']:8.1f} us p99 {row['p99_us']:8.1f} us",
+            flush=True,
+        )
+    return sorted(runs, key=lambda row: row["p50_us"])[len(runs) // 2]
+
+
+def append_jsonl(rows):
+    JSONL.parent.mkdir(parents=True, exist_ok=True)
+    with JSONL.open("a") as file:
+        for row in rows:
+            file.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def load_jsonl():
+    rows = []
+    try:
+        with JSONL.open() as file:
+            for line in file:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return rows
+
+
+def fmt_size(size):
+    if size >= 1024:
+        return f"{size // 1024} KiB"
+    return f"{size} B"
+
+
+def fmt_rate(rate):
+    if rate >= 1_000_000:
+        return f"{rate / 1_000_000:.2f} M/s"
+    return f"{rate / 1_000:.0f} k/s"
+
+
+def print_table(rows, sizes, impls, latency_impls):
+    by_key = {(row["kind"], row["msg_size"], row["impl"]): row for row in rows}
+    print()
+    if impls:
+        print("PUSH/PULL TCP throughput")
+        print("size    impl             msg/s      GB/s   vs zmq4")
+        for size in sizes:
+            base = by_key.get(("pushpull_tcp", size, "zmq4"))
+            base_msgs = base["msgs_s"] if base else 0.0
+            for impl in impls:
+                row = by_key.get(("pushpull_tcp", size, impl))
+                if row is None:
+                    continue
+                ratio = row["msgs_s"] / base_msgs if base_msgs else 0.0
+                print(
+                    f"{size:6d} {impl:12s} {row['msgs_s']:11.0f} "
+                    f"{row['gb_s']:8.3f} {ratio:9.2f}x"
+                )
+            print()
+    if latency_impls:
+        print("REQ/REP TCP latency")
+        print("size    impl             p50 us    p99 us   vs zmq4")
+        for size in sizes:
+            base = by_key.get(("reqrep_tcp_latency", size, "zmq4"))
+            base_p50 = base["p50_us"] if base else 0.0
+            for impl in latency_impls:
+                row = by_key.get(("reqrep_tcp_latency", size, impl))
+                if row is None:
+                    continue
+                ratio = base_p50 / row["p50_us"] if row["p50_us"] else 0.0
+                print(
+                    f"{size:6d} {impl:12s} {row['p50_us']:9.1f} "
+                    f"{row['p99_us']:9.1f} {ratio:9.2f}x"
+                )
+            print()
+
+
+def latest_chart_data(sizes, impls, latency_impls):
+    latest = {}
+    for row in load_jsonl():
+        kind = row.get("kind")
+        impl = row.get("impl")
+        size = row.get("msg_size")
+        key = (kind, impl, size)
+        prev = latest.get(key)
+        if prev is None or row.get("run_id", "") >= prev.get("run_id", ""):
+            latest[key] = row
+
+    throughput = {
+        impl: [
+            latest.get(("pushpull_tcp", impl, size), {}).get("msgs_s", 0.0)
+            for size in sizes
+        ]
+        for impl in impls
+    }
+    latency = {
+        impl: [
+            latest.get(("reqrep_tcp_latency", impl, size), {}).get("p50_us", 0.0)
+            for size in sizes
+        ]
+        for impl in latency_impls
+    }
+    return {"throughput": throughput, "latency": latency}
+
+
+def nice_ceil(value):
+    if value <= 0:
+        return 1
+    exp = math.floor(math.log10(value))
+    base = 10**exp
+    for multiplier in [1, 2, 5, 10]:
+        candidate = multiplier * base
+        if candidate >= value:
+            return candidate
+    return 10 * base
+
+
+def fmt_y_rate(value):
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:g}M"
+    if value >= 1_000:
+        return f"{value / 1_000:g}k"
+    return f"{value:g}"
+
+
+def fmt_y_mbps(value):
+    if value >= 1000:
+        return f"{value / 1000:g} GB/s"
+    if value >= 10:
+        return f"{value:.0f} MB/s"
+    return f"{value:.1f} MB/s"
+
+
+def fmt_y_us(value):
+    if value >= 1000:
+        return f"{value / 1000:g} ms"
+    return f"{value:g} us"
+
+
+def read_chart_hw():
+    config = {}
+    path = ROOT / ".chart_hw"
+    try:
+        with path.open() as file:
+            for line in file:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, sep, value = line.partition("=")
+                if sep:
+                    config[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return config
+
+
+def detect_hardware():
+    config = read_chart_hw()
+    try:
+        cpu = None
+        with open("/proc/cpuinfo") as file:
+            for line in file:
+                if line.startswith("model name"):
+                    cpu = line.split(":", 1)[1].strip()
+                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
+                    break
+        cores = os.cpu_count()
+        if cpu and cores:
+            label = f"{cpu}, {cores} cores"
+            prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
+            postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
+            extras = [part.strip() for part in postfix.split(",")] if postfix else []
+            env_extras = os.environ.get("OMQ_HW_EXTRAS")
+            if env_extras:
+                extras.extend(env_extras.split(","))
+            extras = [part for part in extras if part]
+            if extras:
+                label += ", " + ", ".join(extras)
+            if prefix:
+                label = f"{prefix}, {label}"
+            return label
+    except OSError:
+        pass
+    return None
+
+
+def svg_line(points, color, dashed=False):
+    dash = ' stroke-dasharray="6,4"' if dashed else ""
+    return (
+        f'  <polyline points="{points}" fill="none" stroke="{color}"'
+        f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"{dash}/>'
+    )
+
+
+def gen_chart(data, path, sizes, impls, latency_impls):
+    hw_label = detect_hardware()
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 670 + hw_offset
+    x_left, x_right = 90, 760
+    plot_w = x_right - x_left
+    t1_top = 35 + hw_offset
+    t1_bot = 370 + hw_offset
+    t1_h = t1_bot - t1_top
+    t1_leg_y = t1_bot + 40
+    t2_top = t1_bot + 105
+    t2_bot = t2_top + 120
+    t2_h = t2_bot - t2_top
+    mid_x = (x_left + x_right) / 2
+    xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
+
+    all_rates = [rate for values in data["throughput"].values() for rate in values]
+    all_mbps = [
+        rate * sizes[index] / 1_000_000.0
+        for values in data["throughput"].values()
+        for index, rate in enumerate(values)
+    ]
+    msg_max = max(5_000_000, nice_ceil(max(all_rates or [0]) * 1.05))
+    mbps_max = max(5_000, nice_ceil(max(all_mbps or [0]) * 1.05))
+    lat_max = 200
+
+    def y_msg(value):
+        return t1_bot - (value / msg_max) * t1_h
+
+    def y_mbps(value):
+        return t1_bot - (value / mbps_max) * t1_h
+
+    def y_lat(value):
+        return t2_bot - (min(value, lat_max) / lat_max) * t2_h
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">',
+        f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f' font-size="13" font-weight="700">'
+        f"PUSH/PULL throughput: 2-process, TCP loopback</text>",
+    ]
+    if hw_label:
+        lines.append(
+            f'  <text x="{mid_x}" y="{t1_top - 3}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{html.escape(hw_label)}</text>'
+        )
+
+    for i in range(1, 11):
+        frac = i / 10
+        yy = t1_bot - frac * t1_h
+        lines.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+        lines.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f"{fmt_y_rate(msg_max * frac)}</text>"
+        )
+        lines.append(
+            f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
+            f' dominant-baseline="middle" fill="#6b7280" font-size="10">'
+            f"{fmt_y_mbps(mbps_max * frac)}</text>"
+        )
+
+    for x in xs:
+        lines.append(
+            f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+    lines.extend(
+        [
+            f'  <line x1="{x_left}" y1="{t1_top}" x2="{x_left}" y2="{t1_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_right}" y1="{t1_top}" x2="{x_right}" y2="{t1_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_left}" y1="{t1_bot}" x2="{x_right}" y2="{t1_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+        ]
+    )
+    t1_mid = (t1_top + t1_bot) / 2
+    lines.append(
+        f'  <text x="40" y="{t1_mid:.0f}" text-anchor="middle"'
+        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
+    )
+
+    for impl in impls:
+        values = data["throughput"].get(impl, [])
+        points = " ".join(f"{xs[i]:.1f},{y_msg(value):.1f}" for i, value in enumerate(values))
+        lines.append(svg_line(points, COLORS[impl], dashed=True))
+    for impl in impls:
+        values = data["throughput"].get(impl, [])
+        mbps = [value * sizes[index] / 1_000_000.0 for index, value in enumerate(values)]
+        points = " ".join(f"{xs[i]:.1f},{y_mbps(value):.1f}" for i, value in enumerate(mbps))
+        lines.append(svg_line(points, COLORS[impl]))
+        for i, value in enumerate(mbps):
+            lines.append(
+                f'  <circle cx="{xs[i]:.1f}" cy="{y_mbps(value):.1f}" r="3"'
+                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+            )
+
+    for i, size in enumerate(sizes):
+        lines.append(
+            f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
+            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+        )
+
+    add_legend(lines, [(IMPL_LABELS[impl], COLORS[impl]) for impl in impls], mid_x, t1_leg_y)
+    lines.append(
+        f'  <text x="{mid_x:.1f}" y="{t1_leg_y + 18}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f"dashed = msg/s (left), solid = throughput (right)</text>"
+    )
+
+    lines.append(
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f' font-size="13" font-weight="700">'
+        f"REQ/REP latency: 2-process, TCP loopback, p50 us</text>"
+    )
+
+    for i in range(1, 11):
+        value = lat_max * i / 10
+        yy = y_lat(value)
+        lines.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+        lines.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f"{fmt_y_us(value)}</text>"
+        )
+    for x in xs:
+        lines.append(
+            f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
+            f' stroke="#e5e7eb" stroke-width="1"/>'
+        )
+    lines.extend(
+        [
+            f'  <line x1="{x_left}" y1="{t2_top}" x2="{x_left}" y2="{t2_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+            f'  <line x1="{x_left}" y1="{t2_bot}" x2="{x_right}" y2="{t2_bot}"'
+            f' stroke="#9ca3af" stroke-width="1.5"/>',
+        ]
+    )
+    t2_mid = (t2_top + t2_bot) / 2
+    lines.append(
+        f'  <text x="40" y="{t2_mid:.0f}" text-anchor="middle"'
+        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' transform="rotate(-90,40,{t2_mid:.0f})">p50 latency (us)</text>'
+    )
+    for impl in latency_impls:
+        values = data["latency"].get(impl, [])
+        points = " ".join(f"{xs[i]:.1f},{y_lat(value):.1f}" for i, value in enumerate(values))
+        lines.append(svg_line(points, COLORS[impl]))
+        for i, value in enumerate(values):
+            lines.append(
+                f'  <circle cx="{xs[i]:.1f}" cy="{y_lat(value):.1f}" r="3"'
+                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+            )
+    for i, size in enumerate(sizes):
+        lines.append(
+            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+        )
+
+    add_legend(lines, [(IMPL_LABELS[impl], COLORS[impl]) for impl in latency_impls], mid_x, t2_bot + 40)
+    lines.append("</svg>")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+    print(f"wrote {path}")
+
+
+def add_legend(lines, legend_items, mid_x, leg_y):
+    item_w = 170
+    total_w = len(legend_items) * item_w
+    start_x = mid_x - total_w / 2
+    for index, (label, color) in enumerate(legend_items):
+        lx = start_x + index * item_w
+        lines.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y}" x2="{lx + 14:.0f}" y2="{leg_y}"'
+            f' stroke="{color}" stroke-width="2.5"/>'
+        )
+        lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
+        lines.append(
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
+            f' font-size="11" font-weight="500">{html.escape(label)}</text>'
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--sizes", type=parse_csv_ints)
+    parser.add_argument("--impls", type=parse_csv_strings, default=DEFAULT_IMPLS)
+    parser.add_argument("--latency-impls", type=parse_csv_strings, default=DEFAULT_LATENCY_IMPLS)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--warmup-rounds", type=int, default=1)
+    parser.add_argument("--target-bytes", type=int, default=256 * 1024 * 1024)
+    parser.add_argument("--min-messages", type=int, default=20_000)
+    parser.add_argument("--max-messages", type=int, default=1_000_000)
+    parser.add_argument("--warmup-messages", type=int)
+    parser.add_argument("--latency-iters", type=int, default=10_000)
+    parser.add_argument("--latency-warmup", type=int, default=1_000)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--no-build", action="store_true")
+    parser.add_argument("--no-harness-build", action="store_true")
+    parser.add_argument("--no-save", action="store_true")
+    parser.add_argument("--no-chart", action="store_true")
+    parser.add_argument("--chart-only", action="store_true")
+    parser.add_argument("--throughput-only", action="store_true")
+    parser.add_argument("--latency-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.throughput_only and args.latency_only:
+        parser.error("--throughput-only and --latency-only are mutually exclusive")
+
+    sizes = args.sizes or (QUICK_SIZES if args.quick else DEFAULT_SIZES)
+    if args.quick:
+        args.rounds = min(args.rounds, 1)
+        args.warmup_rounds = 0
+        args.target_bytes = min(args.target_bytes, 64 * 1024 * 1024)
+        args.latency_iters = min(args.latency_iters, 1_000)
+        args.latency_warmup = min(args.latency_warmup, 100)
+    if args.rounds < 1:
+        parser.error("--rounds must be at least 1")
+    if args.warmup_rounds < 0:
+        parser.error("--warmup-rounds cannot be negative")
+    if args.target_bytes <= 0:
+        parser.error("--target-bytes must be positive")
+    if args.min_messages < 1 or args.max_messages < args.min_messages:
+        parser.error("invalid min/max messages")
+    if args.latency_iters < 1 or args.latency_warmup < 0:
+        parser.error("invalid latency iteration counts")
+    for impl in args.impls:
+        if impl not in IMPL_LABELS:
+            parser.error(f"unknown throughput impl: {impl}")
+    for impl in args.latency_impls:
+        if impl not in DEFAULT_LATENCY_IMPLS:
+            parser.error(f"unknown latency impl: {impl}")
+
+    if args.chart_only:
+        data = latest_chart_data(sizes, args.impls, args.latency_impls)
+        gen_chart(data, CHART, sizes, args.impls, args.latency_impls)
+        return
+
+    build_native(args)
+    build_harness(args)
+
+    run_id = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    rows = []
+    print(f"run_id={run_id}")
+    if not args.latency_only:
+        print("PUSH/PULL TCP throughput")
+        for size in sizes:
+            for impl in args.impls:
+                row = run_throughput_cell(impl, size, args)
+                row["run_id"] = run_id
+                row["kind"] = "pushpull_tcp"
+                row["transport"] = "tcp"
+                rows.append(row)
+    if not args.throughput_only:
+        print("REQ/REP TCP latency")
+        for size in sizes:
+            for impl in args.latency_impls:
+                row = run_latency_cell(impl, size, args)
+                row["run_id"] = run_id
+                row["kind"] = "reqrep_tcp_latency"
+                row["transport"] = "tcp"
+                rows.append(row)
+
+    if not args.no_save:
+        append_jsonl(rows)
+        print(f"appended {len(rows)} rows to {JSONL}")
+    print_table(rows, sizes, [] if args.latency_only else args.impls, [] if args.throughput_only else args.latency_impls)
+
+    if not args.no_chart and not args.no_save:
+        data = latest_chart_data(sizes, args.impls, args.latency_impls)
+        gen_chart(data, CHART, sizes, args.impls, args.latency_impls)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except (RuntimeError, subprocess.TimeoutExpired, OSError, FileNotFoundError) as exc:
+        if shutil.which("go") is None:
+            print("go not found", file=sys.stderr)
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -689,7 +689,7 @@ def write_harness():
             f"""\
             module omq-go-perf
 
-            go 1.22
+            go 1.25
 
             require (
             \tgithub.com/paddor/omq.rs/bindings/go v0.0.0

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -1040,6 +1040,12 @@ def detect_hardware():
     return None
 
 
+def chart_selection(args, sizes):
+    if args.latency_only or args.throughput_only:
+        return DEFAULT_SIZES, DEFAULT_IMPLS, DEFAULT_LATENCY_IMPLS
+    return sizes, args.impls, args.latency_impls
+
+
 def svg_line(points, color, dashed=False):
     dash = ' stroke-dasharray="6,4"' if dashed else ""
     return (
@@ -1330,8 +1336,9 @@ def main():
     print_table(rows, sizes, [] if args.latency_only else args.impls, [] if args.throughput_only else args.latency_impls)
 
     if not args.no_chart and not args.no_save:
-        data = latest_chart_data(sizes, args.impls, args.latency_impls)
-        gen_chart(data, CHART, sizes, args.impls, args.latency_impls)
+        chart_sizes, chart_impls, chart_latency_impls = chart_selection(args, sizes)
+        data = latest_chart_data(chart_sizes, chart_impls, chart_latency_impls)
+        gen_chart(data, CHART, chart_sizes, chart_impls, chart_latency_impls)
 
 
 if __name__ == "__main__":

--- a/bindings/go/security.go
+++ b/bindings/go/security.go
@@ -1,0 +1,9 @@
+package omq
+
+func GenerateCurveKeypair() (CurveKeypair, error) {
+	return curveKeypairNative()
+}
+
+func CurvePublic(secretKey string) (string, error) {
+	return curvePublicNative(secretKey)
+}

--- a/bindings/go/security.go
+++ b/bindings/go/security.go
@@ -1,9 +1,11 @@
 package omq
 
+// GenerateCurveKeypair generates a CURVE Z85 key pair.
 func GenerateCurveKeypair() (CurveKeypair, error) {
 	return curveKeypairNative()
 }
 
+// CurvePublic derives a CURVE public key from a Z85 secret key.
 func CurvePublic(secretKey string) (string, error) {
 	return curvePublicNative(secretKey)
 }

--- a/bindings/go/send_ring.go
+++ b/bindings/go/send_ring.go
@@ -1,0 +1,236 @@
+package omq
+
+import (
+	"runtime"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+const (
+	defaultSendRingDescCapacity    = 4096
+	defaultSendRingPayloadCapacity = 16 * 1024 * 1024
+
+	sendRingControlHead   = 0
+	sendRingControlTail   = 128
+	sendRingControlClosed = 256
+)
+
+type sendRingDesc struct {
+	payload    uint64
+	payloadLen uint64
+	payloadEnd uint64
+	_          [5]uint64
+}
+
+type sendRing struct {
+	handle        *nativeSendRing
+	control       unsafe.Pointer
+	descriptors   []sendRingDesc
+	payload       []byte
+	descMask      uint64
+	payloadMask   uint64
+	tail          uint64
+	cachedHead    uint64
+	reclaimedHead uint64
+	payloadTail   uint64
+	payloadHead   uint64
+}
+
+func newSendRing(socket *nativeSocket) (*sendRing, error) {
+	handle, memory, err := sendRingCreateNative(
+		socket,
+		defaultSendRingDescCapacity,
+		defaultSendRingPayloadCapacity,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if memory.control == nil || memory.descriptors == nil || memory.payload == nil ||
+		memory.descCapacity <= 0 || memory.payloadCapacity <= 0 ||
+		!isPowerOfTwo(uint64(memory.descCapacity)) ||
+		!isPowerOfTwo(uint64(memory.payloadCapacity)) {
+		sendRingCloseNative(handle)
+		return nil, &ConfigError{Err: "native send ring returned invalid memory"}
+	}
+	return &sendRing{
+		handle:      handle,
+		control:     memory.control,
+		descriptors: unsafe.Slice((*sendRingDesc)(memory.descriptors), memory.descCapacity),
+		payload:     unsafe.Slice((*byte)(memory.payload), memory.payloadCapacity),
+		descMask:    uint64(memory.descCapacity - 1),
+		payloadMask: uint64(memory.payloadCapacity - 1),
+	}, nil
+}
+
+func (r *sendRing) trySend(body []byte) (bool, error) {
+	if r == nil || r.handle == nil {
+		return false, nil
+	}
+	if len(body) > len(r.payload) {
+		if ok, err := r.drain(-1); err != nil || !ok {
+			return true, err
+		}
+		return false, nil
+	}
+	if r.closedAcquire() {
+		return true, r.error()
+	}
+	if r.descIsFull() {
+		return true, ErrAgain
+	}
+	reservation, ok := r.reservePayload(len(body))
+	if !ok {
+		r.reclaimConsumed()
+		reservation, ok = r.reservePayload(len(body))
+		if !ok {
+			return true, ErrAgain
+		}
+	}
+
+	if len(body) > 0 {
+		copy(r.payload[reservation.offset:reservation.offset+uint64(len(body))], body)
+	}
+	desc := &r.descriptors[r.tail&r.descMask]
+	desc.payload = reservation.offset
+	desc.payloadLen = uint64(len(body))
+	desc.payloadEnd = reservation.end
+	r.tail++
+	atomic.StoreUint64(r.tailPtr(), r.tail)
+	runtime.KeepAlive(body)
+	return true, nil
+}
+
+func (r *sendRing) close() error {
+	if r == nil || r.handle == nil {
+		return nil
+	}
+	_, err := r.drain(-1)
+	sendRingCloseNative(r.handle)
+	r.handle = nil
+	r.control = nil
+	r.descriptors = nil
+	r.payload = nil
+	return err
+}
+
+func (r *sendRing) drain(timeoutMillis int64) (bool, error) {
+	if r == nil || r.handle == nil {
+		return true, nil
+	}
+	start := time.Now()
+	timeout := saturatedNanos(timeoutMillis)
+	spins := 0
+	for r.tail != r.headAcquire() {
+		if r.closedAcquire() {
+			return false, r.error()
+		}
+		if timeoutMillis == 0 {
+			return false, nil
+		}
+		if timeoutMillis > 0 && time.Since(start) >= timeout {
+			return false, nil
+		}
+		spins = sendRingBackoff(spins)
+	}
+	r.reclaimConsumed()
+	return true, nil
+}
+
+func (r *sendRing) descIsFull() bool {
+	if r.tail-r.cachedHead < uint64(len(r.descriptors)) {
+		return false
+	}
+	r.cachedHead = r.headAcquire()
+	return r.tail-r.cachedHead >= uint64(len(r.descriptors))
+}
+
+func (r *sendRing) reservePayload(length int) (sendRingReservation, bool) {
+	if length == 0 {
+		return sendRingReservation{offset: 0, end: r.payloadTail}, true
+	}
+	cursor := r.payloadTail
+	offset := cursor & r.payloadMask
+	needed := uint64(length)
+	if offset+uint64(length) > uint64(len(r.payload)) {
+		pad := uint64(len(r.payload)) - offset
+		cursor += pad
+		needed += pad
+		offset = 0
+	}
+	if cursor+uint64(length)-r.payloadHead > uint64(len(r.payload)) {
+		return sendRingReservation{}, false
+	}
+	r.payloadTail += needed
+	return sendRingReservation{offset: offset, end: cursor + uint64(length)}, true
+}
+
+func (r *sendRing) reclaimConsumed() {
+	head := r.headAcquire()
+	for r.reclaimedHead != head {
+		desc := r.descriptors[r.reclaimedHead&r.descMask]
+		r.payloadHead = desc.payloadEnd
+		r.reclaimedHead++
+	}
+	r.cachedHead = head
+}
+
+func (r *sendRing) headAcquire() uint64 {
+	return atomic.LoadUint64(r.headPtr())
+}
+
+func (r *sendRing) closedAcquire() bool {
+	return atomic.LoadUint64(r.closedPtr()) != 0
+}
+
+func (r *sendRing) error() error {
+	if err := sendRingErrorNative(r.handle); err != nil {
+		return err
+	}
+	return ErrClosed
+}
+
+func (r *sendRing) headPtr() *uint64 {
+	return (*uint64)(unsafe.Add(r.control, sendRingControlHead))
+}
+
+func (r *sendRing) tailPtr() *uint64 {
+	return (*uint64)(unsafe.Add(r.control, sendRingControlTail))
+}
+
+func (r *sendRing) closedPtr() *uint64 {
+	return (*uint64)(unsafe.Add(r.control, sendRingControlClosed))
+}
+
+type sendRingReservation struct {
+	offset uint64
+	end    uint64
+}
+
+func sendRingBackoff(spins int) int {
+	if spins < 256 {
+		runtime.Gosched()
+		return spins + 1
+	}
+	if spins < 512 {
+		runtime.Gosched()
+		return spins + 1
+	}
+	time.Sleep(50 * time.Microsecond)
+	return spins
+}
+
+func saturatedNanos(timeoutMillis int64) time.Duration {
+	if timeoutMillis <= 0 {
+		return time.Duration(timeoutMillis)
+	}
+	maxMillis := int64(1<<63-1) / int64(time.Millisecond)
+	if timeoutMillis >= maxMillis {
+		return time.Duration(1<<63 - 1)
+	}
+	return time.Duration(timeoutMillis) * time.Millisecond
+}
+
+func isPowerOfTwo(value uint64) bool {
+	return value > 0 && value&(value-1) == 0
+}

--- a/bindings/go/send_ring.go
+++ b/bindings/go/send_ring.go
@@ -37,10 +37,14 @@ type sendRing struct {
 	payloadHead   uint64
 }
 
-func newSendRing(socket *nativeSocket) (*sendRing, error) {
+func newSendRing(socket *nativeSocket, ringSize int) (*sendRing, error) {
+	descCapacity := defaultSendRingDescCapacity
+	if ringSize > 0 {
+		descCapacity = ringSize
+	}
 	handle, memory, err := sendRingCreateNative(
 		socket,
-		defaultSendRingDescCapacity,
+		descCapacity,
 		defaultSendRingPayloadCapacity,
 	)
 	if err != nil {
@@ -67,7 +71,7 @@ func (r *sendRing) trySend(body []byte) (bool, error) {
 	if r == nil || r.handle == nil {
 		return false, nil
 	}
-	if len(body) > len(r.payload) {
+	if len(body) >= len(r.payload) {
 		if ok, err := r.drain(-1); err != nil || !ok {
 			return true, err
 		}

--- a/bindings/go/send_ring.go
+++ b/bindings/go/send_ring.go
@@ -109,7 +109,7 @@ func (r *sendRing) close() error {
 	if r == nil || r.handle == nil {
 		return nil
 	}
-	_, err := r.drain(-1)
+	_, err := r.drain(0)
 	sendRingCloseNative(r.handle)
 	r.handle = nil
 	r.control = nil

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -21,9 +21,9 @@ const (
 	soakConnectTimeout = 5 * time.Second
 	soakReportInterval = 10 * time.Second
 
-	soakResourceWarmup     = 30 * time.Second
-	soakResourceWindow     = 2 * time.Minute
-	soakResourceMinSamples = 6
+	soakResourceWarmup     = 10 * time.Minute
+	soakResourceWindow     = 5 * time.Minute
+	soakResourceMinSamples = 12
 )
 
 type soakCounters struct {
@@ -667,7 +667,7 @@ func TestResourceSlopePerSecond(t *testing.T) {
 func TestResourceLiveGrowthDetectsSustainedRSSGrowth(t *testing.T) {
 	start := time.Unix(0, 0)
 	var samples []soakResourceSample
-	for seconds := 0; seconds <= 180; seconds += 20 {
+	for seconds := 0; seconds <= 1_200; seconds += 20 {
 		samples = append(samples, soakResourceSample{
 			at:    start.Add(time.Duration(seconds) * time.Second),
 			value: uint64(seconds) * 1_048_576,
@@ -682,8 +682,8 @@ func TestResourceLiveGrowthDetectsSustainedRSSGrowth(t *testing.T) {
 func TestResourceLiveGrowthIgnoresPlateau(t *testing.T) {
 	start := time.Unix(0, 0)
 	var samples []soakResourceSample
-	for seconds := 0; seconds <= 180; seconds += 20 {
-		value := uint64(min(seconds, 60)) * 1_048_576
+	for seconds := 0; seconds <= 1_200; seconds += 20 {
+		value := uint64(min(seconds, 600)) * 1_048_576
 		samples = append(samples, soakResourceSample{
 			at:    start.Add(time.Duration(seconds) * time.Second),
 			value: value,
@@ -698,7 +698,7 @@ func TestResourceLiveGrowthIgnoresPlateau(t *testing.T) {
 func TestResourceLiveFDGrowthDetectsSustainedGrowth(t *testing.T) {
 	start := time.Unix(0, 0)
 	var samples []soakResourceSample
-	for seconds := 0; seconds <= 180; seconds += 20 {
+	for seconds := 0; seconds <= 1_200; seconds += 20 {
 		samples = append(samples, soakResourceSample{
 			at:    start.Add(time.Duration(seconds) * time.Second),
 			value: uint64(10 + seconds/2),
@@ -838,7 +838,7 @@ func readSoakResourceLimits() soakResourceLimits {
 			[]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 128,
 		),
 		rssGrowthBytes: mibConfig(
-			[]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 256,
+			[]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 512,
 		),
 		fdGrowth: uint64(nonNegativeInt64Config(
 			[]string{"OMQ_GO_SOAK_MAX_FD_GROWTH"}, 128,

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -831,6 +831,8 @@ type soakResourceTracker struct {
 }
 
 func readSoakResourceLimits() soakResourceLimits {
+	// RSS has normal delayed native warm-up under churn. Keep the live
+	// slope gate focused on sustained growth large enough to matter.
 	return soakResourceLimits{
 		heapGrowthBytes: mibConfig(
 			[]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 128,
@@ -857,7 +859,7 @@ func readSoakResourceLimits() soakResourceLimits {
 			[]string{"OMQ_GO_SOAK_HEAP_SLOPE_MIN_GROWTH_MB"}, 16,
 		),
 		rssSlopeMinGrowth: mibConfig(
-			[]string{"OMQ_GO_SOAK_RSS_SLOPE_MIN_GROWTH_MB"}, 64,
+			[]string{"OMQ_GO_SOAK_RSS_SLOPE_MIN_GROWTH_MB"}, 128,
 		),
 		fdSlopeMinGrowth: uint64(nonNegativeInt64Config(
 			[]string{"OMQ_GO_SOAK_FD_SLOPE_MIN_GROWTH"}, 32,

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -792,6 +792,46 @@ func TestResourceLiveFDGrowthDetectsSustainedGrowth(t *testing.T) {
 	}
 }
 
+func TestResourceTailGrowthDetectsDrift(t *testing.T) {
+	start := time.Unix(0, 0)
+	var samples []soakResourceSample
+	for i := 0; i < 100; i++ {
+		value := uint64(100 + i*4)
+		samples = append(samples, soakResourceSample{
+			at:    start.Add(time.Duration(i) * time.Second),
+			value: value * 1_048_576,
+		})
+	}
+	baseline, tailMax, ok := tailGrowthWindow(samples)
+	if !ok {
+		t.Fatal("tailGrowthWindow returned !ok")
+	}
+	growthPercent := float64(saturatingSub(tailMax, baseline)) / float64(baseline) * 100
+	if growthPercent <= 25 {
+		t.Fatalf("growthPercent = %f, want > 25", growthPercent)
+	}
+}
+
+func TestResourceTailGrowthIgnoresPlateau(t *testing.T) {
+	start := time.Unix(0, 0)
+	var samples []soakResourceSample
+	for i := 0; i < 100; i++ {
+		value := uint64(min(100+i*4, 220))
+		samples = append(samples, soakResourceSample{
+			at:    start.Add(time.Duration(i) * time.Second),
+			value: value * 1_048_576,
+		})
+	}
+	baseline, tailMax, ok := tailGrowthWindow(samples)
+	if !ok {
+		t.Fatal("tailGrowthWindow returned !ok")
+	}
+	growthPercent := float64(saturatingSub(tailMax, baseline)) / float64(baseline) * 100
+	if growthPercent > 25 {
+		t.Fatalf("growthPercent = %f, want <= 25", growthPercent)
+	}
+}
+
 func soakSendOptions() []SocketOption {
 	return []SocketOption{
 		Linger(0),
@@ -928,16 +968,17 @@ func float64Config(names []string, fallback float64) float64 {
 }
 
 type soakResourceLimits struct {
-	heapGrowthBytes    uint64
-	rssGrowthBytes     uint64
-	fdGrowth           uint64
-	finalFDGrowth      uint64
-	heapSlopeKiBPerSec float64
-	rssSlopeKiBPerSec  float64
-	fdSlopePerSec      float64
-	heapSlopeMinGrowth uint64
-	rssSlopeMinGrowth  uint64
-	fdSlopeMinGrowth   uint64
+	fdGrowth               uint64
+	finalFDGrowth          uint64
+	heapSlopeKiBPerSec     float64
+	rssSlopeKiBPerSec      float64
+	fdSlopePerSec          float64
+	rssTailGrowthPercent   float64
+	heapSlopeMinGrowth     uint64
+	rssSlopeMinGrowth      uint64
+	fdSlopeMinGrowth       uint64
+	heapResidualFloorBytes uint64
+	rssTailGrowthMinBytes  uint64
 }
 
 type soakResources struct {
@@ -961,15 +1002,7 @@ type soakResourceTracker struct {
 }
 
 func readSoakResourceLimits() soakResourceLimits {
-	// RSS has normal delayed native warm-up under churn. Keep the live
-	// slope gate focused on sustained growth large enough to matter.
 	return soakResourceLimits{
-		heapGrowthBytes: mibConfig(
-			[]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 128,
-		),
-		rssGrowthBytes: mibConfig(
-			[]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 512,
-		),
 		fdGrowth: uint64(nonNegativeInt64Config(
 			[]string{"OMQ_GO_SOAK_MAX_FD_GROWTH"}, 128,
 		)),
@@ -985,6 +1018,9 @@ func readSoakResourceLimits() soakResourceLimits {
 		fdSlopePerSec: float64Config(
 			[]string{"OMQ_GO_SOAK_FD_SLOPE_LIMIT_PER_SEC"}, 0.05,
 		),
+		rssTailGrowthPercent: float64Config(
+			[]string{"OMQ_GO_SOAK_RSS_TAIL_GROWTH_PERCENT"}, 25,
+		),
 		heapSlopeMinGrowth: mibConfig(
 			[]string{"OMQ_GO_SOAK_HEAP_SLOPE_MIN_GROWTH_MB"}, 16,
 		),
@@ -994,6 +1030,12 @@ func readSoakResourceLimits() soakResourceLimits {
 		fdSlopeMinGrowth: uint64(nonNegativeInt64Config(
 			[]string{"OMQ_GO_SOAK_FD_SLOPE_MIN_GROWTH"}, 32,
 		)),
+		heapResidualFloorBytes: mibConfig(
+			[]string{"OMQ_GO_SOAK_HEAP_RESIDUAL_FLOOR_MB"}, 8,
+		),
+		rssTailGrowthMinBytes: mibConfig(
+			[]string{"OMQ_GO_SOAK_RSS_TAIL_GROWTH_MIN_MB"}, 128,
+		),
 	}
 }
 
@@ -1057,6 +1099,9 @@ func (r *soakResourceTracker) assertFinal(t *testing.T, elapsed time.Duration) {
 	r.logSlope(t, "heap", r.heap, 1024, "KiB")
 	r.logSlope(t, "RSS", r.rss, 1024, "KiB")
 	r.logSlope(t, "FD", r.fds, 1, "FDs")
+	r.logRSSPeak(t)
+	r.assertHeapResidual(t, current)
+	r.assertRSSTailStable(t)
 	if current.fdCount > r.baseline.fdCount+r.limits.finalFDGrowth {
 		t.Fatalf(
 			"final FD growth exceeded limit: baseline=%d current=%d limit=%d",
@@ -1099,6 +1144,61 @@ func (r *soakResourceTracker) logSlope(
 		unit,
 		slope/scale,
 		unit,
+	)
+}
+
+func (r *soakResourceTracker) logRSSPeak(t *testing.T) {
+	t.Helper()
+	peak := maxSampleValue(r.rss, 0)
+	if peak == 0 {
+		return
+	}
+	t.Logf("[go-soak] RSS peak %.1f MiB (informational)", float64(peak)/1_048_576)
+}
+
+func (r *soakResourceTracker) assertHeapResidual(t *testing.T, current soakResources) {
+	t.Helper()
+	peak := maxSampleValue(r.heap, r.baseline.heapBytes)
+	threshold := max(peak/20, r.limits.heapResidualFloorBytes)
+	growth := saturatingSub(current.heapBytes, r.baseline.heapBytes)
+	t.Logf(
+		"[go-soak] heap residual %.1f KiB (baseline %.1f MiB, current %.1f MiB, threshold %.1f MiB)",
+		float64(growth)/1024,
+		float64(r.baseline.heapBytes)/1_048_576,
+		float64(current.heapBytes)/1_048_576,
+		float64(threshold)/1_048_576,
+	)
+	if growth > threshold {
+		t.Fatalf(
+			"heap leak detected: residual %.1f KiB exceeds threshold %.1f MiB",
+			float64(growth)/1024,
+			float64(threshold)/1_048_576,
+		)
+	}
+}
+
+func (r *soakResourceTracker) assertRSSTailStable(t *testing.T) {
+	t.Helper()
+	baseline, tailMax, ok := tailGrowthWindow(r.rss)
+	if !ok || baseline == 0 {
+		return
+	}
+	growth := saturatingSub(tailMax, baseline)
+	growthPercent := float64(growth) / float64(baseline) * 100
+	t.Logf(
+		"[go-soak] RSS tail baseline %.1f MiB tail max %.1f MiB growth %.1f%%",
+		float64(baseline)/1_048_576,
+		float64(tailMax)/1_048_576,
+		growthPercent,
+	)
+	if growth < r.limits.rssTailGrowthMinBytes ||
+		growthPercent <= r.limits.rssTailGrowthPercent {
+		return
+	}
+	t.Fatalf(
+		"RSS leak detected: tail grew %.1f%% / %.1f MiB from post-warmup baseline",
+		growthPercent,
+		float64(growth)/1_048_576,
 	)
 }
 
@@ -1246,6 +1346,34 @@ func sampleRange(samples []soakResourceSample) (uint64, uint64) {
 	return minValue, maxValue
 }
 
+func maxSampleValue(samples []soakResourceSample, fallback uint64) uint64 {
+	maxValue := fallback
+	for _, sample := range samples {
+		maxValue = max(maxValue, sample.value)
+	}
+	return maxValue
+}
+
+func tailGrowthWindow(samples []soakResourceSample) (uint64, uint64, bool) {
+	if len(samples) < 10 {
+		return 0, 0, false
+	}
+	warmup := len(samples) / 5
+	postWarmup := samples[warmup:]
+	if len(postWarmup) < 5 {
+		return 0, 0, false
+	}
+	baselineEnd := max(1, len(postWarmup)/10)
+	var baselineSum uint64
+	for _, sample := range postWarmup[:baselineEnd] {
+		baselineSum += sample.value
+	}
+	baseline := baselineSum / uint64(baselineEnd)
+	tailStart := len(postWarmup) * 4 / 5
+	_, tailMax := sampleRange(postWarmup[tailStart:])
+	return baseline, tailMax, true
+}
+
 func saturatingSub(value uint64, other uint64) uint64 {
 	if value < other {
 		return 0
@@ -1263,14 +1391,6 @@ func assertSoakResources(
 	t.Helper()
 	if elapsed < 20*time.Second {
 		return
-	}
-	if current.heapBytes > baseline.heapBytes+limits.heapGrowthBytes {
-		t.Fatalf("heap growth exceeded limit: baseline=%d current=%d limit=%d",
-			baseline.heapBytes, current.heapBytes, limits.heapGrowthBytes)
-	}
-	if current.rssBytes > baseline.rssBytes+limits.rssGrowthBytes {
-		t.Fatalf("RSS growth exceeded limit: baseline=%d current=%d limit=%d",
-			baseline.rssBytes, current.rssBytes, limits.rssGrowthBytes)
 	}
 	if current.fdCount > baseline.fdCount+limits.fdGrowth {
 		t.Fatalf("FD growth exceeded limit: baseline=%d current=%d limit=%d",

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -191,9 +191,7 @@ func startSoakPull(t *testing.T, ctx *Context, endpoint string, extra []SocketOp
 }
 
 func startWorker(wg *sync.WaitGroup, state *soakState, name string, fn func(context.Context) error) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				state.fail(fmt.Errorf("%s: panic: %v", name, recovered))
@@ -204,7 +202,7 @@ func startWorker(wg *sync.WaitGroup, state *soakState, name string, fn func(cont
 			return
 		}
 		state.fail(fmt.Errorf("%s: %w", name, err))
-	}()
+	})
 }
 
 func (s *soakState) fail(err error) {
@@ -434,9 +432,7 @@ func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counter
 	for i, push := range pushes {
 		idx := byte(i)
 		socket := push
-		senders.Add(1)
-		go func() {
-			defer senders.Done()
+		senders.Go(func() {
 			payload := []byte{idx, 0, 0, 0, 0, 0, 0, 0}
 			for senderCtx.Err() == nil {
 				if err := socket.SendTimeout(Bytes(payload), soakSendTimeout); err != nil &&
@@ -445,7 +441,7 @@ func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counter
 				}
 				payload[1]++
 			}
-		}()
+		})
 	}
 
 	poller, err := NewPoller(pulls...)

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -832,6 +832,24 @@ func TestResourceTailGrowthIgnoresPlateau(t *testing.T) {
 	}
 }
 
+func TestResourceRSSResidualIgnoresReleasedHighWater(t *testing.T) {
+	baseline := uint64(124 * 1_048_576)
+	tailMax := uint64(259 * 1_048_576)
+	final := uint64(124 * 1_048_576)
+	if rssResidualLeak(baseline, tailMax, final, 25, 128*1_048_576) {
+		t.Fatal("rssResidualLeak reported released high-water as a leak")
+	}
+}
+
+func TestResourceRSSResidualDetectsRetainedTail(t *testing.T) {
+	baseline := uint64(124 * 1_048_576)
+	tailMax := uint64(259 * 1_048_576)
+	final := uint64(258 * 1_048_576)
+	if !rssResidualLeak(baseline, tailMax, final, 25, 128*1_048_576) {
+		t.Fatal("rssResidualLeak missed retained RSS growth")
+	}
+}
+
 func soakSendOptions() []SocketOption {
 	return []SocketOption{
 		Linger(0),
@@ -1101,7 +1119,7 @@ func (r *soakResourceTracker) assertFinal(t *testing.T, elapsed time.Duration) {
 	r.logSlope(t, "FD", r.fds, 1, "FDs")
 	r.logRSSPeak(t)
 	r.assertHeapResidual(t, current)
-	r.assertRSSTailStable(t)
+	r.assertRSSResidualStable(t, current)
 	if current.fdCount > r.baseline.fdCount+r.limits.finalFDGrowth {
 		t.Fatalf(
 			"final FD growth exceeded limit: baseline=%d current=%d limit=%d",
@@ -1177,28 +1195,38 @@ func (r *soakResourceTracker) assertHeapResidual(t *testing.T, current soakResou
 	}
 }
 
-func (r *soakResourceTracker) assertRSSTailStable(t *testing.T) {
+func (r *soakResourceTracker) assertRSSResidualStable(t *testing.T, current soakResources) {
 	t.Helper()
 	baseline, tailMax, ok := tailGrowthWindow(r.rss)
 	if !ok || baseline == 0 {
 		return
 	}
-	growth := saturatingSub(tailMax, baseline)
-	growthPercent := float64(growth) / float64(baseline) * 100
+	tailGrowth := saturatingSub(tailMax, baseline)
+	tailGrowthPercent := percentGrowth(tailGrowth, baseline)
+	finalGrowth := saturatingSub(current.rssBytes, baseline)
+	finalGrowthPercent := percentGrowth(finalGrowth, baseline)
 	t.Logf(
-		"[go-soak] RSS tail baseline %.1f MiB tail max %.1f MiB growth %.1f%%",
+		"[go-soak] RSS tail baseline %.1f MiB tail max %.1f MiB growth %.1f%% final growth %.1f%%",
 		float64(baseline)/1_048_576,
 		float64(tailMax)/1_048_576,
-		growthPercent,
+		tailGrowthPercent,
+		finalGrowthPercent,
 	)
-	if growth < r.limits.rssTailGrowthMinBytes ||
-		growthPercent <= r.limits.rssTailGrowthPercent {
+	if !rssResidualLeak(
+		baseline,
+		tailMax,
+		current.rssBytes,
+		r.limits.rssTailGrowthPercent,
+		r.limits.rssTailGrowthMinBytes,
+	) {
 		return
 	}
 	t.Fatalf(
-		"RSS leak detected: tail grew %.1f%% / %.1f MiB from post-warmup baseline",
-		growthPercent,
-		float64(growth)/1_048_576,
+		"RSS leak detected: tail grew %.1f%% / %.1f MiB and final RSS retained %.1f%% / %.1f MiB from post-warmup baseline",
+		tailGrowthPercent,
+		float64(tailGrowth)/1_048_576,
+		finalGrowthPercent,
+		float64(finalGrowth)/1_048_576,
 	)
 }
 
@@ -1372,6 +1400,32 @@ func tailGrowthWindow(samples []soakResourceSample) (uint64, uint64, bool) {
 	tailStart := len(postWarmup) * 4 / 5
 	_, tailMax := sampleRange(postWarmup[tailStart:])
 	return baseline, tailMax, true
+}
+
+func rssResidualLeak(
+	baseline uint64,
+	tailMax uint64,
+	final uint64,
+	percentLimit float64,
+	minGrowthBytes uint64,
+) bool {
+	if baseline == 0 {
+		return false
+	}
+	tailGrowth := saturatingSub(tailMax, baseline)
+	finalGrowth := saturatingSub(final, baseline)
+	if tailGrowth < minGrowthBytes || finalGrowth < minGrowthBytes {
+		return false
+	}
+	return percentGrowth(tailGrowth, baseline) > percentLimit &&
+		percentGrowth(finalGrowth, baseline) > percentLimit
+}
+
+func percentGrowth(growth uint64, baseline uint64) float64 {
+	if baseline == 0 {
+		return 0
+	}
+	return float64(growth) / float64(baseline) * 100
 }
 
 func saturatingSub(value uint64, other uint64) uint64 {

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -20,6 +20,10 @@ const (
 	soakSendTimeout    = 500 * time.Millisecond
 	soakConnectTimeout = 5 * time.Second
 	soakReportInterval = 10 * time.Second
+
+	soakResourceWarmup     = 30 * time.Second
+	soakResourceWindow     = 2 * time.Minute
+	soakResourceMinSamples = 6
 )
 
 type soakCounters struct {
@@ -54,8 +58,8 @@ func TestSoakMixedWorkloads(t *testing.T) {
 	defer cancel()
 	state := &soakState{ctx: runCtx, cancel: cancel}
 	counters := &soakCounters{}
-	limits := readSoakResourceLimits()
 	baseline := readSoakResources()
+	limits := readSoakResourceLimits()
 
 	omqCtx, err := Open(Config{IOThreads: workers, RingSize: 4096})
 	if err != nil {
@@ -64,6 +68,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 
 	var wg sync.WaitGroup
 	start := time.Now()
+	resources := newSoakResourceTracker(start, baseline, limits)
 
 	tcpEndpoint, tcpPull := startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", nil)
 	tcpMonitor, err := tcpPull.Monitor()
@@ -135,7 +140,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 			goto done
 		case <-ticker.C:
 			elapsed := time.Since(start)
-			resources := readSoakResources()
+			current := resources.sample(t, elapsed)
 			t.Logf(
 				"[go-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d poller=%d pubsub=%d contexts=%d monitor=%d heap=%dMB rss=%dMB fds=%d",
 				elapsed.Seconds(),
@@ -147,11 +152,10 @@ func TestSoakMixedWorkloads(t *testing.T) {
 				counters.pubSubMessages.Load(),
 				counters.contextCycles.Load(),
 				counters.monitorEvents.Load(),
-				resources.heapBytes/1_048_576,
-				resources.rssBytes/1_048_576,
-				resources.fdCount,
+				current.heapBytes/1_048_576,
+				current.rssBytes/1_048_576,
+				current.fdCount,
 			)
-			assertSoakResources(t, elapsed, baseline, resources, limits)
 			if err := state.err(); err != nil {
 				cancel()
 			}
@@ -167,7 +171,9 @@ done:
 		t.Fatal(err)
 	}
 	runtime.GC()
-	assertSoakResources(t, time.Since(start), baseline, readSoakResources(), limits)
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+	resources.assertFinal(t, time.Since(start))
 	if err := state.err(); err != nil {
 		t.Fatal(err)
 	}
@@ -642,6 +648,68 @@ func assertSoakProgress(t *testing.T, counters *soakCounters) {
 	}
 }
 
+func TestResourceSlopePerSecond(t *testing.T) {
+	start := time.Unix(0, 0)
+	samples := []soakResourceSample{
+		{at: start, value: 10},
+		{at: start.Add(time.Second), value: 20},
+		{at: start.Add(2 * time.Second), value: 30},
+	}
+	slope, ok := slopePerSecond(samples)
+	if !ok {
+		t.Fatal("slopePerSecond returned !ok")
+	}
+	if slope < 9.999 || slope > 10.001 {
+		t.Fatalf("slope = %f, want 10", slope)
+	}
+}
+
+func TestResourceLiveGrowthDetectsSustainedRSSGrowth(t *testing.T) {
+	start := time.Unix(0, 0)
+	var samples []soakResourceSample
+	for seconds := 0; seconds <= 180; seconds += 20 {
+		samples = append(samples, soakResourceSample{
+			at:    start.Add(time.Duration(seconds) * time.Second),
+			value: uint64(seconds) * 1_048_576,
+		})
+	}
+	err := liveGrowthError("RSS", start, samples, 128, 8*1_048_576)
+	if err == nil {
+		t.Fatal("liveGrowthError returned nil")
+	}
+}
+
+func TestResourceLiveGrowthIgnoresPlateau(t *testing.T) {
+	start := time.Unix(0, 0)
+	var samples []soakResourceSample
+	for seconds := 0; seconds <= 180; seconds += 20 {
+		value := uint64(min(seconds, 60)) * 1_048_576
+		samples = append(samples, soakResourceSample{
+			at:    start.Add(time.Duration(seconds) * time.Second),
+			value: value,
+		})
+	}
+	err := liveGrowthError("RSS", start, samples, 128, 8*1_048_576)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResourceLiveFDGrowthDetectsSustainedGrowth(t *testing.T) {
+	start := time.Unix(0, 0)
+	var samples []soakResourceSample
+	for seconds := 0; seconds <= 180; seconds += 20 {
+		samples = append(samples, soakResourceSample{
+			at:    start.Add(time.Duration(seconds) * time.Second),
+			value: uint64(10 + seconds/2),
+		})
+	}
+	err := liveFDGrowthError(start, samples, 0.05, 32)
+	if err == nil {
+		t.Fatal("liveFDGrowthError returned nil")
+	}
+}
+
 func soakSendOptions() []SocketOption {
 	return []SocketOption{
 		Linger(0),
@@ -703,10 +771,43 @@ func int64Config(names []string, fallback int64) int64 {
 	return fallback
 }
 
+func nonNegativeInt64Config(names []string, fallback int64) int64 {
+	value := int64Config(names, fallback)
+	if value < 0 {
+		return fallback
+	}
+	return value
+}
+
+func mibConfig(names []string, fallback int64) uint64 {
+	return uint64(nonNegativeInt64Config(names, fallback)) * 1_048_576
+}
+
+func float64Config(names []string, fallback float64) float64 {
+	for _, name := range names {
+		value := os.Getenv(name)
+		if value == "" {
+			continue
+		}
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return fallback
+}
+
 type soakResourceLimits struct {
-	heapGrowthBytes uint64
-	rssGrowthBytes  uint64
-	fdGrowth        uint64
+	heapGrowthBytes    uint64
+	rssGrowthBytes     uint64
+	fdGrowth           uint64
+	finalFDGrowth      uint64
+	heapSlopeKiBPerSec float64
+	rssSlopeKiBPerSec  float64
+	fdSlopePerSec      float64
+	heapSlopeMinGrowth uint64
+	rssSlopeMinGrowth  uint64
+	fdSlopeMinGrowth   uint64
 }
 
 type soakResources struct {
@@ -715,12 +816,158 @@ type soakResources struct {
 	fdCount   uint64
 }
 
+type soakResourceSample struct {
+	at    time.Time
+	value uint64
+}
+
+type soakResourceTracker struct {
+	started  time.Time
+	baseline soakResources
+	limits   soakResourceLimits
+	heap     []soakResourceSample
+	rss      []soakResourceSample
+	fds      []soakResourceSample
+}
+
 func readSoakResourceLimits() soakResourceLimits {
 	return soakResourceLimits{
-		heapGrowthBytes: uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 384)) * 1_048_576,
-		rssGrowthBytes:  uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 768)) * 1_048_576,
-		fdGrowth:        uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_FD_GROWTH"}, 1024)),
+		heapGrowthBytes: mibConfig(
+			[]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 128,
+		),
+		rssGrowthBytes: mibConfig(
+			[]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 256,
+		),
+		fdGrowth: uint64(nonNegativeInt64Config(
+			[]string{"OMQ_GO_SOAK_MAX_FD_GROWTH"}, 128,
+		)),
+		finalFDGrowth: uint64(nonNegativeInt64Config(
+			[]string{"OMQ_GO_SOAK_MAX_FINAL_FD_GROWTH"}, 16,
+		)),
+		heapSlopeKiBPerSec: float64Config(
+			[]string{"OMQ_GO_SOAK_HEAP_SLOPE_LIMIT_KIB_S"}, 512,
+		),
+		rssSlopeKiBPerSec: float64Config(
+			[]string{"OMQ_GO_SOAK_RSS_SLOPE_LIMIT_KIB_S"}, 1024,
+		),
+		fdSlopePerSec: float64Config(
+			[]string{"OMQ_GO_SOAK_FD_SLOPE_LIMIT_PER_SEC"}, 0.05,
+		),
+		heapSlopeMinGrowth: mibConfig(
+			[]string{"OMQ_GO_SOAK_HEAP_SLOPE_MIN_GROWTH_MB"}, 16,
+		),
+		rssSlopeMinGrowth: mibConfig(
+			[]string{"OMQ_GO_SOAK_RSS_SLOPE_MIN_GROWTH_MB"}, 64,
+		),
+		fdSlopeMinGrowth: uint64(nonNegativeInt64Config(
+			[]string{"OMQ_GO_SOAK_FD_SLOPE_MIN_GROWTH"}, 32,
+		)),
 	}
+}
+
+func newSoakResourceTracker(
+	started time.Time,
+	baseline soakResources,
+	limits soakResourceLimits,
+) *soakResourceTracker {
+	tracker := &soakResourceTracker{
+		started:  started,
+		baseline: baseline,
+		limits:   limits,
+	}
+	tracker.appendSample(started, baseline)
+	return tracker
+}
+
+func (r *soakResourceTracker) sample(t *testing.T, elapsed time.Duration) soakResources {
+	t.Helper()
+	current := readSoakResources()
+	r.appendSample(time.Now(), current)
+	assertSoakResources(t, elapsed, r.baseline, current, r.limits)
+	if err := liveGrowthError(
+		"heap",
+		r.started,
+		r.heap,
+		r.limits.heapSlopeKiBPerSec,
+		r.limits.heapSlopeMinGrowth,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := liveGrowthError(
+		"RSS",
+		r.started,
+		r.rss,
+		r.limits.rssSlopeKiBPerSec,
+		r.limits.rssSlopeMinGrowth,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := liveFDGrowthError(
+		r.started,
+		r.fds,
+		r.limits.fdSlopePerSec,
+		r.limits.fdSlopeMinGrowth,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return current
+}
+
+func (r *soakResourceTracker) assertFinal(t *testing.T, elapsed time.Duration) {
+	t.Helper()
+	current := r.sample(t, elapsed)
+	t.Logf(
+		"[go-soak] final resources heap=%dMB rss=%dMB fds=%d",
+		current.heapBytes/1_048_576,
+		current.rssBytes/1_048_576,
+		current.fdCount,
+	)
+	r.logSlope(t, "heap", r.heap, 1024, "KiB")
+	r.logSlope(t, "RSS", r.rss, 1024, "KiB")
+	r.logSlope(t, "FD", r.fds, 1, "FDs")
+	if current.fdCount > r.baseline.fdCount+r.limits.finalFDGrowth {
+		t.Fatalf(
+			"final FD growth exceeded limit: baseline=%d current=%d limit=%d",
+			r.baseline.fdCount,
+			current.fdCount,
+			r.limits.finalFDGrowth,
+		)
+	}
+}
+
+func (r *soakResourceTracker) appendSample(at time.Time, resources soakResources) {
+	r.heap = append(r.heap, soakResourceSample{at: at, value: resources.heapBytes})
+	r.rss = append(r.rss, soakResourceSample{at: at, value: resources.rssBytes})
+	r.fds = append(r.fds, soakResourceSample{at: at, value: resources.fdCount})
+}
+
+func (r *soakResourceTracker) logSlope(
+	t *testing.T,
+	metric string,
+	samples []soakResourceSample,
+	scale float64,
+	unit string,
+) {
+	t.Helper()
+	if len(samples) < 2 {
+		return
+	}
+	warmup := len(samples) / 5
+	postWarmup := samples[warmup:]
+	slope, ok := slopePerSecond(postWarmup)
+	if !ok {
+		return
+	}
+	minValue, maxValue := sampleRange(postWarmup)
+	t.Logf(
+		"[go-soak] %s range %.1f..%.1f %s slope %.3f %s/s",
+		metric,
+		float64(minValue)/scale,
+		float64(maxValue)/scale,
+		unit,
+		slope/scale,
+		unit,
+	)
 }
 
 func readSoakResources() soakResources {
@@ -735,6 +982,143 @@ func readSoakResources() soakResources {
 		rssBytes:  rss,
 		fdCount:   readFDCount(),
 	}
+}
+
+func liveGrowthError(
+	metric string,
+	started time.Time,
+	samples []soakResourceSample,
+	slopeLimitKiBPerSec float64,
+	minGrowthBytes uint64,
+) error {
+	window, ok := liveGrowthWindow(started, samples)
+	if !ok {
+		return nil
+	}
+	current := window[len(window)-1].value
+	growth := saturatingSub(current, window[0].value)
+	if growth < minGrowthBytes {
+		return nil
+	}
+	slope, ok := slopePerSecond(window)
+	if !ok {
+		return nil
+	}
+	slopeKiBPerSec := slope / 1024
+	if slopeKiBPerSec <= slopeLimitKiBPerSec {
+		return nil
+	}
+	return fmt.Errorf(
+		"live %s growth detected: slope %.1f KiB/s over %.0fs, growth %.1f MiB, current %.1f MiB, limit %.1f KiB/s",
+		metric,
+		slopeKiBPerSec,
+		soakResourceWindow.Seconds(),
+		float64(growth)/1_048_576,
+		float64(current)/1_048_576,
+		slopeLimitKiBPerSec,
+	)
+}
+
+func liveFDGrowthError(
+	started time.Time,
+	samples []soakResourceSample,
+	slopeLimitPerSec float64,
+	minGrowth uint64,
+) error {
+	window, ok := liveGrowthWindow(started, samples)
+	if !ok {
+		return nil
+	}
+	current := window[len(window)-1].value
+	growth := saturatingSub(current, window[0].value)
+	if growth < minGrowth {
+		return nil
+	}
+	slope, ok := slopePerSecond(window)
+	if !ok || slope <= slopeLimitPerSec {
+		return nil
+	}
+	minFD, maxFD := sampleRange(window)
+	return fmt.Errorf(
+		"live FD growth detected: slope %.4f FDs/s over %.0fs, range %d..%d, limit %.4f FDs/s",
+		slope,
+		soakResourceWindow.Seconds(),
+		minFD,
+		maxFD,
+		slopeLimitPerSec,
+	)
+}
+
+func liveGrowthWindow(
+	started time.Time,
+	samples []soakResourceSample,
+) ([]soakResourceSample, bool) {
+	if len(samples) < soakResourceMinSamples {
+		return nil, false
+	}
+	now := samples[len(samples)-1].at
+	if now.Sub(started) < soakResourceWarmup+soakResourceWindow {
+		return nil, false
+	}
+	windowStart := now.Add(-soakResourceWindow)
+	first := 0
+	for i, sample := range samples {
+		if !sample.at.Before(windowStart) {
+			first = i
+			break
+		}
+	}
+	window := samples[first:]
+	if len(window) < soakResourceMinSamples {
+		return nil, false
+	}
+	return window, true
+}
+
+func slopePerSecond(samples []soakResourceSample) (float64, bool) {
+	if len(samples) < 2 {
+		return 0, false
+	}
+	first := samples[0].at
+	elapsed := samples[len(samples)-1].at.Sub(first).Seconds()
+	if elapsed < 1 {
+		return 0, false
+	}
+	n := float64(len(samples))
+	var sumX, sumY, sumXY, sumXX float64
+	for _, sample := range samples {
+		x := sample.at.Sub(first).Seconds()
+		y := float64(sample.value)
+		sumX += x
+		sumY += y
+		sumXY += x * y
+		sumXX += x * x
+	}
+	denom := n*sumXX - sumX*sumX
+	if denom == 0 {
+		return 0, false
+	}
+	return (n*sumXY - sumX*sumY) / denom, true
+}
+
+func sampleRange(samples []soakResourceSample) (uint64, uint64) {
+	if len(samples) == 0 {
+		return 0, 0
+	}
+	minValue := samples[0].value
+	maxValue := samples[0].value
+	for _, sample := range samples[1:] {
+		minValue = min(minValue, sample.value)
+		maxValue = max(maxValue, sample.value)
+	}
+	return minValue, maxValue
+}
+
+func saturatingSub(value uint64, other uint64) uint64 {
+	if value < other {
+		return 0
+	}
+	return value - other
 }
 
 func assertSoakResources(

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -44,6 +44,20 @@ type soakState struct {
 	failure atomic.Value
 }
 
+type soakScenarios struct {
+	selected map[string]bool
+}
+
+var allSoakScenarios = []string{
+	"tcp",
+	"curve",
+	"compression",
+	"inproc",
+	"poller",
+	"pubsub",
+	"context-churn",
+}
+
 func TestSoakMixedWorkloads(t *testing.T) {
 	if !soakEnabled() {
 		t.Skip("set OMQ_GO_SOAK=1 to run Go soak")
@@ -51,6 +65,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 
 	duration := soakDuration()
 	workers := soakWorkers()
+	scenarios := readSoakScenarios(t)
 	oldProcs := runtime.GOMAXPROCS(workers)
 	defer runtime.GOMAXPROCS(oldProcs)
 
@@ -70,67 +85,95 @@ func TestSoakMixedWorkloads(t *testing.T) {
 	start := time.Now()
 	resources := newSoakResourceTracker(start, baseline, limits)
 
-	tcpEndpoint, tcpPull := startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", nil)
-	tcpMonitor, err := tcpPull.Monitor()
-	if err != nil {
-		t.Fatal(err)
+	var tcpEndpoint string
+	var tcpPull *Socket
+	if scenarios.enabled("tcp") {
+		tcpEndpoint, tcpPull = startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", nil)
+		startWorker(&wg, state, "tcp-pull", func(ctx context.Context) error {
+			return soakDrainMessages(ctx, tcpPull, &counters.tcpMessages)
+		})
+		tcpMonitor, err := tcpPull.Monitor()
+		if err != nil {
+			t.Fatal(err)
+		}
+		startWorker(&wg, state, "tcp-monitor", func(ctx context.Context) error {
+			defer tcpMonitor.Close()
+			return soakDrainMonitor(ctx, tcpMonitor, &counters.monitorEvents)
+		})
 	}
-	startWorker(&wg, state, "tcp-pull", func(ctx context.Context) error {
-		return soakDrainMessages(ctx, tcpPull, &counters.tcpMessages)
-	})
-	startWorker(&wg, state, "tcp-monitor", func(ctx context.Context) error {
-		defer tcpMonitor.Close()
-		return soakDrainMonitor(ctx, tcpMonitor, &counters.monitorEvents)
-	})
 
-	serverKey, err := GenerateCurveKeypair()
-	if err != nil {
-		t.Fatal(err)
+	var curveEndpoint string
+	var curvePull *Socket
+	var serverKey CurveKeypair
+	var clientKey CurveKeypair
+	if scenarios.enabled("curve") {
+		var err error
+		serverKey, err = GenerateCurveKeypair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		clientKey, err = GenerateCurveKeypair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		curveEndpoint, curvePull = startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", []SocketOption{
+			CurveServerAuth(serverKey, func(peer PeerInfo) bool {
+				return peer.Mechanism == "CURVE" && peer.PublicKey == clientKey.Public
+			}),
+		})
+		startWorker(&wg, state, "curve-pull", func(ctx context.Context) error {
+			return soakDrainMessages(ctx, curvePull, &counters.curveMessages)
+		})
 	}
-	clientKey, err := GenerateCurveKeypair()
-	if err != nil {
-		t.Fatal(err)
-	}
-	curveEndpoint, curvePull := startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", []SocketOption{
-		CurveServerAuth(serverKey, func(peer PeerInfo) bool {
-			return peer.Mechanism == "CURVE" && peer.PublicKey == clientKey.Public
-		}),
-	})
-	startWorker(&wg, state, "curve-pull", func(ctx context.Context) error {
-		return soakDrainMessages(ctx, curvePull, &counters.curveMessages)
-	})
 
 	churnWorkers := max(1, workers/3)
-	for i := 0; i < churnWorkers; i++ {
-		workerID := i
-		startWorker(&wg, state, fmt.Sprintf("tcp-churn-%d", workerID), func(ctx context.Context) error {
-			return soakChurnPush(ctx, omqCtx, tcpEndpoint, workerID, nil)
-		})
-		startWorker(&wg, state, fmt.Sprintf("curve-churn-%d", workerID), func(ctx context.Context) error {
-			return soakChurnPush(ctx, omqCtx, curveEndpoint, workerID, []SocketOption{
-				CurveClient(clientKey, serverKey.Public),
+	if scenarios.enabled("tcp") {
+		for i := 0; i < churnWorkers; i++ {
+			workerID := i
+			startWorker(&wg, state, fmt.Sprintf("tcp-churn-%d", workerID), func(ctx context.Context) error {
+				return soakChurnPush(ctx, omqCtx, tcpEndpoint, workerID, nil)
 			})
-		})
+		}
+	}
+	if scenarios.enabled("curve") {
+		for i := 0; i < churnWorkers; i++ {
+			workerID := i
+			startWorker(&wg, state, fmt.Sprintf("curve-churn-%d", workerID), func(ctx context.Context) error {
+				return soakChurnPush(ctx, omqCtx, curveEndpoint, workerID, []SocketOption{
+					CurveClient(clientKey, serverKey.Public),
+				})
+			})
+		}
 	}
 
-	startWorker(&wg, state, "lz4-compression", func(ctx context.Context) error {
-		return soakCompressionPair(ctx, omqCtx, "lz4+tcp://127.0.0.1:*", nil, counters)
-	})
-	startWorker(&wg, state, "zstd-compression", func(ctx context.Context) error {
-		return soakCompressionPair(ctx, omqCtx, "zstd+tcp://127.0.0.1:*", zstdTestDict, counters)
-	})
-	startWorker(&wg, state, "inproc-req-rep", func(ctx context.Context) error {
-		return soakInprocReqRep(ctx, omqCtx, counters)
-	})
-	startWorker(&wg, state, "poller-fanin", func(ctx context.Context) error {
-		return soakPollerFanIn(ctx, omqCtx, max(2, min(workers/2, 6)), counters)
-	})
-	startWorker(&wg, state, "pub-sub-churn", func(ctx context.Context) error {
-		return soakPubSubChurn(ctx, omqCtx, counters)
-	})
-	startWorker(&wg, state, "context-churn", func(ctx context.Context) error {
-		return soakContextChurn(ctx, counters)
-	})
+	if scenarios.enabled("compression") {
+		startWorker(&wg, state, "lz4-compression", func(ctx context.Context) error {
+			return soakCompressionPair(ctx, omqCtx, "lz4+tcp://127.0.0.1:*", nil, counters)
+		})
+		startWorker(&wg, state, "zstd-compression", func(ctx context.Context) error {
+			return soakCompressionPair(ctx, omqCtx, "zstd+tcp://127.0.0.1:*", zstdTestDict, counters)
+		})
+	}
+	if scenarios.enabled("inproc") {
+		startWorker(&wg, state, "inproc-req-rep", func(ctx context.Context) error {
+			return soakInprocReqRep(ctx, omqCtx, counters)
+		})
+	}
+	if scenarios.enabled("poller") {
+		startWorker(&wg, state, "poller-fanin", func(ctx context.Context) error {
+			return soakPollerFanIn(ctx, omqCtx, max(2, min(workers/2, 6)), counters)
+		})
+	}
+	if scenarios.enabled("pubsub") {
+		startWorker(&wg, state, "pub-sub-churn", func(ctx context.Context) error {
+			return soakPubSubChurn(ctx, omqCtx, counters)
+		})
+	}
+	if scenarios.enabled("context-churn") {
+		startWorker(&wg, state, "context-churn", func(ctx context.Context) error {
+			return soakContextChurn(ctx, counters)
+		})
+	}
 
 	ticker := time.NewTicker(soakReportInterval)
 	defer ticker.Stop()
@@ -165,8 +208,12 @@ func TestSoakMixedWorkloads(t *testing.T) {
 done:
 	cancel()
 	waitForSoakWorkers(t, &wg)
-	closeSoakSocket(tcpPull)
-	closeSoakSocket(curvePull)
+	if tcpPull != nil {
+		closeSoakSocket(tcpPull)
+	}
+	if curvePull != nil {
+		closeSoakSocket(curvePull)
+	}
 	if err := omqCtx.CloseContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +224,7 @@ done:
 	if err := state.err(); err != nil {
 		t.Fatal(err)
 	}
-	assertSoakProgress(t, counters)
+	assertSoakProgress(t, scenarios, counters)
 }
 
 func startSoakPull(t *testing.T, ctx *Context, endpoint string, extra []SocketOption) (string, *Socket) {
@@ -628,18 +675,53 @@ func waitForSoakWorkers(t *testing.T, wg *sync.WaitGroup) {
 	}
 }
 
-func assertSoakProgress(t *testing.T, counters *soakCounters) {
+func assertSoakProgress(t *testing.T, scenarios soakScenarios, counters *soakCounters) {
 	t.Helper()
 	checks := []struct {
 		name  string
 		count uint64
-	}{
-		{"tcp", counters.tcpMessages.Load()},
-		{"curve", counters.curveMessages.Load()},
-		{"compression", counters.compressionMessages.Load()},
-		{"inproc", counters.inprocMessages.Load()},
-		{"poller", counters.pollerMessages.Load()},
-		{"context-churn", counters.contextCycles.Load()},
+	}{}
+	if scenarios.enabled("tcp") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"tcp", counters.tcpMessages.Load()})
+	}
+	if scenarios.enabled("curve") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"curve", counters.curveMessages.Load()})
+	}
+	if scenarios.enabled("compression") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"compression", counters.compressionMessages.Load()})
+	}
+	if scenarios.enabled("inproc") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"inproc", counters.inprocMessages.Load()})
+	}
+	if scenarios.enabled("poller") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"poller", counters.pollerMessages.Load()})
+	}
+	if scenarios.enabled("pubsub") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"pubsub", counters.pubSubMessages.Load()})
+	}
+	if scenarios.enabled("context-churn") {
+		checks = append(checks, struct {
+			name  string
+			count uint64
+		}{"context-churn", counters.contextCycles.Load()})
 	}
 	for _, check := range checks {
 		if check.count == 0 {
@@ -755,6 +837,54 @@ func soakWorkers() int {
 		return 1
 	}
 	return workers
+}
+
+func readSoakScenarios(t *testing.T) soakScenarios {
+	t.Helper()
+	all := make(map[string]bool, len(allSoakScenarios))
+	selected := make(map[string]bool, len(allSoakScenarios))
+	for _, name := range allSoakScenarios {
+		all[name] = true
+		selected[name] = true
+	}
+	if only := scenarioSet(os.Getenv("OMQ_GO_SOAK_SCENARIOS")); len(only) > 0 {
+		validateSoakScenarioSet(t, only, all)
+		selected = only
+	}
+	skip := scenarioSet(os.Getenv("OMQ_GO_SOAK_SKIP_SCENARIOS"))
+	validateSoakScenarioSet(t, skip, all)
+	for name := range skip {
+		delete(selected, name)
+	}
+	if len(selected) == 0 {
+		t.Fatal("OMQ_GO_SOAK_SCENARIOS selected no soak scenarios")
+	}
+	return soakScenarios{selected: selected}
+}
+
+func scenarioSet(raw string) map[string]bool {
+	set := make(map[string]bool)
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		set[name] = true
+	}
+	return set
+}
+
+func validateSoakScenarioSet(t *testing.T, set map[string]bool, all map[string]bool) {
+	t.Helper()
+	for name := range set {
+		if !all[name] {
+			t.Fatalf("unknown soak scenario %q", name)
+		}
+	}
+}
+
+func (s soakScenarios) enabled(name string) bool {
+	return s.selected[name]
 }
 
 func int64Config(names []string, fallback int64) int64 {

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -27,14 +27,35 @@ const (
 )
 
 type soakCounters struct {
-	tcpMessages         atomic.Uint64
-	curveMessages       atomic.Uint64
-	compressionMessages atomic.Uint64
-	inprocMessages      atomic.Uint64
-	pollerMessages      atomic.Uint64
-	pubSubMessages      atomic.Uint64
-	contextCycles       atomic.Uint64
-	monitorEvents       atomic.Uint64
+	tcpMessages          atomic.Uint64
+	curveMessages        atomic.Uint64
+	compressionMessages  atomic.Uint64
+	inprocMessages       atomic.Uint64
+	pollerMessages       atomic.Uint64
+	pubSubMessages       atomic.Uint64
+	contextCycles        atomic.Uint64
+	monitorEvents        atomic.Uint64
+	tcpLifecycle         soakLifecycleCounters
+	curveLifecycle       soakLifecycleCounters
+	compressionLifecycle soakLifecycleCounters
+	inprocLifecycle      soakLifecycleCounters
+	pollerLifecycle      soakLifecycleCounters
+	pubSubLifecycle      soakLifecycleCounters
+	contextLifecycle     soakLifecycleCounters
+}
+
+type soakLifecycleCounters struct {
+	socketsCreated  atomic.Uint64
+	socketsClosed   atomic.Uint64
+	contextsCreated atomic.Uint64
+	contextsClosed  atomic.Uint64
+}
+
+type soakLifecycleSnapshot struct {
+	socketsCreated  uint64
+	socketsClosed   uint64
+	contextsCreated uint64
+	contextsClosed  uint64
 }
 
 type soakState struct {
@@ -88,7 +109,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 	var tcpEndpoint string
 	var tcpPull *Socket
 	if scenarios.enabled("tcp") {
-		tcpEndpoint, tcpPull = startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", nil)
+		tcpEndpoint, tcpPull = startSoakPull(t, omqCtx, counters, "tcp", "tcp://127.0.0.1:*", nil)
 		startWorker(&wg, state, "tcp-pull", func(ctx context.Context) error {
 			return soakDrainMessages(ctx, tcpPull, &counters.tcpMessages)
 		})
@@ -116,7 +137,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		curveEndpoint, curvePull = startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", []SocketOption{
+		curveEndpoint, curvePull = startSoakPull(t, omqCtx, counters, "curve", "tcp://127.0.0.1:*", []SocketOption{
 			CurveServerAuth(serverKey, func(peer PeerInfo) bool {
 				return peer.Mechanism == "CURVE" && peer.PublicKey == clientKey.Public
 			}),
@@ -131,7 +152,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 		for i := 0; i < churnWorkers; i++ {
 			workerID := i
 			startWorker(&wg, state, fmt.Sprintf("tcp-churn-%d", workerID), func(ctx context.Context) error {
-				return soakChurnPush(ctx, omqCtx, tcpEndpoint, workerID, nil)
+				return soakChurnPush(ctx, omqCtx, counters, "tcp", tcpEndpoint, workerID, nil)
 			})
 		}
 	}
@@ -139,7 +160,7 @@ func TestSoakMixedWorkloads(t *testing.T) {
 		for i := 0; i < churnWorkers; i++ {
 			workerID := i
 			startWorker(&wg, state, fmt.Sprintf("curve-churn-%d", workerID), func(ctx context.Context) error {
-				return soakChurnPush(ctx, omqCtx, curveEndpoint, workerID, []SocketOption{
+				return soakChurnPush(ctx, omqCtx, counters, "curve", curveEndpoint, workerID, []SocketOption{
 					CurveClient(clientKey, serverKey.Public),
 				})
 			})
@@ -183,9 +204,9 @@ func TestSoakMixedWorkloads(t *testing.T) {
 			goto done
 		case <-ticker.C:
 			elapsed := time.Since(start)
-			current := resources.sample(t, elapsed)
+			current := resources.sample()
 			t.Logf(
-				"[go-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d poller=%d pubsub=%d contexts=%d monitor=%d heap=%dMB rss=%dMB fds=%d",
+				"[go-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d poller=%d pubsub=%d contexts=%d monitor=%d heap=%dMB rss=%dMB fds=%d goroutines=%d threads=%d cgo=%d",
 				elapsed.Seconds(),
 				counters.tcpMessages.Load(),
 				counters.curveMessages.Load(),
@@ -198,7 +219,14 @@ func TestSoakMixedWorkloads(t *testing.T) {
 				current.heapBytes/1_048_576,
 				current.rssBytes/1_048_576,
 				current.fdCount,
+				current.goroutines,
+				current.threads,
+				current.cgoCalls,
 			)
+			logSoakResourceDetails(t, current)
+			logSoakNativeStats(t, current.native)
+			logSoakLifecycle(t, counters)
+			resources.assertLive(t, elapsed, current)
 			if err := state.err(); err != nil {
 				cancel()
 			}
@@ -209,10 +237,10 @@ done:
 	cancel()
 	waitForSoakWorkers(t, &wg)
 	if tcpPull != nil {
-		closeSoakSocket(tcpPull)
+		closeSoakScenarioSocket(tcpPull, counters, "tcp")
 	}
 	if curvePull != nil {
-		closeSoakSocket(curvePull)
+		closeSoakScenarioSocket(curvePull, counters, "curve")
 	}
 	if err := omqCtx.CloseContext(context.Background()); err != nil {
 		t.Fatal(err)
@@ -221,23 +249,31 @@ done:
 	time.Sleep(200 * time.Millisecond)
 	runtime.GC()
 	resources.assertFinal(t, time.Since(start))
+	logSoakLifecycle(t, counters)
 	if err := state.err(); err != nil {
 		t.Fatal(err)
 	}
 	assertSoakProgress(t, scenarios, counters)
 }
 
-func startSoakPull(t *testing.T, ctx *Context, endpoint string, extra []SocketOption) (string, *Socket) {
+func startSoakPull(
+	t *testing.T,
+	ctx *Context,
+	counters *soakCounters,
+	scenario string,
+	endpoint string,
+	extra []SocketOption,
+) (string, *Socket) {
 	t.Helper()
 	opts := append([]SocketOption{}, soakRecvOptions()...)
 	opts = append(opts, extra...)
-	pull, err := ctx.Socket(Pull, opts...)
+	pull, err := soakNewSocket(ctx, counters, scenario, Pull, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bound, err := pull.Bind(endpoint)
 	if err != nil {
-		closeSoakSocket(pull)
+		closeSoakScenarioSocket(pull, counters, scenario)
 		t.Fatal(err)
 	}
 	return bound, pull
@@ -304,21 +340,29 @@ func soakDrainMonitor(ctx context.Context, monitor *Monitor, counter *atomic.Uin
 	return errFromContext(ctx)
 }
 
-func soakChurnPush(ctx context.Context, shared *Context, endpoint string, workerID int, extra []SocketOption) error {
+func soakChurnPush(
+	ctx context.Context,
+	shared *Context,
+	counters *soakCounters,
+	scenario string,
+	endpoint string,
+	workerID int,
+	extra []SocketOption,
+) error {
 	seq := uint64(0)
 	for ctx.Err() == nil {
 		opts := append([]SocketOption{}, soakSendOptions()...)
 		opts = append(opts, extra...)
-		push, err := shared.Socket(Push, opts...)
+		push, err := soakNewSocket(shared, counters, scenario, Push, opts...)
 		if err != nil {
 			return err
 		}
 		if err := push.Connect(endpoint); err != nil {
-			closeSoakSocket(push)
+			closeSoakScenarioSocket(push, counters, scenario)
 			return err
 		}
 		if _, err := push.WaitConnectedTimeout(1, soakConnectTimeout); err != nil {
-			closeSoakSocket(push)
+			closeSoakScenarioSocket(push, counters, scenario)
 			if ctx.Err() != nil || errors.Is(err, ErrTimeout) {
 				continue
 			}
@@ -329,12 +373,12 @@ func soakChurnPush(ctx context.Context, shared *Context, endpoint string, worker
 			payload[0] = byte(i)
 			if err := push.SendTimeout(Bytes(payload), soakSendTimeout); err != nil &&
 				!errors.Is(err, ErrTimeout) && !errors.Is(err, ErrAgain) {
-				closeSoakSocket(push)
+				closeSoakScenarioSocket(push, counters, scenario)
 				return err
 			}
 			seq++
 		}
-		closeSoakSocket(push)
+		closeSoakScenarioSocket(push, counters, scenario)
 	}
 	return errFromContext(ctx)
 }
@@ -353,16 +397,16 @@ func soakCompressionPair(ctx context.Context, shared *Context, endpoint string, 
 		pullOpts = append(pullOpts, CompressionDict(dict))
 		pushOpts = append(pushOpts, CompressionDict(dict))
 	}
-	pull, err := shared.Socket(Pull, pullOpts...)
+	pull, err := soakNewSocket(shared, counters, "compression", Pull, pullOpts...)
 	if err != nil {
 		return err
 	}
-	defer closeSoakSocket(pull)
-	push, err := shared.Socket(Push, pushOpts...)
+	defer closeSoakScenarioSocket(pull, counters, "compression")
+	push, err := soakNewSocket(shared, counters, "compression", Push, pushOpts...)
 	if err != nil {
 		return err
 	}
-	defer closeSoakSocket(push)
+	defer closeSoakScenarioSocket(push, counters, "compression")
 	bound, err := pull.Bind(endpoint)
 	if err != nil {
 		return err
@@ -393,16 +437,16 @@ func soakCompressionPair(ctx context.Context, shared *Context, endpoint string, 
 }
 
 func soakInprocReqRep(ctx context.Context, shared *Context, counters *soakCounters) error {
-	rep, err := shared.Socket(Rep, soakRecvOptions()...)
+	rep, err := soakNewSocket(shared, counters, "inproc", Rep, soakRecvOptions()...)
 	if err != nil {
 		return err
 	}
-	defer closeSoakSocket(rep)
-	req, err := shared.Socket(Req, soakSendOptions()...)
+	defer closeSoakScenarioSocket(rep, counters, "inproc")
+	req, err := soakNewSocket(shared, counters, "inproc", Req, soakSendOptions()...)
 	if err != nil {
 		return err
 	}
-	defer closeSoakSocket(req)
+	defer closeSoakScenarioSocket(req, counters, "inproc")
 	endpoint, err := rep.Bind(fmt.Sprintf("inproc://go-soak-req-rep-%d", os.Getpid()))
 	if err != nil {
 		return err
@@ -443,24 +487,24 @@ func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counter
 	pulls := make([]*Socket, 0, channels)
 	pushes := make([]*Socket, 0, channels)
 	for i := 0; i < channels; i++ {
-		pull, err := shared.Socket(Pull, soakRecvOptions()...)
+		pull, err := soakNewSocket(shared, counters, "poller", Pull, soakRecvOptions()...)
 		if err != nil {
 			return err
 		}
-		push, err := shared.Socket(Push, soakSendOptions()...)
+		push, err := soakNewSocket(shared, counters, "poller", Push, soakSendOptions()...)
 		if err != nil {
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(pull, counters, "poller")
 			return err
 		}
 		endpoint, err := pull.Bind(fmt.Sprintf("inproc://go-soak-poller-%d-%d", os.Getpid(), i))
 		if err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "poller")
+			closeSoakScenarioSocket(pull, counters, "poller")
 			return err
 		}
 		if err := push.Connect(endpoint); err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "poller")
+			closeSoakScenarioSocket(pull, counters, "poller")
 			return err
 		}
 		pulls = append(pulls, pull)
@@ -468,10 +512,10 @@ func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counter
 	}
 	defer func() {
 		for _, push := range pushes {
-			closeSoakSocket(push)
+			closeSoakScenarioSocket(push, counters, "poller")
 		}
 		for _, pull := range pulls {
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(pull, counters, "poller")
 		}
 	}()
 
@@ -527,7 +571,7 @@ func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counter
 
 func soakPubSubChurn(ctx context.Context, shared *Context, counters *soakCounters) error {
 	topics := []string{"fast.", "slow.", "all.", "rare."}
-	pub, err := shared.Socket(Pub,
+	pub, err := soakNewSocket(shared, counters, "pubsub", Pub,
 		Linger(0),
 		SendHWM(8192),
 		OnMutePolicy(OnMuteDropNewest),
@@ -536,7 +580,7 @@ func soakPubSubChurn(ctx context.Context, shared *Context, counters *soakCounter
 	if err != nil {
 		return err
 	}
-	defer closeSoakSocket(pub)
+	defer closeSoakScenarioSocket(pub, counters, "pubsub")
 	endpoint, err := pub.Bind("tcp://127.0.0.1:*")
 	if err != nil {
 		return err
@@ -545,7 +589,7 @@ func soakPubSubChurn(ctx context.Context, shared *Context, counters *soakCounter
 	var subs []*Socket
 	defer func() {
 		for _, sub := range subs {
-			closeSoakSocket(sub)
+			closeSoakScenarioSocket(sub, counters, "pubsub")
 		}
 	}()
 
@@ -576,21 +620,21 @@ func soakPubSubChurn(ctx context.Context, shared *Context, counters *soakCounter
 		if time.Since(lastChurn) >= 500*time.Millisecond {
 			lastChurn = time.Now()
 			if len(subs) > 0 {
-				closeSoakSocket(subs[0])
+				closeSoakScenarioSocket(subs[0], counters, "pubsub")
 				copy(subs, subs[1:])
 				subs = subs[:len(subs)-1]
 			}
 			if len(subs) < 10 {
-				sub, err := shared.Socket(Sub, soakRecvOptions()...)
+				sub, err := soakNewSocket(shared, counters, "pubsub", Sub, soakRecvOptions()...)
 				if err != nil {
 					return err
 				}
 				if err := sub.Connect(endpoint); err != nil {
-					closeSoakSocket(sub)
+					closeSoakScenarioSocket(sub, counters, "pubsub")
 					return err
 				}
 				if err := sub.SubscribeString(topics[len(subs)%len(topics)]); err != nil {
-					closeSoakSocket(sub)
+					closeSoakScenarioSocket(sub, counters, "pubsub")
 					return err
 				}
 				subs = append(subs, sub)
@@ -607,54 +651,64 @@ func soakContextChurn(ctx context.Context, counters *soakCounters) error {
 		if err != nil {
 			return err
 		}
-		pull, err := churnCtx.Socket(Pull, Linger(0))
+		counters.scenarioContextCreated("context-churn")
+		pull, err := soakNewSocket(churnCtx, counters, "context-churn", Pull, Linger(0))
 		if err != nil {
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
-		push, err := churnCtx.Socket(Push, Linger(0))
+		push, err := soakNewSocket(churnCtx, counters, "context-churn", Push, Linger(0))
 		if err != nil {
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
 		endpoint, err := pull.Bind(fmt.Sprintf("inproc://go-soak-context-%d-%d", os.Getpid(), seq))
 		if err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "context-churn")
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
 		if err := push.Connect(endpoint); err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "context-churn")
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
 		if err := push.SendTimeout(String("x"), time.Second); err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "context-churn")
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
 		msg, err := pull.RecvTimeout(time.Second)
 		if err != nil {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "context-churn")
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
 		if msg.String() != "x" {
-			closeSoakSocket(push)
-			closeSoakSocket(pull)
+			closeSoakScenarioSocket(push, counters, "context-churn")
+			closeSoakScenarioSocket(pull, counters, "context-churn")
 			_ = churnCtx.Close()
+			counters.scenarioContextClosed("context-churn")
 			return fmt.Errorf("context churn payload mismatch: %q", msg.String())
 		}
-		closeSoakSocket(push)
-		closeSoakSocket(pull)
+		closeSoakScenarioSocket(push, counters, "context-churn")
+		closeSoakScenarioSocket(pull, counters, "context-churn")
 		if err := churnCtx.CloseContext(context.Background()); err != nil {
+			counters.scenarioContextClosed("context-churn")
 			return err
 		}
+		counters.scenarioContextClosed("context-churn")
 		counters.contextCycles.Add(1)
 		seq++
 	}
@@ -850,6 +904,128 @@ func TestResourceRSSResidualDetectsRetainedTail(t *testing.T) {
 	}
 }
 
+func TestResourceParsesProcStatus(t *testing.T) {
+	status := parseProcStatus("Name:\tgo.test\nVmRSS:\t  1234 kB\nVmData:\t  5678 kB\nThreads:\t42\n")
+	if status.vmRSSBytes != 1234*1024 {
+		t.Fatalf("vmRSSBytes = %d", status.vmRSSBytes)
+	}
+	if status.vmDataBytes != 5678*1024 {
+		t.Fatalf("vmDataBytes = %d", status.vmDataBytes)
+	}
+	if status.threads != 42 {
+		t.Fatalf("threads = %d", status.threads)
+	}
+}
+
+func TestResourceParsesProcSmapsRollup(t *testing.T) {
+	smaps := parseProcSmapsRollup("Rss: 100 kB\nAnonymous: 80 kB\nPrivate_Dirty: 60 kB\n")
+	if smaps.rssBytes != 100*1024 {
+		t.Fatalf("rssBytes = %d", smaps.rssBytes)
+	}
+	if smaps.anonymousBytes != 80*1024 {
+		t.Fatalf("anonymousBytes = %d", smaps.anonymousBytes)
+	}
+	if smaps.privateDirtyBytes != 60*1024 {
+		t.Fatalf("privateDirtyBytes = %d", smaps.privateDirtyBytes)
+	}
+}
+
+func TestResourceNativeStatsLiveGrowth(t *testing.T) {
+	baseline := nativeStats{socketsLive: 1, sendRingsLive: 2}
+	current := nativeStats{socketsLive: 2, sendRingsLive: 2}
+	if got := current.liveGrowthSince(baseline); got != "sockets=1" {
+		t.Fatalf("liveGrowthSince = %q", got)
+	}
+	if got := baseline.liveGrowthSince(current); got != "" {
+		t.Fatalf("liveGrowthSince with no growth = %q", got)
+	}
+}
+
+func (c *soakCounters) scenario(name string) *soakLifecycleCounters {
+	switch name {
+	case "tcp":
+		return &c.tcpLifecycle
+	case "curve":
+		return &c.curveLifecycle
+	case "compression":
+		return &c.compressionLifecycle
+	case "inproc":
+		return &c.inprocLifecycle
+	case "poller":
+		return &c.pollerLifecycle
+	case "pubsub":
+		return &c.pubSubLifecycle
+	case "context-churn":
+		return &c.contextLifecycle
+	default:
+		return nil
+	}
+}
+
+func (c *soakCounters) scenarioSocketCreated(name string) {
+	if lifecycle := c.scenario(name); lifecycle != nil {
+		lifecycle.socketsCreated.Add(1)
+	}
+}
+
+func (c *soakCounters) scenarioSocketClosed(name string) {
+	if lifecycle := c.scenario(name); lifecycle != nil {
+		lifecycle.socketsClosed.Add(1)
+	}
+}
+
+func (c *soakCounters) scenarioContextCreated(name string) {
+	if lifecycle := c.scenario(name); lifecycle != nil {
+		lifecycle.contextsCreated.Add(1)
+	}
+}
+
+func (c *soakCounters) scenarioContextClosed(name string) {
+	if lifecycle := c.scenario(name); lifecycle != nil {
+		lifecycle.contextsClosed.Add(1)
+	}
+}
+
+func (c *soakCounters) lifecycleString(name string) string {
+	lifecycle := c.scenario(name)
+	if lifecycle == nil {
+		return "s=0/0 c=0/0"
+	}
+	snapshot := lifecycle.snapshot()
+	return fmt.Sprintf(
+		"s=%d/%d c=%d/%d",
+		snapshot.socketsCreated,
+		snapshot.socketsClosed,
+		snapshot.contextsCreated,
+		snapshot.contextsClosed,
+	)
+}
+
+func (c *soakLifecycleCounters) snapshot() soakLifecycleSnapshot {
+	return soakLifecycleSnapshot{
+		socketsCreated:  c.socketsCreated.Load(),
+		socketsClosed:   c.socketsClosed.Load(),
+		contextsCreated: c.contextsCreated.Load(),
+		contextsClosed:  c.contextsClosed.Load(),
+	}
+}
+
+func (stats nativeStats) liveGrowthSince(baseline nativeStats) string {
+	parts := make([]string, 0, 6)
+	add := func(name string, current uint64, base uint64) {
+		if current > base {
+			parts = append(parts, fmt.Sprintf("%s=%d", name, current-base))
+		}
+	}
+	add("contexts", stats.contextsLive, baseline.contextsLive)
+	add("sockets", stats.socketsLive, baseline.socketsLive)
+	add("monitors", stats.monitorsLive, baseline.monitorsLive)
+	add("send_rings", stats.sendRingsLive, baseline.sendRingsLive)
+	add("recv_rings", stats.recvRingsLive, baseline.recvRingsLive)
+	add("cancels", stats.cancelsLive, baseline.cancelsLive)
+	return strings.Join(parts, " ")
+}
+
 func soakSendOptions() []SocketOption {
 	return []SocketOption{
 		Linger(0),
@@ -1000,9 +1176,24 @@ type soakResourceLimits struct {
 }
 
 type soakResources struct {
-	heapBytes uint64
-	rssBytes  uint64
-	fdCount   uint64
+	heapBytes              uint64
+	heapInuseBytes         uint64
+	heapIdleBytes          uint64
+	heapReleasedBytes      uint64
+	heapSysBytes           uint64
+	stackInuseBytes        uint64
+	sysBytes               uint64
+	rssBytes               uint64
+	vmRSSBytes             uint64
+	vmDataBytes            uint64
+	smapsRSSBytes          uint64
+	smapsAnonymousBytes    uint64
+	smapsPrivateDirtyBytes uint64
+	fdCount                uint64
+	goroutines             uint64
+	cgoCalls               uint64
+	threads                uint64
+	native                 nativeStats
 }
 
 type soakResourceSample struct {
@@ -1071,10 +1262,14 @@ func newSoakResourceTracker(
 	return tracker
 }
 
-func (r *soakResourceTracker) sample(t *testing.T, elapsed time.Duration) soakResources {
-	t.Helper()
+func (r *soakResourceTracker) sample() soakResources {
 	current := readSoakResources()
 	r.appendSample(time.Now(), current)
+	return current
+}
+
+func (r *soakResourceTracker) assertLive(t *testing.T, elapsed time.Duration, current soakResources) {
+	t.Helper()
 	assertSoakResources(t, elapsed, r.baseline, current, r.limits)
 	if err := liveGrowthError(
 		"heap",
@@ -1102,23 +1297,26 @@ func (r *soakResourceTracker) sample(t *testing.T, elapsed time.Duration) soakRe
 	); err != nil {
 		t.Fatal(err)
 	}
-	return current
 }
 
 func (r *soakResourceTracker) assertFinal(t *testing.T, elapsed time.Duration) {
 	t.Helper()
-	current := r.sample(t, elapsed)
+	current := r.sample()
 	t.Logf(
 		"[go-soak] final resources heap=%dMB rss=%dMB fds=%d",
 		current.heapBytes/1_048_576,
 		current.rssBytes/1_048_576,
 		current.fdCount,
 	)
+	logSoakResourceDetails(t, current)
+	logSoakNativeStats(t, current.native)
 	r.logSlope(t, "heap", r.heap, 1024, "KiB")
 	r.logSlope(t, "RSS", r.rss, 1024, "KiB")
 	r.logSlope(t, "FD", r.fds, 1, "FDs")
 	r.logRSSPeak(t)
+	r.assertLive(t, elapsed, current)
 	r.assertHeapResidual(t, current)
+	r.assertNativeResidual(t, current)
 	r.assertRSSResidualStable(t, current)
 	if current.fdCount > r.baseline.fdCount+r.limits.finalFDGrowth {
 		t.Fatalf(
@@ -1174,6 +1372,64 @@ func (r *soakResourceTracker) logRSSPeak(t *testing.T) {
 	t.Logf("[go-soak] RSS peak %.1f MiB (informational)", float64(peak)/1_048_576)
 }
 
+func logSoakResourceDetails(t *testing.T, current soakResources) {
+	t.Helper()
+	t.Logf(
+		"[go-soak-resources] heap_alloc=%dMB heap_inuse=%dMB heap_idle=%dMB heap_released=%dMB heap_sys=%dMB stack_inuse=%dMB sys=%dMB vmrss=%dMB vmdata=%dMB smaps_rss=%dMB anon=%dMB private_dirty=%dMB",
+		current.heapBytes/1_048_576,
+		current.heapInuseBytes/1_048_576,
+		current.heapIdleBytes/1_048_576,
+		current.heapReleasedBytes/1_048_576,
+		current.heapSysBytes/1_048_576,
+		current.stackInuseBytes/1_048_576,
+		current.sysBytes/1_048_576,
+		current.vmRSSBytes/1_048_576,
+		current.vmDataBytes/1_048_576,
+		current.smapsRSSBytes/1_048_576,
+		current.smapsAnonymousBytes/1_048_576,
+		current.smapsPrivateDirtyBytes/1_048_576,
+	)
+}
+
+func logSoakNativeStats(t *testing.T, stats nativeStats) {
+	t.Helper()
+	t.Logf(
+		"[go-soak-native] ctx=%d/%d/%d sockets=%d/%d/%d monitors=%d/%d/%d send_rings=%d/%d/%d recv_rings=%d/%d/%d cancels=%d/%d/%d",
+		stats.contextsCreated,
+		stats.contextsFreed,
+		stats.contextsLive,
+		stats.socketsCreated,
+		stats.socketsFreed,
+		stats.socketsLive,
+		stats.monitorsCreated,
+		stats.monitorsFreed,
+		stats.monitorsLive,
+		stats.sendRingsCreated,
+		stats.sendRingsFreed,
+		stats.sendRingsLive,
+		stats.recvRingsCreated,
+		stats.recvRingsFreed,
+		stats.recvRingsLive,
+		stats.cancelsCreated,
+		stats.cancelsFreed,
+		stats.cancelsLive,
+	)
+}
+
+func logSoakLifecycle(t *testing.T, counters *soakCounters) {
+	t.Helper()
+	t.Logf(
+		"[go-soak-lifecycle] tcp=%s curve=%s compression=%s inproc=%s poller=%s pubsub=%s context-churn=%s",
+		counters.lifecycleString("tcp"),
+		counters.lifecycleString("curve"),
+		counters.lifecycleString("compression"),
+		counters.lifecycleString("inproc"),
+		counters.lifecycleString("poller"),
+		counters.lifecycleString("pubsub"),
+		counters.lifecycleString("context-churn"),
+	)
+}
+
 func (r *soakResourceTracker) assertHeapResidual(t *testing.T, current soakResources) {
 	t.Helper()
 	peak := maxSampleValue(r.heap, r.baseline.heapBytes)
@@ -1192,6 +1448,13 @@ func (r *soakResourceTracker) assertHeapResidual(t *testing.T, current soakResou
 			float64(growth)/1024,
 			float64(threshold)/1_048_576,
 		)
+	}
+}
+
+func (r *soakResourceTracker) assertNativeResidual(t *testing.T, current soakResources) {
+	t.Helper()
+	if leak := current.native.liveGrowthSince(r.baseline.native); leak != "" {
+		t.Fatalf("native handle leak detected: %s", leak)
 	}
 }
 
@@ -1237,10 +1500,27 @@ func readSoakResources() soakResources {
 	if rss == 0 {
 		rss = stats.Sys
 	}
+	status := readProcStatus()
+	smaps := readProcSmapsRollup()
 	return soakResources{
-		heapBytes: stats.Alloc,
-		rssBytes:  rss,
-		fdCount:   readFDCount(),
+		heapBytes:              stats.Alloc,
+		heapInuseBytes:         stats.HeapInuse,
+		heapIdleBytes:          stats.HeapIdle,
+		heapReleasedBytes:      stats.HeapReleased,
+		heapSysBytes:           stats.HeapSys,
+		stackInuseBytes:        stats.StackInuse,
+		sysBytes:               stats.Sys,
+		rssBytes:               rss,
+		vmRSSBytes:             status.vmRSSBytes,
+		vmDataBytes:            status.vmDataBytes,
+		smapsRSSBytes:          smaps.rssBytes,
+		smapsAnonymousBytes:    smaps.anonymousBytes,
+		smapsPrivateDirtyBytes: smaps.privateDirtyBytes,
+		fdCount:                readFDCount(),
+		goroutines:             uint64(runtime.NumGoroutine()),
+		cgoCalls:               uint64(runtime.NumCgoCall()),
+		threads:                status.threads,
+		native:                 nativeStatsNative(),
 	}
 }
 
@@ -1468,6 +1748,88 @@ func readRSSBytes() uint64 {
 	return pages * uint64(os.Getpagesize())
 }
 
+type procStatusResources struct {
+	vmRSSBytes  uint64
+	vmDataBytes uint64
+	threads     uint64
+}
+
+type procSmapsResources struct {
+	rssBytes          uint64
+	anonymousBytes    uint64
+	privateDirtyBytes uint64
+}
+
+func readProcStatus() procStatusResources {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return procStatusResources{}
+	}
+	return parseProcStatus(string(data))
+}
+
+func parseProcStatus(data string) procStatusResources {
+	var resources procStatusResources
+	for _, line := range strings.Split(data, "\n") {
+		switch {
+		case strings.HasPrefix(line, "VmRSS:"):
+			resources.vmRSSBytes = parseProcKBLine(line)
+		case strings.HasPrefix(line, "VmData:"):
+			resources.vmDataBytes = parseProcKBLine(line)
+		case strings.HasPrefix(line, "Threads:"):
+			resources.threads = parseProcUintLine(line)
+		}
+	}
+	return resources
+}
+
+func readProcSmapsRollup() procSmapsResources {
+	data, err := os.ReadFile("/proc/self/smaps_rollup")
+	if err != nil {
+		return procSmapsResources{}
+	}
+	return parseProcSmapsRollup(string(data))
+}
+
+func parseProcSmapsRollup(data string) procSmapsResources {
+	var resources procSmapsResources
+	for _, line := range strings.Split(data, "\n") {
+		switch {
+		case strings.HasPrefix(line, "Rss:"):
+			resources.rssBytes = parseProcKBLine(line)
+		case strings.HasPrefix(line, "Anonymous:"):
+			resources.anonymousBytes = parseProcKBLine(line)
+		case strings.HasPrefix(line, "Private_Dirty:"):
+			resources.privateDirtyBytes = parseProcKBLine(line)
+		}
+	}
+	return resources
+}
+
+func parseProcKBLine(line string) uint64 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	value, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value * 1024
+}
+
+func parseProcUintLine(line string) uint64 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	value, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
 func readFDCount() uint64 {
 	entries, err := os.ReadDir("/proc/self/fd")
 	if err != nil {
@@ -1476,9 +1838,36 @@ func readFDCount() uint64 {
 	return uint64(len(entries))
 }
 
+func soakNewSocket(
+	ctx *Context,
+	counters *soakCounters,
+	scenario string,
+	socketType SocketType,
+	opts ...SocketOption,
+) (*Socket, error) {
+	socket, err := ctx.Socket(socketType, opts...)
+	if err != nil {
+		return nil, err
+	}
+	counters.scenarioSocketCreated(scenario)
+	return socket, nil
+}
+
 func closeSoakSocket(socket *Socket) {
 	if socket != nil {
 		_ = socket.Close(context.Background())
+	}
+}
+
+func closeSoakScenarioSocket(socket *Socket, counters *soakCounters, scenario string) {
+	if socket == nil {
+		return
+	}
+	state := socket.stateOrNil()
+	wasClosed := state == nil || state.closed.Load()
+	_ = socket.Close(context.Background())
+	if !wasClosed {
+		counters.scenarioSocketClosed(scenario)
 	}
 }
 

--- a/bindings/go/soak_test.go
+++ b/bindings/go/soak_test.go
@@ -1,0 +1,805 @@
+package omq
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	soakRecvTimeout    = 200 * time.Millisecond
+	soakSendTimeout    = 500 * time.Millisecond
+	soakConnectTimeout = 5 * time.Second
+	soakReportInterval = 10 * time.Second
+)
+
+type soakCounters struct {
+	tcpMessages         atomic.Uint64
+	curveMessages       atomic.Uint64
+	compressionMessages atomic.Uint64
+	inprocMessages      atomic.Uint64
+	pollerMessages      atomic.Uint64
+	pubSubMessages      atomic.Uint64
+	contextCycles       atomic.Uint64
+	monitorEvents       atomic.Uint64
+}
+
+type soakState struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	once    sync.Once
+	failure atomic.Value
+}
+
+func TestSoakMixedWorkloads(t *testing.T) {
+	if !soakEnabled() {
+		t.Skip("set OMQ_GO_SOAK=1 to run Go soak")
+	}
+
+	duration := soakDuration()
+	workers := soakWorkers()
+	oldProcs := runtime.GOMAXPROCS(workers)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	runCtx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	state := &soakState{ctx: runCtx, cancel: cancel}
+	counters := &soakCounters{}
+	limits := readSoakResourceLimits()
+	baseline := readSoakResources()
+
+	omqCtx, err := Open(Config{IOThreads: workers, RingSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	tcpEndpoint, tcpPull := startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", nil)
+	tcpMonitor, err := tcpPull.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	startWorker(&wg, state, "tcp-pull", func(ctx context.Context) error {
+		return soakDrainMessages(ctx, tcpPull, &counters.tcpMessages)
+	})
+	startWorker(&wg, state, "tcp-monitor", func(ctx context.Context) error {
+		defer tcpMonitor.Close()
+		return soakDrainMonitor(ctx, tcpMonitor, &counters.monitorEvents)
+	})
+
+	serverKey, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientKey, err := GenerateCurveKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	curveEndpoint, curvePull := startSoakPull(t, omqCtx, "tcp://127.0.0.1:*", []SocketOption{
+		CurveServerAuth(serverKey, func(peer PeerInfo) bool {
+			return peer.Mechanism == "CURVE" && peer.PublicKey == clientKey.Public
+		}),
+	})
+	startWorker(&wg, state, "curve-pull", func(ctx context.Context) error {
+		return soakDrainMessages(ctx, curvePull, &counters.curveMessages)
+	})
+
+	churnWorkers := max(1, workers/3)
+	for i := 0; i < churnWorkers; i++ {
+		workerID := i
+		startWorker(&wg, state, fmt.Sprintf("tcp-churn-%d", workerID), func(ctx context.Context) error {
+			return soakChurnPush(ctx, omqCtx, tcpEndpoint, workerID, nil)
+		})
+		startWorker(&wg, state, fmt.Sprintf("curve-churn-%d", workerID), func(ctx context.Context) error {
+			return soakChurnPush(ctx, omqCtx, curveEndpoint, workerID, []SocketOption{
+				CurveClient(clientKey, serverKey.Public),
+			})
+		})
+	}
+
+	startWorker(&wg, state, "lz4-compression", func(ctx context.Context) error {
+		return soakCompressionPair(ctx, omqCtx, "lz4+tcp://127.0.0.1:*", nil, counters)
+	})
+	startWorker(&wg, state, "zstd-compression", func(ctx context.Context) error {
+		return soakCompressionPair(ctx, omqCtx, "zstd+tcp://127.0.0.1:*", zstdTestDict, counters)
+	})
+	startWorker(&wg, state, "inproc-req-rep", func(ctx context.Context) error {
+		return soakInprocReqRep(ctx, omqCtx, counters)
+	})
+	startWorker(&wg, state, "poller-fanin", func(ctx context.Context) error {
+		return soakPollerFanIn(ctx, omqCtx, max(2, min(workers/2, 6)), counters)
+	})
+	startWorker(&wg, state, "pub-sub-churn", func(ctx context.Context) error {
+		return soakPubSubChurn(ctx, omqCtx, counters)
+	})
+	startWorker(&wg, state, "context-churn", func(ctx context.Context) error {
+		return soakContextChurn(ctx, counters)
+	})
+
+	ticker := time.NewTicker(soakReportInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-runCtx.Done():
+			goto done
+		case <-ticker.C:
+			elapsed := time.Since(start)
+			resources := readSoakResources()
+			t.Logf(
+				"[go-soak] %.0fs tcp=%d curve=%d compression=%d inproc=%d poller=%d pubsub=%d contexts=%d monitor=%d heap=%dMB rss=%dMB fds=%d",
+				elapsed.Seconds(),
+				counters.tcpMessages.Load(),
+				counters.curveMessages.Load(),
+				counters.compressionMessages.Load(),
+				counters.inprocMessages.Load(),
+				counters.pollerMessages.Load(),
+				counters.pubSubMessages.Load(),
+				counters.contextCycles.Load(),
+				counters.monitorEvents.Load(),
+				resources.heapBytes/1_048_576,
+				resources.rssBytes/1_048_576,
+				resources.fdCount,
+			)
+			assertSoakResources(t, elapsed, baseline, resources, limits)
+			if err := state.err(); err != nil {
+				cancel()
+			}
+		}
+	}
+
+done:
+	cancel()
+	waitForSoakWorkers(t, &wg)
+	closeSoakSocket(tcpPull)
+	closeSoakSocket(curvePull)
+	if err := omqCtx.CloseContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	runtime.GC()
+	assertSoakResources(t, time.Since(start), baseline, readSoakResources(), limits)
+	if err := state.err(); err != nil {
+		t.Fatal(err)
+	}
+	assertSoakProgress(t, counters)
+}
+
+func startSoakPull(t *testing.T, ctx *Context, endpoint string, extra []SocketOption) (string, *Socket) {
+	t.Helper()
+	opts := append([]SocketOption{}, soakRecvOptions()...)
+	opts = append(opts, extra...)
+	pull, err := ctx.Socket(Pull, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := pull.Bind(endpoint)
+	if err != nil {
+		closeSoakSocket(pull)
+		t.Fatal(err)
+	}
+	return bound, pull
+}
+
+func startWorker(wg *sync.WaitGroup, state *soakState, name string, fn func(context.Context) error) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				state.fail(fmt.Errorf("%s: panic: %v", name, recovered))
+			}
+		}()
+		err := fn(state.ctx)
+		if err == nil || (state.ctx.Err() != nil && soakStopError(err)) {
+			return
+		}
+		state.fail(fmt.Errorf("%s: %w", name, err))
+	}()
+}
+
+func (s *soakState) fail(err error) {
+	if err == nil {
+		return
+	}
+	s.once.Do(func() {
+		s.failure.Store(err)
+		s.cancel()
+	})
+}
+
+func (s *soakState) err() error {
+	value := s.failure.Load()
+	if value == nil {
+		return nil
+	}
+	return value.(error)
+}
+
+func soakDrainMessages(ctx context.Context, socket *Socket, counter *atomic.Uint64) error {
+	for ctx.Err() == nil {
+		_, err := socket.RecvTimeout(soakRecvTimeout)
+		switch {
+		case err == nil:
+			counter.Add(1)
+		case errors.Is(err, ErrTimeout), errors.Is(err, ErrAgain):
+		default:
+			return err
+		}
+	}
+	return errFromContext(ctx)
+}
+
+func soakDrainMonitor(ctx context.Context, monitor *Monitor, counter *atomic.Uint64) error {
+	for ctx.Err() == nil {
+		_, err := monitor.RecvTimeout(soakRecvTimeout)
+		switch {
+		case err == nil:
+			counter.Add(1)
+		case errors.Is(err, ErrTimeout), errors.Is(err, ErrAgain):
+		default:
+			return err
+		}
+	}
+	return errFromContext(ctx)
+}
+
+func soakChurnPush(ctx context.Context, shared *Context, endpoint string, workerID int, extra []SocketOption) error {
+	seq := uint64(0)
+	for ctx.Err() == nil {
+		opts := append([]SocketOption{}, soakSendOptions()...)
+		opts = append(opts, extra...)
+		push, err := shared.Socket(Push, opts...)
+		if err != nil {
+			return err
+		}
+		if err := push.Connect(endpoint); err != nil {
+			closeSoakSocket(push)
+			return err
+		}
+		if _, err := push.WaitConnectedTimeout(1, soakConnectTimeout); err != nil {
+			closeSoakSocket(push)
+			if ctx.Err() != nil || errors.Is(err, ErrTimeout) {
+				continue
+			}
+			return err
+		}
+		payload := soakPayload(fmt.Sprintf("churn-%d", workerID), seq, 256)
+		for i := 0; i < 32 && ctx.Err() == nil; i++ {
+			payload[0] = byte(i)
+			if err := push.SendTimeout(Bytes(payload), soakSendTimeout); err != nil &&
+				!errors.Is(err, ErrTimeout) && !errors.Is(err, ErrAgain) {
+				closeSoakSocket(push)
+				return err
+			}
+			seq++
+		}
+		closeSoakSocket(push)
+	}
+	return errFromContext(ctx)
+}
+
+func soakCompressionPair(ctx context.Context, shared *Context, endpoint string, dict []byte, counters *soakCounters) error {
+	pullOpts := append([]SocketOption{}, soakRecvOptions()...)
+	pushOpts := append([]SocketOption{}, soakSendOptions()...)
+	pullOpts = append(pullOpts, CompressionAutoTrain(true), CompressionDictCapacity(4096))
+	pushOpts = append(pushOpts,
+		CompressionAutoTrain(true),
+		CompressionDictCapacity(4096),
+		CompressionThreshold(32),
+		CompressionLevel(1),
+	)
+	if dict != nil {
+		pullOpts = append(pullOpts, CompressionDict(dict))
+		pushOpts = append(pushOpts, CompressionDict(dict))
+	}
+	pull, err := shared.Socket(Pull, pullOpts...)
+	if err != nil {
+		return err
+	}
+	defer closeSoakSocket(pull)
+	push, err := shared.Socket(Push, pushOpts...)
+	if err != nil {
+		return err
+	}
+	defer closeSoakSocket(push)
+	bound, err := pull.Bind(endpoint)
+	if err != nil {
+		return err
+	}
+	if err := push.Connect(bound); err != nil {
+		return err
+	}
+	if _, err := push.WaitConnectedTimeout(1, soakConnectTimeout); err != nil {
+		return err
+	}
+	var seq uint64
+	for ctx.Err() == nil {
+		payload := soakPayload(endpoint, seq, 1024)
+		if err := push.SendTimeout(Bytes(payload), 5*time.Second); err != nil {
+			return err
+		}
+		msg, err := pull.RecvTimeout(5 * time.Second)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(msg.Bytes(), payload) {
+			return fmt.Errorf("compression payload mismatch on %s", endpoint)
+		}
+		counters.compressionMessages.Add(1)
+		seq++
+	}
+	return errFromContext(ctx)
+}
+
+func soakInprocReqRep(ctx context.Context, shared *Context, counters *soakCounters) error {
+	rep, err := shared.Socket(Rep, soakRecvOptions()...)
+	if err != nil {
+		return err
+	}
+	defer closeSoakSocket(rep)
+	req, err := shared.Socket(Req, soakSendOptions()...)
+	if err != nil {
+		return err
+	}
+	defer closeSoakSocket(req)
+	endpoint, err := rep.Bind(fmt.Sprintf("inproc://go-soak-req-rep-%d", os.Getpid()))
+	if err != nil {
+		return err
+	}
+	if err := req.Connect(endpoint); err != nil {
+		return err
+	}
+	var seq uint64
+	for ctx.Err() == nil {
+		payload := fmt.Sprintf("req-%d", seq)
+		if err := req.SendTimeout(String(payload), 5*time.Second); err != nil {
+			return err
+		}
+		msg, err := rep.RecvTimeout(5 * time.Second)
+		if err != nil {
+			return err
+		}
+		if msg.String() != payload {
+			return fmt.Errorf("inproc request mismatch: %q", msg.String())
+		}
+		if err := rep.SendTimeout(String("ok"), 5*time.Second); err != nil {
+			return err
+		}
+		reply, err := req.RecvTimeout(5 * time.Second)
+		if err != nil {
+			return err
+		}
+		if reply.String() != "ok" {
+			return fmt.Errorf("inproc reply mismatch: %q", reply.String())
+		}
+		counters.inprocMessages.Add(1)
+		seq++
+	}
+	return errFromContext(ctx)
+}
+
+func soakPollerFanIn(ctx context.Context, shared *Context, channels int, counters *soakCounters) error {
+	pulls := make([]*Socket, 0, channels)
+	pushes := make([]*Socket, 0, channels)
+	for i := 0; i < channels; i++ {
+		pull, err := shared.Socket(Pull, soakRecvOptions()...)
+		if err != nil {
+			return err
+		}
+		push, err := shared.Socket(Push, soakSendOptions()...)
+		if err != nil {
+			closeSoakSocket(pull)
+			return err
+		}
+		endpoint, err := pull.Bind(fmt.Sprintf("inproc://go-soak-poller-%d-%d", os.Getpid(), i))
+		if err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			return err
+		}
+		if err := push.Connect(endpoint); err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			return err
+		}
+		pulls = append(pulls, pull)
+		pushes = append(pushes, push)
+	}
+	defer func() {
+		for _, push := range pushes {
+			closeSoakSocket(push)
+		}
+		for _, pull := range pulls {
+			closeSoakSocket(pull)
+		}
+	}()
+
+	var senders sync.WaitGroup
+	senderCtx, stopSenders := context.WithCancel(ctx)
+	defer func() {
+		stopSenders()
+		senders.Wait()
+	}()
+
+	for i, push := range pushes {
+		idx := byte(i)
+		socket := push
+		senders.Add(1)
+		go func() {
+			defer senders.Done()
+			payload := []byte{idx, 0, 0, 0, 0, 0, 0, 0}
+			for senderCtx.Err() == nil {
+				if err := socket.SendTimeout(Bytes(payload), soakSendTimeout); err != nil &&
+					!errors.Is(err, ErrTimeout) && !errors.Is(err, ErrAgain) {
+					return
+				}
+				payload[1]++
+			}
+		}()
+	}
+
+	poller, err := NewPoller(pulls...)
+	if err != nil {
+		return err
+	}
+	seen := make([]uint64, channels)
+	for ctx.Err() == nil {
+		event, err := poller.RecvTimeout(soakRecvTimeout)
+		switch {
+		case err == nil:
+			msg := event.Message.Bytes()
+			if len(msg) == 0 || int(msg[0]) >= channels {
+				return fmt.Errorf("bad poller payload: %x", msg)
+			}
+			seen[int(msg[0])]++
+			counters.pollerMessages.Add(1)
+		case errors.Is(err, ErrTimeout), errors.Is(err, ErrAgain):
+		default:
+			return err
+		}
+	}
+	for i, count := range seen {
+		if count == 0 {
+			return fmt.Errorf("poller channel %d made no progress", i)
+		}
+	}
+	return errFromContext(ctx)
+}
+
+func soakPubSubChurn(ctx context.Context, shared *Context, counters *soakCounters) error {
+	topics := []string{"fast.", "slow.", "all.", "rare."}
+	pub, err := shared.Socket(Pub,
+		Linger(0),
+		SendHWM(8192),
+		OnMutePolicy(OnMuteDropNewest),
+		Workload(WorkloadThroughput),
+	)
+	if err != nil {
+		return err
+	}
+	defer closeSoakSocket(pub)
+	endpoint, err := pub.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		return err
+	}
+
+	var subs []*Socket
+	defer func() {
+		for _, sub := range subs {
+			closeSoakSocket(sub)
+		}
+	}()
+
+	var seq uint64
+	lastChurn := time.Now()
+	for ctx.Err() == nil {
+		topic := topics[int(seq)%len(topics)]
+		for i := 0; i < 128; i++ {
+			if err := pub.SendTimeout(String(fmt.Sprintf("%s%d", topic, seq)), soakSendTimeout); err != nil &&
+				!errors.Is(err, ErrTimeout) && !errors.Is(err, ErrAgain) {
+				return err
+			}
+			seq++
+		}
+		for _, sub := range subs {
+			for {
+				_, err := sub.TryRecv()
+				if err == nil {
+					counters.pubSubMessages.Add(1)
+					continue
+				}
+				if errors.Is(err, ErrAgain) {
+					break
+				}
+				return err
+			}
+		}
+		if time.Since(lastChurn) >= 500*time.Millisecond {
+			lastChurn = time.Now()
+			if len(subs) > 0 {
+				closeSoakSocket(subs[0])
+				copy(subs, subs[1:])
+				subs = subs[:len(subs)-1]
+			}
+			if len(subs) < 10 {
+				sub, err := shared.Socket(Sub, soakRecvOptions()...)
+				if err != nil {
+					return err
+				}
+				if err := sub.Connect(endpoint); err != nil {
+					closeSoakSocket(sub)
+					return err
+				}
+				if err := sub.SubscribeString(topics[len(subs)%len(topics)]); err != nil {
+					closeSoakSocket(sub)
+					return err
+				}
+				subs = append(subs, sub)
+			}
+		}
+	}
+	return errFromContext(ctx)
+}
+
+func soakContextChurn(ctx context.Context, counters *soakCounters) error {
+	var seq uint64
+	for ctx.Err() == nil {
+		churnCtx, err := Open(Config{IOThreads: 1})
+		if err != nil {
+			return err
+		}
+		pull, err := churnCtx.Socket(Pull, Linger(0))
+		if err != nil {
+			_ = churnCtx.Close()
+			return err
+		}
+		push, err := churnCtx.Socket(Push, Linger(0))
+		if err != nil {
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return err
+		}
+		endpoint, err := pull.Bind(fmt.Sprintf("inproc://go-soak-context-%d-%d", os.Getpid(), seq))
+		if err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return err
+		}
+		if err := push.Connect(endpoint); err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return err
+		}
+		if err := push.SendTimeout(String("x"), time.Second); err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return err
+		}
+		msg, err := pull.RecvTimeout(time.Second)
+		if err != nil {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return err
+		}
+		if msg.String() != "x" {
+			closeSoakSocket(push)
+			closeSoakSocket(pull)
+			_ = churnCtx.Close()
+			return fmt.Errorf("context churn payload mismatch: %q", msg.String())
+		}
+		closeSoakSocket(push)
+		closeSoakSocket(pull)
+		if err := churnCtx.CloseContext(context.Background()); err != nil {
+			return err
+		}
+		counters.contextCycles.Add(1)
+		seq++
+	}
+	return errFromContext(ctx)
+}
+
+func waitForSoakWorkers(t *testing.T, wg *sync.WaitGroup) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("soak workers did not stop within 30s")
+	}
+}
+
+func assertSoakProgress(t *testing.T, counters *soakCounters) {
+	t.Helper()
+	checks := []struct {
+		name  string
+		count uint64
+	}{
+		{"tcp", counters.tcpMessages.Load()},
+		{"curve", counters.curveMessages.Load()},
+		{"compression", counters.compressionMessages.Load()},
+		{"inproc", counters.inprocMessages.Load()},
+		{"poller", counters.pollerMessages.Load()},
+		{"context-churn", counters.contextCycles.Load()},
+	}
+	for _, check := range checks {
+		if check.count == 0 {
+			t.Fatalf("%s soak made no progress", check.name)
+		}
+	}
+}
+
+func soakSendOptions() []SocketOption {
+	return []SocketOption{
+		Linger(0),
+		SendHWM(8192),
+		ReconnectInterval(20 * time.Millisecond),
+		Workload(WorkloadThroughput),
+	}
+}
+
+func soakRecvOptions() []SocketOption {
+	return []SocketOption{
+		Linger(0),
+		RecvHWM(8192),
+		HeartbeatInterval(10 * time.Second),
+		Workload(WorkloadThroughput),
+	}
+}
+
+func soakPayload(kind string, seq uint64, size int) []byte {
+	head := fmt.Sprintf(`{"kind":"%s","seq":%d,"pad":"`, kind, seq)
+	tail := `"}`
+	if len(head)+len(tail) > size {
+		panic("soak payload size too small")
+	}
+	return []byte(head + strings.Repeat("x", size-len(head)-len(tail)) + tail)
+}
+
+func soakEnabled() bool {
+	return os.Getenv("OMQ_GO_SOAK") == "1"
+}
+
+func soakDuration() time.Duration {
+	secs := int64Config([]string{"OMQ_GO_SOAK_DURATION_SECS", "OMQ_SOAK_DURATION_SECS"}, 60)
+	if secs < 5 {
+		secs = 5
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func soakWorkers() int {
+	workers := int(int64Config([]string{"OMQ_GO_SOAK_WORKERS"}, int64(runtime.NumCPU())))
+	if workers < 1 {
+		return 1
+	}
+	return workers
+}
+
+func int64Config(names []string, fallback int64) int64 {
+	for _, name := range names {
+		value := os.Getenv(name)
+		if value == "" {
+			continue
+		}
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+type soakResourceLimits struct {
+	heapGrowthBytes uint64
+	rssGrowthBytes  uint64
+	fdGrowth        uint64
+}
+
+type soakResources struct {
+	heapBytes uint64
+	rssBytes  uint64
+	fdCount   uint64
+}
+
+func readSoakResourceLimits() soakResourceLimits {
+	return soakResourceLimits{
+		heapGrowthBytes: uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_HEAP_GROWTH_MB"}, 384)) * 1_048_576,
+		rssGrowthBytes:  uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_RSS_GROWTH_MB"}, 768)) * 1_048_576,
+		fdGrowth:        uint64(int64Config([]string{"OMQ_GO_SOAK_MAX_FD_GROWTH"}, 1024)),
+	}
+}
+
+func readSoakResources() soakResources {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	rss := readRSSBytes()
+	if rss == 0 {
+		rss = stats.Sys
+	}
+	return soakResources{
+		heapBytes: stats.Alloc,
+		rssBytes:  rss,
+		fdCount:   readFDCount(),
+	}
+}
+
+func assertSoakResources(
+	t *testing.T,
+	elapsed time.Duration,
+	baseline soakResources,
+	current soakResources,
+	limits soakResourceLimits,
+) {
+	t.Helper()
+	if elapsed < 20*time.Second {
+		return
+	}
+	if current.heapBytes > baseline.heapBytes+limits.heapGrowthBytes {
+		t.Fatalf("heap growth exceeded limit: baseline=%d current=%d limit=%d",
+			baseline.heapBytes, current.heapBytes, limits.heapGrowthBytes)
+	}
+	if current.rssBytes > baseline.rssBytes+limits.rssGrowthBytes {
+		t.Fatalf("RSS growth exceeded limit: baseline=%d current=%d limit=%d",
+			baseline.rssBytes, current.rssBytes, limits.rssGrowthBytes)
+	}
+	if current.fdCount > baseline.fdCount+limits.fdGrowth {
+		t.Fatalf("FD growth exceeded limit: baseline=%d current=%d limit=%d",
+			baseline.fdCount, current.fdCount, limits.fdGrowth)
+	}
+}
+
+func readRSSBytes() uint64 {
+	data, err := os.ReadFile("/proc/self/statm")
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0
+	}
+	pages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return pages * uint64(os.Getpagesize())
+}
+
+func readFDCount() uint64 {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0
+	}
+	return uint64(len(entries))
+}
+
+func closeSoakSocket(socket *Socket) {
+	if socket != nil {
+		_ = socket.Close(context.Background())
+	}
+}
+
+func soakStopError(err error) bool {
+	return errors.Is(err, ErrCanceled) ||
+		errors.Is(err, ErrTimeout) ||
+		errors.Is(err, ErrClosed) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -738,6 +738,7 @@ type BoundSocket struct {
 	ringSize   int
 	ctx        context.Context
 	cancel     *nativeCancel
+	closed     atomic.Bool
 	sendRing   *sendRing
 	recvRing   *recvRing
 }
@@ -774,6 +775,9 @@ func (s *BoundSocket) Send(ctx context.Context, msg Message) error {
 
 // TrySend sends without waiting from the owner goroutine.
 func (s *BoundSocket) TrySend(msg Message) error {
+	if err := s.ensureOpen(); err != nil {
+		return err
+	}
 	handled, err := s.trySendRing(msg)
 	if handled {
 		return err
@@ -784,6 +788,9 @@ func (s *BoundSocket) TrySend(msg Message) error {
 // SendBlocking sends using the Run context until accepted or canceled.
 func (s *BoundSocket) SendBlocking(msg Message) error {
 	ctx := s.Context()
+	if err := s.ensureOpen(); err != nil {
+		return err
+	}
 	for i := 0; ; i++ {
 		handled, err := s.trySendRing(msg)
 		if !handled {
@@ -826,6 +833,9 @@ func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 
 // TryRecvInto receives a single-part message into dst without waiting.
 func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
+	if err := s.ensureOpen(); err != nil {
+		return 0, err
+	}
 	ring, err := s.ensureRecvRing()
 	if err != nil {
 		return 0, err
@@ -898,6 +908,9 @@ func (s *BoundSocket) TryRecvView(fn func([]byte) error) error {
 }
 
 func (s *BoundSocket) tryRecvView(fn func([]byte) error) (bool, error) {
+	if err := s.ensureOpen(); err != nil {
+		return false, err
+	}
 	ring, err := s.ensureRecvRing()
 	if err != nil {
 		return false, err
@@ -936,6 +949,13 @@ func (s *BoundSocket) RecvViewBlocking(fn func([]byte) error) error {
 	}
 }
 
+func (s *BoundSocket) ensureOpen() error {
+	if s == nil || s.handle == nil || s.closed.Load() {
+		return ErrClosed
+	}
+	return nil
+}
+
 func (s *BoundSocket) trySendRing(msg Message) (bool, error) {
 	if s.socketType != Push && s.socketType != Scatter {
 		return false, nil
@@ -952,6 +972,9 @@ func (s *BoundSocket) trySendRing(msg Message) (bool, error) {
 }
 
 func (s *BoundSocket) ensureSendRing() (*sendRing, error) {
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
 	if s.sendRing != nil {
 		return s.sendRing, nil
 	}
@@ -964,6 +987,9 @@ func (s *BoundSocket) ensureSendRing() (*sendRing, error) {
 }
 
 func (s *BoundSocket) ensureRecvRing() (*recvRing, error) {
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
 	if s.recvRing != nil {
 		return s.recvRing, nil
 	}
@@ -976,6 +1002,10 @@ func (s *BoundSocket) ensureRecvRing() (*recvRing, error) {
 }
 
 func (s *BoundSocket) close() error {
+	s.closed.Store(true)
+	defer func() {
+		s.handle = nil
+	}()
 	if s.recvRing != nil {
 		s.recvRing.close()
 		s.recvRing = nil

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -16,6 +16,7 @@ type Socket struct {
 	owner      *Context
 	ringSize   int
 	overrun    OverrunPolicy
+	handleMu   sync.RWMutex
 	closed     atomic.Bool
 	ops        chan socketOp
 	ownerDone  chan struct{}
@@ -622,7 +623,9 @@ func (s *Socket) startClose(op socketOp) {
 		_, err := s.do(context.Background(), true, op)
 		close(s.ops)
 		<-s.ownerDone
+		s.handleMu.Lock()
 		s.handle = nil
+		s.handleMu.Unlock()
 		s.releaseAuthCallbacks()
 		if s.owner != nil {
 			s.owner.removeSocket(s)
@@ -668,6 +671,18 @@ func (s *Socket) recordOption(record func(*SocketOptions)) {
 	s.optionsMu.Lock()
 	record(&s.options)
 	s.optionsMu.Unlock()
+}
+
+func (s *Socket) nativeHandle() (*nativeSocket, error) {
+	if s == nil || s.closed.Load() {
+		return nil, ErrClosed
+	}
+	s.handleMu.RLock()
+	defer s.handleMu.RUnlock()
+	if s.handle == nil {
+		return nil, ErrClosed
+	}
+	return s.handle, nil
 }
 
 func cloneSocketOptions(options SocketOptions) SocketOptions {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -12,6 +12,9 @@ import (
 type Socket struct {
 	handle     *nativeSocket
 	socketType SocketType
+	owner      *Context
+	ringSize   int
+	overrun    OverrunPolicy
 	closed     atomic.Bool
 	ops        chan socketOp
 	ownerDone  chan struct{}
@@ -48,8 +51,10 @@ type socketOp struct {
 	data          []byte
 	linger        time.Duration
 	useConfigured bool
+	ctx           context.Context
 	run           func(*BoundSocket) error
 	socketType    SocketType
+	ringSize      int
 	call          *socketCall
 }
 
@@ -66,10 +71,19 @@ type socketResult struct {
 	err     error
 }
 
-func newSocket(handle *nativeSocket, socketType SocketType) *Socket {
+func newSocket(
+	handle *nativeSocket,
+	socketType SocketType,
+	owner *Context,
+	ringSize int,
+	overrun OverrunPolicy,
+) *Socket {
 	socket := &Socket{
 		handle:     handle,
 		socketType: socketType,
+		owner:      owner,
+		ringSize:   ringSize,
+		overrun:    overrun,
 		ops:        make(chan socketOp, 1024),
 		ownerDone:  make(chan struct{}),
 	}
@@ -133,7 +147,16 @@ func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
 	case socketOpClose:
 		return socketResult{err: socketCloseNative(handle, op.linger, op.useConfigured)}
 	case socketOpRun:
-		bound := &BoundSocket{handle: handle, socketType: op.socketType}
+		ctx := op.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		bound := &BoundSocket{
+			handle:     handle,
+			socketType: op.socketType,
+			ringSize:   op.ringSize,
+			ctx:        ctx,
+		}
 		err := op.run(bound)
 		closeErr := bound.close()
 		if err != nil {
@@ -394,6 +417,9 @@ func (s *Socket) Close(ctx context.Context) error {
 		close(s.ops)
 		<-s.ownerDone
 		s.handle = nil
+		if s.owner != nil {
+			s.owner.removeSocket(s)
+		}
 	})
 	keepAlive(s)
 	return err
@@ -413,6 +439,9 @@ func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 		close(s.ops)
 		<-s.ownerDone
 		s.handle = nil
+		if s.owner != nil {
+			s.owner.removeSocket(s)
+		}
 	})
 	keepAlive(s)
 	return err
@@ -429,7 +458,16 @@ func (s *Socket) Run(ctx context.Context, fn func(*BoundSocket) error) error {
 	if fn == nil {
 		return &ConfigError{Err: "nil socket run function"}
 	}
-	_, err := s.do(ctx, false, socketOp{kind: socketOpRun, run: fn, socketType: s.socketType})
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := s.do(ctx, false, socketOp{
+		kind:       socketOpRun,
+		ctx:        ctx,
+		run:        fn,
+		socketType: s.socketType,
+		ringSize:   s.ringSize,
+	})
 	keepAlive(s)
 	return err
 }
@@ -448,8 +486,17 @@ func (s *Socket) noFinalizer() {
 type BoundSocket struct {
 	handle     *nativeSocket
 	socketType SocketType
+	ringSize   int
+	ctx        context.Context
 	sendRing   *sendRing
 	recvRing   *recvRing
+}
+
+func (s *BoundSocket) Context() context.Context {
+	if s == nil || s.ctx == nil {
+		return context.Background()
+	}
+	return s.ctx
 }
 
 func (s *BoundSocket) Send(ctx context.Context, msg Message) error {
@@ -482,6 +529,7 @@ func (s *BoundSocket) TrySend(msg Message) error {
 }
 
 func (s *BoundSocket) SendBlocking(msg Message) error {
+	ctx := s.Context()
 	for i := 0; ; i++ {
 		handled, err := s.trySendRing(msg)
 		if !handled {
@@ -493,11 +541,11 @@ func (s *BoundSocket) SendBlocking(msg Message) error {
 		if !errors.Is(err, ErrAgain) {
 			return err
 		}
-		if err := waitRetry(context.Background(), i); err != nil {
+		if err := waitRetry(ctx, i); err != nil {
 			return err
 		}
 	}
-	return socketMessageSendWaitNative(s.handle, msg)
+	return s.Send(ctx, msg)
 }
 
 func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
@@ -508,7 +556,7 @@ func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 		if err := errFromContext(ctx); err != nil {
 			return 0, err
 		}
-		n, err := socketMessageRecvIntoNative(s.handle, dst)
+		n, err := s.TryRecvInto(dst)
 		if err == nil {
 			return n, nil
 		}
@@ -530,11 +578,19 @@ func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
 }
 
 func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
-	ring, err := s.ensureRecvRing()
-	if err != nil {
-		return 0, err
+	ctx := s.Context()
+	for i := 0; ; i++ {
+		n, err := s.TryRecvInto(dst)
+		if err == nil {
+			return n, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return 0, err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return 0, err
+		}
 	}
-	return ring.recvIntoBlocking(dst)
 }
 
 type RecvView struct {
@@ -576,7 +632,7 @@ func (s *BoundSocket) ensureSendRing() (*sendRing, error) {
 	if s.sendRing != nil {
 		return s.sendRing, nil
 	}
-	ring, err := newSendRing(s.handle)
+	ring, err := newSendRing(s.handle, s.ringSize)
 	if err != nil {
 		return nil, err
 	}
@@ -588,7 +644,7 @@ func (s *BoundSocket) ensureRecvRing() (*recvRing, error) {
 	if s.recvRing != nil {
 		return s.recvRing, nil
 	}
-	ring, err := newRecvRing(s.handle)
+	ring, err := newRecvRing(s.handle, s.ringSize)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -21,6 +21,8 @@ type Socket struct {
 	closeDone  chan struct{}
 	closeOnce  sync.Once
 	closeErr   error
+	authMu     sync.Mutex
+	authIDs    []uint64
 }
 
 type socketOpKind uint8
@@ -579,6 +581,7 @@ func (s *Socket) startClose(op socketOp) {
 		close(s.ops)
 		<-s.ownerDone
 		s.handle = nil
+		s.releaseAuthCallbacks()
 		if s.owner != nil {
 			s.owner.removeSocket(s)
 		}
@@ -598,6 +601,22 @@ func (s *Socket) waitClose(ctx context.Context) error {
 
 func (s *Socket) noFinalizer() {
 	runtime.SetFinalizer(s, nil)
+}
+
+func (s *Socket) addAuthCallback(id uint64) {
+	s.authMu.Lock()
+	s.authIDs = append(s.authIDs, id)
+	s.authMu.Unlock()
+}
+
+func (s *Socket) releaseAuthCallbacks() {
+	s.authMu.Lock()
+	ids := s.authIDs
+	s.authIDs = nil
+	s.authMu.Unlock()
+	for _, id := range ids {
+		unregisterAuthCallback(id)
+	}
 }
 
 type BoundSocket struct {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -385,10 +385,18 @@ func (s *Socket) Subscribe(prefix []byte) error {
 	return err
 }
 
+func (s *Socket) SubscribeString(prefix string) error {
+	return s.Subscribe([]byte(prefix))
+}
+
 func (s *Socket) Unsubscribe(prefix []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnsubscribe, data: prefix})
 	keepAlive(s)
 	return err
+}
+
+func (s *Socket) UnsubscribeString(prefix string) error {
+	return s.Unsubscribe([]byte(prefix))
 }
 
 func (s *Socket) Join(group []byte) error {
@@ -397,10 +405,108 @@ func (s *Socket) Join(group []byte) error {
 	return err
 }
 
+func (s *Socket) JoinString(group string) error {
+	return s.Join([]byte(group))
+}
+
 func (s *Socket) Leave(group []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpLeave, data: group})
 	keepAlive(s)
 	return err
+}
+
+func (s *Socket) LeaveString(group string) error {
+	return s.Leave([]byte(group))
+}
+
+func (s *Socket) WaitConnected(ctx context.Context, minPeers int) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var last int
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return last, err
+		}
+		count, err := s.waitConnectedOnce(ctx, minPeers)
+		if err == nil {
+			return count, nil
+		}
+		if !errors.Is(err, ErrTimeout) {
+			return count, err
+		}
+		last = count
+		if err := waitRetry(ctx, i); err != nil {
+			return last, err
+		}
+	}
+}
+
+func (s *Socket) WaitConnectedTimeout(minPeers int, timeout time.Duration) (int, error) {
+	if timeout == 0 {
+		return s.waitConnectedOnce(context.Background(), minPeers)
+	}
+	if timeout < 0 {
+		return s.WaitConnected(context.Background(), minPeers)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.WaitConnected(ctx, minPeers)
+}
+
+func (s *Socket) waitConnectedOnce(ctx context.Context, minPeers int) (int, error) {
+	value, err := s.call(ctx, false, func(handle *nativeSocket) (any, error) {
+		return socketWaitConnectedNative(handle, minPeers, 0)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return value.(int), nil
+}
+
+func (s *Socket) WaitSubscribed(ctx context.Context, minSubscriptions uint64) (uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var last uint64
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return last, err
+		}
+		count, err := s.waitSubscribedOnce(ctx, minSubscriptions)
+		if err == nil {
+			return count, nil
+		}
+		if !errors.Is(err, ErrTimeout) {
+			return count, err
+		}
+		last = count
+		if err := waitRetry(ctx, i); err != nil {
+			return last, err
+		}
+	}
+}
+
+func (s *Socket) WaitSubscribedTimeout(minSubscriptions uint64, timeout time.Duration) (uint64, error) {
+	if timeout == 0 {
+		return s.waitSubscribedOnce(context.Background(), minSubscriptions)
+	}
+	if timeout < 0 {
+		return s.WaitSubscribed(context.Background(), minSubscriptions)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.WaitSubscribed(ctx, minSubscriptions)
+}
+
+func (s *Socket) waitSubscribedOnce(ctx context.Context, minSubscriptions uint64) (uint64, error) {
+	value, err := s.call(ctx, false, func(handle *nativeSocket) (any, error) {
+		return socketWaitSubscribedNative(handle, minSubscriptions, 0)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return value.(uint64), nil
 }
 
 func (s *Socket) Close(ctx context.Context) error {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -1,0 +1,322 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Socket struct {
+	handle     *nativeSocket
+	socketType SocketType
+	closed     atomic.Bool
+	ops        chan socketOp
+	ownerDone  chan struct{}
+	closeOnce  sync.Once
+}
+
+type socketOp struct {
+	fn   func(*nativeSocket) (any, error)
+	resp chan socketResult
+}
+
+type socketResult struct {
+	value any
+	err   error
+}
+
+func newSocket(handle *nativeSocket, socketType SocketType) *Socket {
+	socket := &Socket{
+		handle:     handle,
+		socketType: socketType,
+		ops:        make(chan socketOp, 1024),
+		ownerDone:  make(chan struct{}),
+	}
+	go socket.ownerLoop()
+	return socket
+}
+
+func (s *Socket) ownerLoop() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer close(s.ownerDone)
+
+	handle := s.handle
+	for op := range s.ops {
+		value, err := op.fn(handle)
+		op.resp <- socketResult{value: value, err: err}
+	}
+	if handle != nil {
+		socketFreeNative(handle)
+	}
+}
+
+func (s *Socket) call(ctx context.Context, allowClosed bool, fn func(*nativeSocket) (any, error)) (value any, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.ops == nil {
+		return nil, ErrClosed
+	}
+	if !allowClosed && s.closed.Load() {
+		return nil, ErrClosed
+	}
+	defer func() {
+		if recover() != nil {
+			value = nil
+			err = ErrClosed
+		}
+	}()
+
+	resp := make(chan socketResult, 1)
+	op := socketOp{fn: fn, resp: resp}
+	select {
+	case s.ops <- op:
+	case <-s.ownerDone:
+		return nil, ErrClosed
+	case <-ctx.Done():
+		return nil, errFromContext(ctx)
+	}
+	select {
+	case result := <-resp:
+		return result.value, result.err
+	case <-s.ownerDone:
+		return nil, ErrClosed
+	case <-ctx.Done():
+		return nil, errFromContext(ctx)
+	}
+}
+
+func (s *Socket) Bind(endpoint string) (string, error) {
+	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return socketBindNative(handle, endpoint)
+	})
+	if err != nil {
+		return "", err
+	}
+	keepAlive(s)
+	return value.(string), nil
+}
+
+func (s *Socket) Connect(endpoint string) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketConnectNative(handle, endpoint)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Unbind(endpoint string) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketUnbindNative(handle, endpoint)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Disconnect(endpoint string) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketDisconnectNative(handle, endpoint)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Send(ctx context.Context, msg Message) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return err
+		}
+		err := s.TrySend(msg)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return err
+		}
+		timer := time.NewTimer(retryDelay(i))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return errFromContext(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *Socket) TrySend(msg Message) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketMessageSendNative(handle, msg)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) trySendBatch(messages []Message) (int, error) {
+	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return socketMessagesTrySendNative(handle, messages)
+	})
+	if err != nil {
+		return 0, err
+	}
+	keepAlive(s)
+	return value.(int), nil
+}
+
+func (s *Socket) SendTimeout(msg Message, timeout time.Duration) error {
+	if timeout == 0 {
+		return s.TrySend(msg)
+	}
+	if timeout < 0 {
+		return s.Send(context.Background(), msg)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.Send(ctx, msg)
+}
+
+func (s *Socket) Recv(ctx context.Context) (Message, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return Message{}, err
+		}
+		msg, err := s.TryRecv()
+		if err == nil {
+			return msg, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return Message{}, err
+		}
+		timer := time.NewTimer(retryDelay(i))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return Message{}, errFromContext(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *Socket) TryRecv() (Message, error) {
+	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return socketMessageRecvNative(handle)
+	})
+	if err != nil {
+		return Message{}, err
+	}
+	keepAlive(s)
+	return value.(Message), nil
+}
+
+func (s *Socket) RecvTimeout(timeout time.Duration) (Message, error) {
+	if timeout == 0 {
+		return s.TryRecv()
+	}
+	if timeout < 0 {
+		return s.Recv(context.Background())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.Recv(ctx)
+}
+
+func (s *Socket) Subscribe(prefix []byte) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketSubscribeNative(handle, prefix)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Unsubscribe(prefix []byte) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketUnsubscribeNative(handle, prefix)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Join(group []byte) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketJoinNative(handle, group)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Leave(group []byte) error {
+	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
+		return nil, socketLeaveNative(handle, group)
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.ops == nil {
+		return nil
+	}
+	var err error
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		_, err = s.call(ctx, true, func(handle *nativeSocket) (any, error) {
+			return nil, socketCloseNative(handle, 0, true)
+		})
+		close(s.ops)
+		<-s.ownerDone
+		s.handle = nil
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.ops == nil {
+		return nil
+	}
+	var err error
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		_, err = s.call(ctx, true, func(handle *nativeSocket) (any, error) {
+			return nil, socketCloseNative(handle, linger, false)
+		})
+		close(s.ops)
+		<-s.ownerDone
+		s.handle = nil
+	})
+	keepAlive(s)
+	return err
+}
+
+func (s *Socket) Type() SocketType {
+	if s == nil {
+		return 0
+	}
+	return s.socketType
+}
+
+func (s *Socket) free() {
+	if s == nil || s.ops == nil {
+		return
+	}
+	_ = s.Close(context.Background())
+}
+
+func (s *Socket) noFinalizer() {
+	runtime.SetFinalizer(s, nil)
+}

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -11,22 +11,28 @@ import (
 
 // Socket is a goroutine-safe OMQ socket handle.
 type Socket struct {
-	handle     *nativeSocket
+	state      *socketState
 	socketType SocketType
 	owner      *Context
 	ringSize   int
 	overrun    OverrunPolicy
-	handleMu   sync.RWMutex
-	closed     atomic.Bool
-	ops        chan socketOp
-	ownerDone  chan struct{}
-	closeDone  chan struct{}
-	closeOnce  sync.Once
-	closeErr   error
-	authMu     sync.Mutex
-	authIDs    []uint64
+	cleanup    runtime.Cleanup
 	optionsMu  sync.RWMutex
 	options    SocketOptions
+}
+
+type socketState struct {
+	handle    *nativeSocket
+	owner     *contextState
+	handleMu  sync.RWMutex
+	closed    atomic.Bool
+	ops       chan socketOp
+	ownerDone chan struct{}
+	closeDone chan struct{}
+	closeOnce sync.Once
+	closeErr  error
+	authMu    sync.Mutex
+	authIDs   []uint64
 }
 
 type socketOpKind uint8
@@ -83,20 +89,26 @@ func newSocket(
 	handle *nativeSocket,
 	socketType SocketType,
 	owner *Context,
+	ownerState *contextState,
 	ringSize int,
 	overrun OverrunPolicy,
 ) *Socket {
+	state := &socketState{
+		handle:    handle,
+		owner:     ownerState,
+		ops:       make(chan socketOp, 1024),
+		ownerDone: make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
 	socket := &Socket{
-		handle:     handle,
+		state:      state,
 		socketType: socketType,
 		owner:      owner,
 		ringSize:   ringSize,
 		overrun:    overrun,
-		ops:        make(chan socketOp, 1024),
-		ownerDone:  make(chan struct{}),
-		closeDone:  make(chan struct{}),
 	}
-	go socket.ownerLoop()
+	socket.cleanup = runtime.AddCleanup(socket, cleanupSocketState, state)
+	go state.ownerLoop()
 	return socket
 }
 
@@ -106,7 +118,7 @@ var socketCallPool = sync.Pool{
 	},
 }
 
-func (s *Socket) ownerLoop() {
+func (s *socketState) ownerLoop() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	defer close(s.ownerDone)
@@ -199,14 +211,18 @@ func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
 }
 
 func (s *Socket) call(ctx context.Context, allowClosed bool, fn func(*nativeSocket) (any, error)) (value any, err error) {
-	result, err := s.do(ctx, allowClosed, socketOp{kind: socketOpFunc, fn: fn})
+	state := s.stateOrNil()
+	if state == nil {
+		return nil, ErrClosed
+	}
+	result, err := state.do(ctx, allowClosed, socketOp{kind: socketOpFunc, fn: fn})
 	if err != nil {
 		return nil, err
 	}
 	return result.value, result.err
 }
 
-func (s *Socket) do(ctx context.Context, allowClosed bool, op socketOp) (result socketResult, err error) {
+func (s *socketState) do(ctx context.Context, allowClosed bool, op socketOp) (result socketResult, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -255,7 +271,11 @@ func (s *Socket) do(ctx context.Context, allowClosed bool, op socketOp) (result 
 
 // Bind binds this socket to an endpoint and returns the bound endpoint.
 func (s *Socket) Bind(endpoint string) (string, error) {
-	result, err := s.do(context.Background(), false, socketOp{kind: socketOpBind, endpoint: endpoint})
+	state := s.stateOrNil()
+	if state == nil {
+		return "", ErrClosed
+	}
+	result, err := state.do(context.Background(), false, socketOp{kind: socketOpBind, endpoint: endpoint})
 	if err != nil {
 		return "", err
 	}
@@ -265,21 +285,33 @@ func (s *Socket) Bind(endpoint string) (string, error) {
 
 // Connect connects this socket to an endpoint.
 func (s *Socket) Connect(endpoint string) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpConnect, endpoint: endpoint})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpConnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
 // Unbind removes a previously bound endpoint.
 func (s *Socket) Unbind(endpoint string) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnbind, endpoint: endpoint})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpUnbind, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
 // Disconnect removes a previously connected endpoint.
 func (s *Socket) Disconnect(endpoint string) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpDisconnect, endpoint: endpoint})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpDisconnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
@@ -312,13 +344,21 @@ func (s *Socket) TrySend(msg Message) error {
 }
 
 func (s *Socket) trySend(ctx context.Context, msg Message) error {
-	_, err := s.do(ctx, false, socketOp{kind: socketOpSend, msg: msg})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(ctx, false, socketOp{kind: socketOpSend, msg: msg})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) trySendBatch(messages []Message) (int, error) {
-	result, err := s.do(context.Background(), false, socketOp{kind: socketOpSendBatch, messages: messages})
+	state := s.stateOrNil()
+	if state == nil {
+		return 0, ErrClosed
+	}
+	result, err := state.do(context.Background(), false, socketOp{kind: socketOpSendBatch, messages: messages})
 	if err != nil {
 		return 0, err
 	}
@@ -389,7 +429,11 @@ func (s *Socket) TryRecv() (Message, error) {
 }
 
 func (s *Socket) tryRecv(ctx context.Context) (Message, error) {
-	result, err := s.do(ctx, false, socketOp{kind: socketOpRecv})
+	state := s.stateOrNil()
+	if state == nil {
+		return Message{}, ErrClosed
+	}
+	result, err := state.do(ctx, false, socketOp{kind: socketOpRecv})
 	if err != nil {
 		return Message{}, err
 	}
@@ -403,7 +447,11 @@ func (s *Socket) TryRecvInto(dst []byte) (int, error) {
 }
 
 func (s *Socket) tryRecvInto(ctx context.Context, dst []byte) (int, error) {
-	result, err := s.do(ctx, false, socketOp{kind: socketOpRecvInto, buffer: dst})
+	state := s.stateOrNil()
+	if state == nil {
+		return 0, ErrClosed
+	}
+	result, err := state.do(ctx, false, socketOp{kind: socketOpRecvInto, buffer: dst})
 	if err != nil {
 		return 0, err
 	}
@@ -439,7 +487,11 @@ func (s *Socket) RecvIntoTimeout(dst []byte, timeout time.Duration) (int, error)
 
 // Subscribe adds a SUB prefix.
 func (s *Socket) Subscribe(prefix []byte) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSubscribe, data: prefix})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpSubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
@@ -451,7 +503,11 @@ func (s *Socket) SubscribeString(prefix string) error {
 
 // Unsubscribe removes a SUB prefix.
 func (s *Socket) Unsubscribe(prefix []byte) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnsubscribe, data: prefix})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpUnsubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
@@ -463,7 +519,11 @@ func (s *Socket) UnsubscribeString(prefix string) error {
 
 // Join adds a DISH group.
 func (s *Socket) Join(group []byte) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpJoin, data: group})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpJoin, data: group})
 	keepAlive(s)
 	return err
 }
@@ -475,7 +535,11 @@ func (s *Socket) JoinString(group string) error {
 
 // Leave removes a DISH group.
 func (s *Socket) Leave(group []byte) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpLeave, data: group})
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(context.Background(), false, socketOp{kind: socketOpLeave, data: group})
 	keepAlive(s)
 	return err
 }
@@ -584,14 +648,14 @@ func (s *Socket) Close(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if s == nil || s.ops == nil {
+	state := s.stateOrNil()
+	if state == nil {
 		return nil
 	}
-	s.closeOnce.Do(func() {
-		s.startClose(socketOp{kind: socketOpClose, useConfigured: true})
-	})
+	err := state.close(ctx, socketOp{kind: socketOpClose, useConfigured: true})
+	s.cleanup.Stop()
 	keepAlive(s)
-	return s.waitClose(ctx)
+	return err
 }
 
 // CloseLinger closes the socket with an explicit linger.
@@ -599,14 +663,14 @@ func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if s == nil || s.ops == nil {
+	state := s.stateOrNil()
+	if state == nil {
 		return nil
 	}
-	s.closeOnce.Do(func() {
-		s.startClose(socketOp{kind: socketOpClose, linger: linger})
-	})
+	err := state.close(ctx, socketOp{kind: socketOpClose, linger: linger})
+	s.cleanup.Stop()
 	keepAlive(s)
-	return s.waitClose(ctx)
+	return err
 }
 
 // Type returns this socket's type.
@@ -635,7 +699,11 @@ func (s *Socket) Run(ctx context.Context, fn func(*BoundSocket) error) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	_, err := s.do(ctx, false, socketOp{
+	state := s.stateOrNil()
+	if state == nil {
+		return ErrClosed
+	}
+	_, err := state.do(ctx, false, socketOp{
 		kind:       socketOpRun,
 		ctx:        ctx,
 		run:        fn,
@@ -646,14 +714,26 @@ func (s *Socket) Run(ctx context.Context, fn func(*BoundSocket) error) error {
 	return err
 }
 
-func (s *Socket) free() {
-	if s == nil || s.ops == nil {
+func cleanupSocketState(state *socketState) {
+	if state == nil {
 		return
 	}
-	_ = s.Close(context.Background())
+	go func() {
+		_ = state.close(context.Background(), socketOp{kind: socketOpClose, useConfigured: true})
+	}()
 }
 
-func (s *Socket) startClose(op socketOp) {
+func (s *socketState) close(ctx context.Context, op socketOp) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.closeOnce.Do(func() {
+		s.startClose(op)
+	})
+	return s.waitClose(ctx)
+}
+
+func (s *socketState) startClose(op socketOp) {
 	s.closed.Store(true)
 	go func() {
 		_, err := s.do(context.Background(), true, op)
@@ -668,7 +748,7 @@ func (s *Socket) startClose(op socketOp) {
 	}()
 }
 
-func (s *Socket) waitClose(ctx context.Context) error {
+func (s *socketState) waitClose(ctx context.Context) error {
 	select {
 	case <-s.closeDone:
 		return s.closeErr
@@ -684,17 +764,36 @@ func socketOpContextErr(op socketOp) error {
 	return errFromContext(op.ctx)
 }
 
+func (s *Socket) stateOrNil() *socketState {
+	if s == nil {
+		return nil
+	}
+	return s.state
+}
+
 func (s *Socket) noFinalizer() {
-	runtime.SetFinalizer(s, nil)
+	if s == nil {
+		return
+	}
+	s.cleanup.Stop()
+	keepAlive(s)
 }
 
 func (s *Socket) addAuthCallback(id uint64) {
+	state := s.stateOrNil()
+	if state == nil {
+		return
+	}
+	state.addAuthCallback(id)
+}
+
+func (s *socketState) addAuthCallback(id uint64) {
 	s.authMu.Lock()
 	s.authIDs = append(s.authIDs, id)
 	s.authMu.Unlock()
 }
 
-func (s *Socket) releaseAuthCallbacks() {
+func (s *socketState) releaseAuthCallbacks() {
 	s.authMu.Lock()
 	ids := s.authIDs
 	s.authIDs = nil
@@ -714,15 +813,16 @@ func (s *Socket) recordOption(record func(*SocketOptions)) {
 }
 
 func (s *Socket) nativeHandle() (*nativeSocket, error) {
-	if s == nil || s.closed.Load() {
+	state := s.stateOrNil()
+	if state == nil || state.closed.Load() {
 		return nil, ErrClosed
 	}
-	s.handleMu.RLock()
-	defer s.handleMu.RUnlock()
-	if s.handle == nil {
+	state.handleMu.RLock()
+	defer state.handleMu.RUnlock()
+	if state.handle == nil {
 		return nil, ErrClosed
 	}
-	return s.handle, nil
+	return state.handle, nil
 }
 
 func cloneSocketOptions(options SocketOptions) SocketOptions {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -121,6 +121,9 @@ func (s *Socket) ownerLoop() {
 }
 
 func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
+	if err := socketOpContextErr(op); err != nil {
+		return socketResult{err: err}
+	}
 	switch op.kind {
 	case socketOpFunc:
 		value, err := op.fn(handle)
@@ -210,6 +213,9 @@ func (s *Socket) do(ctx context.Context, allowClosed bool, op socketOp) (result 
 	if !allowClosed && s.closed.Load() {
 		return socketResult{}, ErrClosed
 	}
+	if op.ctx == nil {
+		op.ctx = ctx
+	}
 	defer func() {
 		if recover() != nil {
 			result = socketResult{}
@@ -284,7 +290,7 @@ func (s *Socket) Send(ctx context.Context, msg Message) error {
 		if err := errFromContext(ctx); err != nil {
 			return err
 		}
-		err := s.TrySend(msg)
+		err := s.trySend(ctx, msg)
 		if err == nil {
 			return nil
 		}
@@ -299,7 +305,11 @@ func (s *Socket) Send(ctx context.Context, msg Message) error {
 
 // TrySend sends a message without waiting for queue capacity.
 func (s *Socket) TrySend(msg Message) error {
-	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSend, msg: msg})
+	return s.trySend(context.Background(), msg)
+}
+
+func (s *Socket) trySend(ctx context.Context, msg Message) error {
+	_, err := s.do(ctx, false, socketOp{kind: socketOpSend, msg: msg})
 	keepAlive(s)
 	return err
 }
@@ -335,7 +345,7 @@ func (s *Socket) Recv(ctx context.Context) (Message, error) {
 		if err := errFromContext(ctx); err != nil {
 			return Message{}, err
 		}
-		msg, err := s.TryRecv()
+		msg, err := s.tryRecv(ctx)
 		if err == nil {
 			return msg, nil
 		}
@@ -357,7 +367,7 @@ func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 		if err := errFromContext(ctx); err != nil {
 			return 0, err
 		}
-		n, err := s.TryRecvInto(dst)
+		n, err := s.tryRecvInto(ctx, dst)
 		if err == nil {
 			return n, nil
 		}
@@ -372,7 +382,11 @@ func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 
 // TryRecv receives one message without waiting.
 func (s *Socket) TryRecv() (Message, error) {
-	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecv})
+	return s.tryRecv(context.Background())
+}
+
+func (s *Socket) tryRecv(ctx context.Context) (Message, error) {
+	result, err := s.do(ctx, false, socketOp{kind: socketOpRecv})
 	if err != nil {
 		return Message{}, err
 	}
@@ -382,7 +396,11 @@ func (s *Socket) TryRecv() (Message, error) {
 
 // TryRecvInto receives one single-part message into dst without waiting.
 func (s *Socket) TryRecvInto(dst []byte) (int, error) {
-	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecvInto, buffer: dst})
+	return s.tryRecvInto(context.Background(), dst)
+}
+
+func (s *Socket) tryRecvInto(ctx context.Context, dst []byte) (int, error) {
+	result, err := s.do(ctx, false, socketOp{kind: socketOpRecvInto, buffer: dst})
 	if err != nil {
 		return 0, err
 	}
@@ -657,6 +675,13 @@ func (s *Socket) waitClose(ctx context.Context) error {
 	case <-ctx.Done():
 		return errFromContext(ctx)
 	}
+}
+
+func socketOpContextErr(op socketOp) error {
+	if op.ctx == nil {
+		return nil
+	}
+	return errFromContext(op.ctx)
 }
 
 func (s *Socket) noFinalizer() {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -79,8 +79,6 @@ type socketResult struct {
 	err     error
 }
 
-const boundSocketBlockingPollMillis int64 = 1
-
 func newSocket(
 	handle *nativeSocket,
 	socketType SocketType,
@@ -162,14 +160,29 @@ func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
 		if ctx == nil {
 			ctx = context.Background()
 		}
+		cancel := cancelNewNative()
+		if cancel == nil {
+			return socketResult{err: &Error{Err: "run cancellation allocation failed"}}
+		}
+		cancelRegisterCurrentNative(cancel)
+		cancelDone := make(chan struct{})
+		stopCancel := context.AfterFunc(ctx, func() {
+			cancelNative(cancel)
+			close(cancelDone)
+		})
 		bound := &BoundSocket{
 			handle:     handle,
 			socketType: op.socketType,
 			ringSize:   op.ringSize,
 			ctx:        ctx,
+			cancel:     cancel,
 		}
 		err := op.run(bound)
+		if !stopCancel() {
+			<-cancelDone
+		}
 		closeErr := bound.close()
+		cancelFreeNative(cancel)
 		if err != nil {
 			return socketResult{err: err}
 		}
@@ -699,6 +712,7 @@ type BoundSocket struct {
 	socketType SocketType
 	ringSize   int
 	ctx        context.Context
+	cancel     *nativeCancel
 	sendRing   *sendRing
 	recvRing   *recvRing
 }
@@ -805,11 +819,16 @@ func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
 		if err := errFromContext(ctx); err != nil {
 			return 0, err
 		}
-		n, err := ring.recvInto(dst, boundSocketBlockingPollMillis)
+		n, err := ring.recvIntoCancelable(dst, s.cancel)
 		if err == nil {
 			return n, nil
 		}
-		if !errors.Is(err, ErrAgain) && !errors.Is(err, ErrTimeout) {
+		if errors.Is(err, ErrCanceled) {
+			if ctxErr := errFromContext(ctx); ctxErr != nil {
+				return 0, ctxErr
+			}
+		}
+		if !errors.Is(err, ErrAgain) {
 			return 0, err
 		}
 	}

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -834,28 +834,81 @@ func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
 	}
 }
 
-// RecvView is a borrowed single-part receive view.
-type RecvView struct {
-	data []byte
+// RecvView receives a borrowed single-part payload and passes it to fn.
+//
+// The payload slice is valid only until fn returns. fn must not retain it.
+func (s *BoundSocket) RecvView(ctx context.Context, fn func([]byte) error) error {
+	if fn == nil {
+		return &ConfigError{Err: "nil RecvView callback"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return err
+		}
+		delivered, err := s.tryRecvView(fn)
+		if delivered {
+			return err
+		}
+		if !errors.Is(err, ErrAgain) {
+			return err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return err
+		}
+	}
 }
 
-// Bytes returns the borrowed payload.
-func (v RecvView) Bytes() []byte {
-	return v.data
+// TryRecvView receives a borrowed single-part payload without waiting.
+//
+// The payload slice is valid only until fn returns. fn must not retain it.
+func (s *BoundSocket) TryRecvView(fn func([]byte) error) error {
+	if fn == nil {
+		return &ConfigError{Err: "nil RecvView callback"}
+	}
+	_, err := s.tryRecvView(fn)
+	return err
 }
 
-// Len returns the borrowed payload length.
-func (v RecvView) Len() int {
-	return len(v.data)
-}
-
-// TryRecvView receives a borrowed single-part view without waiting.
-func (s *BoundSocket) TryRecvView() (RecvView, error) {
+func (s *BoundSocket) tryRecvView(fn func([]byte) error) (bool, error) {
 	ring, err := s.ensureRecvRing()
 	if err != nil {
-		return RecvView{}, err
+		return false, err
 	}
-	return ring.tryRecvView()
+	return ring.tryRecvView(fn)
+}
+
+// RecvViewBlocking receives a borrowed payload using the Run context.
+//
+// The payload slice is valid only until fn returns. fn must not retain it.
+func (s *BoundSocket) RecvViewBlocking(fn func([]byte) error) error {
+	if fn == nil {
+		return &ConfigError{Err: "nil RecvView callback"}
+	}
+	ctx := s.Context()
+	ring, err := s.ensureRecvRing()
+	if err != nil {
+		return err
+	}
+	for {
+		if err := errFromContext(ctx); err != nil {
+			return err
+		}
+		delivered, err := ring.recvViewCancelable(s.cancel, fn)
+		if delivered {
+			return err
+		}
+		if errors.Is(err, ErrCanceled) {
+			if ctxErr := errFromContext(ctx); ctxErr != nil {
+				return ctxErr
+			}
+		}
+		if !errors.Is(err, ErrAgain) {
+			return err
+		}
+	}
 }
 
 func (s *BoundSocket) trySendRing(msg Message) (bool, error) {
@@ -898,18 +951,14 @@ func (s *BoundSocket) ensureRecvRing() (*recvRing, error) {
 }
 
 func (s *BoundSocket) close() error {
-	err := socketRecvViewClearNative(s.handle)
 	if s.recvRing != nil {
 		s.recvRing.close()
 		s.recvRing = nil
 	}
 	if s.sendRing == nil {
-		return err
+		return nil
 	}
 	closeErr := s.sendRing.close()
 	s.sendRing = nil
-	if err != nil {
-		return err
-	}
 	return closeErr
 }

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -116,7 +116,10 @@ func (s *Socket) ownerLoop() {
 		op.call.resp <- runSocketOp(handle, op)
 	}
 	if handle != nil {
+		s.handleMu.Lock()
 		socketFreeNative(handle)
+		s.handle = nil
+		s.handleMu.Unlock()
 	}
 }
 
@@ -656,9 +659,6 @@ func (s *Socket) startClose(op socketOp) {
 		_, err := s.do(context.Background(), true, op)
 		close(s.ops)
 		<-s.ownerDone
-		s.handleMu.Lock()
-		s.handle = nil
-		s.handleMu.Unlock()
 		s.releaseAuthCallbacks()
 		if s.owner != nil {
 			s.owner.removeSocket(s)

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -79,6 +79,8 @@ type socketResult struct {
 	err     error
 }
 
+const boundSocketBlockingPollMillis int64 = 1
+
 func newSocket(
 	handle *nativeSocket,
 	socketType SocketType,
@@ -795,15 +797,19 @@ func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
 // RecvIntoBlocking receives into dst using the Run context.
 func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
 	ctx := s.Context()
-	for i := 0; ; i++ {
-		n, err := s.TryRecvInto(dst)
+	ring, err := s.ensureRecvRing()
+	if err != nil {
+		return 0, err
+	}
+	for {
+		if err := errFromContext(ctx); err != nil {
+			return 0, err
+		}
+		n, err := ring.recvInto(dst, boundSocketBlockingPollMillis)
 		if err == nil {
 			return n, nil
 		}
-		if !errors.Is(err, ErrAgain) {
-			return 0, err
-		}
-		if err := waitRetry(ctx, i); err != nil {
+		if !errors.Is(err, ErrAgain) && !errors.Is(err, ErrTimeout) {
 			return 0, err
 		}
 	}

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+// Socket is a goroutine-safe OMQ socket handle.
 type Socket struct {
 	handle     *nativeSocket
 	socketType SocketType
@@ -23,6 +24,8 @@ type Socket struct {
 	closeErr   error
 	authMu     sync.Mutex
 	authIDs    []uint64
+	optionsMu  sync.RWMutex
+	options    SocketOptions
 }
 
 type socketOpKind uint8
@@ -225,6 +228,7 @@ func (s *Socket) do(ctx context.Context, allowClosed bool, op socketOp) (result 
 	}
 }
 
+// Bind binds this socket to an endpoint and returns the bound endpoint.
 func (s *Socket) Bind(endpoint string) (string, error) {
 	result, err := s.do(context.Background(), false, socketOp{kind: socketOpBind, endpoint: endpoint})
 	if err != nil {
@@ -234,24 +238,28 @@ func (s *Socket) Bind(endpoint string) (string, error) {
 	return result.text, nil
 }
 
+// Connect connects this socket to an endpoint.
 func (s *Socket) Connect(endpoint string) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpConnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
+// Unbind removes a previously bound endpoint.
 func (s *Socket) Unbind(endpoint string) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnbind, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
+// Disconnect removes a previously connected endpoint.
 func (s *Socket) Disconnect(endpoint string) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpDisconnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
+// Send sends a message, waiting until ctx is done or the socket accepts it.
 func (s *Socket) Send(ctx context.Context, msg Message) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -273,6 +281,7 @@ func (s *Socket) Send(ctx context.Context, msg Message) error {
 	}
 }
 
+// TrySend sends a message without waiting for queue capacity.
 func (s *Socket) TrySend(msg Message) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSend, msg: msg})
 	keepAlive(s)
@@ -288,6 +297,7 @@ func (s *Socket) trySendBatch(messages []Message) (int, error) {
 	return result.count, nil
 }
 
+// SendTimeout sends a message with libzmq-style timeout semantics.
 func (s *Socket) SendTimeout(msg Message, timeout time.Duration) error {
 	if timeout == 0 {
 		return s.TrySend(msg)
@@ -300,6 +310,7 @@ func (s *Socket) SendTimeout(msg Message, timeout time.Duration) error {
 	return s.Send(ctx, msg)
 }
 
+// Recv receives the next complete message.
 func (s *Socket) Recv(ctx context.Context) (Message, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -321,6 +332,7 @@ func (s *Socket) Recv(ctx context.Context) (Message, error) {
 	}
 }
 
+// RecvInto receives a single-part message into dst.
 func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -342,6 +354,7 @@ func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 	}
 }
 
+// TryRecv receives one message without waiting.
 func (s *Socket) TryRecv() (Message, error) {
 	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecv})
 	if err != nil {
@@ -351,6 +364,7 @@ func (s *Socket) TryRecv() (Message, error) {
 	return result.message, nil
 }
 
+// TryRecvInto receives one single-part message into dst without waiting.
 func (s *Socket) TryRecvInto(dst []byte) (int, error) {
 	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecvInto, buffer: dst})
 	if err != nil {
@@ -360,6 +374,7 @@ func (s *Socket) TryRecvInto(dst []byte) (int, error) {
 	return result.count, nil
 }
 
+// RecvTimeout receives one message with libzmq-style timeout semantics.
 func (s *Socket) RecvTimeout(timeout time.Duration) (Message, error) {
 	if timeout == 0 {
 		return s.TryRecv()
@@ -372,6 +387,7 @@ func (s *Socket) RecvTimeout(timeout time.Duration) (Message, error) {
 	return s.Recv(ctx)
 }
 
+// RecvIntoTimeout receives one single-part message into dst with timeout semantics.
 func (s *Socket) RecvIntoTimeout(dst []byte, timeout time.Duration) (int, error) {
 	if timeout == 0 {
 		return s.TryRecvInto(dst)
@@ -384,46 +400,55 @@ func (s *Socket) RecvIntoTimeout(dst []byte, timeout time.Duration) (int, error)
 	return s.RecvInto(ctx, dst)
 }
 
+// Subscribe adds a SUB prefix.
 func (s *Socket) Subscribe(prefix []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
 
+// SubscribeString adds a SUB prefix from a string.
 func (s *Socket) SubscribeString(prefix string) error {
 	return s.Subscribe([]byte(prefix))
 }
 
+// Unsubscribe removes a SUB prefix.
 func (s *Socket) Unsubscribe(prefix []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnsubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
 
+// UnsubscribeString removes a SUB prefix from a string.
 func (s *Socket) UnsubscribeString(prefix string) error {
 	return s.Unsubscribe([]byte(prefix))
 }
 
+// Join adds a DISH group.
 func (s *Socket) Join(group []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpJoin, data: group})
 	keepAlive(s)
 	return err
 }
 
+// JoinString adds a DISH group from a string.
 func (s *Socket) JoinString(group string) error {
 	return s.Join([]byte(group))
 }
 
+// Leave removes a DISH group.
 func (s *Socket) Leave(group []byte) error {
 	_, err := s.do(context.Background(), false, socketOp{kind: socketOpLeave, data: group})
 	keepAlive(s)
 	return err
 }
 
+// LeaveString removes a DISH group from a string.
 func (s *Socket) LeaveString(group string) error {
 	return s.Leave([]byte(group))
 }
 
+// WaitConnected waits until at least minPeers are connected.
 func (s *Socket) WaitConnected(ctx context.Context, minPeers int) (int, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -447,6 +472,7 @@ func (s *Socket) WaitConnected(ctx context.Context, minPeers int) (int, error) {
 	}
 }
 
+// WaitConnectedTimeout waits until at least minPeers are connected.
 func (s *Socket) WaitConnectedTimeout(minPeers int, timeout time.Duration) (int, error) {
 	if timeout == 0 {
 		return s.waitConnectedOnce(context.Background(), minPeers)
@@ -469,6 +495,7 @@ func (s *Socket) waitConnectedOnce(ctx context.Context, minPeers int) (int, erro
 	return value.(int), nil
 }
 
+// WaitSubscribed waits until at least minSubscriptions are visible.
 func (s *Socket) WaitSubscribed(ctx context.Context, minSubscriptions uint64) (uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -492,6 +519,7 @@ func (s *Socket) WaitSubscribed(ctx context.Context, minSubscriptions uint64) (u
 	}
 }
 
+// WaitSubscribedTimeout waits until at least minSubscriptions are visible.
 func (s *Socket) WaitSubscribedTimeout(minSubscriptions uint64, timeout time.Duration) (uint64, error) {
 	if timeout == 0 {
 		return s.waitSubscribedOnce(context.Background(), minSubscriptions)
@@ -514,6 +542,7 @@ func (s *Socket) waitSubscribedOnce(ctx context.Context, minSubscriptions uint64
 	return value.(uint64), nil
 }
 
+// Close closes the socket using configured linger.
 func (s *Socket) Close(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -528,6 +557,7 @@ func (s *Socket) Close(ctx context.Context) error {
 	return s.waitClose(ctx)
 }
 
+// CloseLinger closes the socket with an explicit linger.
 func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -542,6 +572,7 @@ func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 	return s.waitClose(ctx)
 }
 
+// Type returns this socket's type.
 func (s *Socket) Type() SocketType {
 	if s == nil {
 		return 0
@@ -549,6 +580,17 @@ func (s *Socket) Type() SocketType {
 	return s.socketType
 }
 
+// Options returns a copy of options configured through OMQ.go.
+func (s *Socket) Options() SocketOptions {
+	if s == nil {
+		return SocketOptions{}
+	}
+	s.optionsMu.RLock()
+	defer s.optionsMu.RUnlock()
+	return cloneSocketOptions(s.options)
+}
+
+// Run executes fn on the socket owner goroutine.
 func (s *Socket) Run(ctx context.Context, fn func(*BoundSocket) error) error {
 	if fn == nil {
 		return &ConfigError{Err: "nil socket run function"}
@@ -619,6 +661,22 @@ func (s *Socket) releaseAuthCallbacks() {
 	}
 }
 
+func (s *Socket) recordOption(record func(*SocketOptions)) {
+	if record == nil || s == nil {
+		return
+	}
+	s.optionsMu.Lock()
+	record(&s.options)
+	s.optionsMu.Unlock()
+}
+
+func cloneSocketOptions(options SocketOptions) SocketOptions {
+	options.Identity.Value = append([]byte(nil), options.Identity.Value...)
+	options.CompressionDict.Value = append([]byte(nil), options.CompressionDict.Value...)
+	return options
+}
+
+// BoundSocket is a socket handle valid only inside Socket.Run.
 type BoundSocket struct {
 	handle     *nativeSocket
 	socketType SocketType
@@ -628,6 +686,7 @@ type BoundSocket struct {
 	recvRing   *recvRing
 }
 
+// Context returns the Run context.
 func (s *BoundSocket) Context() context.Context {
 	if s == nil || s.ctx == nil {
 		return context.Background()
@@ -635,6 +694,7 @@ func (s *BoundSocket) Context() context.Context {
 	return s.ctx
 }
 
+// Send sends a message from the owner goroutine.
 func (s *BoundSocket) Send(ctx context.Context, msg Message) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -656,6 +716,7 @@ func (s *BoundSocket) Send(ctx context.Context, msg Message) error {
 	}
 }
 
+// TrySend sends without waiting from the owner goroutine.
 func (s *BoundSocket) TrySend(msg Message) error {
 	handled, err := s.trySendRing(msg)
 	if handled {
@@ -664,6 +725,7 @@ func (s *BoundSocket) TrySend(msg Message) error {
 	return socketMessageSendNative(s.handle, msg)
 }
 
+// SendBlocking sends using the Run context until accepted or canceled.
 func (s *BoundSocket) SendBlocking(msg Message) error {
 	ctx := s.Context()
 	for i := 0; ; i++ {
@@ -684,6 +746,7 @@ func (s *BoundSocket) SendBlocking(msg Message) error {
 	return s.Send(ctx, msg)
 }
 
+// RecvInto receives a single-part message into dst.
 func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -705,6 +768,7 @@ func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 	}
 }
 
+// TryRecvInto receives a single-part message into dst without waiting.
 func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
 	ring, err := s.ensureRecvRing()
 	if err != nil {
@@ -713,6 +777,7 @@ func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
 	return ring.tryRecvInto(dst)
 }
 
+// RecvIntoBlocking receives into dst using the Run context.
 func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
 	ctx := s.Context()
 	for i := 0; ; i++ {
@@ -729,18 +794,22 @@ func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
 	}
 }
 
+// RecvView is a borrowed single-part receive view.
 type RecvView struct {
 	data []byte
 }
 
+// Bytes returns the borrowed payload.
 func (v RecvView) Bytes() []byte {
 	return v.data
 }
 
+// Len returns the borrowed payload length.
 func (v RecvView) Len() int {
 	return len(v.data)
 }
 
+// TryRecvView receives a borrowed single-part view without waiting.
 func (s *BoundSocket) TryRecvView() (RecvView, error) {
 	ring, err := s.ensureRecvRing()
 	if err != nil {

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -18,14 +18,52 @@ type Socket struct {
 	closeOnce  sync.Once
 }
 
+type socketOpKind uint8
+
+const (
+	socketOpFunc socketOpKind = iota
+	socketOpBind
+	socketOpConnect
+	socketOpUnbind
+	socketOpDisconnect
+	socketOpSend
+	socketOpSendBatch
+	socketOpRecv
+	socketOpRecvInto
+	socketOpSubscribe
+	socketOpUnsubscribe
+	socketOpJoin
+	socketOpLeave
+	socketOpClose
+	socketOpRun
+)
+
 type socketOp struct {
-	fn   func(*nativeSocket) (any, error)
+	kind          socketOpKind
+	fn            func(*nativeSocket) (any, error)
+	endpoint      string
+	msg           Message
+	messages      []Message
+	buffer        []byte
+	data          []byte
+	linger        time.Duration
+	useConfigured bool
+	run           func(*BoundSocket) error
+	socketType    SocketType
+	call          *socketCall
+}
+
+type socketCall struct {
 	resp chan socketResult
 }
 
 type socketResult struct {
-	value any
-	err   error
+	value   any
+	message Message
+	text    string
+	count   int
+	monitor *nativeMonitor
+	err     error
 }
 
 func newSocket(handle *nativeSocket, socketType SocketType) *Socket {
@@ -39,6 +77,12 @@ func newSocket(handle *nativeSocket, socketType SocketType) *Socket {
 	return socket
 }
 
+var socketCallPool = sync.Pool{
+	New: func() any {
+		return &socketCall{resp: make(chan socketResult, 1)}
+	},
+}
+
 func (s *Socket) ownerLoop() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -46,81 +90,136 @@ func (s *Socket) ownerLoop() {
 
 	handle := s.handle
 	for op := range s.ops {
-		value, err := op.fn(handle)
-		op.resp <- socketResult{value: value, err: err}
+		op.call.resp <- runSocketOp(handle, op)
 	}
 	if handle != nil {
 		socketFreeNative(handle)
 	}
 }
 
+func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
+	switch op.kind {
+	case socketOpFunc:
+		value, err := op.fn(handle)
+		return socketResult{value: value, err: err}
+	case socketOpBind:
+		text, err := socketBindNative(handle, op.endpoint)
+		return socketResult{text: text, err: err}
+	case socketOpConnect:
+		return socketResult{err: socketConnectNative(handle, op.endpoint)}
+	case socketOpUnbind:
+		return socketResult{err: socketUnbindNative(handle, op.endpoint)}
+	case socketOpDisconnect:
+		return socketResult{err: socketDisconnectNative(handle, op.endpoint)}
+	case socketOpSend:
+		return socketResult{err: socketMessageSendNative(handle, op.msg)}
+	case socketOpSendBatch:
+		count, err := socketMessagesTrySendNative(handle, op.messages)
+		return socketResult{count: count, err: err}
+	case socketOpRecv:
+		msg, err := socketMessageRecvNative(handle)
+		return socketResult{message: msg, err: err}
+	case socketOpRecvInto:
+		count, err := socketMessageRecvIntoNative(handle, op.buffer)
+		return socketResult{count: count, err: err}
+	case socketOpSubscribe:
+		return socketResult{err: socketSubscribeNative(handle, op.data)}
+	case socketOpUnsubscribe:
+		return socketResult{err: socketUnsubscribeNative(handle, op.data)}
+	case socketOpJoin:
+		return socketResult{err: socketJoinNative(handle, op.data)}
+	case socketOpLeave:
+		return socketResult{err: socketLeaveNative(handle, op.data)}
+	case socketOpClose:
+		return socketResult{err: socketCloseNative(handle, op.linger, op.useConfigured)}
+	case socketOpRun:
+		bound := &BoundSocket{handle: handle, socketType: op.socketType}
+		err := op.run(bound)
+		closeErr := bound.close()
+		if err != nil {
+			return socketResult{err: err}
+		}
+		return socketResult{err: closeErr}
+	default:
+		return socketResult{err: &ConfigError{Err: "unknown socket op"}}
+	}
+}
+
 func (s *Socket) call(ctx context.Context, allowClosed bool, fn func(*nativeSocket) (any, error)) (value any, err error) {
+	result, err := s.do(ctx, allowClosed, socketOp{kind: socketOpFunc, fn: fn})
+	if err != nil {
+		return nil, err
+	}
+	return result.value, result.err
+}
+
+func (s *Socket) do(ctx context.Context, allowClosed bool, op socketOp) (result socketResult, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if s == nil || s.ops == nil {
-		return nil, ErrClosed
+		return socketResult{}, ErrClosed
 	}
 	if !allowClosed && s.closed.Load() {
-		return nil, ErrClosed
+		return socketResult{}, ErrClosed
 	}
 	defer func() {
 		if recover() != nil {
-			value = nil
+			result = socketResult{}
 			err = ErrClosed
 		}
 	}()
 
-	resp := make(chan socketResult, 1)
-	op := socketOp{fn: fn, resp: resp}
+	call := socketCallPool.Get().(*socketCall)
+	op.call = call
+	putCall := true
+	defer func() {
+		if putCall {
+			socketCallPool.Put(call)
+		}
+	}()
 	select {
 	case s.ops <- op:
 	case <-s.ownerDone:
-		return nil, ErrClosed
+		return socketResult{}, ErrClosed
 	case <-ctx.Done():
-		return nil, errFromContext(ctx)
+		return socketResult{}, errFromContext(ctx)
 	}
 	select {
-	case result := <-resp:
-		return result.value, result.err
+	case result := <-call.resp:
+		return result, result.err
 	case <-s.ownerDone:
-		return nil, ErrClosed
+		putCall = false
+		return socketResult{}, ErrClosed
 	case <-ctx.Done():
-		return nil, errFromContext(ctx)
+		putCall = false
+		return socketResult{}, errFromContext(ctx)
 	}
 }
 
 func (s *Socket) Bind(endpoint string) (string, error) {
-	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return socketBindNative(handle, endpoint)
-	})
+	result, err := s.do(context.Background(), false, socketOp{kind: socketOpBind, endpoint: endpoint})
 	if err != nil {
 		return "", err
 	}
 	keepAlive(s)
-	return value.(string), nil
+	return result.text, nil
 }
 
 func (s *Socket) Connect(endpoint string) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketConnectNative(handle, endpoint)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpConnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) Unbind(endpoint string) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketUnbindNative(handle, endpoint)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnbind, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) Disconnect(endpoint string) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketDisconnectNative(handle, endpoint)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpDisconnect, endpoint: endpoint})
 	keepAlive(s)
 	return err
 }
@@ -140,33 +239,25 @@ func (s *Socket) Send(ctx context.Context, msg Message) error {
 		if !errors.Is(err, ErrAgain) {
 			return err
 		}
-		timer := time.NewTimer(retryDelay(i))
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return errFromContext(ctx)
-		case <-timer.C:
+		if err := waitRetry(ctx, i); err != nil {
+			return err
 		}
 	}
 }
 
 func (s *Socket) TrySend(msg Message) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketMessageSendNative(handle, msg)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSend, msg: msg})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) trySendBatch(messages []Message) (int, error) {
-	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return socketMessagesTrySendNative(handle, messages)
-	})
+	result, err := s.do(context.Background(), false, socketOp{kind: socketOpSendBatch, messages: messages})
 	if err != nil {
 		return 0, err
 	}
 	keepAlive(s)
-	return value.(int), nil
+	return result.count, nil
 }
 
 func (s *Socket) SendTimeout(msg Message, timeout time.Duration) error {
@@ -196,25 +287,49 @@ func (s *Socket) Recv(ctx context.Context) (Message, error) {
 		if !errors.Is(err, ErrAgain) {
 			return Message{}, err
 		}
-		timer := time.NewTimer(retryDelay(i))
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return Message{}, errFromContext(ctx)
-		case <-timer.C:
+		if err := waitRetry(ctx, i); err != nil {
+			return Message{}, err
+		}
+	}
+}
+
+func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return 0, err
+		}
+		n, err := s.TryRecvInto(dst)
+		if err == nil {
+			return n, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return 0, err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return 0, err
 		}
 	}
 }
 
 func (s *Socket) TryRecv() (Message, error) {
-	value, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return socketMessageRecvNative(handle)
-	})
+	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecv})
 	if err != nil {
 		return Message{}, err
 	}
 	keepAlive(s)
-	return value.(Message), nil
+	return result.message, nil
+}
+
+func (s *Socket) TryRecvInto(dst []byte) (int, error) {
+	result, err := s.do(context.Background(), false, socketOp{kind: socketOpRecvInto, buffer: dst})
+	if err != nil {
+		return 0, err
+	}
+	keepAlive(s)
+	return result.count, nil
 }
 
 func (s *Socket) RecvTimeout(timeout time.Duration) (Message, error) {
@@ -229,34 +344,38 @@ func (s *Socket) RecvTimeout(timeout time.Duration) (Message, error) {
 	return s.Recv(ctx)
 }
 
+func (s *Socket) RecvIntoTimeout(dst []byte, timeout time.Duration) (int, error) {
+	if timeout == 0 {
+		return s.TryRecvInto(dst)
+	}
+	if timeout < 0 {
+		return s.RecvInto(context.Background(), dst)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.RecvInto(ctx, dst)
+}
+
 func (s *Socket) Subscribe(prefix []byte) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketSubscribeNative(handle, prefix)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpSubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) Unsubscribe(prefix []byte) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketUnsubscribeNative(handle, prefix)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpUnsubscribe, data: prefix})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) Join(group []byte) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketJoinNative(handle, group)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpJoin, data: group})
 	keepAlive(s)
 	return err
 }
 
 func (s *Socket) Leave(group []byte) error {
-	_, err := s.call(context.Background(), false, func(handle *nativeSocket) (any, error) {
-		return nil, socketLeaveNative(handle, group)
-	})
+	_, err := s.do(context.Background(), false, socketOp{kind: socketOpLeave, data: group})
 	keepAlive(s)
 	return err
 }
@@ -271,9 +390,7 @@ func (s *Socket) Close(ctx context.Context) error {
 	var err error
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
-		_, err = s.call(ctx, true, func(handle *nativeSocket) (any, error) {
-			return nil, socketCloseNative(handle, 0, true)
-		})
+		_, err = s.do(ctx, true, socketOp{kind: socketOpClose, useConfigured: true})
 		close(s.ops)
 		<-s.ownerDone
 		s.handle = nil
@@ -292,9 +409,7 @@ func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 	var err error
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
-		_, err = s.call(ctx, true, func(handle *nativeSocket) (any, error) {
-			return nil, socketCloseNative(handle, linger, false)
-		})
+		_, err = s.do(ctx, true, socketOp{kind: socketOpClose, linger: linger})
 		close(s.ops)
 		<-s.ownerDone
 		s.handle = nil
@@ -310,6 +425,15 @@ func (s *Socket) Type() SocketType {
 	return s.socketType
 }
 
+func (s *Socket) Run(ctx context.Context, fn func(*BoundSocket) error) error {
+	if fn == nil {
+		return &ConfigError{Err: "nil socket run function"}
+	}
+	_, err := s.do(ctx, false, socketOp{kind: socketOpRun, run: fn, socketType: s.socketType})
+	keepAlive(s)
+	return err
+}
+
 func (s *Socket) free() {
 	if s == nil || s.ops == nil {
 		return
@@ -319,4 +443,172 @@ func (s *Socket) free() {
 
 func (s *Socket) noFinalizer() {
 	runtime.SetFinalizer(s, nil)
+}
+
+type BoundSocket struct {
+	handle     *nativeSocket
+	socketType SocketType
+	sendRing   *sendRing
+	recvRing   *recvRing
+}
+
+func (s *BoundSocket) Send(ctx context.Context, msg Message) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return err
+		}
+		err := s.TrySend(msg)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *BoundSocket) TrySend(msg Message) error {
+	handled, err := s.trySendRing(msg)
+	if handled {
+		return err
+	}
+	return socketMessageSendNative(s.handle, msg)
+}
+
+func (s *BoundSocket) SendBlocking(msg Message) error {
+	for i := 0; ; i++ {
+		handled, err := s.trySendRing(msg)
+		if !handled {
+			break
+		}
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return err
+		}
+		if err := waitRetry(context.Background(), i); err != nil {
+			return err
+		}
+	}
+	return socketMessageSendWaitNative(s.handle, msg)
+}
+
+func (s *BoundSocket) RecvInto(ctx context.Context, dst []byte) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for i := 0; ; i++ {
+		if err := errFromContext(ctx); err != nil {
+			return 0, err
+		}
+		n, err := socketMessageRecvIntoNative(s.handle, dst)
+		if err == nil {
+			return n, nil
+		}
+		if !errors.Is(err, ErrAgain) {
+			return 0, err
+		}
+		if err := waitRetry(ctx, i); err != nil {
+			return 0, err
+		}
+	}
+}
+
+func (s *BoundSocket) TryRecvInto(dst []byte) (int, error) {
+	ring, err := s.ensureRecvRing()
+	if err != nil {
+		return 0, err
+	}
+	return ring.tryRecvInto(dst)
+}
+
+func (s *BoundSocket) RecvIntoBlocking(dst []byte) (int, error) {
+	ring, err := s.ensureRecvRing()
+	if err != nil {
+		return 0, err
+	}
+	return ring.recvIntoBlocking(dst)
+}
+
+type RecvView struct {
+	data []byte
+}
+
+func (v RecvView) Bytes() []byte {
+	return v.data
+}
+
+func (v RecvView) Len() int {
+	return len(v.data)
+}
+
+func (s *BoundSocket) TryRecvView() (RecvView, error) {
+	ring, err := s.ensureRecvRing()
+	if err != nil {
+		return RecvView{}, err
+	}
+	return ring.tryRecvView()
+}
+
+func (s *BoundSocket) trySendRing(msg Message) (bool, error) {
+	if s.socketType != Push && s.socketType != Scatter {
+		return false, nil
+	}
+	parts := msg.partsView()
+	if len(parts) != 1 {
+		return false, nil
+	}
+	ring, err := s.ensureSendRing()
+	if err != nil {
+		return true, err
+	}
+	return ring.trySend(parts[0])
+}
+
+func (s *BoundSocket) ensureSendRing() (*sendRing, error) {
+	if s.sendRing != nil {
+		return s.sendRing, nil
+	}
+	ring, err := newSendRing(s.handle)
+	if err != nil {
+		return nil, err
+	}
+	s.sendRing = ring
+	return ring, nil
+}
+
+func (s *BoundSocket) ensureRecvRing() (*recvRing, error) {
+	if s.recvRing != nil {
+		return s.recvRing, nil
+	}
+	ring, err := newRecvRing(s.handle)
+	if err != nil {
+		return nil, err
+	}
+	s.recvRing = ring
+	return ring, nil
+}
+
+func (s *BoundSocket) close() error {
+	err := socketRecvViewClearNative(s.handle)
+	if s.recvRing != nil {
+		s.recvRing.close()
+		s.recvRing = nil
+	}
+	if s.sendRing == nil {
+		return err
+	}
+	closeErr := s.sendRing.close()
+	s.sendRing = nil
+	if err != nil {
+		return err
+	}
+	return closeErr
 }

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -18,7 +18,9 @@ type Socket struct {
 	closed     atomic.Bool
 	ops        chan socketOp
 	ownerDone  chan struct{}
+	closeDone  chan struct{}
 	closeOnce  sync.Once
+	closeErr   error
 }
 
 type socketOpKind uint8
@@ -86,6 +88,7 @@ func newSocket(
 		overrun:    overrun,
 		ops:        make(chan socketOp, 1024),
 		ownerDone:  make(chan struct{}),
+		closeDone:  make(chan struct{}),
 	}
 	go socket.ownerLoop()
 	return socket
@@ -516,19 +519,11 @@ func (s *Socket) Close(ctx context.Context) error {
 	if s == nil || s.ops == nil {
 		return nil
 	}
-	var err error
 	s.closeOnce.Do(func() {
-		s.closed.Store(true)
-		_, err = s.do(ctx, true, socketOp{kind: socketOpClose, useConfigured: true})
-		close(s.ops)
-		<-s.ownerDone
-		s.handle = nil
-		if s.owner != nil {
-			s.owner.removeSocket(s)
-		}
+		s.startClose(socketOp{kind: socketOpClose, useConfigured: true})
 	})
 	keepAlive(s)
-	return err
+	return s.waitClose(ctx)
 }
 
 func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
@@ -538,19 +533,11 @@ func (s *Socket) CloseLinger(ctx context.Context, linger time.Duration) error {
 	if s == nil || s.ops == nil {
 		return nil
 	}
-	var err error
 	s.closeOnce.Do(func() {
-		s.closed.Store(true)
-		_, err = s.do(ctx, true, socketOp{kind: socketOpClose, linger: linger})
-		close(s.ops)
-		<-s.ownerDone
-		s.handle = nil
-		if s.owner != nil {
-			s.owner.removeSocket(s)
-		}
+		s.startClose(socketOp{kind: socketOpClose, linger: linger})
 	})
 	keepAlive(s)
-	return err
+	return s.waitClose(ctx)
 }
 
 func (s *Socket) Type() SocketType {
@@ -583,6 +570,30 @@ func (s *Socket) free() {
 		return
 	}
 	_ = s.Close(context.Background())
+}
+
+func (s *Socket) startClose(op socketOp) {
+	s.closed.Store(true)
+	go func() {
+		_, err := s.do(context.Background(), true, op)
+		close(s.ops)
+		<-s.ownerDone
+		s.handle = nil
+		if s.owner != nil {
+			s.owner.removeSocket(s)
+		}
+		s.closeErr = err
+		close(s.closeDone)
+	}()
+}
+
+func (s *Socket) waitClose(ctx context.Context) error {
+	select {
+	case <-s.closeDone:
+		return s.closeErr
+	case <-ctx.Done():
+		return errFromContext(ctx)
+	}
 }
 
 func (s *Socket) noFinalizer() {

--- a/bindings/go/socket_test.go
+++ b/bindings/go/socket_test.go
@@ -1,0 +1,139 @@
+package omq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSendCopiesBeforeCallerCanMutate(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-send-copy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte("before")
+	if err := push.SendTimeout(Bytes(body), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	body[0] = 'x'
+	assertRecvString(t, pull, "before")
+}
+
+func TestRecvIntoRejectsTooSmallDestination(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-recv-into-small")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("larger"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2)
+	if _, err := pull.RecvIntoTimeout(buf, time.Second); !isMessageTooLarge(err) {
+		t.Fatalf("RecvIntoTimeout err = %v, want MessageTooLargeError", err)
+	}
+}
+
+func TestRecvIntoRejectsMultipart(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("inproc://go-recv-into-multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(Multipart([]byte("a"), []byte("b")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 8)
+	if _, err := pull.RecvIntoTimeout(buf, time.Second); !isConfigError(err) {
+		t.Fatalf("RecvIntoTimeout err = %v, want ConfigError", err)
+	}
+}
+
+func TestReqRepRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	rep := newTestSocket(t, ctx, Rep)
+	defer closeSocket(t, rep)
+	req := newTestSocket(t, ctx, Req)
+	defer closeSocket(t, req)
+
+	endpoint, err := rep.Bind("inproc://go-req-rep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := req.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := req.SendTimeout(String("question"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	query, err := rep.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := query.String(); got != "question" {
+		t.Fatalf("query = %q, want question", got)
+	}
+	if err := rep.SendTimeout(String("answer"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := req.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reply.String(); got != "answer" {
+		t.Fatalf("reply = %q, want answer", got)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	if err := pull.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := pull.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func isMessageTooLarge(err error) bool {
+	var tooLarge *MessageTooLargeError
+	return errors.As(err, &tooLarge)
+}

--- a/bindings/go/socket_types_test.go
+++ b/bindings/go/socket_types_test.go
@@ -124,6 +124,104 @@ func TestChannelAndPairRoundTrip(t *testing.T) {
 	testBidirectionalInproc(t, Pair, "inproc://go-pair", "x", "y")
 }
 
+func TestPeerRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	a, err := ctx.Socket(Peer, Identity([]byte("peer-a")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, a)
+	b, err := ctx.Socket(Peer, Identity([]byte("peer-b")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, b)
+
+	endpoint, err := a.Bind("inproc://go-peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SendTimeout(Multipart([]byte("peer-a"), []byte("hello a")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	got, err := a.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(Multipart([]byte("peer-b"), []byte("hello a"))) {
+		t.Fatalf("message = %#v", got.Parts())
+	}
+	if err := a.SendTimeout(Multipart([]byte("peer-b"), []byte("hello b")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	got, err = b.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(Multipart([]byte("peer-a"), []byte("hello b"))) {
+		t.Fatalf("message = %#v", got.Parts())
+	}
+}
+
+func TestClientServerMultipleClients(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	server := newTestSocket(t, ctx, Server)
+	defer closeSocket(t, server)
+	clients := make([]*Socket, 3)
+	for i := range clients {
+		client, err := ctx.Socket(Client, Identity([]byte{'c', byte('0' + i)}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer closeSocket(t, client)
+		clients[i] = client
+	}
+
+	endpoint, err := server.Bind("inproc://go-client-server-many")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, client := range clients {
+		if err := client.Connect(endpoint); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, client := range clients {
+		if err := client.SendTimeout(String("from-"+string(rune('0'+i))), time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < len(clients); i++ {
+		request, err := server.RecvTimeout(time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if request.Len() != 2 {
+			t.Fatalf("request parts = %#v", request.Parts())
+		}
+		reply := Route(request.Route(), String("re:"+string(request.Part(1))))
+		if err := server.SendTimeout(reply, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, client := range clients {
+		msg, err := client.RecvTimeout(time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := msg.String(); len(got) < 3 || got[:3] != "re:" {
+			t.Fatalf("reply = %q, want re:*", got)
+		}
+	}
+}
+
 func testBidirectionalInproc(t *testing.T, socketType SocketType, endpoint, first, second string) {
 	t.Helper()
 	ctx := openTestContext(t)

--- a/bindings/go/socket_types_test.go
+++ b/bindings/go/socket_types_test.go
@@ -1,0 +1,322 @@
+package omq
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDealerRouterRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	router := newTestSocket(t, ctx, Router)
+	defer closeSocket(t, router)
+	dealer, err := ctx.Socket(Dealer, Identity([]byte("dealer-1")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, dealer)
+
+	endpoint, err := router.Bind("inproc://go-dealer-router")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dealer.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := dealer.SendTimeout(String("hello"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	request, err := router.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Len() != 2 || string(request.Part(0)) != "dealer-1" || string(request.Part(1)) != "hello" {
+		t.Fatalf("request parts = %#v", request.Parts())
+	}
+	if err := router.SendTimeout(Route(request.Part(0), String("world")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := dealer.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reply.String(); got != "world" {
+		t.Fatalf("reply = %q, want world", got)
+	}
+}
+
+func TestClientServerRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	server := newTestSocket(t, ctx, Server)
+	defer closeSocket(t, server)
+	client, err := ctx.Socket(Client, Identity([]byte("client-1")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSocket(t, client)
+
+	endpoint, err := server.Bind("inproc://go-client-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.SendTimeout(String("ping"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	request, err := server.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Len() != 2 || string(request.Part(0)) != "client-1" || string(request.Part(1)) != "ping" {
+		t.Fatalf("request parts = %#v", request.Parts())
+	}
+	if err := server.SendTimeout(Route(request.Part(0), String("pong")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := client.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reply.String(); got != "pong" {
+		t.Fatalf("reply = %q, want pong", got)
+	}
+}
+
+func TestScatterGatherRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	gather := newTestSocket(t, ctx, Gather)
+	defer closeSocket(t, gather)
+	scatter := newTestSocket(t, ctx, Scatter)
+	defer closeSocket(t, scatter)
+
+	endpoint, err := gather.Bind("inproc://go-scatter-gather")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scatter.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := scatter.SendTimeout(String("work"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := gather.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != "work" {
+		t.Fatalf("message = %q, want work", got)
+	}
+}
+
+func TestChannelAndPairRoundTrip(t *testing.T) {
+	testBidirectionalInproc(t, Channel, "inproc://go-channel", "one", "two")
+	testBidirectionalInproc(t, Pair, "inproc://go-pair", "x", "y")
+}
+
+func testBidirectionalInproc(t *testing.T, socketType SocketType, endpoint, first, second string) {
+	t.Helper()
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	a := newTestSocket(t, ctx, socketType)
+	defer closeSocket(t, a)
+	b := newTestSocket(t, ctx, socketType)
+	defer closeSocket(t, b)
+
+	bound, err := a.Bind(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Connect(bound); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SendTimeout(String(first), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := b.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != first {
+		t.Fatalf("message = %q, want %q", got, first)
+	}
+	if err := b.SendTimeout(String(second), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	msg, err = a.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg.String(); got != second {
+		t.Fatalf("message = %q, want %q", got, second)
+	}
+}
+
+func TestSinglePartSocketsRejectMultipart(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	tests := []struct {
+		name       string
+		socketType SocketType
+		endpoint   string
+		message    Message
+	}{
+		{name: "client", socketType: Client, endpoint: "inproc://go-client-rejects-multipart", message: Multipart([]byte("a"), []byte("b"))},
+		{name: "server", socketType: Server, endpoint: "inproc://go-server-requires-routing", message: String("missing-routing-id")},
+		{name: "scatter", socketType: Scatter, endpoint: "inproc://go-scatter-rejects-multipart", message: Multipart([]byte("a"), []byte("b"))},
+		{name: "channel", socketType: Channel, endpoint: "inproc://go-channel-rejects-multipart", message: Multipart([]byte("a"), []byte("b"))},
+		{name: "radio", socketType: Radio, endpoint: "inproc://go-radio-requires-group", message: String("missing-group")},
+	}
+	for _, test := range tests {
+		socket := newTestSocket(t, ctx, test.socketType)
+		if _, err := socket.Bind(test.endpoint); err != nil {
+			t.Fatal(err)
+		}
+		err := socket.SendTimeout(test.message, time.Second)
+		closeSocket(t, socket)
+		if !isProtocolError(err) {
+			t.Fatalf("%s send err = %v, want ProtocolError", test.name, err)
+		}
+	}
+}
+
+func TestRadioDishFiltersGroupsAndStringHelpers(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	radio := newTestSocket(t, ctx, Radio)
+	defer closeSocket(t, radio)
+	dish := newTestSocket(t, ctx, Dish)
+	defer closeSocket(t, dish)
+
+	endpoint, err := radio.Bind("inproc://go-radio-dish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dish.JoinString("weather"); err != nil {
+		t.Fatal(err)
+	}
+	if err := dish.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := radio.WaitConnectedTimeout(1, time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := radio.SendTimeout(Group("news", []byte("ignored")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := radio.SendTimeout(Group("weather", []byte("sunny")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	received, err := dish.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if received.Len() != 2 || string(received.Part(0)) != "weather" || string(received.Part(1)) != "sunny" {
+		t.Fatalf("received parts = %#v", received.Parts())
+	}
+
+	if err := dish.LeaveString("weather"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if err := radio.SendTimeout(Group("weather", []byte("rain")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dish.RecvTimeout(150 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+}
+
+func TestJoinOnWrongSocketTypeIsProtocolError(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	if _, err := pull.Bind("inproc://go-join-wrong-type"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pull.JoinString("g"); !isProtocolError(err) {
+		t.Fatalf("Join err = %v, want ProtocolError", err)
+	}
+}
+
+func TestStreamRawTCPRoundTrip(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	stream := newTestSocket(t, ctx, Stream)
+	defer closeSocket(t, stream)
+	endpoint, err := stream.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := strings.TrimPrefix(endpoint, "tcp://")
+	raw, err := net.DialTimeout("tcp", address, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if err := raw.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	connected, err := stream.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := connected.Part(0)
+	if connected.Len() != 2 || len(identity) == 0 || len(connected.Part(1)) != 0 {
+		t.Fatalf("connected parts = %#v", connected.Parts())
+	}
+	data, err := stream.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Len() != 2 || string(data.Part(0)) != string(identity) || string(data.Part(1)) != "hello" {
+		t.Fatalf("data parts = %#v", data.Parts())
+	}
+	if err := stream.SendTimeout(Route(identity, String("world")), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, 5)
+	if _, err := raw.Read(reply); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply) != "world" {
+		t.Fatalf("raw reply = %q, want world", reply)
+	}
+}
+
+func TestStreamRejectsNonTCPTransports(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	stream := newTestSocket(t, ctx, Stream)
+	defer closeSocket(t, stream)
+	if _, err := stream.Bind("inproc://go-stream-inproc"); !isProtocolError(err) {
+		t.Fatalf("Bind err = %v, want ProtocolError", err)
+	}
+}
+
+func isProtocolError(err error) bool {
+	var protocol *ProtocolError
+	return errors.As(err, &protocol)
+}

--- a/bindings/go/socket_types_test.go
+++ b/bindings/go/socket_types_test.go
@@ -146,6 +146,9 @@ func TestPeerRoundTrip(t *testing.T) {
 	if err := b.Connect(endpoint); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := b.WaitConnectedTimeout(1, time.Second); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.SendTimeout(Multipart([]byte("peer-a"), []byte("hello a")), time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -298,6 +301,11 @@ func TestRadioDishFiltersGroupsAndStringHelpers(t *testing.T) {
 	defer closeSocket(t, radio)
 	dish := newTestSocket(t, ctx, Dish)
 	defer closeSocket(t, dish)
+	monitor, err := radio.Monitor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer monitor.Close()
 
 	endpoint, err := radio.Bind("inproc://go-radio-dish")
 	if err != nil {
@@ -312,6 +320,7 @@ func TestRadioDishFiltersGroupsAndStringHelpers(t *testing.T) {
 	if _, err := radio.WaitConnectedTimeout(1, time.Second); err != nil {
 		t.Fatal(err)
 	}
+	_ = receiveMonitorKind(t, monitor, "JOIN_RECEIVED")
 
 	if err := radio.SendTimeout(Group("news", []byte("ignored")), time.Second); err != nil {
 		t.Fatal(err)

--- a/bindings/go/time_test.go
+++ b/bindings/go/time_test.go
@@ -1,0 +1,24 @@
+package omq
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDurationMillisRoundsPositiveDurationsUp(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		want     int64
+	}{
+		{duration: 0, want: 0},
+		{duration: time.Nanosecond, want: 1},
+		{duration: time.Millisecond, want: 1},
+		{duration: time.Millisecond + time.Nanosecond, want: 2},
+		{duration: -time.Nanosecond, want: -1},
+	}
+	for _, test := range tests {
+		if got := durationMillis(test.duration); got != test.want {
+			t.Fatalf("durationMillis(%s) = %d, want %d", test.duration, got, test.want)
+		}
+	}
+}

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -103,3 +103,23 @@ type ShareKey struct {
 	High uint64
 	Low  uint64
 }
+
+type CurveKeypair struct {
+	Public string
+	Secret string
+}
+
+type WorkloadProfile int32
+
+const (
+	WorkloadThroughput WorkloadProfile = iota
+	WorkloadLatency
+)
+
+type OnMute int32
+
+const (
+	OnMuteBlock OnMute = iota
+	OnMuteDropNewest
+	OnMuteDropOldest
+)

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -1,27 +1,48 @@
 package omq
 
+// SocketType identifies an OMQ socket type.
 type SocketType int32
 
 const (
+	// Pair is a bidirectional exclusive 1:1 socket.
 	Pair SocketType = iota + 1
+	// Pub publishes topic-prefixed messages to Sub sockets.
 	Pub
+	// Sub receives subscribed topic prefixes from Pub sockets.
 	Sub
+	// Req sends one request and then receives one reply.
 	Req
+	// Rep receives one request and then sends one reply.
 	Rep
+	// Dealer is an async request/reply socket without the REQ FSM.
 	Dealer
+	// Router routes multipart messages by leading identity frame.
 	Router
+	// Pull fair-queues messages from Push sockets.
 	Pull
+	// Push round-robins messages to Pull sockets.
 	Push
+	// XPub exposes raw subscription frames.
 	XPub
+	// XSub sends raw subscription frames upstream.
 	XSub
+	// Stream bridges raw TCP connections.
 	Stream
+	// Server is a single-part ROUTER-style socket.
 	Server
+	// Client is a single-part DEALER-style socket.
 	Client
+	// Radio publishes group-addressed messages to Dish sockets.
 	Radio
+	// Dish receives joined groups from Radio sockets.
 	Dish
+	// Gather fair-queues single-part messages from Scatter sockets.
 	Gather
+	// Scatter round-robins single-part messages to Gather sockets.
 	Scatter
+	// Peer is a bidirectional identity-routed peer socket.
 	Peer
+	// Channel is a bidirectional single-part PAIR-style socket.
 	Channel
 )
 
@@ -90,49 +111,78 @@ func (t SocketType) canRecv() bool {
 	}
 }
 
+// OverrunPolicy controls how channel adapters handle full Go channels.
 type OverrunPolicy int
 
 const (
+	// OverrunBlock blocks until channel space is available.
 	OverrunBlock OverrunPolicy = iota
+	// OverrunDropOldest drops the oldest channel item.
 	OverrunDropOldest
+	// OverrunDropNewest drops the newest incoming item.
 	OverrunDropNewest
+	// OverrunReturnError reports an overrun through the error channel.
 	OverrunReturnError
 )
 
+// ShareKey identifies a process-local shared native context.
 type ShareKey struct {
+	// High is the high 64 bits of the share key.
 	High uint64
-	Low  uint64
+	// Low is the low 64 bits of the share key.
+	Low uint64
 }
 
+// CurveKeypair is a Z85 CURVE public/secret key pair.
 type CurveKeypair struct {
+	// Public is the Z85 public key.
 	Public string
+	// Secret is the Z85 secret key.
 	Secret string
 }
 
+// PeerInfo describes a peer seen by auth callbacks or monitor events.
 type PeerInfo struct {
-	Mechanism    string
-	PublicKey    string
-	Identity     []byte
-	Username     string
-	Password     string
+	// Mechanism is the ZMTP mechanism name.
+	Mechanism string
+	// PublicKey is the peer CURVE public key.
+	PublicKey string
+	// Identity is the peer routing identity.
+	Identity []byte
+	// Username is the PLAIN username.
+	Username string
+	// Password is the PLAIN password.
+	Password string
+	// ConnectionID is the native per-socket connection id.
 	ConnectionID uint64
-	PeerAddress  string
-	SocketType   string
-	ZMTPMajor    uint8
-	ZMTPMinor    uint8
+	// PeerAddress is the remote TCP address when known.
+	PeerAddress string
+	// SocketType is the peer READY socket type when known.
+	SocketType string
+	// ZMTPMajor is the negotiated ZMTP major version.
+	ZMTPMajor uint8
+	// ZMTPMinor is the negotiated ZMTP minor version.
+	ZMTPMinor uint8
 }
 
+// WorkloadProfile selects native throughput or latency tuning.
 type WorkloadProfile int32
 
 const (
+	// WorkloadThroughput favors batching and throughput.
 	WorkloadThroughput WorkloadProfile = iota
+	// WorkloadLatency favors lower latency.
 	WorkloadLatency
 )
 
+// OnMute controls native send behavior when outbound queues are full.
 type OnMute int32
 
 const (
+	// OnMuteBlock waits for queue capacity.
 	OnMuteBlock OnMute = iota
+	// OnMuteDropNewest drops the newest message on mute.
 	OnMuteDropNewest
+	// OnMuteDropOldest drops the oldest queued message on mute.
 	OnMuteDropOldest
 )

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -1,0 +1,105 @@
+package omq
+
+type SocketType int32
+
+const (
+	Pair SocketType = iota + 1
+	Pub
+	Sub
+	Req
+	Rep
+	Dealer
+	Router
+	Pull
+	Push
+	XPub
+	XSub
+	Stream
+	Server
+	Client
+	Radio
+	Dish
+	Gather
+	Scatter
+	Peer
+	Channel
+)
+
+func (t SocketType) String() string {
+	switch t {
+	case Pair:
+		return "PAIR"
+	case Pub:
+		return "PUB"
+	case Sub:
+		return "SUB"
+	case Req:
+		return "REQ"
+	case Rep:
+		return "REP"
+	case Dealer:
+		return "DEALER"
+	case Router:
+		return "ROUTER"
+	case Pull:
+		return "PULL"
+	case Push:
+		return "PUSH"
+	case XPub:
+		return "XPUB"
+	case XSub:
+		return "XSUB"
+	case Stream:
+		return "STREAM"
+	case Server:
+		return "SERVER"
+	case Client:
+		return "CLIENT"
+	case Radio:
+		return "RADIO"
+	case Dish:
+		return "DISH"
+	case Gather:
+		return "GATHER"
+	case Scatter:
+		return "SCATTER"
+	case Peer:
+		return "PEER"
+	case Channel:
+		return "CHANNEL"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func (t SocketType) canSend() bool {
+	switch t {
+	case Sub, Pull, Gather, Dish:
+		return false
+	default:
+		return true
+	}
+}
+
+func (t SocketType) canRecv() bool {
+	switch t {
+	case Pub, Push, Scatter, Radio:
+		return false
+	default:
+		return true
+	}
+}
+
+type OverrunPolicy int
+
+const (
+	OverrunBlock OverrunPolicy = iota
+	OverrunDropOldest
+	OverrunDropNewest
+	OverrunReturnError
+)
+
+type ShareKey struct {
+	High uint64
+	Low  uint64
+}

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -109,6 +109,14 @@ type CurveKeypair struct {
 	Secret string
 }
 
+type PeerInfo struct {
+	Mechanism string
+	PublicKey string
+	Identity  []byte
+	Username  string
+	Password  string
+}
+
 type WorkloadProfile int32
 
 const (

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -110,11 +110,16 @@ type CurveKeypair struct {
 }
 
 type PeerInfo struct {
-	Mechanism string
-	PublicKey string
-	Identity  []byte
-	Username  string
-	Password  string
+	Mechanism    string
+	PublicKey    string
+	Identity     []byte
+	Username     string
+	Password     string
+	ConnectionID uint64
+	PeerAddress  string
+	SocketType   string
+	ZMTPMajor    uint8
+	ZMTPMinor    uint8
 }
 
 type WorkloadProfile int32

--- a/bindings/go/unbind_disconnect_test.go
+++ b/bindings/go/unbind_disconnect_test.go
@@ -1,0 +1,71 @@
+package omq
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDisconnectThenReconnect(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Disconnect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("again"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	assertRecvString(t, pull, "again")
+}
+
+func TestUnbindThenBindAgain(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	pull := newTestSocket(t, ctx, Pull)
+	defer closeSocket(t, pull)
+	push := newTestSocket(t, ctx, Push)
+	defer closeSocket(t, push)
+
+	endpoint, err := pull.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pull.Unbind(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pull.Bind(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := push.WaitConnectedTimeout(1, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := push.SendTimeout(String("after-rebind"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	assertRecvString(t, pull, "after-rebind")
+}

--- a/omq-libzmq/tests/cppzmq/common.hpp
+++ b/omq-libzmq/tests/cppzmq/common.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+#ifndef ZMQ_BUILD_DRAFT_API
+#define ZMQ_BUILD_DRAFT_API
+#endif
+
+#include "zmq.h"
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+static_assert(ZMQ_VERSION_MAJOR == 4, "expected omq-libzmq zmq.h");
+static_assert(ZMQ_VERSION_MINOR == 3, "expected omq-libzmq zmq.h");
+static_assert(ZMQ_VERSION_PATCH == 6, "expected omq-libzmq zmq.h");
+static_assert(sizeof(zmq_msg_t) == 64, "zmq_msg_t ABI size mismatch");
+
+namespace cppzmq_tests {
+inline void expect(bool ok, const char *msg)
+{
+    if (!ok) {
+        throw std::runtime_error(msg);
+    }
+}
+
+inline std::string message_string(const zmq::message_t &msg)
+{
+    return {static_cast<const char *>(msg.data()), msg.size()};
+}
+
+inline void set_timeouts(zmq::socket_t &socket, int ms = 5000)
+{
+    socket.set(zmq::sockopt::linger, 0);
+    socket.set(zmq::sockopt::sndtimeo, ms);
+    socket.set(zmq::sockopt::rcvtimeo, ms);
+}
+
+inline void settle()
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+}
+
+inline std::string bind_random(zmq::socket_t &socket, const std::string &scheme)
+{
+    socket.bind(scheme + "://127.0.0.1:*");
+    return socket.get(zmq::sockopt::last_endpoint);
+}
+
+inline std::string bind_random_tcp(zmq::socket_t &socket)
+{
+    return bind_random(socket, "tcp");
+}
+
+inline std::string bind_random_lz4_tcp(zmq::socket_t &socket)
+{
+    return bind_random(socket, "lz4+tcp");
+}
+
+inline std::string bind_random_zstd_tcp(zmq::socket_t &socket)
+{
+    return bind_random(socket, "zstd+tcp");
+}
+
+inline void send_bytes(zmq::socket_t &socket,
+                       const void *data,
+                       size_t size,
+                       zmq::send_flags flags = zmq::send_flags::none)
+{
+    const auto sent = socket.send(zmq::buffer(data, size), flags);
+    expect(sent && *sent == size, "send failed");
+}
+
+inline void send_string(zmq::socket_t &socket,
+                        const std::string &data,
+                        zmq::send_flags flags = zmq::send_flags::none)
+{
+    send_bytes(socket, data.data(), data.size(), flags);
+}
+
+inline void send_text(zmq::socket_t &socket,
+                      const char *text,
+                      zmq::send_flags flags = zmq::send_flags::none)
+{
+    send_bytes(socket, text, std::strlen(text), flags);
+}
+
+inline void send_two(zmq::socket_t &socket,
+                     const std::string &first,
+                     const std::string &second)
+{
+    send_string(socket, first, zmq::send_flags::sndmore);
+    send_string(socket, second);
+}
+
+inline std::string recv_string(zmq::socket_t &socket)
+{
+    zmq::message_t msg;
+    const auto got = socket.recv(msg, zmq::recv_flags::none);
+    expect(got.has_value(), "recv timed out");
+    expect(*got == msg.size(), "recv size mismatch");
+    return message_string(msg);
+}
+
+inline std::vector<std::string> recv_strings(zmq::socket_t &socket)
+{
+    std::vector<zmq::message_t> messages;
+    const auto got = zmq::recv_multipart(socket, std::back_inserter(messages));
+    expect(got.has_value(), "multipart recv timed out");
+
+    std::vector<std::string> out;
+    out.reserve(messages.size());
+    for (const auto &msg : messages) {
+        out.push_back(message_string(msg));
+    }
+    return out;
+}
+
+inline void expect_payload(const std::string &actual, const char *expected)
+{
+    expect(actual == expected, "payload mismatch");
+}
+
+inline void expect_socket_type(zmq::socket_t &socket, zmq::socket_type expected)
+{
+    expect(socket.get(zmq::sockopt::socket_type) == expected,
+           "socket type mismatch");
+}
+
+inline void expect_size(size_t actual, size_t expected)
+{
+    expect(actual == expected, "part count mismatch");
+}
+
+inline void print_passed(const char *name)
+{
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    zmq::version(&major, &minor, &patch);
+    std::cout << "cppzmq " << name << " passed: " << major << '.' << minor
+              << '.' << patch << '\n';
+}
+} // namespace cppzmq_tests

--- a/omq-libzmq/tests/cppzmq/compression.cpp
+++ b/omq-libzmq/tests/cppzmq/compression.cpp
@@ -1,0 +1,62 @@
+#include "common.hpp"
+
+using namespace cppzmq_tests;
+
+namespace {
+void push_pull_compressed(const char *name,
+                          std::string (*bind_fn)(zmq::socket_t &),
+                          unsigned char byte)
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t push(ctx, zmq::socket_type::push);
+    zmq::socket_t pull(ctx, zmq::socket_type::pull);
+    set_timeouts(push);
+    set_timeouts(pull);
+
+    const std::string endpoint = bind_fn(pull);
+    push.connect(endpoint);
+    settle();
+
+    const std::vector<unsigned char> payload(4096, byte);
+    send_bytes(push, payload.data(), payload.size());
+
+    zmq::message_t msg;
+    const auto got = pull.recv(msg, zmq::recv_flags::none);
+    expect(got && *got == payload.size(), name);
+    expect(msg.size() == payload.size(), "compressed payload size mismatch");
+    const auto *data = static_cast<const unsigned char *>(msg.data());
+    expect(std::equal(data, data + msg.size(), payload.begin()),
+           "compressed payload mismatch");
+}
+
+void pub_sub_compressed(std::string (*bind_fn)(zmq::socket_t &))
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t pub(ctx, zmq::socket_type::pub);
+    zmq::socket_t sub(ctx, zmq::socket_type::sub);
+    set_timeouts(pub);
+    set_timeouts(sub);
+
+    const std::string endpoint = bind_fn(pub);
+    sub.set(zmq::sockopt::subscribe, "metrics");
+    sub.connect(endpoint);
+    settle();
+
+    for (int i = 0; i < 5; ++i) {
+        send_text(pub, "metrics:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
+
+    const std::string got = recv_string(sub);
+    expect_payload(got, "metrics:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+}
+} // namespace
+
+int main()
+{
+    push_pull_compressed("lz4+tcp PUSH/PULL", bind_random_lz4_tcp, 0x42);
+    push_pull_compressed("zstd+tcp PUSH/PULL", bind_random_zstd_tcp, 0x37);
+    pub_sub_compressed(bind_random_lz4_tcp);
+    pub_sub_compressed(bind_random_zstd_tcp);
+    print_passed("compression");
+    return 0;
+}

--- a/omq-libzmq/tests/cppzmq/monitor.cpp
+++ b/omq-libzmq/tests/cppzmq/monitor.cpp
@@ -1,0 +1,88 @@
+#include "common.hpp"
+
+#include <set>
+
+using namespace cppzmq_tests;
+
+namespace {
+class RecordingMonitor : public zmq::monitor_t
+{
+  public:
+    bool wait_for(std::initializer_list<int> wanted)
+    {
+        const std::set<int> target(wanted);
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+        while (std::chrono::steady_clock::now() < deadline) {
+            bool complete = true;
+            for (int event : target) {
+                if (events.count(event) == 0) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (complete) {
+                return true;
+            }
+            check_event(100);
+        }
+        return false;
+    }
+
+    void on_event_listening(const zmq_event_t &event, const char *addr) override
+    {
+        (void)event;
+        events.insert(ZMQ_EVENT_LISTENING);
+        listening_endpoint = addr;
+    }
+
+    void on_event_accepted(const zmq_event_t &event, const char *addr) override
+    {
+        (void)event;
+        (void)addr;
+        events.insert(ZMQ_EVENT_ACCEPTED);
+    }
+
+    void on_event_handshake_succeeded(const zmq_event_t &event,
+                                      const char *addr) override
+    {
+        (void)event;
+        (void)addr;
+        events.insert(ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
+    }
+
+    std::set<int> events;
+    std::string listening_endpoint;
+};
+} // namespace
+
+int main()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t pull(ctx, zmq::socket_type::pull);
+    set_timeouts(pull);
+
+    RecordingMonitor monitor;
+    monitor.init(pull, "inproc://cppzmq-monitor", ZMQ_EVENT_ALL);
+
+    const std::string endpoint = bind_random_tcp(pull);
+    expect(monitor.wait_for({ZMQ_EVENT_LISTENING}), "missing LISTENING event");
+    expect(monitor.listening_endpoint == endpoint, "LISTENING endpoint mismatch");
+
+    zmq::socket_t push(ctx, zmq::socket_type::push);
+    set_timeouts(push);
+    push.connect(endpoint);
+
+    expect(monitor.wait_for(
+               {ZMQ_EVENT_LISTENING, ZMQ_EVENT_ACCEPTED,
+                ZMQ_EVENT_HANDSHAKE_SUCCEEDED}),
+           "missing accepted or handshake monitor event");
+
+    send_text(push, "monitor");
+    expect_payload(recv_string(pull), "monitor");
+
+    monitor.abort();
+    print_passed("monitor");
+    return 0;
+}

--- a/omq-libzmq/tests/cppzmq/socket_types.cpp
+++ b/omq-libzmq/tests/cppzmq/socket_types.cpp
@@ -1,0 +1,395 @@
+#include "common.hpp"
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+using namespace cppzmq_tests;
+
+namespace {
+#ifndef _WIN32
+class RawTcpSocket
+{
+  public:
+    explicit RawTcpSocket(int fd) : fd_(fd) {}
+    RawTcpSocket(const RawTcpSocket &) = delete;
+    RawTcpSocket &operator=(const RawTcpSocket &) = delete;
+    ~RawTcpSocket()
+    {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    void write_all(const char *data, size_t len)
+    {
+        size_t written = 0;
+        while (written < len) {
+            const ssize_t n = ::send(fd_, data + written, len - written, 0);
+            expect(n > 0, "raw TCP send failed");
+            written += static_cast<size_t>(n);
+        }
+    }
+
+    std::string read_some()
+    {
+        char buf[128];
+        const ssize_t n = ::recv(fd_, buf, sizeof(buf), 0);
+        expect(n > 0, "raw TCP recv failed");
+        return {buf, static_cast<size_t>(n)};
+    }
+
+  private:
+    int fd_;
+};
+
+uint16_t port_from_endpoint(const std::string &endpoint)
+{
+    const size_t pos = endpoint.rfind(':');
+    expect(pos != std::string::npos, "bad TCP endpoint");
+    const int port = std::stoi(endpoint.substr(pos + 1));
+    expect(port > 0 && port <= 65535, "bad TCP port");
+    return static_cast<uint16_t>(port);
+}
+
+RawTcpSocket connect_raw_tcp(const std::string &endpoint)
+{
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    expect(fd >= 0, "raw TCP socket failed");
+
+    timeval tv {};
+    tv.tv_sec = 5;
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port_from_endpoint(endpoint));
+    const int parsed = ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+    expect(parsed == 1, "inet_pton failed");
+
+    const int rc =
+        ::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+    expect(rc == 0, "raw TCP connect failed");
+    return RawTcpSocket(fd);
+}
+#endif
+
+void verify_abi()
+{
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    zmq::version(&major, &minor, &patch);
+    expect(major == 4 && minor == 3 && patch == 6,
+           "runtime zmq_version mismatch");
+
+    zmq::context_t ctx(1);
+    expect(ctx.get(zmq::ctxopt::msg_t_size) == 64, "ZMQ_MSG_T_SIZE mismatch");
+}
+
+void pair_inproc()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t a(ctx, zmq::socket_type::pair);
+    zmq::socket_t b(ctx, zmq::socket_type::pair);
+    expect_socket_type(a, zmq::socket_type::pair);
+    expect_socket_type(b, zmq::socket_type::pair);
+    set_timeouts(a);
+    set_timeouts(b);
+
+    a.bind("inproc://cppzmq-pair");
+    b.connect("inproc://cppzmq-pair");
+    settle();
+
+    send_text(a, "pair-a");
+    send_text(b, "pair-b");
+    expect_payload(recv_string(b), "pair-a");
+    expect_payload(recv_string(a), "pair-b");
+}
+
+void push_pull_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t push(ctx, zmq::socket_type::push);
+    zmq::socket_t pull(ctx, zmq::socket_type::pull);
+    expect_socket_type(push, zmq::socket_type::push);
+    expect_socket_type(pull, zmq::socket_type::pull);
+    set_timeouts(push);
+    set_timeouts(pull);
+
+    const std::string endpoint = bind_random_tcp(pull);
+    push.connect(endpoint);
+    settle();
+
+    send_text(push, "push-pull");
+    expect_payload(recv_string(pull), "push-pull");
+}
+
+void pub_sub_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t pub(ctx, zmq::socket_type::pub);
+    zmq::socket_t sub(ctx, zmq::socket_type::sub);
+    expect_socket_type(pub, zmq::socket_type::pub);
+    expect_socket_type(sub, zmq::socket_type::sub);
+    set_timeouts(pub);
+    set_timeouts(sub);
+
+    const std::string endpoint = bind_random_tcp(pub);
+    sub.set(zmq::sockopt::subscribe, "topic");
+    sub.connect(endpoint);
+    settle();
+
+    for (int i = 0; i < 5; ++i) {
+        send_text(pub, "topic-data");
+    }
+    expect_payload(recv_string(sub), "topic-data");
+}
+
+void req_rep_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t req(ctx, zmq::socket_type::req);
+    zmq::socket_t rep(ctx, zmq::socket_type::rep);
+    expect_socket_type(req, zmq::socket_type::req);
+    expect_socket_type(rep, zmq::socket_type::rep);
+    set_timeouts(req);
+    set_timeouts(rep);
+
+    const std::string endpoint = bind_random_tcp(rep);
+    req.connect(endpoint);
+    settle();
+
+    send_text(req, "ping");
+    expect_payload(recv_string(rep), "ping");
+    send_text(rep, "pong");
+    expect_payload(recv_string(req), "pong");
+}
+
+void dealer_router_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t dealer(ctx, zmq::socket_type::dealer);
+    zmq::socket_t router(ctx, zmq::socket_type::router);
+    expect_socket_type(dealer, zmq::socket_type::dealer);
+    expect_socket_type(router, zmq::socket_type::router);
+    set_timeouts(dealer);
+    set_timeouts(router);
+
+    dealer.set(zmq::sockopt::routing_id, "dealer-a");
+    const std::string endpoint = bind_random_tcp(router);
+    dealer.connect(endpoint);
+    settle();
+
+    send_text(dealer, "hello");
+    const std::vector<std::string> request = recv_strings(router);
+    expect_size(request.size(), 2);
+    expect_payload(request[0], "dealer-a");
+    expect_payload(request[1], "hello");
+
+    send_two(router, request[0], "world");
+    expect_payload(recv_string(dealer), "world");
+}
+
+void xpub_xsub_inproc()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t xpub(ctx, zmq::socket_type::xpub);
+    zmq::socket_t xsub(ctx, zmq::socket_type::xsub);
+    expect_socket_type(xpub, zmq::socket_type::xpub);
+    expect_socket_type(xsub, zmq::socket_type::xsub);
+    set_timeouts(xpub);
+    set_timeouts(xsub);
+
+    xpub.bind("inproc://cppzmq-xpub-xsub");
+    xsub.connect("inproc://cppzmq-xpub-xsub");
+    settle();
+
+    const std::string subscription("\001topic", 6);
+    send_string(xsub, subscription);
+    const std::string got_subscription = recv_string(xpub);
+    expect(got_subscription == subscription, "XPUB subscription mismatch");
+
+    send_text(xpub, "topic-body");
+    expect_payload(recv_string(xsub), "topic-body");
+}
+
+void stream_tcp()
+{
+#ifndef _WIN32
+    zmq::context_t ctx(1);
+    zmq::socket_t stream(ctx, zmq::socket_type::stream);
+    expect_socket_type(stream, zmq::socket_type::stream);
+    set_timeouts(stream);
+
+    const std::string endpoint = bind_random_tcp(stream);
+    RawTcpSocket raw = connect_raw_tcp(endpoint);
+
+    std::vector<std::string> frames = recv_strings(stream);
+    expect_size(frames.size(), 2);
+    expect(!frames[0].empty(), "STREAM identity is empty");
+    expect(frames[1].empty(), "STREAM connect notification data not empty");
+    const std::string identity = frames[0];
+
+    raw.write_all("stream-in", 9);
+    frames = recv_strings(stream);
+    expect_size(frames.size(), 2);
+    expect(frames[0] == identity, "STREAM identity mismatch");
+    expect_payload(frames[1], "stream-in");
+
+    send_two(stream, identity, "stream-out");
+    expect_payload(raw.read_some(), "stream-out");
+#endif
+}
+
+void server_client_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t server(ctx, zmq::socket_type::server);
+    zmq::socket_t client(ctx, zmq::socket_type::client);
+    expect_socket_type(server, zmq::socket_type::server);
+    expect_socket_type(client, zmq::socket_type::client);
+    set_timeouts(server);
+    set_timeouts(client);
+
+    const std::string endpoint = bind_random_tcp(server);
+    client.connect(endpoint);
+    settle();
+
+    send_text(client, "request");
+    const std::vector<std::string> frames = recv_strings(server);
+    expect_size(frames.size(), 2);
+    expect(!frames[0].empty(), "SERVER routing id missing");
+    expect_payload(frames[1], "request");
+
+    send_two(server, frames[0], "reply");
+    expect_payload(recv_string(client), "reply");
+}
+
+void radio_dish_inproc()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t radio(ctx, zmq::socket_type::radio);
+    zmq::socket_t dish(ctx, zmq::socket_type::dish);
+    expect_socket_type(radio, zmq::socket_type::radio);
+    expect_socket_type(dish, zmq::socket_type::dish);
+    set_timeouts(radio);
+    set_timeouts(dish);
+
+    radio.bind("inproc://cppzmq-radio-dish");
+    dish.join("weather");
+    dish.connect("inproc://cppzmq-radio-dish");
+    settle();
+
+    zmq::message_t msg("weather sunny", 13);
+    msg.set_group("weather");
+    const auto sent = radio.send(msg, zmq::send_flags::none);
+    expect(sent && *sent == 13, "RADIO send failed");
+
+    expect_payload(recv_string(dish), "weather sunny");
+}
+
+void scatter_gather_tcp()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t scatter(ctx, zmq::socket_type::scatter);
+    zmq::socket_t gather(ctx, zmq::socket_type::gather);
+    expect_socket_type(scatter, zmq::socket_type::scatter);
+    expect_socket_type(gather, zmq::socket_type::gather);
+    set_timeouts(scatter);
+    set_timeouts(gather);
+
+    const std::string endpoint = bind_random_tcp(gather);
+    scatter.connect(endpoint);
+    settle();
+
+    send_text(scatter, "scatter");
+    expect_payload(recv_string(gather), "scatter");
+}
+
+void peer_inproc()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t a(ctx, zmq::socket_type::peer);
+    zmq::socket_t b(ctx, zmq::socket_type::peer);
+    expect_socket_type(a, zmq::socket_type::peer);
+    expect_socket_type(b, zmq::socket_type::peer);
+    set_timeouts(a);
+    set_timeouts(b);
+
+    a.set(zmq::sockopt::routing_id, "peer-a");
+    b.set(zmq::sockopt::routing_id, "peer-b");
+    a.bind("inproc://cppzmq-peer");
+    b.connect("inproc://cppzmq-peer");
+    settle();
+
+    send_two(b, "peer-a", "hello-a");
+    std::vector<std::string> frames = recv_strings(a);
+    expect_size(frames.size(), 2);
+    expect_payload(frames[0], "peer-b");
+    expect_payload(frames[1], "hello-a");
+
+    send_two(a, "peer-b", "hello-b");
+    frames = recv_strings(b);
+    expect_size(frames.size(), 2);
+    expect_payload(frames[0], "peer-a");
+    expect_payload(frames[1], "hello-b");
+}
+
+void channel_inproc()
+{
+    zmq::context_t ctx(1);
+    zmq::socket_t a(ctx, zmq::socket_type::channel);
+    zmq::socket_t b(ctx, zmq::socket_type::channel);
+    expect_socket_type(a, zmq::socket_type::channel);
+    expect_socket_type(b, zmq::socket_type::channel);
+    set_timeouts(a);
+    set_timeouts(b);
+
+    a.bind("inproc://cppzmq-channel");
+    b.connect("inproc://cppzmq-channel");
+    settle();
+
+    send_text(a, "chan-a");
+    send_text(b, "chan-b");
+    expect_payload(recv_string(b), "chan-a");
+    expect_payload(recv_string(a), "chan-b");
+}
+
+void dgram_rejected()
+{
+    zmq::context_t ctx(1);
+    bool rejected = false;
+    try {
+        zmq::socket_t dgram(ctx, zmq::socket_type::dgram);
+    } catch (const zmq::error_t &err) {
+        rejected = err.num() == EINVAL;
+    }
+    expect(rejected, "DGRAM should be rejected");
+}
+} // namespace
+
+int main()
+{
+    verify_abi();
+    pair_inproc();
+    push_pull_tcp();
+    pub_sub_tcp();
+    req_rep_tcp();
+    dealer_router_tcp();
+    xpub_xsub_inproc();
+    stream_tcp();
+    server_client_tcp();
+    radio_dish_inproc();
+    scatter_gather_tcp();
+    peer_inproc();
+    channel_inproc();
+    dgram_rejected();
+    print_passed("socket types");
+    return 0;
+}

--- a/omq-tokio/src/blocking.rs
+++ b/omq-tokio/src/blocking.rs
@@ -24,6 +24,7 @@ use omq_proto::message::Message;
 use crate::context::Context;
 use crate::socket::handle::Socket as AsyncSocket;
 use crate::socket::monitor::{ConnectionStatus, MonitorStream};
+pub use crate::socket::recv::BlockingRecvCancel;
 
 /// Blocking socket handle.
 ///
@@ -133,6 +134,37 @@ impl Socket {
         self.inner.blocking_recv_many_into(max, out)
     }
 
+    /// Receive up to `max` messages unless `cancel` fires first.
+    ///
+    /// Returns `Ok(None)` when canceled before the first message arrives.
+    /// After the first message, ready messages are drained without checking
+    /// cancellation.
+    pub fn recv_many_cancelable_into(
+        &self,
+        max: usize,
+        cancel: &BlockingRecvCancel,
+        out: &mut Vec<Message>,
+    ) -> Result<Option<usize>> {
+        self.inner
+            .blocking_recv_many_cancelable_into(max, cancel, out)
+    }
+
+    /// Receive up to `max` messages using a pre-registered cancel handle.
+    ///
+    /// This is for foreign runtimes that pin the blocking socket to one OS
+    /// thread and call [`BlockingRecvCancel::register_current_thread_once`]
+    /// before repeated receives.
+    #[inline]
+    pub fn recv_many_registered_cancelable_into(
+        &self,
+        max: usize,
+        cancel: &BlockingRecvCancel,
+        out: &mut Vec<Message>,
+    ) -> Result<Option<usize>> {
+        self.inner
+            .blocking_recv_many_registered_cancelable_into(max, cancel, out)
+    }
+
     pub fn recv_many_timeout(&self, max: usize, timeout: Duration) -> Result<Vec<Message>> {
         self.inner.blocking_recv_many_timeout(max, timeout)
     }
@@ -231,5 +263,132 @@ impl Socket {
         let s = self.inner;
         self.ctx
             .block_on(async move { s.close_with_linger(linger).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Options, SocketType};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    static NEXT_ENDPOINT: AtomicUsize = AtomicUsize::new(0);
+
+    fn endpoint(prefix: &str) -> Endpoint {
+        format!(
+            "inproc://{prefix}-{}",
+            NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed)
+        )
+        .parse()
+        .unwrap()
+    }
+
+    fn blocking_pull(ctx: &Context, endpoint: &Endpoint) -> Socket {
+        let pull = ctx.blocking_socket(SocketType::Pull, Options::default());
+        pull.bind(endpoint.clone()).unwrap();
+        pull
+    }
+
+    #[test]
+    fn cancelable_recv_returns_none_when_pre_canceled() {
+        let ctx = Context::new();
+        let endpoint = endpoint("blocking-cancel-pre");
+        let pull = blocking_pull(&ctx, &endpoint);
+        let cancel = BlockingRecvCancel::new();
+        cancel.cancel();
+
+        let mut messages = Vec::new();
+        let received = pull
+            .recv_many_cancelable_into(1, &cancel, &mut messages)
+            .unwrap();
+
+        assert_eq!(received, None);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn registered_cancelable_recv_returns_none_when_pre_canceled() {
+        let ctx = Context::new();
+        let endpoint = endpoint("blocking-cancel-registered-pre");
+        let pull = blocking_pull(&ctx, &endpoint);
+        let cancel = BlockingRecvCancel::new();
+        cancel.register_current_thread_once();
+        cancel.cancel();
+
+        let mut messages = Vec::new();
+        let received = pull
+            .recv_many_registered_cancelable_into(1, &cancel, &mut messages)
+            .unwrap();
+
+        assert_eq!(received, None);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn cancelable_recv_wakes_parked_receiver() {
+        let ctx = Context::new();
+        let endpoint = endpoint("blocking-cancel-parked");
+        let pull = blocking_pull(&ctx, &endpoint);
+        let cancel = Arc::new(BlockingRecvCancel::new());
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker_cancel = Arc::clone(&cancel);
+
+        std::thread::spawn(move || {
+            let mut messages = Vec::new();
+            started_tx.send(()).unwrap();
+            let result = pull.recv_many_cancelable_into(1, &worker_cancel, &mut messages);
+            done_tx.send((result, messages.len())).unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        cancel.cancel();
+
+        let (result, len) = done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn cancelable_recv_returns_message_when_data_arrives() {
+        let ctx = Context::new();
+        let endpoint = endpoint("blocking-cancel-data");
+        let pull = blocking_pull(&ctx, &endpoint);
+        let push = ctx.blocking_socket(SocketType::Push, Options::default());
+        push.connect(endpoint).unwrap();
+
+        let cancel = Arc::new(BlockingRecvCancel::new());
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker_cancel = Arc::clone(&cancel);
+
+        std::thread::spawn(move || {
+            let mut messages = Vec::new();
+            started_tx.send(()).unwrap();
+            let result = pull
+                .recv_many_cancelable_into(8, &worker_cancel, &mut messages)
+                .map(|count| {
+                    let first = messages
+                        .first()
+                        .and_then(|message| message.part_bytes(0))
+                        .map(|bytes| bytes.to_vec());
+                    (count, first)
+                });
+            done_tx.send(result).unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        push.send(Message::from_slice(b"ok")).unwrap();
+
+        let (count, first) = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .unwrap();
+        assert_eq!(count, Some(1));
+        assert_eq!(first.as_deref(), Some(&b"ok"[..]));
     }
 }

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -18,7 +18,7 @@ use omq_proto::type_state::TypeState;
 
 use super::actor::{CloseLinger, SocketCommand, SocketDriver, spawn_driver};
 use super::monitor::{ConnectionStatus, MonitorPublisher, MonitorStream};
-use super::recv::{SpscAwareRecv, SpscHandles, SpscPush};
+use super::recv::{BlockingRecvCancel, SpscAwareRecv, SpscHandles, SpscPush};
 use crate::routing::{RepEnvelope, SendStrategy, SendSubmitter};
 use crate::transport::inproc::InprocRegistry;
 
@@ -593,6 +593,124 @@ impl Socket {
         }
     }
 
+    pub(crate) fn blocking_recv_cancelable(
+        &self,
+        cancel: &BlockingRecvCancel,
+    ) -> Result<Option<Message>> {
+        match self.inner.socket_type {
+            SocketType::Req => loop {
+                let Some(mut msg) = self.inner.recv_rx.blocking_recv_cancelable(cancel)? else {
+                    return Ok(None);
+                };
+                match msg.pop_front() {
+                    Some(delim) if delim.is_empty() => {}
+                    _ => continue,
+                }
+                self.inner
+                    .req_awaiting_reply
+                    .store(false, Ordering::Release);
+                return Ok(Some(msg));
+            },
+            SocketType::Rep => loop {
+                let Some(msg) = self.inner.recv_rx.blocking_recv_cancelable(cancel)? else {
+                    return Ok(None);
+                };
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(Some(msg));
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(Some(body));
+                }
+            },
+            _ => self.inner.recv_rx.blocking_recv_cancelable(cancel),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn blocking_recv_registered_cancelable(
+        &self,
+        cancel: &BlockingRecvCancel,
+    ) -> Result<Option<Message>> {
+        match self.inner.socket_type {
+            SocketType::Req => loop {
+                let Some(mut msg) = self
+                    .inner
+                    .recv_rx
+                    .blocking_recv_registered_cancelable(cancel)?
+                else {
+                    return Ok(None);
+                };
+                match msg.pop_front() {
+                    Some(delim) if delim.is_empty() => {}
+                    _ => continue,
+                }
+                self.inner
+                    .req_awaiting_reply
+                    .store(false, Ordering::Release);
+                return Ok(Some(msg));
+            },
+            SocketType::Rep => loop {
+                let Some(msg) = self
+                    .inner
+                    .recv_rx
+                    .blocking_recv_registered_cancelable(cancel)?
+                else {
+                    return Ok(None);
+                };
+                if msg.len() < 2 || !msg.part_bytes(1).is_some_and(|part| part.is_empty()) {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(Some(msg));
+                }
+                let body = self
+                    .inner
+                    .type_state
+                    .lock()
+                    .expect("type_state")
+                    .post_recv(SocketType::Rep, msg)?;
+                if let Some(body) = body {
+                    let current = self
+                        .inner
+                        .rep_pending
+                        .lock()
+                        .expect("rep pending")
+                        .pop_front();
+                    *self.inner.rep_current.lock().expect("rep current") = current;
+                    return Ok(Some(body));
+                }
+            },
+            _ => self
+                .inner
+                .recv_rx
+                .blocking_recv_registered_cancelable(cancel),
+        }
+    }
+
     /// Blocking receive with a timeout for sync callers.
     pub(crate) fn blocking_recv_timeout(&self, timeout: std::time::Duration) -> Result<Message> {
         let now = std::time::Instant::now();
@@ -661,6 +779,43 @@ impl Socket {
         let start_len = out.len();
         out.push(self.blocking_recv()?);
         self.try_recv_many_after_first(max, start_len, out)
+    }
+
+    pub(crate) fn blocking_recv_many_cancelable_into(
+        &self,
+        max: usize,
+        cancel: &BlockingRecvCancel,
+        out: &mut Vec<Message>,
+    ) -> Result<Option<usize>> {
+        if max == 0 {
+            return Ok(Some(0));
+        }
+        let start_len = out.len();
+        let Some(message) = self.blocking_recv_cancelable(cancel)? else {
+            return Ok(None);
+        };
+        out.push(message);
+        self.try_recv_many_after_first(max, start_len, out)
+            .map(Some)
+    }
+
+    #[inline]
+    pub(crate) fn blocking_recv_many_registered_cancelable_into(
+        &self,
+        max: usize,
+        cancel: &BlockingRecvCancel,
+        out: &mut Vec<Message>,
+    ) -> Result<Option<usize>> {
+        if max == 0 {
+            return Ok(Some(0));
+        }
+        let start_len = out.len();
+        let Some(message) = self.blocking_recv_registered_cancelable(cancel)? else {
+            return Ok(None);
+        };
+        out.push(message);
+        self.try_recv_many_after_first(max, start_len, out)
+            .map(Some)
     }
 
     pub(crate) fn blocking_recv_many_timeout(

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -139,6 +139,93 @@ impl std::fmt::Debug for BlockingRecvWaker {
     }
 }
 
+/// Cancellation handle for blocking receive calls.
+#[derive(Debug)]
+pub struct BlockingRecvCancel {
+    canceled: AtomicBool,
+    registered: AtomicBool,
+    thread: Mutex<Option<std::thread::Thread>>,
+}
+
+impl BlockingRecvCancel {
+    /// Create a cancel handle in the active state.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            canceled: AtomicBool::new(false),
+            registered: AtomicBool::new(false),
+            thread: Mutex::new(None),
+        }
+    }
+
+    /// Cancel current and future receive waits.
+    #[inline]
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.lock().unwrap().clone() {
+            thread.unpark();
+        }
+    }
+
+    /// Returns whether this handle has been canceled.
+    #[inline]
+    #[must_use]
+    pub fn is_canceled(&self) -> bool {
+        self.canceled.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub(crate) fn register(&self, thread: &std::thread::Thread) {
+        *self.thread.lock().unwrap() = Some(thread.clone());
+        self.registered.store(true, Ordering::Release);
+        if self.is_canceled() {
+            thread.unpark();
+        }
+    }
+
+    /// Register the current OS thread once for repeated cancelable receives.
+    ///
+    /// This avoids per-call registration when a foreign binding owns the
+    /// blocking socket thread.
+    pub fn register_current_thread_once(&self) {
+        if self
+            .registered
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let thread = std::thread::current();
+        *self.thread.lock().unwrap() = Some(thread.clone());
+        if self.is_canceled() {
+            thread.unpark();
+        }
+    }
+
+    #[inline]
+    fn unregister(&self) {
+        *self.thread.lock().unwrap() = None;
+        self.registered.store(false, Ordering::Release);
+    }
+}
+
+impl Default for BlockingRecvCancel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct BlockingRecvCancelGuard<'a> {
+    cancel: &'a BlockingRecvCancel,
+}
+
+impl Drop for BlockingRecvCancelGuard<'_> {
+    fn drop(&mut self) {
+        self.cancel.unregister();
+    }
+}
+
 /// Bumped by the actor whenever the consumers Vec changes. Lets
 /// `SpscAwareRecv` skip re-cloning the Vec when nothing changed.
 pub(crate) type SpscConsumerGeneration = Arc<AtomicU64>;
@@ -670,6 +757,64 @@ impl SpscAwareRecv {
                         continue;
                     }
                     std::thread::park();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn blocking_recv_cancelable(
+        &self,
+        cancel: &BlockingRecvCancel,
+    ) -> Result<Option<Message>> {
+        let thread = std::thread::current();
+        self.blocking_recv_waker.register(thread.clone());
+        cancel.register(&thread);
+        let _guard = BlockingRecvCancelGuard { cancel };
+        if cancel.is_canceled() {
+            return Ok(None);
+        }
+        self.blocking_recv_registered_cancelable(cancel)
+    }
+
+    #[inline]
+    pub(crate) fn blocking_recv_registered_cancelable(
+        &self,
+        cancel: &BlockingRecvCancel,
+    ) -> Result<Option<Message>> {
+        self.blocking_recv_waker.register(std::thread::current());
+        let mut woke_without_message = false;
+        loop {
+            match self.try_drain() {
+                DrainResult::Message(msg) => return Ok(Some(msg)),
+                DrainResult::Closed => return Err(Error::Closed),
+                DrainResult::Empty => {
+                    if woke_without_message && cancel.is_canceled() {
+                        self.blocking_recv_waker.cancel_sleep();
+                        return Ok(None);
+                    }
+                    woke_without_message = false;
+                }
+            }
+            self.blocking_recv_waker.prepare_sleep();
+            match self.try_drain() {
+                DrainResult::Message(msg) => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Ok(Some(msg));
+                }
+                DrainResult::Closed => {
+                    self.blocking_recv_waker.cancel_sleep();
+                    return Err(Error::Closed);
+                }
+                DrainResult::Empty => {
+                    if !self.buffered_sources_empty() {
+                        self.blocking_recv_waker.cancel_sleep();
+                        if cancel.is_canceled() {
+                            return Ok(None);
+                        }
+                        continue;
+                    }
+                    std::thread::park();
+                    woke_without_message = true;
                 }
             }
         }

--- a/omq-tokio/tests/loom_signal.rs
+++ b/omq-tokio/tests/loom_signal.rs
@@ -313,6 +313,50 @@ impl ModelBlockingRecvWaker {
     }
 }
 
+#[derive(Debug)]
+struct ModelBlockingRecvCancel {
+    canceled: AtomicBool,
+    registered: AtomicBool,
+    thread_present: Mutex<bool>,
+    unparked: AtomicBool,
+}
+
+impl ModelBlockingRecvCancel {
+    fn new() -> Self {
+        Self {
+            canceled: AtomicBool::new(false),
+            registered: AtomicBool::new(false),
+            thread_present: Mutex::new(false),
+            unparked: AtomicBool::new(false),
+        }
+    }
+
+    fn register_current_thread_once(&self) {
+        if self
+            .registered
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        *self.thread_present.lock().unwrap() = true;
+        if self.canceled.load(Ordering::Acquire) {
+            self.unparked.store(true, Ordering::Release);
+        }
+    }
+
+    fn cancel(&self) {
+        self.canceled.store(true, Ordering::Release);
+        if *self.thread_present.lock().unwrap() {
+            self.unparked.store(true, Ordering::Release);
+        }
+    }
+
+    fn was_unparked(&self) -> bool {
+        self.unparked.load(Ordering::Acquire)
+    }
+}
+
 #[test]
 fn state_signal_catches_change_between_check_and_wait_registration() {
     loom::model(|| {
@@ -350,6 +394,33 @@ fn state_signal_catches_change_between_check_and_wait_registration() {
         assert!(
             observed.load(Ordering::SeqCst) || signal.has_woken_waiter(),
             "generation change must be observed or wake a registered waiter"
+        );
+    });
+}
+
+#[test]
+fn blocking_recv_cancel_registration_cannot_lose_cancel_wake() {
+    loom::model(|| {
+        let cancel = Arc::new(ModelBlockingRecvCancel::new());
+
+        let register_cancel = cancel.clone();
+        let register = thread::spawn(move || {
+            thread::yield_now();
+            register_cancel.register_current_thread_once();
+        });
+
+        let fire_cancel = cancel.clone();
+        let fire = thread::spawn(move || {
+            thread::yield_now();
+            fire_cancel.cancel();
+        });
+
+        register.join().unwrap();
+        fire.join().unwrap();
+
+        assert!(
+            cancel.was_unparked(),
+            "cancel racing with thread registration must leave an unpark token"
         );
     });
 }

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -271,6 +271,13 @@ run omq_cargo clippy --all-targets --no-deps -- -D warnings
 run omq_cargo clippy -p omq-libzmq --all-targets --no-deps -- -D warnings
 run omq_cargo_with_rust_tools test
 run omq_cargo_with_rust_tools test -p omq-libzmq
+if command -v "${CXX:-c++}" >/dev/null 2>&1 \
+    && command -v pkg-config >/dev/null 2>&1 \
+    && pkg-config --exists cppzmq; then
+    run "$_repo_root/scripts/test-cppzmq.sh"
+else
+    echo "skip: cppzmq tests require C++ compiler and cppzmq"
+fi
 
 if [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
     echo "skip: perf gate disabled on CI"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -6,6 +6,8 @@
 # Knobs:
 #   OMQ_FUZZ=1          opt in to the ~1 M-iter hand-rolled fuzz suites
 #   OMQ_SKIP_PYOMQ=1    skip the pyomq build + pytest pass
+#   OMQ_SKIP_GO=1       skip the Go binding build + test pass
+#   OMQ_GO_RACE=1       run Go binding tests with the race detector too
 #   OMQ_TEST_RETRIES=N  retry each step up to N times (default 2) -
 #                       a few timing-sensitive tests may need one
 #                       retry on heavily loaded runners.
@@ -277,6 +279,13 @@ if command -v "${CXX:-c++}" >/dev/null 2>&1 \
     run "$_repo_root/scripts/test-cppzmq.sh"
 else
     echo "skip: cppzmq tests require C++ compiler and cppzmq"
+fi
+if [[ "${OMQ_SKIP_GO:-}" == "1" ]]; then
+    echo "skip: OMQ_SKIP_GO=1"
+elif command -v go >/dev/null 2>&1; then
+    run "$_repo_root/scripts/test-go.sh"
+else
+    echo "skip: Go binding tests require go"
 fi
 
 if [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then

--- a/scripts/test-cppzmq.sh
+++ b/scripts/test-cppzmq.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+cxx="${CXX:-c++}"
+cargo_cmd="${CARGO:-cargo}"
+
+if ! command -v "$cxx" >/dev/null 2>&1; then
+    echo "error: C++ compiler not found: $cxx" >&2
+    exit 1
+fi
+
+if ! command -v pkg-config >/dev/null 2>&1; then
+    echo "error: pkg-config not found" >&2
+    exit 1
+fi
+
+if ! pkg-config --exists cppzmq; then
+    echo "error: cppzmq not found. Install cppzmq-dev." >&2
+    exit 1
+fi
+
+"$cargo_cmd" build -p omq-libzmq
+
+out_dir="$repo_root/target/omq-test-tools"
+lib_dir="$repo_root/target/debug"
+cppzmq_dir="$repo_root/omq-libzmq/tests/cppzmq"
+mkdir -p "$out_dir"
+
+read -r -a cppzmq_cflags <<<"$(pkg-config --cflags cppzmq)"
+
+case "$(uname -s)" in
+    Darwin)
+        export DYLD_LIBRARY_PATH="$lib_dir:${DYLD_LIBRARY_PATH:-}"
+        ;;
+    *)
+        export LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}"
+        ;;
+esac
+
+for src in "$cppzmq_dir"/*.cpp; do
+    name="$(basename "$src" .cpp)"
+    out="$out_dir/cppzmq-$name"
+    "$cxx" \
+        -std=c++17 \
+        -Wall \
+        -Wextra \
+        -Werror \
+        -I "$repo_root/omq-libzmq/include" \
+        -I "$cppzmq_dir" \
+        "${cppzmq_cflags[@]}" \
+        "$src" \
+        -L "$lib_dir" \
+        -lomq_zmq \
+        -pthread \
+        -Wl,-rpath,"$lib_dir" \
+        -o "$out"
+    "$out"
+done

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+cargo_cmd="${CARGO:-cargo}"
+
+"$cargo_cmd" build --release --manifest-path bindings/go/native/Cargo.toml
+
+case "$(uname -s)" in
+    Darwin)
+        export DYLD_LIBRARY_PATH="$repo_root/bindings/go/native/target/release:$repo_root/bindings/go/native/target/debug:${DYLD_LIBRARY_PATH:-}"
+        ;;
+    *)
+        export LD_LIBRARY_PATH="$repo_root/bindings/go/native/target/release:$repo_root/bindings/go/native/target/debug:${LD_LIBRARY_PATH:-}"
+        ;;
+esac
+
+(cd bindings/go && go test -count=1 ./...)
+if [[ "${OMQ_GO_RACE:-}" == "1" ]]; then
+    (cd bindings/go && go test -race -count=1 ./...)
+fi


### PR DESCRIPTION
- Adds the OMQ.go binding backed by the native omq-tokio core, including contexts, sockets, monitors, poller, proxy, auth/CURVE, compression options, channel adapter, and hot-path Socket.Run APIs.
- Adds Go API parity coverage, race-oriented tests, soak coverage, native wrapper leak instrumentation, and development docs.
- Adds TCP performance harnessing with append-only cache rows and the generated Go binding performance chart.
- Adds cppzmq compatibility tests against the libomq_zmq compatibility ABI.