### PR TITLE
ci: track zguide lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ Cargo.lock
 Cargo.lock.bak
 !bindings/java/native/Cargo.lock
 !bindings/pyomq/Cargo.lock
+!examples/zguide/Cargo.lock
 /bindings/pyomq/dist/*.whl
-!examples/zguide-tokio/Cargo.lock
 !scripts/tmq_bench_peer/Cargo.lock
 uv.lock
 .DS_Store


### PR DESCRIPTION
- Allow `examples/zguide/Cargo.lock` through root `.gitignore` so `release-plz` no longer sees a tracked ignored lockfile after package updates.
- Remove stale `examples/zguide-tokio/Cargo.lock` exception from the same ignore block.