### PR TITLE
Unify binding benchmark charts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -212,13 +212,10 @@ Results go to `~/.cache/omq/comparisons.jsonl`. APPEND-ONLY!
 
 ## Updating Charts
 
-Chart subtitles show hardware info auto-detected from `/proc/cpuinfo`
-and sysfs. On machines where sysfs is absent, create `.chart_hw` in the
-repo root:
+Chart subtitles come from `.chart_hw` in the repo root:
 
 ```text
-prefix=Linux VM on a 2018 Mac Mini
-postfix=performance governor, turbo off
+label=Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off
 ```
 
 `omq-bench` and binding chart scripts read the repo-root `.chart_hw`

--- a/bindings/go/DEVELOPMENT.md
+++ b/bindings/go/DEVELOPMENT.md
@@ -128,8 +128,8 @@ binary. Do not set `OMQ_GO_BENCH_PEER` manually.
 
 ## Performance Chart
 
-The chart script runs two-process TCP PUSH/PULL throughput over fixed time
-windows and REQ/REP latency over fixed iteration counts, then appends rows to:
+The chart script runs two-process TCP PUSH/PULL throughput and REQ/REP latency
+over fixed time windows, then appends rows to:
 
 ```text
 ~/.cache/omq.go/bindings.jsonl
@@ -153,9 +153,10 @@ Full default run:
 bindings/go/scripts/update_perf.py
 ```
 
-Default throughput window is 3 seconds per size, implementation, and measured
-round, after a 0.5 second receiver warmup window. `--quick` uses 1.5 seconds
-and 0.2 seconds.
+Defaults are 3 measured rounds per size and implementation. Throughput uses
+2.5 second windows; latency uses 1.5 second windows and only measures sizes up
+to 4 KiB. Each round uses a 0.5 second warmup window, and the median round is
+kept. `--quick` uses one 0.5 second measured round and 0.1 second warmup.
 
 Default sizes are:
 
@@ -189,7 +190,8 @@ Useful chart script flags:
 - `--warmup-rounds N`
 - `--duration SECONDS`
 - `--warmup-duration SECONDS`
-- `--latency-iters N`
+- `--latency-duration SECONDS`
+- `--latency-warmup-duration SECONDS`
 - `--no-save`
 - `--no-chart`
 - `--no-build`

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -7,7 +7,7 @@ thread(s), matching the normal libzmq architecture. Public socket calls are
 goroutine-safe and context-cancelable. Hot loops can bind directly to the
 socket owner goroutine.
 
-![OMQ.go performance](doc/charts/bindings.svg)
+![OMQ.go performance](https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/go/doc/charts/bindings.svg)
 
 ## Build, install, test
 

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -1,194 +1,179 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="684" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Intel Core i7-8700B @ 3.20GHz, 12 cores</text>
-  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
-  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
-  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">7M</text>
-  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">9M</text>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
-  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
-  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="211.8" y1="49" x2="211.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="272.7" y1="49" x2="272.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="333.6" y1="49" x2="333.6" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="394.5" y1="49" x2="394.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="455.5" y1="49" x2="455.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="516.4" y1="49" x2="516.4" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="577.3" y1="49" x2="577.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="638.2" y1="49" x2="638.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="699.1" y1="49" x2="699.1" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <rect width="850" height="684" fill="#000000"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">6M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">7M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">8M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">9M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">10M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="211.8" y1="49" x2="211.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="272.7" y1="49" x2="272.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="333.6" y1="49" x2="333.6" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="394.5" y1="49" x2="394.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="455.5" y1="49" x2="455.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="516.4" y1="49" x2="516.4" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="577.3" y1="49" x2="577.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="638.2" y1="49" x2="638.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="699.1" y1="49" x2="699.1" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,123.5 150.9,133.5 211.8,268.5 272.7,274.4 333.6,285.6 394.5,302.1 455.5,328.1 516.4,348.0 577.3,365.7 638.2,370.8 699.1,377.2 760.0,380.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,330.9 150.9,331.1 211.8,332.0 272.7,337.8 333.6,344.9 394.5,356.0 455.5,360.1 516.4,372.4 577.3,378.5 638.2,380.8 699.1,381.9 760.0,382.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,375.7 150.9,368.0 211.8,369.2 272.7,355.9 333.6,333.6 394.5,300.2 455.5,269.6 516.4,236.4 577.3,234.0 638.2,168.0 699.1,160.1 760.0,151.2" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="375.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="368.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="369.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="355.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="333.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="300.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="269.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="236.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="234.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="168.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="160.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="151.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,382.3 150.9,380.6 211.8,377.3 272.7,372.2 333.6,364.0 394.5,355.3 455.5,335.1 516.4,336.6 577.3,338.6 638.2,330.9 699.1,315.4 760.0,272.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="380.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="377.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="372.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="364.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="355.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="335.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="336.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="338.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="330.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="315.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="272.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="150.9" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="211.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="272.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="333.6" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="394.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="455.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="516.4" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="577.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="638.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="699.1" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="255" y1="424" x2="269" y2="424" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="262" cy="424" r="2.5" fill="#f97316"/>
-  <text x="275" y="428" fill="#374151" font-size="11" font-weight="500">OMQ.go hot path</text>
-  <line x1="425" y1="424" x2="439" y2="424" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="432" cy="424" r="2.5" fill="#2563eb"/>
-  <text x="445" y="428" fill="#374151" font-size="11" font-weight="500">zmq4</text>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,97.9 150.9,145.0 211.8,264.1 272.7,275.9 333.6,286.8 394.5,304.8 455.5,328.4 516.4,345.9 577.3,362.1 638.2,371.7 699.1,377.0 760.0,380.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,332.5 150.9,334.4 211.8,334.3 272.7,340.4 333.6,345.4 394.5,351.5 455.5,361.1 516.4,373.9 577.3,379.0 638.2,380.9 699.1,382.0 760.0,382.3" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,374.8 150.9,368.7 211.8,368.7 272.7,356.3 333.6,334.2 394.5,302.9 455.5,270.2 516.4,227.9 577.3,204.9 638.2,182.4 699.1,154.2 760.0,151.7" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="374.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="368.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="368.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="356.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="334.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="302.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="270.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="227.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="204.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="182.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="154.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="151.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,382.4 150.9,380.8 211.8,377.6 272.7,372.8 333.6,364.2 394.5,350.7 455.5,337.1 516.4,342.8 577.3,343.1 638.2,333.8 699.1,319.0 760.0,275.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="382.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="380.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="377.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="372.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="364.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="350.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="337.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="342.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="343.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="333.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="319.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="275.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="150.9" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="211.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="272.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="333.6" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="394.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="455.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="516.4" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="577.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="638.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="699.1" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <line x1="255" y1="424" x2="269" y2="424" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="262" cy="424" r="2.5" fill="#ef4444"/>
+  <text x="275" y="428" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go hot path</text>
+  <line x1="425" y1="424" x2="439" y2="424" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="432" cy="424" r="2.5" fill="#60a5fa"/>
+  <text x="445" y="428" fill="#e5e7eb" font-size="11" font-weight="500">zmq4</text>
   <text x="425.0" y="442" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left), solid = throughput (right)</text>
-  <text x="425.0" y="472" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 us</text>
-  <line x1="90" y1="597.0" x2="760" y2="597.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="597.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 us</text>
-  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 us</text>
-  <line x1="90" y1="573.0" x2="760" y2="573.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="573.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 us</text>
-  <line x1="90" y1="561.0" x2="760" y2="561.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="561.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 us</text>
-  <line x1="90" y1="549.0" x2="760" y2="549.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 us</text>
-  <line x1="90" y1="537.0" x2="760" y2="537.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="537.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 us</text>
-  <line x1="90" y1="525.0" x2="760" y2="525.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="525.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 us</text>
-  <line x1="90" y1="513.0" x2="760" y2="513.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="513.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 us</text>
-  <line x1="90" y1="501.0" x2="760" y2="501.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="501.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 us</text>
-  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 us</text>
-  <line x1="90.0" y1="489" x2="90.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="150.9" y1="489" x2="150.9" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="211.8" y1="489" x2="211.8" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="272.7" y1="489" x2="272.7" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="333.6" y1="489" x2="333.6" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="394.5" y1="489" x2="394.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="455.5" y1="489" x2="455.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="516.4" y1="489" x2="516.4" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="577.3" y1="489" x2="577.3" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="638.2" y1="489" x2="638.2" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="699.1" y1="489" x2="699.1" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="489" x2="760.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="425.0" y="472" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 us</text>
+  <line x1="90" y1="597.0" x2="760" y2="597.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="597.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 us</text>
+  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 us</text>
+  <line x1="90" y1="573.0" x2="760" y2="573.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="573.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 us</text>
+  <line x1="90" y1="561.0" x2="760" y2="561.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="561.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 us</text>
+  <line x1="90" y1="549.0" x2="760" y2="549.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 us</text>
+  <line x1="90" y1="537.0" x2="760" y2="537.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="537.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 us</text>
+  <line x1="90" y1="525.0" x2="760" y2="525.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="525.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 us</text>
+  <line x1="90" y1="513.0" x2="760" y2="513.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="513.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 us</text>
+  <line x1="90" y1="501.0" x2="760" y2="501.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="501.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 us</text>
+  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 us</text>
+  <line x1="90.0" y1="489" x2="90.0" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="173.8" y1="489" x2="173.8" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="257.5" y1="489" x2="257.5" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="341.2" y1="489" x2="341.2" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="489" x2="425.0" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="508.8" y1="489" x2="508.8" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="592.5" y1="489" x2="592.5" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="676.2" y1="489" x2="676.2" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="489" x2="760.0" y2="609" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,506.8 150.9,513.1 211.8,511.0 272.7,503.8 333.6,509.4 394.5,508.0 455.5,506.4 516.4,504.5 577.3,501.4 638.2,490.6 699.1,489.0 760.0,489.0" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="506.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="513.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="511.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="503.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="509.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="508.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="506.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="504.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="501.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="490.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="489.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,567.8 150.9,567.9 211.8,567.3 272.7,568.2 333.6,568.8 394.5,566.6 455.5,567.1 516.4,567.3 577.3,561.7 638.2,559.1 699.1,552.5 760.0,544.1" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="567.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="567.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="567.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="568.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="568.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="566.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="567.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="567.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="561.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="559.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="552.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="544.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,548.7 150.9,551.9 211.8,549.6 272.7,544.8 333.6,550.0 394.5,549.6 455.5,551.1 516.4,547.7 577.3,544.9 638.2,537.7 699.1,534.9 760.0,522.4" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="548.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="551.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="549.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="544.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="550.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="549.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="551.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="547.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="544.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="537.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="534.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="522.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="272.7" y="623" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="333.6" y="623" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="394.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="455.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="516.4" y="623" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="577.3" y="623" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="638.2" y="623" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="699.1" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="170" y1="649" x2="184" y2="649" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="177" cy="649" r="2.5" fill="#dc2626"/>
-  <text x="190" y="653" fill="#374151" font-size="11" font-weight="500">OMQ.go scalar</text>
-  <line x1="340" y1="649" x2="354" y2="649" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="347" cy="649" r="2.5" fill="#f97316"/>
-  <text x="360" y="653" fill="#374151" font-size="11" font-weight="500">OMQ.go Socket.Run</text>
-  <line x1="510" y1="649" x2="524" y2="649" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="517" cy="649" r="2.5" fill="#2563eb"/>
-  <text x="530" y="653" fill="#374151" font-size="11" font-weight="500">zmq4</text>
+  <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
+  <polyline points="90.0,507.8 173.8,505.1 257.5,505.6 341.2,504.6 425.0,505.5 508.8,505.0 592.5,501.3 676.2,505.4 760.0,496.4" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="507.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="505.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="505.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="504.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="505.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="505.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="501.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="505.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="496.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,568.4 173.8,568.2 257.5,567.6 341.2,566.5 425.0,567.7 508.8,566.2 592.5,568.7 676.2,566.3 760.0,562.5" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="568.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="568.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="567.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="566.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="567.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="566.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="568.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="566.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="562.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,545.7 173.8,543.0 257.5,543.2 341.2,544.7 425.0,545.4 508.8,545.5 592.5,548.3 676.2,547.3 760.0,544.4" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="545.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="543.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="543.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="544.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="545.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="545.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="548.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="547.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="544.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="173.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="257.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="341.2" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="425.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="508.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="592.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="676.2" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="760.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="170" y1="649" x2="184" y2="649" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="177" cy="649" r="2.5" fill="#ef4444"/>
+  <text x="190" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go scalar</text>
+  <line x1="340" y1="649" x2="354" y2="649" stroke="#fb923c" stroke-width="2.5"/>
+  <circle cx="347" cy="649" r="2.5" fill="#fb923c"/>
+  <text x="360" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go Socket.Run</text>
+  <line x1="510" y1="649" x2="524" y2="649" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="517" cy="649" r="2.5" fill="#60a5fa"/>
+  <text x="530" y="653" fill="#e5e7eb" font-size="11" font-weight="500">zmq4</text>
 </svg>

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -36,6 +36,7 @@ CHART = CHART_DIR / "bindings.svg"
 
 DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [16, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
 DEFAULT_IMPLS = ["omq-run-into", "zmq4"]
 DEFAULT_LATENCY_IMPLS = ["omq", "omq-run", "zmq4"]
 IMPL_LABELS = {
@@ -45,10 +46,10 @@ IMPL_LABELS = {
     "zmq4": "zmq4",
 }
 COLORS = {
-    "omq": "#dc2626",
-    "omq-run": "#f97316",
-    "omq-run-into": "#f97316",
-    "zmq4": "#2563eb",
+    "omq": "#ef4444",
+    "omq-run": "#fb923c",
+    "omq-run-into": "#ef4444",
+    "zmq4": "#60a5fa",
 }
 
 GO_PEER = r'''
@@ -71,6 +72,7 @@ const hwm = 1_000_000
 const linger = 5 * time.Second
 const timeout = 120 * time.Second
 const maxTimeCheckMessages = 1024
+const latencySampleCapacity = 16384
 
 type result struct {
 	Impl     string  `json:"impl"`
@@ -86,7 +88,7 @@ type result struct {
 
 func main() {
 	if len(os.Args) != 8 {
-		die("usage: omq-go-bench-peer <pushpull|reqrep> <omq|omq-run|omq-run-into|zmq4> <push|pull|req|rep> <endpoint> <size> <duration|messages> <warmup>")
+		die("usage: omq-go-bench-peer <pushpull|reqrep> <omq|omq-run|omq-run-into|zmq4> <push|pull|req|rep> <endpoint> <size> <duration> <warmup>")
 	}
 	bench := os.Args[1]
 	impl := os.Args[2]
@@ -113,16 +115,16 @@ func main() {
 			die("bad pushpull role: " + role)
 		}
 	case "reqrep":
-		messages := parseInt(os.Args[6], "messages")
-		warmup := parseInt(os.Args[7], "warmup")
-		if messages <= 0 || warmup < 0 {
-			die("invalid messages/warmup")
+		duration := parseDurationSeconds(os.Args[6], "duration")
+		warmup := parseDurationSeconds(os.Args[7], "warmup")
+		if duration <= 0 || warmup < 0 {
+			die("invalid duration/warmup")
 		}
 		switch role {
 		case "rep":
-			runRep(impl, endpoint, size, messages, warmup)
+			runRep(impl, endpoint, size)
 		case "req":
-			runReq(impl, endpoint, size, messages, warmup)
+			runReq(impl, endpoint, size, duration, warmup)
 		default:
 			die("bad reqrep role: " + role)
 		}
@@ -441,33 +443,33 @@ func printThroughput(impl string, endpoint string, size int, messages int, start
 	})
 }
 
-func runRep(impl string, endpoint string, size int, messages int, warmup int) {
+func runRep(impl string, endpoint string, size int) {
 	switch impl {
 	case "omq":
-		runOMQRep(endpoint, messages+warmup)
+		runOMQRep(endpoint)
 	case "omq-run":
-		runOMQRepRun(endpoint, size, messages+warmup)
+		runOMQRepRun(endpoint, size)
 	case "zmq4":
-		runZMQRep(endpoint, messages+warmup)
+		runZMQRep(endpoint)
 	default:
 		die("latency unsupported for impl: " + impl)
 	}
 }
 
-func runReq(impl string, endpoint string, size int, messages int, warmup int) {
+func runReq(impl string, endpoint string, size int, duration time.Duration, warmup time.Duration) {
 	switch impl {
 	case "omq":
-		runOMQReq(endpoint, size, messages, warmup)
+		runOMQReq(endpoint, size, duration, warmup)
 	case "omq-run":
-		runOMQReqRun(endpoint, size, messages, warmup)
+		runOMQReqRun(endpoint, size, duration, warmup)
 	case "zmq4":
-		runZMQReq(endpoint, size, messages, warmup)
+		runZMQReq(endpoint, size, duration, warmup)
 	default:
 		die("latency unsupported for impl: " + impl)
 	}
 }
 
-func runOMQRep(endpoint string, count int) {
+func runOMQRep(endpoint string) {
 	ctx, rep := openOMQSocket(omq.Rep, false)
 	defer ctx.Close()
 	defer rep.Close(context.Background())
@@ -477,7 +479,7 @@ func runOMQRep(endpoint string, count int) {
 	ready(endpoint)
 	runCtx, cancel := benchContext()
 	defer cancel()
-	for i := 0; i < count; i++ {
+	for {
 		msg, err := rep.Recv(runCtx)
 		if err != nil {
 			die(err.Error())
@@ -488,7 +490,7 @@ func runOMQRep(endpoint string, count int) {
 	}
 }
 
-func runOMQRepRun(endpoint string, size int, count int) {
+func runOMQRepRun(endpoint string, size int) {
 	ctx, rep := openOMQSocket(omq.Rep, false)
 	defer ctx.Close()
 	defer rep.Close(context.Background())
@@ -501,7 +503,7 @@ func runOMQRepRun(endpoint string, size int, count int) {
 	buffer := make([]byte, size)
 	reply := omq.Bytes(makePayload(size))
 	err := rep.Run(runCtx, func(socket *omq.BoundSocket) error {
-		for i := 0; i < count; i++ {
+		for {
 			n, err := socket.RecvIntoBlocking(buffer)
 			if err != nil {
 				return err
@@ -520,7 +522,7 @@ func runOMQRepRun(endpoint string, size int, count int) {
 	}
 }
 
-func runOMQReq(endpoint string, size int, messages int, warmup int) {
+func runOMQReq(endpoint string, size int, duration time.Duration, warmup time.Duration) {
 	ctx, req := openOMQSocket(omq.Req, true)
 	defer ctx.Close()
 	defer req.Close(context.Background())
@@ -531,19 +533,24 @@ func runOMQReq(endpoint string, size int, messages int, warmup int) {
 	msg := omq.Bytes(payload)
 	runCtx, cancel := benchContext()
 	defer cancel()
-	for i := 0; i < warmup; i++ {
+	warmupDeadline := time.Now().Add(warmup)
+	for time.Now().Before(warmupDeadline) {
 		omqRoundTrip(req, runCtx, msg, size)
 	}
-	durations := make([]float64, messages)
-	for i := 0; i < messages; i++ {
+	deadline := time.Now().Add(duration)
+	durations := make([]float64, 0, latencySampleCapacity)
+	for {
 		started := time.Now()
 		omqRoundTrip(req, runCtx, msg, size)
-		durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+		durations = append(durations, float64(time.Since(started).Nanoseconds())/1000.0)
+		if !time.Now().Before(deadline) {
+			break
+		}
 	}
-	printLatency("omq", endpoint, size, messages, durations)
+	printLatency("omq", endpoint, size, durations)
 }
 
-func runOMQReqRun(endpoint string, size int, messages int, warmup int) {
+func runOMQReqRun(endpoint string, size int, duration time.Duration, warmup time.Duration) {
 	ctx, req := openOMQSocket(omq.Req, true)
 	defer ctx.Close()
 	defer req.Close(context.Background())
@@ -553,28 +560,33 @@ func runOMQReqRun(endpoint string, size int, messages int, warmup int) {
 	payload := makePayload(size)
 	msg := omq.Bytes(payload)
 	buffer := make([]byte, size)
-	durations := make([]float64, messages)
+	durations := make([]float64, 0, latencySampleCapacity)
 	runCtx, cancel := benchContext()
 	defer cancel()
 	err := req.Run(runCtx, func(socket *omq.BoundSocket) error {
-		for i := 0; i < warmup; i++ {
+		warmupDeadline := time.Now().Add(warmup)
+		for time.Now().Before(warmupDeadline) {
 			if err := omqRoundTripRun(socket, msg, buffer, size); err != nil {
 				return err
 			}
 		}
-		for i := 0; i < messages; i++ {
+		deadline := time.Now().Add(duration)
+		for {
 			started := time.Now()
 			if err := omqRoundTripRun(socket, msg, buffer, size); err != nil {
 				return err
 			}
-			durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+			durations = append(durations, float64(time.Since(started).Nanoseconds())/1000.0)
+			if !time.Now().Before(deadline) {
+				break
+			}
 		}
 		return nil
 	})
 	if err != nil {
 		die(err.Error())
 	}
-	printLatency("omq-run", endpoint, size, messages, durations)
+	printLatency("omq-run", endpoint, size, durations)
 }
 
 func omqRoundTrip(req *omq.Socket, ctx context.Context, msg omq.Message, size int) {
@@ -604,7 +616,7 @@ func omqRoundTripRun(req *omq.BoundSocket, msg omq.Message, buffer []byte, size 
 	return nil
 }
 
-func runZMQRep(endpoint string, count int) {
+func runZMQRep(endpoint string) {
 	ctx, rep := openZMQSocket(zmq4.REP, false)
 	defer ctx.Term()
 	defer rep.Close()
@@ -612,7 +624,7 @@ func runZMQRep(endpoint string, count int) {
 		die(err.Error())
 	}
 	ready(endpoint)
-	for i := 0; i < count; i++ {
+	for {
 		msg, err := rep.RecvBytes(0)
 		if err != nil {
 			die(err.Error())
@@ -623,7 +635,7 @@ func runZMQRep(endpoint string, count int) {
 	}
 }
 
-func runZMQReq(endpoint string, size int, messages int, warmup int) {
+func runZMQReq(endpoint string, size int, duration time.Duration, warmup time.Duration) {
 	ctx, req := openZMQSocket(zmq4.REQ, true)
 	defer ctx.Term()
 	defer req.Close()
@@ -631,16 +643,21 @@ func runZMQReq(endpoint string, size int, messages int, warmup int) {
 		die(err.Error())
 	}
 	payload := makePayload(size)
-	for i := 0; i < warmup; i++ {
+	warmupDeadline := time.Now().Add(warmup)
+	for time.Now().Before(warmupDeadline) {
 		zmqRoundTrip(req, payload, size)
 	}
-	durations := make([]float64, messages)
-	for i := 0; i < messages; i++ {
+	deadline := time.Now().Add(duration)
+	durations := make([]float64, 0, latencySampleCapacity)
+	for {
 		started := time.Now()
 		zmqRoundTrip(req, payload, size)
-		durations[i] = float64(time.Since(started).Nanoseconds()) / 1000.0
+		durations = append(durations, float64(time.Since(started).Nanoseconds())/1000.0)
+		if !time.Now().Before(deadline) {
+			break
+		}
 	}
-	printLatency("zmq4", endpoint, size, messages, durations)
+	printLatency("zmq4", endpoint, size, durations)
 }
 
 func zmqRoundTrip(req *zmq4.Socket, payload []byte, size int) {
@@ -656,8 +673,9 @@ func zmqRoundTrip(req *zmq4.Socket, payload []byte, size int) {
 	}
 }
 
-func printLatency(impl string, endpoint string, size int, messages int, durations []float64) {
+func printLatency(impl string, endpoint string, size int, durations []float64) {
 	sort.Float64s(durations)
+	messages := len(durations)
 	p50 := durations[len(durations)*50/100]
 	p99 := durations[len(durations)*99/100]
 	printResult(result{
@@ -699,6 +717,10 @@ def parse_csv_ints(value):
 
 def parse_csv_strings(value):
     return [part for part in value.split(",") if part]
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
 
 
 def run(cmd, cwd=ROOT, timeout=None, fail_on_warning=True):
@@ -880,11 +902,11 @@ def run_throughput_pair_once(impl, size, duration, warmup, timeout):
         raise
 
 
-def run_pair_once(bench, impl, receiver_role, sender_role, size, messages, warmup, timeout):
+def run_pair_once(bench, impl, receiver_role, sender_role, size, duration, warmup, timeout):
     endpoint = free_endpoint()
     env = env_with_native_lib()
     receiver = subprocess.Popen(
-        peer_cmd(bench, impl, receiver_role, endpoint, size, messages, warmup),
+        peer_cmd(bench, impl, receiver_role, endpoint, size, duration, warmup),
         cwd=ROOT,
         env=env,
         text=True,
@@ -898,7 +920,7 @@ def run_pair_once(bench, impl, receiver_role, sender_role, size, messages, warmu
             raise RuntimeError(f"receiver did not become ready:\n{ready or ''}{out}{err}")
 
         sender = subprocess.run(
-            peer_cmd(bench, impl, sender_role, endpoint, size, messages, warmup),
+            peer_cmd(bench, impl, sender_role, endpoint, size, duration, warmup),
             cwd=ROOT,
             env=env,
             text=True,
@@ -911,13 +933,15 @@ def run_pair_once(bench, impl, receiver_role, sender_role, size, messages, warmu
         if sender.returncode != 0:
             raise RuntimeError(f"sender failed:\n{sender.stdout}{sender.stderr}")
 
+        if bench == "reqrep":
+            out, err = kill(receiver)
+            fail_on_noise("receiver", ready + out, err)
+            return parse_result(sender.stdout)
         out, err = receiver.communicate(timeout=timeout)
         out = ready + out
         fail_on_noise("receiver", out, err)
         if receiver.returncode != 0:
             raise RuntimeError(f"receiver failed:\n{out}{err}")
-        if bench == "reqrep":
-            return parse_result(sender.stdout)
         return parse_result(out)
     except Exception:
         kill(receiver)
@@ -948,17 +972,28 @@ def run_throughput_cell(impl, size, args):
 
 
 def run_latency_cell(impl, size, args):
-    messages = args.latency_iters
-    warmup = args.latency_warmup
     runs = []
     total = args.warmup_rounds + args.rounds
+    timeout = args.timeout + args.latency_warmup_duration + args.latency_duration
     for round_index in range(total):
-        row = run_pair_once("reqrep", impl, "rep", "req", size, messages, warmup, args.timeout)
+        row = run_pair_once(
+            "reqrep",
+            impl,
+            "rep",
+            "req",
+            size,
+            f"{args.latency_duration:.6f}",
+            f"{args.latency_warmup_duration:.6f}",
+            timeout,
+        )
+        row["target_seconds"] = args.latency_duration
+        row["warmup_seconds"] = args.latency_warmup_duration
         if round_index >= args.warmup_rounds:
             runs.append(row)
         print(
             f"  {impl:12s} size={size:6d} round={round_index + 1}/{total} "
-            f"p50 {row['p50_us']:8.1f} us p99 {row['p99_us']:8.1f} us",
+            f"p50 {row['p50_us']:8.1f} us p99 {row['p99_us']:8.1f} us "
+            f"n={row['messages']}",
             flush=True,
         )
     return sorted(runs, key=lambda row: row["p50_us"])[len(runs) // 2]
@@ -996,7 +1031,7 @@ def fmt_rate(rate):
     return f"{rate / 1_000:.0f} k/s"
 
 
-def print_table(rows, sizes, impls, latency_impls):
+def print_table(rows, sizes, latency_sizes, impls, latency_impls):
     by_key = {(row["kind"], row["msg_size"], row["impl"]): row for row in rows}
     print()
     if impls:
@@ -1018,7 +1053,7 @@ def print_table(rows, sizes, impls, latency_impls):
     if latency_impls:
         print("REQ/REP TCP latency")
         print("size    impl             p50 us    p99 us   vs zmq4")
-        for size in sizes:
+        for size in latency_sizes:
             base = by_key.get(("reqrep_tcp_latency", size, "zmq4"))
             base_p50 = base["p50_us"] if base else 0.0
             for impl in latency_impls:
@@ -1033,7 +1068,7 @@ def print_table(rows, sizes, impls, latency_impls):
             print()
 
 
-def latest_chart_data(sizes, impls, latency_impls):
+def latest_chart_data(sizes, latency_sizes, impls, latency_impls):
     latest = {}
     for row in load_jsonl():
         kind = row.get("kind")
@@ -1054,7 +1089,7 @@ def latest_chart_data(sizes, impls, latency_impls):
     latency = {
         impl: [
             latest.get(("reqrep_tcp_latency", impl, size), {}).get("p50_us", 0.0)
-            for size in sizes
+            for size in latency_sizes
         ]
         for impl in latency_impls
     }
@@ -1114,38 +1149,29 @@ def read_chart_hw():
 
 def detect_hardware():
     config = read_chart_hw()
-    try:
-        cpu = None
-        with open("/proc/cpuinfo") as file:
-            for line in file:
-                if line.startswith("model name"):
-                    cpu = line.split(":", 1)[1].strip()
-                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
-                    break
-        cores = os.cpu_count()
-        if cpu and cores:
-            label = f"{cpu}, {cores} cores"
-            prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
-            postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
-            extras = [part.strip() for part in postfix.split(",")] if postfix else []
-            env_extras = os.environ.get("OMQ_HW_EXTRAS")
-            if env_extras:
-                extras.extend(env_extras.split(","))
-            extras = [part for part in extras if part]
-            if extras:
-                label += ", " + ", ".join(extras)
-            if prefix:
-                label = f"{prefix}, {label}"
-            return label
-    except OSError:
-        pass
+    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
     return None
 
 
 def chart_selection(args, sizes):
     if args.latency_only or args.throughput_only:
-        return DEFAULT_SIZES, DEFAULT_IMPLS, DEFAULT_LATENCY_IMPLS
-    return sizes, args.impls, args.latency_impls
+        return (
+            DEFAULT_SIZES,
+            latency_sizes_from(DEFAULT_SIZES),
+            DEFAULT_IMPLS,
+            DEFAULT_LATENCY_IMPLS,
+        )
+    return sizes, latency_sizes_from(sizes), args.impls, args.latency_impls
 
 
 def svg_line(points, color, dashed=False):
@@ -1156,7 +1182,7 @@ def svg_line(points, color, dashed=False):
     )
 
 
-def gen_chart(data, path, sizes, impls, latency_impls):
+def gen_chart(data, path, sizes, latency_sizes, impls, latency_impls):
     hw_label = detect_hardware()
     hw_offset = 14 if hw_label else 0
     svg_w = 850
@@ -1172,6 +1198,10 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t2_h = t2_bot - t2_top
     mid_x = (x_left + x_right) / 2
     xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
+    lat_xs = [
+        x_left + i * plot_w / max(len(latency_sizes) - 1, 1)
+        for i in range(len(latency_sizes))
+    ]
 
     all_rates = [rate for values in data["throughput"].values() for rate in values]
     all_mbps = [
@@ -1195,8 +1225,8 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     lines = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">',
-        f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
-        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>',
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"PUSH/PULL throughput: 2-process, TCP loopback</text>",
     ]
@@ -1211,23 +1241,23 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         yy = t1_bot - frac * t1_h
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_rate(msg_max * frac)}</text>"
         )
         lines.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
-            f' dominant-baseline="middle" fill="#6b7280" font-size="10">'
+            f' dominant-baseline="middle" fill="#9ca3af" font-size="10">'
             f"{fmt_y_mbps(mbps_max * frac)}</text>"
         )
 
     for x in xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
     lines.extend(
         [
@@ -1242,7 +1272,7 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t1_mid = (t1_top + t1_bot) / 2
     lines.append(
         f'  <text x="40" y="{t1_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
     )
 
@@ -1258,13 +1288,13 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         for i, value in enumerate(mbps):
             lines.append(
                 f'  <circle cx="{xs[i]:.1f}" cy="{y_mbps(value):.1f}" r="3"'
-                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+                f' fill="{COLORS[impl]}" stroke="#000000" stroke-width="1"/>'
             )
 
     for i, size in enumerate(sizes):
         lines.append(
             f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     add_legend(lines, [(IMPL_LABELS[impl], COLORS[impl]) for impl in impls], mid_x, t1_leg_y)
@@ -1275,7 +1305,7 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     )
 
     lines.append(
-        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"REQ/REP latency: 2-process, TCP loopback, p50 us</text>"
     )
@@ -1285,17 +1315,17 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         yy = y_lat(value)
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_us(value)}</text>"
         )
-    for x in xs:
+    for x in lat_xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
     lines.extend(
         [
@@ -1308,22 +1338,24 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t2_mid = (t2_top + t2_bot) / 2
     lines.append(
         f'  <text x="40" y="{t2_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t2_mid:.0f})">p50 latency (us)</text>'
     )
     for impl in latency_impls:
         values = data["latency"].get(impl, [])
-        points = " ".join(f"{xs[i]:.1f},{y_lat(value):.1f}" for i, value in enumerate(values))
+        points = " ".join(
+            f"{lat_xs[i]:.1f},{y_lat(value):.1f}" for i, value in enumerate(values)
+        )
         lines.append(svg_line(points, COLORS[impl]))
         for i, value in enumerate(values):
             lines.append(
-                f'  <circle cx="{xs[i]:.1f}" cy="{y_lat(value):.1f}" r="3"'
-                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{y_lat(value):.1f}" r="3"'
+                f' fill="{COLORS[impl]}" stroke="#000000" stroke-width="1"/>'
             )
-    for i, size in enumerate(sizes):
+    for i, size in enumerate(latency_sizes):
         lines.append(
-            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     add_legend(lines, [(IMPL_LABELS[impl], COLORS[impl]) for impl in latency_impls], mid_x, t2_bot + 40)
@@ -1346,7 +1378,7 @@ def add_legend(lines, legend_items, mid_x, leg_y):
         )
         lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
         lines.append(
-            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
             f' font-size="11" font-weight="500">{html.escape(label)}</text>'
         )
 
@@ -1358,11 +1390,11 @@ def main():
     parser.add_argument("--impls", type=parse_csv_strings, default=DEFAULT_IMPLS)
     parser.add_argument("--latency-impls", type=parse_csv_strings, default=DEFAULT_LATENCY_IMPLS)
     parser.add_argument("--rounds", type=int, default=3)
-    parser.add_argument("--warmup-rounds", type=int, default=1)
-    parser.add_argument("--duration", type=float, default=3.0)
+    parser.add_argument("--warmup-rounds", type=int, default=0)
+    parser.add_argument("--duration", type=float, default=2.5)
     parser.add_argument("--warmup-duration", type=float, default=0.5)
-    parser.add_argument("--latency-iters", type=int, default=10_000)
-    parser.add_argument("--latency-warmup", type=int, default=1_000)
+    parser.add_argument("--latency-duration", type=float, default=1.5)
+    parser.add_argument("--latency-warmup-duration", type=float)
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--no-harness-build", action="store_true")
@@ -1380,10 +1412,11 @@ def main():
     if args.quick:
         args.rounds = min(args.rounds, 1)
         args.warmup_rounds = 0
-        args.duration = min(args.duration, 1.5)
-        args.warmup_duration = min(args.warmup_duration, 0.2)
-        args.latency_iters = min(args.latency_iters, 1_000)
-        args.latency_warmup = min(args.latency_warmup, 100)
+        args.duration = min(args.duration, 0.5)
+        args.latency_duration = min(args.latency_duration, 0.5)
+        args.warmup_duration = min(args.warmup_duration, 0.1)
+    if args.latency_warmup_duration is None:
+        args.latency_warmup_duration = args.warmup_duration
     if args.rounds < 1:
         parser.error("--rounds must be at least 1")
     if args.warmup_rounds < 0:
@@ -1392,18 +1425,21 @@ def main():
         parser.error("--duration must be positive")
     if args.warmup_duration < 0:
         parser.error("--warmup-duration cannot be negative")
-    if args.latency_iters < 1 or args.latency_warmup < 0:
-        parser.error("invalid latency iteration counts")
+    if args.latency_duration <= 0:
+        parser.error("--latency-duration must be positive")
+    if args.latency_warmup_duration < 0:
+        parser.error("--latency-warmup-duration cannot be negative")
     for impl in args.impls:
         if impl not in IMPL_LABELS:
             parser.error(f"unknown throughput impl: {impl}")
     for impl in args.latency_impls:
         if impl not in DEFAULT_LATENCY_IMPLS:
             parser.error(f"unknown latency impl: {impl}")
+    latency_sizes = latency_sizes_from(sizes)
 
     if args.chart_only:
-        data = latest_chart_data(sizes, args.impls, args.latency_impls)
-        gen_chart(data, CHART, sizes, args.impls, args.latency_impls)
+        data = latest_chart_data(sizes, latency_sizes, args.impls, args.latency_impls)
+        gen_chart(data, CHART, sizes, latency_sizes, args.impls, args.latency_impls)
         return
 
     build_native(args)
@@ -1423,7 +1459,7 @@ def main():
                 rows.append(row)
     if not args.throughput_only:
         print("REQ/REP TCP latency")
-        for size in sizes:
+        for size in latency_sizes:
             for impl in args.latency_impls:
                 row = run_latency_cell(impl, size, args)
                 row["run_id"] = run_id
@@ -1434,12 +1470,29 @@ def main():
     if not args.no_save:
         append_jsonl(rows)
         print(f"appended {len(rows)} rows to {JSONL}")
-    print_table(rows, sizes, [] if args.latency_only else args.impls, [] if args.throughput_only else args.latency_impls)
+    print_table(
+        rows,
+        sizes,
+        latency_sizes,
+        [] if args.latency_only else args.impls,
+        [] if args.throughput_only else args.latency_impls,
+    )
 
     if not args.no_chart and not args.no_save:
-        chart_sizes, chart_impls, chart_latency_impls = chart_selection(args, sizes)
-        data = latest_chart_data(chart_sizes, chart_impls, chart_latency_impls)
-        gen_chart(data, CHART, chart_sizes, chart_impls, chart_latency_impls)
+        chart_sizes, chart_latency_sizes, chart_impls, chart_latency_impls = chart_selection(
+            args, sizes
+        )
+        data = latest_chart_data(
+            chart_sizes, chart_latency_sizes, chart_impls, chart_latency_impls
+        )
+        gen_chart(
+            data,
+            CHART,
+            chart_sizes,
+            chart_latency_sizes,
+            chart_impls,
+            chart_latency_impls,
+        )
 
 
 if __name__ == "__main__":

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -25,8 +25,9 @@ small API built around `AutoCloseable`, `Duration`, `ByteBuffer`, and
 </p>
 
 2-process loopback PUSH/PULL throughput and REQ/REP p50 latency vs JeroMQ
-over TCP. Both panels warm the JVM before timed samples. Results are median
-local runs from `scripts/bench_pushpull_tcp.py`.
+over TCP. Throughput uses 3 median-selected 2.5 second rounds; latency uses
+3 median-selected 1.5 second rounds and measures sizes up to 4 KiB. Each round
+has a 0.5 second warmup window.
 
 ## Build, install, test
 

--- a/bindings/java/doc/charts/pushpull_tcp.svg
+++ b/bindings/java/doc/charts/pushpull_tcp.svg
@@ -1,236 +1,218 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="684" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">JIT-warmed PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off</text>
-  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
-  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">6M</text>
-  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">7M</text>
-  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">8M</text>
-  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">9M</text>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
-  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">10M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
-  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <rect width="850" height="684" fill="#000000"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">JIT-warmed PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">6M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">7M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">8M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">9M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">10M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,168.1 145.8,166.4 201.7,161.0 257.5,234.5 313.3,244.7 369.2,255.9 425.0,289.3 480.8,317.1 536.7,346.6 592.5,363.8 648.3,374.1 704.2,378.8 760.0,381.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,160.8 145.8,166.5 201.7,136.6 257.5,242.1 313.3,239.2 369.2,254.8 425.0,285.2 480.8,315.0 536.7,341.9 592.5,360.4 648.3,370.4 704.2,376.6 760.0,380.1" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,225.1 145.8,230.3 201.7,241.6 257.5,260.3 313.3,284.5 369.2,306.3 425.0,332.6 480.8,351.4 536.7,366.4 592.5,374.5 648.3,379.5 704.2,381.5 760.0,382.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,230.0 145.8,243.9 201.7,248.7 257.5,261.3 313.3,279.8 369.2,308.1 425.0,331.7 480.8,352.1 536.7,366.3 592.5,374.8 648.3,379.3 704.2,381.5 760.0,382.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,380.5 145.8,377.0 201.7,369.7 257.5,364.9 313.3,348.3 369.2,318.4 425.0,287.0 480.8,247.0 536.7,230.9 592.5,218.8 648.3,221.7 704.2,213.7 760.0,213.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="377.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="369.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="364.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="348.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="318.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="287.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="247.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="230.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="218.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="221.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="213.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="213.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,380.4 145.8,377.0 201.7,368.2 257.5,365.8 313.3,346.9 369.2,317.8 425.0,282.8 480.8,242.6 536.7,211.7 592.5,190.5 648.3,161.9 704.2,142.5 760.0,126.8" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="377.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="368.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="365.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="346.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="317.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="282.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="242.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="211.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="190.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="161.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="142.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="126.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,381.5 145.8,379.1 201.7,374.9 257.5,368.2 313.3,358.5 369.2,344.2 425.0,331.4 480.8,317.3 536.7,312.1 592.5,306.0 648.3,309.5 704.2,302.2 760.0,267.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="381.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="379.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="374.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="368.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="358.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="344.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="331.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="317.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="312.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="306.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="309.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="302.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="267.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,381.5 145.8,379.5 201.7,375.3 257.5,368.3 313.3,357.3 369.2,345.2 425.0,330.4 480.8,318.7 536.7,311.5 592.5,309.0 648.3,307.3 704.2,301.1 760.0,263.4" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="381.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="379.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="375.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="368.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="357.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="345.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="330.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="318.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="311.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="309.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="307.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="301.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="263.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <text x="425.0" y="447" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">JIT-warmed REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
-  <line x1="90" y1="584.0" x2="760" y2="584.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="584.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
-  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
-  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
-  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
-  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
-  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
-  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="464" x2="145.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="464" x2="201.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="464" x2="257.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="464" x2="369.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="464" x2="425.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="464" x2="480.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="464" x2="592.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="464" x2="648.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="464" x2="704.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,155.0 145.8,148.0 201.7,164.2 257.5,235.0 313.3,243.7 369.2,254.5 425.0,284.4 480.8,318.1 536.7,345.5 592.5,363.1 648.3,374.0 704.2,378.6 760.0,381.3" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,156.4 145.8,132.7 201.7,168.0 257.5,235.1 313.3,240.0 369.2,254.3 425.0,285.3 480.8,314.5 536.7,342.6 592.5,360.2 648.3,370.4 704.2,376.8 760.0,380.1" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,230.1 145.8,231.2 201.7,237.3 257.5,256.1 313.3,275.0 369.2,305.0 425.0,329.1 480.8,351.6 536.7,365.4 592.5,374.5 648.3,379.3 704.2,381.8 760.0,382.2" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,222.1 145.8,233.4 201.7,241.0 257.5,255.8 313.3,275.7 369.2,303.6 425.0,330.2 480.8,351.8 536.7,366.3 592.5,375.3 648.3,379.8 704.2,381.5 760.0,382.2" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.3 145.8,376.4 201.7,369.9 257.5,364.9 313.3,348.1 369.2,317.7 425.0,282.0 480.8,249.0 536.7,226.1 592.5,212.7 648.3,220.8 704.2,207.5 760.0,205.6" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="376.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="369.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="364.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="348.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="317.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="282.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="249.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="226.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="212.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="220.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="207.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="205.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,380.4 145.8,376.0 201.7,370.2 257.5,364.9 313.3,347.1 369.2,317.6 425.0,282.9 480.8,241.6 536.7,214.3 592.5,189.3 648.3,161.0 704.2,146.5 760.0,129.2" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="376.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="370.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="364.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="347.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="317.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="282.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="241.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="214.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="189.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="161.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="146.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="129.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,381.5 145.8,379.1 201.7,374.6 257.5,367.6 313.3,356.1 369.2,343.6 425.0,327.8 480.8,317.6 536.7,307.9 592.5,306.1 648.3,306.7 704.2,312.2 760.0,263.8" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="379.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="374.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="367.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="356.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="343.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="327.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="317.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="307.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="306.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="306.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="312.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="263.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,381.4 145.8,379.2 201.7,374.8 257.5,367.6 313.3,356.3 369.2,342.9 425.0,328.9 480.8,318.0 536.7,311.4 592.5,312.8 648.3,315.3 704.2,301.1 760.0,265.2" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="379.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="374.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="367.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="356.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="342.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="328.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="318.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="311.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="312.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="315.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="301.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="265.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="145.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="201.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="257.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="313.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="369.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="425.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="480.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="536.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="592.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="648.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="704.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <text x="425.0" y="447" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">JIT-warmed REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90" y1="584.0" x2="760" y2="584.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="584.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 µs</text>
+  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 µs</text>
+  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 µs</text>
+  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 µs</text>
+  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 µs</text>
+  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 µs</text>
+  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="164.4" y1="464" x2="164.4" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="238.9" y1="464" x2="238.9" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="387.8" y1="464" x2="387.8" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="462.2" y1="464" x2="462.2" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="611.1" y1="464" x2="611.1" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="685.6" y1="464" x2="685.6" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,529.7 145.8,526.0 201.7,527.4 257.5,529.2 313.3,527.7 369.2,528.0 425.0,525.8 480.8,526.1 536.7,522.4 592.5,517.1 648.3,513.3 704.2,493.8 760.0,475.1" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="529.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="526.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="527.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="529.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="527.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="528.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="525.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="526.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="522.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="517.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="513.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="493.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="475.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,527.4 145.8,527.3 201.7,528.4 257.5,525.9 313.3,526.9 369.2,527.8 425.0,525.8 480.8,526.9 536.7,524.6 592.5,519.2 648.3,513.2 704.2,498.3 760.0,478.5" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="527.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="527.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="528.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="525.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="526.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="527.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="525.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="526.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="524.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="519.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="513.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="498.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="478.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,510.8 145.8,508.5 201.7,511.9 257.5,508.4 313.3,506.2 369.2,511.0 425.0,503.6 480.8,503.0 536.7,506.2 592.5,504.9 648.3,490.7 704.2,482.1 760.0,464.0" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="510.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="508.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="511.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="508.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="506.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="511.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="503.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="503.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="506.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="504.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="490.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="482.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="464.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,509.0 145.8,511.5 201.7,505.9 257.5,507.8 313.3,504.4 369.2,502.9 425.0,507.1 480.8,506.4 536.7,503.0 592.5,505.2 648.3,488.0 704.2,481.2 760.0,464.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="509.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="511.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="505.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="507.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="504.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="502.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="507.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="506.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="503.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="505.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="488.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="481.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="464.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="65" y1="624" x2="79" y2="624" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="72" cy="624" r="2.5" fill="#dc2626"/>
-  <text x="85" y="628" fill="#374151" font-size="11" font-weight="500">OMQ.java</text>
-  <line x1="245" y1="624" x2="259" y2="624" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="252" cy="624" r="2.5" fill="#f97316"/>
-  <text x="265" y="628" fill="#374151" font-size="11" font-weight="500">OMQ.java receiveInto</text>
-  <line x1="425" y1="624" x2="439" y2="624" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="432" cy="624" r="2.5" fill="#2563eb"/>
-  <text x="445" y="628" fill="#374151" font-size="11" font-weight="500">JeroMQ</text>
-  <line x1="605" y1="624" x2="619" y2="624" stroke="#8b5cf6" stroke-width="2.5"/>
-  <circle cx="612" cy="624" r="2.5" fill="#8b5cf6"/>
-  <text x="625" y="628" fill="#374151" font-size="11" font-weight="500">JeroMQ recvByteBuffer</text>
+  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
+  <polyline points="90.0,528.8 164.4,527.3 238.9,524.8 313.3,525.2 387.8,527.1 462.2,527.6 536.7,526.1 611.1,525.0 685.6,521.3 760.0,514.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="528.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="527.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="524.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="525.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="527.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="527.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="526.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="525.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="521.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="514.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,527.8 164.4,526.7 238.9,527.3 313.3,528.8 387.8,525.2 462.2,524.7 536.7,528.3 611.1,524.7 685.6,521.5 760.0,514.9" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="526.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="527.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="528.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="525.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="524.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="528.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="524.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="521.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="514.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,500.9 164.4,503.4 238.9,501.5 313.3,501.4 387.8,504.7 462.2,505.5 536.7,506.1 611.1,486.3 685.6,501.9 760.0,498.7" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="500.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="503.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="501.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="501.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="504.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="505.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="506.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="486.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="501.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="498.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,506.3 164.4,505.0 238.9,501.5 313.3,497.3 387.8,500.0 462.2,500.2 536.7,497.8 611.1,499.4 685.6,499.0 760.0,489.1" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="506.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="505.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="501.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="497.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="500.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="500.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="497.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="499.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="499.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="489.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="164.4" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="238.9" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="313.3" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="387.8" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="462.2" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="536.7" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="611.1" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="685.6" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="760.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="65" y1="624" x2="79" y2="624" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="72" cy="624" r="2.5" fill="#ef4444"/>
+  <text x="85" y="628" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.java</text>
+  <line x1="245" y1="624" x2="259" y2="624" stroke="#fb923c" stroke-width="2.5"/>
+  <circle cx="252" cy="624" r="2.5" fill="#fb923c"/>
+  <text x="265" y="628" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.java receiveInto</text>
+  <line x1="425" y1="624" x2="439" y2="624" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="432" cy="624" r="2.5" fill="#60a5fa"/>
+  <text x="445" y="628" fill="#e5e7eb" font-size="11" font-weight="500">JeroMQ</text>
+  <line x1="605" y1="624" x2="619" y2="624" stroke="#a855f7" stroke-width="2.5"/>
+  <circle cx="612" cy="624" r="2.5" fill="#a855f7"/>
+  <text x="625" y="628" fill="#e5e7eb" font-size="11" font-weight="500">JeroMQ recvByteBuffer</text>
   <text x="425.0" y="646" text-anchor="middle" fill="#9ca3af" font-size="9">top dashed = msg/s (left) · top solid = GB/s (right) · bottom solid = p50 latency</text>
 </svg>

--- a/bindings/java/scripts/bench_pushpull_tcp.py
+++ b/bindings/java/scripts/bench_pushpull_tcp.py
@@ -20,25 +20,26 @@ PUSHPULL_CLASS = "io.omq.perf.PushPullTcpPeer"
 REQREP_CLASS = "io.omq.perf.ReqRepTcpPeer"
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [8, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
 DEFAULT_IMPLS = ["omq", "omq-into", "jeromq", "jeromq-into"]
-DEFAULT_THROUGHPUT_DURATION = 2.0
+DEFAULT_THROUGHPUT_DURATION = 2.5
 QUICK_THROUGHPUT_DURATION = 0.5
 DEFAULT_THROUGHPUT_WARMUP = 0.5
 QUICK_THROUGHPUT_WARMUP = 0.1
-DEFAULT_LATENCY_WARMUP = 50_000
-DEFAULT_LATENCY_ITERS = 50_000
-QUICK_LATENCY_WARMUP = 5_000
-QUICK_LATENCY_ITERS = 5_000
+DEFAULT_LATENCY_DURATION = 1.5
+QUICK_LATENCY_DURATION = 0.5
+DEFAULT_LATENCY_WARMUP = 0.5
+QUICK_LATENCY_WARMUP = 0.1
 CHART_DIR = ROOT / "doc" / "charts"
 JSONL = (
     Path(os.environ.get("OMQ_JAVA_CACHE_DIR", Path.home() / ".cache" / "omq.java"))
     / "pushpull-tcp.jsonl"
 )
 
-C_OMQ = "#dc2626"
-C_OMQ_INTO = "#f97316"
-C_JEROMQ = "#2563eb"
-C_JEROMQ_INTO = "#8b5cf6"
+C_OMQ = "#ef4444"
+C_OMQ_INTO = "#fb923c"
+C_JEROMQ = "#60a5fa"
+C_JEROMQ_INTO = "#a855f7"
 LATENCY_MIN_US = 20.0
 LATENCY_MAX_US = 120.0
 
@@ -49,6 +50,10 @@ def parse_csv_ints(value):
 
 def parse_csv_strings(value):
     return [part for part in value.split(",") if part]
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
 
 
 def load_jsonl():
@@ -271,10 +276,10 @@ def run_cell(cp, impl, size, args):
     return sorted(runs, key=lambda row: row["msgs_s"])[len(runs) // 2]
 
 
-def run_latency_cell_once(cp, impl, size, iterations, warmup, timeout):
+def run_latency_cell_once(cp, impl, size, duration, warmup, timeout):
     endpoint = free_endpoint()
     rep = subprocess.Popen(
-        java_cmd(REQREP_CLASS, cp, impl, "rep", endpoint, size, iterations, warmup),
+        java_cmd(REQREP_CLASS, cp, impl, "rep", endpoint, size, duration, warmup),
         cwd=ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -287,7 +292,7 @@ def run_latency_cell_once(cp, impl, size, iterations, warmup, timeout):
             raise RuntimeError(f"REP did not become ready:\n{ready or ''}{out}{err}")
 
         req = subprocess.run(
-            java_cmd(REQREP_CLASS, cp, impl, "req", endpoint, size, iterations, warmup),
+            java_cmd(REQREP_CLASS, cp, impl, "req", endpoint, size, duration, warmup),
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -299,11 +304,8 @@ def run_latency_cell_once(cp, impl, size, iterations, warmup, timeout):
         if req.returncode != 0:
             raise RuntimeError(f"REQ failed:\n{req.stdout}{req.stderr}")
 
-        out, err = rep.communicate(timeout=timeout)
-        out = ready + out
-        fail_on_noise("REP", out, err)
-        if rep.returncode != 0:
-            raise RuntimeError(f"REP failed:\n{out}{err}")
+        out, err = kill(rep)
+        fail_on_noise("REP", ready + out, err)
         return parse_result(req.stdout)
     except Exception:
         kill(rep)
@@ -318,16 +320,18 @@ def run_latency_cell(cp, impl, size, args):
             cp,
             impl,
             size,
-            args.latency_iterations,
-            args.latency_warmup_messages,
-            args.timeout,
+            args.latency_duration,
+            args.latency_warmup_duration,
+            args.timeout + args.latency_warmup_duration + args.latency_duration,
         )
-        result["warmup_messages"] = args.latency_warmup_messages
+        result["target_seconds"] = args.latency_duration
+        result["warmup_seconds"] = args.latency_warmup_duration
         if round_index >= args.warmup_rounds:
             runs.append(result)
         print(
             f"  {impl:8s} size={size:6d} round={round_index + 1}/{total} "
-            f"p50 {result['p50_us']:8.1f} µs p99 {result['p99_us']:8.1f} µs",
+            f"p50 {result['p50_us']:8.1f} µs p99 {result['p99_us']:8.1f} µs "
+            f"n={result['iterations']}",
             flush=True,
         )
     return sorted(runs, key=lambda row: row["p50_us"])[len(runs) // 2]
@@ -361,13 +365,16 @@ def latest_rows(kind, sizes, impls, fallback):
     }
 
 
-def chart_data_from_jsonl(sizes):
+def chart_data_from_jsonl(sizes, latency_sizes):
     return {
         "throughput": latest_rows(
             "pushpull_tcp", sizes, DEFAULT_IMPLS, {"msgs_s": 0.0, "gb_s": 0.0}
         ),
         "latency": latest_rows(
-            "reqrep_tcp_latency", sizes, DEFAULT_IMPLS, {"p50_us": 0.0, "p99_us": 0.0}
+            "reqrep_tcp_latency",
+            latency_sizes,
+            DEFAULT_IMPLS,
+            {"p50_us": 0.0, "p99_us": 0.0},
         ),
     }
 
@@ -438,36 +445,22 @@ def escape_svg(value):
 
 def detect_hardware():
     config = read_chart_hw()
-    try:
-        cpu = None
-        with open("/proc/cpuinfo") as file:
-            for line in file:
-                if line.startswith("model name"):
-                    cpu = line.split(":", 1)[1].strip()
-                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
-                    break
-        cores = os.cpu_count()
-        if cpu and cores:
-            label = f"{cpu}, {cores} cores"
-            prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
-            postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
-            extras = [item.strip() for item in postfix.split(",")] if postfix else []
-            hw_extras = os.environ.get("OMQ_HW_EXTRAS")
-            if hw_extras:
-                extras.extend(hw_extras.split(","))
-            extras = [item for item in (item.strip() for item in extras) if item]
-            if extras:
-                label += ", " + ", ".join(extras)
-            if prefix:
-                label = f"{prefix}, {label}"
-            return label
-    except OSError:
-        pass
+    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
     return None
 
 
-def gen_chart(sizes, path):
-    data = chart_data_from_jsonl(sizes)
+def gen_chart(sizes, latency_sizes, path):
+    data = chart_data_from_jsonl(sizes, latency_sizes)
     throughput = data["throughput"]
     latency = data["latency"]
     series = [
@@ -494,6 +487,10 @@ def gen_chart(sizes, path):
     plot_w = x_right - x_left
     mid_x = (x_left + x_right) / 2
     xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
+    lat_xs = [
+        x_left + i * plot_w / max(len(latency_sizes) - 1, 1)
+        for i in range(len(latency_sizes))
+    ]
 
     def y_msg(value):
         return t1_bot - (value / msg_max) * t1_h
@@ -509,8 +506,8 @@ def gen_chart(sizes, path):
     lines = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">',
-        f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
-        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>',
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         "JIT-warmed PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>",
     ]
@@ -527,23 +524,23 @@ def gen_chart(sizes, path):
         gbs_val = gbs_max * frac
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_rate(msg_val)}</text>"
         )
         lines.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
-            f' dominant-baseline="middle" fill="#6b7280" font-size="10">'
+            f' dominant-baseline="middle" fill="#9ca3af" font-size="10">'
             f"{fmt_y_gbs(gbs_val)}</text>"
         )
 
     for x in xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     lines.extend(
@@ -560,7 +557,7 @@ def gen_chart(sizes, path):
     y_mid = (t1_top + t1_bot) / 2
     lines.append(
         f'  <text x="40" y="{y_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{y_mid:.0f})">msg/s</text>'
     )
 
@@ -587,17 +584,17 @@ def gen_chart(sizes, path):
             yy = y_gbs(row["gb_s"])
             lines.append(
                 f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
     for i, size in enumerate(sizes):
         lines.append(
             f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     lines.append(
-        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         "JIT-warmed REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
     )
@@ -606,18 +603,18 @@ def gen_chart(sizes, path):
         yy = y_lat(value)
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_us(value)}</text>"
         )
 
-    for x in xs:
+    for x in lat_xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     lines.extend(
@@ -632,14 +629,15 @@ def gen_chart(sizes, path):
     y_mid = (t2_top + t2_bot) / 2
     lines.append(
         f'  <text x="40" y="{y_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{y_mid:.0f})">p50 latency (µs)</text>'
     )
 
     for _, color, impl in series:
         rows = latency[impl]
         points = " ".join(
-            f"{xs[i]:.1f},{y_lat(row['p50_us']):.1f}" for i, row in enumerate(rows)
+            f"{lat_xs[i]:.1f},{y_lat(row['p50_us']):.1f}"
+            for i, row in enumerate(rows)
         )
         lines.append(
             f'  <polyline points="{points}" fill="none" stroke="{color}"'
@@ -648,14 +646,14 @@ def gen_chart(sizes, path):
         for i, row in enumerate(rows):
             yy = y_lat(row["p50_us"])
             lines.append(
-                f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
-    for i, size in enumerate(sizes):
+    for i, size in enumerate(latency_sizes):
         lines.append(
-            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     legend_y = t2_bot + 40
@@ -671,7 +669,7 @@ def gen_chart(sizes, path):
         )
         lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{legend_y}" r="2.5" fill="{color}"/>')
         lines.append(
-            f'  <text x="{lx + 20:.0f}" y="{legend_y + 4}" fill="#374151"'
+            f'  <text x="{lx + 20:.0f}" y="{legend_y + 4}" fill="#e5e7eb"'
             f' font-size="11" font-weight="500">{escape_svg(label)}</text>'
         )
 
@@ -728,7 +726,7 @@ def main():
     parser.add_argument("--sizes", type=parse_csv_ints)
     parser.add_argument("--impls", type=parse_csv_strings, default=DEFAULT_IMPLS)
     parser.add_argument("--rounds", type=int, default=3)
-    parser.add_argument("--warmup-rounds", type=int, default=1)
+    parser.add_argument("--warmup-rounds", type=int, default=0)
     parser.add_argument("--throughput-duration", type=float)
     parser.add_argument(
         "--throughput-warmup",
@@ -737,16 +735,14 @@ def main():
     )
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument(
-        "--latency-warmup",
-        "--latency-warmup-messages",
-        dest="latency_warmup_messages",
-        type=int,
+        "--latency-warmup-duration",
+        dest="latency_warmup_duration",
+        type=float,
     )
     parser.add_argument(
-        "--latency-iters",
-        "--latency-iterations",
-        dest="latency_iterations",
-        type=int,
+        "--latency-duration",
+        dest="latency_duration",
+        type=float,
     )
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--no-build", action="store_true")
@@ -760,6 +756,9 @@ def main():
         parser.error("--throughput-only and --latency-only are mutually exclusive")
     if args.chart_only and (args.throughput_only or args.latency_only):
         parser.error("--chart-only cannot be combined with benchmark selection")
+    if args.quick:
+        args.rounds = min(args.rounds, 1)
+        args.warmup_rounds = 0
     if args.rounds < 1:
         parser.error("--rounds must be at least 1")
     if args.warmup_rounds < 0:
@@ -776,21 +775,22 @@ def main():
         parser.error("--throughput-duration must be greater than zero")
     if args.throughput_warmup < 0:
         parser.error("--throughput-warmup cannot be negative")
-    if args.latency_warmup_messages is None:
-        args.latency_warmup_messages = (
+    if args.latency_warmup_duration is None:
+        args.latency_warmup_duration = (
             QUICK_LATENCY_WARMUP if args.quick else DEFAULT_LATENCY_WARMUP
         )
-    if args.latency_iterations is None:
-        args.latency_iterations = QUICK_LATENCY_ITERS if args.quick else DEFAULT_LATENCY_ITERS
-    if args.latency_warmup_messages < 0:
-        parser.error("--latency-warmup cannot be negative")
-    if args.latency_iterations < 1:
-        parser.error("--latency-iters must be at least 1")
+    if args.latency_duration is None:
+        args.latency_duration = QUICK_LATENCY_DURATION if args.quick else DEFAULT_LATENCY_DURATION
+    if args.latency_warmup_duration < 0:
+        parser.error("--latency-warmup-duration cannot be negative")
+    if args.latency_duration <= 0:
+        parser.error("--latency-duration must be greater than zero")
 
     sizes = args.sizes or (QUICK_SIZES if args.quick else DEFAULT_SIZES)
+    latency_sizes = latency_sizes_from(sizes)
     chart_path = CHART_DIR / "pushpull_tcp.svg"
     if args.chart_only:
-        gen_chart(sizes, chart_path)
+        gen_chart(sizes, latency_sizes, chart_path)
         return
 
     build(args)
@@ -813,7 +813,7 @@ def main():
 
     if not args.throughput_only:
         print("\nREQ/REP latency (TCP)...")
-        for size in sizes:
+        for size in latency_sizes:
             for impl in args.impls:
                 row = run_latency_cell(cp, impl, size, args)
                 row["run_id"] = run_id
@@ -825,10 +825,10 @@ def main():
     if throughput_rows:
         print_table(throughput_rows, sizes, args.impls)
     if latency_rows:
-        print_latency_table(latency_rows, sizes, args.impls)
+        print_latency_table(latency_rows, latency_sizes, args.impls)
     print(f"appended {len(rows)} rows to {JSONL}")
     if not args.no_chart:
-        gen_chart(sizes, chart_path)
+        gen_chart(sizes, latency_sizes, chart_path)
 
 
 if __name__ == "__main__":

--- a/bindings/java/src/test/java/io/omq/perf/ReqRepTcpPeer.java
+++ b/bindings/java/src/test/java/io/omq/perf/ReqRepTcpPeer.java
@@ -24,47 +24,47 @@ public final class ReqRepTcpPeer {
         if (args.length != 6) {
             throw new IllegalArgumentException(
                     "usage: <omq|omq-into|jeromq|jeromq-into> "
-                            + "<req|rep> <endpoint> <size> <iterations> <warmup>");
+                            + "<req|rep> <endpoint> <size> <duration_secs> <warmup_secs>");
         }
 
         Impl impl = Impl.parse(args[0]);
         Role role = Role.parse(args[1]);
         String endpoint = args[2];
         int size = Integer.parseInt(args[3]);
-        int iterations = Integer.parseInt(args[4]);
-        int warmup = Integer.parseInt(args[5]);
-        if (size < 0 || iterations <= 0 || warmup < 0) {
-            throw new IllegalArgumentException("invalid size/iterations/warmup");
+        long durationNanos = parsePositiveSeconds(args[4], "duration_secs");
+        long warmupNanos = parseNonNegativeSeconds(args[5], "warmup_secs");
+        if (size < 0) {
+            throw new IllegalArgumentException("invalid size");
         }
 
         if (role == Role.REP) {
-            runRep(impl, endpoint, size, iterations + warmup);
+            runRep(impl, endpoint, size);
         } else {
-            runReq(impl, endpoint, size, iterations, warmup);
+            runReq(impl, endpoint, size, durationNanos, warmupNanos);
         }
     }
 
-    private static void runRep(Impl impl, String endpoint, int size, int exchanges) {
+    private static void runRep(Impl impl, String endpoint, int size) {
         switch (impl) {
-            case OMQ -> runOmqRep(endpoint, size, exchanges, false);
-            case OMQ_INTO -> runOmqRep(endpoint, size, exchanges, true);
-            case JEROMQ -> runJeroRep(endpoint, size, exchanges, false);
-            case JEROMQ_INTO -> runJeroRep(endpoint, size, exchanges, true);
+            case OMQ -> runOmqRep(endpoint, size, false);
+            case OMQ_INTO -> runOmqRep(endpoint, size, true);
+            case JEROMQ -> runJeroRep(endpoint, size, false);
+            case JEROMQ_INTO -> runJeroRep(endpoint, size, true);
         }
     }
 
     private static void runReq(
-            Impl impl, String endpoint, int size, int iterations, int warmup) {
+            Impl impl, String endpoint, int size, long durationNanos, long warmupNanos) {
         switch (impl) {
-            case OMQ -> runOmqReq(endpoint, size, iterations, warmup, false);
-            case OMQ_INTO -> runOmqReq(endpoint, size, iterations, warmup, true);
-            case JEROMQ -> runJeroReq(endpoint, size, iterations, warmup, false);
-            case JEROMQ_INTO -> runJeroReq(endpoint, size, iterations, warmup, true);
+            case OMQ -> runOmqReq(endpoint, size, durationNanos, warmupNanos, false);
+            case OMQ_INTO -> runOmqReq(endpoint, size, durationNanos, warmupNanos, true);
+            case JEROMQ -> runJeroReq(endpoint, size, durationNanos, warmupNanos, false);
+            case JEROMQ_INTO -> runJeroReq(endpoint, size, durationNanos, warmupNanos, true);
         }
     }
 
     private static void runOmqRep(
-            String endpoint, int size, int exchanges, boolean receiveInto) {
+            String endpoint, int size, boolean receiveInto) {
         byte[] payload = payload(size);
         try (Context context = OMQ.context();
              Socket rep = context.socket(SocketType.REP)
@@ -76,12 +76,12 @@ public final class ReqRepTcpPeer {
             ready(endpoint);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                for (int i = 0; i < exchanges; i++) {
+                while (true) {
                     receiveOmqInto(rep, buffer, size);
                     rep.send(payload);
                 }
             } else {
-                for (int i = 0; i < exchanges; i++) {
+                while (true) {
                     receiveOmq(rep, size);
                     rep.send(payload);
                 }
@@ -90,7 +90,7 @@ public final class ReqRepTcpPeer {
     }
 
     private static void runOmqReq(
-            String endpoint, int size, int iterations, int warmup, boolean receiveInto) {
+            String endpoint, int size, long durationNanos, long warmupNanos, boolean receiveInto) {
         byte[] payload = payload(size);
         try (Context context = OMQ.context();
              Socket req = context.socket(SocketType.REQ)
@@ -102,37 +102,41 @@ public final class ReqRepTcpPeer {
             req.waitConnected(1, CONNECT_TIMEOUT);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                for (int i = 0; i < warmup; i++) {
+                long warmupDeadline = System.nanoTime() + warmupNanos;
+                while (System.nanoTime() < warmupDeadline) {
                     req.send(payload);
                     receiveOmqInto(req, buffer, size);
                 }
-                long[] rtts = new long[iterations];
-                for (int i = 0; i < iterations; i++) {
+                LongArray rtts = new LongArray();
+                long deadline = System.nanoTime() + durationNanos;
+                do {
                     long started = System.nanoTime();
                     req.send(payload);
                     receiveOmqInto(req, buffer, size);
-                    rtts[i] = System.nanoTime() - started;
-                }
-                result(Impl.OMQ_INTO.name, endpoint, size, iterations, rtts);
+                    rtts.add(System.nanoTime() - started);
+                } while (System.nanoTime() < deadline);
+                result(Impl.OMQ_INTO.name, endpoint, size, rtts.toArray());
             } else {
-                for (int i = 0; i < warmup; i++) {
+                long warmupDeadline = System.nanoTime() + warmupNanos;
+                while (System.nanoTime() < warmupDeadline) {
                     req.send(payload);
                     receiveOmq(req, size);
                 }
-                long[] rtts = new long[iterations];
-                for (int i = 0; i < iterations; i++) {
+                LongArray rtts = new LongArray();
+                long deadline = System.nanoTime() + durationNanos;
+                do {
                     long started = System.nanoTime();
                     req.send(payload);
                     receiveOmq(req, size);
-                    rtts[i] = System.nanoTime() - started;
-                }
-                result(Impl.OMQ.name, endpoint, size, iterations, rtts);
+                    rtts.add(System.nanoTime() - started);
+                } while (System.nanoTime() < deadline);
+                result(Impl.OMQ.name, endpoint, size, rtts.toArray());
             }
         }
     }
 
     private static void runJeroRep(
-            String endpoint, int size, int exchanges, boolean receiveInto) {
+            String endpoint, int size, boolean receiveInto) {
         byte[] payload = payload(size);
         try (org.zeromq.ZContext context = new org.zeromq.ZContext();
              org.zeromq.ZMQ.Socket rep = context.createSocket(org.zeromq.SocketType.REP)) {
@@ -143,12 +147,12 @@ public final class ReqRepTcpPeer {
             ready(endpoint);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                for (int i = 0; i < exchanges; i++) {
+                while (true) {
                     receiveJeroInto(rep, buffer, size);
                     sendJero(rep, payload);
                 }
             } else {
-                for (int i = 0; i < exchanges; i++) {
+                while (true) {
                     receiveJero(rep, size);
                     sendJero(rep, payload);
                 }
@@ -157,7 +161,7 @@ public final class ReqRepTcpPeer {
     }
 
     private static void runJeroReq(
-            String endpoint, int size, int iterations, int warmup, boolean receiveInto) {
+            String endpoint, int size, long durationNanos, long warmupNanos, boolean receiveInto) {
         byte[] payload = payload(size);
         try (org.zeromq.ZContext context = new org.zeromq.ZContext();
              org.zeromq.ZMQ.Socket req = context.createSocket(org.zeromq.SocketType.REQ)) {
@@ -168,31 +172,35 @@ public final class ReqRepTcpPeer {
             sleep(100);
             if (receiveInto) {
                 ByteBuffer buffer = ByteBuffer.allocateDirect(size);
-                for (int i = 0; i < warmup; i++) {
+                long warmupDeadline = System.nanoTime() + warmupNanos;
+                while (System.nanoTime() < warmupDeadline) {
                     sendJero(req, payload);
                     receiveJeroInto(req, buffer, size);
                 }
-                long[] rtts = new long[iterations];
-                for (int i = 0; i < iterations; i++) {
+                LongArray rtts = new LongArray();
+                long deadline = System.nanoTime() + durationNanos;
+                do {
                     long started = System.nanoTime();
                     sendJero(req, payload);
                     receiveJeroInto(req, buffer, size);
-                    rtts[i] = System.nanoTime() - started;
-                }
-                result(Impl.JEROMQ_INTO.name, endpoint, size, iterations, rtts);
+                    rtts.add(System.nanoTime() - started);
+                } while (System.nanoTime() < deadline);
+                result(Impl.JEROMQ_INTO.name, endpoint, size, rtts.toArray());
             } else {
-                for (int i = 0; i < warmup; i++) {
+                long warmupDeadline = System.nanoTime() + warmupNanos;
+                while (System.nanoTime() < warmupDeadline) {
                     sendJero(req, payload);
                     receiveJero(req, size);
                 }
-                long[] rtts = new long[iterations];
-                for (int i = 0; i < iterations; i++) {
+                LongArray rtts = new LongArray();
+                long deadline = System.nanoTime() + durationNanos;
+                do {
                     long started = System.nanoTime();
                     sendJero(req, payload);
                     receiveJero(req, size);
-                    rtts[i] = System.nanoTime() - started;
-                }
-                result(Impl.JEROMQ.name, endpoint, size, iterations, rtts);
+                    rtts.add(System.nanoTime() - started);
+                } while (System.nanoTime() < deadline);
+                result(Impl.JEROMQ.name, endpoint, size, rtts.toArray());
             }
         }
     }
@@ -248,8 +256,9 @@ public final class ReqRepTcpPeer {
     }
 
     private static void result(
-            String impl, String endpoint, int size, int iterations, long[] rtts) {
+            String impl, String endpoint, int size, long[] rtts) {
         Arrays.sort(rtts);
+        int iterations = rtts.length;
         double p50 = rtts[iterations * 50 / 100] / 1_000.0;
         double p99 = rtts[Math.min(iterations - 1, iterations * 99 / 100)] / 1_000.0;
         System.out.printf(
@@ -258,6 +267,22 @@ public final class ReqRepTcpPeer {
                         + "\"iterations\":%d,\"p50_us\":%.3f,\"p99_us\":%.3f}%n",
                 impl, endpoint, size, iterations, p50, p99);
         System.out.flush();
+    }
+
+    private static long parsePositiveSeconds(String value, String name) {
+        long nanos = parseNonNegativeSeconds(value, name);
+        if (nanos <= 0) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+        return nanos;
+    }
+
+    private static long parseNonNegativeSeconds(String value, String name) {
+        double seconds = Double.parseDouble(value);
+        if (seconds < 0.0) {
+            throw new IllegalArgumentException(name + " must be non-negative");
+        }
+        return (long) (seconds * 1_000_000_000.0);
     }
 
     private static void sleep(long millis) {
@@ -301,6 +326,23 @@ public final class ReqRepTcpPeer {
                 case "rep" -> REP;
                 default -> throw new IllegalArgumentException("unknown role: " + value);
             };
+        }
+    }
+
+    private static final class LongArray {
+        private long[] values = new long[16_384];
+        private int len;
+
+        void add(long value) {
+            if (len == values.length) {
+                values = Arrays.copyOf(values, values.length * 2);
+            }
+            values[len] = value;
+            len++;
+        }
+
+        long[] toArray() {
+            return Arrays.copyOf(values, len);
         }
     }
 }

--- a/bindings/lua/DEVELOPMENT.md
+++ b/bindings/lua/DEVELOPMENT.md
@@ -97,6 +97,11 @@ Full default run:
 bindings/lua/scripts/update_perf.py
 ```
 
+Defaults are 3 measured rounds per size and implementation. Throughput uses
+2.5 second windows; latency uses 1.5 second windows and only measures sizes up
+to 4 KiB. Each round uses a 0.5 second warmup window, and the median round is
+kept. `--quick` uses one 0.5 second measured round and 0.1 second warmup.
+
 Useful flags:
 
 - `--sizes 16,128,1k,8k,32k`
@@ -105,8 +110,8 @@ Useful flags:
 - `--rounds N`
 - `--duration SECONDS`
 - `--warmup-duration SECONDS`
-- `--latency-iters N`
-- `--latency-warmup N`
+- `--latency-duration SECONDS`
+- `--latency-warmup-duration SECONDS`
 - `--chart-only`
 - `--no-save`
 - `--no-chart`

--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -84,7 +84,7 @@ ctx:term()
 
 ## Performance Chart
 
-![OMQ.lua performance](doc/charts/bindings.svg)
+![OMQ.lua performance](https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/lua/doc/charts/bindings.svg)
 
 Generate a quick local chart:
 

--- a/bindings/lua/doc/charts/bindings.svg
+++ b/bindings/lua/doc/charts/bindings.svg
@@ -1,178 +1,166 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="684" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off</text>
-  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
-  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
-  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
-  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3.5M</text>
-  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4.5M</text>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
-  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
-  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="211.8" y1="49" x2="211.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="272.7" y1="49" x2="272.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="333.6" y1="49" x2="333.6" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="394.5" y1="49" x2="394.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="455.5" y1="49" x2="455.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="516.4" y1="49" x2="516.4" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="577.3" y1="49" x2="577.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="638.2" y1="49" x2="638.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="699.1" y1="49" x2="699.1" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <rect width="850" height="684" fill="#000000"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">500k</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.5M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.5M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4.5M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="211.8" y1="49" x2="211.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="272.7" y1="49" x2="272.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="333.6" y1="49" x2="333.6" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="394.5" y1="49" x2="394.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="455.5" y1="49" x2="455.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="516.4" y1="49" x2="516.4" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="577.3" y1="49" x2="577.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="638.2" y1="49" x2="638.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="699.1" y1="49" x2="699.1" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,180.5 150.9,195.9 211.8,208.6 272.7,305.3 333.6,305.9 394.5,310.0 455.5,328.3 516.4,352.9 577.3,363.1 638.2,364.6 699.1,372.0 760.0,377.4" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,142.1 150.9,160.3 211.8,180.3 272.7,272.8 333.6,280.9 394.5,303.9 455.5,337.4 516.4,362.2 577.3,377.9 638.2,379.9 699.1,380.2 760.0,380.6" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,380.7 150.9,378.0 211.8,372.8 272.7,373.9 333.6,364.0 394.5,346.1 455.5,327.0 516.4,320.3 577.3,298.3 638.2,225.0 699.1,187.9 760.0,166.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="378.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="372.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="373.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="364.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="346.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="327.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="320.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="298.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="225.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="187.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="166.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,380.1 150.9,376.8 211.8,371.0 272.7,369.8 333.6,357.6 394.5,343.0 455.5,336.3 516.4,339.4 577.3,358.9 638.2,350.7 699.1,322.5 760.0,271.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="376.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="371.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="369.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="357.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="343.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="336.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="339.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="358.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="350.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="322.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="271.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="150.9" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="211.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="272.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="333.6" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="394.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="455.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="516.4" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="577.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="638.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="699.1" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="356" y1="424" x2="370" y2="424" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="363" cy="424" r="2.5" fill="#dc2626"/>
-  <text x="376" y="428" fill="#374151" font-size="11" font-weight="500">OMQ.lua</text>
-  <line x1="449" y1="424" x2="463" y2="424" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="456" cy="424" r="2.5" fill="#2563eb"/>
-  <text x="469" y="428" fill="#374151" font-size="11" font-weight="500">lzmq</text>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,229.7 150.9,233.5 211.8,240.1 272.7,297.5 333.6,303.7 394.5,319.7 455.5,331.9 516.4,355.2 577.3,362.4 638.2,364.7 699.1,372.3 760.0,377.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,145.9 150.9,156.5 211.8,181.9 272.7,271.9 333.6,282.6 394.5,305.9 455.5,339.0 516.4,364.5 577.3,380.2 638.2,380.0 699.1,380.3 760.0,380.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,381.5 150.9,379.2 211.8,374.8 272.7,372.9 333.6,363.4 394.5,351.1 455.5,330.7 516.4,325.0 577.3,295.6 638.2,225.7 699.1,191.7 760.0,161.6" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="379.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="374.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="372.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="363.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="351.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="330.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="325.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="295.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="225.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="191.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="161.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,380.2 150.9,376.7 211.8,371.1 272.7,369.7 333.6,358.1 394.5,344.0 455.5,338.0 516.4,344.1 577.3,368.4 638.2,351.4 699.1,323.2 760.0,272.2" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="376.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="371.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="369.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="358.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="344.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="338.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="344.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="368.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="351.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="323.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="272.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="150.9" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="211.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="272.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="333.6" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="394.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="455.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="516.4" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="577.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="638.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="699.1" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <line x1="356" y1="424" x2="370" y2="424" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="363" cy="424" r="2.5" fill="#ef4444"/>
+  <text x="376" y="428" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.lua</text>
+  <line x1="449" y1="424" x2="463" y2="424" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="456" cy="424" r="2.5" fill="#60a5fa"/>
+  <text x="469" y="428" fill="#e5e7eb" font-size="11" font-weight="500">lzmq</text>
   <text x="425.0" y="442" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left), solid = throughput (right)</text>
-  <text x="425.0" y="472" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 us (lower is better)</text>
-  <line x1="90" y1="597.0" x2="760" y2="597.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="597.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 us</text>
-  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 us</text>
-  <line x1="90" y1="573.0" x2="760" y2="573.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="573.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 us</text>
-  <line x1="90" y1="561.0" x2="760" y2="561.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="561.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 us</text>
-  <line x1="90" y1="549.0" x2="760" y2="549.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 us</text>
-  <line x1="90" y1="537.0" x2="760" y2="537.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="537.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 us</text>
-  <line x1="90" y1="525.0" x2="760" y2="525.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="525.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 us</text>
-  <line x1="90" y1="513.0" x2="760" y2="513.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="513.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 us</text>
-  <line x1="90" y1="501.0" x2="760" y2="501.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="501.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 us</text>
-  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 us</text>
-  <line x1="90.0" y1="489" x2="90.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="150.9" y1="489" x2="150.9" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="211.8" y1="489" x2="211.8" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="272.7" y1="489" x2="272.7" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="333.6" y1="489" x2="333.6" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="394.5" y1="489" x2="394.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="455.5" y1="489" x2="455.5" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="516.4" y1="489" x2="516.4" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="577.3" y1="489" x2="577.3" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="638.2" y1="489" x2="638.2" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="699.1" y1="489" x2="699.1" y2="609" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="489" x2="760.0" y2="609" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="425.0" y="472" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 us (lower is better)</text>
+  <line x1="90" y1="597.0" x2="760" y2="597.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="597.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 us</text>
+  <line x1="90" y1="585.0" x2="760" y2="585.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="585.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 us</text>
+  <line x1="90" y1="573.0" x2="760" y2="573.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="573.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 us</text>
+  <line x1="90" y1="561.0" x2="760" y2="561.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="561.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 us</text>
+  <line x1="90" y1="549.0" x2="760" y2="549.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 us</text>
+  <line x1="90" y1="537.0" x2="760" y2="537.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="537.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 us</text>
+  <line x1="90" y1="525.0" x2="760" y2="525.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="525.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 us</text>
+  <line x1="90" y1="513.0" x2="760" y2="513.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="513.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 us</text>
+  <line x1="90" y1="501.0" x2="760" y2="501.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="501.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 us</text>
+  <line x1="90" y1="489.0" x2="760" y2="489.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="489.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 us</text>
+  <line x1="90.0" y1="489" x2="90.0" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="173.8" y1="489" x2="173.8" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="257.5" y1="489" x2="257.5" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="341.2" y1="489" x2="341.2" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="489" x2="425.0" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="508.8" y1="489" x2="508.8" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="592.5" y1="489" x2="592.5" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="676.2" y1="489" x2="676.2" y2="609" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="489" x2="760.0" y2="609" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,571.6 150.9,571.9 211.8,565.8 272.7,565.7 333.6,565.8 394.5,565.1 455.5,565.1 516.4,563.9 577.3,557.9 638.2,554.9 699.1,554.6 760.0,542.9" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="571.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="571.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="565.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="565.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="565.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="565.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="565.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="563.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="557.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="554.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="554.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="542.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,550.6 150.9,550.4 211.8,549.5 272.7,550.8 333.6,549.8 394.5,548.9 455.5,548.3 516.4,548.6 577.3,548.6 638.2,541.3 699.1,536.7 760.0,527.9" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="550.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="150.9" cy="550.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="211.8" cy="549.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="272.7" cy="550.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="333.6" cy="549.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="394.5" cy="548.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="455.5" cy="548.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="516.4" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="577.3" cy="548.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="638.2" cy="541.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="699.1" cy="536.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="527.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="150.9" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="211.8" y="623" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="272.7" y="623" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="333.6" y="623" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="394.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="455.5" y="623" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="516.4" y="623" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="577.3" y="623" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="638.2" y="623" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="699.1" y="623" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="623" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="356" y1="649" x2="370" y2="649" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="363" cy="649" r="2.5" fill="#dc2626"/>
-  <text x="376" y="653" fill="#374151" font-size="11" font-weight="500">OMQ.lua</text>
-  <line x1="449" y1="649" x2="463" y2="649" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="456" cy="649" r="2.5" fill="#2563eb"/>
-  <text x="469" y="653" fill="#374151" font-size="11" font-weight="500">lzmq</text>
+  <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
+  <polyline points="90.0,568.0 173.8,568.4 257.5,566.2 341.2,566.8 425.0,566.2 508.8,566.0 592.5,565.5 676.2,564.6 760.0,556.4" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="568.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="568.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="566.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="566.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="566.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="566.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="565.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="564.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="556.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,549.7 173.8,549.5 257.5,548.9 341.2,549.3 425.0,549.7 508.8,548.9 592.5,548.4 676.2,548.2 760.0,547.3" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="549.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="549.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="549.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="549.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="548.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="547.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="173.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="257.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="341.2" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="425.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="508.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="592.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="676.2" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="760.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="356" y1="649" x2="370" y2="649" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="363" cy="649" r="2.5" fill="#ef4444"/>
+  <text x="376" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.lua</text>
+  <line x1="449" y1="649" x2="463" y2="649" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="456" cy="649" r="2.5" fill="#60a5fa"/>
+  <text x="469" y="653" fill="#e5e7eb" font-size="11" font-weight="500">lzmq</text>
 </svg>

--- a/bindings/lua/doc/charts/bindings.svg
+++ b/bindings/lua/doc/charts/bindings.svg
@@ -48,34 +48,34 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,229.7 150.9,233.5 211.8,240.1 272.7,297.5 333.6,303.7 394.5,319.7 455.5,331.9 516.4,355.2 577.3,362.4 638.2,364.7 699.1,372.3 760.0,377.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,145.9 150.9,156.5 211.8,181.9 272.7,271.9 333.6,282.6 394.5,305.9 455.5,339.0 516.4,364.5 577.3,380.2 638.2,380.0 699.1,380.3 760.0,380.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,381.5 150.9,379.2 211.8,374.8 272.7,372.9 333.6,363.4 394.5,351.1 455.5,330.7 516.4,325.0 577.3,295.6 638.2,225.7 699.1,191.7 760.0,161.6" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="381.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="379.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="374.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="372.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="363.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="351.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="330.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="325.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="295.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="225.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="191.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="161.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,380.2 150.9,376.7 211.8,371.1 272.7,369.7 333.6,358.1 394.5,344.0 455.5,338.0 516.4,344.1 577.3,368.4 638.2,351.4 699.1,323.2 760.0,272.2" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,210.0 150.9,218.9 211.8,226.7 272.7,298.5 333.6,305.8 394.5,318.1 455.5,333.2 516.4,355.0 577.3,361.8 638.2,364.9 699.1,372.3 760.0,377.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,145.0 150.9,157.5 211.8,184.4 272.7,272.0 333.6,282.5 394.5,306.1 455.5,342.2 516.4,364.4 577.3,380.0 638.2,380.1 699.1,380.3 760.0,380.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,381.2 150.9,378.7 211.8,373.9 272.7,373.1 333.6,364.0 394.5,350.3 455.5,331.9 516.4,324.7 577.3,293.1 638.2,227.3 699.1,192.1 760.0,169.9" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="381.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="378.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="373.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="373.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="364.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="350.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="331.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="324.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="293.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="227.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="192.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="169.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,380.2 150.9,376.8 211.8,371.2 272.7,369.7 333.6,358.0 394.5,344.1 455.5,341.2 516.4,343.8 577.3,367.8 638.2,352.1 699.1,323.2 760.0,273.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="380.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="376.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="371.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="376.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="371.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="272.7" cy="369.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="358.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="344.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="338.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="344.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="368.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="351.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="358.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="344.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="341.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="343.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="367.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="352.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="699.1" cy="323.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="272.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="273.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="150.9" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="211.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
@@ -128,26 +128,26 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,568.0 173.8,568.4 257.5,566.2 341.2,566.8 425.0,566.2 508.8,566.0 592.5,565.5 676.2,564.6 760.0,556.4" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="568.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="568.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="566.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="566.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="566.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,570.6 173.8,570.8 257.5,567.0 341.2,565.6 425.0,566.3 508.8,566.0 592.5,565.4 676.2,564.5 760.0,558.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="570.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="570.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="567.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="565.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="566.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
   <circle cx="508.8" cy="566.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="565.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="564.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="556.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,549.7 173.8,549.5 257.5,548.9 341.2,549.3 425.0,549.7 508.8,548.9 592.5,548.4 676.2,548.2 760.0,547.3" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="549.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="549.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="549.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="549.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="548.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="547.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="565.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="564.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="558.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,549.6 173.8,550.7 257.5,551.4 341.2,548.4 425.0,548.9 508.8,548.7 592.5,550.2 676.2,548.7 760.0,547.8" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="549.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="550.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="551.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="548.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="550.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="548.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="547.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="173.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="257.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/lua/native/src/lib.rs
+++ b/bindings/lua/native/src/lib.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_void};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -146,6 +147,7 @@ struct SocketInner {
     // OMQ/libzmq sockets stay single-threaded. Atomic keeps close/drop
     // idempotent without making the socket handle Send or Sync.
     raw: AtomicUsize,
+    recv_scratch: RefCell<Vec<u8>>,
     context_handle: ContextHandle,
 }
 
@@ -159,6 +161,7 @@ impl SocketInner {
     }
 
     fn close(&self) -> LuaResult<()> {
+        self.clear_recv_scratch()?;
         let raw = self.raw.swap(0, Ordering::AcqRel);
         if raw == 0 {
             return Ok(());
@@ -166,6 +169,16 @@ impl SocketInner {
         let rc = omq_zmq::zmq_close(raw as *mut c_void);
         self.context_handle.release()?;
         check_rc(rc)
+    }
+
+    fn clear_recv_scratch(&self) -> LuaResult<()> {
+        let mut scratch = self
+            .recv_scratch
+            .try_borrow_mut()
+            .map_err(|_| LuaError::runtime("socket receive buffer is busy"))?;
+        scratch.clear();
+        scratch.shrink_to_fit();
+        Ok(())
     }
 }
 
@@ -242,6 +255,7 @@ impl NativeContext {
         Ok(NativeSocket {
             inner: Rc::new(SocketInner {
                 raw: AtomicUsize::new(raw as usize),
+                recv_scratch: RefCell::new(Vec::new()),
                 context_handle,
             }),
         })
@@ -468,8 +482,54 @@ impl NativeSocket {
         max_size: Option<usize>,
         flags: i32,
     ) -> LuaResult<Option<LuaString>> {
+        if let Some(max_size) = max_size {
+            return self.recv_lua_string_bounded(lua, max_size, flags);
+        }
         self.recv_lua_frame(lua, max_size, flags)
             .map(|frame| frame.map(|(part, _)| part))
+    }
+
+    fn recv_lua_string_bounded(
+        &self,
+        lua: &Lua,
+        max_size: usize,
+        flags: i32,
+    ) -> LuaResult<Option<LuaString>> {
+        let sock = self.inner.ptr()?;
+        let mut scratch = self
+            .inner
+            .recv_scratch
+            .try_borrow_mut()
+            .map_err(|_| LuaError::runtime("socket receive buffer is busy"))?;
+        let current_capacity = scratch.capacity();
+        if current_capacity < max_size {
+            scratch
+                .try_reserve_exact(max_size - current_capacity)
+                .map_err(|err| {
+                    LuaError::external(format!("receive buffer allocation failed: {err}"))
+                })?;
+        }
+
+        let rc = omq_zmq::zmq_recv(sock, scratch.as_mut_ptr().cast(), max_size, flags);
+        if rc < 0 {
+            if omq_zmq::zmq_errno() == libc::EAGAIN && (flags & ZMQ_DONTWAIT) != 0 {
+                return Ok(None);
+            }
+            return Err(last_error());
+        }
+
+        let len = usize::try_from(rc).map_err(|_| LuaError::runtime("negative receive size"))?;
+        if len > max_size {
+            return Err(LuaError::runtime(format!(
+                "received message exceeded Lua receive limit: size={len} limit={max_size}",
+            )));
+        }
+
+        // SAFETY: zmq_recv initialized exactly len bytes when len <= max_size.
+        let bytes = unsafe { std::slice::from_raw_parts(scratch.as_ptr(), len) };
+        let out = lua.create_string(bytes);
+        scratch.clear();
+        Ok(Some(out?))
     }
 
     fn recv_lua_parts(

--- a/bindings/lua/scripts/bench_peer.lua
+++ b/bindings/lua/scripts/bench_peer.lua
@@ -61,7 +61,8 @@ local function print_throughput(result_impl, messages, started, ended)
   }, { "impl", "endpoint", "msg_size", "messages", "seconds", "msgs_s", "gb_s" })
 end
 
-local function print_latency(result_impl, messages, samples)
+local function print_latency(result_impl, samples)
+  local messages = #samples
   table.sort(samples)
   local p50_index = math.min(messages, math.floor(messages * 50 / 100) + 1)
   local p99_index = math.min(messages, math.floor(messages * 99 / 100) + 1)
@@ -210,12 +211,12 @@ local function run_lzmq_push()
   end
 end
 
-local function run_omq_rep(count)
+local function run_omq_rep()
   local ctx, rep = open_omq_socket("rep", false)
   rep:bind(endpoint)
   print("READY " .. endpoint)
   io.stdout:flush()
-  for _ = 1, count do
+  while true do
     local msg = rep:recv(size)
     if #msg ~= size then
       die("bad message size")
@@ -226,12 +227,13 @@ local function run_omq_rep(count)
   ctx:term()
 end
 
-local function run_omq_req(messages, warmup_messages)
+local function run_omq_req(duration, warmup_seconds)
   local ctx, req = open_omq_socket("req", true)
   req:set_recv_timeout(timeout_ms)
   req:connect(endpoint)
   local msg = payload(size)
-  for _ = 1, warmup_messages do
+  local warmup_deadline = clock() + warmup_seconds
+  while clock() < warmup_deadline do
     req:send(msg)
     local reply = req:recv(size)
     if #reply ~= size then
@@ -239,26 +241,27 @@ local function run_omq_req(messages, warmup_messages)
     end
   end
   local samples = {}
-  for i = 1, messages do
+  local deadline = clock() + duration
+  repeat
     local started = clock()
     req:send(msg)
     local reply = req:recv(size)
     if #reply ~= size then
       die("bad reply size")
     end
-    samples[i] = (clock() - started) * 1000000.0
-  end
-  print_latency("omq.lua", messages, samples)
+    samples[#samples + 1] = (clock() - started) * 1000000.0
+  until clock() >= deadline
+  print_latency("omq.lua", samples)
   req:close()
   ctx:term()
 end
 
-local function run_lzmq_rep(count)
+local function run_lzmq_rep()
   local ctx, rep = open_lzmq_socket(require("lzmq").REP, false)
   checked(rep:bind(endpoint))
   print("READY " .. endpoint)
   io.stdout:flush()
-  for _ = 1, count do
+  while true do
     local msg = checked(rep:recv())
     if #msg ~= size then
       die("bad message size")
@@ -269,12 +272,13 @@ local function run_lzmq_rep(count)
   checked(ctx:term())
 end
 
-local function run_lzmq_req(messages, warmup_messages)
+local function run_lzmq_req(duration, warmup_seconds)
   local ctx, req = open_lzmq_socket(require("lzmq").REQ, true)
   checked(req:set_rcvtimeo(timeout_ms))
   checked(req:connect(endpoint))
   local msg = payload(size)
-  for _ = 1, warmup_messages do
+  local warmup_deadline = clock() + warmup_seconds
+  while clock() < warmup_deadline do
     checked(req:send(msg))
     local reply = checked(req:recv())
     if #reply ~= size then
@@ -282,16 +286,17 @@ local function run_lzmq_req(messages, warmup_messages)
     end
   end
   local samples = {}
-  for i = 1, messages do
+  local deadline = clock() + duration
+  repeat
     local started = clock()
     checked(req:send(msg))
     local reply = checked(req:recv())
     if #reply ~= size then
       die("bad reply size")
     end
-    samples[i] = (clock() - started) * 1000000.0
-  end
-  print_latency("lzmq", messages, samples)
+    samples[#samples + 1] = (clock() - started) * 1000000.0
+  until clock() >= deadline
+  print_latency("lzmq", samples)
   checked(req:close(1000))
   checked(ctx:term())
 end
@@ -305,16 +310,16 @@ elseif bench == "pushpull" and impl == "lzmq" and role == "pull" then
 elseif bench == "pushpull" and impl == "lzmq" and role == "push" then
   run_lzmq_push()
 elseif bench == "reqrep" and impl == "omq.lua" and role == "rep" then
-  run_omq_rep(amount + warmup)
+  run_omq_rep()
 elseif bench == "reqrep" and impl == "omq.lua" and role == "req" then
   run_omq_req(amount, warmup)
 elseif bench == "reqrep" and impl == "lzmq" and role == "rep" then
-  run_lzmq_rep(amount + warmup)
+  run_lzmq_rep()
 elseif bench == "reqrep" and impl == "lzmq" and role == "req" then
   run_lzmq_req(amount, warmup)
 else
   die(
     "usage: bench_peer.lua <pushpull|reqrep> <omq.lua|lzmq> "
-      .. "<pull|push|req|rep> <endpoint> <size> <duration|messages> <warmup>"
+      .. "<pull|push|req|rep> <endpoint> <size> <duration> <warmup>"
   )
 end

--- a/bindings/lua/scripts/bench_peer.lua
+++ b/bindings/lua/scripts/bench_peer.lua
@@ -129,7 +129,7 @@ local function recv_omq_for(socket, seconds)
   local deadline = clock() + seconds
   local recv = socket.recv
   while true do
-    local msg = recv(socket)
+    local msg = recv(socket, size)
     if #msg ~= size then
       die("bad message size")
     end

--- a/bindings/lua/scripts/update_perf.py
+++ b/bindings/lua/scripts/update_perf.py
@@ -33,6 +33,7 @@ CHART_DIR = ROOT / "doc" / "charts"
 CHART = CHART_DIR / "bindings.svg"
 DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [16, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
 DEFAULT_IMPLS = ["omq.lua", "lzmq"]
 DEFAULT_LATENCY_IMPLS = ["omq.lua", "lzmq"]
 IMPL_LABELS = {
@@ -40,8 +41,8 @@ IMPL_LABELS = {
     "lzmq": "lzmq",
 }
 COLORS = {
-    "omq.lua": "#dc2626",
-    "lzmq": "#2563eb",
+    "omq.lua": "#ef4444",
+    "lzmq": "#60a5fa",
 }
 _LUAROCKS_ENV = None
 
@@ -73,6 +74,10 @@ def parse_csv_ints(value):
 
 def parse_csv_strings(value):
     return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
 
 
 def luarocks_env():
@@ -310,7 +315,7 @@ def run_pair_once(
     receiver_role,
     sender_role,
     size,
-    messages,
+    duration,
     warmup,
     timeout,
     profile,
@@ -318,7 +323,7 @@ def run_pair_once(
     endpoint = free_endpoint()
     env = lua_env(profile)
     receiver = subprocess.Popen(
-        peer_cmd(lua_bin, bench, impl, receiver_role, endpoint, size, messages, warmup),
+        peer_cmd(lua_bin, bench, impl, receiver_role, endpoint, size, duration, warmup),
         cwd=REPO,
         env=env,
         text=True,
@@ -332,7 +337,7 @@ def run_pair_once(
             raise RuntimeError(f"receiver did not become ready:\n{ready or ''}{out}{err}")
 
         sender = subprocess.run(
-            peer_cmd(lua_bin, bench, impl, sender_role, endpoint, size, messages, warmup),
+            peer_cmd(lua_bin, bench, impl, sender_role, endpoint, size, duration, warmup),
             cwd=REPO,
             env=env,
             text=True,
@@ -345,13 +350,15 @@ def run_pair_once(
         if sender.returncode != 0:
             raise RuntimeError(f"sender failed:\n{sender.stdout}{sender.stderr}")
 
+        if bench == "reqrep":
+            out, err = kill(receiver)
+            fail_on_noise("receiver", ready + out, err)
+            return parse_result(sender.stdout)
         out, err = receiver.communicate(timeout=timeout)
         out = ready + out
         fail_on_noise("receiver", out, err)
         if receiver.returncode != 0:
             raise RuntimeError(f"receiver failed:\n{out}{err}")
-        if bench == "reqrep":
-            return parse_result(sender.stdout)
         return parse_result(out)
     except Exception:
         kill(receiver)
@@ -384,10 +391,9 @@ def run_throughput_cell(lua_bin, impl, size, args, profile):
 
 
 def run_latency_cell(lua_bin, impl, size, args, profile):
-    messages = args.latency_iters
-    warmup = args.latency_warmup
     runs = []
     total = args.warmup_rounds + args.rounds
+    timeout = args.timeout + args.latency_warmup_duration + args.latency_duration
     for round_index in range(total):
         row = run_pair_once(
             lua_bin,
@@ -396,16 +402,19 @@ def run_latency_cell(lua_bin, impl, size, args, profile):
             "rep",
             "req",
             size,
-            messages,
-            warmup,
-            args.timeout,
+            f"{args.latency_duration:.6f}",
+            f"{args.latency_warmup_duration:.6f}",
+            timeout,
             profile,
         )
+        row["target_seconds"] = args.latency_duration
+        row["warmup_seconds"] = args.latency_warmup_duration
         if round_index >= args.warmup_rounds:
             runs.append(row)
         print(
             f"  {impl:12s} size={size:6d} round={round_index + 1}/{total} "
-            f"p50 {row['p50_us']:8.1f} us p99 {row['p99_us']:8.1f} us",
+            f"p50 {row['p50_us']:8.1f} us p99 {row['p99_us']:8.1f} us "
+            f"n={row['messages']}",
             flush=True,
         )
     return sorted(runs, key=lambda row: row["p50_us"])[len(runs) // 2]
@@ -444,7 +453,7 @@ def fmt_size(size):
     return f"{size} B"
 
 
-def print_table(rows, sizes, impls, latency_impls):
+def print_table(rows, sizes, latency_sizes, impls, latency_impls):
     by_key = {(row["kind"], row["msg_size"], row["impl"]): row for row in rows}
     print()
     if impls:
@@ -466,7 +475,7 @@ def print_table(rows, sizes, impls, latency_impls):
     if latency_impls:
         print("REQ/REP TCP latency")
         print("size    impl             p50 us    p99 us   vs lzmq")
-        for size in sizes:
+        for size in latency_sizes:
             base = by_key.get(("reqrep_tcp_latency", size, "lzmq"))
             base_p50 = base["p50_us"] if base else 0.0
             for impl in latency_impls:
@@ -481,7 +490,7 @@ def print_table(rows, sizes, impls, latency_impls):
             print()
 
 
-def latest_chart_data(sizes, impls, latency_impls):
+def latest_chart_data(sizes, latency_sizes, impls, latency_impls):
     latest = {}
     for row in load_jsonl():
         kind = normalized_kind(row)
@@ -502,7 +511,7 @@ def latest_chart_data(sizes, impls, latency_impls):
     latency = {
         impl: [
             latest.get(("reqrep_tcp_latency", impl, size), {}).get("p50_us", 0.0)
-            for size in sizes
+            for size in latency_sizes
         ]
         for impl in latency_impls
     }
@@ -562,38 +571,29 @@ def read_chart_hw():
 
 def detect_hardware():
     config = read_chart_hw()
-    try:
-        cpu = None
-        with open("/proc/cpuinfo") as file:
-            for line in file:
-                if line.startswith("model name"):
-                    cpu = line.split(":", 1)[1].strip()
-                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
-                    break
-        cores = os.cpu_count()
-        if cpu and cores:
-            label = f"{cpu}, {cores} cores"
-            prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
-            postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
-            extras = [part.strip() for part in postfix.split(",")] if postfix else []
-            env_extras = os.environ.get("OMQ_HW_EXTRAS")
-            if env_extras:
-                extras.extend(env_extras.split(","))
-            extras = [part for part in extras if part]
-            if extras:
-                label += ", " + ", ".join(extras)
-            if prefix:
-                label = f"{prefix}, {label}"
-            return label
-    except OSError:
-        pass
+    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
     return None
 
 
 def chart_selection(args, sizes):
     if args.latency_only or args.throughput_only:
-        return DEFAULT_SIZES, DEFAULT_IMPLS, DEFAULT_LATENCY_IMPLS
-    return sizes, args.impls, args.latency_impls
+        return (
+            DEFAULT_SIZES,
+            latency_sizes_from(DEFAULT_SIZES),
+            DEFAULT_IMPLS,
+            DEFAULT_LATENCY_IMPLS,
+        )
+    return sizes, latency_sizes_from(sizes), args.impls, args.latency_impls
 
 
 def svg_line(points, color, dashed=False):
@@ -608,7 +608,7 @@ def visible_impls(data, key, impls):
     return [impl for impl in impls if any(data[key].get(impl, []))]
 
 
-def gen_chart(data, path, sizes, impls, latency_impls):
+def gen_chart(data, path, sizes, latency_sizes, impls, latency_impls):
     impls = visible_impls(data, "throughput", impls)
     latency_impls = visible_impls(data, "latency", latency_impls)
     hw_label = detect_hardware()
@@ -626,6 +626,10 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t2_h = t2_bot - t2_top
     mid_x = (x_left + x_right) / 2
     xs = [x_left + i * plot_w / max(len(sizes) - 1, 1) for i in range(len(sizes))]
+    lat_xs = [
+        x_left + i * plot_w / max(len(latency_sizes) - 1, 1)
+        for i in range(len(latency_sizes))
+    ]
 
     all_rates = [rate for values in data["throughput"].values() for rate in values]
     all_mbps = [
@@ -650,8 +654,8 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     lines = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">',
-        f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>',
-        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>',
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>",
     ]
@@ -666,23 +670,23 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         yy = t1_bot - frac * t1_h
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_rate(msg_max * frac)}</text>"
         )
         lines.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
-            f' dominant-baseline="middle" fill="#6b7280" font-size="10">'
+            f' dominant-baseline="middle" fill="#9ca3af" font-size="10">'
             f"{fmt_y_mbps(mbps_max * frac)}</text>"
         )
 
     for x in xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
     lines.extend(
         [
@@ -697,7 +701,7 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t1_mid = (t1_top + t1_bot) / 2
     lines.append(
         f'  <text x="40" y="{t1_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
     )
 
@@ -713,13 +717,13 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         for i, value in enumerate(mbps):
             lines.append(
                 f'  <circle cx="{xs[i]:.1f}" cy="{y_mbps(value):.1f}" r="3"'
-                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+                f' fill="{COLORS[impl]}" stroke="#000000" stroke-width="1"/>'
             )
 
     for i, size in enumerate(sizes):
         lines.append(
             f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     add_legend(lines, [(IMPL_LABELS[impl], COLORS[impl]) for impl in impls], mid_x, t1_leg_y)
@@ -730,7 +734,7 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     )
 
     lines.append(
-        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"REQ/REP latency: 2-process, TCP loopback, p50 us (lower is better)</text>"
     )
@@ -740,17 +744,17 @@ def gen_chart(data, path, sizes, impls, latency_impls):
         yy = y_lat(value)
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{fmt_y_us(value)}</text>"
         )
-    for x in xs:
+    for x in lat_xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
     lines.extend(
         [
@@ -763,22 +767,24 @@ def gen_chart(data, path, sizes, impls, latency_impls):
     t2_mid = (t2_top + t2_bot) / 2
     lines.append(
         f'  <text x="40" y="{t2_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t2_mid:.0f})">p50 latency (us)</text>'
     )
     for impl in latency_impls:
         values = data["latency"].get(impl, [])
-        points = " ".join(f"{xs[i]:.1f},{y_lat(value):.1f}" for i, value in enumerate(values))
+        points = " ".join(
+            f"{lat_xs[i]:.1f},{y_lat(value):.1f}" for i, value in enumerate(values)
+        )
         lines.append(svg_line(points, COLORS[impl]))
         for i, value in enumerate(values):
             lines.append(
-                f'  <circle cx="{xs[i]:.1f}" cy="{y_lat(value):.1f}" r="3"'
-                f' fill="{COLORS[impl]}" stroke="white" stroke-width="1"/>'
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{y_lat(value):.1f}" r="3"'
+                f' fill="{COLORS[impl]}" stroke="#000000" stroke-width="1"/>'
             )
-    for i, size in enumerate(sizes):
+    for i, size in enumerate(latency_sizes):
         lines.append(
-            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(size)}</text>'
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
 
     add_legend(
@@ -812,7 +818,7 @@ def add_legend(lines, legend_items, mid_x, leg_y):
         )
         lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
         lines.append(
-            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
             f' font-size="11" font-weight="500">{html.escape(label)}</text>'
         )
         lx += item_widths[index] + item_gap
@@ -825,11 +831,11 @@ def main():
     parser.add_argument("--impls", type=parse_csv_strings, default=DEFAULT_IMPLS)
     parser.add_argument("--latency-impls", type=parse_csv_strings, default=DEFAULT_LATENCY_IMPLS)
     parser.add_argument("--rounds", type=int, default=3)
-    parser.add_argument("--warmup-rounds", type=int, default=1)
-    parser.add_argument("--duration", type=float, default=3.0)
+    parser.add_argument("--warmup-rounds", type=int, default=0)
+    parser.add_argument("--duration", type=float, default=2.5)
     parser.add_argument("--warmup-duration", type=float, default=0.5)
-    parser.add_argument("--latency-iters", type=int, default=10_000)
-    parser.add_argument("--latency-warmup", type=int, default=1_000)
+    parser.add_argument("--latency-duration", type=float, default=1.5)
+    parser.add_argument("--latency-warmup-duration", type=float)
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--lua", default=os.environ.get("OMQ_LUA", "/usr/bin/lua"))
     parser.add_argument("--no-build", action="store_true")
@@ -848,10 +854,11 @@ def main():
     if args.quick:
         args.rounds = min(args.rounds, 1)
         args.warmup_rounds = 0
-        args.duration = min(args.duration, 1.5)
-        args.warmup_duration = min(args.warmup_duration, 0.2)
-        args.latency_iters = min(args.latency_iters, 1_000)
-        args.latency_warmup = min(args.latency_warmup, 100)
+        args.duration = min(args.duration, 0.5)
+        args.latency_duration = min(args.latency_duration, 0.5)
+        args.warmup_duration = min(args.warmup_duration, 0.1)
+    if args.latency_warmup_duration is None:
+        args.latency_warmup_duration = args.warmup_duration
     if args.rounds < 1:
         parser.error("--rounds must be at least 1")
     if args.warmup_rounds < 0:
@@ -860,18 +867,21 @@ def main():
         parser.error("--duration must be positive")
     if args.warmup_duration < 0:
         parser.error("--warmup-duration cannot be negative")
-    if args.latency_iters < 1 or args.latency_warmup < 0:
-        parser.error("invalid latency iteration counts")
+    if args.latency_duration <= 0:
+        parser.error("--latency-duration must be positive")
+    if args.latency_warmup_duration < 0:
+        parser.error("--latency-warmup-duration cannot be negative")
     for impl in args.impls:
         if impl not in IMPL_LABELS:
             parser.error(f"unknown throughput impl: {impl}")
     for impl in args.latency_impls:
         if impl not in IMPL_LABELS:
             parser.error(f"unknown latency impl: {impl}")
+    latency_sizes = latency_sizes_from(sizes)
 
     if args.chart_only:
-        data = latest_chart_data(sizes, args.impls, args.latency_impls)
-        gen_chart(data, CHART, sizes, args.impls, args.latency_impls)
+        data = latest_chart_data(sizes, latency_sizes, args.impls, args.latency_impls)
+        gen_chart(data, CHART, sizes, latency_sizes, args.impls, args.latency_impls)
         return
 
     if shutil.which(args.lua) is None and not Path(args.lua).exists():
@@ -912,7 +922,7 @@ def main():
                 rows.append(row)
     if latency_impls:
         print("REQ/REP TCP latency")
-        for size in sizes:
+        for size in latency_sizes:
             for impl in latency_impls:
                 row = run_latency_cell(args.lua, impl, size, args, profile)
                 row["run_id"] = run_id
@@ -925,12 +935,23 @@ def main():
     if not args.no_save:
         append_jsonl(rows)
         print(f"appended {len(rows)} rows to {JSONL}")
-    print_table(rows, sizes, throughput_impls, latency_impls)
+    print_table(rows, sizes, latency_sizes, throughput_impls, latency_impls)
 
     if not args.no_chart and not args.no_save:
-        chart_sizes, chart_impls, chart_latency_impls = chart_selection(args, sizes)
-        data = latest_chart_data(chart_sizes, chart_impls, chart_latency_impls)
-        gen_chart(data, CHART, chart_sizes, chart_impls, chart_latency_impls)
+        chart_sizes, chart_latency_sizes, chart_impls, chart_latency_impls = chart_selection(
+            args, sizes
+        )
+        data = latest_chart_data(
+            chart_sizes, chart_latency_sizes, chart_impls, chart_latency_impls
+        )
+        gen_chart(
+            data,
+            CHART,
+            chart_sizes,
+            chart_latency_sizes,
+            chart_impls,
+            chart_latency_impls,
+        )
 
 
 if __name__ == "__main__":

--- a/bindings/node/DEVELOPMENT.md
+++ b/bindings/node/DEVELOPMENT.md
@@ -63,11 +63,17 @@ OMQ_NODE_BENCH_QUICK=1 npm run bench
 OMQ_NODE_BENCH_IMPLS=omq-node npm run bench
 OMQ_NODE_BENCH_IMPLS=zeromq.js npm run bench
 OMQ_NODE_BENCH_SIZES=8,64,1k,32k npm run bench
-OMQ_NODE_BENCH_THROUGHPUT_DURATION_SECS=3 npm run bench
-OMQ_NODE_BENCH_WARMUP_DURATION_SECS=1 npm run bench
-OMQ_NODE_BENCH_LATENCY_MESSAGES=100000 npm run bench
+OMQ_NODE_BENCH_ROUNDS=1 npm run bench
+OMQ_NODE_BENCH_THROUGHPUT_DURATION_SECS=2.5 npm run bench
+OMQ_NODE_BENCH_WARMUP_DURATION_SECS=0.5 npm run bench
+OMQ_NODE_BENCH_LATENCY_DURATION_SECS=1.5 npm run bench
 OMQ_NODE_BENCH_NO_CHART=1 npm run bench
 ```
+
+Defaults are 3 measured rounds per implementation and size. Throughput keeps
+the median msg/s round over 2.5 second windows. Latency keeps the median p50
+round over 1.5 second windows and only measures sizes up to 4 KiB. Each round
+uses a 0.5 second warmup window.
 
 Do not run benchmarks or profilers in parallel with other CPU-heavy work.
 
@@ -85,11 +91,10 @@ Chart output:
 bindings/node/doc/charts/bindings.svg
 ```
 
-Hardware subtitle comes from the repo-root `.chart_hw` when present:
+Hardware subtitle comes from the repo-root `.chart_hw`:
 
 ```text
-prefix=Ryzen 9 9950X
-postfix=turbo off, performance governor
+label=Ryzen 9 9950X, 16 cores, turbo off, performance governor
 ```
 
 `.chart_hw` is local-only and gitignored.

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -11,7 +11,7 @@ This package is for Node main/server processes. Browser code should use
 `@zeromq/omq`.
 
 <p align="center">
-  <img src="doc/charts/bindings.svg" alt="@zeromq/omq-node sync API vs zeromq.js TCP throughput and latency" width="850">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/node/doc/charts/bindings.svg" alt="@zeromq/omq-node sync API vs zeromq.js TCP throughput and latency" width="850">
 </p>
 
 2-process loopback PUSH/PULL throughput and REQ/REP p50 latency: per-message

--- a/bindings/node/doc/charts/bindings.svg
+++ b/bindings/node/doc/charts/bindings.svg
@@ -1,212 +1,197 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="684" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 12 cores, performance governor, turbo off</text>
-  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200k</text>
-  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">400k</text>
-  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">600k</text>
-  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">800k</text>
-  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.2M</text>
-  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.4M</text>
-  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.6M</text>
-  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.8M</text>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
-  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
-  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <rect width="850" height="684" fill="#000000"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200k</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">400k</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">600k</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">800k</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.2M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.4M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.6M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.8M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,71.3 145.8,75.0 201.7,86.7 257.5,126.8 313.3,187.2 369.2,206.4 425.0,196.7 480.8,221.0 536.7,268.5 592.5,303.5 648.3,329.0 704.2,352.1 760.0,367.5" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
-  <polyline points="90.0,153.9 145.8,137.6 201.7,169.1 257.5,179.7 313.3,213.0 369.2,196.9 425.0,200.9 480.8,224.4 536.7,272.5 592.5,304.5 648.3,330.3 704.2,354.2 760.0,367.9" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
-  <polyline points="90.0,345.5 145.8,347.3 201.7,345.7 257.5,352.0 313.3,350.9 369.2,351.4 425.0,352.3 480.8,352.2 536.7,353.3 592.5,356.5 648.3,362.3 704.2,373.0 760.0,374.6" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
-  <polyline points="90.0,383.0 145.8,382.0 201.7,380.2 257.5,377.4 313.3,373.9 369.2,365.8 425.0,345.6 480.8,317.2 536.7,289.4 592.5,252.1 648.3,203.8 704.2,175.1 760.0,167.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="380.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="377.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="373.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="365.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="345.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="317.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="289.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="252.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="203.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="175.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="167.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.3 145.8,382.4 201.7,381.2 257.5,378.8 313.3,375.2 369.2,364.8 425.0,346.5 480.8,318.6 536.7,292.6 592.5,253.7 648.3,208.0 704.2,188.8 760.0,172.7" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="381.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="378.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="375.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="364.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="346.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="318.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="292.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="253.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="208.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="188.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="172.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.9 145.8,383.8 201.7,383.5 257.5,383.2 313.3,382.3 369.2,380.7 425.0,377.5 480.8,371.0 536.7,358.8 592.5,339.0 648.3,312.9 704.2,311.6 760.0,261.3" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="383.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="383.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="383.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="382.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="380.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="377.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="371.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="358.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="339.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="312.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="311.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="261.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <text x="425.0" y="447" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
-  <line x1="90" y1="572.0" x2="760" y2="572.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="572.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
-  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
-  <line x1="90" y1="548.0" x2="760" y2="548.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="548.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
-  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
-  <line x1="90" y1="524.0" x2="760" y2="524.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="524.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
-  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
-  <line x1="90" y1="500.0" x2="760" y2="500.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="500.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 µs</text>
-  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 µs</text>
-  <line x1="90" y1="476.0" x2="760" y2="476.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="476.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 µs</text>
-  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 µs</text>
-  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="464" x2="145.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="464" x2="201.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="464" x2="257.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="464" x2="369.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="464" x2="425.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="464" x2="480.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="464" x2="592.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="464" x2="648.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="464" x2="704.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,92.0 145.8,95.0 201.7,92.1 257.5,141.4 313.3,193.7 369.2,199.9 425.0,207.5 480.8,218.9 536.7,263.2 592.5,303.0 648.3,328.9 704.2,354.1 760.0,367.8" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,155.5 145.8,155.4 201.7,170.1 257.5,176.3 313.3,213.7 369.2,218.0 425.0,200.8 480.8,230.1 536.7,257.9 592.5,303.8 648.3,329.7 704.2,352.8 760.0,367.4" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,346.5 145.8,346.5 201.7,346.3 257.5,349.9 313.3,350.5 369.2,351.1 425.0,351.7 480.8,351.8 536.7,354.1 592.5,356.6 648.3,362.8 704.2,373.3 760.0,375.0" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,383.1 145.8,382.2 201.7,380.3 257.5,377.8 313.3,374.3 369.2,365.1 425.0,347.9 480.8,316.4 536.7,285.0 592.5,251.3 648.3,203.4 704.2,188.3 760.0,171.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="382.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="380.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="377.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="374.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="365.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="347.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="316.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="285.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="251.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="203.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="188.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="171.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,383.3 145.8,382.5 201.7,381.3 257.5,378.7 313.3,375.3 369.2,367.0 425.0,346.5 480.8,321.0 536.7,280.7 592.5,252.6 648.3,206.2 704.2,179.8 760.0,166.7" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="382.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="381.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="378.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="375.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="367.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="346.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="321.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="280.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="252.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="206.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="179.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="166.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,383.9 145.8,383.8 201.7,383.5 257.5,383.1 313.3,382.3 369.2,380.6 425.0,377.4 480.8,370.8 536.7,359.5 592.5,339.0 648.3,314.5 704.2,313.7 760.0,266.2" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="383.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="383.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="383.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="382.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="380.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="377.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="370.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="359.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="339.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="314.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="313.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="266.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="145.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="201.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="257.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="313.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="369.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="425.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="480.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="536.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="592.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="648.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="704.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <text x="425.0" y="447" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90" y1="572.0" x2="760" y2="572.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="572.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 µs</text>
+  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 µs</text>
+  <line x1="90" y1="548.0" x2="760" y2="548.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="548.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 µs</text>
+  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 µs</text>
+  <line x1="90" y1="524.0" x2="760" y2="524.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="524.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 µs</text>
+  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 µs</text>
+  <line x1="90" y1="500.0" x2="760" y2="500.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="500.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 µs</text>
+  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 µs</text>
+  <line x1="90" y1="476.0" x2="760" y2="476.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="476.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 µs</text>
+  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 µs</text>
+  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="164.4" y1="464" x2="164.4" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="238.9" y1="464" x2="238.9" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="387.8" y1="464" x2="387.8" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="462.2" y1="464" x2="462.2" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="611.1" y1="464" x2="611.1" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="685.6" y1="464" x2="685.6" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,537.3 145.8,536.6 201.7,534.3 257.5,536.2 313.3,535.7 369.2,537.8 425.0,537.7 480.8,535.6 536.7,534.0 592.5,528.4 648.3,523.9 704.2,508.4 760.0,473.8" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="537.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="536.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="534.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="536.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="535.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="537.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="537.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="535.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="534.0" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="528.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="523.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="508.4" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="473.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,549.7 145.8,551.5 201.7,549.8 257.5,551.0 313.3,550.7 369.2,549.5 425.0,550.1 480.8,549.9 536.7,548.2 592.5,544.7 648.3,540.8 704.2,530.1 760.0,515.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="549.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="551.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="549.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="551.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="550.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="549.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="550.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="549.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="548.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="544.7" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="540.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="530.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="515.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,510.0 145.8,504.7 201.7,506.9 257.5,506.6 313.3,507.8 369.2,500.2 425.0,498.9 480.8,500.2 536.7,498.5 592.5,497.1 648.3,491.1 704.2,486.2 760.0,477.7" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="510.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="504.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="506.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="506.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="507.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="500.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="498.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="500.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="498.5" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="497.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="491.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="486.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="477.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="155" y1="624" x2="169" y2="624" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="162" cy="624" r="2.5" fill="#dc2626"/>
-  <text x="175" y="628" fill="#374151" font-size="11" font-weight="500">omq-node sync API</text>
-  <line x1="335" y1="624" x2="349" y2="624" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="342" cy="624" r="2.5" fill="#f97316"/>
-  <text x="355" y="628" fill="#374151" font-size="11" font-weight="500">omq-node async API</text>
-  <line x1="515" y1="624" x2="529" y2="624" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="522" cy="624" r="2.5" fill="#2563eb"/>
-  <text x="535" y="628" fill="#374151" font-size="11" font-weight="500">zeromq.js async API</text>
+  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
+  <polyline points="90.0,537.3 164.4,536.8 238.9,536.9 313.3,536.8 387.8,537.0 462.2,538.1 536.7,536.3 611.1,535.5 685.6,534.4 760.0,531.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="537.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="536.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="536.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="536.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="537.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="538.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="536.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="535.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="534.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="531.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,551.4 164.4,552.2 238.9,551.4 313.3,550.0 387.8,549.7 462.2,550.8 536.7,550.7 611.1,550.5 685.6,548.8 760.0,544.8" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="551.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="552.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="551.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="550.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="549.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="550.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="550.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="550.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="548.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="544.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,506.3 164.4,507.2 238.9,507.0 313.3,505.4 387.8,505.3 462.2,501.1 536.7,499.8 611.1,499.8 685.6,500.5 760.0,499.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="506.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="507.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="507.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="505.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="505.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="501.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="499.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="499.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="500.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="499.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="164.4" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="238.9" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="313.3" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="387.8" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="462.2" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="536.7" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="611.1" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="685.6" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="760.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="155" y1="624" x2="169" y2="624" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="162" cy="624" r="2.5" fill="#ef4444"/>
+  <text x="175" y="628" fill="#e5e7eb" font-size="11" font-weight="500">omq-node sync API</text>
+  <line x1="335" y1="624" x2="349" y2="624" stroke="#fb923c" stroke-width="2.5"/>
+  <circle cx="342" cy="624" r="2.5" fill="#fb923c"/>
+  <text x="355" y="628" fill="#e5e7eb" font-size="11" font-weight="500">omq-node async API</text>
+  <line x1="515" y1="624" x2="529" y2="624" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="522" cy="624" r="2.5" fill="#60a5fa"/>
+  <text x="535" y="628" fill="#e5e7eb" font-size="11" font-weight="500">zeromq.js async API</text>
   <text x="425.0" y="642" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = throughput (right)</text>
 </svg>

--- a/bindings/node/scripts/omq-node-bench.js
+++ b/bindings/node/scripts/omq-node-bench.js
@@ -10,12 +10,16 @@ const { Worker, isMainThread, parentPort, workerData } = require("node:worker_th
 const CACHE_DIR = path.join(os.homedir(), ".cache", "omq.node");
 const DATA_FILE = path.join(CACHE_DIR, "bindings.jsonl");
 const CHART_FILE = path.resolve(__dirname, "../doc/charts/bindings.svg");
-const DEFAULT_LATENCY_COUNT = 50_000;
+const DEFAULT_LATENCY_DURATION_MS = 1500;
 const DEFAULT_THROUGHPUT_DURATION_MS = 2500;
 const DEFAULT_WARMUP_DURATION_MS = 500;
+const QUICK_DURATION_MS = 500;
+const QUICK_WARMUP_DURATION_MS = 100;
+const DEFAULT_ROUNDS = 3;
 const DEFAULT_BENCH_TIMEOUT_MS = 60_000;
 const DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768];
 const QUICK_SIZES = [16];
+const LATENCY_MAX_SIZE = 4096;
 const STOP_PAYLOAD = "__OMQ_NODE_BENCH_STOP__";
 const STOP_BUFFER = Buffer.from(STOP_PAYLOAD);
 const THROUGHPUT_HWM_BYTES = 128 * 1024 * 1024;
@@ -61,11 +65,14 @@ if (!isMainThread) {
 
 async function main() {
   fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const latencyCount = positiveInt(process.env.OMQ_NODE_BENCH_LATENCY_MESSAGES, DEFAULT_LATENCY_COUNT);
-  const throughputDurationMs = throughputDurationMsFromEnv();
-  const warmupDurationMs = warmupDurationMsFromEnv();
+  const quick = process.env.OMQ_NODE_BENCH_QUICK === "1";
+  const throughputDurationMs = throughputDurationMsFromEnv(quick);
+  const latencyDurationMs = latencyDurationMsFromEnv(quick);
+  const warmupDurationMs = warmupDurationMsFromEnv(quick);
+  const rounds = roundsFromEnv(quick);
   const timeoutMs = positiveInt(process.env.OMQ_NODE_BENCH_TIMEOUT_MS, DEFAULT_BENCH_TIMEOUT_MS);
   const sizes = parseSizes(process.env.OMQ_NODE_BENCH_SIZES ?? process.env.OMQ_NODE_BENCH_SIZE);
+  const latencySizes = sizes.filter((size) => size <= LATENCY_MAX_SIZE);
   const impls = parseImpls(process.env.OMQ_NODE_BENCH_IMPLS);
   const zeromqLoadable = canLoadZeromq();
   const runId = `${Date.now()}-${process.pid}`;
@@ -79,46 +86,72 @@ async function main() {
   }
 
   for (const size of sizes) {
-    const latencyCountForThisSize = latencyCountForSize(latencyCount, size);
-
     if (runOmq) {
-      await warmupThroughput(warmupDurationMs, (durationMs) =>
-        runOmqInprocThroughput({ mode: "sync", durationMs, size, runId: `${runId}-warmup` }),
-      );
-      appendRecord(await runOmqInprocThroughput({ mode: "sync", durationMs: throughputDurationMs, size, runId }));
-      await warmupThroughput(warmupDurationMs, (durationMs) =>
-        runOmqTcpThroughput({ mode: "sync", durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
-      );
-      appendRecord(await runOmqTcpThroughput({ mode: "sync", durationMs: throughputDurationMs, size, runId, timeoutMs }));
-      appendRecord(await runOmqTcpLatency({ mode: "sync", count: latencyCountForThisSize, size, runId, timeoutMs }));
-
-      await warmupThroughput(warmupDurationMs, (durationMs) =>
-        runOmqInprocThroughput({ mode: "async", durationMs, size, runId: `${runId}-warmup` }),
-      );
-      appendRecord(await runOmqInprocThroughput({ mode: "async", durationMs: throughputDurationMs, size, runId }));
-      await warmupThroughput(warmupDurationMs, (durationMs) =>
-        runOmqTcpThroughput({ mode: "async", durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
-      );
-      appendRecord(await runOmqTcpThroughput({ mode: "async", durationMs: throughputDurationMs, size, runId, timeoutMs }));
-      appendRecord(await runOmqTcpLatency({ mode: "async", count: latencyCountForThisSize, size, runId, timeoutMs }));
+      appendRecord(await measureThroughputRounds(
+        rounds,
+        (durationMs) => runOmqInprocThroughput({ mode: "sync", durationMs, size, runId: `${runId}-warmup` }),
+        () => runOmqInprocThroughput({ mode: "sync", durationMs: throughputDurationMs, size, runId }),
+        warmupDurationMs,
+      ));
+      appendRecord(await measureThroughputRounds(
+        rounds,
+        (durationMs) => runOmqTcpThroughput({ mode: "sync", durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
+        () => runOmqTcpThroughput({ mode: "sync", durationMs: throughputDurationMs, size, runId, timeoutMs }),
+        warmupDurationMs,
+      ));
+      appendRecord(await measureThroughputRounds(
+        rounds,
+        (durationMs) => runOmqInprocThroughput({ mode: "async", durationMs, size, runId: `${runId}-warmup` }),
+        () => runOmqInprocThroughput({ mode: "async", durationMs: throughputDurationMs, size, runId }),
+        warmupDurationMs,
+      ));
+      appendRecord(await measureThroughputRounds(
+        rounds,
+        (durationMs) => runOmqTcpThroughput({ mode: "async", durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
+        () => runOmqTcpThroughput({ mode: "async", durationMs: throughputDurationMs, size, runId, timeoutMs }),
+        warmupDurationMs,
+      ));
+      if (latencySizes.includes(size)) {
+        appendRecord(await measureLatencyRounds(rounds, () => runOmqTcpLatency({
+          mode: "sync",
+          durationMs: latencyDurationMs,
+          warmupDurationMs,
+          size,
+          runId,
+          timeoutMs,
+        })));
+        appendRecord(await measureLatencyRounds(rounds, () => runOmqTcpLatency({
+          mode: "async",
+          durationMs: latencyDurationMs,
+          warmupDurationMs,
+          size,
+          runId,
+          timeoutMs,
+        })));
+      }
     }
 
     if (runZeromq) {
-      await warmupThroughput(warmupDurationMs, (durationMs) =>
-        runZeromqTcpThroughput({ durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
-      );
-      appendRecord(await runZeromqTcpThroughput({
-        durationMs: throughputDurationMs,
-        size,
-        runId,
-        timeoutMs,
-      }));
-      appendRecord(await runZeromqTcpLatency({
-        count: latencyCountForThisSize,
-        size,
-        runId,
-        timeoutMs,
-      }));
+      appendRecord(await measureThroughputRounds(
+        rounds,
+        (durationMs) => runZeromqTcpThroughput({ durationMs, size, runId: `${runId}-warmup`, timeoutMs }),
+        () => runZeromqTcpThroughput({
+          durationMs: throughputDurationMs,
+          size,
+          runId,
+          timeoutMs,
+        }),
+        warmupDurationMs,
+      ));
+      if (latencySizes.includes(size)) {
+        appendRecord(await measureLatencyRounds(rounds, () => runZeromqTcpLatency({
+          durationMs: latencyDurationMs,
+          warmupDurationMs,
+          size,
+          runId,
+          timeoutMs,
+        })));
+      }
     }
   }
   if (process.env.OMQ_NODE_BENCH_NO_CHART === "1") {
@@ -132,6 +165,28 @@ async function main() {
 function appendRecord(record) {
   fs.appendFileSync(DATA_FILE, `${JSON.stringify(record)}\n`);
   printRecord(record);
+}
+
+async function measureThroughputRounds(rounds, warmupRun, measuredRun, warmupDurationMs) {
+  const records = [];
+  for (let round = 0; round < rounds; round++) {
+    await warmupThroughput(warmupDurationMs, warmupRun);
+    records.push(await measuredRun());
+  }
+  return medianBy(records, (record) => record.msgPerSec);
+}
+
+async function measureLatencyRounds(rounds, measuredRun) {
+  const records = [];
+  for (let round = 0; round < rounds; round++) {
+    records.push(await measuredRun());
+  }
+  return medianBy(records, (record) => record.latencyUs);
+}
+
+function medianBy(records, valueOf) {
+  const sorted = [...records].sort((a, b) => valueOf(a) - valueOf(b));
+  return sorted[Math.floor(sorted.length / 2)];
 }
 
 async function warmupThroughput(durationMs, run) {
@@ -154,6 +209,7 @@ async function runOmqInprocThroughput({ mode, durationMs, size, runId }) {
   const context = new Context();
   const push = new Push(benchOptions({ durationMs, metric: "throughput", mode, size }), context);
   let receiver;
+  let receiverExit;
   try {
     const endpoint = `inproc://omq-node-bench-${process.pid}-${Date.now()}-${size}`;
     receiver = new Worker(__filename, {
@@ -167,6 +223,7 @@ async function runOmqInprocThroughput({ mode, durationMs, size, runId }) {
         metric: "throughput",
       },
     });
+    receiverExit = waitWorkerExit(receiver);
     await waitWorker(receiver, "ready");
     await push.connect(endpoint);
     push.waitConnectedSync(1, 5000);
@@ -178,6 +235,11 @@ async function runOmqInprocThroughput({ mode, durationMs, size, runId }) {
     if (mode === "async") await push.send(STOP_PAYLOAD);
     else push.sendSync(STOP_PAYLOAD);
     const recv = await waitWorker(receiver, "done");
+    const exitCode = await receiverExit;
+    receiver = undefined;
+    if (exitCode !== 0) {
+      throw new Error(`worker failed after done: code=${exitCode}`);
+    }
     return throughputRecord({
       runId,
       impl: "omq-node",
@@ -228,9 +290,9 @@ async function runOmqTcpThroughput({ mode, durationMs, size, runId, timeoutMs })
   }
 }
 
-async function runOmqTcpLatency({ mode, count, size, runId, timeoutMs }) {
+async function runOmqTcpLatency({ mode, durationMs, warmupDurationMs, size, runId, timeoutMs }) {
   const endpoint = await freeTcpEndpoint();
-  const common = { impl: "omq-node", mode, transport: "tcp", metric: "latency", endpoint, count, size };
+  const common = { impl: "omq-node", mode, transport: "tcp", metric: "latency", endpoint, durationMs, warmupDurationMs, size };
   const rep = forkPeer({ ...common, role: "rep" });
   let req;
   try {
@@ -245,8 +307,11 @@ async function runOmqTcpLatency({ mode, count, size, runId, timeoutMs }) {
       impl: "omq-node",
       mode,
       transport: "tcp",
-      count,
+      count: result.count,
       size,
+      elapsedSec: result.elapsedSec,
+      targetSec: durationMs / 1000,
+      warmupSec: warmupDurationMs / 1000,
       latencyUs: result.p50Us,
       avgLatencyUs: result.latencyUs,
       p99Us: result.p99Us,
@@ -291,9 +356,9 @@ async function runZeromqTcpThroughput({ durationMs, size, runId, timeoutMs }) {
   }
 }
 
-async function runZeromqTcpLatency({ count, size, runId, timeoutMs }) {
+async function runZeromqTcpLatency({ durationMs, warmupDurationMs, size, runId, timeoutMs }) {
   const endpoint = await freeTcpEndpoint();
-  const common = { impl: "zeromq.js", transport: "tcp", metric: "latency", endpoint, count, size };
+  const common = { impl: "zeromq.js", transport: "tcp", metric: "latency", endpoint, durationMs, warmupDurationMs, size };
   const rep = forkPeer({ ...common, role: "rep" });
   let req;
   try {
@@ -308,8 +373,11 @@ async function runZeromqTcpLatency({ count, size, runId, timeoutMs }) {
       impl: "zeromq.js",
       mode: "async",
       transport: "tcp",
-      count,
+      count: result.count,
       size,
+      elapsedSec: result.elapsedSec,
+      targetSec: durationMs / 1000,
+      warmupSec: warmupDurationMs / 1000,
       latencyUs: result.p50Us,
       avgLatencyUs: result.latencyUs,
       p99Us: result.p99Us,
@@ -337,15 +405,21 @@ async function runWorker(config) {
   const { Context, Pull } = require("../dist");
   const context = Context.fromShareKey(config.shareKey);
   const pull = new Pull(benchOptions(config), context);
+  let closed = false;
   try {
     await pull.bind(config.endpoint);
     parentPort.postMessage({ kind: "ready" });
     await waitWorkerStart();
     const result = config.mode === "async" ? await recvUntilStopAsync(pull) : recvUntilStopSync(pull);
-    parentPort.postMessage({ kind: "done", count: result.count, elapsedSec: result.elapsedSec });
-  } finally {
     pull.close();
     context.close();
+    closed = true;
+    parentPort.postMessage({ kind: "done", count: result.count, elapsedSec: result.elapsedSec });
+  } finally {
+    if (!closed) {
+      pull.close();
+      context.close();
+    }
   }
 }
 
@@ -407,9 +481,11 @@ async function runOmqProcessPeer(config) {
   await sendReady();
   await waitUntilStart(config);
   const payload = Buffer.alloc(config.size, 7);
+  await warmupOmqLatency(req, payload, config);
   const start = process.hrtime.bigint();
+  const deadline = start + BigInt(Math.round(config.durationMs * 1_000_000));
   const rtts = [];
-  for (let i = 0; i < config.count; i++) {
+  do {
     const roundStart = process.hrtime.bigint();
     if (config.mode === "async") {
       await req.send(payload);
@@ -419,7 +495,7 @@ async function runOmqProcessPeer(config) {
       req.recvSync();
     }
     rtts.push(secondsSince(roundStart) * 1_000_000);
-  }
+  } while (process.hrtime.bigint() < deadline);
   const elapsedSec = secondsSince(start);
   rtts.sort((a, b) => a - b);
   if (config.mode === "async") {
@@ -431,7 +507,9 @@ async function runOmqProcessPeer(config) {
   }
   await sendIpc({
     kind: "done",
-    latencyUs: elapsedSec * 1_000_000 / config.count,
+    count: rtts.length,
+    elapsedSec,
+    latencyUs: elapsedSec * 1_000_000 / rtts.length,
     p50Us: percentile(rtts, 50),
     p99Us: percentile(rtts, 99),
     p999Us: percentile(rtts, 99.9),
@@ -504,21 +582,25 @@ async function runZeromqProcessPeer(config) {
   await sendReady();
   await waitUntilStart(config);
   const payload = Buffer.alloc(config.size, 7);
+  await warmupZeromqLatency(req, payload, config);
   const start = process.hrtime.bigint();
+  const deadline = start + BigInt(Math.round(config.durationMs * 1_000_000));
   const rtts = [];
-  for (let i = 0; i < config.count; i++) {
+  do {
     const roundStart = process.hrtime.bigint();
     await req.send(payload);
     await req.receive();
     rtts.push(secondsSince(roundStart) * 1_000_000);
-  }
+  } while (process.hrtime.bigint() < deadline);
   const elapsedSec = secondsSince(start);
   rtts.sort((a, b) => a - b);
   await req.send("__OMQ_NODE_BENCH_STOP__");
   await req.receive();
   await sendIpc({
     kind: "done",
-    latencyUs: elapsedSec * 1_000_000 / config.count,
+    count: rtts.length,
+    elapsedSec,
+    latencyUs: elapsedSec * 1_000_000 / rtts.length,
     p50Us: percentile(rtts, 50),
     p99Us: percentile(rtts, 99),
     p999Us: percentile(rtts, 99.9),
@@ -532,9 +614,7 @@ function benchOptions(config) {
   const hwmBase =
     config.metric === "throughput"
       ? throughputHighWaterMarkForSize(config.size)
-      : Number.isFinite(config.count)
-        ? config.count + 1
-        : 262_144;
+      : 262_144;
   return {
     sendHighWaterMark: Math.max(1000, Math.min(hwmBase, 262_144)),
     receiveHighWaterMark: Math.max(1000, Math.min(hwmBase, 262_144)),
@@ -597,6 +677,35 @@ async function sendOmqForDurationAsync(socket, payload, durationMs) {
     }
   } while (process.hrtime.bigint() < deadline);
   return { count, elapsedSec: secondsSince(start) };
+}
+
+async function warmupOmqLatency(socket, payload, config) {
+  if (!Number.isFinite(config.warmupDurationMs) || config.warmupDurationMs <= 0) {
+    return;
+  }
+  const start = process.hrtime.bigint();
+  const deadline = start + BigInt(Math.round(config.warmupDurationMs * 1_000_000));
+  do {
+    if (config.mode === "async") {
+      await socket.send(payload);
+      await socket.recv();
+    } else {
+      socket.sendSync(payload);
+      socket.recvSync();
+    }
+  } while (process.hrtime.bigint() < deadline);
+}
+
+async function warmupZeromqLatency(socket, payload, config) {
+  if (!Number.isFinite(config.warmupDurationMs) || config.warmupDurationMs <= 0) {
+    return;
+  }
+  const start = process.hrtime.bigint();
+  const deadline = start + BigInt(Math.round(config.warmupDurationMs * 1_000_000));
+  do {
+    await socket.send(payload);
+    await socket.receive();
+  } while (process.hrtime.bigint() < deadline);
 }
 
 function timeCheckIntervalForSize(size) {
@@ -676,6 +785,12 @@ function waitWorkerStart() {
         resolve();
       }
     });
+  });
+}
+
+function waitWorkerExit(worker) {
+  return new Promise((resolve) => {
+    worker.once("exit", resolve);
   });
 }
 
@@ -825,7 +940,22 @@ function throughputRecord({ runId, impl, mode, transport, count, size, elapsedSe
   };
 }
 
-function latencyRecord({ runId, impl, mode, transport, count, size, latencyUs, avgLatencyUs, p99Us, p999Us, maxUs }) {
+function latencyRecord({
+  runId,
+  impl,
+  mode,
+  transport,
+  count,
+  size,
+  elapsedSec,
+  targetSec,
+  warmupSec,
+  latencyUs,
+  avgLatencyUs,
+  p99Us,
+  p999Us,
+  maxUs,
+}) {
   return {
     runId,
     date: new Date().toISOString(),
@@ -835,6 +965,9 @@ function latencyRecord({ runId, impl, mode, transport, count, size, latencyUs, a
     transport,
     size,
     count,
+    elapsedSec,
+    targetSec,
+    warmupSec,
     latencyUs,
     avgLatencyUs,
     p99Us,
@@ -890,26 +1023,45 @@ function positiveNumber(raw, fallback) {
   return value;
 }
 
-function throughputDurationMsFromEnv() {
+function throughputDurationMsFromEnv(quick) {
   const rawMs = process.env.OMQ_NODE_BENCH_THROUGHPUT_DURATION_MS;
+  const fallback = quick ? QUICK_DURATION_MS : DEFAULT_THROUGHPUT_DURATION_MS;
   if (rawMs !== undefined) {
-    return Math.round(positiveNumber(rawMs, DEFAULT_THROUGHPUT_DURATION_MS));
+    return Math.round(positiveNumber(rawMs, fallback));
   }
   const rawSecs =
     process.env.OMQ_NODE_BENCH_THROUGHPUT_DURATION_SECS ??
     process.env.OMQ_NODE_BENCH_DURATION_SECS;
-  const seconds = positiveNumber(rawSecs, DEFAULT_THROUGHPUT_DURATION_MS / 1000);
+  const seconds = positiveNumber(rawSecs, fallback / 1000);
   return Math.round(seconds * 1000);
 }
 
-function warmupDurationMsFromEnv() {
+function warmupDurationMsFromEnv(quick) {
   const rawMs = process.env.OMQ_NODE_BENCH_WARMUP_DURATION_MS;
+  const fallback = quick ? QUICK_WARMUP_DURATION_MS : DEFAULT_WARMUP_DURATION_MS;
   if (rawMs !== undefined) {
-    return Math.round(positiveNumber(rawMs, DEFAULT_WARMUP_DURATION_MS));
+    return Math.round(positiveNumber(rawMs, fallback));
   }
   const rawSecs = process.env.OMQ_NODE_BENCH_WARMUP_DURATION_SECS;
-  const seconds = positiveNumber(rawSecs, DEFAULT_WARMUP_DURATION_MS / 1000);
+  const seconds = positiveNumber(rawSecs, fallback / 1000);
   return Math.round(seconds * 1000);
+}
+
+function latencyDurationMsFromEnv(quick) {
+  const rawMs = process.env.OMQ_NODE_BENCH_LATENCY_DURATION_MS;
+  const fallback = quick ? QUICK_DURATION_MS : DEFAULT_LATENCY_DURATION_MS;
+  if (rawMs !== undefined) {
+    return Math.round(positiveNumber(rawMs, fallback));
+  }
+  const rawSecs =
+    process.env.OMQ_NODE_BENCH_LATENCY_DURATION_SECS ??
+    process.env.OMQ_NODE_BENCH_DURATION_SECS;
+  const seconds = positiveNumber(rawSecs, fallback / 1000);
+  return Math.round(seconds * 1000);
+}
+
+function roundsFromEnv(quick) {
+  return positiveInt(process.env.OMQ_NODE_BENCH_ROUNDS, quick ? 1 : DEFAULT_ROUNDS);
 }
 
 function throughputHighWaterMarkForSize(size) {
@@ -961,11 +1113,6 @@ function parseSizes(raw) {
     throw new Error("at least one benchmark size required");
   }
   return sizes;
-}
-
-function latencyCountForSize(baseCount, size) {
-  const byteBudget = 16 * 1024 * 1024;
-  return Math.min(baseCount, 20_000, Math.max(200, Math.floor(byteBudget / size)));
 }
 
 function secondsSince(start) {

--- a/bindings/node/scripts/update_perf.py
+++ b/bindings/node/scripts/update_perf.py
@@ -14,15 +14,16 @@ import sys
 
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 SIZES = DEFAULT_SIZES.copy()
+LATENCY_MAX_SIZE = 4096
 CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 _CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "omq.node")
 JSONL_FILE = os.path.join(_CACHE_DIR, "bindings.jsonl")
 
 # Colors: warm = omq-node, cool = zeromq.js
-C_OMQ_SYNC = "#dc2626"
-C_OMQ_ASYNC = "#f97316"
-C_ZMQ = "#2563eb"
+C_OMQ_SYNC = "#ef4444"
+C_OMQ_ASYNC = "#fb923c"
+C_ZMQ = "#60a5fa"
 
 
 def load_jsonl():
@@ -96,6 +97,7 @@ def _latest_complete_rows(rows):
         required = set()
         for size in SIZES:
             required.add(("throughput", "tcp", size))
+        for size in latency_sizes_from(SIZES):
             required.add(("latency", "tcp", size))
 
         complete = [
@@ -121,6 +123,7 @@ def _latest_rows(rows):
 
 def chart_data_from_jsonl():
     latest = _latest_rows(load_jsonl())
+    latency_sizes = latency_sizes_from(SIZES)
 
     def get_tp(impl, mode, transport, size):
         row = latest.get((impl, mode, "throughput", transport, size))
@@ -134,10 +137,14 @@ def chart_data_from_jsonl():
         "omq_sync_tp": [get_tp("omq-node", "sync", "tcp", size) for size in SIZES],
         "omq_async_tp": [get_tp("omq-node", "async", "tcp", size) for size in SIZES],
         "zmq_async_tp": [get_tp("zeromq.js", "async", "tcp", size) for size in SIZES],
-        "omq_sync_lat": [get_lat("omq-node", "sync", size) for size in SIZES],
-        "omq_async_lat": [get_lat("omq-node", "async", size) for size in SIZES],
-        "zmq_async_lat": [get_lat("zeromq.js", "async", size) for size in SIZES],
+        "omq_sync_lat": [get_lat("omq-node", "sync", size) for size in latency_sizes],
+        "omq_async_lat": [get_lat("omq-node", "async", size) for size in latency_sizes],
+        "zmq_async_lat": [get_lat("zeromq.js", "async", size) for size in latency_sizes],
     }
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
 
 
 def fmt_size(size):
@@ -199,36 +206,24 @@ def _read_chart_hw():
 
 def _detect_hardware():
     hw_conf = _read_chart_hw()
-    try:
-        cpu = None
-        with open("/proc/cpuinfo") as f:
-            for line in f:
-                if line.startswith("model name"):
-                    cpu = line.split(":", 1)[1].strip()
-                    cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
-                    break
-        cores = os.cpu_count()
-        if cpu and cores:
-            label = f"{cpu}, {cores} cores"
-            prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
-            postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
-            extras = [e.strip() for e in postfix.split(",")] if postfix else []
-            hw_extras = os.environ.get("OMQ_HW_EXTRAS")
-            if hw_extras:
-                extras.extend(hw_extras.split(","))
-            extras = [e.strip() for e in extras if e.strip()]
-            if extras:
-                label += ", " + ", ".join(extras)
-            if prefix:
-                label = f"{prefix}, {label}"
-            return label
-    except OSError:
-        pass
+    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
     return None
 
 
 def gen_combined_chart(data, path):
     n = len(SIZES)
+    latency_sizes = latency_sizes_from(SIZES)
+    lat_n = len(latency_sizes)
     hw_label = _detect_hardware()
     hw_offset = 14 if hw_label else 0
     svg_w = 850
@@ -244,6 +239,7 @@ def gen_combined_chart(data, path):
     t2_h = t2_bot - t2_top
 
     xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
+    lat_xs = [x_left + i * plot_w / max(lat_n - 1, 1) for i in range(lat_n)]
     mid_x = (x_left + x_right) / 2
 
     omq_sync_tp = data["omq_sync_tp"]
@@ -270,10 +266,10 @@ def gen_combined_chart(data, path):
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">'
     )
-    lines.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>')
+    lines.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>')
 
     lines.append(
-        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>"
     )
@@ -291,23 +287,23 @@ def gen_combined_chart(data, path):
         yy = t1_bot - frac * t1_h
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151"'
+            f' dominant-baseline="middle" fill="#e5e7eb"'
             f' font-size="10">{_fmt_y_rate(msg_val)}</text>'
         )
         lines.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
-            f' dominant-baseline="middle" fill="#6b7280"'
+            f' dominant-baseline="middle" fill="#9ca3af"'
             f' font-size="10">{_fmt_mbps(mbps_val)}</text>'
         )
 
     for x in xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     lines.append(
@@ -326,7 +322,7 @@ def gen_combined_chart(data, path):
     t1_mid = (t1_top + t1_bot) / 2
     lines.append(
         f'  <text x="40" y="{t1_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
     )
 
@@ -348,17 +344,17 @@ def gen_combined_chart(data, path):
             yy = y_mbps(v)
             lines.append(
                 f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
     for i in range(n):
         lines.append(
             f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(SIZES[i])}</text>'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(SIZES[i])}</text>'
         )
 
     lines.append(
-        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
     )
@@ -368,18 +364,18 @@ def gen_combined_chart(data, path):
         yy = y_lat(v)
         lines.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         lines.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{_fmt_y_us(v)}</text>"
         )
 
-    for x in xs:
+    for x in lat_xs:
         lines.append(
             f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     lines.append(
@@ -394,7 +390,7 @@ def gen_combined_chart(data, path):
     t2_mid = (t2_top + t2_bot) / 2
     lines.append(
         f'  <text x="40" y="{t2_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t2_mid:.0f})">p50 latency (µs)</text>'
     )
 
@@ -405,20 +401,20 @@ def gen_combined_chart(data, path):
     ]
 
     for _, color, vals in lat_series:
-        _draw_series(lines, xs, vals, y_lat, color, stroke_width="2.5")
+        _draw_series(lines, lat_xs, vals, y_lat, color, stroke_width="2.5")
         for i, v in enumerate(vals):
             if v <= 0:
                 continue
             yy = y_lat(v)
             lines.append(
-                f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
-    for i in range(n):
+    for i in range(lat_n):
         lines.append(
-            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(SIZES[i])}</text>'
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(latency_sizes[i])}</text>'
         )
 
     leg_y = t2_bot + 40
@@ -439,7 +435,7 @@ def gen_combined_chart(data, path):
         )
         lines.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
         lines.append(
-            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
             f' font-size="11" font-weight="500">{label}</text>'
         )
 

--- a/bindings/pyomq/CLAUDE.md
+++ b/bindings/pyomq/CLAUDE.md
@@ -46,6 +46,10 @@ python scripts/update_perf.py --chart-only   # regenerate SVG from JSONL
 
 Results in `~/.cache/omq/bindings.jsonl` (latest `run_id` per impl wins).
 Regenerates `doc/charts/bindings.svg` and the proxy table in `README.md`.
+Defaults are 3 measured rounds per size and implementation. Throughput uses
+2.5 second windows; latency uses 1.5 second windows and only measures sizes up
+to 4 KiB. Each round uses a 0.5 second warmup window, and the median round is
+kept. `--quick` uses one 0.5 second measured round and 0.1 second warmup.
 
 The proxy PUSH/PULL benchmark uses a native omq-tokio client
 (`omq_bench_proxy_client`) to saturate the proxy without Python

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -80,8 +80,8 @@ See [COMPARISONS.md](https://github.com/paddor/omq.rs/blob/main/COMPARISONS.md) 
 <!-- PROXY_PERF:START -->
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
-| PUSH/PULL msg/s    |  2.77 M/s |  1.53 M/s | **1.81×** |
-| REQ/REP rt/s       |   8,360/s |   4,511/s | **1.85×** |
+| PUSH/PULL msg/s    |  2.88 M/s |  1.53 M/s | **1.88×** |
+| REQ/REP rt/s       |   8,049/s |   4,511/s | **1.78×** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -1,244 +1,226 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 684" font-family="system-ui, -apple-system, sans-serif">
-  <rect width="850" height="684" fill="white"/>
-  <text x="425.0" y="32" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
-  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, Intel Core i7-8700B @ 3.20GHz, 6 cores, performance governor, turbo off</text>
-  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">500k</text>
-  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">500 MB/s</text>
-  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1M</text>
-  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1 GB/s</text>
-  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">1.5M</text>
-  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">1.5 GB/s</text>
-  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2M</text>
-  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2 GB/s</text>
-  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">2.5M</text>
-  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">2.5 GB/s</text>
-  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3M</text>
-  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3 GB/s</text>
-  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">3.5M</text>
-  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">3.5 GB/s</text>
-  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4M</text>
-  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4 GB/s</text>
-  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">4.5M</text>
-  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">4.5 GB/s</text>
-  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">5M</text>
-  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#6b7280" font-size="10">5 GB/s</text>
-  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#e5e7eb" stroke-width="1"/>
+  <rect width="850" height="684" fill="#000000"/>
+  <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">500k</text>
+  <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
+  <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
+  <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.5M</text>
+  <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
+  <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
+  <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5M</text>
+  <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
+  <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
+  <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
+  <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.5M</text>
+  <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
+  <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
+  <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4.5M</text>
+  <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
+  <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5M</text>
+  <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
+  <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="145.8" y1="49" x2="145.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="201.7" y1="49" x2="201.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="257.5" y1="49" x2="257.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="49" x2="313.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="369.2" y1="49" x2="369.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="49" x2="425.0" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="480.8" y1="49" x2="480.8" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="49" x2="536.7" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="592.5" y1="49" x2="592.5" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="648.3" y1="49" x2="648.3" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="704.2" y1="49" x2="704.2" y2="384" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="49" x2="760.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="49" x2="90" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,244.8 145.8,249.8 201.7,247.2 257.5,253.9 313.3,275.9 369.2,255.9 425.0,257.2 480.8,273.6 536.7,284.3 592.5,325.6 648.3,351.0 704.2,366.7 760.0,375.4" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,319.7 145.8,319.0 201.7,318.8 257.5,320.0 313.3,320.6 369.2,322.7 425.0,324.3 480.8,329.2 536.7,339.8 592.5,349.2 648.3,358.2 704.2,365.7 760.0,376.5" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,305.5 145.8,306.4 201.7,303.5 257.5,314.7 313.3,326.6 369.2,336.9 425.0,333.7 480.8,343.9 536.7,356.1 592.5,367.6 648.3,375.3 704.2,379.4 760.0,380.2" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,380.6 145.8,380.5 201.7,380.6 257.5,380.6 313.3,380.6 369.2,380.5 425.0,380.6 480.8,380.6 536.7,380.7 592.5,380.9 648.3,380.9 704.2,381.0 760.0,381.2" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="90.0,382.9 145.8,381.9 201.7,379.6 257.5,375.7 313.3,370.2 369.2,351.2 425.0,319.1 480.8,270.9 536.7,179.9 592.5,144.8 648.3,113.6 704.2,101.2 760.0,101.7" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="382.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="381.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="379.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="375.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="370.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="351.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="319.1" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="270.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="179.9" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="144.8" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="113.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="101.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="101.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,379.9 313.3,375.9 369.2,368.3 425.0,353.4 480.8,327.9 536.7,293.5 592.5,241.5 648.3,172.8 704.2,85.0 760.0,137.4" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="383.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="381.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="379.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="375.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="368.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="353.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="327.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="293.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="241.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="172.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="85.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="137.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,383.4 145.8,382.8 201.7,381.4 257.5,379.6 313.3,376.7 369.2,371.9 425.0,358.3 480.8,342.9 536.7,326.9 592.5,316.6 648.3,313.1 704.2,309.2 760.0,261.1" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="383.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="382.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="381.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="379.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="376.7" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="371.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="358.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="342.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="326.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="316.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="313.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="309.2" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="261.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.8 313.3,383.6 369.2,383.1 425.0,382.3 480.8,380.5 536.7,377.2 592.5,371.2 648.3,358.7 704.2,334.9 760.0,291.6" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="384.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="383.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="383.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="383.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="383.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="382.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="380.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="377.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="371.2" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="358.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="334.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="291.6" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="398" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="398" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="398" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="398" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="398" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="398" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <text x="425.0" y="447" text-anchor="middle" fill="#111827" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
-  <line x1="90" y1="572.0" x2="760" y2="572.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="572.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">20 µs</text>
-  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">40 µs</text>
-  <line x1="90" y1="548.0" x2="760" y2="548.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="548.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">60 µs</text>
-  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">80 µs</text>
-  <line x1="90" y1="524.0" x2="760" y2="524.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="524.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">100 µs</text>
-  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">120 µs</text>
-  <line x1="90" y1="500.0" x2="760" y2="500.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="500.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">140 µs</text>
-  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">160 µs</text>
-  <line x1="90" y1="476.0" x2="760" y2="476.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="476.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">180 µs</text>
-  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#374151" font-size="10">200 µs</text>
-  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="145.8" y1="464" x2="145.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="201.7" y1="464" x2="201.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="257.5" y1="464" x2="257.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="369.2" y1="464" x2="369.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="425.0" y1="464" x2="425.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="480.8" y1="464" x2="480.8" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="592.5" y1="464" x2="592.5" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="648.3" y1="464" x2="648.3" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="704.2" y1="464" x2="704.2" y2="584" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
+  <polyline points="90.0,256.2 145.8,260.1 201.7,259.6 257.5,275.5 313.3,272.3 369.2,269.4 425.0,264.6 480.8,281.0 536.7,289.8 592.5,326.4 648.3,352.1 704.2,366.9 760.0,375.4" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,316.4 145.8,319.0 201.7,317.9 257.5,321.9 313.3,319.7 369.2,322.0 425.0,324.7 480.8,330.2 536.7,338.0 592.5,348.7 648.3,357.5 704.2,367.3 760.0,375.4" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,305.5 145.8,306.4 201.7,303.5 257.5,314.7 313.3,326.6 369.2,336.9 425.0,333.7 480.8,343.9 536.7,356.1 592.5,367.6 648.3,375.3 704.2,379.4 760.0,380.2" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,380.6 145.8,380.5 201.7,380.6 257.5,380.6 313.3,380.6 369.2,380.5 425.0,380.6 480.8,380.6 536.7,380.7 592.5,380.9 648.3,380.9 704.2,381.0 760.0,381.2" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="90.0,383.0 145.8,382.0 201.7,380.0 257.5,377.1 313.3,369.7 369.2,354.7 425.0,322.9 480.8,278.5 536.7,191.1 592.5,148.1 648.3,122.9 704.2,104.5 760.0,100.8" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="382.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="380.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="377.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="369.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="354.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="322.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="278.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="191.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="148.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="122.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="104.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="100.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,383.5 145.8,383.0 201.7,381.9 257.5,380.0 313.3,375.8 369.2,368.1 425.0,353.6 480.8,328.9 536.7,289.8 592.5,239.4 648.3,166.7 704.2,110.9 760.0,103.5" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="383.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="381.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="380.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="375.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="368.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="353.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="328.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="289.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="239.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="166.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="110.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="103.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,383.4 145.8,382.8 201.7,381.4 257.5,379.6 313.3,376.7 369.2,371.9 425.0,358.3 480.8,342.9 536.7,326.9 592.5,316.6 648.3,313.1 704.2,309.2 760.0,261.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="383.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="382.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="381.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="379.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="376.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="371.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="358.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="342.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="326.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="316.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="313.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="309.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="261.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,384.0 145.8,383.9 201.7,383.9 257.5,383.8 313.3,383.6 369.2,383.1 425.0,382.3 480.8,380.5 536.7,377.2 592.5,371.2 648.3,358.7 704.2,334.9 760.0,291.6" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="384.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="145.8" cy="383.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="201.7" cy="383.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="383.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="383.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="369.2" cy="383.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="382.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="480.8" cy="380.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="377.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="371.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="648.3" cy="358.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="704.2" cy="334.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="291.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="145.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="201.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="257.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="313.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="369.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="425.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="480.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="536.7" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="592.5" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="648.3" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="704.2" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="760.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <text x="425.0" y="447" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="90" y1="572.0" x2="760" y2="572.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="572.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 µs</text>
+  <line x1="90" y1="560.0" x2="760" y2="560.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="560.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 µs</text>
+  <line x1="90" y1="548.0" x2="760" y2="548.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="548.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 µs</text>
+  <line x1="90" y1="536.0" x2="760" y2="536.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="536.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 µs</text>
+  <line x1="90" y1="524.0" x2="760" y2="524.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="524.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 µs</text>
+  <line x1="90" y1="512.0" x2="760" y2="512.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="512.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 µs</text>
+  <line x1="90" y1="500.0" x2="760" y2="500.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="500.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 µs</text>
+  <line x1="90" y1="488.0" x2="760" y2="488.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="488.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 µs</text>
+  <line x1="90" y1="476.0" x2="760" y2="476.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="476.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 µs</text>
+  <line x1="90" y1="464.0" x2="760" y2="464.0" stroke="#374151" stroke-width="1"/>
+  <text x="82" y="464.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 µs</text>
+  <line x1="90.0" y1="464" x2="90.0" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="164.4" y1="464" x2="164.4" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="238.9" y1="464" x2="238.9" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="313.3" y1="464" x2="313.3" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="387.8" y1="464" x2="387.8" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="462.2" y1="464" x2="462.2" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="536.7" y1="464" x2="536.7" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="611.1" y1="464" x2="611.1" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="685.6" y1="464" x2="685.6" y2="584" stroke="#374151" stroke-width="1"/>
+  <line x1="760.0" y1="464" x2="760.0" y2="584" stroke="#374151" stroke-width="1"/>
   <line x1="90" y1="464" x2="90" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="584" x2="760" y2="584" stroke="#9ca3af" stroke-width="1.5"/>
-  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
-  <polyline points="90.0,550.7 145.8,550.5 201.7,550.7 257.5,551.3 313.3,550.6 369.2,552.5 425.0,551.3 480.8,550.7 536.7,548.3 592.5,546.2 648.3,543.7 704.2,532.2 760.0,521.2" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="550.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="550.6" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="552.5" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="551.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="550.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="548.3" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="546.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="543.7" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="532.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="521.2" r="3" fill="#dc2626" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,517.2 145.8,516.5 201.7,515.5 257.5,517.8 313.3,518.9 369.2,516.4 425.0,516.8 480.8,516.8 536.7,514.3 592.5,511.1 648.3,508.6 704.2,501.1 760.0,495.0" fill="none" stroke="#f97316" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="517.2" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="516.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="515.5" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="517.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="518.9" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="516.4" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="516.8" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="514.3" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="511.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="508.6" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="501.1" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="495.0" r="3" fill="#f97316" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,527.6 145.8,527.1 201.7,527.8 257.5,527.3 313.3,525.3 369.2,527.4 425.0,526.1 480.8,526.4 536.7,524.4 592.5,524.0 648.3,509.9 704.2,508.3 760.0,499.8" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="527.6" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="527.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="527.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="527.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="525.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="527.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="526.1" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="526.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="524.4" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="524.0" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="509.9" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="508.3" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="499.8" r="3" fill="#2563eb" stroke="white" stroke-width="1"/>
-  <polyline points="90.0,487.8 145.8,489.4 201.7,487.8 257.5,487.1 313.3,488.3 369.2,486.7 425.0,487.1 480.8,486.5 536.7,487.0 592.5,483.9 648.3,453.7 704.2,450.8 760.0,443.0" fill="none" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="487.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="145.8" cy="489.4" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="201.7" cy="487.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="257.5" cy="487.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="313.3" cy="488.3" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="369.2" cy="486.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="425.0" cy="487.1" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="480.8" cy="486.5" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="536.7" cy="487.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="592.5" cy="483.9" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="648.3" cy="453.7" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="704.2" cy="450.8" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <circle cx="760.0" cy="443.0" r="3" fill="#8b5cf6" stroke="white" stroke-width="1"/>
-  <text x="90.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 B</text>
-  <text x="145.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 B</text>
-  <text x="201.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 B</text>
-  <text x="257.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">64 B</text>
-  <text x="313.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">128 B</text>
-  <text x="369.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">256 B</text>
-  <text x="425.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">512 B</text>
-  <text x="480.8" y="598" text-anchor="middle" fill="#374151" font-size="8.5">1 KiB</text>
-  <text x="536.7" y="598" text-anchor="middle" fill="#374151" font-size="8.5">2 KiB</text>
-  <text x="592.5" y="598" text-anchor="middle" fill="#374151" font-size="8.5">4 KiB</text>
-  <text x="648.3" y="598" text-anchor="middle" fill="#374151" font-size="8.5">8 KiB</text>
-  <text x="704.2" y="598" text-anchor="middle" fill="#374151" font-size="8.5">16 KiB</text>
-  <text x="760.0" y="598" text-anchor="middle" fill="#374151" font-size="8.5">32 KiB</text>
-  <line x1="145" y1="624" x2="159" y2="624" stroke="#dc2626" stroke-width="2.5"/>
-  <circle cx="152" cy="624" r="2.5" fill="#dc2626"/>
-  <text x="165" y="628" fill="#374151" font-size="11" font-weight="500">pyomq</text>
-  <line x1="285" y1="624" x2="299" y2="624" stroke="#f97316" stroke-width="2.5"/>
-  <circle cx="292" cy="624" r="2.5" fill="#f97316"/>
-  <text x="305" y="628" fill="#374151" font-size="11" font-weight="500">pyomq async</text>
-  <line x1="425" y1="624" x2="439" y2="624" stroke="#2563eb" stroke-width="2.5"/>
-  <circle cx="432" cy="624" r="2.5" fill="#2563eb"/>
-  <text x="445" y="628" fill="#374151" font-size="11" font-weight="500">pyzmq</text>
-  <line x1="565" y1="624" x2="579" y2="624" stroke="#8b5cf6" stroke-width="2.5"/>
-  <circle cx="572" cy="624" r="2.5" fill="#8b5cf6"/>
-  <text x="585" y="628" fill="#374151" font-size="11" font-weight="500">pyzmq async</text>
+  <text x="40" y="524" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,524)">p50 latency (µs)</text>
+  <polyline points="90.0,550.4 164.4,549.7 238.9,549.7 313.3,549.9 387.8,549.7 462.2,550.2 536.7,549.3 611.1,549.2 685.6,548.7 760.0,542.7" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="550.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="549.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="549.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="549.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="549.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="550.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="549.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="549.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="548.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="542.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,515.4 164.4,516.5 238.9,515.1 313.3,515.1 387.8,516.7 462.2,515.3 536.7,514.8 611.1,515.0 685.6,513.8 760.0,510.8" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="515.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="516.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="515.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="515.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="516.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="515.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="514.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="515.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="513.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="510.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,527.6 164.4,527.1 238.9,527.8 313.3,527.3 387.8,525.3 462.2,527.4 536.7,526.1 611.1,526.4 685.6,524.4 760.0,524.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="527.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="527.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="527.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="527.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="525.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="527.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="526.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="526.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="524.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="524.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,487.8 164.4,489.4 238.9,487.8 313.3,487.1 387.8,488.3 462.2,486.7 536.7,487.1 611.1,486.5 685.6,487.0 760.0,483.9" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="487.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="164.4" cy="489.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="238.9" cy="487.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="313.3" cy="487.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="387.8" cy="488.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="462.2" cy="486.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="536.7" cy="487.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="611.1" cy="486.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="685.6" cy="487.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="483.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="90.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 B</text>
+  <text x="164.4" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="238.9" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="313.3" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="387.8" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="462.2" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="536.7" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="611.1" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="685.6" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="760.0" y="598" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="145" y1="624" x2="159" y2="624" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="152" cy="624" r="2.5" fill="#ef4444"/>
+  <text x="165" y="628" fill="#e5e7eb" font-size="11" font-weight="500">pyomq</text>
+  <line x1="285" y1="624" x2="299" y2="624" stroke="#fb923c" stroke-width="2.5"/>
+  <circle cx="292" cy="624" r="2.5" fill="#fb923c"/>
+  <text x="305" y="628" fill="#e5e7eb" font-size="11" font-weight="500">pyomq async</text>
+  <line x1="425" y1="624" x2="439" y2="624" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="432" cy="624" r="2.5" fill="#60a5fa"/>
+  <text x="445" y="628" fill="#e5e7eb" font-size="11" font-weight="500">pyzmq</text>
+  <line x1="565" y1="624" x2="579" y2="624" stroke="#a855f7" stroke-width="2.5"/>
+  <circle cx="572" cy="624" r="2.5" fill="#a855f7"/>
+  <text x="585" y="628" fill="#e5e7eb" font-size="11" font-weight="500">pyzmq async</text>
   <text x="425.0" y="642" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) · solid = throughput (right)</text>
 </svg>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -17,12 +17,14 @@ import time
 
 DEFAULT_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [8, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
 SIZES = DEFAULT_SIZES.copy()
-TARGET_RUNTIME_S = 0.4
+TARGET_RUNTIME_S = 2.5
+THROUGHPUT_WARMUP_S = 0.5
 N_ROUNDS = 3
-WARMUP_ROUNDS = 1
-LATENCY_WARMUP = 1000
-LATENCY_ITERS = 10000
+WARMUP_ROUNDS = 0
+LATENCY_WARMUP_S = 0.5
+LATENCY_RUNTIME_S = 1.5
 SUBPROCESS_TIMEOUT_S = 30.0
 LATENCY_TIMEOUT_S = 60.0
 SUBPROCESS_RETRIES = 2
@@ -62,6 +64,18 @@ def save_results(
     run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
 ):
     rows = []
+    def latency_fields(values):
+        fields = {
+            "p50_us": values[0],
+            "p99_us": values[1],
+        }
+        if len(values) >= 4:
+            fields["messages"] = values[2]
+            fields["seconds"] = values[3]
+            fields["target_seconds"] = LATENCY_RUNTIME_S
+            fields["warmup_seconds"] = LATENCY_WARMUP_S
+        return fields
+
     for i, size in enumerate(SIZES):
         rows.append(
             {
@@ -96,6 +110,7 @@ def save_results(
                 "msgs_s": atp_tcp[i],
             }
         )
+    for i, size in enumerate(latency_sizes_from(SIZES)):
         rows.append(
             {
                 "run_id": run_id,
@@ -103,8 +118,7 @@ def save_results(
                 "kind": "latency",
                 "mode": "sync",
                 "msg_size": size,
-                "p50_us": lat[i][0],
-                "p99_us": lat[i][1],
+                **latency_fields(lat[i]),
             }
         )
         rows.append(
@@ -114,8 +128,7 @@ def save_results(
                 "kind": "latency",
                 "mode": "async",
                 "msg_size": size,
-                "p50_us": alat[i][0],
-                "p99_us": alat[i][1],
+                **latency_fields(alat[i]),
             }
         )
     rows.append(
@@ -163,6 +176,7 @@ def save_proxy_results(run_id, impl, proxy_pp, proxy_rr):
 
 def chart_data_from_jsonl():
     rows = load_jsonl()
+    latency_sizes = latency_sizes_from(SIZES)
 
     latest = {}
     for r in rows:
@@ -189,10 +203,10 @@ def chart_data_from_jsonl():
     sync_pz_tp = [get_tp("sync", "pyzmq", "tcp", s) for s in SIZES]
     async_omq_tp = [get_tp("async", "pyomq", "tcp", s) for s in SIZES]
     async_pz_tp = [get_tp("async", "pyzmq", "tcp", s) for s in SIZES]
-    sync_omq_lat = [get_lat("sync", "pyomq", s) for s in SIZES]
-    sync_pz_lat = [get_lat("sync", "pyzmq", s) for s in SIZES]
-    async_omq_lat = [get_lat("async", "pyomq", s) for s in SIZES]
-    async_pz_lat = [get_lat("async", "pyzmq", s) for s in SIZES]
+    sync_omq_lat = [get_lat("sync", "pyomq", s) for s in latency_sizes]
+    sync_pz_lat = [get_lat("sync", "pyzmq", s) for s in latency_sizes]
+    async_omq_lat = [get_lat("async", "pyomq", s) for s in latency_sizes]
+    async_pz_lat = [get_lat("async", "pyzmq", s) for s in latency_sizes]
 
     return {
         "sync_omq_tp": sync_omq_tp,
@@ -207,6 +221,15 @@ def chart_data_from_jsonl():
 
 
 # ── helpers ──────────────────────────────────────────────────────────
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
+
+
+def median(values, key=lambda value: value):
+    ordered = sorted(values, key=key)
+    return ordered[len(ordered) // 2]
 
 
 def free_tcp():
@@ -263,10 +286,11 @@ def parse_sizes(value):
 def configure_benchmark(args):
     global SIZES
     global TARGET_RUNTIME_S
+    global THROUGHPUT_WARMUP_S
     global N_ROUNDS
     global WARMUP_ROUNDS
-    global LATENCY_WARMUP
-    global LATENCY_ITERS
+    global LATENCY_WARMUP_S
+    global LATENCY_RUNTIME_S
     global SUBPROCESS_TIMEOUT_S
     global LATENCY_TIMEOUT_S
     global SUBPROCESS_RETRIES
@@ -277,11 +301,12 @@ def configure_benchmark(args):
 
     if args.quick:
         SIZES = QUICK_SIZES.copy()
-        TARGET_RUNTIME_S = 0.15
+        TARGET_RUNTIME_S = 0.5
+        THROUGHPUT_WARMUP_S = 0.1
         N_ROUNDS = 1
         WARMUP_ROUNDS = 0
-        LATENCY_WARMUP = 100
-        LATENCY_ITERS = 1000
+        LATENCY_WARMUP_S = 0.1
+        LATENCY_RUNTIME_S = 0.5
         SUBPROCESS_TIMEOUT_S = 15.0
         LATENCY_TIMEOUT_S = 20.0
         SUBPROCESS_RETRIES = 0
@@ -294,10 +319,16 @@ def configure_benchmark(args):
         N_ROUNDS = args.rounds
     if args.target_runtime is not None:
         TARGET_RUNTIME_S = args.target_runtime
-    if args.latency_warmup is not None:
-        LATENCY_WARMUP = args.latency_warmup
-    if args.latency_iters is not None:
-        LATENCY_ITERS = args.latency_iters
+        if args.latency_duration is None:
+            LATENCY_RUNTIME_S = min(TARGET_RUNTIME_S, LATENCY_RUNTIME_S)
+    if args.warmup_duration is not None:
+        THROUGHPUT_WARMUP_S = args.warmup_duration
+        if args.latency_warmup_duration is None:
+            LATENCY_WARMUP_S = THROUGHPUT_WARMUP_S
+    if args.latency_warmup_duration is not None:
+        LATENCY_WARMUP_S = args.latency_warmup_duration
+    if args.latency_duration is not None:
+        LATENCY_RUNTIME_S = args.latency_duration
     if args.timeout is not None:
         SUBPROCESS_TIMEOUT_S = args.timeout
         LATENCY_TIMEOUT_S = max(args.timeout, 1.0)
@@ -308,10 +339,12 @@ def configure_benchmark(args):
         raise argparse.ArgumentTypeError("--rounds must be at least 1")
     if TARGET_RUNTIME_S <= 0:
         raise argparse.ArgumentTypeError("--target-runtime must be positive")
-    if LATENCY_WARMUP < 0:
-        raise argparse.ArgumentTypeError("--latency-warmup cannot be negative")
-    if LATENCY_ITERS < 1:
-        raise argparse.ArgumentTypeError("--latency-iters must be at least 1")
+    if THROUGHPUT_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--warmup-duration cannot be negative")
+    if LATENCY_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--latency-warmup-duration cannot be negative")
+    if LATENCY_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--latency-duration must be positive")
     if SUBPROCESS_TIMEOUT_S <= 0 or LATENCY_TIMEOUT_S <= 0:
         raise argparse.ArgumentTypeError("--timeout must be positive")
     if PROXY_DURATION_S <= 0:
@@ -323,51 +356,36 @@ def configure_benchmark(args):
 
 def _run_subprocess(code, label, timeout=None, retries=None):
     timeout = SUBPROCESS_TIMEOUT_S if timeout is None else timeout
-    retries = SUBPROCESS_RETRIES if retries is None else retries
-    for attempt in range(1 + retries):
-        try:
-            r = subprocess.run(
-                [sys.executable, "-c", code],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-        except subprocess.TimeoutExpired:
-            sys.stderr.write(f"  [{label} timeout, attempt {attempt + 1}]\n")
-            continue
-        if r.returncode != 0:
-            sys.stderr.write(f"  [{label} failed, attempt {attempt + 1}]\n")
-            continue
-        return json.loads(r.stdout.strip())
-    return None
+    try:
+        r = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"{label} timeout after {timeout}s") from error
+    if r.returncode != 0:
+        raise RuntimeError(f"{label} failed:\n{r.stdout}{r.stderr}")
+    return json.loads(r.stdout.strip())
 
 
-def _throughput_iters(size, n_target_per_s, *, max_messages=None):
-    n = max(int(n_target_per_s * TARGET_RUNTIME_S), 100)
-    if max_messages is not None:
-        n = min(n, max_messages)
-    if THROUGHPUT_MAX_BYTES is not None:
-        byte_limited = max(100, THROUGHPUT_MAX_BYTES // max(size, 1))
-        n = min(n, byte_limited)
-    return n
-
-
-def _measure_throughput_subprocess(lib_name, transport, size, n_target_per_s=200_000):
+def _measure_throughput_subprocess(lib_name, transport, size, duration=None):
     """Run a throughput measurement. TCP uses 2 separate processes (push +
     pull) so each gets its own runtime. Inproc must stay single-process."""
+    duration = TARGET_RUNTIME_S if duration is None else duration
     if lib_name == "pyzmq":
         lib_import = "import zmq as lib"
     else:
         lib_import = "import pyomq as lib"
 
-    n = _throughput_iters(size, n_target_per_s)
-
     if transport == "inproc":
         code = f"""
 import threading, time, json
 {lib_import}
-n = {n}
 payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
 ep = f'inproc://bench-{{time.monotonic_ns()}}'
 ctx = lib.Context()
 pull = ctx.socket(lib.PULL)
@@ -377,17 +395,25 @@ push.linger = 0
 pull.bind(ep)
 push.connect(ep)
 def sender():
-    for _ in range(n):
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
         push.send(payload)
+    push.send(stop)
 t = threading.Thread(target=sender)
-start = time.monotonic()
 t.start()
-for _ in range(n):
-    pull.recv()
-elapsed = time.monotonic() - start
+start = None
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    if start is None:
+        start = time.monotonic()
+    count += 1
+elapsed = time.monotonic() - start if start is not None else 0.0
 t.join()
 push.close(); pull.close()
-print(json.dumps(n / elapsed))
+print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
 import sys; sys.stdout.flush(); import os; os._exit(0)
 """
         result = _run_subprocess(code, f"{lib_name} inproc {size}B")
@@ -396,8 +422,9 @@ import sys; sys.stdout.flush(); import os; os._exit(0)
     push_code = f"""
 import time, sys
 {lib_import}
-n = {n}
 payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
 ctx = lib.Context()
 push = ctx.socket(lib.PUSH)
 push.linger = 0
@@ -406,8 +433,10 @@ ep = push.last_endpoint
 if isinstance(ep, bytes): ep = ep.decode()
 port = ep.rsplit(':', 1)[1]
 print(port, flush=True)
-for _ in range(n):
+deadline = time.monotonic() + duration
+while time.monotonic() < deadline:
     push.send(payload)
+push.send(stop)
 sys.stdin.readline()
 push.close()
 import os; os._exit(0)
@@ -415,18 +444,24 @@ import os; os._exit(0)
     pull_code = f"""
 import time, json, sys
 {lib_import}
-n = {n}
 port = sys.argv[1]
+stop = b'__OMQ_BENCH_STOP__'
 ctx = lib.Context()
 pull = ctx.socket(lib.PULL)
 pull.linger = 0
 pull.connect(f'tcp://127.0.0.1:{{port}}')
-start = time.monotonic()
-for _ in range(n):
-    pull.recv()
-elapsed = time.monotonic() - start
+start = None
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    if start is None:
+        start = time.monotonic()
+    count += 1
+elapsed = time.monotonic() - start if start is not None else 0.0
 pull.close()
-print(json.dumps(n / elapsed))
+print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
 sys.stdout.flush()
 import os; os._exit(0)
 """
@@ -490,18 +525,21 @@ def run_throughput(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        for _ in range(WARMUP_ROUNDS):
-            _measure_throughput_subprocess(lib_name, "inproc", size)
-            _measure_throughput_subprocess(lib_name, "tcp", size)
-
-        inproc = max(
-            _measure_throughput_subprocess(lib_name, "inproc", size)
-            for _ in range(N_ROUNDS)
-        )
-        tcp = max(
-            _measure_throughput_subprocess(lib_name, "tcp", size)
-            for _ in range(N_ROUNDS)
-        )
+        inproc_runs = []
+        tcp_runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_throughput_subprocess(
+                    lib_name, "inproc", size, duration=THROUGHPUT_WARMUP_S
+                )
+            inproc_runs.append(_measure_throughput_subprocess(lib_name, "inproc", size))
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_throughput_subprocess(
+                    lib_name, "tcp", size, duration=THROUGHPUT_WARMUP_S
+                )
+            tcp_runs.append(_measure_throughput_subprocess(lib_name, "tcp", size))
+        inproc = median(inproc_runs)
+        tcp = median(tcp_runs)
         inproc_results.append(inproc)
         tcp_results.append(tcp)
         print(f" inproc {fmt_rate(inproc):>10}  tcp {fmt_rate(tcp):>10}")
@@ -512,8 +550,9 @@ def run_throughput(lib_name):
 # ── async PUSH/PULL throughput ───────────────────────────────────────
 
 
-def _measure_async_subprocess(lib_name, size, n_target_per_s=200_000):
+def _measure_async_subprocess(lib_name, size, duration=None):
     """Async throughput: push in one process, async pull in another."""
+    duration = TARGET_RUNTIME_S if duration is None else duration
     if lib_name == "pyzmq":
         lib_import = "import zmq as lib; import zmq.asyncio as alib"
         push_import = "import zmq as lib"
@@ -521,13 +560,12 @@ def _measure_async_subprocess(lib_name, size, n_target_per_s=200_000):
         lib_import = "import pyomq as lib; import pyomq.asyncio as alib"
         push_import = "import pyomq as lib"
 
-    n = _throughput_iters(size, n_target_per_s, max_messages=20_000)
-
     push_code = f"""
-import sys
+import sys, time
 {push_import}
-n = {n}
 payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
 ctx = lib.Context()
 push = ctx.socket(lib.PUSH)
 push.linger = 0
@@ -536,8 +574,10 @@ ep = push.last_endpoint
 if isinstance(ep, bytes): ep = ep.decode()
 port = ep.rsplit(':', 1)[1]
 print(port, flush=True)
-for _ in range(n):
+deadline = time.monotonic() + duration
+while time.monotonic() < deadline:
     push.send(payload)
+push.send(stop)
 sys.stdin.readline()
 push.close()
 import os; os._exit(0)
@@ -547,20 +587,22 @@ import asyncio, time, json, sys
 {lib_import}
 async def run():
     port = sys.argv[1]
-    n = {n}
+    stop = b'__OMQ_BENCH_STOP__'
     ctx = alib.Context()
     pull = ctx.socket(lib.PULL)
     pull.linger = 0
     pull.connect(f'tcp://127.0.0.1:{{port}}')
     count = 0; start = None
-    for _ in range(n):
-        await pull.recv()
+    while True:
+        msg = await pull.recv()
+        if msg == stop:
+            break
         if start is None:
             start = time.monotonic()
         count += 1
-    elapsed = time.monotonic() - start
+    elapsed = time.monotonic() - start if start is not None else 0.0
     pull.close()
-    print(json.dumps(count / elapsed))
+    print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
     sys.stdout.flush(); import os; os._exit(0)
 asyncio.run(run())
 """
@@ -623,10 +665,12 @@ def run_async_throughput(lib_name):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
-        for _ in range(WARMUP_ROUNDS):
-            _measure_async_subprocess(lib_name, size)
-
-        tcp = max(_measure_async_subprocess(lib_name, size) for _ in range(N_ROUNDS))
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_async_subprocess(lib_name, size, duration=THROUGHPUT_WARMUP_S)
+            runs.append(_measure_async_subprocess(lib_name, size))
+        tcp = median(runs)
         results.append(tcp)
         print(f" {fmt_rate(tcp):>10}")
 
@@ -636,7 +680,7 @@ def run_async_throughput(lib_name):
 # ── sync REQ/REP latency ────────────────────────────────────────────
 
 
-def _measure_latency_subprocess(lib_name, size, warmup, iters):
+def _measure_latency_subprocess(lib_name, size, warmup_seconds, duration_seconds):
     code = f"""
 import time, threading, json, socket as sock
 def free_tcp():
@@ -661,27 +705,39 @@ req.connect(ep)
 time.sleep(0.05)
 def echo():
     try:
-        for _ in range({warmup} + {iters} + 100):
-            rep.send(rep.recv())
+        while True:
+            msg = rep.recv()
+            rep.send(msg)
+            if msg == b'__OMQ_BENCH_STOP__':
+                break
     except Exception:
         pass
 t = threading.Thread(target=echo, daemon=True)
 t.start()
-for _ in range({warmup}):
+warmup_deadline = time.monotonic() + {warmup_seconds}
+while time.monotonic() < warmup_deadline:
     req.send(payload)
     req.recv()
 rtts = []
-for _ in range({iters}):
+start = time.monotonic()
+deadline = start + {duration_seconds}
+while True:
     t0 = time.monotonic()
     req.send(payload)
     req.recv()
     rtts.append(time.monotonic() - t0)
+    if time.monotonic() >= deadline:
+        break
+elapsed = time.monotonic() - start
+req.send(b'__OMQ_BENCH_STOP__')
+req.recv()
 req.close()
 rep.close()
+t.join(timeout=1.0)
 rtts.sort()
 p50 = rtts[len(rtts)*50//100]*1e6
 p99 = rtts[len(rtts)*99//100]*1e6
-print(json.dumps([p50, p99]))
+print(json.dumps([p50, p99, len(rtts), elapsed]))
 import sys; sys.stdout.flush(); import os; os._exit(0)
 """
     result = _run_subprocess(
@@ -694,27 +750,38 @@ import sys; sys.stdout.flush(); import os; os._exit(0)
 
 def run_latency(lib_name):
     results = []
-    for size in SIZES:
+    for size in latency_sizes_from(SIZES):
         label = fmt_size(size)
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
         warmup = (0.0, 0.0)
         for _ in range(WARMUP_ROUNDS):
-            warmup = _measure_latency_subprocess(lib_name, size, 200, 200)
+            warmup = _measure_latency_subprocess(
+                lib_name,
+                size,
+                min(LATENCY_WARMUP_S, 0.05),
+                min(LATENCY_RUNTIME_S, 0.05),
+            )
         if warmup == (999999.0, 999999.0):
             results.append(warmup)
             print(" timeout")
             continue
 
         runs = [
-            _measure_latency_subprocess(lib_name, size, LATENCY_WARMUP, LATENCY_ITERS)
+            _measure_latency_subprocess(
+                lib_name,
+                size,
+                LATENCY_WARMUP_S,
+                LATENCY_RUNTIME_S,
+            )
             for _ in range(N_ROUNDS)
         ]
-        p50 = min(r[0] for r in runs)
-        p99 = min(r[1] for r in runs)
-        results.append((p50, p99))
-        print(f" p50 {p50:.1f} µs  p99 {p99:.1f} µs")
+        selected = median(runs, key=lambda row: row[0])
+        results.append(selected)
+        print(
+            f" p50 {selected[0]:.1f} µs  p99 {selected[1]:.1f} µs  n={selected[2]}"
+        )
 
     return results
 
@@ -722,7 +789,7 @@ def run_latency(lib_name):
 # ── async REQ/REP latency ───────────────────────────────────────────
 
 
-def _measure_async_latency_subprocess(lib_name, size, warmup, iters):
+def _measure_async_latency_subprocess(lib_name, size, warmup_seconds, duration_seconds):
     if lib_name == "pyzmq":
         lib_import = "import zmq; import zmq.asyncio; lib = zmq; actx = zmq.asyncio"
     else:
@@ -749,30 +816,36 @@ async def run():
     await asyncio.sleep(0.05)
     async def echo():
         try:
-            for _ in range({warmup} + {iters} + 100):
+            while True:
                 msg = await rep.recv()
                 {send_await}rep.send(msg)
+                if msg == b'__OMQ_BENCH_STOP__':
+                    break
         except Exception:
             pass
     task = asyncio.create_task(echo())
-    for _ in range({warmup}):
+    warmup_deadline = time.monotonic() + {warmup_seconds}
+    while time.monotonic() < warmup_deadline:
         {send_await}req.send(payload)
         await req.recv()
     rtts = []
-    for _ in range({iters}):
+    start = time.monotonic()
+    deadline = start + {duration_seconds}
+    while True:
         t0 = time.monotonic()
         {send_await}req.send(payload)
         await req.recv()
         rtts.append(time.monotonic() - t0)
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
+        if time.monotonic() >= deadline:
+            break
+    elapsed = time.monotonic() - start
+    {send_await}req.send(b'__OMQ_BENCH_STOP__')
+    await req.recv()
+    await task
     rtts.sort()
     p50 = rtts[len(rtts)*50//100]*1e6
     p99 = rtts[len(rtts)*99//100]*1e6
-    print(json.dumps([p50, p99]))
+    print(json.dumps([p50, p99, len(rtts), elapsed]))
     import sys; sys.stdout.flush(); import os; os._exit(0)
 asyncio.run(run())
 """
@@ -786,14 +859,19 @@ asyncio.run(run())
 
 def run_async_latency(lib_name):
     results = []
-    for size in SIZES:
+    for size in latency_sizes_from(SIZES):
         label = fmt_size(size)
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
 
         warmup = (0.0, 0.0)
         for _ in range(WARMUP_ROUNDS):
-            warmup = _measure_async_latency_subprocess(lib_name, size, 200, 200)
+            warmup = _measure_async_latency_subprocess(
+                lib_name,
+                size,
+                min(LATENCY_WARMUP_S, 0.05),
+                min(LATENCY_RUNTIME_S, 0.05),
+            )
         if warmup == (999999.0, 999999.0):
             results.append(warmup)
             print(" timeout")
@@ -801,14 +879,15 @@ def run_async_latency(lib_name):
 
         runs = [
             _measure_async_latency_subprocess(
-                lib_name, size, LATENCY_WARMUP, LATENCY_ITERS
+                lib_name, size, LATENCY_WARMUP_S, LATENCY_RUNTIME_S
             )
             for _ in range(N_ROUNDS)
         ]
-        p50 = min(r[0] for r in runs)
-        p99 = min(r[1] for r in runs)
-        results.append((p50, p99))
-        print(f" p50 {p50:.1f} µs  p99 {p99:.1f} µs")
+        selected = median(runs, key=lambda row: row[0])
+        results.append(selected)
+        print(
+            f" p50 {selected[0]:.1f} µs  p99 {selected[1]:.1f} µs  n={selected[2]}"
+        )
 
     return results
 
@@ -816,7 +895,7 @@ def run_async_latency(lib_name):
 # ── proxy forwarding (2-process) ─────────────────────────────────────
 
 
-def _measure_proxy_subprocess(lib_name, pattern, n):
+def _measure_proxy_subprocess(lib_name, pattern, duration):
     if lib_name == "pyzmq":
         lib_import = "import zmq as lib"
     else:
@@ -877,29 +956,37 @@ except Exception:
 import threading, time, json, sys, os
 {lib_import}
 payload = b'x' * 128
-n = {n}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
 ctx = lib.Context()
 push = ctx.socket(lib.PUSH)
 pull = ctx.socket(lib.PULL)
 push.linger = 0
 push.connect('{fe_ep}')
 pull.connect('{be_ep}')
-for _ in range(200):
+warmup_deadline = time.monotonic() + min(duration, 0.05)
+while time.monotonic() < warmup_deadline:
     push.send(b'w')
     pull.recv()
 def sender():
-    for _ in range(n):
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
         push.send(payload)
+    push.send(stop)
 t = threading.Thread(target=sender)
 start = time.monotonic()
 t.start()
-for _ in range(n):
-    pull.recv()
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    count += 1
 elapsed = time.monotonic() - start
 t.join()
 push.close()
 pull.close()
-print(json.dumps(n / elapsed))
+print(json.dumps(count / elapsed))
 sys.stdout.flush(); os._exit(0)
 """
     else:
@@ -907,7 +994,7 @@ sys.stdout.flush(); os._exit(0)
 import threading, time, json, sys, os
 {lib_import}
 payload = b'x' * 128
-n = {n}
+duration = {duration}
 ctx = lib.Context()
 client = ctx.socket(lib.REQ)
 worker = ctx.socket(lib.REP)
@@ -915,19 +1002,23 @@ client.linger = 0
 worker.linger = 0
 client.connect('{fe_ep}')
 worker.connect('{be_ep}')
-for _ in range(100):
+warmup_deadline = time.monotonic() + min(duration, 0.05)
+while time.monotonic() < warmup_deadline:
     client.send(b'w')
     worker.send(worker.recv())
     client.recv()
 start = time.monotonic()
-for _ in range(n):
+count = 0
+deadline = start + duration
+while time.monotonic() < deadline:
     client.send(payload)
     worker.send(worker.recv())
     client.recv()
+    count += 1
 elapsed = time.monotonic() - start
 client.close()
 worker.close()
-print(json.dumps(n / elapsed))
+print(json.dumps(count / elapsed))
 sys.stdout.flush(); os._exit(0)
 """
 
@@ -1033,27 +1124,35 @@ def run_proxy(lib_name):
     sys.stdout.write("  PUSH/PULL ...")
     sys.stdout.flush()
     if client is not None:
-        for _ in range(WARMUP_ROUNDS):
-            _measure_proxy_native(lib_name, client, min(PROXY_DURATION_S, 1.0))
-        pushpull_rate = max(
-            _measure_proxy_native(lib_name, client) for _ in range(N_ROUNDS)
-        )
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_proxy_native(
+                    lib_name, client, min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+                )
+            runs.append(_measure_proxy_native(lib_name, client))
+        pushpull_rate = median(runs)
     else:
-        for _ in range(WARMUP_ROUNDS):
-            _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
-        pushpull_rate = max(
-            _measure_proxy_subprocess(lib_name, "pushpull", 200_000)
-            for _ in range(N_ROUNDS)
-        )
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_proxy_subprocess(
+                    lib_name, "pushpull", min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+                )
+            runs.append(_measure_proxy_subprocess(lib_name, "pushpull", PROXY_DURATION_S))
+        pushpull_rate = median(runs)
     print(f" {fmt_rate(pushpull_rate)}")
 
     sys.stdout.write("  REQ/REP ...")
     sys.stdout.flush()
-    for _ in range(WARMUP_ROUNDS):
-        _measure_proxy_subprocess(lib_name, "reqrep", 10_000)
-    reqrep_rate = max(
-        _measure_proxy_subprocess(lib_name, "reqrep", 10_000) for _ in range(N_ROUNDS)
-    )
+    runs = []
+    for _ in range(N_ROUNDS):
+        if THROUGHPUT_WARMUP_S > 0:
+            _measure_proxy_subprocess(
+                lib_name, "reqrep", min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+            )
+        runs.append(_measure_proxy_subprocess(lib_name, "reqrep", PROXY_DURATION_S))
+    reqrep_rate = median(runs)
     print(f" {fmt_rate(reqrep_rate)}")
 
     return pushpull_rate, reqrep_rate
@@ -1062,10 +1161,10 @@ def run_proxy(lib_name):
 # ── SVG chart generation ────────────────────────────────────────────
 
 # Colors: warm = pyomq, cool = pyzmq
-C_PYOMQ = "#dc2626"
-C_PYOMQ_ASYNC = "#f97316"
-C_PYZMQ = "#2563eb"
-C_PYZMQ_ASYNC = "#8b5cf6"
+C_PYOMQ = "#ef4444"
+C_PYOMQ_ASYNC = "#fb923c"
+C_PYZMQ = "#60a5fa"
+C_PYZMQ_ASYNC = "#a855f7"
 
 
 def _nice_ceil(v):
@@ -1121,35 +1220,24 @@ def _read_chart_hw():
 
 def _detect_hardware():
     hw_conf = _read_chart_hw()
-    try:
-        cpu = None
-        for line in open("/proc/cpuinfo"):
-            if line.startswith("model name"):
-                cpu = line.split(":", 1)[1].strip()
-                cpu = cpu.replace("(R)", "").replace("(TM)", "").replace("CPU ", "")
-                break
-        cores = os.cpu_count()
-        if cpu and cores:
-            label = f"{cpu}, {cores} cores"
-            prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
-            postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
-            extras = [e.strip() for e in postfix.split(",")] if postfix else []
-            hw_extras = os.environ.get("OMQ_HW_EXTRAS")
-            if hw_extras:
-                extras.extend(hw_extras.split(","))
-            extras = [e.strip() for e in extras if e.strip()]
-            if extras:
-                label += ", " + ", ".join(extras)
-            if prefix:
-                label = f"{prefix}, {label}"
-            return label
-    except OSError:
-        pass
+    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
     return None
 
 
 def gen_combined_chart(data, path):
     n = len(SIZES)
+    latency_sizes = latency_sizes_from(SIZES)
+    lat_n = len(latency_sizes)
     hw_label = _detect_hardware()
     hw_offset = 14 if hw_label else 0
     svg_w = 850
@@ -1165,6 +1253,7 @@ def gen_combined_chart(data, path):
     t2_h = t2_bot - t2_top
 
     xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
+    lat_xs = [x_left + i * plot_w / max(lat_n - 1, 1) for i in range(lat_n)]
     mid_x = (x_left + x_right) / 2
 
     sync_omq_tp = data["sync_omq_tp"]
@@ -1194,12 +1283,12 @@ def gen_combined_chart(data, path):
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
         f' font-family="system-ui, -apple-system, sans-serif">'
     )
-    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="white"/>')
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>')
 
     # ── TOP PANEL: THROUGHPUT ──────────────────────────────────────
 
     L.append(
-        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>"
     )
@@ -1217,23 +1306,23 @@ def gen_combined_chart(data, path):
         yy = t1_bot - frac * t1_h
         L.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         L.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151"'
+            f' dominant-baseline="middle" fill="#e5e7eb"'
             f' font-size="10">{_fmt_y_rate(msg_val)}</text>'
         )
         L.append(
             f'  <text x="{x_right + 8}" y="{yy:.1f}" text-anchor="start"'
-            f' dominant-baseline="middle" fill="#6b7280"'
+            f' dominant-baseline="middle" fill="#9ca3af"'
             f' font-size="10">{_fmt_mbps(mbps_val)}</text>'
         )
 
     for x in xs:
         L.append(
             f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     L.append(
@@ -1252,7 +1341,7 @@ def gen_combined_chart(data, path):
     t1_mid = (t1_top + t1_bot) / 2
     L.append(
         f'  <text x="40" y="{t1_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t1_mid:.0f})">msg/s</text>'
     )
 
@@ -1281,19 +1370,19 @@ def gen_combined_chart(data, path):
             yy = y_mbps(v)
             L.append(
                 f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
     for i in range(n):
         L.append(
             f'  <text x="{xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(SIZES[i])}</text>'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(SIZES[i])}</text>'
         )
 
     # ── BOTTOM PANEL: LATENCY ─────────────────────────────────────
 
     L.append(
-        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#111827"'
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
         f"REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
     )
@@ -1307,18 +1396,18 @@ def gen_combined_chart(data, path):
         yy = y_lat(v)
         L.append(
             f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
         L.append(
             f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
-            f' dominant-baseline="middle" fill="#374151" font-size="10">'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
             f"{_fmt_y_us(v)}</text>"
         )
 
-    for x in xs:
+    for x in lat_xs:
         L.append(
             f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
-            f' stroke="#e5e7eb" stroke-width="1"/>'
+            f' stroke="#374151" stroke-width="1"/>'
         )
 
     L.append(
@@ -1333,7 +1422,7 @@ def gen_combined_chart(data, path):
     t2_mid = (t2_top + t2_bot) / 2
     L.append(
         f'  <text x="40" y="{t2_mid:.0f}" text-anchor="middle"'
-        f' dominant-baseline="middle" fill="#374151" font-size="10" font-weight="600"'
+        f' dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600"'
         f' transform="rotate(-90,40,{t2_mid:.0f})">p50 latency (µs)</text>'
     )
 
@@ -1345,7 +1434,7 @@ def gen_combined_chart(data, path):
     ]
 
     for _, color, vals in lat_series:
-        pts = " ".join(f"{xs[i]:.1f},{y_lat(v):.1f}" for i, v in enumerate(vals))
+        pts = " ".join(f"{lat_xs[i]:.1f},{y_lat(v):.1f}" for i, v in enumerate(vals))
         L.append(
             f'  <polyline points="{pts}" fill="none" stroke="{color}"'
             f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
@@ -1353,14 +1442,14 @@ def gen_combined_chart(data, path):
         for i, v in enumerate(vals):
             yy = y_lat(v)
             L.append(
-                f'  <circle cx="{xs[i]:.1f}" cy="{yy:.1f}" r="3"'
-                f' fill="{color}" stroke="white" stroke-width="1"/>'
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
             )
 
-    for i in range(n):
+    for i in range(lat_n):
         L.append(
-            f'  <text x="{xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
-            f' fill="#374151" font-size="8.5">{fmt_size(SIZES[i])}</text>'
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(latency_sizes[i])}</text>'
         )
 
     # ── LEGEND ────────────────────────────────────────────────────
@@ -1384,7 +1473,7 @@ def gen_combined_chart(data, path):
         )
         L.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
         L.append(
-            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#374151"'
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
             f' font-size="11" font-weight="500">{label}</text>'
         )
 
@@ -1486,8 +1575,21 @@ def main():
         type=float,
         help="target throughput runtime per round in seconds",
     )
-    parser.add_argument("--latency-warmup", type=int, help="REQ/REP warmup iterations")
-    parser.add_argument("--latency-iters", type=int, help="REQ/REP measured iterations")
+    parser.add_argument(
+        "--warmup-duration",
+        type=float,
+        help="PUSH/PULL throughput warmup duration per round in seconds",
+    )
+    parser.add_argument(
+        "--latency-warmup-duration",
+        type=float,
+        help="REQ/REP latency warmup duration in seconds",
+    )
+    parser.add_argument(
+        "--latency-duration",
+        type=float,
+        help="REQ/REP latency measurement duration in seconds",
+    )
     parser.add_argument(
         "--timeout", type=float, help="subprocess timeout per attempt in seconds"
     )
@@ -1522,8 +1624,9 @@ def main():
             args.sizes,
             args.rounds,
             args.target_runtime,
-            args.latency_warmup,
-            args.latency_iters,
+            args.warmup_duration,
+            args.latency_warmup_duration,
+            args.latency_duration,
             args.timeout,
             args.proxy_duration,
         )
@@ -1551,8 +1654,9 @@ def main():
             args.sizes,
             args.rounds,
             args.target_runtime,
-            args.latency_warmup,
-            args.latency_iters,
+            args.warmup_duration,
+            args.latency_warmup_duration,
+            args.latency_duration,
             args.timeout,
             args.proxy_duration,
         )

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -166,36 +166,30 @@ pub(crate) fn msg_axis_2m(max_val: f64) -> (f64, usize) {
 pub(crate) fn detect_hardware() -> Option<String> {
     let hw_conf = read_chart_hw();
 
-    let model = std::fs::read_to_string("/proc/cpuinfo")
-        .ok()?
-        .lines()
-        .find(|l| l.starts_with("model name"))?
-        .split(':')
-        .nth(1)?
-        .trim()
-        .to_string();
-    let cores = std::thread::available_parallelism().map_or(0, std::num::NonZero::get);
-    if cores == 0 {
-        return None;
+    if let Ok(label) = std::env::var("OMQ_HW_LABEL")
+        && !label.is_empty()
+    {
+        return Some(label);
     }
-
-    let mut label = format!("{model}, {cores} cores");
+    if let Some(label) = hw_conf.get("label")
+        && !label.is_empty()
+    {
+        return Some(label.clone());
+    }
 
     let postfix = std::env::var("OMQ_HW_POSTFIX")
         .ok()
         .or_else(|| hw_conf.get("postfix").cloned());
-    if let Some(pf) = postfix {
-        label = format!("{label}, {pf}");
-    }
-
     let prefix = std::env::var("OMQ_HW_PREFIX")
         .ok()
         .or_else(|| hw_conf.get("prefix").cloned());
-    if let Some(p) = prefix {
-        label = format!("{p}, {label}");
-    }
 
-    Some(label)
+    match (prefix, postfix) {
+        (Some(prefix), Some(postfix)) => Some(format!("{prefix}, {postfix}")),
+        (Some(prefix), None) => Some(prefix),
+        (None, Some(postfix)) => Some(postfix),
+        (None, None) => None,
+    }
 }
 
 fn read_chart_hw() -> BTreeMap<String, String> {


### PR DESCRIPTION
- Switch binding benchmark charts to dark backgrounds with shared chart settings and hardware subtitles from `.chart_hw`.
- Use absolute raw GitHub URLs for benchmark chart embeds in binding READMEs.
- Standardize binding benchmark rounds, durations, warmups, and median selection while keeping latency sizes capped at 4 KiB.
- Restore Lua small-message throughput by using the bounded receive path in its benchmark and refresh the Lua chart through 32 KiB throughput.