### PR TITLE
bench: time Java throughput samples

### DIFF
--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Use timed PUSH/PULL throughput samples for the OMQ.java performance chart
+  instead of fixed message-count runs.
+
 ## [0.3.0]
 
 - Publish OMQ.java as a Java-only main jar plus platform classifier runtime jars.

--- a/bindings/java/doc/charts/pushpull_tcp.svg
+++ b/bindings/java/doc/charts/pushpull_tcp.svg
@@ -49,66 +49,66 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,193.1 145.8,188.7 201.7,200.3 257.5,256.8 313.3,252.8 369.2,277.5 425.0,298.0 480.8,326.8 536.7,349.2 592.5,362.6 648.3,373.4 704.2,377.6 760.0,380.8" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,159.6 145.8,166.3 201.7,165.8 257.5,257.0 313.3,268.4 369.2,273.4 425.0,292.5 480.8,313.6 536.7,342.3 592.5,360.5 648.3,371.2 704.2,377.0 760.0,380.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,280.0 145.8,282.5 201.7,287.6 257.5,297.1 313.3,313.1 369.2,323.8 425.0,341.5 480.8,357.9 536.7,367.0 592.5,374.0 648.3,378.9 704.2,381.0 760.0,382.1" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,264.4 145.8,281.7 201.7,283.6 257.5,303.5 313.3,309.4 369.2,324.6 425.0,342.0 480.8,356.7 536.7,365.9 592.5,373.9 648.3,378.7 704.2,381.7 760.0,381.9" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,380.9 145.8,377.7 201.7,372.2 257.5,367.7 313.3,350.4 369.2,329.5 425.0,295.9 480.8,267.0 536.7,241.3 592.5,208.5 648.3,209.7 704.2,174.0 760.0,175.3" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="377.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="372.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="367.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="350.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="329.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="295.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="267.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="241.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="208.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="209.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="174.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="175.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,380.4 145.8,377.0 201.7,370.0 257.5,367.7 313.3,354.4 369.2,327.4 425.0,290.3 480.8,239.8 536.7,213.2 592.5,191.8 648.3,174.9 704.2,153.7 760.0,130.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,168.1 145.8,166.4 201.7,161.0 257.5,234.5 313.3,244.7 369.2,255.9 425.0,289.3 480.8,317.1 536.7,346.6 592.5,363.8 648.3,374.1 704.2,378.8 760.0,381.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,160.8 145.8,166.5 201.7,136.6 257.5,242.1 313.3,239.2 369.2,254.8 425.0,285.2 480.8,315.0 536.7,341.9 592.5,360.4 648.3,370.4 704.2,376.6 760.0,380.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,225.1 145.8,230.3 201.7,241.6 257.5,260.3 313.3,284.5 369.2,306.3 425.0,332.6 480.8,351.4 536.7,366.4 592.5,374.5 648.3,379.5 704.2,381.5 760.0,382.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,230.0 145.8,243.9 201.7,248.7 257.5,261.3 313.3,279.8 369.2,308.1 425.0,331.7 480.8,352.1 536.7,366.3 592.5,374.8 648.3,379.3 704.2,381.5 760.0,382.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.5 145.8,377.0 201.7,369.7 257.5,364.9 313.3,348.3 369.2,318.4 425.0,287.0 480.8,247.0 536.7,230.9 592.5,218.8 648.3,221.7 704.2,213.7 760.0,213.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="377.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="369.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="364.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="348.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="318.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="287.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="247.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="230.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="218.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="221.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="213.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="213.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,380.4 145.8,377.0 201.7,368.2 257.5,365.8 313.3,346.9 369.2,317.8 425.0,282.8 480.8,242.6 536.7,211.7 592.5,190.5 648.3,161.9 704.2,142.5 760.0,126.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="380.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="377.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="370.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="367.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="354.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="327.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="290.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="239.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="213.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="191.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="174.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="153.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="130.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.3 145.8,380.8 201.7,377.8 257.5,372.9 313.3,365.9 369.2,353.2 425.0,340.5 480.8,330.6 536.7,314.2 592.5,302.1 648.3,300.6 704.2,286.8 760.0,259.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="380.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="372.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="365.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="353.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="340.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="330.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="314.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="302.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="300.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="286.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="259.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.1 145.8,380.7 201.7,377.6 257.5,373.7 313.3,364.9 369.2,353.6 425.0,341.0 480.8,328.1 536.7,309.8 592.5,301.4 648.3,296.8 704.2,309.2 760.0,248.7" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="380.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="377.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="373.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="364.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="353.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="341.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="328.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="309.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="301.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="296.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="309.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="248.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="368.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="365.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="346.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="317.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="282.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="242.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="211.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="190.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="161.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="142.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="126.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,381.5 145.8,379.1 201.7,374.9 257.5,368.2 313.3,358.5 369.2,344.2 425.0,331.4 480.8,317.3 536.7,312.1 592.5,306.0 648.3,309.5 704.2,302.2 760.0,267.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="379.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="374.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="368.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="358.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="344.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="331.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="317.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="312.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="306.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="309.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="302.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="267.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,381.5 145.8,379.5 201.7,375.3 257.5,368.3 313.3,357.3 369.2,345.2 425.0,330.4 480.8,318.7 536.7,311.5 592.5,309.0 648.3,307.3 704.2,301.1 760.0,263.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="379.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="375.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="368.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="357.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="345.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="330.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="318.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="311.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="309.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="307.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="301.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="263.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
   <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
@@ -151,61 +151,61 @@
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,527.4 145.8,527.3 201.7,529.8 257.5,528.5 313.3,527.3 369.2,527.4 425.0,526.9 480.8,526.5 536.7,521.8 592.5,515.1 648.3,513.2 704.2,496.6 760.0,474.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="527.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="529.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="528.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="527.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="526.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="526.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="521.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="515.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="513.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="496.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="474.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,527.7 145.8,527.3 201.7,526.8 257.5,528.1 313.3,527.7 369.2,527.0 425.0,525.7 480.8,526.9 536.7,525.6 592.5,517.9 648.3,513.6 704.2,501.4 760.0,480.6" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="527.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,529.7 145.8,526.0 201.7,527.4 257.5,529.2 313.3,527.7 369.2,528.0 425.0,525.8 480.8,526.1 536.7,522.4 592.5,517.1 648.3,513.3 704.2,493.8 760.0,475.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="529.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="526.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="529.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="527.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="528.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="525.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="526.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="522.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="517.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="513.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="493.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="475.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,527.4 145.8,527.3 201.7,528.4 257.5,525.9 313.3,526.9 369.2,527.8 425.0,525.8 480.8,526.9 536.7,524.6 592.5,519.2 648.3,513.2 704.2,498.3 760.0,478.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="145.8" cy="527.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="526.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="528.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="527.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="527.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="525.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="528.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="525.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="526.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="527.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="525.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
   <circle cx="480.8" cy="526.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="525.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="517.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="513.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="501.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="480.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,513.7 145.8,510.9 201.7,506.7 257.5,511.0 313.3,511.6 369.2,510.3 425.0,508.8 480.8,508.6 536.7,505.2 592.5,501.6 648.3,482.5 704.2,481.2 760.0,464.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="513.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="510.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="506.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="511.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="510.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="508.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="508.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="505.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="501.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="482.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="481.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="524.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="519.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="513.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="498.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <circle cx="760.0" cy="478.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,510.8 145.8,508.5 201.7,511.9 257.5,508.4 313.3,506.2 369.2,511.0 425.0,503.6 480.8,503.0 536.7,506.2 592.5,504.9 648.3,490.7 704.2,482.1 760.0,464.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="510.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="508.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="511.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="508.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="506.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="503.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="503.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="506.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="504.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="490.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="482.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="464.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,507.1 145.8,508.6 201.7,510.8 257.5,507.2 313.3,505.5 369.2,509.8 425.0,505.3 480.8,504.8 536.7,508.2 592.5,505.0 648.3,492.2 704.2,484.9 760.0,464.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="507.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="508.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="510.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="507.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="505.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="509.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="505.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="504.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="508.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="505.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="492.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="484.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <polyline points="90.0,509.0 145.8,511.5 201.7,505.9 257.5,507.8 313.3,504.4 369.2,502.9 425.0,507.1 480.8,506.4 536.7,503.0 592.5,505.2 648.3,488.0 704.2,481.2 760.0,464.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="509.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="145.8" cy="511.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="201.7" cy="505.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="257.5" cy="507.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="313.3" cy="504.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="369.2" cy="502.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="425.0" cy="507.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="480.8" cy="506.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="536.7" cy="503.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="592.5" cy="505.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="648.3" cy="488.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
+  <circle cx="704.2" cy="481.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <circle cx="760.0" cy="464.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
   <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
   <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>

--- a/bindings/java/scripts/bench_pushpull_tcp.py
+++ b/bindings/java/scripts/bench_pushpull_tcp.py
@@ -21,8 +21,10 @@ REQREP_CLASS = "io.omq.perf.ReqRepTcpPeer"
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [8, 128, 1024, 4096, 32768]
 DEFAULT_IMPLS = ["omq", "omq-into", "jeromq", "jeromq-into"]
-DEFAULT_THROUGHPUT_WARMUP = 50_000
-QUICK_THROUGHPUT_WARMUP = 5_000
+DEFAULT_THROUGHPUT_DURATION = 2.0
+QUICK_THROUGHPUT_DURATION = 0.5
+DEFAULT_THROUGHPUT_WARMUP = 0.5
+QUICK_THROUGHPUT_WARMUP = 0.1
 DEFAULT_LATENCY_WARMUP = 50_000
 DEFAULT_LATENCY_ITERS = 50_000
 QUICK_LATENCY_WARMUP = 5_000
@@ -129,22 +131,10 @@ def free_endpoint():
     return f"tcp://127.0.0.1:{port}"
 
 
-def message_count(size, args):
-    by_bytes = args.target_bytes // max(size, 1)
-    return max(args.min_messages, min(args.max_messages, by_bytes))
-
-
-def throughput_warmup_count(messages, args):
-    if args.warmup_messages is not None:
-        return args.warmup_messages
-    base = QUICK_THROUGHPUT_WARMUP if args.quick else DEFAULT_THROUGHPUT_WARMUP
-    return min(messages, max(base, messages // 20))
-
-
-def java_cmd(class_name, cp, impl, role, endpoint, size, messages, warmup, batch=None):
+def java_cmd(class_name, cp, impl, role, endpoint, size, measure, warmup, batch=None):
     args = [
         str(size),
-        str(messages),
+        str(measure),
         str(warmup),
     ]
     if batch is not None:
@@ -192,61 +182,90 @@ def fail_on_noise(name, stdout, stderr):
 def kill(proc):
     if proc.poll() is None:
         proc.kill()
-        proc.communicate(timeout=5)
+    return proc.communicate(timeout=5)
 
 
-def run_cell_once(cp, impl, size, messages, warmup, batch, timeout):
+def run_cell_once(cp, impl, size, duration, warmup, batch, timeout):
     endpoint = free_endpoint()
     pull = subprocess.Popen(
-        java_cmd(PUSHPULL_CLASS, cp, impl, "pull", endpoint, size, messages, warmup, batch),
+        java_cmd(PUSHPULL_CLASS, cp, impl, "pull", endpoint, size, duration, warmup, batch),
         cwd=ROOT,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+    push = None
     try:
         ready = read_line_timeout(pull, 10)
         if ready is None or not ready.startswith("READY "):
             out, err = pull.communicate(timeout=1) if pull.poll() is not None else ("", "")
             raise RuntimeError(f"receiver did not become ready:\n{ready or ''}{out}{err}")
 
-        push = subprocess.run(
-            java_cmd(PUSHPULL_CLASS, cp, impl, "push", endpoint, size, messages, warmup, batch),
+        push = subprocess.Popen(
+            java_cmd(PUSHPULL_CLASS, cp, impl, "push", endpoint, size, duration, warmup, batch),
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=timeout,
-            check=False,
         )
-        fail_on_noise("sender", push.stdout, push.stderr)
-        if push.returncode != 0:
-            raise RuntimeError(f"sender failed:\n{push.stdout}{push.stderr}")
 
-        out, err = pull.communicate(timeout=timeout)
+        deadline = time.monotonic() + timeout
+        while pull.poll() is None:
+            if push.poll() is not None:
+                push_out, push_err = push.communicate(timeout=1)
+                pull_out, pull_err = kill(pull)
+                raise RuntimeError(
+                    "sender exited before receiver:\n"
+                    + push_out
+                    + push_err
+                    + "\nreceiver output:\n"
+                    + ready
+                    + pull_out
+                    + pull_err
+                )
+            if time.monotonic() >= deadline:
+                raise subprocess.TimeoutExpired(pull.args, timeout)
+            time.sleep(0.05)
+
+        out, err = pull.communicate(timeout=1)
         out = ready + out
+        push_out, push_err = kill(push)
+        push = None
+        fail_on_noise("sender", push_out, push_err)
         fail_on_noise("receiver", out, err)
         if pull.returncode != 0:
             raise RuntimeError(f"receiver failed:\n{out}{err}")
         return parse_result(out)
-    except Exception:
+    except Exception as exc:
         kill(pull)
+        if push is not None:
+            push_out, push_err = kill(push)
+            if push_out or push_err:
+                raise RuntimeError(f"sender output before failure:\n{push_out}{push_err}") from exc
         raise
 
 
 def run_cell(cp, impl, size, args):
-    messages = message_count(size, args)
-    warmup = throughput_warmup_count(messages, args)
     runs = []
     total = args.warmup_rounds + args.rounds
     for round_index in range(total):
-        result = run_cell_once(cp, impl, size, messages, warmup, args.batch_size, args.timeout)
-        result["warmup_messages"] = warmup
+        result = run_cell_once(
+            cp,
+            impl,
+            size,
+            args.throughput_duration,
+            args.throughput_warmup,
+            args.batch_size,
+            args.timeout,
+        )
+        result["target_seconds"] = args.throughput_duration
+        result["warmup_seconds"] = args.throughput_warmup
         if round_index >= args.warmup_rounds:
             runs.append(result)
         print(
             f"  {impl:8s} size={size:6d} round={round_index + 1}/{total} "
-            f"warmup={warmup:7d} {result['msgs_s']:12.0f} msg/s {result['gb_s']:7.3f} GB/s",
+            f"{result['seconds']:5.2f}s {result['msgs_s']:12.0f} msg/s "
+            f"{result['gb_s']:7.3f} GB/s",
             flush=True,
         )
     return sorted(runs, key=lambda row: row["msgs_s"])[len(runs) // 2]
@@ -710,19 +729,25 @@ def main():
     parser.add_argument("--impls", type=parse_csv_strings, default=DEFAULT_IMPLS)
     parser.add_argument("--rounds", type=int, default=3)
     parser.add_argument("--warmup-rounds", type=int, default=1)
-    parser.add_argument("--target-bytes", type=int, default=256 * 1024 * 1024)
-    parser.add_argument("--min-messages", type=int, default=20_000)
-    parser.add_argument("--max-messages", type=int, default=1_000_000)
+    parser.add_argument("--throughput-duration", type=float)
     parser.add_argument(
         "--throughput-warmup",
-        "--throughput-warmup-messages",
-        "--warmup-messages",
-        dest="warmup_messages",
-        type=int,
+        dest="throughput_warmup",
+        type=float,
     )
     parser.add_argument("--batch-size", type=int, default=64)
-    parser.add_argument("--latency-warmup", "--latency-warmup-messages", dest="latency_warmup_messages", type=int)
-    parser.add_argument("--latency-iters", "--latency-iterations", dest="latency_iterations", type=int)
+    parser.add_argument(
+        "--latency-warmup",
+        "--latency-warmup-messages",
+        dest="latency_warmup_messages",
+        type=int,
+    )
+    parser.add_argument(
+        "--latency-iters",
+        "--latency-iterations",
+        dest="latency_iterations",
+        type=int,
+    )
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--chart-only", action="store_true")
@@ -739,7 +764,17 @@ def main():
         parser.error("--rounds must be at least 1")
     if args.warmup_rounds < 0:
         parser.error("--warmup-rounds cannot be negative")
-    if args.warmup_messages is not None and args.warmup_messages < 0:
+    if args.throughput_duration is None:
+        args.throughput_duration = (
+            QUICK_THROUGHPUT_DURATION if args.quick else DEFAULT_THROUGHPUT_DURATION
+        )
+    if args.throughput_warmup is None:
+        args.throughput_warmup = (
+            QUICK_THROUGHPUT_WARMUP if args.quick else DEFAULT_THROUGHPUT_WARMUP
+        )
+    if args.throughput_duration <= 0:
+        parser.error("--throughput-duration must be greater than zero")
+    if args.throughput_warmup < 0:
         parser.error("--throughput-warmup cannot be negative")
     if args.latency_warmup_messages is None:
         args.latency_warmup_messages = (

--- a/bindings/java/src/test/java/io/omq/perf/PushPullTcpPeer.java
+++ b/bindings/java/src/test/java/io/omq/perf/PushPullTcpPeer.java
@@ -23,46 +23,47 @@ public final class PushPullTcpPeer {
         if (args.length != 6 && args.length != 7) {
             throw new IllegalArgumentException(
                     "usage: <omq|omq-into|jeromq|jeromq-into> "
-                            + "<push|pull> <endpoint> <size> <messages> <warmup> [batch]");
+                            + "<push|pull> <endpoint> <size> "
+                            + "<duration_secs> <warmup_secs> [batch]");
         }
 
         Impl impl = Impl.parse(args[0]);
         Role role = Role.parse(args[1]);
         String endpoint = args[2];
         int size = Integer.parseInt(args[3]);
-        int messages = Integer.parseInt(args[4]);
-        int warmup = Integer.parseInt(args[5]);
+        long durationNanos = parsePositiveSeconds(args[4], "duration_secs");
+        long warmupNanos = parseNonNegativeSeconds(args[5], "warmup_secs");
         int batch = args.length == 7 ? Integer.parseInt(args[6]) : 64;
-        if (size < 0 || messages <= 0 || warmup < 0 || batch <= 0) {
-            throw new IllegalArgumentException("invalid size/messages/warmup");
+        if (size < 0 || batch <= 0) {
+            throw new IllegalArgumentException("invalid size/batch");
         }
 
         if (role == Role.PULL) {
-            runPull(impl, endpoint, size, messages, warmup, batch);
+            runPull(impl, endpoint, size, durationNanos, warmupNanos, batch);
         } else {
-            runPush(impl, endpoint, size, messages, warmup);
+            runPush(impl, endpoint, size);
         }
     }
 
     private static void runPull(
-            Impl impl, String endpoint, int size, int messages, int warmup, int batch) {
+            Impl impl, String endpoint, int size, long durationNanos, long warmupNanos, int batch) {
         switch (impl) {
-            case OMQ -> runOmqPull(endpoint, size, messages, warmup, false);
-            case OMQ_INTO -> runOmqPull(endpoint, size, messages, warmup, true);
-            case JEROMQ -> runJeroPull(endpoint, size, messages, warmup, false);
-            case JEROMQ_INTO -> runJeroPull(endpoint, size, messages, warmup, true);
+            case OMQ -> runOmqPull(endpoint, size, durationNanos, warmupNanos, false);
+            case OMQ_INTO -> runOmqPull(endpoint, size, durationNanos, warmupNanos, true);
+            case JEROMQ -> runJeroPull(endpoint, size, durationNanos, warmupNanos, false);
+            case JEROMQ_INTO -> runJeroPull(endpoint, size, durationNanos, warmupNanos, true);
         }
     }
 
-    private static void runPush(Impl impl, String endpoint, int size, int messages, int warmup) {
+    private static void runPush(Impl impl, String endpoint, int size) {
         switch (impl) {
-            case OMQ, OMQ_INTO -> runOmqPush(endpoint, size, messages, warmup);
-            case JEROMQ, JEROMQ_INTO -> runJeroPush(endpoint, size, messages, warmup);
+            case OMQ, OMQ_INTO -> runOmqPush(endpoint, size);
+            case JEROMQ, JEROMQ_INTO -> runJeroPush(endpoint, size);
         }
     }
 
     private static void runOmqPull(
-            String endpoint, int size, int messages, int warmup, boolean receiveInto) {
+            String endpoint, int size, long durationNanos, long warmupNanos, boolean receiveInto) {
         try (Context context = OMQ.context();
              Socket pull = context.socket(SocketType.PULL)
                      .workloadProfile(WorkloadProfile.THROUGHPUT)
@@ -72,20 +73,20 @@ public final class PushPullTcpPeer {
             ready(endpoint);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                receiveInto(pull, buffer, size, warmup);
+                receiveIntoUntil(pull, buffer, size, System.nanoTime() + warmupNanos);
                 long started = System.nanoTime();
-                receiveInto(pull, buffer, size, messages);
-                result(Impl.OMQ_INTO.name, endpoint, size, messages, started, System.nanoTime());
+                long count = receiveIntoUntil(pull, buffer, size, started + durationNanos);
+                result(Impl.OMQ_INTO.name, endpoint, size, count, started, System.nanoTime());
             } else {
-                receiveBytes(pull, size, warmup);
+                receiveBytesUntil(pull, size, System.nanoTime() + warmupNanos);
                 long started = System.nanoTime();
-                receiveBytes(pull, size, messages);
-                result(Impl.OMQ.name, endpoint, size, messages, started, System.nanoTime());
+                long count = receiveBytesUntil(pull, size, started + durationNanos);
+                result(Impl.OMQ.name, endpoint, size, count, started, System.nanoTime());
             }
         }
     }
 
-    private static void runOmqPush(String endpoint, int size, int messages, int warmup) {
+    private static void runOmqPush(String endpoint, int size) {
         byte[] payload = payload(size);
         try (Context context = OMQ.context();
              Socket push = context.socket(SocketType.PUSH)
@@ -94,12 +95,12 @@ public final class PushPullTcpPeer {
                      .linger(LINGER)) {
             push.connect(endpoint);
             push.waitConnected(1, CONNECT_TIMEOUT);
-            sendOmq(push, payload, warmup + messages);
+            sendOmqForever(push, payload);
         }
     }
 
     private static void runJeroPull(
-            String endpoint, int size, int messages, int warmup, boolean receiveInto) {
+            String endpoint, int size, long durationNanos, long warmupNanos, boolean receiveInto) {
         try (org.zeromq.ZContext context = new org.zeromq.ZContext();
              org.zeromq.ZMQ.Socket pull = context.createSocket(org.zeromq.SocketType.PULL)) {
             pull.setRcvHWM(HWM);
@@ -108,20 +109,20 @@ public final class PushPullTcpPeer {
             ready(endpoint);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                receiveJeroInto(pull, buffer, size, warmup);
+                receiveJeroIntoUntil(pull, buffer, size, System.nanoTime() + warmupNanos);
                 long started = System.nanoTime();
-                receiveJeroInto(pull, buffer, size, messages);
-                result(Impl.JEROMQ_INTO.name, endpoint, size, messages, started, System.nanoTime());
+                long count = receiveJeroIntoUntil(pull, buffer, size, started + durationNanos);
+                result(Impl.JEROMQ_INTO.name, endpoint, size, count, started, System.nanoTime());
             } else {
-                receiveJero(pull, size, warmup);
+                receiveJeroUntil(pull, size, System.nanoTime() + warmupNanos);
                 long started = System.nanoTime();
-                receiveJero(pull, size, messages);
-                result(Impl.JEROMQ.name, endpoint, size, messages, started, System.nanoTime());
+                long count = receiveJeroUntil(pull, size, started + durationNanos);
+                result(Impl.JEROMQ.name, endpoint, size, count, started, System.nanoTime());
             }
         }
     }
 
-    private static void runJeroPush(String endpoint, int size, int messages, int warmup) {
+    private static void runJeroPush(String endpoint, int size) {
         byte[] payload = payload(size);
         try (org.zeromq.ZContext context = new org.zeromq.ZContext();
              org.zeromq.ZMQ.Socket push = context.createSocket(org.zeromq.SocketType.PUSH)) {
@@ -129,61 +130,74 @@ public final class PushPullTcpPeer {
             push.setLinger((int) LINGER.toMillis());
             push.connect(endpoint);
             sleep(250);
-            sendJero(push, payload, warmup + messages);
+            sendJeroForever(push, payload);
         }
     }
 
-    private static void sendOmq(Socket push, byte[] payload, int count) {
-        for (int i = 0; i < count; i++) {
+    private static void sendOmqForever(Socket push, byte[] payload) {
+        while (true) {
             push.send(payload);
         }
     }
 
-    private static void sendJero(org.zeromq.ZMQ.Socket push, byte[] payload, int count) {
-        for (int i = 0; i < count; i++) {
+    private static void sendJeroForever(org.zeromq.ZMQ.Socket push, byte[] payload) {
+        while (true) {
             if (!push.send(payload, 0)) {
                 throw new IllegalStateException("JeroMQ send failed");
             }
         }
     }
 
-    private static void receiveBytes(Socket pull, int size, int count) {
-        for (int i = 0; i < count; i++) {
+    private static long receiveBytesUntil(Socket pull, int size, long deadlineNanos) {
+        long count = 0;
+        while (System.nanoTime() < deadlineNanos) {
             byte[] body = pull.receiveBytes();
             if (body.length != size) {
                 throw new IllegalStateException("expected " + size + " bytes, got " + body.length);
             }
+            count++;
         }
+        return count;
     }
 
-    private static void receiveInto(Socket pull, ByteBuffer buffer, int size, int count) {
-        for (int i = 0; i < count; i++) {
+    private static long receiveIntoUntil(
+            Socket pull, ByteBuffer buffer, int size, long deadlineNanos) {
+        long count = 0;
+        while (System.nanoTime() < deadlineNanos) {
             buffer.clear();
             int received = pull.receiveInto(buffer);
             if (received != size) {
                 throw new IllegalStateException("expected " + size + " bytes, got " + received);
             }
+            count++;
         }
+        return count;
     }
 
-    private static void receiveJero(org.zeromq.ZMQ.Socket pull, int size, int count) {
-        for (int i = 0; i < count; i++) {
+    private static long receiveJeroUntil(org.zeromq.ZMQ.Socket pull, int size, long deadlineNanos) {
+        long count = 0;
+        while (System.nanoTime() < deadlineNanos) {
             byte[] body = pull.recv(0);
             if (body.length != size) {
                 throw new IllegalStateException("expected " + size + " bytes, got " + body.length);
             }
+            count++;
         }
+        return count;
     }
 
-    private static void receiveJeroInto(
-            org.zeromq.ZMQ.Socket pull, ByteBuffer buffer, int size, int count) {
-        for (int i = 0; i < count; i++) {
+    private static long receiveJeroIntoUntil(
+            org.zeromq.ZMQ.Socket pull, ByteBuffer buffer, int size, long deadlineNanos) {
+        long count = 0;
+        while (System.nanoTime() < deadlineNanos) {
             buffer.clear();
             int received = pull.recvByteBuffer(buffer, 0);
             if (received != size) {
                 throw new IllegalStateException("expected " + size + " bytes, got " + received);
             }
+            count++;
         }
+        return count;
     }
 
     private static byte[] payload(int size) {
@@ -200,7 +214,7 @@ public final class PushPullTcpPeer {
     }
 
     private static void result(
-            String impl, String endpoint, int size, int messages, long started, long ended) {
+            String impl, String endpoint, int size, long messages, long started, long ended) {
         double seconds = (ended - started) / 1_000_000_000.0;
         double messagesPerSecond = messages / seconds;
         double gbPerSecond = messagesPerSecond * size / 1_000_000_000.0;
@@ -210,6 +224,34 @@ public final class PushPullTcpPeer {
                         + "\"messages\":%d,\"seconds\":%.9f,\"msgs_s\":%.3f,\"gb_s\":%.6f}%n",
                 impl, endpoint, size, messages, seconds, messagesPerSecond, gbPerSecond);
         System.out.flush();
+    }
+
+    private static long parsePositiveSeconds(String value, String label) {
+        long nanos = parseSeconds(value, label);
+        if (nanos <= 0) {
+            throw new IllegalArgumentException(label + " must be greater than zero");
+        }
+        return nanos;
+    }
+
+    private static long parseNonNegativeSeconds(String value, String label) {
+        long nanos = parseSeconds(value, label);
+        if (nanos < 0) {
+            throw new IllegalArgumentException(label + " must be non-negative");
+        }
+        return nanos;
+    }
+
+    private static long parseSeconds(String value, String label) {
+        double seconds = Double.parseDouble(value);
+        if (!Double.isFinite(seconds)) {
+            throw new IllegalArgumentException(label + " must be finite");
+        }
+        double nanos = seconds * 1_000_000_000.0;
+        if (nanos > Long.MAX_VALUE) {
+            throw new IllegalArgumentException(label + " is too large");
+        }
+        return Math.round(nanos);
     }
 
     private static void sleep(long millis) {


### PR DESCRIPTION
- Measure OMQ.java PUSH/PULL throughput with fixed-duration receiver windows instead of fixed message counts.
- Keep the sender process running until the timed receiver completes, then stop it from the Python harness.
- Regenerate `bindings/java/doc/charts/pushpull_tcp.svg` from timed throughput and latency samples.