### PR TITLE
RFC: Caller-driven DEALER I/O for lower latency under Wine

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -137,6 +137,29 @@ Stateless sends bypass the actor through `SendSubmitter`. REQ/REP still check
 shared type state before submit. Plain recv paths bypass the actor when no
 identity, group, or subscription post-processing is needed.
 
+### Caller-driven exclusive sockets
+
+`omq_tokio::exclusive::Socket` is an opt-in alternative for latency-sensitive,
+single-peer workloads. It owns both the Tokio TCP stream and the sans-I/O
+`omq_proto::Connection`; the caller drives TCP, ZMTP, reconnects, and heartbeat
+timers through methods requiring `&mut self`.
+
+```text
+regular Socket:   caller -> routing/queue -> ConnectionDriver task -> TCP
+exclusive Socket: caller -> omq_proto::Connection                  -> TCP
+```
+
+The exclusive path removes the connection-driver task and userspace data relay,
+but deliberately gives up the regular socket's cloneable handles, multi-peer
+routing, background progress, and userspace outbound queue. A failed send is
+not replayed because it is ambiguous whether the peer received a partial or
+complete command. When no `send` or `recv` future is active, the application
+must call `maintain()` to drive idle heartbeat and reconnect work.
+
+The initial implementation supports one connected TCP DEALER using the NULL
+mechanism. Unsupported socket types and transports return explicit configuration
+errors; bind/accept and additional socket semantics can be added incrementally.
+
 ## Messages
 
 `Payload` and `Message` are small-value enums optimized for common single-part

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `exclusive::ExclusiveDealer`, a caller-owned direct-I/O DEALER for
-  latency-sensitive TCP workloads, with configurable timeouts, reconnects,
-  heartbeats, and lifecycle monitoring.
+- `exclusive::Socket`, a caller-owned direct-I/O socket for latency-sensitive
+  single-peer workloads, initially supporting connected TCP DEALER with
+  configurable timeouts, reconnects, heartbeats, and lifecycle monitoring.
 
 ### Changed
 

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `exclusive::ExclusiveDealer`, a caller-owned direct-I/O DEALER for
+  latency-sensitive TCP workloads, with configurable timeouts, reconnects,
+  heartbeats, and lifecycle monitoring.
+
 ### Changed
 
 - Large direct receives now reuse bounded pooled buffers for medium-large

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -75,13 +75,13 @@ path = "src/bin/bench_proxy_client.rs"
 name = "omq_perf_verify"
 path = "src/bin/perf_verify.rs"
 
-[[bin]]
-name = "omq_exclusive_dealer_latency"
-path = "src/bin/exclusive_dealer_latency.rs"
-
 [[example]]
 name = "pub_sub_lz4"
 required-features = ["lz4"]
+
+[[bench]]
+name = "exclusive_latency"
+harness = false
 
 [[bench]]
 name = "push_pull"

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -75,6 +75,10 @@ path = "src/bin/bench_proxy_client.rs"
 name = "omq_perf_verify"
 path = "src/bin/perf_verify.rs"
 
+[[bin]]
+name = "omq_exclusive_dealer_latency"
+path = "src/bin/exclusive_dealer_latency.rs"
+
 [[example]]
 name = "pub_sub_lz4"
 required-features = ["lz4"]

--- a/omq-tokio/benches/exclusive_latency.rs
+++ b/omq-tokio/benches/exclusive_latency.rs
@@ -3,16 +3,16 @@
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use omq_tokio::exclusive::ExclusiveDealer;
+use omq_tokio::exclusive::{Options as ExclusiveOptions, Socket as ExclusiveSocket};
 use omq_tokio::options::WorkloadProfile;
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
 fn usage() -> ! {
     eprintln!(
         "usage:\n  \
-         omq_exclusive_dealer_latency server <bind-uri>\n  \
-         omq_exclusive_dealer_latency standard <connect-uri> <size> <iterations> <warmup>\n  \
-         omq_exclusive_dealer_latency exclusive <host:port> <size> <iterations> <warmup>"
+         exclusive_latency server <bind-uri>\n  \
+         exclusive_latency standard <connect-uri> <size> <iterations> <warmup>\n  \
+         exclusive_latency exclusive <connect-uri> <size> <iterations> <warmup>"
     );
     std::process::exit(2);
 }
@@ -80,10 +80,18 @@ async fn run_client(mode: &str, address: &str, size: usize, iterations: usize, w
             regular = Some(socket);
         }
         "exclusive" => {
+            let endpoint: Endpoint = address.parse().expect("valid exclusive TCP endpoint");
             exclusive = Some(
-                ExclusiveDealer::connect(address, identity)
-                    .await
-                    .expect("connect exclusive DEALER"),
+                ExclusiveSocket::connect(
+                    SocketType::Dealer,
+                    endpoint,
+                    ExclusiveOptions {
+                        identity,
+                        ..ExclusiveOptions::default()
+                    },
+                )
+                .await
+                .expect("connect exclusive DEALER"),
             );
         }
         _ => unreachable!(),
@@ -113,7 +121,7 @@ async fn run_client(mode: &str, address: &str, size: usize, iterations: usize, w
 
 async fn round_trip(
     regular: Option<&Socket>,
-    exclusive: Option<&mut ExclusiveDealer>,
+    exclusive: Option<&mut ExclusiveSocket>,
     message: &Message,
 ) {
     if let Some(socket) = regular {

--- a/omq-tokio/src/bin/exclusive_dealer_latency.rs
+++ b/omq-tokio/src/bin/exclusive_dealer_latency.rs
@@ -1,0 +1,131 @@
+//! Reproducer for comparing the regular and caller-driven DEALER paths.
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::exclusive::ExclusiveDealer;
+use omq_tokio::options::WorkloadProfile;
+use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+
+fn usage() -> ! {
+    eprintln!(
+        "usage:\n  \
+         omq_exclusive_dealer_latency server <bind-uri>\n  \
+         omq_exclusive_dealer_latency standard <connect-uri> <size> <iterations> <warmup>\n  \
+         omq_exclusive_dealer_latency exclusive <host:port> <size> <iterations> <warmup>"
+    );
+    std::process::exit(2);
+}
+
+fn argument<T: std::str::FromStr>(args: &[String], index: usize, name: &str) -> T {
+    args.get(index)
+        .unwrap_or_else(|| usage())
+        .parse()
+        .unwrap_or_else(|_| panic!("invalid {name}"))
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create Tokio runtime");
+    runtime.block_on(async_main(&args));
+}
+
+async fn async_main(args: &[String]) {
+    match args.get(1).map(String::as_str) {
+        Some("server") => run_server(argument(args, 2, "bind URI")).await,
+        Some(mode @ ("standard" | "exclusive")) => {
+            let address = args.get(2).unwrap_or_else(|| usage());
+            let size = argument(args, 3, "message size");
+            let iterations = argument(args, 4, "iteration count");
+            let warmup = argument(args, 5, "warmup count");
+            run_client(mode, address, size, iterations, warmup).await;
+        }
+        _ => usage(),
+    }
+}
+
+async fn run_server(endpoint: Endpoint) {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let bound = router.bind(endpoint).await.expect("bind ROUTER");
+    eprintln!("READY {bound}");
+    loop {
+        let message = router.recv().await.expect("receive request");
+        router.send(message).await.expect("echo response");
+    }
+}
+
+async fn run_client(mode: &str, address: &str, size: usize, iterations: usize, warmup: usize) {
+    assert!(iterations > 0, "iterations must be greater than zero");
+    let payload = Bytes::from(vec![b'x'; size]);
+    let message = Message::single(payload);
+    let identity = Bytes::from_static(b"exclusive-latency-reproducer");
+
+    let mut regular = None;
+    let mut exclusive = None;
+    match mode {
+        "standard" => {
+            let endpoint: Endpoint = address.parse().expect("valid connect URI");
+            let options = Options::default()
+                .identity(identity)
+                .workload_profile(WorkloadProfile::Latency);
+            let socket = Socket::new(SocketType::Dealer, options);
+            socket.connect(endpoint).await.expect("connect DEALER");
+            socket
+                .wait_connected(1, Duration::from_secs(10))
+                .await
+                .expect("wait for DEALER handshake");
+            regular = Some(socket);
+        }
+        "exclusive" => {
+            exclusive = Some(
+                ExclusiveDealer::connect(address, identity)
+                    .await
+                    .expect("connect exclusive DEALER"),
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    for _ in 0..warmup {
+        round_trip(regular.as_ref(), exclusive.as_mut(), &message).await;
+    }
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        round_trip(regular.as_ref(), exclusive.as_mut(), &message).await;
+        samples.push(started.elapsed().as_nanos() as u64);
+    }
+    samples.sort_unstable();
+
+    println!("mode,size,iterations,warmup,p50_us,p95_us,p99_us,max_us");
+    println!(
+        "{mode},{size},{iterations},{warmup},{:.3},{:.3},{:.3},{:.3}",
+        percentile_us(&samples, 50.0),
+        percentile_us(&samples, 95.0),
+        percentile_us(&samples, 99.0),
+        percentile_us(&samples, 100.0),
+    );
+}
+
+async fn round_trip(
+    regular: Option<&Socket>,
+    exclusive: Option<&mut ExclusiveDealer>,
+    message: &Message,
+) {
+    if let Some(socket) = regular {
+        socket.send(message.clone()).await.expect("standard send");
+        socket.recv().await.expect("standard receive");
+    } else if let Some(socket) = exclusive {
+        socket.send(message).await.expect("exclusive send");
+        socket.recv().await.expect("exclusive receive");
+    }
+}
+
+fn percentile_us(sorted: &[u64], percentile: f64) -> f64 {
+    let index = ((sorted.len() as f64 * percentile / 100.0) as usize).min(sorted.len() - 1);
+    sorted[index] as f64 / 1_000.0
+}

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -447,7 +447,8 @@ mod tests {
         assert!(dealer.recv().await.is_err());
         let (router2, rebound) = router().await;
         // A new ephemeral port is expected; exercise explicit reconnect state
-        // here, while restart-on-the-same-address is covered by the Wine test.
+        // here. Restart-on-the-same-address is covered by the external Wine
+        // reproduction procedure.
         dealer.address = rebound;
         dealer.reconnect_now().await.unwrap();
         let server = tokio::spawn(async move {

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -1,0 +1,138 @@
+//! Exclusively owned, direct-I/O sockets for latency-sensitive callers.
+//!
+//! Unlike [`crate::Socket`], these sockets are deliberately not cloneable and
+//! require `&mut self` for data-plane operations. This lets the caller poll
+//! TCP and the ZMTP codec directly, without a connection-driver task or relay
+//! ring. The initial prototype supports one connected NULL-mechanism DEALER.
+
+use bytes::{Bytes, BytesMut};
+use omq_proto::proto::{Connection, ConnectionConfig, Event, Role};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::{Error, Message, Result, SocketType};
+
+/// A single-peer DEALER whose caller owns the TCP data path.
+#[derive(Debug)]
+pub struct ExclusiveDealer {
+    stream: TcpStream,
+    connection: Connection,
+    read_buf: BytesMut,
+    write_buf: BytesMut,
+}
+
+impl ExclusiveDealer {
+    /// Connect and complete the ZMTP NULL handshake.
+    pub async fn connect(address: impl tokio::net::ToSocketAddrs, identity: Bytes) -> Result<Self> {
+        let stream = TcpStream::connect(address).await?;
+        stream.set_nodelay(true)?;
+        let connection = Connection::new(
+            ConnectionConfig::new(Role::Client, SocketType::Dealer).identity(identity),
+        );
+        let mut dealer = Self {
+            stream,
+            connection,
+            read_buf: BytesMut::with_capacity(4 * 1024),
+            write_buf: BytesMut::with_capacity(4 * 1024),
+        };
+        dealer.finish_handshake().await?;
+        Ok(dealer)
+    }
+
+    async fn finish_handshake(&mut self) -> Result<()> {
+        while !self.connection.is_ready() {
+            self.flush_connection().await?;
+            if self.connection.is_ready() {
+                break;
+            }
+            self.read_once().await?;
+            while let Some(event) = self.connection.poll_event() {
+                if let Event::HandshakeSucceeded { .. } = event {
+                    break;
+                }
+            }
+        }
+        self.flush_connection().await
+    }
+
+    /// Encode and write one complete ZMTP message directly to TCP.
+    pub async fn send(&mut self, message: &Message) -> Result<()> {
+        self.write_buf.clear();
+        self.connection
+            .send_message_flat(message, &mut self.write_buf);
+        self.stream.write_all(&self.write_buf).await?;
+        Ok(())
+    }
+
+    /// Read and decode the next complete message directly from TCP.
+    pub async fn recv(&mut self) -> Result<Message> {
+        loop {
+            if let Some(message) = self.connection.poll_message() {
+                return Ok(message);
+            }
+            self.read_once().await?;
+            // PING processing can queue PONG while decoding input.
+            self.flush_connection().await?;
+        }
+    }
+
+    async fn read_once(&mut self) -> Result<()> {
+        let n = self.stream.read_buf(&mut self.read_buf).await?;
+        if n == 0 {
+            return Err(Error::Closed);
+        }
+        self.connection.handle_input(self.read_buf.split().freeze())
+    }
+
+    async fn flush_connection(&mut self) -> Result<()> {
+        while self.connection.has_pending_transmit() {
+            let chunks = self.connection.transmit_chunks_capped(64);
+            let n = self.stream.write_vectored(&chunks).await?;
+            drop(chunks);
+            if n == 0 {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "exclusive DEALER write returned zero",
+                )));
+            }
+            self.connection.advance_transmit(n);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Endpoint, Options, Socket};
+
+    #[tokio::test]
+    async fn dealer_round_trips_with_standard_router() {
+        let router = Socket::new(SocketType::Router, Options::default());
+        let bound = router
+            .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
+            .await
+            .unwrap();
+        let Endpoint::Tcp { host, port } = bound else {
+            panic!("expected TCP endpoint")
+        };
+        let server = tokio::spawn(async move {
+            for _ in 0..100 {
+                let message = router.recv().await.unwrap();
+                router.send(message).await.unwrap();
+            }
+        });
+        let mut dealer = ExclusiveDealer::connect(
+            format!("{host}:{port}"),
+            Bytes::from_static(b"exclusive-test"),
+        )
+        .await
+        .unwrap();
+        for sequence in 0_u64..100 {
+            let message = Message::single(Bytes::copy_from_slice(&sequence.to_le_bytes()));
+            dealer.send(&message).await.unwrap();
+            assert_eq!(dealer.recv().await.unwrap(), message);
+        }
+        server.await.unwrap();
+    }
+}

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -1,104 +1,394 @@
 //! Exclusively owned, direct-I/O sockets for latency-sensitive callers.
 //!
-//! Unlike [`crate::Socket`], these sockets are deliberately not cloneable and
-//! require `&mut self` for data-plane operations. This lets the caller poll
-//! TCP and the ZMTP codec directly, without a connection-driver task or relay
-//! ring. The initial prototype supports one connected NULL-mechanism DEALER.
+//! These sockets deliberately require `&mut self`: the caller polls TCP and
+//! ZMTP directly, without a connection-driver task or data relay ring.
+
+use std::io;
+use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
+use omq_proto::proto::command::Command;
 use omq_proto::proto::{Connection, ConnectionConfig, Event, Role};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::sync::broadcast;
 
-use crate::{Error, Message, Result, SocketType};
+use crate::{Error, Message, ReconnectPolicy, Result, SocketType};
 
-/// A single-peer DEALER whose caller owns the TCP data path.
+/// Reliability settings for [`ExclusiveDealer`].
+#[derive(Clone, Copy, Debug)]
+pub struct ExclusiveDealerOptions {
+    pub connect_timeout: Duration,
+    pub handshake_timeout: Duration,
+    pub io_timeout: Option<Duration>,
+    pub reconnect: ReconnectPolicy,
+    pub heartbeat_interval: Option<Duration>,
+    pub heartbeat_timeout: Option<Duration>,
+}
+
+impl Default for ExclusiveDealerOptions {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(5),
+            handshake_timeout: Duration::from_secs(5),
+            io_timeout: None,
+            reconnect: ReconnectPolicy::default(),
+            heartbeat_interval: None,
+            heartbeat_timeout: None,
+        }
+    }
+}
+
+/// Lifecycle event for an exclusive socket.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ExclusiveEvent {
+    Connected,
+    HandshakeSucceeded,
+    Disconnected { reason: String },
+    ReconnectDelayed { retry_in: Duration, attempt: u32 },
+    Closed,
+}
+
 #[derive(Debug)]
-pub struct ExclusiveDealer {
+struct LiveConnection {
     stream: TcpStream,
     connection: Connection,
     read_buf: BytesMut,
     write_buf: BytesMut,
+    last_input: Instant,
+    last_ping: Instant,
+    ping_sequence: u64,
+}
+
+/// A single-peer DEALER whose caller owns the TCP data path.
+///
+/// A failed `send` is never retried automatically: the peer may have received
+/// a partial or complete command. The next operation may restore the
+/// connection, but the application decides whether a command is safe to retry.
+#[derive(Debug)]
+pub struct ExclusiveDealer {
+    address: String,
+    identity: Bytes,
+    options: ExclusiveDealerOptions,
+    live: Option<LiveConnection>,
+    monitor: broadcast::Sender<ExclusiveEvent>,
+    reconnect_attempt: u32,
+    retry_at: Option<Instant>,
+    closed: bool,
 }
 
 impl ExclusiveDealer {
-    /// Connect and complete the ZMTP NULL handshake.
-    pub async fn connect(address: impl tokio::net::ToSocketAddrs, identity: Bytes) -> Result<Self> {
-        let stream = TcpStream::connect(address).await?;
-        stream.set_nodelay(true)?;
-        let connection = Connection::new(
-            ConnectionConfig::new(Role::Client, SocketType::Dealer).identity(identity),
-        );
+    pub async fn connect(address: impl Into<String>, identity: Bytes) -> Result<Self> {
+        Self::connect_with_options(address, identity, ExclusiveDealerOptions::default()).await
+    }
+
+    pub async fn connect_with_options(
+        address: impl Into<String>,
+        identity: Bytes,
+        options: ExclusiveDealerOptions,
+    ) -> Result<Self> {
+        let (monitor, _) = broadcast::channel(1024);
         let mut dealer = Self {
-            stream,
-            connection,
-            read_buf: BytesMut::with_capacity(4 * 1024),
-            write_buf: BytesMut::with_capacity(4 * 1024),
+            address: address.into(),
+            identity,
+            options,
+            live: None,
+            monitor,
+            reconnect_attempt: 0,
+            retry_at: None,
+            closed: false,
         };
-        dealer.finish_handshake().await?;
+        dealer.establish().await?;
         Ok(dealer)
     }
 
-    async fn finish_handshake(&mut self) -> Result<()> {
-        while !self.connection.is_ready() {
-            self.flush_connection().await?;
-            if self.connection.is_ready() {
-                break;
-            }
-            self.read_once().await?;
-            while let Some(event) = self.connection.poll_event() {
-                if let Event::HandshakeSucceeded { .. } = event {
-                    break;
-                }
-            }
-        }
-        self.flush_connection().await
+    pub fn monitor(&self) -> broadcast::Receiver<ExclusiveEvent> {
+        self.monitor.subscribe()
     }
 
-    /// Encode and write one complete ZMTP message directly to TCP.
+    pub fn is_connected(&self) -> bool {
+        self.live.is_some()
+    }
+
+    /// Encode and write one message. Failed writes are not replayed.
     pub async fn send(&mut self, message: &Message) -> Result<()> {
-        self.write_buf.clear();
-        self.connection
-            .send_message_flat(message, &mut self.write_buf);
-        self.stream.write_all(&self.write_buf).await?;
+        self.ensure_connected().await?;
+        let timeout = self.options.io_timeout;
+        let result = run_timeout(timeout, async {
+            let live = self.live.as_mut().expect("connected");
+            live.write_buf.clear();
+            live.connection
+                .send_message_flat(message, &mut live.write_buf);
+            live.stream
+                .write_all(&live.write_buf)
+                .await
+                .map_err(Error::Io)
+        })
+        .await;
+        if let Err(error) = result {
+            self.mark_disconnected(&error);
+            return Err(error);
+        }
         Ok(())
     }
 
-    /// Read and decode the next complete message directly from TCP.
+    /// Receive one message. A timeout or transport error disconnects the
+    /// current peer; a later operation attempts reconnection.
     pub async fn recv(&mut self) -> Result<Message> {
-        loop {
-            if let Some(message) = self.connection.poll_message() {
-                return Ok(message);
-            }
-            self.read_once().await?;
-            // PING processing can queue PONG while decoding input.
-            self.flush_connection().await?;
+        self.ensure_connected().await?;
+        let timeout = self.options.io_timeout;
+        let result = run_timeout(timeout, recv_live(self.live.as_mut().expect("connected"))).await;
+        if let Err(error) = &result {
+            self.mark_disconnected(error);
         }
+        result
     }
 
-    async fn read_once(&mut self) -> Result<()> {
-        let n = self.stream.read_buf(&mut self.read_buf).await?;
-        if n == 0 {
+    /// Drive heartbeat and reconnect work. Call this from the bridge timer
+    /// when no data operation is active; it never runs a background data task.
+    pub async fn maintain(&mut self) -> Result<()> {
+        self.ensure_connected().await?;
+        let input_result = drain_ready_input(self.live.as_mut().expect("connected"));
+        if let Err(error) = input_result {
+            self.mark_disconnected(&error);
+            return Err(error);
+        }
+        let flush_result = run_timeout(
+            self.options.io_timeout,
+            flush_live(self.live.as_mut().expect("connected")),
+        )
+        .await;
+        if let Err(error) = flush_result {
+            self.mark_disconnected(&error);
+            return Err(error);
+        }
+        let now = Instant::now();
+        let live = self.live.as_mut().expect("connected");
+        if let Some(timeout) = self.options.heartbeat_timeout
+            && now.duration_since(live.last_input) >= timeout
+        {
+            let error = timed_out("exclusive DEALER heartbeat timeout");
+            self.mark_disconnected(&error);
+            return Err(error);
+        }
+        if let Some(interval) = self.options.heartbeat_interval
+            && now.duration_since(live.last_ping) >= interval
+        {
+            live.ping_sequence = live.ping_sequence.wrapping_add(1);
+            let context = Bytes::copy_from_slice(&live.ping_sequence.to_le_bytes());
+            live.connection.send_command(&Command::Ping {
+                ttl_deciseconds: 0,
+                context,
+            })?;
+            let result = run_timeout(self.options.io_timeout, flush_live(live)).await;
+            if let Err(error) = result {
+                self.mark_disconnected(&error);
+                return Err(error);
+            }
+            live.last_ping = now;
+        }
+        Ok(())
+    }
+
+    pub async fn reconnect_now(&mut self) -> Result<()> {
+        self.live = None;
+        self.retry_at = None;
+        self.establish().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.closed = true;
+        self.retry_at = None;
+        if let Some(mut live) = self.live.take() {
+            live.stream.shutdown().await?;
+        }
+        let _ = self.monitor.send(ExclusiveEvent::Closed);
+        Ok(())
+    }
+
+    async fn ensure_connected(&mut self) -> Result<()> {
+        if self.closed {
             return Err(Error::Closed);
         }
-        self.connection.handle_input(self.read_buf.split().freeze())
+        if self.live.is_some() {
+            return Ok(());
+        }
+        if matches!(self.options.reconnect, ReconnectPolicy::Disabled) {
+            return Err(Error::Closed);
+        }
+        if let Some(retry_at) = self.retry_at {
+            tokio::time::sleep_until(retry_at.into()).await;
+        }
+        self.establish().await
     }
 
-    async fn flush_connection(&mut self) -> Result<()> {
-        while self.connection.has_pending_transmit() {
-            let chunks = self.connection.transmit_chunks_capped(64);
-            let n = self.stream.write_vectored(&chunks).await?;
-            drop(chunks);
-            if n == 0 {
-                return Err(Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::WriteZero,
-                    "exclusive DEALER write returned zero",
-                )));
+    async fn establish(&mut self) -> Result<()> {
+        let result = establish_live(
+            &self.address,
+            self.identity.clone(),
+            self.options.connect_timeout,
+            self.options.handshake_timeout,
+        )
+        .await;
+        match result {
+            Ok(live) => {
+                self.live = Some(live);
+                self.reconnect_attempt = 0;
+                self.retry_at = None;
+                let _ = self.monitor.send(ExclusiveEvent::Connected);
+                let _ = self.monitor.send(ExclusiveEvent::HandshakeSucceeded);
+                Ok(())
             }
-            self.connection.advance_transmit(n);
+            Err(error) => {
+                self.schedule_reconnect();
+                Err(error)
+            }
         }
-        Ok(())
     }
+
+    fn mark_disconnected(&mut self, error: &Error) {
+        if self.live.take().is_some() {
+            let _ = self.monitor.send(ExclusiveEvent::Disconnected {
+                reason: error.to_string(),
+            });
+        }
+        self.schedule_reconnect();
+    }
+
+    fn schedule_reconnect(&mut self) {
+        let Some(delay) = reconnect_delay(self.options.reconnect, self.reconnect_attempt) else {
+            self.retry_at = None;
+            return;
+        };
+        self.reconnect_attempt = self.reconnect_attempt.saturating_add(1);
+        self.retry_at = Some(Instant::now() + delay);
+        let _ = self.monitor.send(ExclusiveEvent::ReconnectDelayed {
+            retry_in: delay,
+            attempt: self.reconnect_attempt,
+        });
+    }
+}
+
+fn reconnect_delay(policy: ReconnectPolicy, attempt: u32) -> Option<Duration> {
+    match policy {
+        ReconnectPolicy::Fixed(delay) => Some(delay),
+        ReconnectPolicy::Exponential { min, max } => {
+            let multiplier = 1_u32.checked_shl(attempt.min(31)).unwrap_or(u32::MAX);
+            Some(min.saturating_mul(multiplier).min(max))
+        }
+        _ => None,
+    }
+}
+
+async fn establish_live(
+    address: &str,
+    identity: Bytes,
+    connect_timeout: Duration,
+    handshake_timeout: Duration,
+) -> Result<LiveConnection> {
+    let stream = tokio::time::timeout(connect_timeout, TcpStream::connect(address))
+        .await
+        .map_err(|_| timed_out("exclusive DEALER connect timeout"))??;
+    stream.set_nodelay(true)?;
+    let connection =
+        Connection::new(ConnectionConfig::new(Role::Client, SocketType::Dealer).identity(identity));
+    let now = Instant::now();
+    let mut live = LiveConnection {
+        stream,
+        connection,
+        read_buf: BytesMut::with_capacity(4 * 1024),
+        write_buf: BytesMut::with_capacity(4 * 1024),
+        last_input: now,
+        last_ping: now,
+        ping_sequence: 0,
+    };
+    tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
+        .await
+        .map_err(|_| timed_out("exclusive DEALER handshake timeout"))??;
+    Ok(live)
+}
+
+async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
+    while !live.connection.is_ready() {
+        flush_live(live).await?;
+        if live.connection.is_ready() {
+            break;
+        }
+        read_live_once(live).await?;
+        while let Some(event) = live.connection.poll_event() {
+            if let Event::HandshakeSucceeded { .. } = event {
+                break;
+            }
+        }
+    }
+    flush_live(live).await
+}
+
+async fn recv_live(live: &mut LiveConnection) -> Result<Message> {
+    loop {
+        if let Some(message) = live.connection.poll_message() {
+            return Ok(message);
+        }
+        read_live_once(live).await?;
+        flush_live(live).await?;
+    }
+}
+
+async fn read_live_once(live: &mut LiveConnection) -> Result<()> {
+    let n = live.stream.read_buf(&mut live.read_buf).await?;
+    if n == 0 {
+        return Err(Error::Closed);
+    }
+    live.last_input = Instant::now();
+    live.connection.handle_input(live.read_buf.split().freeze())
+}
+
+fn drain_ready_input(live: &mut LiveConnection) -> Result<()> {
+    loop {
+        match live.stream.try_read_buf(&mut live.read_buf) {
+            Ok(0) => return Err(Error::Closed),
+            Ok(_) => {
+                live.last_input = Instant::now();
+                live.connection
+                    .handle_input(live.read_buf.split().freeze())?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) => return Err(Error::Io(error)),
+        }
+    }
+}
+
+async fn flush_live(live: &mut LiveConnection) -> Result<()> {
+    while live.connection.has_pending_transmit() {
+        let chunks = live.connection.transmit_chunks_capped(64);
+        let n = live.stream.write_vectored(&chunks).await?;
+        drop(chunks);
+        if n == 0 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "exclusive DEALER write returned zero",
+            )));
+        }
+        live.connection.advance_transmit(n);
+    }
+    Ok(())
+}
+
+async fn run_timeout<T>(
+    timeout: Option<Duration>,
+    future: impl Future<Output = Result<T>>,
+) -> Result<T> {
+    match timeout {
+        Some(timeout) => tokio::time::timeout(timeout, future)
+            .await
+            .map_err(|_| timed_out("exclusive DEALER I/O timeout"))?,
+        None => future.await,
+    }
+}
+
+fn timed_out(message: &'static str) -> Error {
+    Error::Io(io::Error::new(io::ErrorKind::TimedOut, message))
 }
 
 #[cfg(test)]
@@ -106,33 +396,79 @@ mod tests {
     use super::*;
     use crate::{Endpoint, Options, Socket};
 
-    #[tokio::test]
-    async fn dealer_round_trips_with_standard_router() {
+    async fn router() -> (Socket, String) {
         let router = Socket::new(SocketType::Router, Options::default());
         let bound = router
             .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
             .await
             .unwrap();
         let Endpoint::Tcp { host, port } = bound else {
-            panic!("expected TCP endpoint")
+            panic!()
         };
+        (router, format!("{host}:{port}"))
+    }
+
+    #[tokio::test]
+    async fn dealer_round_trips_with_standard_router() {
+        let (router, address) = router().await;
         let server = tokio::spawn(async move {
             for _ in 0..100 {
                 let message = router.recv().await.unwrap();
                 router.send(message).await.unwrap();
             }
         });
-        let mut dealer = ExclusiveDealer::connect(
-            format!("{host}:{port}"),
-            Bytes::from_static(b"exclusive-test"),
-        )
-        .await
-        .unwrap();
+        let mut dealer = ExclusiveDealer::connect(address, Bytes::from_static(b"exclusive-test"))
+            .await
+            .unwrap();
         for sequence in 0_u64..100 {
             let message = Message::single(Bytes::copy_from_slice(&sequence.to_le_bytes()));
             dealer.send(&message).await.unwrap();
             assert_eq!(dealer.recv().await.unwrap(), message);
         }
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconnect_preserves_identity_and_reports_events() {
+        let (router1, address) = router().await;
+        let mut dealer = ExclusiveDealer::connect_with_options(
+            address.clone(),
+            Bytes::from_static(b"stable-id"),
+            ExclusiveDealerOptions {
+                reconnect: ReconnectPolicy::Fixed(Duration::from_millis(1)),
+                io_timeout: Some(Duration::from_millis(100)),
+                ..ExclusiveDealerOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut monitor = dealer.monitor();
+        drop(router1);
+        assert!(dealer.recv().await.is_err());
+        let (router2, rebound) = router().await;
+        // A new ephemeral port is expected; exercise explicit reconnect state
+        // here, while restart-on-the-same-address is covered by the Wine test.
+        dealer.address = rebound;
+        dealer.reconnect_now().await.unwrap();
+        let server = tokio::spawn(async move {
+            let message = router2.recv().await.unwrap();
+            assert_eq!(message.part_bytes(0).unwrap().as_ref(), b"stable-id");
+            router2.send(message).await.unwrap();
+        });
+        let message = Message::single(Bytes::from_static(b"after-reconnect"));
+        dealer.send(&message).await.unwrap();
+        assert_eq!(dealer.recv().await.unwrap(), message);
+        server.await.unwrap();
+        let events: Vec<_> = std::iter::from_fn(|| monitor.try_recv().ok()).collect();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ExclusiveEvent::Disconnected { .. }))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ExclusiveEvent::HandshakeSucceeded))
+        );
     }
 }

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -33,7 +33,9 @@ pub struct Options {
     pub heartbeat_interval: Option<Duration>,
     /// TTL announced to the peer in outbound PING commands.
     pub heartbeat_ttl: Option<Duration>,
-    /// Disconnect when no inbound traffic arrives within this duration.
+    /// Time allowed for peer activity after an outbound heartbeat PING.
+    ///
+    /// Defaults to `heartbeat_interval` when heartbeats are enabled.
     pub heartbeat_timeout: Option<Duration>,
 }
 
@@ -108,8 +110,8 @@ struct LiveConnection {
     connection: Connection,
     read_buf: BytesMut,
     write_buf: BytesMut,
-    last_input: Instant,
     last_ping: Instant,
+    heartbeat_deadline: Option<Instant>,
     ping_sequence: u64,
 }
 
@@ -193,7 +195,7 @@ impl Socket {
         self.ensure_connected().await?;
         let io_timeout = self.options.io_timeout;
         let heartbeat_interval = self.options.heartbeat_interval;
-        let heartbeat_timeout = self.options.heartbeat_timeout;
+        let heartbeat_timeout = effective_heartbeat_timeout(&self.options);
         let heartbeat_ttl = heartbeat_ttl_deciseconds(self.options.heartbeat_ttl);
         let result = run_timeout(
             io_timeout,
@@ -218,7 +220,9 @@ impl Socket {
     /// sockets never run a background task.
     pub async fn maintain(&mut self) -> Result<()> {
         self.ensure_connected().await?;
-        let input_result = drain_ready_input(self.live.as_mut().expect("connected"));
+        let heartbeat_timeout = effective_heartbeat_timeout(&self.options);
+        let input_result =
+            drain_ready_input(self.live.as_mut().expect("connected"), heartbeat_timeout);
         if let Err(error) = input_result {
             self.mark_disconnected(&error);
             return Err(error);
@@ -234,8 +238,9 @@ impl Socket {
         }
         let now = Instant::now();
         let live = self.live.as_mut().expect("connected");
-        if let Some(timeout) = self.options.heartbeat_timeout
-            && now.duration_since(live.last_input) >= timeout
+        if live
+            .heartbeat_deadline
+            .is_some_and(|deadline| now >= deadline)
         {
             let error = Error::Timeout;
             self.mark_disconnected(&error);
@@ -247,6 +252,7 @@ impl Socket {
             queue_ping(
                 live,
                 heartbeat_ttl_deciseconds(self.options.heartbeat_ttl),
+                heartbeat_timeout.expect("heartbeat interval supplies timeout"),
                 now,
             )?;
             let result = run_timeout(self.options.io_timeout, flush_live(live)).await;
@@ -402,8 +408,8 @@ async fn establish_live(
         connection,
         read_buf: BytesMut::with_capacity(4 * 1024),
         write_buf: BytesMut::with_capacity(4 * 1024),
-        last_input: now,
         last_ping: now,
+        heartbeat_deadline: None,
         ping_sequence: 0,
     };
     tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
@@ -418,7 +424,7 @@ async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
         if live.connection.is_ready() {
             break;
         }
-        read_live_once(live).await?;
+        read_live_once(live, None).await?;
         while let Some(event) = live.connection.poll_event() {
             if let ProtoEvent::HandshakeSucceeded { .. } = event {
                 break;
@@ -440,19 +446,24 @@ async fn recv_live(
         }
 
         let ping_deadline = heartbeat_interval.map(|interval| live.last_ping + interval);
-        let idle_deadline = heartbeat_timeout.map(|timeout| live.last_input + timeout);
+        let heartbeat_deadline = live.heartbeat_deadline;
         tokio::select! {
             biased;
-            result = read_live_once(live) => {
+            result = read_live_once(live, heartbeat_timeout) => {
                 result?;
                 flush_live(live).await?;
             }
-            () = sleep_until(idle_deadline), if idle_deadline.is_some() => {
+            () = sleep_until(heartbeat_deadline), if heartbeat_deadline.is_some() => {
                 return Err(Error::Timeout);
             }
             () = sleep_until(ping_deadline), if ping_deadline.is_some() => {
                 let now = Instant::now();
-                queue_ping(live, heartbeat_ttl_deciseconds, now)?;
+                queue_ping(
+                    live,
+                    heartbeat_ttl_deciseconds,
+                    heartbeat_timeout.expect("heartbeat interval supplies timeout"),
+                    now,
+                )?;
                 flush_live(live).await?;
             }
         }
@@ -471,7 +482,18 @@ fn heartbeat_ttl_deciseconds(ttl: Option<Duration>) -> u16 {
         .unwrap_or(0)
 }
 
-fn queue_ping(live: &mut LiveConnection, ttl_deciseconds: u16, now: Instant) -> Result<()> {
+fn effective_heartbeat_timeout(options: &Options) -> Option<Duration> {
+    options
+        .heartbeat_interval
+        .map(|interval| options.heartbeat_timeout.unwrap_or(interval))
+}
+
+fn queue_ping(
+    live: &mut LiveConnection,
+    ttl_deciseconds: u16,
+    heartbeat_timeout: Duration,
+    now: Instant,
+) -> Result<()> {
     live.ping_sequence = live.ping_sequence.wrapping_add(1);
     let context = Bytes::copy_from_slice(&live.ping_sequence.to_le_bytes());
     live.connection.send_command(&Command::Ping {
@@ -479,24 +501,37 @@ fn queue_ping(live: &mut LiveConnection, ttl_deciseconds: u16, now: Instant) -> 
         context,
     })?;
     live.last_ping = now;
+    if live.heartbeat_deadline.is_none() {
+        live.heartbeat_deadline = now.checked_add(heartbeat_timeout);
+    }
     Ok(())
 }
 
-async fn read_live_once(live: &mut LiveConnection) -> Result<()> {
+fn note_inbound_traffic(live: &mut LiveConnection, heartbeat_timeout: Option<Duration>) {
+    if live.heartbeat_deadline.is_some() {
+        live.heartbeat_deadline =
+            heartbeat_timeout.and_then(|timeout| Instant::now().checked_add(timeout));
+    }
+}
+
+async fn read_live_once(
+    live: &mut LiveConnection,
+    heartbeat_timeout: Option<Duration>,
+) -> Result<()> {
     let n = live.stream.read_buf(&mut live.read_buf).await?;
     if n == 0 {
         return Err(Error::Closed);
     }
-    live.last_input = Instant::now();
+    note_inbound_traffic(live, heartbeat_timeout);
     live.connection.handle_input(live.read_buf.split().freeze())
 }
 
-fn drain_ready_input(live: &mut LiveConnection) -> Result<()> {
+fn drain_ready_input(live: &mut LiveConnection, heartbeat_timeout: Option<Duration>) -> Result<()> {
     loop {
         match live.stream.try_read_buf(&mut live.read_buf) {
             Ok(0) => return Err(Error::Closed),
             Ok(_) => {
-                live.last_input = Instant::now();
+                note_inbound_traffic(live, heartbeat_timeout);
                 live.connection
                     .handle_input(live.read_buf.split().freeze())?;
             }
@@ -542,6 +577,7 @@ fn timed_out(message: &'static str) -> Error {
 mod tests {
     use super::*;
     use crate::{Options as RegularOptions, Socket as RegularSocket};
+    use tokio::net::TcpListener;
 
     async fn router() -> (RegularSocket, Endpoint) {
         let router = RegularSocket::new(SocketType::Router, RegularOptions::default());
@@ -550,6 +586,32 @@ mod tests {
             .await
             .unwrap();
         (router, bound)
+    }
+
+    async fn unresponsive_router() -> (Endpoint, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint: Endpoint = format!("tcp://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let now = Instant::now();
+            let mut live = LiveConnection {
+                stream,
+                connection: Connection::new(ConnectionConfig::new(
+                    Role::Server,
+                    SocketType::Router,
+                )),
+                read_buf: BytesMut::with_capacity(4 * 1024),
+                write_buf: BytesMut::with_capacity(4 * 1024),
+                last_ping: now,
+                heartbeat_deadline: None,
+                ping_sequence: 0,
+            };
+            finish_handshake(&mut live).await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+        (endpoint, server)
     }
 
     #[tokio::test]
@@ -651,29 +713,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recv_enforces_idle_timeout_without_maintenance() {
-        let (router, endpoint) = router().await;
-        let server = tokio::spawn(async move {
-            let _message = router.recv().await.unwrap();
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        });
+    async fn recv_does_not_time_out_before_first_ping() {
+        let (endpoint, server) = unresponsive_router().await;
         let mut socket = Socket::connect(
             SocketType::Dealer,
             endpoint,
             Options {
+                heartbeat_interval: Some(Duration::from_millis(100)),
                 heartbeat_timeout: Some(Duration::from_millis(20)),
                 ..Options::default()
             },
         )
         .await
         .unwrap();
-        socket
-            .send(&Message::single(Bytes::from_static(b"timeout")))
-            .await
-            .unwrap();
-        assert!(matches!(socket.recv().await, Err(Error::Timeout)));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), socket.recv())
+                .await
+                .is_err()
+        );
+        assert!(socket.is_connected());
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(150), socket.recv()).await,
+            Ok(Err(Error::Timeout))
+        ));
         assert!(!socket.is_connected());
-        server.await.unwrap();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn heartbeat_timeout_defaults_to_interval() {
+        let (endpoint, server) = unresponsive_router().await;
+        let mut socket = Socket::connect(
+            SocketType::Dealer,
+            endpoint,
+            Options {
+                heartbeat_interval: Some(Duration::from_millis(20)),
+                ..Options::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(200), socket.recv()).await,
+            Ok(Err(Error::Timeout))
+        ));
+        assert!(!socket.is_connected());
+        server.abort();
     }
 
     #[tokio::test]

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -7,42 +7,94 @@ use std::io;
 use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
+use omq_proto::endpoint::Host;
 use omq_proto::proto::command::Command;
-use omq_proto::proto::{Connection, ConnectionConfig, Event, Role};
+use omq_proto::proto::{Connection, ConnectionConfig, Event as ProtoEvent, Role};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
 
-use crate::{Error, Message, ReconnectPolicy, Result, SocketType};
+use crate::{Endpoint, Error, Message, ReconnectPolicy, Result, SocketType};
 
-/// Reliability settings for [`ExclusiveDealer`].
-#[derive(Clone, Copy, Debug)]
-pub struct ExclusiveDealerOptions {
+/// Configuration for a caller-driven [`Socket`].
+#[derive(Clone, Debug)]
+pub struct Options {
+    /// ZMTP routing identity presented to the peer.
+    pub identity: Bytes,
+    /// Maximum time allowed to establish the TCP connection.
     pub connect_timeout: Duration,
+    /// Maximum time allowed to complete the ZMTP handshake.
     pub handshake_timeout: Duration,
+    /// Optional deadline for each `send`, `recv`, or maintenance write.
     pub io_timeout: Option<Duration>,
+    /// Reconnection policy applied by the next operation after a disconnect.
     pub reconnect: ReconnectPolicy,
+    /// Interval between outbound ZMTP PING commands.
     pub heartbeat_interval: Option<Duration>,
+    /// TTL announced to the peer in outbound PING commands.
+    pub heartbeat_ttl: Option<Duration>,
+    /// Disconnect when no inbound traffic arrives within this duration.
     pub heartbeat_timeout: Option<Duration>,
 }
 
-impl Default for ExclusiveDealerOptions {
+impl Default for Options {
     fn default() -> Self {
         Self {
+            identity: Bytes::new(),
             connect_timeout: Duration::from_secs(5),
             handshake_timeout: Duration::from_secs(5),
             io_timeout: None,
             reconnect: ReconnectPolicy::default(),
             heartbeat_interval: None,
+            heartbeat_ttl: None,
             heartbeat_timeout: None,
         }
+    }
+}
+
+impl Options {
+    fn validate(&self) -> Result<()> {
+        if self.identity.len() > 255 {
+            return Err(Error::Config(format!(
+                "exclusive socket identity length {} exceeds ZMTP limit of 255",
+                self.identity.len()
+            )));
+        }
+        if self.connect_timeout.is_zero() {
+            return Err(Error::Config(
+                "exclusive socket connect_timeout must be non-zero".into(),
+            ));
+        }
+        if self.handshake_timeout.is_zero() {
+            return Err(Error::Config(
+                "exclusive socket handshake_timeout must be non-zero".into(),
+            ));
+        }
+        if self.heartbeat_interval.is_some_and(|value| value.is_zero()) {
+            return Err(Error::Config(
+                "exclusive socket heartbeat_interval must be non-zero".into(),
+            ));
+        }
+        if self.heartbeat_timeout.is_some_and(|value| value.is_zero()) {
+            return Err(Error::Config(
+                "exclusive socket heartbeat_timeout must be non-zero".into(),
+            ));
+        }
+        if let Some(ttl) = self.heartbeat_ttl
+            && ttl > Duration::from_millis(6_553_500)
+        {
+            return Err(Error::Config(format!(
+                "exclusive socket heartbeat_ttl {ttl:?} exceeds ZMTP maximum of 6553.5s"
+            )));
+        }
+        Ok(())
     }
 }
 
 /// Lifecycle event for an exclusive socket.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub enum ExclusiveEvent {
+pub enum Event {
     Connected,
     HandshakeSucceeded,
     Disconnected { reason: String },
@@ -61,37 +113,39 @@ struct LiveConnection {
     ping_sequence: u64,
 }
 
-/// A single-peer DEALER whose caller owns the TCP data path.
+/// A single-peer socket whose caller owns the TCP data path.
+///
+/// The initial implementation supports only a connected TCP DEALER using the
+/// NULL mechanism. Unsupported socket types and transports return a
+/// configuration error.
 ///
 /// A failed `send` is never retried automatically: the peer may have received
 /// a partial or complete command. The next operation may restore the
 /// connection, but the application decides whether a command is safe to retry.
 #[derive(Debug)]
-pub struct ExclusiveDealer {
-    address: String,
-    identity: Bytes,
-    options: ExclusiveDealerOptions,
+pub struct Socket {
+    kind: SocketType,
+    endpoint: Endpoint,
+    options: Options,
     live: Option<LiveConnection>,
-    monitor: broadcast::Sender<ExclusiveEvent>,
+    monitor: broadcast::Sender<Event>,
     reconnect_attempt: u32,
     retry_at: Option<Instant>,
     closed: bool,
 }
 
-impl ExclusiveDealer {
-    pub async fn connect(address: impl Into<String>, identity: Bytes) -> Result<Self> {
-        Self::connect_with_options(address, identity, ExclusiveDealerOptions::default()).await
-    }
-
-    pub async fn connect_with_options(
-        address: impl Into<String>,
-        identity: Bytes,
-        options: ExclusiveDealerOptions,
+impl Socket {
+    /// Connect a caller-driven socket.
+    pub async fn connect(
+        socket_type: SocketType,
+        endpoint: Endpoint,
+        options: Options,
     ) -> Result<Self> {
+        validate_mode(socket_type, &endpoint, &options)?;
         let (monitor, _) = broadcast::channel(1024);
-        let mut dealer = Self {
-            address: address.into(),
-            identity,
+        let mut socket = Self {
+            kind: socket_type,
+            endpoint,
             options,
             live: None,
             monitor,
@@ -99,11 +153,11 @@ impl ExclusiveDealer {
             retry_at: None,
             closed: false,
         };
-        dealer.establish().await?;
-        Ok(dealer)
+        socket.establish().await?;
+        Ok(socket)
     }
 
-    pub fn monitor(&self) -> broadcast::Receiver<ExclusiveEvent> {
+    pub fn monitor(&self) -> broadcast::Receiver<Event> {
         self.monitor.subscribe()
     }
 
@@ -137,16 +191,31 @@ impl ExclusiveDealer {
     /// current peer; a later operation attempts reconnection.
     pub async fn recv(&mut self) -> Result<Message> {
         self.ensure_connected().await?;
-        let timeout = self.options.io_timeout;
-        let result = run_timeout(timeout, recv_live(self.live.as_mut().expect("connected"))).await;
+        let io_timeout = self.options.io_timeout;
+        let heartbeat_interval = self.options.heartbeat_interval;
+        let heartbeat_timeout = self.options.heartbeat_timeout;
+        let heartbeat_ttl = heartbeat_ttl_deciseconds(self.options.heartbeat_ttl);
+        let result = run_timeout(
+            io_timeout,
+            recv_live(
+                self.live.as_mut().expect("connected"),
+                heartbeat_interval,
+                heartbeat_timeout,
+                heartbeat_ttl,
+            ),
+        )
+        .await;
         if let Err(error) = &result {
             self.mark_disconnected(error);
         }
         result
     }
 
-    /// Drive heartbeat and reconnect work. Call this from the bridge timer
-    /// when no data operation is active; it never runs a background data task.
+    /// Drive heartbeat and reconnect work when no data operation is active.
+    ///
+    /// `recv` drives heartbeat timers while it waits. An otherwise idle
+    /// application must call this method from its own timer because exclusive
+    /// sockets never run a background task.
     pub async fn maintain(&mut self) -> Result<()> {
         self.ensure_connected().await?;
         let input_result = drain_ready_input(self.live.as_mut().expect("connected"));
@@ -168,30 +237,31 @@ impl ExclusiveDealer {
         if let Some(timeout) = self.options.heartbeat_timeout
             && now.duration_since(live.last_input) >= timeout
         {
-            let error = timed_out("exclusive DEALER heartbeat timeout");
+            let error = Error::Timeout;
             self.mark_disconnected(&error);
             return Err(error);
         }
         if let Some(interval) = self.options.heartbeat_interval
             && now.duration_since(live.last_ping) >= interval
         {
-            live.ping_sequence = live.ping_sequence.wrapping_add(1);
-            let context = Bytes::copy_from_slice(&live.ping_sequence.to_le_bytes());
-            live.connection.send_command(&Command::Ping {
-                ttl_deciseconds: 0,
-                context,
-            })?;
+            queue_ping(
+                live,
+                heartbeat_ttl_deciseconds(self.options.heartbeat_ttl),
+                now,
+            )?;
             let result = run_timeout(self.options.io_timeout, flush_live(live)).await;
             if let Err(error) = result {
                 self.mark_disconnected(&error);
                 return Err(error);
             }
-            live.last_ping = now;
         }
         Ok(())
     }
 
     pub async fn reconnect_now(&mut self) -> Result<()> {
+        if self.closed {
+            return Err(Error::Closed);
+        }
         self.live = None;
         self.retry_at = None;
         self.establish().await
@@ -203,7 +273,7 @@ impl ExclusiveDealer {
         if let Some(mut live) = self.live.take() {
             live.stream.shutdown().await?;
         }
-        let _ = self.monitor.send(ExclusiveEvent::Closed);
+        let _ = self.monitor.send(Event::Closed);
         Ok(())
     }
 
@@ -225,8 +295,9 @@ impl ExclusiveDealer {
 
     async fn establish(&mut self) -> Result<()> {
         let result = establish_live(
-            &self.address,
-            self.identity.clone(),
+            self.kind,
+            &self.endpoint,
+            self.options.identity.clone(),
             self.options.connect_timeout,
             self.options.handshake_timeout,
         )
@@ -236,8 +307,8 @@ impl ExclusiveDealer {
                 self.live = Some(live);
                 self.reconnect_attempt = 0;
                 self.retry_at = None;
-                let _ = self.monitor.send(ExclusiveEvent::Connected);
-                let _ = self.monitor.send(ExclusiveEvent::HandshakeSucceeded);
+                let _ = self.monitor.send(Event::Connected);
+                let _ = self.monitor.send(Event::HandshakeSucceeded);
                 Ok(())
             }
             Err(error) => {
@@ -249,7 +320,7 @@ impl ExclusiveDealer {
 
     fn mark_disconnected(&mut self, error: &Error) {
         if self.live.take().is_some() {
-            let _ = self.monitor.send(ExclusiveEvent::Disconnected {
+            let _ = self.monitor.send(Event::Disconnected {
                 reason: error.to_string(),
             });
         }
@@ -263,7 +334,7 @@ impl ExclusiveDealer {
         };
         self.reconnect_attempt = self.reconnect_attempt.saturating_add(1);
         self.retry_at = Some(Instant::now() + delay);
-        let _ = self.monitor.send(ExclusiveEvent::ReconnectDelayed {
+        let _ = self.monitor.send(Event::ReconnectDelayed {
             retry_in: delay,
             attempt: self.reconnect_attempt,
         });
@@ -281,18 +352,50 @@ fn reconnect_delay(policy: ReconnectPolicy, attempt: u32) -> Option<Duration> {
     }
 }
 
+fn validate_mode(socket_type: SocketType, endpoint: &Endpoint, options: &Options) -> Result<()> {
+    if socket_type != SocketType::Dealer {
+        return Err(Error::Config(format!(
+            "exclusive sockets currently support only DEALER, not {socket_type:?}"
+        )));
+    }
+    match endpoint {
+        Endpoint::Tcp {
+            host: Host::Wildcard,
+            ..
+        } => {
+            return Err(Error::Config(
+                "exclusive sockets cannot connect to a wildcard TCP host".into(),
+            ));
+        }
+        Endpoint::Tcp { .. } => {}
+        _ => {
+            return Err(Error::Config(format!(
+                "exclusive sockets currently support only tcp:// endpoints, not {endpoint}"
+            )));
+        }
+    }
+    options.validate()
+}
+
 async fn establish_live(
-    address: &str,
+    socket_type: SocketType,
+    endpoint: &Endpoint,
     identity: Bytes,
     connect_timeout: Duration,
     handshake_timeout: Duration,
 ) -> Result<LiveConnection> {
-    let stream = tokio::time::timeout(connect_timeout, TcpStream::connect(address))
+    let Endpoint::Tcp { host, port } = endpoint else {
+        return Err(Error::Config(
+            "exclusive sockets currently support only tcp:// endpoints".into(),
+        ));
+    };
+    let host = host.to_string();
+    let stream = tokio::time::timeout(connect_timeout, TcpStream::connect((host.as_str(), *port)))
         .await
-        .map_err(|_| timed_out("exclusive DEALER connect timeout"))??;
+        .map_err(|_| timed_out("exclusive socket connect timeout"))??;
     stream.set_nodelay(true)?;
     let connection =
-        Connection::new(ConnectionConfig::new(Role::Client, SocketType::Dealer).identity(identity));
+        Connection::new(ConnectionConfig::new(Role::Client, socket_type).identity(identity));
     let now = Instant::now();
     let mut live = LiveConnection {
         stream,
@@ -305,7 +408,7 @@ async fn establish_live(
     };
     tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
         .await
-        .map_err(|_| timed_out("exclusive DEALER handshake timeout"))??;
+        .map_err(|_| timed_out("exclusive socket handshake timeout"))??;
     Ok(live)
 }
 
@@ -317,7 +420,7 @@ async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
         }
         read_live_once(live).await?;
         while let Some(event) = live.connection.poll_event() {
-            if let Event::HandshakeSucceeded { .. } = event {
+            if let ProtoEvent::HandshakeSucceeded { .. } = event {
                 break;
             }
         }
@@ -325,14 +428,58 @@ async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
     flush_live(live).await
 }
 
-async fn recv_live(live: &mut LiveConnection) -> Result<Message> {
+async fn recv_live(
+    live: &mut LiveConnection,
+    heartbeat_interval: Option<Duration>,
+    heartbeat_timeout: Option<Duration>,
+    heartbeat_ttl_deciseconds: u16,
+) -> Result<Message> {
     loop {
         if let Some(message) = live.connection.poll_message() {
             return Ok(message);
         }
-        read_live_once(live).await?;
-        flush_live(live).await?;
+
+        let ping_deadline = heartbeat_interval.map(|interval| live.last_ping + interval);
+        let idle_deadline = heartbeat_timeout.map(|timeout| live.last_input + timeout);
+        tokio::select! {
+            biased;
+            result = read_live_once(live) => {
+                result?;
+                flush_live(live).await?;
+            }
+            () = sleep_until(idle_deadline), if idle_deadline.is_some() => {
+                return Err(Error::Timeout);
+            }
+            () = sleep_until(ping_deadline), if ping_deadline.is_some() => {
+                let now = Instant::now();
+                queue_ping(live, heartbeat_ttl_deciseconds, now)?;
+                flush_live(live).await?;
+            }
+        }
     }
+}
+
+async fn sleep_until(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
+
+fn heartbeat_ttl_deciseconds(ttl: Option<Duration>) -> u16 {
+    ttl.and_then(|duration| u16::try_from(duration.as_millis() / 100).ok())
+        .unwrap_or(0)
+}
+
+fn queue_ping(live: &mut LiveConnection, ttl_deciseconds: u16, now: Instant) -> Result<()> {
+    live.ping_sequence = live.ping_sequence.wrapping_add(1);
+    let context = Bytes::copy_from_slice(&live.ping_sequence.to_le_bytes());
+    live.connection.send_command(&Command::Ping {
+        ttl_deciseconds,
+        context,
+    })?;
+    live.last_ping = now;
+    Ok(())
 }
 
 async fn read_live_once(live: &mut LiveConnection) -> Result<()> {
@@ -367,7 +514,7 @@ async fn flush_live(live: &mut LiveConnection) -> Result<()> {
         if n == 0 {
             return Err(Error::Io(io::Error::new(
                 io::ErrorKind::WriteZero,
-                "exclusive DEALER write returned zero",
+                "exclusive socket write returned zero",
             )));
         }
         live.connection.advance_transmit(n);
@@ -382,7 +529,7 @@ async fn run_timeout<T>(
     match timeout {
         Some(timeout) => tokio::time::timeout(timeout, future)
             .await
-            .map_err(|_| timed_out("exclusive DEALER I/O timeout"))?,
+            .map_err(|_| timed_out("exclusive socket I/O timeout"))?,
         None => future.await,
     }
 }
@@ -394,82 +541,153 @@ fn timed_out(message: &'static str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Endpoint, Options, Socket};
+    use crate::{Options as RegularOptions, Socket as RegularSocket};
 
-    async fn router() -> (Socket, String) {
-        let router = Socket::new(SocketType::Router, Options::default());
+    async fn router() -> (RegularSocket, Endpoint) {
+        let router = RegularSocket::new(SocketType::Router, RegularOptions::default());
         let bound = router
             .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
             .await
             .unwrap();
-        let Endpoint::Tcp { host, port } = bound else {
-            panic!()
-        };
-        (router, format!("{host}:{port}"))
+        (router, bound)
     }
 
     #[tokio::test]
     async fn dealer_round_trips_with_standard_router() {
-        let (router, address) = router().await;
+        let (router, endpoint) = router().await;
         let server = tokio::spawn(async move {
             for _ in 0..100 {
                 let message = router.recv().await.unwrap();
                 router.send(message).await.unwrap();
             }
         });
-        let mut dealer = ExclusiveDealer::connect(address, Bytes::from_static(b"exclusive-test"))
-            .await
-            .unwrap();
+        let mut socket = Socket::connect(
+            SocketType::Dealer,
+            endpoint,
+            Options {
+                identity: Bytes::from_static(b"exclusive-test"),
+                ..Options::default()
+            },
+        )
+        .await
+        .unwrap();
         for sequence in 0_u64..100 {
             let message = Message::single(Bytes::copy_from_slice(&sequence.to_le_bytes()));
-            dealer.send(&message).await.unwrap();
-            assert_eq!(dealer.recv().await.unwrap(), message);
+            socket.send(&message).await.unwrap();
+            assert_eq!(socket.recv().await.unwrap(), message);
         }
         server.await.unwrap();
     }
 
     #[tokio::test]
     async fn reconnect_preserves_identity_and_reports_events() {
-        let (router1, address) = router().await;
-        let mut dealer = ExclusiveDealer::connect_with_options(
-            address.clone(),
-            Bytes::from_static(b"stable-id"),
-            ExclusiveDealerOptions {
+        let (router1, endpoint) = router().await;
+        let mut socket = Socket::connect(
+            SocketType::Dealer,
+            endpoint,
+            Options {
+                identity: Bytes::from_static(b"stable-id"),
                 reconnect: ReconnectPolicy::Fixed(Duration::from_millis(1)),
                 io_timeout: Some(Duration::from_millis(100)),
-                ..ExclusiveDealerOptions::default()
+                ..Options::default()
             },
         )
         .await
         .unwrap();
-        let mut monitor = dealer.monitor();
+        let mut monitor = socket.monitor();
         drop(router1);
-        assert!(dealer.recv().await.is_err());
+        assert!(socket.recv().await.is_err());
         let (router2, rebound) = router().await;
         // A new ephemeral port is expected; exercise explicit reconnect state
         // here. Restart-on-the-same-address is covered by the external Wine
         // reproduction procedure.
-        dealer.address = rebound;
-        dealer.reconnect_now().await.unwrap();
+        socket.endpoint = rebound;
+        socket.reconnect_now().await.unwrap();
         let server = tokio::spawn(async move {
             let message = router2.recv().await.unwrap();
             assert_eq!(message.part_bytes(0).unwrap().as_ref(), b"stable-id");
             router2.send(message).await.unwrap();
         });
         let message = Message::single(Bytes::from_static(b"after-reconnect"));
-        dealer.send(&message).await.unwrap();
-        assert_eq!(dealer.recv().await.unwrap(), message);
+        socket.send(&message).await.unwrap();
+        assert_eq!(socket.recv().await.unwrap(), message);
         server.await.unwrap();
         let events: Vec<_> = std::iter::from_fn(|| monitor.try_recv().ok()).collect();
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, ExclusiveEvent::Disconnected { .. }))
+                .any(|e| matches!(e, Event::Disconnected { .. }))
         );
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, ExclusiveEvent::HandshakeSucceeded))
+                .any(|e| matches!(e, Event::HandshakeSucceeded))
         );
+    }
+
+    #[tokio::test]
+    async fn recv_drives_heartbeat_while_waiting_for_reply() {
+        let (router, endpoint) = router().await;
+        let server = tokio::spawn(async move {
+            let message = router.recv().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            router.send(message).await.unwrap();
+        });
+        let mut socket = Socket::connect(
+            SocketType::Dealer,
+            endpoint,
+            Options {
+                heartbeat_interval: Some(Duration::from_millis(10)),
+                heartbeat_timeout: Some(Duration::from_millis(40)),
+                ..Options::default()
+            },
+        )
+        .await
+        .unwrap();
+        let message = Message::single(Bytes::from_static(b"heartbeat"));
+        socket.send(&message).await.unwrap();
+        assert_eq!(socket.recv().await.unwrap(), message);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn recv_enforces_idle_timeout_without_maintenance() {
+        let (router, endpoint) = router().await;
+        let server = tokio::spawn(async move {
+            let _message = router.recv().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+        let mut socket = Socket::connect(
+            SocketType::Dealer,
+            endpoint,
+            Options {
+                heartbeat_timeout: Some(Duration::from_millis(20)),
+                ..Options::default()
+            },
+        )
+        .await
+        .unwrap();
+        socket
+            .send(&Message::single(Bytes::from_static(b"timeout")))
+            .await
+            .unwrap();
+        assert!(matches!(socket.recv().await, Err(Error::Timeout)));
+        assert!(!socket.is_connected());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unsupported_modes_fail_before_connecting() {
+        let endpoint: Endpoint = "tcp://127.0.0.1:1".parse().unwrap();
+        let error = Socket::connect(SocketType::Pair, endpoint, Options::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Config(message) if message.contains("only DEALER")));
+
+        let endpoint: Endpoint = "inproc://exclusive".parse().unwrap();
+        let error = Socket::connect(SocketType::Dealer, endpoint, Options::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Config(message) if message.contains("only tcp://")));
     }
 }

--- a/omq-tokio/src/lib.rs
+++ b/omq-tokio/src/lib.rs
@@ -24,6 +24,7 @@ compile_error!("omq-tokio requires target_has_atomic = \"64\"");
 pub mod blocking;
 pub mod context;
 pub mod engine;
+pub mod exclusive;
 pub mod proxy;
 pub(crate) mod routing;
 pub mod socket;


### PR DESCRIPTION
## Summary

Add an opt-in `ExclusiveDealer` socket for latency-sensitive, single-peer workloads.

Unlike the existing cloneable `Socket`, `ExclusiveDealer` requires exclusive `&mut self` access and directly owns its TCP stream and ZMTP connection. This removes the connection-driver task and remaining userspace queue and wakeup handoffs from the data path, while preserving OMQ's protocol implementation and wire compatibility.

The regular `Socket` implementation and its behavior are unchanged.

This is a prototype/RFC. The public API and its eventual integration strategy are intentionally open for discussion. In particular, feedback is welcome on whether this should remain a narrowly scoped socket, become a caller-driven backend behind the existing API, or be pursued as further optimization of the regular latency profile.

## Motivation

OMQ's regular socket API supports concurrent cloned handles, multiple peers, routing, background reconnect, monitoring, and rich lifecycle behavior. Its latency profile already bypasses the socket actor on supported hot paths, but a connection-driver task and synchronization between the caller and driver remain.

For single-peer request/reply-style workloads, applications may already provide exclusive socket ownership and not need concurrent cloned handles. In this case, polling TCP and the sans-I/O ZMTP codec directly can substantially reduce scheduling overhead.

This is especially visible on platforms where reactor and task wakeups are more expensive. The API itself is platform-independent; the measurements below also include a native Linux control.

## Design

`ExclusiveDealer`:

- is opt-in and does not change the existing `Socket`;
- requires `&mut self` for send, receive, and maintenance;
- directly owns a Tokio `TcpStream` and `omq_proto::Connection`;
- supports a stable routing identity;
- supports connect, handshake, and I/O timeouts;
- supports fixed and exponential reconnect policies;
- exposes lifecycle monitor events;
- supports heartbeat maintenance and peer-idle timeout;
- never automatically replays a failed send;
- has no userspace outbound queue, preserving direct TCP backpressure.

A send failure is intentionally treated as ambiguous: the peer may have received some or all of the message. Reconnection restores the transport but leaves retry and idempotency decisions to the application.

## Results

Existing 80-byte DEALER/ROUTER sequential loopback measurements:

| Environment               | Regular OMQ p50 | `ExclusiveDealer` p50 |
| ------------------------- | --------------: | --------------------: |
| Linux                     |        10.97 us |                9.4 us |
| Windows binary under Wine |         76.2 us |          21.1-25.1 us |

Latest 100k Wine run:

- p50: 21.1 us
- p99: 66.3 us
- p99.9: 244.1 us

Four concurrent Wine clients completed two million total round trips:

- p50: 26.9-27.2 us
- p99: 92.6-95.9 us
- no lost exchanges

The exclusive client also completed 100k round trips against a PyZMQ ROUTER.

A gateway restart test confirmed reconnect and stable identity behavior. The client resumed exchanges after the server returned, without automatically replaying failed sends.

The self-contained Flatpak reproduction below provides an additional 64-byte A/B measurement. Across three alternating runs, regular OMQ measured 77.5-86.5 us p50 under Wine, while `ExclusiveDealer` measured 19.5-24.0 us. The corresponding native Linux control measured approximately 10-12 us for both paths.

## Validation

- standard OMQ ROUTER interoperability test;
- reconnect and stable identity test;
- PyZMQ ROUTER interoperability;
- four-client Wine benchmark;
- gateway stop/restart test;
- `cargo clippy -p omq-tokio --lib -- -D warnings`;
- Windows GNU cross-compilation with `cargo-zigbuild`;
- self-contained Windows GNU cross-build and Flatpak Wine A/B reproduction documented below.

## Limitations

The initial API intentionally supports one connected TCP DEALER using the NULL mechanism. It does not currently provide multi-peer routing, binding, IPC, CURVE/PLAIN, or concurrent cloned handles. Those workloads should continue to use the regular `Socket` API.

---

## Bottles/Flatpak Wine reproduction

This A/B benchmark compares the existing latency-profile `Socket` DEALER with the caller-driven `ExclusiveDealer`. Both clients use the same Windows binary, message sequence, and native Linux ROUTER echo server. The benchmark inputs, executable, Wine environment, server, and message sequence are held constant. The selected OMQ client implementation is the only benchmark parameter that changes.

### Build

Install the Rust Windows GNU target. The following downloads and extracts the MinGW-w64 linker under the ignored `target/` directory, without installing host packages:

```sh
rustup target add x86_64-pc-windows-gnu

mkdir -p target/mingw/packages target/mingw/root
cd target/mingw/packages
apt download \
  binutils-mingw-w64-x86-64 \
  mingw-w64-common \
  mingw-w64-x86-64-dev \
  gcc-mingw-w64-base \
  gcc-mingw-w64-x86-64-posix-runtime \
  gcc-mingw-w64-x86-64-posix
for package_file in ./*.deb; do
  dpkg-deb -x "$package_file" ../root
done
cd ../../..

MINGW_ROOT="$PWD/target/mingw/root/usr"
PATH="$MINGW_ROOT/bin:$PATH" \
CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$MINGW_ROOT/bin/x86_64-w64-mingw32-gcc-posix" \
CARGO_TARGET_X86_64_PC_WINDOWS_GNU_AR="$MINGW_ROOT/bin/x86_64-w64-mingw32-ar" \
cargo build --release --target x86_64-pc-windows-gnu \
  -p omq-tokio --bin omq_exclusive_dealer_latency
```

The executable is `target/x86_64-pc-windows-gnu/release/omq_exclusive_dealer_latency.exe`.

### Create an isolated Wine environment

Install Bottles from Flathub. Create a clean 64-bit bottle using the system Wine runner exposed by Bottles:

```sh
flatpak install flathub com.usebottles.bottles
flatpak run --command=bottles-cli com.usebottles.bottles new \
  --bottle-name omq-wine-repro \
  --environment application \
  --arch win64 \
  --runner sys-wine-11.0
```

Runner names are versioned. Use the current `sys-wine-*` entry shown by:

```sh
flatpak run --command=bottles-cli com.usebottles.bottles list components
```

The bottle is an isolated Wine prefix. Deleting `omq-wine-repro` in Bottles removes its state. The commands below grant the Flatpak read-only access to the repository for that invocation only; no persistent Flatpak override is needed.

### Run the A/B comparison

In terminal 1, start the native Linux echo server:

```sh
cargo run --release -p omq-tokio --bin omq_exclusive_dealer_latency -- \
  server tcp://0.0.0.0:5555
```

In terminal 2, run both Windows client paths under exactly the same bottle. Invoking `/app/bin/wine` directly makes the command synchronous and preserves the benchmark's stdout; `bottles-cli run` may return before the program exits. This is suitable for this self-contained executable, but it bypasses some per-program launch configuration normally applied by `bottles-cli run`.

Inside the Flatpak, `/var/data` is Bottles' persistent data directory. The prefix path below assumes the bottle name is exactly `omq-wine-repro`:

```sh
EXE="$PWD/target/x86_64-pc-windows-gnu/release/omq_exclusive_dealer_latency.exe"

flatpak run --filesystem="$PWD:ro" --command=sh \
  com.usebottles.bottles -c \
  'WINEPREFIX=/var/data/bottles/bottles/omq-wine-repro \
   /app/bin/wine "$1" standard tcp://127.0.0.1:5555 64 100000 10000' \
  sh "$EXE"

flatpak run --filesystem="$PWD:ro" --command=sh \
  com.usebottles.bottles -c \
  'WINEPREFIX=/var/data/bottles/bottles/omq-wine-repro \
   /app/bin/wine "$1" exclusive 127.0.0.1:5555 64 100000 10000' \
  sh "$EXE"
```

Each command emits one CSV header and row containing p50, p95, p99, and maximum round-trip latency in microseconds. Repeat each command at least three times, alternating their order. Keep the machine idle and record the following with the results:

```sh
flatpak info com.usebottles.bottles | sed -n '1,20p'
flatpak run --command=sh com.usebottles.bottles -c '/app/bin/wine --version'
rustc --version --verbose
uname -a
```

Bottles may log a missing `zenity` dialog helper when run from the terminal. This does not affect the benchmark, which does not use GUI file dialogs.

For a native control, run the same client without Wine against the same server:

```sh
cargo run --release -p omq-tokio --bin omq_exclusive_dealer_latency -- \
  standard tcp://127.0.0.1:5555 64 100000 10000
cargo run --release -p omq-tokio --bin omq_exclusive_dealer_latency -- \
  exclusive 127.0.0.1:5555 64 100000 10000
```

### Raw reproduction results

The commands above use 100,000 measured iterations and 10,000 warmup iterations for a more robust reproduction. The raw results below were collected on 2026-08-13 using 64-byte messages, 20,000 measured iterations, and 2,000 warmup iterations per run. Runs alternated between modes.

Environment:

- Debian GNU/Linux 13.6, Linux 6.12.100+deb13-amd64
- Bottles 66.0, Flatpak commit `c1cb8388d6a8`
- Wine 11.0 (`/app/bin/wine`) in a clean `application`/`win64` bottle
- rustc 1.97.1, target `x86_64-pc-windows-gnu`
- Native Linux ROUTER and Wine Windows DEALER communicated over TCP loopback

Wine/Bottles results (microseconds):

| mode      | run |  p50 |   p95 |   p99 |     max |
| --------- | --: | ---: | ----: | ----: | ------: |
| standard  |   1 | 86.5 | 186.6 | 302.9 |  1855.8 |
| standard  |   2 | 84.0 | 187.4 | 303.6 |  2195.3 |
| standard  |   3 | 77.5 | 162.8 | 275.8 |  1896.3 |
| exclusive |   1 | 19.8 |  58.0 | 142.9 |  1622.8 |
| exclusive |   2 | 24.0 |  60.8 | 176.5 | 11071.6 |
| exclusive |   3 | 19.5 |  55.6 |  71.8 |  1234.8 |

Native Linux control results (microseconds):

| mode      | run |    p50 |    p95 |    p99 |      max |
| --------- | --: | -----: | -----: | -----: | -------: |
| standard  |   1 | 10.226 | 27.491 | 35.647 |  355.199 |
| standard  |   2 | 12.207 | 24.955 | 57.206 | 1795.587 |
| standard  |   3 | 12.131 | 27.571 | 38.298 | 1563.341 |
| exclusive |   1 | 10.158 | 16.771 | 28.730 |  943.843 |
| exclusive |   2 | 10.245 | 27.815 | 37.157 | 1305.653 |
| exclusive |   3 | 10.181 | 27.265 | 30.198 |  466.674 |

The Wine runs reproduce the reported median-latency gap. Across the three runs, the median of the reported p50 values was 84.0 us for the standard path and 19.8 us for the exclusive path, a reduction of approximately 76% (about 4.2x).

The native Linux control showed no comparable median-latency difference, suggesting that the benefit is specific to the additional task and wakeup costs observed under Wine. This is an inference from the benchmark rather than proof of the precise underlying mechanism.

Maximum latency was noisy in both environments and is reported for completeness; it is not used as the primary comparison.
