### PR TITLE
Improve OMQ.lua send/recv fast paths

### DIFF
--- a/bindings/lua/doc/architecture.md
+++ b/bindings/lua/doc/architecture.md
@@ -35,8 +35,7 @@ Send:
 
 ```text
 Lua Socket:send
-  -> mlua userdata method
-  -> omq_native::NativeSocket::send
+  -> raw Lua C userdata method
   -> zmq_send
   -> omq-libzmq send path
   -> omq-tokio socket/routing/send pipe
@@ -48,20 +47,20 @@ Receive:
 ```text
 IO thread reads and decodes transport
   -> omq-libzmq receive queue
-  -> zmq_msg_recv
-  -> Lua string
+  -> raw Lua C userdata method
+  -> zmq_recv / zmq_msg_recv
+  -> lua_pushlstring
 ```
 
-Single-part small messages stay inline in OMQ message storage. The Lua binding
-still allocates a Lua string for every received message, as lzmq does.
+Single-part messages up to OMQ's inline cutoff stay inline in OMQ message
+storage. The Lua binding still allocates a Lua string for every received
+message, as lzmq does.
 
 ## Small-Message Cost
 
-For 16 byte TCP PUSH/PULL, fixed overhead dominates. The current hot path pays:
+For 16 byte TCP PUSH/PULL, fixed overhead dominates. The hot path still pays:
 
 - Lua VM method dispatch.
-- mlua userdata type check and borrow.
-- Rust callback and error conversion.
 - `omq-libzmq` C ABI checks.
 - OMQ routing, HWM, timeout, and closed-peer checks.
 - Lua string allocation on receive.
@@ -75,16 +74,9 @@ Lua C function -> libzmq -> lua_pushlstring
 OMQ.lua is closer to:
 
 ```text
-Lua -> mlua callback -> Rust userdata -> omq-libzmq -> omq-tokio -> mlua string
+Lua C userdata method -> omq-libzmq -> omq-tokio -> lua_pushlstring
 ```
 
-The extra safety and integration layers cost little in absolute time, but at
-3M messages/s a 50 ns per-message delta is visible.
-
-OPTIMIZATION: If small-message throughput becomes a focused target, add raw
-Lua C API fast paths for `Socket:send(string[, flags])` and
-`Socket:recv([max_size, flags])`. They can store the raw socket pointer in Lua
-userdata, call `zmq_send`/`zmq_msg_recv` directly, and use `lua_pushlstring` for
-receive. Keep setup, options, multipart, docs, and tests in the current mlua
-layer. This narrows the gap to lzmq but adds unsafe Lua stack code and needs
-dedicated regression and perf tests.
+The raw userdata keeps the mlua layer out of per-message send/recv. Setup,
+socket options, helper peers, docs, and tests still live in the public Lua
+wrapper and Rust module.

--- a/bindings/lua/doc/charts/bindings.svg
+++ b/bindings/lua/doc/charts/bindings.svg
@@ -3,34 +3,34 @@
   <text x="425.0" y="32" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
   <text x="425.0" y="46" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
   <line x1="90" y1="350.5" x2="760" y2="350.5" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">500k</text>
+  <text x="82" y="350.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">600k</text>
   <text x="768" y="350.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">500 MB/s</text>
   <line x1="90" y1="317.0" x2="760" y2="317.0" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <text x="82" y="317.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.2M</text>
   <text x="768" y="317.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1 GB/s</text>
   <line x1="90" y1="283.5" x2="760" y2="283.5" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.5M</text>
+  <text x="82" y="283.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.8M</text>
   <text x="768" y="283.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">1.5 GB/s</text>
   <line x1="90" y1="250.0" x2="760" y2="250.0" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <text x="82" y="250.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.4M</text>
   <text x="768" y="250.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2 GB/s</text>
   <line x1="90" y1="216.5" x2="760" y2="216.5" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5M</text>
+  <text x="82" y="216.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
   <text x="768" y="216.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">2.5 GB/s</text>
   <line x1="90" y1="183.0" x2="760" y2="183.0" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3M</text>
+  <text x="82" y="183.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.6M</text>
   <text x="768" y="183.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3 GB/s</text>
   <line x1="90" y1="149.5" x2="760" y2="149.5" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.5M</text>
+  <text x="82" y="149.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4.2M</text>
   <text x="768" y="149.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">3.5 GB/s</text>
   <line x1="90" y1="116.0" x2="760" y2="116.0" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <text x="82" y="116.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4.8M</text>
   <text x="768" y="116.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4 GB/s</text>
   <line x1="90" y1="82.5" x2="760" y2="82.5" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4.5M</text>
+  <text x="82" y="82.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5.4M</text>
   <text x="768" y="82.5" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">4.5 GB/s</text>
   <line x1="90" y1="49.0" x2="760" y2="49.0" stroke="#374151" stroke-width="1"/>
-  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">5M</text>
+  <text x="82" y="49.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">6M</text>
   <text x="768" y="49.0" text-anchor="start" dominant-baseline="middle" fill="#9ca3af" font-size="10">5 GB/s</text>
   <line x1="90.0" y1="49" x2="90.0" y2="384" stroke="#374151" stroke-width="1"/>
   <line x1="150.9" y1="49" x2="150.9" y2="384" stroke="#374151" stroke-width="1"/>
@@ -48,34 +48,34 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,210.0 150.9,218.9 211.8,226.7 272.7,298.5 333.6,305.8 394.5,318.1 455.5,333.2 516.4,355.0 577.3,361.8 638.2,364.9 699.1,372.3 760.0,377.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,145.0 150.9,157.5 211.8,184.4 272.7,272.0 333.6,282.5 394.5,306.1 455.5,342.2 516.4,364.4 577.3,380.0 638.2,380.1 699.1,380.3 760.0,380.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,381.2 150.9,378.7 211.8,373.9 272.7,373.1 333.6,364.0 394.5,350.3 455.5,331.9 516.4,324.7 577.3,293.1 638.2,227.3 699.1,192.1 760.0,169.9" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="381.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="378.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="373.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="373.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="364.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="350.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="331.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="324.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="293.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="227.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="192.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="169.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,380.2 150.9,376.8 211.8,371.2 272.7,369.7 333.6,358.0 394.5,344.1 455.5,341.2 516.4,343.8 577.3,367.8 638.2,352.1 699.1,323.2 760.0,273.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="380.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="376.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="371.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="369.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="358.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="344.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="341.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="343.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="367.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="352.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="323.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="273.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,89.5 150.9,128.5 211.8,162.6 272.7,298.5 333.6,301.1 394.5,312.2 455.5,334.7 516.4,355.2 577.3,371.4 638.2,368.7 699.1,374.1 760.0,378.3" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,188.8 150.9,198.9 211.8,215.3 272.7,292.4 333.6,299.1 394.5,319.4 455.5,346.9 516.4,367.4 577.3,380.9 638.2,380.6 699.1,380.9 760.0,381.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,378.3 150.9,374.2 211.8,367.0 272.7,370.9 333.6,358.5 394.5,339.9 455.5,323.4 516.4,313.2 577.3,321.9 638.2,234.1 699.1,188.6 760.0,161.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="378.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="374.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="367.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="370.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="358.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="339.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="323.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="313.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="321.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="234.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="188.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="161.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,380.3 150.9,376.9 211.8,371.0 272.7,369.9 333.6,357.9 394.5,344.3 455.5,338.4 516.4,343.1 577.3,368.9 638.2,350.6 699.1,322.5 760.0,271.8" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="380.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="376.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="371.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="369.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="357.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="344.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="338.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="343.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="368.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="350.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="322.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="271.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="150.9" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="211.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
@@ -128,26 +128,26 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,570.6 173.8,570.8 257.5,567.0 341.2,565.6 425.0,566.3 508.8,566.0 592.5,565.4 676.2,564.5 760.0,558.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="570.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="570.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="567.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="565.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="566.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="566.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="565.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="564.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="558.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,549.6 173.8,550.7 257.5,551.4 341.2,548.4 425.0,548.9 508.8,548.7 592.5,550.2 676.2,548.7 760.0,547.8" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,573.8 173.8,572.9 257.5,572.7 341.2,571.9 425.0,571.1 508.8,570.3 592.5,568.2 676.2,565.9 760.0,560.5" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="573.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="572.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="572.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="571.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="571.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="570.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="568.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="565.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="560.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,549.6 173.8,550.1 257.5,548.8 341.2,548.8 425.0,548.4 508.8,548.2 592.5,548.1 676.2,547.3 760.0,547.9" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="549.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="550.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="551.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="548.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="548.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="550.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="548.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="547.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="550.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="548.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="548.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="548.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="548.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="547.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="547.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="173.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="257.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/lua/native/src/lib.rs
+++ b/bindings/lua/native/src/lib.rs
@@ -1,13 +1,16 @@
 use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_void};
+use std::os::raw::{c_char, c_int};
+use std::ptr;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
+use mlua::ffi;
 use mlua::prelude::*;
-use mlua::{Table, UserData, UserDataMethods};
+use mlua::{AnyUserData, Table, UserData, UserDataMethods};
 
 const ZMQ_PAIR: i32 = 0;
 const ZMQ_PUB: i32 = 1;
@@ -32,6 +35,7 @@ const ZMQ_SNDTIMEO: i32 = 28;
 const ZMQ_LAST_ENDPOINT: i32 = 32;
 const OMQ_ARENA_THRESHOLD: i32 = 10_001;
 const LAST_ENDPOINT_CAPACITY: usize = 512;
+const RAW_SOCKET_MT: &[u8] = b"omq.RawSocket\0";
 
 static START: OnceLock<Instant> = OnceLock::new();
 
@@ -198,6 +202,35 @@ struct NativeSocket {
 }
 
 #[derive(Debug)]
+struct RawSocket {
+    socket: Option<NativeSocket>,
+    recv_scratch: Vec<u8>,
+}
+
+impl RawSocket {
+    #[inline]
+    fn socket(&self) -> Result<&NativeSocket, String> {
+        self.socket
+            .as_ref()
+            .ok_or_else(|| "socket closed".to_owned())
+    }
+
+    #[inline]
+    fn inner(&self) -> Result<&SocketInner, String> {
+        Ok(&self.socket()?.inner)
+    }
+
+    fn close(&mut self) -> Result<(), String> {
+        self.recv_scratch.clear();
+        self.recv_scratch.shrink_to_fit();
+        let Some(socket) = self.socket.take() else {
+            return Ok(());
+        };
+        socket.inner.close().map_err(|err| err.to_string())
+    }
+}
+
+#[derive(Debug)]
 enum NativeThreadValue {
     Payload(Vec<u8>),
     Count(usize),
@@ -215,8 +248,8 @@ struct NativeJoin {
 
 impl UserData for NativeContext {
     fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method("socket", |_, this, socket_type: i32| {
-            this.socket(socket_type)
+        methods.add_method("socket", |lua, this, socket_type: i32| {
+            this.raw_socket(lua, socket_type)
         });
         methods.add_method("close", |_, this, ()| {
             this.inner.close()?;
@@ -245,6 +278,15 @@ impl UserData for NativeContext {
 }
 
 impl NativeContext {
+    fn raw_socket(&self, lua: &Lua, socket_type: i32) -> LuaResult<AnyUserData> {
+        let socket = self.socket(socket_type)?;
+        unsafe {
+            lua.exec_raw((), |state| {
+                push_raw_socket(state, socket);
+            })
+        }
+    }
+
     fn socket(&self, socket_type: i32) -> LuaResult<NativeSocket> {
         let context_handle = self.inner.reserve_handle()?;
         let raw = omq_zmq::zmq_socket(context_handle.context_ptr(), socket_type);
@@ -348,17 +390,23 @@ impl UserData for NativeSocket {
         });
         methods.add_method(
             "send",
-            |_, this, (payload, flags): (LuaEither<LuaString, Table>, Option<i32>)| {
+            |_, this, (payload, flags): (LuaValue, Option<i32>)| {
                 match payload {
-                    LuaEither::Left(payload) => {
+                    LuaValue::String(payload) => {
                         this.send(payload.as_bytes().as_ref(), flags.unwrap_or(0))?;
                     }
-                    LuaEither::Right(parts) => {
+                    LuaValue::Table(parts) => {
                         let mut out = Vec::new();
                         for value in parts.sequence_values::<LuaString>() {
                             out.push(value?.as_bytes().to_vec());
                         }
                         this.send_parts(&out, flags.unwrap_or(0))?;
+                    }
+                    value => {
+                        return Err(LuaError::external(format!(
+                            "send payload must be string or table, got {}",
+                            value.type_name()
+                        )));
                     }
                 }
                 Ok(true)
@@ -950,6 +998,572 @@ fn set_sock_i32(sock: *mut c_void, option: i32, value: i32) -> Result<(), String
             "zmq_setsockopt({option}) failed: {}",
             last_error_message()
         ))
+    }
+}
+
+fn cstr(bytes: &'static [u8]) -> *const c_char {
+    bytes.as_ptr().cast()
+}
+
+fn lua_fail(state: *mut ffi::lua_State, message: String) -> c_int {
+    unsafe {
+        ffi::lua_pushlstring(state, message.as_ptr().cast(), message.len());
+    }
+    drop(message);
+    unsafe { ffi::lua_error(state) }
+}
+
+#[inline]
+fn lua_bool(state: *mut ffi::lua_State, value: bool) -> c_int {
+    unsafe {
+        ffi::lua_pushboolean(state, i32::from(value));
+    }
+    1
+}
+
+#[inline]
+fn raw_finish(state: *mut ffi::lua_State, result: Result<c_int, String>) -> c_int {
+    match result {
+        Ok(count) => count,
+        Err(err) => lua_fail(state, err),
+    }
+}
+
+fn lua_type_name(state: *mut ffi::lua_State, index: c_int) -> String {
+    unsafe {
+        let type_id = ffi::lua_type(state, index);
+        let name = ffi::lua_typename(state, type_id);
+        if name.is_null() {
+            return "unknown".to_owned();
+        }
+        CStr::from_ptr(name).to_string_lossy().into_owned()
+    }
+}
+
+#[inline]
+fn raw_socket_mut(state: *mut ffi::lua_State) -> Result<&'static mut RawSocket, String> {
+    let ptr = unsafe { ffi::luaL_testudata(state, 1, cstr(RAW_SOCKET_MT)) as *mut RawSocket };
+    if ptr.is_null() {
+        return Err("bad socket userdata".to_owned());
+    }
+    Ok(unsafe { &mut *ptr })
+}
+
+#[inline]
+fn lua_optional_i32(state: *mut ffi::lua_State, index: c_int, default: i32) -> Result<i32, String> {
+    if unsafe { ffi::lua_isnoneornil(state, index) } != 0 {
+        return Ok(default);
+    }
+    let mut is_num = 0;
+    let value = unsafe { ffi::lua_tointegerx(state, index, &mut is_num) };
+    if is_num == 0 {
+        return Err(format!(
+            "argument {index} must be integer, got {}",
+            lua_type_name(state, index)
+        ));
+    }
+    i32::try_from(value).map_err(|_| format!("argument {index} out of i32 range"))
+}
+
+fn lua_required_i32(state: *mut ffi::lua_State, index: c_int) -> Result<i32, String> {
+    lua_optional_i32(state, index, i32::MIN).and_then(|value| {
+        if value == i32::MIN && unsafe { ffi::lua_isnoneornil(state, index) } != 0 {
+            Err(format!("missing argument {index}"))
+        } else {
+            Ok(value)
+        }
+    })
+}
+
+fn lua_required_i64(state: *mut ffi::lua_State, index: c_int) -> Result<i64, String> {
+    if unsafe { ffi::lua_isnoneornil(state, index) } != 0 {
+        return Err(format!("missing argument {index}"));
+    }
+    let mut is_num = 0;
+    let value = unsafe { ffi::lua_tointegerx(state, index, &mut is_num) };
+    if is_num == 0 {
+        return Err(format!(
+            "argument {index} must be integer, got {}",
+            lua_type_name(state, index)
+        ));
+    }
+    Ok(value)
+}
+
+#[inline]
+fn lua_optional_usize(state: *mut ffi::lua_State, index: c_int) -> Result<Option<usize>, String> {
+    if unsafe { ffi::lua_isnoneornil(state, index) } != 0 {
+        return Ok(None);
+    }
+    let mut is_num = 0;
+    let value = unsafe { ffi::lua_tointegerx(state, index, &mut is_num) };
+    if is_num == 0 {
+        return Err(format!(
+            "argument {index} must be integer, got {}",
+            lua_type_name(state, index)
+        ));
+    }
+    usize::try_from(value)
+        .map(Some)
+        .map_err(|_| format!("argument {index} must be non-negative"))
+}
+
+#[inline]
+fn lua_string_bytes(state: *mut ffi::lua_State, index: c_int) -> Result<&'static [u8], String> {
+    if unsafe { ffi::lua_type(state, index) } != ffi::LUA_TSTRING {
+        return Err(format!(
+            "argument {index} must be string, got {}",
+            lua_type_name(state, index)
+        ));
+    }
+    let mut len = 0_usize;
+    let ptr = unsafe { ffi::lua_tolstring(state, index, &mut len) };
+    if ptr.is_null() {
+        return Err(format!("argument {index} string data was null"));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) })
+}
+
+fn lua_endpoint_string(state: *mut ffi::lua_State, index: c_int) -> Result<String, String> {
+    let bytes = lua_string_bytes(state, index)?;
+    let endpoint = std::str::from_utf8(bytes)
+        .map_err(|_| format!("argument {index} endpoint must be UTF-8"))?;
+    Ok(endpoint.to_owned())
+}
+
+#[inline]
+fn raw_socket_send_bytes(socket: &NativeSocket, payload: &[u8], flags: i32) -> Result<(), String> {
+    socket.send(payload, flags).map_err(|err| err.to_string())
+}
+
+fn raw_socket_send_parts_at(
+    state: *mut ffi::lua_State,
+    socket: &NativeSocket,
+    table_index: c_int,
+    flags: i32,
+) -> Result<(), String> {
+    let len = unsafe { ffi::lua_rawlen(state, table_index) };
+    if len == 0 {
+        return Err("multipart send requires at least one part".to_owned());
+    }
+    let table_index = unsafe { ffi::lua_absindex(state, table_index) };
+    for idx in 1..=len {
+        unsafe {
+            ffi::lua_geti(
+                state,
+                table_index,
+                idx.try_into().map_err(|_| "multipart index overflow")?,
+            );
+        }
+        let payload = lua_string_bytes(state, -1);
+        let part_flags = if idx == len {
+            flags
+        } else {
+            flags | ZMQ_SNDMORE
+        };
+        let result = payload.and_then(|payload| raw_socket_send_bytes(socket, payload, part_flags));
+        unsafe {
+            ffi::lua_pop(state, 1);
+        }
+        result?;
+    }
+    Ok(())
+}
+
+fn raw_socket_recv_bounded(
+    state: *mut ffi::lua_State,
+    socket: &mut RawSocket,
+    max_size: usize,
+    flags: i32,
+) -> Result<c_int, String> {
+    let sock = socket
+        .socket()?
+        .inner
+        .ptr()
+        .map_err(|err| err.to_string())?;
+    let scratch = &mut socket.recv_scratch;
+    let current_capacity = scratch.capacity();
+    if current_capacity < max_size {
+        scratch
+            .try_reserve_exact(max_size - current_capacity)
+            .map_err(|err| format!("receive buffer allocation failed: {err}"))?;
+    }
+
+    let rc = omq_zmq::zmq_recv(sock, scratch.as_mut_ptr().cast(), max_size, flags);
+    if rc < 0 {
+        if omq_zmq::zmq_errno() == libc::EAGAIN && (flags & ZMQ_DONTWAIT) != 0 {
+            unsafe {
+                ffi::lua_pushnil(state);
+            }
+            return Ok(1);
+        }
+        return Err(last_error_message());
+    }
+
+    let len = usize::try_from(rc).map_err(|_| "negative receive size".to_owned())?;
+    if len > max_size {
+        return Err(format!(
+            "received message exceeded Lua receive limit: size={len} limit={max_size}",
+        ));
+    }
+
+    unsafe {
+        ffi::lua_pushlstring(state, scratch.as_ptr().cast(), len);
+    }
+    scratch.clear();
+    Ok(1)
+}
+
+fn raw_socket_recv_frame(
+    state: *mut ffi::lua_State,
+    sock: *mut c_void,
+    max_size: Option<usize>,
+    flags: i32,
+) -> Result<Option<bool>, String> {
+    let mut msg = std::mem::MaybeUninit::<omq_zmq::OmqMsgRepr>::uninit();
+    check_rc(omq_zmq::zmq_msg_init(msg.as_mut_ptr())).map_err(|err| err.to_string())?;
+    let msg = msg.as_mut_ptr();
+
+    let rc = omq_zmq::zmq_msg_recv(msg, sock, flags);
+    if rc < 0 {
+        let errno = omq_zmq::zmq_errno();
+        let _ = omq_zmq::zmq_msg_close(msg);
+        if errno == libc::EAGAIN && (flags & ZMQ_DONTWAIT) != 0 {
+            unsafe {
+                ffi::lua_pushnil(state);
+            }
+            return Ok(None);
+        }
+        return Err(error_message(errno));
+    }
+
+    let len = omq_zmq::zmq_msg_size(msg);
+    if let Some(max) = max_size
+        && len > max
+    {
+        let _ = omq_zmq::zmq_msg_close(msg);
+        return Err(format!(
+            "received message exceeded Lua receive limit: size={len} limit={max}",
+        ));
+    }
+
+    let data = omq_zmq::zmq_msg_data(msg);
+    if len == 0 {
+        unsafe {
+            ffi::lua_pushlstring(state, c"".as_ptr(), 0);
+        }
+    } else {
+        if data.is_null() {
+            let _ = omq_zmq::zmq_msg_close(msg);
+            return Err("received message data was null".to_owned());
+        }
+        unsafe {
+            ffi::lua_pushlstring(state, data.cast::<c_char>(), len);
+        }
+    }
+    let more = omq_zmq::zmq_msg_more(msg) != 0;
+    check_rc(omq_zmq::zmq_msg_close(msg)).map_err(|err| err.to_string())?;
+    Ok(Some(more))
+}
+
+fn raw_socket_recv(
+    state: *mut ffi::lua_State,
+    max_size: Option<usize>,
+    flags: i32,
+) -> Result<c_int, String> {
+    let socket = raw_socket_mut(state)?;
+    if let Some(max_size) = max_size {
+        return raw_socket_recv_bounded(state, socket, max_size, flags);
+    }
+    let sock = socket.inner()?.ptr().map_err(|err| err.to_string())?;
+    raw_socket_recv_frame(state, sock, None, flags).map(|_| 1)
+}
+
+unsafe extern "C-unwind" fn raw_socket_gc(state: *mut ffi::lua_State) -> c_int {
+    let ptr = unsafe { ffi::lua_touserdata(state, 1) as *mut RawSocket };
+    if !ptr.is_null() {
+        unsafe {
+            ptr::drop_in_place(ptr);
+        }
+    }
+    0
+}
+
+unsafe extern "C-unwind" fn raw_socket_bind(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let endpoint = lua_endpoint_string(state, 2)?;
+            let bound = socket
+                .socket()?
+                .bind(endpoint)
+                .map_err(|err| err.to_string())?;
+            unsafe {
+                ffi::lua_pushlstring(state, bound.as_ptr().cast(), bound.len());
+            }
+            Ok(1)
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_connect(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let endpoint = lua_endpoint_string(state, 2)?;
+            socket
+                .socket()?
+                .connect(endpoint)
+                .map_err(|err| err.to_string())?;
+            Ok(lua_bool(state, true))
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_close(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        raw_socket_mut(state)
+            .and_then(RawSocket::close)
+            .map(|()| lua_bool(state, true)),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_send(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let flags = lua_optional_i32(state, 3, 0)?;
+            match unsafe { ffi::lua_type(state, 2) } {
+                ffi::LUA_TSTRING => {
+                    let payload = lua_string_bytes(state, 2)?;
+                    raw_socket_send_bytes(socket.socket()?, payload, flags)?;
+                }
+                ffi::LUA_TTABLE => {
+                    raw_socket_send_parts_at(state, socket.socket()?, 2, flags)?;
+                }
+                _ => {
+                    return Err(format!(
+                        "send payload must be string or table, got {}",
+                        lua_type_name(state, 2)
+                    ));
+                }
+            }
+            Ok(lua_bool(state, true))
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_send_parts(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            if unsafe { ffi::lua_type(state, 2) } != ffi::LUA_TTABLE {
+                return Err(format!(
+                    "argument 2 must be table, got {}",
+                    lua_type_name(state, 2)
+                ));
+            }
+            let flags = lua_optional_i32(state, 3, 0)?;
+            raw_socket_send_parts_at(state, socket.socket()?, 2, flags)?;
+            Ok(lua_bool(state, true))
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_recv_method(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let max_size = lua_optional_usize(state, 2)?;
+            let flags = lua_optional_i32(state, 3, 0)?;
+            raw_socket_recv(state, max_size, flags)
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_try_recv(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let max_size = lua_optional_usize(state, 2)?;
+            raw_socket_recv(state, max_size, ZMQ_DONTWAIT)
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_recv_parts(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let inner = socket.inner()?;
+            let sock = inner.ptr().map_err(|err| err.to_string())?;
+            let max_size = lua_optional_usize(state, 2)?;
+            let flags = lua_optional_i32(state, 3, 0)?;
+            unsafe {
+                ffi::lua_createtable(state, 0, 0);
+            }
+            let mut idx = 1_i64;
+            loop {
+                let more = raw_socket_recv_frame(state, sock, max_size, flags)?;
+                if more.is_none() {
+                    break;
+                }
+                unsafe {
+                    ffi::lua_rawseti(state, -2, idx);
+                }
+                if !more.unwrap_or(false) {
+                    break;
+                }
+                idx += 1;
+            }
+            Ok(1)
+        })(),
+    )
+}
+
+fn raw_socket_set_i32(state: *mut ffi::lua_State, option: i32) -> Result<c_int, String> {
+    let socket = raw_socket_mut(state)?;
+    let value = lua_required_i32(state, 2)?;
+    socket
+        .socket()?
+        .set_i32(option, value)
+        .map_err(|err| err.to_string())?;
+    Ok(lua_bool(state, true))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_linger(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_i32(state, ZMQ_LINGER))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_send_timeout(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_i32(state, ZMQ_SNDTIMEO))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_recv_timeout(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_i32(state, ZMQ_RCVTIMEO))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_send_hwm(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_i32(state, ZMQ_SNDHWM))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_recv_hwm(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_i32(state, ZMQ_RCVHWM))
+}
+
+unsafe extern "C-unwind" fn raw_socket_set_arena_threshold(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let value = lua_required_i64(state, 2)?;
+            socket
+                .socket()?
+                .set_i64(OMQ_ARENA_THRESHOLD, value)
+                .map_err(|err| err.to_string())?;
+            Ok(lua_bool(state, true))
+        })(),
+    )
+}
+
+unsafe extern "C-unwind" fn raw_socket_get_arena_threshold(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let value = socket
+                .socket()?
+                .get_i64(OMQ_ARENA_THRESHOLD)
+                .map_err(|err| err.to_string())?;
+            unsafe {
+                ffi::lua_pushinteger(state, value);
+            }
+            Ok(1)
+        })(),
+    )
+}
+
+fn raw_socket_set_bytes(state: *mut ffi::lua_State, option: i32) -> Result<c_int, String> {
+    let socket = raw_socket_mut(state)?;
+    let value = lua_string_bytes(state, 2)?;
+    socket
+        .socket()?
+        .set_bytes(option, value)
+        .map_err(|err| err.to_string())?;
+    Ok(lua_bool(state, true))
+}
+
+unsafe extern "C-unwind" fn raw_socket_subscribe(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_bytes(state, ZMQ_SUBSCRIBE))
+}
+
+unsafe extern "C-unwind" fn raw_socket_unsubscribe(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_set_bytes(state, ZMQ_UNSUBSCRIBE))
+}
+
+fn raw_set_cfunc(state: *mut ffi::lua_State, name: &'static [u8], func: ffi::lua_CFunction) {
+    unsafe {
+        ffi::lua_pushcfunction(state, func);
+        ffi::lua_setfield(state, -2, cstr(name));
+    }
+}
+
+fn ensure_raw_socket_metatable(state: *mut ffi::lua_State) {
+    unsafe {
+        if ffi::luaL_newmetatable(state, cstr(RAW_SOCKET_MT)) != 0 {
+            ffi::lua_pushvalue(state, -1);
+            ffi::lua_setfield(state, -2, cstr(b"__index\0"));
+            raw_set_cfunc(state, b"__gc\0", raw_socket_gc);
+            raw_set_cfunc(state, b"bind\0", raw_socket_bind);
+            raw_set_cfunc(state, b"connect\0", raw_socket_connect);
+            raw_set_cfunc(state, b"close\0", raw_socket_close);
+            raw_set_cfunc(state, b"send\0", raw_socket_send);
+            raw_set_cfunc(state, b"send_parts\0", raw_socket_send_parts);
+            raw_set_cfunc(state, b"recv\0", raw_socket_recv_method);
+            raw_set_cfunc(state, b"try_recv\0", raw_socket_try_recv);
+            raw_set_cfunc(state, b"recv_parts\0", raw_socket_recv_parts);
+            raw_set_cfunc(state, b"set_linger\0", raw_socket_set_linger);
+            raw_set_cfunc(state, b"set_send_timeout\0", raw_socket_set_send_timeout);
+            raw_set_cfunc(state, b"set_recv_timeout\0", raw_socket_set_recv_timeout);
+            raw_set_cfunc(state, b"set_send_hwm\0", raw_socket_set_send_hwm);
+            raw_set_cfunc(state, b"set_recv_hwm\0", raw_socket_set_recv_hwm);
+            raw_set_cfunc(
+                state,
+                b"set_arena_threshold\0",
+                raw_socket_set_arena_threshold,
+            );
+            raw_set_cfunc(
+                state,
+                b"get_arena_threshold\0",
+                raw_socket_get_arena_threshold,
+            );
+            raw_set_cfunc(state, b"subscribe\0", raw_socket_subscribe);
+            raw_set_cfunc(state, b"unsubscribe\0", raw_socket_unsubscribe);
+        }
+    }
+}
+
+fn push_raw_socket(state: *mut ffi::lua_State, socket: NativeSocket) {
+    ensure_raw_socket_metatable(state);
+    unsafe {
+        let ud =
+            ffi::lua_newuserdatauv(state, std::mem::size_of::<RawSocket>(), 0) as *mut RawSocket;
+        ptr::write(
+            ud,
+            RawSocket {
+                socket: Some(socket),
+                recv_scratch: Vec::new(),
+            },
+        );
+        ffi::lua_pushvalue(state, -2);
+        ffi::lua_setmetatable(state, -2);
+        ffi::lua_remove(state, -2);
     }
 }
 

--- a/bindings/lua/scripts/update_perf.py
+++ b/bindings/lua/scripts/update_perf.py
@@ -34,6 +34,7 @@ CHART = CHART_DIR / "bindings.svg"
 DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [16, 128, 1024, 4096, 32768]
 LATENCY_MAX_SIZE = 4096
+THROUGHPUT_MSG_MAX = 6_000_000
 DEFAULT_IMPLS = ["omq.lua", "lzmq"]
 DEFAULT_LATENCY_IMPLS = ["omq.lua", "lzmq"]
 IMPL_LABELS = {
@@ -637,7 +638,7 @@ def gen_chart(data, path, sizes, latency_sizes, impls, latency_impls):
         for values in data["throughput"].values()
         for index, rate in enumerate(values)
     ]
-    msg_max = max(5_000_000, nice_ceil(max(all_rates or [0]) * 1.05))
+    msg_max = THROUGHPUT_MSG_MAX
     mbps_max = max(5_000, nice_ceil(max(all_mbps or [0]) * 1.05))
     lat_values = [v for values in data["latency"].values() for v in values]
     lat_max = max(200, nice_ceil(max(lat_values or [0]) * 1.05))


### PR DESCRIPTION
- Use Lua C userdata fast paths for OMQ.lua send/recv.
- Regenerate Lua benchmark chart with 6M msg/s scale.