### PR TITLE
Split binding lint and test CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
 
   java-test:
     name: java-test (${{ matrix.os }})
-    needs: [changes, java-lint]
+    needs: [changes, linux-gate, java-lint]
     if: needs.changes.outputs.run_java == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,30 +83,9 @@ jobs:
             echo 'lint_matrix={"include":[{"name":"Linux","kind":"rust","os":"ubuntu-latest"},{"name":"macOS Intel","kind":"rust","os":"macos-15-intel"},{"name":"macOS ARM64","kind":"rust","os":"macos-15"},{"name":"Windows","kind":"rust","os":"windows-latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
-  go-fmt:
-    name: go fmt
+  go-lint:
+    name: go fmt + vet
     needs: [changes]
-    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_go == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version: "1.25"
-          cache-dependency-path: bindings/go/go.mod
-      - name: gofmt
-        working-directory: bindings/go
-        run: |
-          files="$(gofmt -l .)"
-          if [[ -n "$files" ]]; then
-            printf '%s\n' "$files"
-            exit 1
-          fi
-
-  go-vet:
-    name: go vet
-    needs: [changes, go-fmt]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -122,6 +101,14 @@ jobs:
         with:
           go-version: "1.25"
           cache-dependency-path: bindings/go/go.mod
+      - name: gofmt
+        working-directory: bindings/go
+        run: |
+          files="$(gofmt -l .)"
+          if [[ -n "$files" ]]; then
+            printf '%s\n' "$files"
+            exit 1
+          fi
       - name: build native
         run: cargo build --release --manifest-path bindings/go/native/Cargo.toml
       - name: go vet
@@ -132,7 +119,7 @@ jobs:
 
   go-test:
     name: go test
-    needs: [changes, linux-gate, go-vet]
+    needs: [changes, linux-gate, go-lint]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -708,8 +695,7 @@ jobs:
         pyomq-test,
         java-lint,
         java-test,
-        go-fmt,
-        go-vet,
+        go-lint,
         go-test,
         lua-lint,
         lua-test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
             exit 1
           fi
 
-  go-test:
-    name: go test
+  go-vet:
+    name: go vet
     needs: [changes, go-fmt]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_go == 'true'
     runs-on: ubuntu-latest
@@ -129,15 +129,61 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/bindings/go/native/target/release:${{ github.workspace }}/bindings/go/native/target/debug
         run: go vet ./...
+
+  go-test:
+    name: go test
+    needs: [changes, linux-gate, go-vet]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: bindings/go/native
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.25"
+          cache-dependency-path: bindings/go/go.mod
+      - name: build native
+        run: cargo build --release --manifest-path bindings/go/native/Cargo.toml
       - name: go test
         working-directory: bindings/go
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/bindings/go/native/target/release:${{ github.workspace }}/bindings/go/native/target/debug
         run: go test -count=1 ./...
 
+  lua-lint:
+    name: lua lint
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_lua == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: bindings/lua/native
+      - name: install Lua
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.4
+      - name: cargo fmt
+        run: cargo fmt --manifest-path bindings/lua/native/Cargo.toml --check
+      - name: cargo clippy
+        run: cargo clippy --manifest-path bindings/lua/native/Cargo.toml --all-targets -- -D warnings
+      - name: lua syntax
+        run: luac5.4 -p bindings/lua/lua/omq.lua bindings/lua/scripts/*.lua bindings/lua/tests/test_*.lua
+
   lua-test:
     name: lua test
-    needs: [changes]
+    needs: [changes, linux-gate, lua-lint]
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_lua == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -663,7 +709,9 @@ jobs:
         java-lint,
         java-test,
         go-fmt,
+        go-vet,
         go-test,
+        lua-lint,
         lua-test,
       ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Splits Go CI into a combined `go fmt + vet` lint job and a gated `go test` job.
- Adds `lua lint` for Lua syntax plus native Rust fmt/clippy.
- Moves Go, Lua, and Java real tests behind `linux gate` so first batch stays lint-focused.