### PR TITLE
Expand caller-driven exclusive sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ OMQ is designed for real ZMQ behavior, not just happy-path PUSH/PULL throughput.
   [doc/libzmq/semantics.md](doc/libzmq/semantics.md).
 - The hot paths are size-aware and latency-conscious: tiny messages stay inline without allocation, inproc passes messages by value, and large payloads use zero-copy buffers where it matters.
 - Latency-sensitive single-peer TCP flows can use `omq_tokio::exclusive::Socket`
-  to drive `DEALER`, `REQ`, or `REP` directly from the caller task.
+  to drive `PAIR`, `DEALER`, `ROUTER`, `REQ`, `REP`, `CLIENT`, or `SERVER`
+  directly from the caller task.
 - The only Rust ZeroMQ implementation following libzmq's architecture: application threads stay separate from dedicated background IO threads, IO work scales linearly across those threads, and PUB peers are assigned to IO lanes automatically.
 - Memory-safe Rust for the public crates. `unsafe` is isolated and checked with Miri.
 - Benchmarks cover the real shapes: CPU accounting, fan-in/fan-out, fairness, transport differences.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ OMQ is designed for real ZMQ behavior, not just happy-path PUSH/PULL throughput.
 - Documented libzmq compatibility edges for no-peer sends, linger, and HWM:
   [doc/libzmq/semantics.md](doc/libzmq/semantics.md).
 - The hot paths are size-aware and latency-conscious: tiny messages stay inline without allocation, inproc passes messages by value, and large payloads use zero-copy buffers where it matters.
+- Latency-sensitive single-peer TCP flows can use `omq_tokio::exclusive::Socket`
+  to drive `DEALER`, `REQ`, or `REP` directly from the caller task.
 - The only Rust ZeroMQ implementation following libzmq's architecture: application threads stay separate from dedicated background IO threads, IO work scales linearly across those threads, and PUB peers are assigned to IO lanes automatically.
 - Memory-safe Rust for the public crates. `unsafe` is isolated and checked with Miri.
 - Benchmarks cover the real shapes: CPU accounting, fan-in/fan-out, fairness, transport differences.
@@ -78,6 +80,7 @@ inside an existing tokio runtime.
 | `Context::new().socket(...)` | Async socket, OMQ-owned IO threads | Linear IO-lane scaling; PUB peers are sharded across lanes |
 | `Context::current().socket(...)` | Async socket, caller's active tokio runtime | Tokio scheduler/work stealing; PUB fan-out stays on one OMQ lane |
 | `Context::new().blocking_socket(...)` | Sync socket, OMQ-owned IO threads | Linear IO-lane scaling; caller thread stays out of IO |
+| `omq_tokio::exclusive::Socket::{connect, bind}(...)` | Caller-driven async socket | Single TCP peer, no background driver task |
 
 Supported 32-bit Linux targets are `i686-unknown-linux-gnu` and
 `armv7-unknown-linux-gnueabihf`. They require native 64-bit atomics. ZMTP wire

--- a/bindings/lua/native/Cargo.lock
+++ b/bindings/lua/native/Cargo.lock
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "zrip"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa05c09787b3aaaaa57870dca9fd9f3b4934018cbb5dde1b112017e2e70ec491"
+checksum = "6ef05d0a0abfcffec1d7dabdbd73373fef2b5838c20dc86ad8b6b6ee1a48a3cb"
 dependencies = [
  "zrip-core",
  "zrip-decode",
@@ -1525,24 +1525,24 @@ dependencies = [
 
 [[package]]
 name = "zrip-core"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9335acd94c1f09f729178fc339f9d49790254c1e98ba076f88df3a3f534c4e7d"
+checksum = "d0122e5712041938e8a1a4db57975da142f9b9cd1aab24cf8a94bb2ce4b79774"
 
 [[package]]
 name = "zrip-decode"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1801cd8b5d374e2bc31cd8a231182dd47e621492fa0bf68ca7d3033e001cd06b"
+checksum = "8a21823fd3263a53b26c082461bd411006652fa3e0d7842c5bac552ac5498bab"
 dependencies = [
  "zrip-core",
 ]
 
 [[package]]
 name = "zrip-encode"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e7e22b665b947f0240b44805713e87a15c34e86d0891cbe2856c575c5cda1d"
+checksum = "d5df1e3a40c73ef22d3ac48ac5cdb56a20d0f56ad00b56575bc515a990862e8c"
 dependencies = [
  "zrip-core",
 ]

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "zrip"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6514da35b51d81bfc515782396980ac909fe46925fd19701b36329ddec46e8"
+checksum = "6ef05d0a0abfcffec1d7dabdbd73373fef2b5838c20dc86ad8b6b6ee1a48a3cb"
 dependencies = [
  "zrip-core",
  "zrip-decode",
@@ -1153,24 +1153,24 @@ dependencies = [
 
 [[package]]
 name = "zrip-core"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9335acd94c1f09f729178fc339f9d49790254c1e98ba076f88df3a3f534c4e7d"
+checksum = "d0122e5712041938e8a1a4db57975da142f9b9cd1aab24cf8a94bb2ce4b79774"
 
 [[package]]
 name = "zrip-decode"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c26a2ea54a97d013b6f2a430b659fb77e0d5feb0aa3f80cb8c141d6827beba"
+checksum = "8a21823fd3263a53b26c082461bd411006652fa3e0d7842c5bac552ac5498bab"
 dependencies = [
  "zrip-core",
 ]
 
 [[package]]
 name = "zrip-encode"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e7e22b665b947f0240b44805713e87a15c34e86d0891cbe2856c575c5cda1d"
+checksum = "d5df1e3a40c73ef22d3ac48ac5cdb56a20d0f56ad00b56575bc515a990862e8c"
 dependencies = [
  "zrip-core",
 ]

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -142,7 +142,8 @@ identity, group, or subscription post-processing is needed.
 `omq_tokio::exclusive::Socket` is an opt-in alternative for latency-sensitive,
 single-peer workloads. It owns both the Tokio TCP stream and the sans-I/O
 `omq_proto::Connection`; the caller drives TCP, ZMTP, reconnects, and heartbeat
-timers through methods requiring `&mut self`.
+timers through methods requiring `&mut self`. It supports TCP `PAIR`,
+`DEALER`, `ROUTER`, `REQ`, `REP`, `CLIENT`, and `SERVER`.
 
 ```text
 regular Socket:   caller -> routing/queue -> ConnectionDriver task -> TCP

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -156,9 +156,10 @@ not replayed because it is ambiguous whether the peer received a partial or
 complete command. When no `send` or `recv` future is active, the application
 must call `maintain()` to drive idle heartbeat and reconnect work.
 
-The initial implementation supports one connected TCP DEALER using the NULL
-mechanism. Unsupported socket types and transports return explicit configuration
-errors; bind/accept and additional socket semantics can be added incrementally.
+The initial implementation supports connected TCP DEALER, REQ, and REP sockets
+using the NULL mechanism. Unsupported socket types and transports return
+explicit configuration errors; bind/accept and additional socket semantics can
+be added incrementally.
 
 ## Messages
 

--- a/doc/charts/main_reqrep_tcp.svg
+++ b/doc/charts/main_reqrep_tcp.svg
@@ -1,7 +1,7 @@
-<svg viewBox="0 0 850 482" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="850" height="482" opacity="1" fill="#000000" stroke="none"/>
+<svg viewBox="0 0 850 498" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="850" height="498" opacity="1" fill="#000000" stroke="none"/>
 <text x="425" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">REQ/REP latency, TCP loopback, 2-process</text>
-<text x="425" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz, 6 cores, performance governor, turbo on</text>
+<text x="425" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
 <text x="415" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 p50 round-trip latency (lower is better)
 </text>
@@ -67,48 +67,54 @@ p50 round-trip latency (lower is better)
 4 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="819,312 819,317 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="70,181 257,178 444,179 631,176 819,175 "/>
-<circle cx="70" cy="181" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="178" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="179" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="176" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="175" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="70,117 257,81 444,86 631,91 819,91 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="70,188 257,180 444,184 631,183 819,183 "/>
+<circle cx="70" cy="188" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="180" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="184" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="183" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="183" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="70,117 257,114 444,117 631,87 819,86 "/>
 <circle cx="70" cy="117" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="81" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="86" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="91" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="91" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="70,228 257,230 444,228 631,228 819,223 "/>
+<circle cx="257" cy="114" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="117" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="87" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="86" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="70,228 257,228 444,228 631,227 819,224 "/>
 <circle cx="70" cy="228" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="230" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="228" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="228" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="228" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="223" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="70,126 257,133 444,133 631,136 819,116 "/>
-<circle cx="70" cy="126" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="133" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="133" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="136" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="116" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="70,222 257,220 444,217 631,221 819,203 "/>
-<circle cx="70" cy="222" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="220" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="217" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="221" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="203" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="70,182 257,177 444,175 631,180 819,163 "/>
-<circle cx="70" cy="182" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="177" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="175" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="180" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="163" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="70,128 257,121 444,119 631,113 819,107 "/>
-<circle cx="70" cy="128" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="121" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="119" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="631" cy="113" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="107" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="227" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="224" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="70,90 257,96 444,93 631,90 819,87 "/>
+<circle cx="70" cy="90" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="96" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="93" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="90" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="87" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2DD4BF" stroke-width="2" points="70,237 257,236 444,238 631,234 819,224 "/>
+<circle cx="70" cy="237" r="2.5" opacity="1" fill="#2DD4BF" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="236" r="2.5" opacity="1" fill="#2DD4BF" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="238" r="2.5" opacity="1" fill="#2DD4BF" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="234" r="2.5" opacity="1" fill="#2DD4BF" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="224" r="2.5" opacity="1" fill="#2DD4BF" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="70,221 257,218 444,220 631,217 819,206 "/>
+<circle cx="70" cy="221" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="218" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="220" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="217" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="206" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="70,189 257,179 444,186 631,186 819,165 "/>
+<circle cx="70" cy="189" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="179" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="186" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="186" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="165" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="70,114 257,109 444,117 631,118 819,124 "/>
+<circle cx="70" cy="114" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="109" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="117" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="118" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="124" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <text x="250" y="344" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 threads
 </text>
@@ -126,10 +132,10 @@ libzmq v4.3.5
 1 IO
 </text>
 <text x="360" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-57%
+49%
 </text>
 <text x="450" y="360" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-62%
+74%
 </text>
 <polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="78,382 92,382 "/>
 <text x="98" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -139,10 +145,10 @@ omq
 1 IO
 </text>
 <text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-76%
+78%
 </text>
 <text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-85%
+94%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -155,58 +161,71 @@ CT
 58%
 </text>
 <text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-59%
-</text>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="78,414 92,414 "/>
-<text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-tmq v0.5.0
-</text>
-<text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-1 IO
-</text>
-<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-58%
-</text>
-<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-61%
-</text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,430 92,430 "/>
-<text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs v0.6.0
-</text>
-<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
-</text>
-<text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-55%
-</text>
-<text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-57%
-</text>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,446 92,446 "/>
-<text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq v0.5.24
-</text>
-<text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
-</text>
-<text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-63%
-</text>
-<text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 68%
 </text>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,462 92,462 "/>
+<polyline fill="none" opacity="1" stroke="#2DD4BF" stroke-width="2" points="78,414 92,414 "/>
+<text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+omq
+</text>
+<text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+EXCL
+</text>
+<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+55%
+</text>
+<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+59%
+</text>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="78,430 92,430 "/>
+<text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+tmq v0.5.0
+</text>
+<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+1 IO
+</text>
+<text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+51%
+</text>
+<text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,446 92,446 "/>
+<text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+zmq.rs v0.6.0
+</text>
+<text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+53%
+</text>
+<text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+63%
+</text>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring v0.5.24
+rzmq v0.5.24
 </text>
 <text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-6 MT
+12 MT
 </text>
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-95%
+61%
 </text>
 <text x="450" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-104%
+86%
+</text>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,478 92,478 "/>
+<text x="98" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+rzmq-iouring v0.5.24
+</text>
+<text x="250" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+92%
+</text>
+<text x="450" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+126%
 </text>
 </svg>

--- a/omq-bench/src/bench/comparisons.rs
+++ b/omq-bench/src/bench/comparisons.rs
@@ -132,6 +132,22 @@ static IMPLS: &[ImplDef] = &[
         env: &[("OMQ_IO_THREADS", "1")],
     },
     ImplDef {
+        name: "omq-tokio-exclusive",
+        binary_from: Some("omq-tokio-ct"),
+        prefix: "E",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "",
+        inproc_lat_subcmd: "",
+        inproc_pubsub_subcmd: "",
+        pub_needs_peer_count: false,
+        fanout_subcmd: "",
+        fanio_needs_peer_count: false,
+        supports_pubsub: false,
+        env: &[],
+    },
+    ImplDef {
         name: "libzmq",
         binary_from: None,
         prefix: "z",
@@ -295,6 +311,30 @@ static IMPLS: &[ImplDef] = &[
 
 fn find_impl(name: &str) -> Option<&'static ImplDef> {
     IMPLS.iter().find(|i| i.name == name)
+}
+
+fn supports_pushpull(def: &ImplDef) -> bool {
+    def.name != "omq-tokio-exclusive"
+}
+
+fn supports_fanio(def: &ImplDef) -> bool {
+    !def.fanout_subcmd.is_empty()
+}
+
+fn latency_req_subcmd(def: &ImplDef) -> &'static str {
+    if def.name == "omq-tokio-exclusive" {
+        "req-exclusive"
+    } else {
+        "req"
+    }
+}
+
+fn latency_rep_subcmd(def: &ImplDef) -> &'static str {
+    if def.name == "omq-tokio-exclusive" {
+        "rep-exclusive"
+    } else {
+        "rep"
+    }
 }
 
 #[cfg(test)]
@@ -1326,7 +1366,7 @@ fn run_latency_cell(
     let rep_env: Vec<(&str, &str)> = def.env.to_vec();
     let req_env: Vec<(&str, &str)> = def.env.to_vec();
 
-    let mut rep_cmd = vec![peer_binary_str, "rep"];
+    let mut rep_cmd = vec![peer_binary_str, latency_rep_subcmd(def)];
     if transport == TransportKind::Tcp {
         rep_cmd.extend(["tcp://127.0.0.1:0", &size_str]);
     } else {
@@ -1353,7 +1393,7 @@ fn run_latency_cell(
     let req_output = process::capture(
         &[
             binary_str,
-            "req",
+            latency_req_subcmd(def),
             &connect_addr,
             &size_str,
             &iters_str,
@@ -1558,75 +1598,82 @@ pub(crate) fn run(args: ComparisonsArgs) {
 
         // Throughput
         if !args.no_throughput {
-            eprintln!("\n=== Throughput / {transport_str} ===");
-            print_throughput_header(&active_impls);
+            let throughput_impls: Vec<&str> = active_impls
+                .iter()
+                .filter(|&&name| supports_pushpull(find_impl(name).unwrap()))
+                .copied()
+                .collect();
+            if !throughput_impls.is_empty() {
+                eprintln!("\n=== Throughput / {transport_str} ===");
+                print_throughput_header(&throughput_impls);
 
-            for &size in &sizes {
-                let mut cells = Vec::with_capacity(active_impls.len());
-                for &impl_name in &active_impls {
-                    let def = find_impl(impl_name).unwrap();
-                    let binary = binaries[impl_name].as_path();
-                    let peer_binary = binary;
+                for &size in &sizes {
+                    let mut cells = Vec::with_capacity(throughput_impls.len());
+                    for &impl_name in &throughput_impls {
+                        let def = find_impl(impl_name).unwrap();
+                        let binary = binaries[impl_name].as_path();
+                        let peer_binary = binary;
 
-                    let result = run_throughput_cell(
-                        binary,
-                        peer_binary,
-                        def,
-                        transport,
-                        size,
-                        duration,
-                        rounds,
-                        base_port,
-                    );
+                        let result = run_throughput_cell(
+                            binary,
+                            peer_binary,
+                            def,
+                            transport,
+                            size,
+                            duration,
+                            rounds,
+                            base_port,
+                        );
 
-                    let cpu_time = match (result.push_cpu, result.pull_cpu) {
-                        (Some(pc), Some(rc)) => Some(pc + rc),
-                        (Some(pc), None) => Some(pc),
-                        _ => None,
-                    };
+                        let cpu_time = match (result.push_cpu, result.pull_cpu) {
+                            (Some(pc), Some(rc)) => Some(pc + rc),
+                            (Some(pc), None) => Some(pc),
+                            _ => None,
+                        };
 
-                    let row = ComparisonRow {
-                        run_id: run_id.clone(),
-                        impl_name: impl_name.to_string(),
-                        kind: "throughput".to_string(),
-                        transport: transport_str.to_string(),
-                        msg_size: size,
-                        peers: None,
-                        msgs_s: Some(result.msgs_s),
-                        mbps: Some(result.mbps),
-                        elapsed: Some(result.elapsed),
-                        cpu_time,
-                        push_cpu_time: result.push_cpu,
-                        pull_cpu_time: result.pull_cpu,
-                        pub_cpu_time: None,
-                        req_cpu_time: None,
-                        p50_us: None,
-                        p99_us: None,
-                        p999_us: None,
-                        max_us: None,
-                        iterations: None,
-                        peer_min: None,
-                        peer_max: None,
-                        peer_p10: None,
-                        peer_p25: None,
-                        peer_median: None,
-                        peer_p75: None,
-                        peer_p90: None,
-                        zero_transport: if result.msgs_s == 0.0 {
-                            Some(true)
+                        let row = ComparisonRow {
+                            run_id: run_id.clone(),
+                            impl_name: impl_name.to_string(),
+                            kind: "throughput".to_string(),
+                            transport: transport_str.to_string(),
+                            msg_size: size,
+                            peers: None,
+                            msgs_s: Some(result.msgs_s),
+                            mbps: Some(result.mbps),
+                            elapsed: Some(result.elapsed),
+                            cpu_time,
+                            push_cpu_time: result.push_cpu,
+                            pull_cpu_time: result.pull_cpu,
+                            pub_cpu_time: None,
+                            req_cpu_time: None,
+                            p50_us: None,
+                            p99_us: None,
+                            p999_us: None,
+                            max_us: None,
+                            iterations: None,
+                            peer_min: None,
+                            peer_max: None,
+                            peer_p10: None,
+                            peer_p25: None,
+                            peer_median: None,
+                            peer_p75: None,
+                            peer_p90: None,
+                            zero_transport: if result.msgs_s == 0.0 {
+                                Some(true)
+                            } else {
+                                None
+                            },
+                        };
+                        jsonl::append_jsonl(&jsonl_path, &row);
+
+                        if size >= 1024 {
+                            cells.push(fmt_gbps(result.mbps));
                         } else {
-                            None
-                        },
-                    };
-                    jsonl::append_jsonl(&jsonl_path, &row);
-
-                    if size >= 1024 {
-                        cells.push(fmt_gbps(result.mbps));
-                    } else {
-                        cells.push(fmt_rate(result.msgs_s));
+                            cells.push(fmt_rate(result.msgs_s));
+                        }
                     }
+                    print_table_row(&size_label(size), &cells, 14);
                 }
-                print_table_row(&size_label(size), &cells, 14);
             }
         }
 
@@ -1795,7 +1842,7 @@ pub(crate) fn run(args: ComparisonsArgs) {
                 .iter()
                 .filter(|&&name| {
                     let def = find_impl(name).unwrap();
-                    def.class != Some(ImplClass::Curve)
+                    supports_fanio(def) && def.class != Some(ImplClass::Curve)
                 })
                 .copied()
                 .collect();
@@ -1881,7 +1928,7 @@ pub(crate) fn run(args: ComparisonsArgs) {
                 .iter()
                 .filter(|&&name| {
                     let def = find_impl(name).unwrap();
-                    def.class != Some(ImplClass::Curve)
+                    supports_fanio(def) && def.class != Some(ImplClass::Curve)
                 })
                 .copied()
                 .collect();
@@ -2161,5 +2208,13 @@ mod tests {
             latency_sizes_from(&[16, 1024, 4096, 8192, 16384]),
             vec![16, 1024, 4096]
         );
+    }
+
+    #[test]
+    fn exclusive_latency_uses_exclusive_req_and_rep() {
+        let def = find_impl("omq-tokio-exclusive").unwrap();
+
+        assert_eq!(latency_req_subcmd(def), "req-exclusive");
+        assert_eq!(latency_rep_subcmd(def), "rep-exclusive");
     }
 }

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -55,6 +55,7 @@ pub(crate) const C_LIBZMQ: RGBColor = RGBColor(250, 204, 21);
 pub(crate) const C_LIBZMQ_2T: RGBColor = RGBColor(245, 158, 11);
 pub(crate) const C_OMQ_1T: RGBColor = RGBColor(239, 68, 68);
 pub(crate) const C_OMQ_CT: RGBColor = RGBColor(251, 113, 133);
+pub(crate) const C_OMQ_EXCLUSIVE: RGBColor = RGBColor(45, 212, 191);
 pub(crate) const C_OMQ_2T: RGBColor = RGBColor(185, 28, 28);
 pub(crate) const C_ZMQRS: RGBColor = RGBColor(96, 165, 250);
 pub(crate) const C_TMQ: RGBColor = RGBColor(168, 85, 247);

--- a/omq-bench/src/chart/main_tcp.rs
+++ b/omq-bench/src/chart/main_tcp.rs
@@ -1,6 +1,6 @@
 use super::common::{
-    self, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_CT, C_RZMQ, C_RZMQ_IOURING, C_TMQ,
-    C_ZMQRS, Impl, draw_latency_single_panel_with_versions,
+    self, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_CT, C_OMQ_EXCLUSIVE, C_RZMQ,
+    C_RZMQ_IOURING, C_TMQ, C_ZMQRS, Impl, draw_latency_single_panel_with_versions,
     draw_throughput_dual_panel_fixed_2m_msgs_with_versions,
     draw_throughput_dual_panel_with_versions, load_latency, load_tput, out_dir,
 };
@@ -74,6 +74,12 @@ const REQREP_IMPLS: &[Impl] = &[
         label: "omq",
         threads: "CT",
         color: C_OMQ_CT,
+    },
+    Impl {
+        key: "omq-tokio-exclusive",
+        label: "omq",
+        threads: "EXCL",
+        color: C_OMQ_EXCLUSIVE,
     },
     Impl {
         key: "tmq",

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -285,6 +285,10 @@ name = "omq_soak_curve"
 path = "tests/omq_soak_curve.rs"
 
 [[test]]
+name = "omq_soak_exclusive"
+path = "tests/omq_soak_exclusive.rs"
+
+[[test]]
 name = "omq_soak_hwm_reconnect"
 path = "tests/omq_soak_hwm_reconnect.rs"
 

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -8,6 +8,8 @@
 //! Latency (REQ/REP):
 //!   `bench_peer_tokio` rep \<addr\> \<`msg_size`\>
 //!   `bench_peer_tokio` req \<addr\> \<`msg_size`\> \<iterations\> \<warmup\>
+//!   `bench_peer_tokio` rep-exclusive \<addr\> \<`msg_size`\>
+//!   `bench_peer_tokio` req-exclusive \<addr\> \<`msg_size`\> \<iterations\> \<warmup\>
 //!
 //! \<addr\>: a port number (`4000`), an `ip:port` pair (`0.0.0.0:4000`),
 //!   a full URI (`tcp://0.0.0.0:4000`), or an IPC path (`ipc:///tmp/foo.sock`).
@@ -32,7 +34,8 @@ fn quantile(sorted: &[f64], probability: f64) -> f64 {
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
-use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
+use omq_tokio::exclusive::{Options as ExclusiveOptions, Socket as ExclusiveSocket};
+use omq_tokio::{Endpoint, Error, Message, MonitorEvent, Options, Socket, SocketType};
 use std::net::Ipv4Addr;
 
 fn parse_ep(s: &str) -> Endpoint {
@@ -161,12 +164,24 @@ async fn async_main(args: Vec<String>, ctx: omq_tokio::Context) {
             let size: usize = args[3].parse().expect("msg_size");
             run_rep(&ctx, ep, size).await;
         }
+        Some("rep-exclusive") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            run_rep_exclusive(&ctx, ep, size).await;
+        }
         Some("req") => {
             let ep = parse_ep(&args[2]);
             let size: usize = args[3].parse().expect("msg_size");
             let iterations: usize = args[4].parse().expect("iterations");
             let warmup: usize = args[5].parse().expect("warmup");
             run_req(&ctx, ep, size, iterations, warmup).await;
+        }
+        Some("req-exclusive") => {
+            let ep = parse_ep(&args[2]);
+            let size: usize = args[3].parse().expect("msg_size");
+            let iterations: usize = args[4].parse().expect("iterations");
+            let warmup: usize = args[5].parse().expect("warmup");
+            run_req_exclusive(ep, size, iterations, warmup).await;
         }
         Some("pub") => {
             let ep = parse_ep(&args[2]);
@@ -256,6 +271,8 @@ async fn async_main(args: Vec<String>, ctx: omq_tokio::Context) {
             eprintln!("       bench_peer_tokio inproc <name> <size> <duration_secs>");
             eprintln!("       bench_peer_tokio rep <addr> <size>");
             eprintln!("       bench_peer_tokio req <addr> <size> <iterations> <warmup>");
+            eprintln!("       bench_peer_tokio rep-exclusive <addr> <size>");
+            eprintln!("       bench_peer_tokio req-exclusive <addr> <size> <iterations> <warmup>");
             eprintln!("       bench_peer_tokio inproc-latency <name> <size> <iterations> <warmup>");
             eprintln!("<addr>: port number or full endpoint (tcp:// ipc://)");
             std::process::exit(1);
@@ -1050,6 +1067,24 @@ async fn run_rep(ctx: &omq_tokio::Context, ep: Endpoint, size: usize) {
     }
 }
 
+async fn run_rep_exclusive(ctx: &omq_tokio::Context, ep: Endpoint, _size: usize) {
+    let (mut rep, bound) = ExclusiveSocket::bind(SocketType::Rep, ep, ExclusiveOptions::default())
+        .await
+        .expect("exclusive rep bind");
+    report_bound_port(ctx, &bound).await;
+    loop {
+        let msg = match rep.recv().await {
+            Ok(msg) => msg,
+            Err(Error::Closed | Error::Io(_)) => continue,
+            Err(error) => panic!("{error}"),
+        };
+        match rep.send(&msg).await {
+            Ok(()) | Err(Error::Closed | Error::Io(_)) => {}
+            Err(error) => panic!("{error}"),
+        }
+    }
+}
+
 async fn run_req(
     ctx: &omq_tokio::Context,
     ep: Endpoint,
@@ -1075,6 +1110,39 @@ async fn run_req(
     for _ in 0..iterations {
         let t0 = Instant::now();
         req.send(Message::single(payload.clone())).await.unwrap();
+        req.recv().await.unwrap();
+        rtts.push(t0.elapsed().as_nanos() as u64);
+    }
+    let cpu = cpu_time_secs() - cpu_before;
+    let elapsed = t_wall.elapsed().as_secs_f64();
+
+    rtts.sort_unstable();
+    let p50 = percentile(&rtts, 50.0);
+    let p99 = percentile(&rtts, 99.0);
+    let p999 = percentile(&rtts, 99.9);
+    let max = percentile(&rtts, 100.0);
+    println!("{p50:.3} {p99:.3} {p999:.3} {max:.3} {iterations} {cpu:.6} {elapsed:.6}");
+}
+
+async fn run_req_exclusive(ep: Endpoint, size: usize, iterations: usize, warmup: usize) {
+    let mut req = ExclusiveSocket::connect(SocketType::Req, ep, ExclusiveOptions::default())
+        .await
+        .expect("exclusive req connect");
+
+    let payload = Bytes::from(vec![b'x'; size]);
+    let message = Message::single(payload);
+
+    for _ in 0..warmup {
+        req.send(&message).await.unwrap();
+        req.recv().await.unwrap();
+    }
+
+    let t_wall = Instant::now();
+    let cpu_before = cpu_time_secs();
+    let mut rtts = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let t0 = Instant::now();
+        req.send(&message).await.unwrap();
         req.recv().await.unwrap();
         rtts.push(t0.elapsed().as_nanos() as u64);
     }

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -4,14 +4,16 @@
 //! ZMTP directly, without a connection-driver task or data relay ring.
 
 use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use omq_proto::endpoint::Host;
 use omq_proto::proto::command::Command;
 use omq_proto::proto::{Connection, ConnectionConfig, Event as ProtoEvent, Role};
+use omq_proto::type_state::TypeState;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast;
 
 use crate::{Endpoint, Error, Message, ReconnectPolicy, Result, SocketType};
@@ -97,10 +99,23 @@ impl Options {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Event {
+    /// TCP connection established.
     Connected,
+    /// ZMTP greeting and mechanism handshake completed.
     HandshakeSucceeded,
-    Disconnected { reason: String },
-    ReconnectDelayed { retry_in: Duration, attempt: u32 },
+    /// Active peer disconnected or failed.
+    Disconnected {
+        /// Human-readable disconnect reason.
+        reason: String,
+    },
+    /// Reconnect attempt scheduled after a failure.
+    ReconnectDelayed {
+        /// Delay before the next reconnect attempt.
+        retry_in: Duration,
+        /// One-based reconnect attempt number.
+        attempt: u32,
+    },
+    /// Socket closed by the caller.
     Closed,
 }
 
@@ -115,11 +130,17 @@ struct LiveConnection {
     ping_sequence: u64,
 }
 
+#[derive(Debug)]
+enum Mode {
+    Connect,
+    Bind { listener: TcpListener },
+}
+
 /// A single-peer socket whose caller owns the TCP data path.
 ///
-/// The initial implementation supports only a connected TCP DEALER using the
-/// NULL mechanism. Unsupported socket types and transports return a
-/// configuration error.
+/// Supports connected or bound TCP `DEALER`, `REQ`, and `REP` sockets using the NULL
+/// mechanism. Unsupported socket types and transports return a configuration
+/// error.
 ///
 /// A failed `send` is never retried automatically: the peer may have received
 /// a partial or complete command. The next operation may restore the
@@ -129,40 +150,80 @@ pub struct Socket {
     kind: SocketType,
     endpoint: Endpoint,
     options: Options,
+    mode: Mode,
     live: Option<LiveConnection>,
     monitor: broadcast::Sender<Event>,
     reconnect_attempt: u32,
     retry_at: Option<Instant>,
+    type_state: TypeState,
+    rep_request_pending: bool,
     closed: bool,
 }
 
 impl Socket {
-    /// Connect a caller-driven socket.
+    /// Connect a caller-driven TCP socket.
+    ///
+    /// Currently supports `DEALER`, `REQ`, and `REP`.
     pub async fn connect(
         socket_type: SocketType,
         endpoint: Endpoint,
         options: Options,
     ) -> Result<Self> {
-        validate_mode(socket_type, &endpoint, &options)?;
+        validate_connect_mode(socket_type, &endpoint, &options)?;
         let (monitor, _) = broadcast::channel(1024);
         let mut socket = Self {
             kind: socket_type,
             endpoint,
             options,
+            mode: Mode::Connect,
             live: None,
             monitor,
             reconnect_attempt: 0,
             retry_at: None,
+            type_state: TypeState::new(),
+            rep_request_pending: false,
             closed: false,
         };
         socket.establish().await?;
         Ok(socket)
     }
 
+    /// Bind a caller-driven TCP socket and return its bound endpoint.
+    ///
+    /// The socket accepts one peer at a time. If the peer disconnects, the next
+    /// operation waits for a new peer on the same listener.
+    ///
+    /// Currently supports `DEALER`, `REQ`, and `REP`.
+    pub async fn bind(
+        socket_type: SocketType,
+        endpoint: Endpoint,
+        options: Options,
+    ) -> Result<(Self, Endpoint)> {
+        validate_bind_mode(socket_type, &endpoint, &options)?;
+        let (listener, bound) = bind_tcp_listener(&endpoint).await?;
+        let (monitor, _) = broadcast::channel(1024);
+        let socket = Self {
+            kind: socket_type,
+            endpoint: bound.clone(),
+            options,
+            mode: Mode::Bind { listener },
+            live: None,
+            monitor,
+            reconnect_attempt: 0,
+            retry_at: None,
+            type_state: TypeState::new(),
+            rep_request_pending: false,
+            closed: false,
+        };
+        Ok((socket, bound))
+    }
+
+    /// Subscribe to lifecycle events for this socket.
     pub fn monitor(&self) -> broadcast::Receiver<Event> {
         self.monitor.subscribe()
     }
 
+    /// Return true while a live TCP/ZMTP connection is active.
     pub fn is_connected(&self) -> bool {
         self.live.is_some()
     }
@@ -170,12 +231,13 @@ impl Socket {
     /// Encode and write one message. Failed writes are not replayed.
     pub async fn send(&mut self, message: &Message) -> Result<()> {
         self.ensure_connected().await?;
+        let wire_message = self.type_state.pre_send(self.kind, message.clone())?;
         let timeout = self.options.io_timeout;
         let result = run_timeout(timeout, async {
             let live = self.live.as_mut().expect("connected");
             live.write_buf.clear();
             live.connection
-                .send_message_flat(message, &mut live.write_buf);
+                .send_message_flat(&wire_message, &mut live.write_buf);
             live.stream
                 .write_all(&live.write_buf)
                 .await
@@ -186,31 +248,50 @@ impl Socket {
             self.mark_disconnected(&error);
             return Err(error);
         }
+        if self.kind == SocketType::Rep {
+            self.rep_request_pending = false;
+        }
         Ok(())
     }
 
     /// Receive one message. A timeout or transport error disconnects the
     /// current peer; a later operation attempts reconnection.
     pub async fn recv(&mut self) -> Result<Message> {
-        self.ensure_connected().await?;
-        let io_timeout = self.options.io_timeout;
-        let heartbeat_interval = self.options.heartbeat_interval;
-        let heartbeat_timeout = effective_heartbeat_timeout(&self.options);
-        let heartbeat_ttl = heartbeat_ttl_deciseconds(self.options.heartbeat_ttl);
-        let result = run_timeout(
-            io_timeout,
-            recv_live(
-                self.live.as_mut().expect("connected"),
-                heartbeat_interval,
-                heartbeat_timeout,
-                heartbeat_ttl,
-            ),
-        )
-        .await;
-        if let Err(error) = &result {
-            self.mark_disconnected(error);
+        loop {
+            if self.kind == SocketType::Rep && self.rep_request_pending {
+                return Err(Error::Protocol(
+                    "REP socket must send a reply before receiving again".into(),
+                ));
+            }
+            self.ensure_connected().await?;
+            let io_timeout = self.options.io_timeout;
+            let heartbeat_interval = self.options.heartbeat_interval;
+            let heartbeat_timeout = effective_heartbeat_timeout(&self.options);
+            let heartbeat_ttl = heartbeat_ttl_deciseconds(self.options.heartbeat_ttl);
+            let result = run_timeout(
+                io_timeout,
+                recv_live(
+                    self.live.as_mut().expect("connected"),
+                    heartbeat_interval,
+                    heartbeat_timeout,
+                    heartbeat_ttl,
+                ),
+            )
+            .await;
+            let message = match result {
+                Ok(message) => message,
+                Err(error) => {
+                    self.mark_disconnected(&error);
+                    return Err(error);
+                }
+            };
+            if let Some(message) = self.type_state.post_recv(self.kind, message)? {
+                if self.kind == SocketType::Rep {
+                    self.rep_request_pending = true;
+                }
+                return Ok(message);
+            }
         }
-        result
     }
 
     /// Drive heartbeat and reconnect work when no data operation is active.
@@ -263,15 +344,19 @@ impl Socket {
         Ok(())
     }
 
+    /// Drop any current connection and reconnect immediately.
     pub async fn reconnect_now(&mut self) -> Result<()> {
         if self.closed {
             return Err(Error::Closed);
         }
         self.live = None;
         self.retry_at = None;
+        self.type_state.on_peer_disconnected();
+        self.rep_request_pending = false;
         self.establish().await
     }
 
+    /// Close the socket and shut down the active TCP stream.
     pub async fn close(&mut self) -> Result<()> {
         self.closed = true;
         self.retry_at = None;
@@ -299,14 +384,28 @@ impl Socket {
     }
 
     async fn establish(&mut self) -> Result<()> {
-        let result = establish_live(
-            self.kind,
-            &self.endpoint,
-            self.options.identity.clone(),
-            self.options.connect_timeout,
-            self.options.handshake_timeout,
-        )
-        .await;
+        let result = match &mut self.mode {
+            Mode::Connect => {
+                establish_connected_live(
+                    self.kind,
+                    &self.endpoint,
+                    self.options.identity.clone(),
+                    self.options.connect_timeout,
+                    self.options.handshake_timeout,
+                )
+                .await
+            }
+            Mode::Bind { listener } => {
+                establish_bound_live(
+                    self.kind,
+                    listener,
+                    self.options.identity.clone(),
+                    self.options.connect_timeout,
+                    self.options.handshake_timeout,
+                )
+                .await
+            }
+        };
         match result {
             Ok(live) => {
                 self.live = Some(live);
@@ -325,6 +424,8 @@ impl Socket {
 
     fn mark_disconnected(&mut self, error: &Error) {
         if self.live.take().is_some() {
+            self.type_state.on_peer_disconnected();
+            self.rep_request_pending = false;
             let _ = self.monitor.send(Event::Disconnected {
                 reason: error.to_string(),
             });
@@ -333,6 +434,11 @@ impl Socket {
     }
 
     fn schedule_reconnect(&mut self) {
+        if matches!(self.mode, Mode::Bind { .. }) {
+            self.reconnect_attempt = 0;
+            self.retry_at = None;
+            return;
+        }
         let Some(delay) = reconnect_delay(self.options.reconnect, self.reconnect_attempt) else {
             self.retry_at = None;
             return;
@@ -357,12 +463,24 @@ fn reconnect_delay(policy: ReconnectPolicy, attempt: u32) -> Option<Duration> {
     }
 }
 
-fn validate_mode(socket_type: SocketType, endpoint: &Endpoint, options: &Options) -> Result<()> {
-    if socket_type != SocketType::Dealer {
+fn validate_socket_type(socket_type: SocketType) -> Result<()> {
+    if !matches!(
+        socket_type,
+        SocketType::Dealer | SocketType::Req | SocketType::Rep
+    ) {
         return Err(Error::Config(format!(
-            "exclusive sockets currently support only DEALER, not {socket_type:?}"
+            "exclusive sockets currently support only DEALER, REQ, and REP, not {socket_type:?}"
         )));
     }
+    Ok(())
+}
+
+fn validate_connect_mode(
+    socket_type: SocketType,
+    endpoint: &Endpoint,
+    options: &Options,
+) -> Result<()> {
+    validate_socket_type(socket_type)?;
     match endpoint {
         Endpoint::Tcp {
             host: Host::Wildcard,
@@ -382,7 +500,54 @@ fn validate_mode(socket_type: SocketType, endpoint: &Endpoint, options: &Options
     options.validate()
 }
 
-async fn establish_live(
+fn validate_bind_mode(
+    socket_type: SocketType,
+    endpoint: &Endpoint,
+    options: &Options,
+) -> Result<()> {
+    validate_socket_type(socket_type)?;
+    match endpoint {
+        Endpoint::Tcp { .. } => {}
+        _ => {
+            return Err(Error::Config(format!(
+                "exclusive sockets currently support only tcp:// endpoints, not {endpoint}"
+            )));
+        }
+    }
+    options.validate()
+}
+
+async fn bind_tcp_listener(endpoint: &Endpoint) -> Result<(TcpListener, Endpoint)> {
+    let Endpoint::Tcp { host, port } = endpoint else {
+        return Err(Error::Config(
+            "exclusive sockets currently support only tcp:// endpoints".into(),
+        ));
+    };
+    let addr = resolve_bind_addr(host, *port).await?;
+    let listener = crate::transport::tcp::reuse_addr_bind(addr)?;
+    let local = listener.local_addr()?;
+    let bound = Endpoint::Tcp {
+        host: Host::Ip(local.ip()),
+        port: local.port(),
+    };
+    Ok((listener, bound))
+}
+
+async fn resolve_bind_addr(host: &Host, port: u16) -> Result<SocketAddr> {
+    match host {
+        Host::Wildcard => Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)),
+        Host::Ip(ip) => Ok(SocketAddr::new(*ip, port)),
+        Host::Name(name) => tokio::net::lookup_host((name.as_str(), port))
+            .await?
+            .next()
+            .ok_or_else(|| Error::Io(io::Error::other(format!("no addresses for {name}:{port}")))),
+        _ => Err(Error::Config(
+            "exclusive sockets do not support this TCP host type".into(),
+        )),
+    }
+}
+
+async fn establish_connected_live(
     socket_type: SocketType,
     endpoint: &Endpoint,
     identity: Bytes,
@@ -401,6 +566,35 @@ async fn establish_live(
     stream.set_nodelay(true)?;
     let connection =
         Connection::new(ConnectionConfig::new(Role::Client, socket_type).identity(identity));
+    let now = Instant::now();
+    let mut live = LiveConnection {
+        stream,
+        connection,
+        read_buf: BytesMut::with_capacity(4 * 1024),
+        write_buf: BytesMut::with_capacity(4 * 1024),
+        last_ping: now,
+        heartbeat_deadline: None,
+        ping_sequence: 0,
+    };
+    tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
+        .await
+        .map_err(|_| timed_out("exclusive socket handshake timeout"))??;
+    Ok(live)
+}
+
+async fn establish_bound_live(
+    socket_type: SocketType,
+    listener: &TcpListener,
+    identity: Bytes,
+    connect_timeout: Duration,
+    handshake_timeout: Duration,
+) -> Result<LiveConnection> {
+    let (stream, _) = tokio::time::timeout(connect_timeout, listener.accept())
+        .await
+        .map_err(|_| timed_out("exclusive socket accept timeout"))??;
+    stream.set_nodelay(true)?;
+    let connection =
+        Connection::new(ConnectionConfig::new(Role::Server, socket_type).identity(identity));
     let now = Instant::now();
     let mut live = LiveConnection {
         stream,
@@ -581,6 +775,33 @@ mod tests {
         (router, bound)
     }
 
+    async fn regular_rep() -> (RegularSocket, Endpoint) {
+        let rep = RegularSocket::new(SocketType::Rep, RegularOptions::default());
+        let bound = rep
+            .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
+            .await
+            .unwrap();
+        (rep, bound)
+    }
+
+    async fn regular_req() -> (RegularSocket, Endpoint) {
+        let req = RegularSocket::new(SocketType::Req, RegularOptions::default());
+        let bound = req
+            .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
+            .await
+            .unwrap();
+        (req, bound)
+    }
+
+    async fn regular_dealer() -> (RegularSocket, Endpoint) {
+        let dealer = RegularSocket::new(SocketType::Dealer, RegularOptions::default());
+        let bound = dealer
+            .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
+            .await
+            .unwrap();
+        (dealer, bound)
+    }
+
     async fn unresponsive_router() -> (Endpoint, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint: Endpoint = format!("tcp://{}", listener.local_addr().unwrap())
@@ -660,6 +881,136 @@ mod tests {
             assert_eq!(socket.recv().await.unwrap(), message);
         }
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn req_round_trips_with_standard_rep() {
+        let (rep, endpoint) = regular_rep().await;
+        let server = tokio::spawn(async move {
+            for sequence in 0_u64..10 {
+                let request = rep.recv().await.unwrap();
+                assert_eq!(request, Message::single(sequence.to_le_bytes().to_vec()));
+                rep.send(Message::single((sequence + 1).to_le_bytes().to_vec()))
+                    .await
+                    .unwrap();
+            }
+        });
+        let mut socket = Socket::connect(SocketType::Req, endpoint, Options::default())
+            .await
+            .unwrap();
+        for sequence in 0_u64..10 {
+            let request = Message::single(sequence.to_le_bytes().to_vec());
+            socket.send(&request).await.unwrap();
+            assert_eq!(
+                socket.recv().await.unwrap(),
+                Message::single((sequence + 1).to_le_bytes().to_vec())
+            );
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn req_rejects_second_send_before_reply() {
+        let (rep, endpoint) = regular_rep().await;
+        let server = tokio::spawn(async move {
+            let _ = rep.recv().await.unwrap();
+        });
+        let mut socket = Socket::connect(SocketType::Req, endpoint, Options::default())
+            .await
+            .unwrap();
+        socket.send(&Message::single("first")).await.unwrap();
+        let error = socket.send(&Message::single("second")).await.unwrap_err();
+        assert!(matches!(error, Error::Protocol(message) if message.contains("receive a reply")));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rep_round_trips_with_standard_req() {
+        let (req, endpoint) = regular_req().await;
+        let mut socket = Socket::connect(SocketType::Rep, endpoint, Options::default())
+            .await
+            .unwrap();
+        for sequence in 0_u64..10 {
+            req.send(Message::single(sequence.to_le_bytes().to_vec()))
+                .await
+                .unwrap();
+            assert_eq!(
+                socket.recv().await.unwrap(),
+                Message::single(sequence.to_le_bytes().to_vec())
+            );
+            socket
+                .send(&Message::single((sequence + 1).to_le_bytes().to_vec()))
+                .await
+                .unwrap();
+            assert_eq!(
+                req.recv().await.unwrap(),
+                Message::single((sequence + 1).to_le_bytes().to_vec())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bound_rep_round_trips_with_exclusive_req() {
+        let (mut rep, endpoint) = Socket::bind(
+            SocketType::Rep,
+            "tcp://127.0.0.1:0".parse().unwrap(),
+            Options::default(),
+        )
+        .await
+        .unwrap();
+        let server = tokio::spawn(async move {
+            for sequence in 0_u64..10 {
+                assert_eq!(
+                    rep.recv().await.unwrap(),
+                    Message::single(sequence.to_le_bytes().to_vec())
+                );
+                rep.send(&Message::single((sequence + 1).to_le_bytes().to_vec()))
+                    .await
+                    .unwrap();
+            }
+        });
+        let mut req = Socket::connect(SocketType::Req, endpoint, Options::default())
+            .await
+            .unwrap();
+        for sequence in 0_u64..10 {
+            req.send(&Message::single(sequence.to_le_bytes().to_vec()))
+                .await
+                .unwrap();
+            assert_eq!(
+                req.recv().await.unwrap(),
+                Message::single((sequence + 1).to_le_bytes().to_vec())
+            );
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rep_rejects_send_before_request() {
+        let (_req, endpoint) = regular_req().await;
+        let mut socket = Socket::connect(SocketType::Rep, endpoint, Options::default())
+            .await
+            .unwrap();
+        let error = socket.send(&Message::single("early")).await.unwrap_err();
+        assert!(matches!(error, Error::Protocol(message) if message.contains("receive a request")));
+    }
+
+    #[tokio::test]
+    async fn rep_rejects_second_recv_before_reply() {
+        let (dealer, endpoint) = regular_dealer().await;
+        let mut socket = Socket::connect(SocketType::Rep, endpoint, Options::default())
+            .await
+            .unwrap();
+        dealer
+            .send(Message::multipart(["", "first"]))
+            .await
+            .unwrap();
+        dealer
+            .send(Message::multipart(["", "second"]))
+            .await
+            .unwrap();
+        assert_eq!(socket.recv().await.unwrap(), Message::single("first"));
+        let error = socket.recv().await.unwrap_err();
+        assert!(matches!(error, Error::Protocol(message) if message.contains("send a reply")));
     }
 
     #[tokio::test]
@@ -815,7 +1166,9 @@ mod tests {
         let error = Socket::connect(SocketType::Pair, endpoint, Options::default())
             .await
             .unwrap_err();
-        assert!(matches!(error, Error::Config(message) if message.contains("only DEALER")));
+        assert!(
+            matches!(error, Error::Config(message) if message.contains("only DEALER, REQ, and REP"))
+        );
 
         let endpoint: Endpoint = "inproc://exclusive".parse().unwrap();
         let error = Socket::connect(SocketType::Dealer, endpoint, Options::default())

--- a/omq-tokio/src/exclusive.rs
+++ b/omq-tokio/src/exclusive.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use omq_proto::endpoint::Host;
+use omq_proto::message::generated_identity;
 use omq_proto::proto::command::Command;
 use omq_proto::proto::{Connection, ConnectionConfig, Event as ProtoEvent, Role};
 use omq_proto::type_state::TypeState;
@@ -128,6 +129,7 @@ struct LiveConnection {
     last_ping: Instant,
     heartbeat_deadline: Option<Instant>,
     ping_sequence: u64,
+    peer_identity: Bytes,
 }
 
 #[derive(Debug)]
@@ -138,9 +140,9 @@ enum Mode {
 
 /// A single-peer socket whose caller owns the TCP data path.
 ///
-/// Supports connected or bound TCP `DEALER`, `REQ`, and `REP` sockets using the NULL
-/// mechanism. Unsupported socket types and transports return a configuration
-/// error.
+/// Supports connected or bound TCP `PAIR`, `DEALER`, `ROUTER`, `REQ`, `REP`,
+/// `CLIENT`, and `SERVER` sockets using the NULL mechanism. Unsupported socket
+/// types and transports return a configuration error.
 ///
 /// A failed `send` is never retried automatically: the peer may have received
 /// a partial or complete command. The next operation may restore the
@@ -163,7 +165,8 @@ pub struct Socket {
 impl Socket {
     /// Connect a caller-driven TCP socket.
     ///
-    /// Currently supports `DEALER`, `REQ`, and `REP`.
+    /// Currently supports `PAIR`, `DEALER`, `ROUTER`, `REQ`, `REP`,
+    /// `CLIENT`, and `SERVER`.
     pub async fn connect(
         socket_type: SocketType,
         endpoint: Endpoint,
@@ -193,7 +196,8 @@ impl Socket {
     /// The socket accepts one peer at a time. If the peer disconnects, the next
     /// operation waits for a new peer on the same listener.
     ///
-    /// Currently supports `DEALER`, `REQ`, and `REP`.
+    /// Currently supports `PAIR`, `DEALER`, `ROUTER`, `REQ`, `REP`,
+    /// `CLIENT`, and `SERVER`.
     pub async fn bind(
         socket_type: SocketType,
         endpoint: Endpoint,
@@ -231,7 +235,11 @@ impl Socket {
     /// Encode and write one message. Failed writes are not replayed.
     pub async fn send(&mut self, message: &Message) -> Result<()> {
         self.ensure_connected().await?;
-        let wire_message = self.type_state.pre_send(self.kind, message.clone())?;
+        let mut wire_message = self.type_state.pre_send(self.kind, message.clone())?;
+        if is_identity_routed(self.kind) {
+            let peer_identity = self.live.as_ref().expect("connected").peer_identity.clone();
+            wire_message = strip_single_peer_identity(self.kind, &peer_identity, wire_message)?;
+        }
         let timeout = self.options.io_timeout;
         let result = run_timeout(timeout, async {
             let live = self.live.as_mut().expect("connected");
@@ -284,6 +292,12 @@ impl Socket {
                     self.mark_disconnected(&error);
                     return Err(error);
                 }
+            };
+            let message = if is_identity_routed(self.kind) {
+                let peer_identity = self.live.as_ref().expect("connected").peer_identity.clone();
+                Message::with_prefix(peer_identity, message)
+            } else {
+                message
             };
             if let Some(message) = self.type_state.post_recv(self.kind, message)? {
                 if self.kind == SocketType::Rep {
@@ -466,10 +480,16 @@ fn reconnect_delay(policy: ReconnectPolicy, attempt: u32) -> Option<Duration> {
 fn validate_socket_type(socket_type: SocketType) -> Result<()> {
     if !matches!(
         socket_type,
-        SocketType::Dealer | SocketType::Req | SocketType::Rep
+        SocketType::Dealer
+            | SocketType::Router
+            | SocketType::Req
+            | SocketType::Rep
+            | SocketType::Pair
+            | SocketType::Client
+            | SocketType::Server
     ) {
         return Err(Error::Config(format!(
-            "exclusive sockets currently support only DEALER, REQ, and REP, not {socket_type:?}"
+            "exclusive sockets currently support only PAIR, DEALER, ROUTER, REQ, REP, CLIENT, and SERVER, not {socket_type:?}"
         )));
     }
     Ok(())
@@ -575,8 +595,9 @@ async fn establish_connected_live(
         last_ping: now,
         heartbeat_deadline: None,
         ping_sequence: 0,
+        peer_identity: Bytes::new(),
     };
-    tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
+    live.peer_identity = tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
         .await
         .map_err(|_| timed_out("exclusive socket handshake timeout"))??;
     Ok(live)
@@ -604,14 +625,16 @@ async fn establish_bound_live(
         last_ping: now,
         heartbeat_deadline: None,
         ping_sequence: 0,
+        peer_identity: Bytes::new(),
     };
-    tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
+    live.peer_identity = tokio::time::timeout(handshake_timeout, finish_handshake(&mut live))
         .await
         .map_err(|_| timed_out("exclusive socket handshake timeout"))??;
     Ok(live)
 }
 
-async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
+async fn finish_handshake(live: &mut LiveConnection) -> Result<Bytes> {
+    let mut peer_identity = None;
     while !live.connection.is_ready() {
         flush_live(live).await?;
         if live.connection.is_ready() {
@@ -619,12 +642,42 @@ async fn finish_handshake(live: &mut LiveConnection) -> Result<()> {
         }
         read_live_once(live).await?;
         while let Some(event) = live.connection.poll_event() {
-            if let ProtoEvent::HandshakeSucceeded { .. } = event {
+            if let ProtoEvent::HandshakeSucceeded {
+                peer_properties, ..
+            } = event
+            {
+                peer_identity = Some(
+                    peer_properties
+                        .identity
+                        .clone()
+                        .unwrap_or_else(|| generated_identity(0)),
+                );
                 break;
             }
         }
     }
-    flush_live(live).await
+    flush_live(live).await?;
+    Ok(peer_identity.unwrap_or_else(|| generated_identity(0)))
+}
+
+fn is_identity_routed(socket_type: SocketType) -> bool {
+    matches!(socket_type, SocketType::Router | SocketType::Server)
+}
+
+fn strip_single_peer_identity(
+    socket_type: SocketType,
+    peer_identity: &Bytes,
+    mut message: Message,
+) -> Result<Message> {
+    let Some(identity) = message.pop_front() else {
+        return Err(Error::Protocol(format!(
+            "{socket_type:?} socket requires a routing identity frame"
+        )));
+    };
+    if identity != *peer_identity {
+        return Err(Error::Unroutable);
+    }
+    Ok(message)
 }
 
 async fn recv_live(
@@ -802,6 +855,18 @@ mod tests {
         (dealer, bound)
     }
 
+    async fn regular_dealer_with_identity(identity: &'static [u8]) -> (RegularSocket, Endpoint) {
+        let dealer = RegularSocket::new(
+            SocketType::Dealer,
+            RegularOptions::default().identity(Bytes::from_static(identity)),
+        );
+        let bound = dealer
+            .bind("tcp://127.0.0.1:0".parse::<Endpoint>().unwrap())
+            .await
+            .unwrap();
+        (dealer, bound)
+    }
+
     async fn unresponsive_router() -> (Endpoint, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint: Endpoint = format!("tcp://{}", listener.local_addr().unwrap())
@@ -821,6 +886,7 @@ mod tests {
                 last_ping: now,
                 heartbeat_deadline: None,
                 ping_sequence: 0,
+                peer_identity: generated_identity(0),
             };
             finish_handshake(&mut live).await.unwrap();
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -847,6 +913,7 @@ mod tests {
                 last_ping: now,
                 heartbeat_deadline: None,
                 ping_sequence: 0,
+                peer_identity: generated_identity(0),
             };
             finish_handshake(&mut live).await.unwrap();
             read_live_once(&mut live).await.unwrap();
@@ -982,6 +1049,132 @@ mod tests {
             );
         }
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn router_round_trips_with_standard_dealer() {
+        let (dealer, endpoint) = regular_dealer_with_identity(b"dealer-a").await;
+        let mut router = Socket::connect(SocketType::Router, endpoint, Options::default())
+            .await
+            .unwrap();
+
+        dealer.send(Message::single("ping")).await.unwrap();
+        let request = router.recv().await.unwrap();
+        assert_eq!(request.part_bytes(0).unwrap().as_ref(), b"dealer-a");
+        assert_eq!(request.part_bytes(1).unwrap().as_ref(), b"ping");
+
+        router
+            .send(&Message::multipart([
+                Bytes::from_static(b"dealer-a"),
+                Bytes::from_static(b"pong"),
+            ]))
+            .await
+            .unwrap();
+        assert_eq!(dealer.recv().await.unwrap(), Message::single("pong"));
+    }
+
+    #[tokio::test]
+    async fn router_rejects_unknown_identity() {
+        let (_dealer, endpoint) = regular_dealer_with_identity(b"dealer-a").await;
+        let mut router = Socket::connect(SocketType::Router, endpoint, Options::default())
+            .await
+            .unwrap();
+
+        let error = router
+            .send(&Message::multipart([
+                Bytes::from_static(b"wrong"),
+                Bytes::from_static(b"body"),
+            ]))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Unroutable));
+    }
+
+    #[tokio::test]
+    async fn client_server_round_trip() {
+        let (mut server, endpoint) = Socket::bind(
+            SocketType::Server,
+            "tcp://127.0.0.1:0".parse().unwrap(),
+            Options::default(),
+        )
+        .await
+        .unwrap();
+        let server_task = tokio::spawn(async move {
+            let request = server.recv().await.unwrap();
+            assert_eq!(request.part_bytes(0).unwrap().as_ref(), b"client-a");
+            assert_eq!(request.part_bytes(1).unwrap().as_ref(), b"request");
+            server
+                .send(&Message::multipart(["client-a", "reply"]))
+                .await
+        });
+
+        let mut client = Socket::connect(
+            SocketType::Client,
+            endpoint,
+            Options {
+                identity: Bytes::from_static(b"client-a"),
+                ..Options::default()
+            },
+        )
+        .await
+        .unwrap();
+        client.send(&Message::single("request")).await.unwrap();
+        assert_eq!(client.recv().await.unwrap(), Message::single("reply"));
+        server_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn client_rejects_multipart_send() {
+        let (mut server, endpoint) = Socket::bind(
+            SocketType::Server,
+            "tcp://127.0.0.1:0".parse().unwrap(),
+            Options::default(),
+        )
+        .await
+        .unwrap();
+        let server_task = tokio::spawn(async move {
+            let _ = server.recv().await;
+        });
+        let mut client = Socket::connect(SocketType::Client, endpoint, Options::default())
+            .await
+            .unwrap();
+
+        let error = client
+            .send(&Message::multipart(["a", "b"]))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, Error::Protocol(message) if message.contains("single-part messages"))
+        );
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn pair_round_trips() {
+        let (mut bound, endpoint) = Socket::bind(
+            SocketType::Pair,
+            "tcp://127.0.0.1:0".parse().unwrap(),
+            Options::default(),
+        )
+        .await
+        .unwrap();
+        let server = tokio::spawn(async move {
+            assert_eq!(bound.recv().await.unwrap(), Message::single("from-client"));
+            bound.send(&Message::single("from-server")).await
+        });
+
+        let mut connected = Socket::connect(SocketType::Pair, endpoint, Options::default())
+            .await
+            .unwrap();
+        connected
+            .send(&Message::single("from-client"))
+            .await
+            .unwrap();
+        assert_eq!(
+            connected.recv().await.unwrap(),
+            Message::single("from-server")
+        );
+        server.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -1163,11 +1356,11 @@ mod tests {
     #[tokio::test]
     async fn unsupported_modes_fail_before_connecting() {
         let endpoint: Endpoint = "tcp://127.0.0.1:1".parse().unwrap();
-        let error = Socket::connect(SocketType::Pair, endpoint, Options::default())
+        let error = Socket::connect(SocketType::Push, endpoint, Options::default())
             .await
             .unwrap_err();
         assert!(
-            matches!(error, Error::Config(message) if message.contains("only DEALER, REQ, and REP"))
+            matches!(error, Error::Config(message) if message.contains("PAIR, DEALER, ROUTER"))
         );
 
         let endpoint: Endpoint = "inproc://exclusive".parse().unwrap();

--- a/omq-tokio/tests/omq_soak_exclusive.rs
+++ b/omq-tokio/tests/omq_soak_exclusive.rs
@@ -1,0 +1,362 @@
+#![cfg(feature = "soak")]
+//! Soak: caller-driven exclusive sockets under peer churn.
+//!
+//! Exercises every exclusive socket type over TCP with both sides using the
+//! exclusive API. Each scenario keeps one bound socket alive, repeatedly
+//! connects a peer, exchanges one round trip, idles while both sides call
+//! `maintain()` to drive heartbeats, then drops the peer and verifies the
+//! bound side observes the disappearance.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::exclusive::{
+    Event as ExclusiveEvent, Options as ExclusiveOptions, Socket as ExclusiveSocket,
+};
+use omq_tokio::{Endpoint, Error, Message, ReconnectPolicy, SocketType};
+use tokio::sync::broadcast::error::TryRecvError;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_millis(120);
+const IO_TIMEOUT: Duration = Duration::from_secs(1);
+const IDLE_MAINTAIN: Duration = Duration::from_millis(70);
+const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug)]
+enum Flow {
+    Pair,
+    DealerRouter,
+    ReqRep,
+    ClientServer,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Scenario {
+    name: &'static str,
+    bind_kind: SocketType,
+    connect_kind: SocketType,
+    flow: Flow,
+}
+
+struct ScenarioState {
+    spec: Scenario,
+    bound: ExclusiveSocket,
+    endpoint: Endpoint,
+    monitor: tokio::sync::broadcast::Receiver<ExclusiveEvent>,
+    cycles: u64,
+    disconnects: u64,
+}
+
+fn exclusive_options(kind: SocketType, side: &str) -> ExclusiveOptions {
+    let identity = match kind {
+        SocketType::Dealer => Bytes::from(format!("dealer-{side}")),
+        SocketType::Client => Bytes::from(format!("client-{side}")),
+        SocketType::Req => Bytes::from(format!("req-{side}")),
+        SocketType::Rep => Bytes::from(format!("rep-{side}")),
+        SocketType::Router => Bytes::from(format!("router-{side}")),
+        SocketType::Server => Bytes::from(format!("server-{side}")),
+        SocketType::Pair => Bytes::from(format!("pair-{side}")),
+        _ => Bytes::new(),
+    };
+    ExclusiveOptions {
+        identity,
+        connect_timeout: Duration::from_secs(1),
+        handshake_timeout: Duration::from_secs(1),
+        io_timeout: Some(IO_TIMEOUT),
+        reconnect: ReconnectPolicy::Fixed(Duration::from_millis(5)),
+        heartbeat_interval: Some(HEARTBEAT_INTERVAL),
+        heartbeat_ttl: Some(HEARTBEAT_TIMEOUT),
+        heartbeat_timeout: Some(HEARTBEAT_TIMEOUT),
+    }
+}
+
+async fn make_state(spec: Scenario) -> ScenarioState {
+    let (bound, endpoint) = ExclusiveSocket::bind(
+        spec.bind_kind,
+        soak_common::tcp_ep(0),
+        exclusive_options(spec.bind_kind, "bind"),
+    )
+    .await
+    .unwrap();
+    let monitor = bound.monitor();
+    ScenarioState {
+        spec,
+        bound,
+        endpoint,
+        monitor,
+        cycles: 0,
+        disconnects: 0,
+    }
+}
+
+async fn connect_peer(state: &mut ScenarioState) -> ExclusiveSocket {
+    let connect = ExclusiveSocket::connect(
+        state.spec.connect_kind,
+        state.endpoint.clone(),
+        exclusive_options(state.spec.connect_kind, "connect"),
+    );
+    let accept = state.bound.maintain();
+    let (connected, accepted) = tokio::join!(connect, accept);
+    accepted.unwrap();
+    connected.unwrap()
+}
+
+async fn cycle(state: &mut ScenarioState) {
+    let mut peer = connect_peer(state).await;
+    exchange_once(&state.spec, &mut state.bound, &mut peer, state.cycles).await;
+    drive_idle_heartbeats(&mut state.bound, &mut peer).await;
+    drop(peer);
+    wait_for_peer_disappearance(&mut state.bound).await;
+    state.disconnects += drain_disconnect_events(&mut state.monitor);
+    state.cycles += 1;
+}
+
+async fn exchange_once(
+    spec: &Scenario,
+    bound: &mut ExclusiveSocket,
+    peer: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    match spec.flow {
+        Flow::Pair => exchange_pair(bound, peer, seq).await,
+        Flow::DealerRouter => exchange_dealer_router(spec, bound, peer, seq).await,
+        Flow::ReqRep => exchange_req_rep(spec, bound, peer, seq).await,
+        Flow::ClientServer => exchange_client_server(spec, bound, peer, seq).await,
+    }
+}
+
+async fn exchange_pair(bound: &mut ExclusiveSocket, peer: &mut ExclusiveSocket, seq: u64) {
+    let body = format!("pair-{seq}");
+    peer.send(&Message::single(body.clone())).await.unwrap();
+    assert_eq!(bound.recv().await.unwrap(), Message::single(body));
+    bound.send(&Message::single("pair-reply")).await.unwrap();
+    assert_eq!(peer.recv().await.unwrap(), Message::single("pair-reply"));
+}
+
+async fn exchange_dealer_router(
+    spec: &Scenario,
+    bound: &mut ExclusiveSocket,
+    peer: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    if spec.bind_kind == SocketType::Dealer {
+        dealer_router_round_trip(bound, peer, seq).await;
+    } else {
+        dealer_router_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn dealer_router_round_trip(
+    dealer: &mut ExclusiveSocket,
+    router: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    let body = format!("dealer-router-{seq}");
+    dealer.send(&Message::single(body.clone())).await.unwrap();
+    let request = router.recv().await.unwrap();
+    let identity = request.part_bytes(0).unwrap().clone();
+    assert_eq!(request.part_bytes(1).unwrap(), body.as_bytes());
+    router
+        .send(&Message::multipart([
+            identity,
+            Bytes::from_static(b"dealer-router-reply"),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        dealer.recv().await.unwrap(),
+        Message::single("dealer-router-reply")
+    );
+}
+
+async fn exchange_req_rep(
+    spec: &Scenario,
+    bound: &mut ExclusiveSocket,
+    peer: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    if spec.bind_kind == SocketType::Req {
+        req_rep_round_trip(bound, peer, seq).await;
+    } else {
+        req_rep_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn req_rep_round_trip(req: &mut ExclusiveSocket, rep: &mut ExclusiveSocket, seq: u64) {
+    let body = format!("req-rep-{seq}");
+    req.send(&Message::single(body.clone())).await.unwrap();
+    assert_eq!(rep.recv().await.unwrap(), Message::single(body));
+    rep.send(&Message::single("req-rep-reply")).await.unwrap();
+    assert_eq!(req.recv().await.unwrap(), Message::single("req-rep-reply"));
+}
+
+async fn exchange_client_server(
+    spec: &Scenario,
+    bound: &mut ExclusiveSocket,
+    peer: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    if spec.bind_kind == SocketType::Client {
+        client_server_round_trip(bound, peer, seq).await;
+    } else {
+        client_server_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn client_server_round_trip(
+    client: &mut ExclusiveSocket,
+    server: &mut ExclusiveSocket,
+    seq: u64,
+) {
+    let body = format!("client-server-{seq}");
+    client.send(&Message::single(body.clone())).await.unwrap();
+    let request = server.recv().await.unwrap();
+    let identity = request.part_bytes(0).unwrap().clone();
+    assert_eq!(request.part_bytes(1).unwrap(), body.as_bytes());
+    server
+        .send(&Message::multipart([
+            identity,
+            Bytes::from_static(b"client-server-reply"),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        client.recv().await.unwrap(),
+        Message::single("client-server-reply")
+    );
+}
+
+async fn drive_idle_heartbeats(bound: &mut ExclusiveSocket, peer: &mut ExclusiveSocket) {
+    let start = Instant::now();
+    while start.elapsed() < IDLE_MAINTAIN {
+        let (bound_result, peer_result) = tokio::join!(bound.maintain(), peer.maintain());
+        bound_result.unwrap();
+        peer_result.unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+async fn wait_for_peer_disappearance(bound: &mut ExclusiveSocket) {
+    let start = Instant::now();
+    loop {
+        match bound.maintain().await {
+            Ok(()) => {}
+            Err(Error::Closed | Error::Timeout | Error::Io(_)) => return,
+            Err(error) => panic!("unexpected exclusive peer disappearance error: {error}"),
+        }
+        assert!(
+            start.elapsed() < DISCONNECT_TIMEOUT,
+            "exclusive bound socket did not observe peer disappearance"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+fn drain_disconnect_events(monitor: &mut tokio::sync::broadcast::Receiver<ExclusiveEvent>) -> u64 {
+    let mut disconnected = 0;
+    loop {
+        match monitor.try_recv() {
+            Ok(ExclusiveEvent::Disconnected { .. }) => disconnected += 1,
+            Ok(_) => {}
+            Err(TryRecvError::Empty | TryRecvError::Closed) => return disconnected,
+            Err(TryRecvError::Lagged(skipped)) => {
+                panic!("exclusive monitor lagged during soak: skipped {skipped}");
+            }
+        }
+    }
+}
+
+#[test]
+fn soak_exclusive_all_supported_types() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
+        let specs = [
+            Scenario {
+                name: "pair",
+                bind_kind: SocketType::Pair,
+                connect_kind: SocketType::Pair,
+                flow: Flow::Pair,
+            },
+            Scenario {
+                name: "dealer-router",
+                bind_kind: SocketType::Router,
+                connect_kind: SocketType::Dealer,
+                flow: Flow::DealerRouter,
+            },
+            Scenario {
+                name: "router-dealer",
+                bind_kind: SocketType::Dealer,
+                connect_kind: SocketType::Router,
+                flow: Flow::DealerRouter,
+            },
+            Scenario {
+                name: "req-rep",
+                bind_kind: SocketType::Rep,
+                connect_kind: SocketType::Req,
+                flow: Flow::ReqRep,
+            },
+            Scenario {
+                name: "rep-req",
+                bind_kind: SocketType::Req,
+                connect_kind: SocketType::Rep,
+                flow: Flow::ReqRep,
+            },
+            Scenario {
+                name: "client-server",
+                bind_kind: SocketType::Server,
+                connect_kind: SocketType::Client,
+                flow: Flow::ClientServer,
+            },
+            Scenario {
+                name: "server-client",
+                bind_kind: SocketType::Client,
+                connect_kind: SocketType::Server,
+                flow: Flow::ClientServer,
+            },
+        ];
+        let mut states = Vec::new();
+        for spec in specs {
+            states.push(make_state(spec).await);
+        }
+
+        let start = Instant::now();
+        let mut last_log = start;
+        while start.elapsed() < duration {
+            for state in &mut states {
+                cycle(state).await;
+            }
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!("[exclusive] {:.0}s:", start.elapsed().as_secs_f64());
+                for state in &states {
+                    eprintln!(
+                        "  {}: {} cycles, {} disconnects",
+                        state.spec.name, state.cycles, state.disconnects
+                    );
+                }
+                last_log = Instant::now();
+            }
+        }
+
+        for state in &mut states {
+            assert!(state.cycles > 0, "{} had no cycles", state.spec.name);
+            assert_eq!(
+                state.disconnects, state.cycles,
+                "{} missed disconnect events",
+                state.spec.name
+            );
+            state.bound.close().await.unwrap();
+        }
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("exclusive");
+}


### PR DESCRIPTION
- Adds `omq_tokio::exclusive::Socket` support for `PAIR`, `ROUTER`, `REQ`, `REP`, `CLIENT`, and `SERVER` through the existing `exclusive` API.
- Preserves normal identity-prefixed routing for single-peer `ROUTER` and `SERVER` sockets while keeping wire I/O direct and caller-driven.
- Adds exclusive `REQ`/`REP` benchmark peers and refreshes `doc/charts/main_reqrep_tcp.svg` with the exclusive implementation.
- Updates `README.md`, `doc/architecture.md`, and public API docs for the expanded exclusive socket surface.
- Adds unit coverage plus a feature-gated exclusive soak test for peer churn, `maintain()`-driven heartbeats, RSS, heap, and FD stability.
- Refreshes lockfiles for the bundled Zrip dependency update.