### PR TITLE
Fix binding audit findings

### DIFF
--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -1005,6 +1005,10 @@ fn duration_from_timeout_millis(timeout_millis: i64) -> Option<Duration> {
     }
 }
 
+fn deadline_after(timeout: Duration) -> Option<Instant> {
+    Instant::now().checked_add(timeout)
+}
+
 fn duration_from_millis(millis: i64) -> Result<Duration, Error> {
     if millis < 0 {
         return Err(Error::Config("duration must be non-negative".to_string()));
@@ -1302,12 +1306,12 @@ fn try_send_with_timeout(
         return status_from_result(native.send(message));
     }
 
-    let deadline = Instant::now() + Duration::from_millis(timeout_millis as u64);
+    let deadline = deadline_after(Duration::from_millis(timeout_millis as u64));
     loop {
         match native.try_send(message) {
             Ok(()) => return OmqGoStatus::ok(),
             Err(TrySendError::Full(returned)) => {
-                if Instant::now() >= deadline {
+                if deadline.is_some_and(|d| Instant::now() >= d) {
                     return OmqGoStatus::err(TIMEOUT, "operation timed out");
                 }
                 message = returned;
@@ -3201,5 +3205,20 @@ pub extern "C" fn omq_go_native_stats(out: *mut OmqGoNativeStats) {
             cancels_freed,
             cancels_live,
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn huge_deadline_overflow_is_effectively_forever() {
+        assert!(deadline_after(Duration::MAX).is_none());
+    }
+
+    #[test]
+    fn small_deadline_is_concrete() {
+        assert!(deadline_after(Duration::from_millis(1)).is_some());
     }
 }

--- a/bindings/java/src/main/java/io/omq/RecvRing.java
+++ b/bindings/java/src/main/java/io/omq/RecvRing.java
@@ -41,66 +41,86 @@ final class RecvRing implements AutoCloseable {
     private long head;
     private long releasedHead;
     private long cachedTail;
+    private int activeOps;
 
     Message receive(long socketHandle, long timeoutMillis) {
-        ensure(socketHandle);
-        Desc desc = next(timeoutMillis);
+        enter(socketHandle);
         try {
-            return readMessage(desc);
+            Desc desc = next(timeoutMillis);
+            try {
+                return readMessage(desc);
+            } finally {
+                advance();
+            }
         } finally {
-            advance();
+            exit();
         }
     }
 
     byte[] receiveBytes(long socketHandle, long timeoutMillis) {
-        ensure(socketHandle);
-        Desc desc = next(timeoutMillis);
+        enter(socketHandle);
         try {
-            if (desc.partCount() != 1) {
-                throw new IllegalStateException("message has " + desc.partCount() + " parts");
+            Desc desc = next(timeoutMillis);
+            try {
+                if (desc.partCount() != 1) {
+                    throw new IllegalStateException("message has " + desc.partCount() + " parts");
+                }
+                return readBytes(desc);
+            } finally {
+                advance();
             }
-            return readBytes(desc);
         } finally {
-            advance();
+            exit();
         }
     }
 
     int receiveInto(long socketHandle, ByteBuffer destination, long timeoutMillis) {
-        ensure(socketHandle);
-        Desc desc = next(timeoutMillis);
+        enter(socketHandle);
         try {
-            if (desc.partCount() != 1) {
-                throw new IllegalStateException("message has " + desc.partCount() + " parts");
+            Desc desc = next(timeoutMillis);
+            try {
+                if (desc.partCount() != 1) {
+                    throw new IllegalStateException("message has " + desc.partCount() + " parts");
+                }
+                if (destination.isReadOnly()) {
+                    throw new ReadOnlyBufferException();
+                }
+                int len = checkedIntLength(desc.payloadLen());
+                if (len > destination.remaining()) {
+                    throw new BufferOverflowException();
+                }
+                if (len > 0) {
+                    MemorySegment.copy(
+                            source(desc), sourceOffset(desc),
+                            MemorySegment.ofBuffer(destination), 0,
+                            len);
+                }
+                destination.position(destination.position() + len);
+                return len;
+            } finally {
+                advance();
             }
-            if (destination.isReadOnly()) {
-                throw new ReadOnlyBufferException();
-            }
-            int len = checkedIntLength(desc.payloadLen());
-            if (len > destination.remaining()) {
-                throw new BufferOverflowException();
-            }
-            if (len > 0) {
-                MemorySegment.copy(
-                        source(desc), sourceOffset(desc),
-                        MemorySegment.ofBuffer(destination), 0,
-                        len);
-            }
-            destination.position(destination.position() + len);
-            return len;
         } finally {
-            advance();
+            exit();
         }
     }
 
     Optional<Message> tryReceiveCachedMessage() {
-        if (handle == 0 || !hasCached()) {
-            return Optional.empty();
+        synchronized (this) {
+            if (handle == 0 || !hasCached()) {
+                return Optional.empty();
+            }
+            activeOps++;
         }
-        Desc desc = current();
         try {
-            return Optional.of(readMessage(desc));
+            Desc desc = current();
+            try {
+                return Optional.of(readMessage(desc));
+            } finally {
+                advance();
+            }
         } finally {
-            advance();
+            exit();
         }
     }
 
@@ -207,8 +227,22 @@ final class RecvRing implements AutoCloseable {
         }
     }
 
+    private void enter(long socketHandle) {
+        synchronized (this) {
+            ensureOpen(socketHandle);
+            activeOps++;
+        }
+    }
+
+    private synchronized void exit() {
+        activeOps--;
+        if (activeOps == 0) {
+            notifyAll();
+        }
+    }
+
     @SuppressWarnings("restricted")
-    private void ensure(long socketHandle) {
+    private void ensureOpen(long socketHandle) {
         if (handle != 0) {
             return;
         }
@@ -240,14 +274,28 @@ final class RecvRing implements AutoCloseable {
 
     @Override
     public void close() {
-        long current = handle;
-        if (current == 0) {
-            return;
+        long current;
+        boolean interrupted = false;
+        synchronized (this) {
+            current = handle;
+            if (current == 0) {
+                return;
+            }
+            handle = 0;
+            while (activeOps != 0) {
+                try {
+                    wait();
+                } catch (InterruptedException error) {
+                    interrupted = true;
+                }
+            }
+            control = null;
+            descriptors = null;
+            payload = null;
         }
-        handle = 0;
-        control = null;
-        descriptors = null;
-        payload = null;
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
         NativeFfm.recvRingClose(current);
     }
 

--- a/bindings/java/src/main/java/io/omq/Socket.java
+++ b/bindings/java/src/main/java/io/omq/Socket.java
@@ -914,10 +914,13 @@ public final class Socket implements AutoCloseable {
     }
 
     private <T> T withRecvRing(RecvRingAction<T> action) {
+        RecvRing ring;
+        long handle;
         synchronized (state) {
-            long handle = state.handle();
-            return action.apply(state.recvRing, handle);
+            handle = state.handle();
+            ring = state.recvRing;
         }
+        return action.apply(ring, handle);
     }
 
     private boolean drainSendRing(long timeoutMillis) {
@@ -1081,8 +1084,8 @@ public final class Socket implements AutoCloseable {
             long handle = this.handle.getAndSet(0);
             if (handle != 0) {
                 sendRing.close();
-                recvRing.close();
                 Native.socketClose(handle);
+                recvRing.close();
             }
             owner.remove(this);
         }

--- a/bindings/java/src/main/java/io/omq/Socket.java
+++ b/bindings/java/src/main/java/io/omq/Socket.java
@@ -1008,17 +1008,18 @@ public final class Socket implements AutoCloseable {
     }
 
     private Message receiveVirtual(long timeoutMillis) {
+        NativeFuture<Message> future;
         synchronized (state) {
             long handle = state.handle();
             Optional<Message> cached = state.recvRing.tryReceiveCachedMessage();
             if (cached.isPresent()) {
                 return cached.orElseThrow();
             }
-            NativeFuture<Message> future = new NativeFuture<>();
+            future = new NativeFuture<>();
             long task = Native.socketRecvAsync(handle, timeoutMillis, future);
             future.setNativeTask(task);
-            return await(future);
         }
+        return await(future);
     }
 
     private static int writeInto(Message message, ByteBuffer destination) {

--- a/bindings/java/src/test/java/io/omq/SocketTest.java
+++ b/bindings/java/src/test/java/io/omq/SocketTest.java
@@ -383,6 +383,48 @@ final class SocketTest {
     }
 
     @Test
+    void virtualThreadReceiveUnblocksWhenSocketCloses() throws Exception {
+        Context context = OMQ.context();
+        Socket pull = context.socket(SocketType.PULL);
+        pull.bind("inproc://virtual-receive-close-" + UUID.randomUUID());
+
+        CompletableFuture<Throwable> received = new CompletableFuture<>();
+        Thread receiver = Thread.ofVirtual().start(() -> {
+            try {
+                pull.receive();
+                received.complete(null);
+            } catch (Throwable error) {
+                received.complete(error);
+            }
+        });
+
+        Thread.sleep(50);
+        CompletableFuture<Void> closed = new CompletableFuture<>();
+        Thread closer = Thread.ofPlatform().daemon().start(() -> {
+            try {
+                pull.close();
+                closed.complete(null);
+            } catch (Throwable error) {
+                closed.completeExceptionally(error);
+            }
+        });
+
+        boolean closeCompleted = false;
+        try {
+            closed.get(1, TimeUnit.SECONDS);
+            closeCompleted = true;
+            Throwable error = received.get(1, TimeUnit.SECONDS);
+            assertTrue(error instanceof ClosedException, "receive should fail with ClosedException");
+            receiver.join(5_000);
+            closer.join(5_000);
+        } finally {
+            if (closeCompleted) {
+                context.close();
+            }
+        }
+    }
+
+    @Test
     void timedSendSucceedsBeforeTimeout() {
         try (Context context = OMQ.context();
              Socket pull = context.socket(SocketType.PULL);

--- a/bindings/java/src/test/java/io/omq/SocketTest.java
+++ b/bindings/java/src/test/java/io/omq/SocketTest.java
@@ -425,6 +425,48 @@ final class SocketTest {
     }
 
     @Test
+    void platformThreadReceiveUnblocksWhenSocketCloses() throws Exception {
+        Context context = OMQ.context();
+        Socket pull = context.socket(SocketType.PULL);
+        pull.bind("inproc://platform-receive-close-" + UUID.randomUUID());
+
+        CompletableFuture<Throwable> received = new CompletableFuture<>();
+        Thread receiver = Thread.ofPlatform().daemon().start(() -> {
+            try {
+                pull.receive();
+                received.complete(null);
+            } catch (Throwable error) {
+                received.complete(error);
+            }
+        });
+
+        Thread.sleep(50);
+        CompletableFuture<Void> closed = new CompletableFuture<>();
+        Thread closer = Thread.ofPlatform().daemon().start(() -> {
+            try {
+                pull.close();
+                closed.complete(null);
+            } catch (Throwable error) {
+                closed.completeExceptionally(error);
+            }
+        });
+
+        boolean closeCompleted = false;
+        try {
+            closed.get(1, TimeUnit.SECONDS);
+            closeCompleted = true;
+            Throwable error = received.get(1, TimeUnit.SECONDS);
+            assertTrue(error instanceof ClosedException, "receive should fail with ClosedException");
+            receiver.join(5_000);
+            closer.join(5_000);
+        } finally {
+            if (closeCompleted) {
+                context.close();
+            }
+        }
+    }
+
+    @Test
     void timedSendSucceedsBeforeTimeout() {
         try (Context context = OMQ.context();
              Socket pull = context.socket(SocketType.PULL);

--- a/bindings/node/dist/index.js
+++ b/bindings/node/dist/index.js
@@ -5,7 +5,6 @@ exports.curveKeypair = curveKeypair;
 exports.curvePublic = curvePublic;
 const node_buffer_1 = require("node:buffer");
 const node_module_1 = require("node:module");
-const promises_1 = require("node:timers/promises");
 const native = loadNative();
 const RECV_PREFETCH = 64;
 /** Immutable OMQ message wrapper with one or more frames. */
@@ -198,15 +197,20 @@ class Socket {
         this.#checkOpen();
         if (options.signal)
             throwIfAborted(options.signal);
-        while (true) {
-            const raw = this.#tryRecvRaw();
-            if (raw !== null) {
-                return raw;
-            }
-            if (options.signal)
-                throwIfAborted(options.signal);
-            this.#checkOpen();
-            await yieldToEventLoop(options.signal);
+        const raw = this.#tryRecvRaw();
+        if (raw !== null) {
+            return raw;
+        }
+        if (options.signal)
+            throwIfAborted(options.signal);
+        this.#checkOpen();
+        try {
+            return messageFromNative(await this.native.recvRaw(options.signal));
+        }
+        catch (error) {
+            if (options.signal?.aborted)
+                throwAbortError();
+            throw error;
         }
     }
     /** Synchronously receive one message. */
@@ -651,11 +655,11 @@ function throwIfAborted(signal) {
     }
     throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }
+function throwAbortError() {
+    throw new DOMException("The operation was aborted", "AbortError");
+}
 function isClosedError(error) {
     return error instanceof Error && error.message.toLowerCase().includes("closed");
-}
-function yieldToEventLoop(signal) {
-    return signal === undefined ? (0, promises_1.setImmediate)() : (0, promises_1.setImmediate)(undefined, { signal });
 }
 function loadNative() {
     const require = (0, node_module_1.createRequire)(__filename);

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -19,6 +19,7 @@ export declare class NativeSocket {
   recv(): Array<Uint8Array>
   recvSync(): Array<Uint8Array>
   recvRawSync(): Uint8Array | Array<Uint8Array>
+  recvRaw(signal?: AbortSignal | undefined | null): Promise<Uint8Array | Array<Uint8Array>>
   recvTimeout(timeoutMs: number): Array<Uint8Array> | null
   tryRecv(): Array<Uint8Array> | null
   tryRecvRaw(): Uint8Array | Array<Uint8Array> | null

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use napi::bindgen_prelude::{
-    BufferSlice, Env, FromNapiValue, TypedArrayType, Uint8Array, Uint32Array,
+    AbortSignal, AsyncTask, BufferSlice, Env, FromNapiValue, Task, TypedArrayType, Uint8Array,
+    Uint32Array,
 };
 use napi::{Either, Error as NapiError, Result, Status, sys};
 use napi_derive::napi;
@@ -111,6 +112,35 @@ pub struct NativePackedMessages {
     pub part_offsets: Uint32Array,
     pub part_lengths: Uint32Array,
     pub message_parts: Uint32Array,
+}
+
+pub struct RecvRawTask {
+    socket: omq_tokio::blocking::Socket,
+    cancel: Arc<omq_tokio::blocking::BlockingRecvCancel>,
+}
+
+impl Task for RecvRawTask {
+    type Output = Message;
+    type JsValue = Either<Uint8Array, Vec<Uint8Array>>;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        self.cancel.register_current_thread_once();
+        let mut out = Vec::with_capacity(1);
+        match self
+            .socket
+            .recv_many_registered_cancelable_into(1, &self.cancel, &mut out)
+        {
+            Ok(Some(_)) => out
+                .pop()
+                .ok_or_else(|| napi_error("recv returned no message")),
+            Ok(None) => Err(NapiError::new(Status::Cancelled, "recv aborted")),
+            Err(error) => Err(map_omq_error(error)),
+        }
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        message_to_raw(&env, output)
+    }
 }
 
 #[napi]
@@ -284,6 +314,20 @@ impl NativeSocket {
         })
     }
 
+    #[napi(ts_return_type = "Promise<Uint8Array | Array<Uint8Array>>")]
+    pub fn recv_raw(&self, signal: Option<AbortSignal>) -> Result<AsyncTask<RecvRawTask>> {
+        let socket = self.socket_clone()?;
+        let cancel = Arc::new(omq_tokio::blocking::BlockingRecvCancel::new());
+        if let Some(signal) = signal.as_ref() {
+            let cancel = cancel.clone();
+            signal.on_abort(move || cancel.cancel());
+        }
+        Ok(AsyncTask::with_optional_signal(
+            RecvRawTask { socket, cancel },
+            signal,
+        ))
+    }
+
     #[napi]
     pub fn recv_timeout(&self, env: Env, timeout_ms: u32) -> Result<Option<Vec<Uint8Array>>> {
         self.with_socket_ref(|socket| {
@@ -448,14 +492,21 @@ impl NativeSocket {
         &self,
         f: impl FnOnce(&omq_tokio::blocking::Socket) -> Result<T>,
     ) -> Result<T> {
+        let socket = self.socket_clone()?;
+        f(&socket)
+    }
+
+    fn socket_clone(&self) -> Result<omq_tokio::blocking::Socket> {
         self.check_open()?;
         let guard = self
             .inner
             .socket
             .read()
             .map_err(|_| napi_error("socket lock poisoned"))?;
-        let socket = guard.as_ref().ok_or_else(|| napi_error("socket closed"))?;
-        f(socket)
+        guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| napi_error("socket closed"))
     }
 
     fn take_socket(&self) -> Result<Option<omq_tokio::blocking::Socket>> {

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -3,9 +3,9 @@ use std::mem;
 use std::ptr;
 use std::slice;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -24,9 +24,67 @@ use omq_tokio::{
 #[derive(Debug)]
 struct ContextState {
     ctx: RwLock<Option<OmqContext>>,
+    sockets: Mutex<Vec<Weak<SocketState>>>,
     closed: AtomicBool,
     owns_runtime: bool,
     share_key: u128,
+}
+
+impl ContextState {
+    fn register_socket(&self, socket: &Arc<SocketState>) -> Result<()> {
+        self.sockets
+            .lock()
+            .map_err(|_| napi_error("context socket list poisoned"))?
+            .push(Arc::downgrade(socket));
+        Ok(())
+    }
+
+    fn close_live_sockets(&self) {
+        let sockets = match self.sockets.lock() {
+            Ok(mut guard) => mem::take(&mut *guard),
+            Err(_) => return,
+        };
+        for socket in sockets.into_iter().filter_map(|socket| socket.upgrade()) {
+            let _ = socket.close_socket();
+        }
+    }
+}
+
+impl SocketState {
+    fn socket_clone(&self) -> Result<omq_tokio::blocking::Socket> {
+        self.check_open()?;
+        let guard = self
+            .socket
+            .read()
+            .map_err(|_| napi_error("socket lock poisoned"))?;
+        guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| napi_error("socket closed"))
+    }
+
+    fn take_socket(&self) -> Result<Option<omq_tokio::blocking::Socket>> {
+        self.socket
+            .write()
+            .map_err(|_| napi_error("socket lock poisoned"))
+            .map(|mut guard| guard.take())
+    }
+
+    fn close_socket(&self) -> Result<()> {
+        if !self.closed.swap(true, Ordering::AcqRel)
+            && let Some(socket) = self.take_socket()?
+        {
+            socket.close().map_err(map_omq_error)?;
+        }
+        Ok(())
+    }
+
+    fn check_open(&self) -> Result<()> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(napi_error("socket closed"));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -156,6 +214,7 @@ impl NativeContext {
         Self {
             inner: Arc::new(ContextState {
                 ctx: RwLock::new(Some(ctx)),
+                sockets: Mutex::new(Vec::new()),
                 closed: AtomicBool::new(false),
                 owns_runtime: true,
                 share_key,
@@ -186,23 +245,21 @@ impl NativeContext {
         let socket_type = parse_socket_type(&socket_type)?;
         let options = build_options(options)?;
         let socket = ctx.blocking_socket(socket_type, options);
-        Ok(NativeSocket {
-            inner: Arc::new(SocketState {
-                socket: RwLock::new(Some(socket)),
-                closed: AtomicBool::new(false),
-            }),
-        })
+        let inner = Arc::new(SocketState {
+            socket: RwLock::new(Some(socket)),
+            closed: AtomicBool::new(false),
+        });
+        self.inner.register_socket(&inner)?;
+        Ok(NativeSocket { inner })
     }
 
     #[napi]
     pub fn close(&self) {
         if !self.inner.closed.swap(true, Ordering::AcqRel) {
-            let ctx = self
-                .inner
-                .ctx
-                .write()
-                .ok()
-                .and_then(|mut guard| guard.take());
+            let ctx = self.inner.ctx.write().ok().and_then(|mut guard| {
+                self.inner.close_live_sockets();
+                guard.take()
+            });
             if let Some(ctx) = ctx
                 && self.inner.owns_runtime
             {
@@ -480,12 +537,7 @@ impl NativeSocket {
 
     #[napi]
     pub fn close(&self) -> Result<()> {
-        if !self.inner.closed.swap(true, Ordering::AcqRel)
-            && let Some(socket) = self.take_socket()?
-        {
-            socket.close().map_err(map_omq_error)?;
-        }
-        Ok(())
+        self.inner.close_socket()
     }
 
     fn with_socket_ref<T>(
@@ -497,31 +549,7 @@ impl NativeSocket {
     }
 
     fn socket_clone(&self) -> Result<omq_tokio::blocking::Socket> {
-        self.check_open()?;
-        let guard = self
-            .inner
-            .socket
-            .read()
-            .map_err(|_| napi_error("socket lock poisoned"))?;
-        guard
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| napi_error("socket closed"))
-    }
-
-    fn take_socket(&self) -> Result<Option<omq_tokio::blocking::Socket>> {
-        self.inner
-            .socket
-            .write()
-            .map_err(|_| napi_error("socket lock poisoned"))
-            .map(|mut guard| guard.take())
-    }
-
-    fn check_open(&self) -> Result<()> {
-        if self.inner.closed.load(Ordering::Acquire) {
-            return Err(napi_error("socket closed"));
-        }
-        Ok(())
+        self.inner.socket_clone()
     }
 }
 
@@ -550,6 +578,7 @@ pub fn native_context_from_share_key(share_key: String) -> Result<NativeContext>
         inner: Arc::new(ContextState {
             share_key: ctx.share_key(),
             ctx: RwLock::new(Some(ctx)),
+            sockets: Mutex::new(Vec::new()),
             closed: AtomicBool::new(false),
             owns_runtime: false,
         }),
@@ -558,11 +587,7 @@ pub fn native_context_from_share_key(share_key: String) -> Result<NativeContext>
 
 impl Drop for NativeSocket {
     fn drop(&mut self) {
-        if !self.inner.closed.swap(true, Ordering::AcqRel)
-            && let Ok(Some(socket)) = self.take_socket()
-        {
-            let _ = socket.close();
-        }
+        let _ = self.inner.close_socket();
     }
 }
 

--- a/bindings/node/test/lifecycle.test.js
+++ b/bindings/node/test/lifecycle.test.js
@@ -19,6 +19,19 @@ test("abort signal rejects pending recv", async () => {
   }
 });
 
+test("pending recv does not spin event loop", async () => {
+  const pull = new Pull();
+  try {
+    const started = process.cpuUsage();
+    await assert.rejects(pull.recv({ signal: AbortSignal.timeout(250) }), { name: "AbortError" });
+    const used = process.cpuUsage(started);
+    const cpuMs = (used.user + used.system) / 1000;
+    assert.ok(cpuMs < 60, `CPU time ${cpuMs.toFixed(1)}ms during idle recv`);
+  } finally {
+    pull.close();
+  }
+});
+
 test("dispose hooks close resources", () => {
   const context = new Context();
   const pull = new Pull({}, context);

--- a/bindings/node/test/lifecycle.test.js
+++ b/bindings/node/test/lifecycle.test.js
@@ -41,6 +41,24 @@ test("dispose hooks close resources", () => {
   assert.throws(() => context.shareKey(), /closed/);
 });
 
+test("context close closes live sockets", () => {
+  const context = new Context();
+  const pull = new Pull({}, context);
+  context.close();
+  assert.throws(() => pull.tryRecv(), /closed/);
+  assert.doesNotThrow(() => pull.close());
+});
+
+test("context close rejects pending recv", async () => {
+  const context = new Context();
+  const pull = new Pull({}, context);
+  const pending = pull.recv();
+  setTimeout(() => context.close(), 25);
+  await assert.rejects(pending, /closed/);
+  assert.throws(() => pull.tryRecv(), /closed/);
+  assert.doesNotThrow(() => pull.close());
+});
+
 test("async iterator exits on close", async () => {
   const pull = new Pull();
   const seen = [];

--- a/bindings/node/ts/index.ts
+++ b/bindings/node/ts/index.ts
@@ -1,6 +1,5 @@
 import { Buffer } from "node:buffer";
 import { createRequire } from "node:module";
-import { setImmediate as setImmediatePromise } from "node:timers/promises";
 
 type NativeContextOptions = {
   ioThreads?: number;
@@ -57,6 +56,7 @@ type NativeSocket = {
   sendOneSync(payload: Uint8Array): void;
   recv(): Uint8Array[];
   recvRawSync(): Uint8Array | Uint8Array[];
+  recvRaw(signal?: AbortSignal): Promise<Uint8Array | Uint8Array[]>;
   recvSync(): Uint8Array[];
   recvTimeout(timeoutMs: number): Uint8Array[] | null;
   tryRecv(): Uint8Array[] | null;
@@ -404,14 +404,17 @@ export class Socket {
   async recv(options: RecvOptions = {}): Promise<Message> {
     this.#checkOpen();
     if (options.signal) throwIfAborted(options.signal);
-    while (true) {
-      const raw = this.#tryRecvRaw();
-      if (raw !== null) {
-        return raw;
-      }
-      if (options.signal) throwIfAborted(options.signal);
-      this.#checkOpen();
-      await yieldToEventLoop(options.signal);
+    const raw = this.#tryRecvRaw();
+    if (raw !== null) {
+      return raw;
+    }
+    if (options.signal) throwIfAborted(options.signal);
+    this.#checkOpen();
+    try {
+      return messageFromNative(await this.native.recvRaw(options.signal));
+    } catch (error) {
+      if (options.signal?.aborted) throwAbortError();
+      throw error;
     }
   }
 
@@ -890,12 +893,12 @@ function throwIfAborted(signal: AbortSignal): void {
   throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }
 
-function isClosedError(error: unknown): boolean {
-  return error instanceof Error && error.message.toLowerCase().includes("closed");
+function throwAbortError(): never {
+  throw new DOMException("The operation was aborted", "AbortError");
 }
 
-function yieldToEventLoop(signal?: AbortSignal): Promise<void> {
-  return signal === undefined ? setImmediatePromise() : setImmediatePromise(undefined, { signal });
+function isClosedError(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes("closed");
 }
 
 function loadNative(): NativeModule {

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -1182,13 +1182,20 @@ class Poller:
     def poll(self, timeout: int | None = None) -> list[tuple[Socket, int]]:
         if not self._sockets:
             return []
+        ready: dict[int, int] = {
+            k: POLLOUT for k, (_, f) in self._sockets.items() if f & POLLOUT
+        }
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
         if not pollin_socks:
-            return []
+            return [(s, ready[k]) for k, (s, _) in self._sockets.items() if k in ready]
         t = None if (timeout is None or timeout < 0) else int(timeout)
+        if ready:
+            t = 0
         ready_ids = _native.wait_any(pollin_socks, t)
+        for rid in ready_ids:
+            ready[rid] = ready.get(rid, 0) | POLLIN
         return [
-            (self._sockets[rid][0], POLLIN) for rid in ready_ids if rid in self._sockets
+            (s, ready[k]) for k, (s, _) in self._sockets.items() if k in ready
         ]
 
 

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -34,6 +34,7 @@ from . import (
     LINGER,
     _TYPE_NAMES,
     POLLIN,
+    POLLOUT,
     _BaseSocket,
 )
 
@@ -590,14 +591,21 @@ class Poller:
     async def poll(self, timeout: int | None = None) -> list[tuple[Socket, int]]:
         if not self._sockets:
             return []
+        ready: dict[int, int] = {
+            k: POLLOUT for k, (_, f) in self._sockets.items() if f & POLLOUT
+        }
         pollin_socks = [s._sock for k, (s, f) in self._sockets.items() if f & POLLIN]
         if not pollin_socks:
-            return []
+            return [(s, ready[k]) for k, (s, _) in self._sockets.items() if k in ready]
         t = None if (timeout is None or timeout < 0) else int(timeout)
+        if ready:
+            t = 0
         loop = asyncio.get_running_loop()
         ready_ids = await loop.run_in_executor(None, _native.wait_any, pollin_socks, t)
+        for rid in ready_ids:
+            ready[rid] = ready.get(rid, 0) | POLLIN
         return [
-            (self._sockets[rid][0], POLLIN) for rid in ready_ids if rid in self._sockets
+            (s, ready[k]) for k, (s, _) in self._sockets.items() if k in ready
         ]
 
 

--- a/bindings/pyomq/src/runtime.rs
+++ b/bindings/pyomq/src/runtime.rs
@@ -18,7 +18,7 @@
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::FutureExt;
 use omq_tokio::Socket as InnerSocket;
@@ -739,7 +739,7 @@ pub fn wait_any(
     }
 
     let recv_signal = global_recv_signal();
-    let deadline = timeout_ms.map(|ms| std::time::Instant::now() + Duration::from_millis(ms));
+    let deadline = timeout_ms.and_then(|ms| Instant::now().checked_add(Duration::from_millis(ms)));
 
     recv_signal.park_begin();
     let ready = poll_ready(&sockets);
@@ -751,7 +751,7 @@ pub fn wait_any(
     loop {
         let wait_dur = match deadline {
             Some(d) => {
-                let now = std::time::Instant::now();
+                let now = Instant::now();
                 if now >= d {
                     recv_signal.park_end();
                     return vec![];
@@ -771,7 +771,7 @@ pub fn wait_any(
             recv_signal.park_end();
             return ready;
         }
-        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+        if deadline.is_some_and(|d| Instant::now() >= d) {
             recv_signal.park_end();
             return vec![];
         }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -39,6 +39,10 @@ static FORKED: AtomicBool = AtomicBool::new(false);
 #[cfg(unix)]
 static ATFORK_REGISTERED: std::sync::Once = std::sync::Once::new();
 
+fn deadline_after(timeout: Duration) -> Option<Instant> {
+    Instant::now().checked_add(timeout)
+}
+
 #[cfg(unix)]
 extern "C" fn atfork_child() {
     FORKED.store(true, Ordering::Relaxed);
@@ -902,7 +906,7 @@ impl Socket {
             Err(TrySendError::Full(msg)) => py.detach(|| match timeout {
                 None => sock.send(msg).map_err(map_err),
                 Some(timeout) => {
-                    let deadline = Instant::now() + timeout;
+                    let deadline = deadline_after(timeout);
                     let mut msg = msg;
                     loop {
                         match sock.try_send(msg) {
@@ -911,7 +915,7 @@ impl Socket {
                             Err(TrySendError::Closed) => return Err(map_err(PError::Closed)),
                             Err(TrySendError::Error(e)) => return Err(map_err(e)),
                         }
-                        if Instant::now() >= deadline {
+                        if deadline.is_some_and(|d| Instant::now() >= d) {
                             return Err(timeout_err());
                         }
                         std::thread::sleep(Duration::from_millis(1));
@@ -977,14 +981,14 @@ impl Socket {
                 }
             },
             Some(timeout) => {
-                let deadline = Instant::now() + timeout;
+                let deadline = deadline_after(timeout);
                 loop {
                     match sock.try_recv() {
                         Ok(msg) => return Ok(msg),
                         Err(omq_proto::error::Error::Closed) => {
                             return Err(map_err(omq_proto::error::Error::Closed));
                         }
-                        Err(_) if Instant::now() < deadline => {
+                        Err(_) if deadline.is_none_or(|d| Instant::now() < d) => {
                             std::thread::sleep(Duration::from_millis(1));
                         }
                         Err(_) => return Err(timeout_err()),

--- a/bindings/pyomq/tests/test_async_compat.py
+++ b/bindings/pyomq/tests/test_async_compat.py
@@ -171,6 +171,17 @@ async def test_async_underlying():
         sock.close()
 
 
+async def test_async_poller_reports_pollout():
+    ctx = zmq_async.Context()
+    push = ctx.socket(zmq.PUSH)
+    try:
+        poller = zmq_async.Poller()
+        poller.register(push, zmq.POLLOUT)
+        assert await poller.poll(timeout=1000) == [(push, zmq.POLLOUT)]
+    finally:
+        push.close()
+
+
 async def test_async_attr_linger():
     ctx = zmq_async.Context()
     sock = ctx.socket(zmq.PUSH)

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -560,6 +560,19 @@ def test_select_timeout():
         ctx.term()
 
 
+def test_select_wlist_reports_pollout():
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    try:
+        rready, wready, xready = zmq.select([], [push], [], timeout=1.0)
+        assert rready == []
+        assert wready == [push]
+        assert xready == []
+    finally:
+        push.close()
+        ctx.term()
+
+
 def test_select_ready(tcp_endpoint):
     import time
 

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -1,5 +1,6 @@
 """setsockopt / getsockopt round-trip + behaviour for Group A, B, C."""
 
+import threading
 import time
 
 import pytest
@@ -111,6 +112,29 @@ def test_rcvtimeo_raises_eagain():
         assert elapsed < 1.0
     finally:
         s.close()
+        ctx.term()
+
+
+def test_huge_rcvtimeo_receives_late_message():
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    endpoint = f"inproc://huge-timeout-{id(pull)}"
+    try:
+        pull.bind(endpoint)
+        push.connect(endpoint)
+        pull.setsockopt(zmq.RCVTIMEO, 2**63 - 1)
+
+        thread = threading.Thread(
+            target=lambda: (time.sleep(0.02), push.send(b"late")),
+            daemon=True,
+        )
+        thread.start()
+        assert pull.recv() == b"late"
+        thread.join(timeout=1)
+    finally:
+        push.close()
+        pull.close()
         ctx.term()
 
 

--- a/bindings/pyomq/tests/test_poller.py
+++ b/bindings/pyomq/tests/test_poller.py
@@ -52,6 +52,19 @@ def test_poll_timeout_empty(tcp_endpoint):
         ctx.term()
 
 
+def test_pollout_ready_immediately():
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    try:
+        poller = zmq.Poller()
+        poller.register(push, zmq.POLLOUT)
+        events = poller.poll(timeout=1000)
+        assert events == [(push, zmq.POLLOUT)]
+    finally:
+        push.close()
+        ctx.term()
+
+
 def test_poll_multiple_ready(tcp_endpoint):
     ctx = zmq.Context()
     push1 = ctx.socket(zmq.PUSH)

--- a/bindings/pyomq/tests/test_poller.py
+++ b/bindings/pyomq/tests/test_poller.py
@@ -1,5 +1,6 @@
 """Poller tests."""
 
+import threading
 import time
 
 import pyomq as zmq
@@ -48,6 +49,31 @@ def test_poll_timeout_empty(tcp_endpoint):
         events = poller.poll(timeout=50)
         assert events == []
     finally:
+        pull.close()
+        ctx.term()
+
+
+def test_poll_huge_timeout_receives_late_message():
+    ctx = zmq.Context()
+    pull = ctx.socket(zmq.PULL)
+    push = ctx.socket(zmq.PUSH)
+    endpoint = f"inproc://poll-huge-timeout-{id(pull)}"
+    try:
+        pull.bind(endpoint)
+        push.connect(endpoint)
+        poller = zmq.Poller()
+        poller.register(pull, zmq.POLLIN)
+
+        thread = threading.Thread(
+            target=lambda: (time.sleep(0.02), push.send(b"late")),
+            daemon=True,
+        )
+        thread.start()
+        assert poller.poll(timeout=2**64 - 1) == [(pull, zmq.POLLIN)]
+        assert pull.recv() == b"late"
+        thread.join(timeout=1)
+    finally:
+        push.close()
         pull.close()
         ctx.term()
 

--- a/omq-libzmq/src/poller.rs
+++ b/omq-libzmq/src/poller.rs
@@ -273,11 +273,7 @@ pub extern "C" fn zmq_poller_wait_all(
     }
 
     if poll_items.is_empty() {
-        return if timeout < 0 {
-            fail(libc::EFAULT)
-        } else {
-            fail(libc::EAGAIN)
-        };
+        return fail(libc::EAGAIN);
     }
 
     let rc = crate::poll::zmq_poll(

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -4,7 +4,7 @@
 //! Recv: bypass ring -> yring consumers -> block on `RecvNotify`.
 use std::ffi::c_int;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 
@@ -274,16 +274,21 @@ fn block_recv_result<T>(
     mut try_pop: impl FnMut() -> Result<Option<T>, c_int>,
 ) -> Result<T, c_int> {
     if rcvtimeo > 0 {
-        let deadline = std::time::Instant::now() + Duration::from_millis(rcvtimeo as u64);
+        let deadline = Instant::now().checked_add(Duration::from_millis(rcvtimeo as u64));
         loop {
             if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                return Err(libc::EAGAIN);
-            }
-            let ms = remaining.as_millis().min(i32::MAX as u128) as c_int;
+            let ms = match deadline {
+                Some(deadline) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(libc::EAGAIN);
+                    }
+                    remaining.as_millis().min(i32::MAX as u128) as c_int
+                }
+                None => i32::MAX,
+            };
             let recv_notify = sock.notify.recv_notifier();
             let _ = recv_notify.wait_for_readable(ms);
             if sock.ctx.is_effectively_terminated() {
@@ -443,10 +448,19 @@ pub(crate) fn send_bytes(sock: &Arc<OmqSocket>, data: &[u8], flags: c_int) -> c_
             let s = inner.clone();
             if sndtimeo > 0 {
                 let timeout = Duration::from_millis(sndtimeo as u64);
-                match handle.block_on(async { tokio::time::timeout(timeout, s.send(msg)).await }) {
-                    Ok(Ok(())) => ret_len,
-                    Ok(Err(_)) => fail(ETERM),
-                    Err(_elapsed) => fail(libc::EAGAIN),
+                if Instant::now().checked_add(timeout).is_some() {
+                    match handle
+                        .block_on(async { tokio::time::timeout(timeout, s.send(msg)).await })
+                    {
+                        Ok(Ok(())) => ret_len,
+                        Ok(Err(_)) => fail(ETERM),
+                        Err(_elapsed) => fail(libc::EAGAIN),
+                    }
+                } else {
+                    match handle.block_on(s.send(msg)) {
+                        Ok(()) => ret_len,
+                        Err(_) => fail(ETERM),
+                    }
                 }
             } else {
                 match handle.block_on(s.send(msg)) {

--- a/omq-libzmq/src/timers.rs
+++ b/omq-libzmq/src/timers.rs
@@ -11,7 +11,7 @@ type TimerFn = unsafe extern "C" fn(c_int, *mut c_void);
 struct TimerEntry {
     id: c_int,
     interval: Duration,
-    next: Instant,
+    next: Option<Instant>,
     handler: TimerFn,
     arg: *mut c_void,
 }
@@ -45,6 +45,10 @@ fn find_timer(entries: &[TimerEntry], id: c_int) -> Option<usize> {
 
 fn interval_from_ms(interval: usize) -> Duration {
     Duration::from_millis(interval.try_into().unwrap_or(u64::MAX))
+}
+
+fn deadline_after(interval: Duration) -> Option<Instant> {
+    Instant::now().checked_add(interval)
 }
 
 #[unsafe(no_mangle)]
@@ -90,7 +94,7 @@ pub extern "C" fn zmq_timers_add(
     timers.entries.push(TimerEntry {
         id,
         interval,
-        next: Instant::now() + interval,
+        next: deadline_after(interval),
         handler,
         arg,
     });
@@ -125,7 +129,7 @@ pub extern "C" fn zmq_timers_set_interval(
     };
     let interval = interval_from_ms(interval);
     timers.entries[idx].interval = interval;
-    timers.entries[idx].next = Instant::now() + interval;
+    timers.entries[idx].next = deadline_after(interval);
     0
 }
 
@@ -138,7 +142,7 @@ pub extern "C" fn zmq_timers_reset(timers_ptr: *mut c_void, timer_id: c_int) -> 
     let Some(idx) = find_timer(&timers.entries, timer_id) else {
         return fail(libc::EINVAL);
     };
-    timers.entries[idx].next = Instant::now() + timers.entries[idx].interval;
+    timers.entries[idx].next = deadline_after(timers.entries[idx].interval);
     0
 }
 
@@ -148,8 +152,11 @@ pub extern "C" fn zmq_timers_timeout(timers_ptr: *mut c_void) -> c_long {
         Ok(t) => t,
         Err(e) => return c_long::from(fail(e)),
     };
-    let Some(next) = timers.entries.iter().map(|entry| entry.next).min() else {
+    if timers.entries.is_empty() {
         return -1;
+    }
+    let Some(next) = timers.entries.iter().filter_map(|entry| entry.next).min() else {
+        return c_long::MAX;
     };
     let now = Instant::now();
     if next <= now {
@@ -169,9 +176,9 @@ pub extern "C" fn zmq_timers_execute(timers_ptr: *mut c_void) -> c_int {
         let now = Instant::now();
         let mut callbacks = Vec::new();
         for entry in &mut timers.entries {
-            if entry.next <= now {
+            if entry.next.is_some_and(|next| next <= now) {
                 callbacks.push((entry.id, entry.handler, entry.arg));
-                entry.next = now + entry.interval;
+                entry.next = now.checked_add(entry.interval);
             }
         }
         callbacks
@@ -233,6 +240,31 @@ mod tests {
         assert_eq!(zmq_timers_timeout(timers), -1);
         assert_eq!(zmq_timers_cancel(timers, id), -1);
         assert_eq!(crate::zmq_errno(), libc::EINVAL);
+
+        let mut timers_slot = timers;
+        assert_eq!(zmq_timers_destroy(&raw mut timers_slot), 0);
+        assert!(timers_slot.is_null());
+    }
+
+    #[test]
+    fn huge_timer_interval_does_not_panic() {
+        let timers = zmq_timers_new();
+        assert!(!timers.is_null());
+
+        let fired = AtomicUsize::new(0);
+        let id = zmq_timers_add(
+            timers,
+            usize::MAX,
+            Some(count_timer),
+            std::ptr::from_ref(&fired).cast::<c_void>().cast_mut(),
+        );
+        assert!(id > 0);
+        assert_eq!(zmq_timers_timeout(timers), c_long::MAX);
+        assert_eq!(zmq_timers_execute(timers), 0);
+        assert_eq!(fired.load(Ordering::SeqCst), 0);
+        assert_eq!(zmq_timers_set_interval(timers, id, usize::MAX), 0);
+        assert_eq!(zmq_timers_reset(timers, id), 0);
+        assert_eq!(zmq_timers_timeout(timers), c_long::MAX);
 
         let mut timers_slot = timers;
         assert_eq!(zmq_timers_destroy(&raw mut timers_slot), 0);

--- a/omq-libzmq/tests/poller.rs
+++ b/omq-libzmq/tests/poller.rs
@@ -260,6 +260,12 @@ fn empty_poller_wait_maps_timeout_to_eagain() {
     );
     assert_eq!(omq_zmq::zmq_errno(), libc::EAGAIN);
 
+    assert_eq!(
+        zmq_poller_wait(poller, std::ptr::from_mut(&mut event).cast(), -1),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EAGAIN);
+
     let mut poller_slot = poller;
     assert_eq!(zmq_poller_destroy(&mut poller_slot), 0);
 }

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -876,8 +876,9 @@ where
         let mut arena_buf: Vec<u8> = Vec::new();
         let mut pipe_batch: Vec<Message> = Vec::new();
         let mut last_input = Instant::now();
-        let mut handshake_deadline: Option<Instant> =
-            config.handshake_timeout.map(|d| last_input + d);
+        let mut handshake_deadline: Option<Instant> = config
+            .handshake_timeout
+            .and_then(|d| last_input.checked_add(d));
         let hb_interval = config.heartbeat_interval;
         let hb_timeout = config
             .heartbeat_timeout
@@ -887,8 +888,7 @@ where
             .heartbeat_ttl
             .and_then(|d| u16::try_from(d.as_millis() / 100).ok())
             .unwrap_or(0);
-        let hb_sleep = tokio::time::sleep(hb_interval.unwrap_or(Duration::MAX));
-        tokio::pin!(hb_sleep);
+        let mut hb_deadline = hb_interval.and_then(|d| Instant::now().checked_add(d));
         let mut hb_ping_sent = false;
 
         loop {
@@ -985,7 +985,6 @@ where
             }
 
             let want_write = connection.has_pending_transmit() || !eq.is_empty();
-            let hb_enabled = hb_interval.is_some();
 
             // Latency-routed REQ/REP sends are encoded into the wire slot by
             // the caller. Drain that already-queued work before polling the
@@ -1120,7 +1119,7 @@ where
                 // been sent: on unidirectional sockets (PUSH, PUB) the
                 // peer has no data to send, so last_input stays at
                 // handshake time until the first PONG arrives.
-                () = &mut hb_sleep, if hb_enabled => {
+                () = sleep_until_opt(hb_deadline), if hb_deadline.is_some() => {
                     if hb_ping_sent && last_input.elapsed() > hb_timeout {
                         return Err(Error::Timeout);
                     }
@@ -1130,9 +1129,7 @@ where
                     };
                     let _ = connection.send_command(&ping);
                     hb_ping_sent = true;
-                    hb_sleep.as_mut().reset(
-                        tokio::time::Instant::now() + hb_interval.unwrap(),
-                    );
+                    hb_deadline = hb_interval.and_then(|d| Instant::now().checked_add(d));
                 }
 
             }

--- a/omq-tokio/src/socket/actor/mod.rs
+++ b/omq-tokio/src/socket/actor/mod.rs
@@ -451,7 +451,7 @@ impl SocketDriver {
         // close() sets the closed flag; existing ring data can still be drained.
         // Non-zero linger keeps endpoints alive so late peers can take queued
         // sends before the deadline.
-        self.close_deadline = linger.map(|d| Instant::now() + d);
+        self.close_deadline = linger.and_then(|d| Instant::now().checked_add(d));
         // If linger is zero, shut down the strategy now so in-flight
         // pumps bail immediately.
         if matches!(linger, Some(Duration::ZERO)) {

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -1047,7 +1047,7 @@ impl Socket {
         min_peers: usize,
         timeout: std::time::Duration,
     ) -> Result<usize> {
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = super::deadline_after(timeout).map(tokio::time::Instant::from_std);
         loop {
             let conns = self.connections().await?;
             let ready = if self.inner.socket_type == SocketType::Stream {
@@ -1058,13 +1058,13 @@ impl Socket {
             if ready >= min_peers {
                 return Ok(ready);
             }
-            if tokio::time::Instant::now() >= deadline {
+            if deadline.is_some_and(|d| tokio::time::Instant::now() >= d) {
                 return Err(Error::Timeout);
             }
-            tokio::time::sleep_until(
-                deadline.min(tokio::time::Instant::now() + std::time::Duration::from_millis(5)),
-            )
-            .await;
+            let now = tokio::time::Instant::now();
+            let poll_deadline = now + std::time::Duration::from_millis(5);
+            tokio::time::sleep_until(deadline.map_or(poll_deadline, |d| d.min(poll_deadline)))
+                .await;
         }
     }
 
@@ -1081,19 +1081,19 @@ impl Socket {
         min_subscriptions: u64,
         timeout: std::time::Duration,
     ) -> Result<u64> {
-        let deadline = tokio::time::Instant::now() + timeout;
+        let deadline = super::deadline_after(timeout).map(tokio::time::Instant::from_std);
         loop {
             let count = self.inner.subscribe_count.load(Ordering::Acquire);
             if count >= min_subscriptions {
                 return Ok(count);
             }
-            if tokio::time::Instant::now() >= deadline {
+            if deadline.is_some_and(|d| tokio::time::Instant::now() >= d) {
                 return Err(Error::Timeout);
             }
-            tokio::time::sleep_until(
-                deadline.min(tokio::time::Instant::now() + std::time::Duration::from_millis(5)),
-            )
-            .await;
+            let now = tokio::time::Instant::now();
+            let poll_deadline = now + std::time::Duration::from_millis(5);
+            tokio::time::sleep_until(deadline.map_or(poll_deadline, |d| d.min(poll_deadline)))
+                .await;
         }
     }
 

--- a/omq-tokio/src/socket/mod.rs
+++ b/omq-tokio/src/socket/mod.rs
@@ -19,3 +19,7 @@ pub use monitor::{
     ConnectionStatus, DisconnectReason, MonitorEvent, MonitorRecvError, MonitorStream,
     MonitorTryRecvError, PeerCommandKind, PeerIdent, PeerInfo,
 };
+
+pub(crate) fn deadline_after(timeout: std::time::Duration) -> Option<std::time::Instant> {
+    std::time::Instant::now().checked_add(timeout)
+}

--- a/omq-tokio/tests/linger.rs
+++ b/omq-tokio/tests/linger.rs
@@ -296,6 +296,18 @@ async fn close_with_linger_zero_overrides_configured_forever() {
 }
 
 #[tokio::test]
+async fn close_with_huge_linger_does_not_panic() {
+    let push = Socket::new(SocketType::Push, Options::default());
+    tokio::time::timeout(
+        Duration::from_millis(500),
+        push.close_with_linger(Some(Duration::MAX)),
+    )
+    .await
+    .expect("close with huge linger hung")
+    .expect("close with huge linger failed");
+}
+
+#[tokio::test]
 async fn linger_completes_within_timeout_after_peer_disconnect() {
     // Queued messages cannot be delivered after the peer disconnects.
     // close() with a finite linger must return within the linger window

--- a/omq-tokio/tests/monitor.rs
+++ b/omq-tokio/tests/monitor.rs
@@ -15,6 +15,16 @@ fn inproc_ep(name: &str) -> Endpoint {
 }
 
 #[tokio::test]
+async fn wait_connected_accepts_huge_timeout() {
+    let pull = Socket::new(SocketType::Pull, Options::default());
+    let ready = pull
+        .wait_connected(0, Duration::MAX)
+        .await
+        .expect("huge wait_connected timeout panicked");
+    assert_eq!(ready, 0);
+}
+
+#[tokio::test]
 async fn monitor_listening_event_on_bind() {
     let ep = inproc_ep("mon-listen");
     let s = Socket::new(SocketType::Pull, Options::default());

--- a/omq-tokio/tests/pub_sub.rs
+++ b/omq-tokio/tests/pub_sub.rs
@@ -725,6 +725,16 @@ async fn wait_subscribed_times_out_with_no_subscribers() {
 }
 
 #[tokio::test]
+async fn wait_subscribed_accepts_huge_timeout() {
+    let pub_ = Socket::new(SocketType::Pub, Options::default());
+    let count = pub_
+        .wait_subscribed(0, Duration::MAX)
+        .await
+        .expect("huge wait_subscribed timeout panicked");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
 async fn wait_subscribed_cumulative_across_peers() {
     let pub_ = Socket::new(SocketType::Pub, Options::default());
     let port = test_support::bind_loopback(&pub_).await;


### PR DESCRIPTION
- Fix `pyomq` `POLLOUT` polling so write readiness uses the write mask.
- Avoid Node async receive idle polling while preserving close wakeups.
- Make Java virtual and platform receive paths unblock cleanly on close.
- Guard deadline arithmetic overflow and empty-poller errno behavior.
- Track Node context sockets and close them before context termination.