### PR TITLE
bench: allow arena threshold sweeps

### DIFF
--- a/omq-tokio/benches/common/mod.rs
+++ b/omq-tokio/benches/common/mod.rs
@@ -14,9 +14,9 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use omq_tokio::Endpoint;
 #[cfg(unix)]
 use omq_tokio::IpcPath;
+use omq_tokio::{Endpoint, Options};
 
 /// Default size sweep: three points that cover the small/medium/large
 /// knee of the throughput curve. Pass `--all-sizes` to the bench binary
@@ -175,6 +175,14 @@ pub(crate) fn peers_override() -> Option<Vec<usize>> {
     std::env::var("OMQ_BENCH_PEERS")
         .ok()
         .map(|s| s.split(',').filter_map(|t| t.trim().parse().ok()).collect())
+}
+
+pub(crate) fn options(_msg_size: usize) -> Options {
+    let mut o = Options::default();
+    if let Ok(val) = std::env::var("OMQ_BENCH_ARENA_THRESHOLD") {
+        o = o.arena_threshold(val.parse().expect("OMQ_BENCH_ARENA_THRESHOLD"));
+    }
+    o
 }
 
 /// Build a fresh endpoint for cell `seq` on `transport`. For TCP we

--- a/omq-tokio/benches/pub_sub.rs
+++ b/omq-tokio/benches/pub_sub.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use omq_tokio::{Message, Options, Socket, SocketType};
+use omq_tokio::{Message, Socket, SocketType};
 
 const PATTERN: &str = "pub_sub";
 const PEER_COUNTS: &[usize] = &[3];
@@ -41,12 +41,12 @@ fn main() {
 
 async fn run_cell(transport: &str, peers: usize, size: usize, seq: usize) -> common::Cell {
     let ep = common::endpoint(transport, seq);
-    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let pub_ = Socket::new(SocketType::Pub, common::options(size));
     pub_.bind(ep.clone()).await.expect("bind PUB");
 
     let mut subs: Vec<Socket> = Vec::with_capacity(peers);
     for _ in 0..peers {
-        let s = Socket::new(SocketType::Sub, Options::default());
+        let s = Socket::new(SocketType::Sub, common::options(size));
         s.connect(ep.clone()).await.expect("connect SUB");
         s.subscribe(Bytes::new()).await.expect("subscribe");
         subs.push(s);

--- a/omq-tokio/benches/push_pull.rs
+++ b/omq-tokio/benches/push_pull.rs
@@ -5,7 +5,7 @@ mod common;
 
 use std::sync::Arc;
 
-use omq_tokio::{Message, Options, Socket, SocketType};
+use omq_tokio::{Message, Socket, SocketType};
 
 const PATTERN: &str = "push_pull";
 const PEER_COUNTS: &[usize] = &[1, 8];
@@ -37,12 +37,12 @@ fn main() {
 
 async fn run_cell(transport: &str, peers: usize, size: usize, seq: usize) -> common::Cell {
     let ep = common::endpoint(transport, seq);
-    let pull = Socket::new(SocketType::Pull, Options::default());
+    let pull = Socket::new(SocketType::Pull, common::options(size));
     pull.bind(ep.clone()).await.expect("bind PULL");
 
     let mut pushes: Vec<Socket> = Vec::with_capacity(peers);
     for _ in 0..peers {
-        let p = Socket::new(SocketType::Push, Options::default());
+        let p = Socket::new(SocketType::Push, common::options(size));
         p.connect(ep.clone()).await.expect("connect PUSH");
         pushes.push(p);
     }

--- a/omq-tokio/benches/push_pull_fanout.rs
+++ b/omq-tokio/benches/push_pull_fanout.rs
@@ -10,7 +10,7 @@ mod common;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use omq_tokio::{Message, Options, Socket, SocketType};
+use omq_tokio::{Message, Socket, SocketType};
 
 const PATTERN: &str = "push_pull_fanout";
 const PEER_COUNTS: &[usize] = &[1, 8];
@@ -42,12 +42,12 @@ fn main() {
 
 async fn run_cell(transport: &str, peers: usize, size: usize, seq: usize) -> common::Cell {
     let ep = common::endpoint(transport, seq);
-    let push = Socket::new(SocketType::Push, Options::default());
+    let push = Socket::new(SocketType::Push, common::options(size));
     push.bind(ep.clone()).await.expect("bind PUSH");
 
     let mut pulls: Vec<Socket> = Vec::with_capacity(peers);
     for _ in 0..peers {
-        let p = Socket::new(SocketType::Pull, Options::default());
+        let p = Socket::new(SocketType::Pull, common::options(size));
         p.connect(ep.clone()).await.expect("connect PULL");
         pulls.push(p);
     }

--- a/omq-tokio/src/bin/bench_peer_blocking.rs
+++ b/omq-tokio/src/bin/bench_peer_blocking.rs
@@ -211,6 +211,9 @@ fn bench_options(msg_size: usize) -> Options {
     if let Ok(val) = std::env::var("OMQ_BENCH_ZSTD_LEVEL") {
         o = o.compression_level(val.parse().expect("OMQ_BENCH_ZSTD_LEVEL"));
     }
+    if let Ok(val) = std::env::var("OMQ_BENCH_ARENA_THRESHOLD") {
+        o = o.arena_threshold(val.parse().expect("OMQ_BENCH_ARENA_THRESHOLD"));
+    }
     o
 }
 


### PR DESCRIPTION
- Adds `OMQ_BENCH_ARENA_THRESHOLD` support to the blocking benchmark peer.
- Routes Tokio PUSH/PULL, PUSH fan-out, and PUB/SUB cargo benches through shared benchmark options.
- Leaves production arena defaults unchanged.