### PR TITLE
Name Go chart benchmark peer for OMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Pure Rust [ZeroMQ](https://zeromq.org): brokerless message passing for distribut
 - 3 security mechanisms: NULL, PLAIN, CURVE
 - OMQ-owned background I/O threads on Linux, macOS, and Windows
 - No C compiler, no libzmq, no libsodium
-- Bindings: [OMQ.rb](https://github.com/zeromq/omq.rb) (Ruby),
-  [pyomq](bindings/pyomq/) (Python), [OMQ.java](bindings/java/) (Java),
-  and C API ([omq-libzmq](omq-libzmq/))
+- Bindings and compatibility APIs:
+  - [omq-libzmq](omq-libzmq/) C API, libzmq-compatible `libomq_zmq`
+  - [pyomq](bindings/pyomq/) Python, sync + asyncio
+  - [OMQ.rb](https://github.com/zeromq/omq.rb) Ruby
+  - [OMQ.java](bindings/java/) Java 25, sync + async
+  - [OMQ.go](bindings/go/) Go 1.25, goroutine-safe API
+  - [@zeromq/omq-node](bindings/node/) Node.js 24.11, native addon
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/doc/charts/main_pushpull_tcp.svg" alt="PUSH/PULL throughput: TCP implementations" width="950">
@@ -137,6 +141,8 @@ Five Cargo workspace crates plus language bindings.
 | [`omq-bench`](omq-bench/) | Benchmark runner and SVG chart generator | Bench-only process control and CPU accounting |
 | [`pyomq`](bindings/pyomq/) | Python binding (PyO3 over omq-tokio, sync + asyncio) | PyO3 FFI boundary |
 | [`OMQ.java`](bindings/java/) | Java 25 binding (JNI/FFM over omq-tokio, sync + async) | JNI/FFM boundary |
+| [`OMQ.go`](bindings/go/) | Go 1.25 binding (cgo over omq-tokio, goroutine-safe API) | cgo/native ABI boundary |
+| [`@zeromq/omq-node`](bindings/node/) | Node.js 24.11 binding (NAPI over omq-tokio, native addon) | NAPI/native addon boundary |
 
 ## Testing
 

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -30,7 +30,7 @@ CACHE_DIR = Path(
 )
 JSONL = CACHE_DIR / "bindings.jsonl"
 HARNESS_DIR = CACHE_DIR / "pushpull_tcp_peer"
-HARNESS_BIN = HARNESS_DIR / "perf-peer"
+HARNESS_BIN = HARNESS_DIR / "omq-go-bench-peer"
 CHART_DIR = ROOT / "doc" / "charts"
 CHART = CHART_DIR / "bindings.svg"
 
@@ -86,7 +86,7 @@ type result struct {
 
 func main() {
 	if len(os.Args) != 8 {
-		die("usage: perf-peer <pushpull|reqrep> <omq|omq-run|omq-run-into|zmq4> <push|pull|req|rep> <endpoint> <size> <duration|messages> <warmup>")
+		die("usage: omq-go-bench-peer <pushpull|reqrep> <omq|omq-run|omq-run-into|zmq4> <push|pull|req|rep> <endpoint> <size> <duration|messages> <warmup>")
 	}
 	bench := os.Args[1]
 	impl := os.Args[2]


### PR DESCRIPTION
- Rename the generated Go performance chart peer from `perf-peer` to `omq-go-bench-peer`.
- Update the generated peer usage text to match the executable name.
- List `OMQ.go` and `@zeromq/omq-node` in the main README binding summary and workspace table.