### PR TITLE
chore: prepare binding releases

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -215,8 +215,8 @@ jobs:
         run: |
           mkdir smoke
           cd smoke
-          root="../dist/zeromq-omq-node-${{ needs.package.outputs.version }}.tgz"
-          platform="../dist/zeromq-omq-node-${{ matrix.platform }}-${{ needs.package.outputs.version }}.tgz"
+          root="../dist/paddor-omq-node-${{ needs.package.outputs.version }}.tgz"
+          platform="../dist/paddor-omq-node-${{ matrix.platform }}-${{ needs.package.outputs.version }}.tgz"
           test -f "$root"
           test -f "$platform"
           npm install --omit=optional "$platform" "$root"
@@ -225,7 +225,7 @@ jobs:
         working-directory: smoke
         run: |
           node <<'NODE'
-          const { Context, Pull, Push } = require("@zeromq/omq-node");
+          const { Context, Pull, Push } = require("@paddor/omq-node");
 
           (async () => {
             const context = new Context();
@@ -257,7 +257,7 @@ jobs:
     timeout-minutes: 15
     environment:
       name: npm
-      url: https://www.npmjs.com/package/@zeromq/omq-node
+      url: https://www.npmjs.com/package/@paddor/omq-node
     permissions:
       contents: read
       id-token: write
@@ -275,7 +275,7 @@ jobs:
       - name: Publish platform packages
         shell: bash
         run: |
-          root="dist/zeromq-omq-node-${{ needs.package.outputs.version }}.tgz"
+          root="dist/paddor-omq-node-${{ needs.package.outputs.version }}.tgz"
           for package in dist/*.tgz; do
             if [[ "$package" == "$root" ]]; then
               continue
@@ -283,4 +283,4 @@ jobs:
             npm publish "$package" --access public --provenance
           done
       - name: Publish root package
-        run: npm publish "dist/zeromq-omq-node-${{ needs.package.outputs.version }}.tgz" --access public --provenance
+        run: npm publish "dist/paddor-omq-node-${{ needs.package.outputs.version }}.tgz" --access public --provenance

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -371,9 +371,68 @@ GitHub releases. Configuration lives in `release-plz.toml`.
 4. **Merge the release PR.** release-plz tags and publishes to
    crates.io automatically.
 
-5. **pyomq** if changed: bump `bindings/pyomq/Cargo.toml` and
-   `bindings/pyomq/pyproject.toml`, run `cargo update -p pyomq` inside
-   `bindings/pyomq`, add a changelog entry, then push a `pyomq-v*` tag.
+5. **Bindings** if changed: prepare the binding release on a PR, merge it,
+   then tag from the merged `main` commit. Do not tag before the release PR is
+   merged.
+
+### Binding Releases
+
+`pyomq` publishes to PyPI from `.github/workflows/release-pyomq.yml`.
+Prepare a release by bumping `bindings/pyomq/Cargo.toml` and
+`bindings/pyomq/pyproject.toml`, running `cargo update -p pyomq` inside
+`bindings/pyomq`, and adding a `bindings/pyomq/CHANGELOG.md` entry. After
+the PR is merged, push a tag:
+
+```sh
+git tag -a pyomq-v0.20.0 -m "pyomq 0.20.0"
+git push origin pyomq-v0.20.0
+gh run watch --repo paddor/omq.rs --exit-status
+```
+
+`OMQ.java` publishes to Maven Central from
+`.github/workflows/release-java.yml`. Prepare a release by adding a
+`bindings/java/CHANGELOG.md` entry. The workflow version comes from the tag
+or manual `workflow_dispatch` input; `pom.xml` normally stays at
+`${revision}`. Required repository secrets are `CENTRAL_USERNAME`,
+`CENTRAL_PASSWORD`, `MAVEN_GPG_PRIVATE_KEY`, and `MAVEN_GPG_PASSPHRASE`.
+After the PR is merged, push a tag:
+
+```sh
+git tag -a omq-java-v0.3.1 -m "OMQ.java 0.3.1"
+git push origin omq-java-v0.3.1
+gh run watch --repo paddor/omq.rs --exit-status
+```
+
+The workflow uploads a validated Central deployment with
+`central.autoPublish=false`; publish the validated deployment in Central after
+the workflow passes.
+
+`OMQ.go` is a Go subdirectory module. It has no registry account or upload
+step; the Git tag is the release. After the PR is merged, push a subdirectory
+module tag from `main`:
+
+```sh
+git tag -a bindings/go/v0.1.0 -m "OMQ.go 0.1.0"
+git push origin bindings/go/v0.1.0
+go list -m github.com/paddor/omq.rs/bindings/go@v0.1.0
+```
+
+The public Go module proxy discovers the version from that tag.
+
+`OMQ.node` publishes to npm from `.github/workflows/release-node.yml`.
+Prepare a release by checking `bindings/node/package.json`,
+`bindings/node/npm/*/package.json`, and
+`bindings/node/scripts/prepare-release.js`. The workflow version comes from
+the tag or manual `workflow_dispatch` input, builds all platform native
+addons, packs platform packages, smoke-tests host tarballs, publishes
+platform packages first, then publishes the root package. Required repository
+secret: `NPM_TOKEN`. After the PR is merged, push a tag:
+
+```sh
+git tag -a omq-node-v0.1.0 -m "OMQ.node 0.1.0"
+git push origin omq-node-v0.1.0
+gh run watch --repo paddor/omq.rs --exit-status
+```
 
 ### Crates To Check
 

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
+## [0.3.1]
+
 - Use timed PUSH/PULL throughput samples for the OMQ.java performance chart
   instead of fixed message-count runs.
+- Fix receive ring close races for both virtual-thread and platform-thread
+  receive paths.
+- Use ISC license metadata in Maven and native Cargo manifests.
+- Bundle native backend updates from `omq-tokio` 0.21.2 and related crates.
 
 ## [0.3.0]
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,4 +1,4 @@
-# @zeromq/omq-node
+# @paddor/omq-node
 
 Native Node.js binding for OMQ.rs.
 
@@ -11,11 +11,11 @@ This package is for Node main/server processes. Browser code should use
 `@zeromq/omq`.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/node/doc/charts/bindings.svg" alt="@zeromq/omq-node sync API vs zeromq.js TCP throughput and latency" width="850">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/node/doc/charts/bindings.svg" alt="@paddor/omq-node sync API vs zeromq.js TCP throughput and latency" width="850">
 </p>
 
 2-process loopback PUSH/PULL throughput and REQ/REP p50 latency: per-message
-`@zeromq/omq-node` sync API calls vs per-message `zeromq.js` calls over TCP.
+`@paddor/omq-node` sync API calls vs per-message `zeromq.js` calls over TCP.
 
 ## Highlights
 
@@ -55,13 +55,13 @@ local development. Published packages can load a matching platform prebuild.
 - Sockets are single-thread objects on the JavaScript side; create more
   sockets for more concurrent flows.
 
-`@zeromq/omq-node` is not a `zeromq.js` compatibility layer. It follows ZMQ
+`@paddor/omq-node` is not a `zeromq.js` compatibility layer. It follows ZMQ
 socket semantics, but exposes a Node API shaped around this binding.
 
 Example:
 
 ```js
-const { Pull, Push } = require("@zeromq/omq-node");
+const { Pull, Push } = require("@paddor/omq-node");
 
 async function main() {
   const pull = new Pull();
@@ -84,7 +84,7 @@ main();
 Shared `inproc://` context:
 
 ```js
-const { Context, Pull, Push } = require("@zeromq/omq-node");
+const { Context, Pull, Push } = require("@paddor/omq-node");
 
 async function main() {
   const owner = new Context();
@@ -111,7 +111,7 @@ main();
 Socket options:
 
 ```js
-const { Push } = require("@zeromq/omq-node");
+const { Push } = require("@paddor/omq-node");
 
 async function main() {
   const push = new Push({

--- a/bindings/node/dist/index.js
+++ b/bindings/node/dist/index.js
@@ -676,7 +676,7 @@ function loadNative() {
                 // Fall through to source-build message below.
             }
         }
-        const message = "Cannot load @zeromq/omq-node native addon. Run `npm run build:native` in bindings/node or install a matching prebuild.";
+        const message = "Cannot load @paddor/omq-node native addon. Run `npm run build:native` in bindings/node or install a matching prebuild.";
         const error = new Error(message);
         error.cause = localError;
         throw error;
@@ -689,21 +689,21 @@ function platformPackageName() {
         const report = process.report?.getReport();
         const libc = report?.header?.glibcVersionRuntime ? "gnu" : "musl";
         if (arch === "x64")
-            return `@zeromq/omq-node-linux-x64-${libc}`;
+            return `@paddor/omq-node-linux-x64-${libc}`;
         if (arch === "arm64")
-            return `@zeromq/omq-node-linux-arm64-${libc}`;
+            return `@paddor/omq-node-linux-arm64-${libc}`;
     }
     if (platform === "darwin") {
         if (arch === "x64")
-            return "@zeromq/omq-node-darwin-x64";
+            return "@paddor/omq-node-darwin-x64";
         if (arch === "arm64")
-            return "@zeromq/omq-node-darwin-arm64";
+            return "@paddor/omq-node-darwin-arm64";
     }
     if (platform === "win32") {
         if (arch === "x64")
-            return "@zeromq/omq-node-win32-x64-msvc";
+            return "@paddor/omq-node-win32-x64-msvc";
         if (arch === "arm64")
-            return "@zeromq/omq-node-win32-arm64-msvc";
+            return "@paddor/omq-node-win32-arm64-msvc";
     }
     return undefined;
 }

--- a/bindings/node/npm/darwin-arm64/README.md
+++ b/bindings/node/npm/darwin-arm64/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-darwin-arm64`
+# `@paddor/omq-node-darwin-arm64`
 
-This is the **aarch64-apple-darwin** binary for `@zeromq/omq-node`
+This is the **aarch64-apple-darwin** binary for `@paddor/omq-node`

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-darwin-arm64",
+  "name": "@paddor/omq-node-darwin-arm64",
   "version": "0.1.0",
   "cpu": [
     "arm64"

--- a/bindings/node/npm/darwin-x64/README.md
+++ b/bindings/node/npm/darwin-x64/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-darwin-x64`
+# `@paddor/omq-node-darwin-x64`
 
-This is the **x86_64-apple-darwin** binary for `@zeromq/omq-node`
+This is the **x86_64-apple-darwin** binary for `@paddor/omq-node`

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-darwin-x64",
+  "name": "@paddor/omq-node-darwin-x64",
   "version": "0.1.0",
   "cpu": [
     "x64"

--- a/bindings/node/npm/linux-arm64-gnu/README.md
+++ b/bindings/node/npm/linux-arm64-gnu/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-linux-arm64-gnu`
+# `@paddor/omq-node-linux-arm64-gnu`
 
-This is the **aarch64-unknown-linux-gnu** binary for `@zeromq/omq-node`
+This is the **aarch64-unknown-linux-gnu** binary for `@paddor/omq-node`

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-linux-arm64-gnu",
+  "name": "@paddor/omq-node-linux-arm64-gnu",
   "version": "0.1.0",
   "cpu": [
     "arm64"

--- a/bindings/node/npm/linux-arm64-musl/README.md
+++ b/bindings/node/npm/linux-arm64-musl/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-linux-arm64-musl`
+# `@paddor/omq-node-linux-arm64-musl`
 
-This is the **aarch64-unknown-linux-musl** binary for `@zeromq/omq-node`
+This is the **aarch64-unknown-linux-musl** binary for `@paddor/omq-node`

--- a/bindings/node/npm/linux-arm64-musl/package.json
+++ b/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-linux-arm64-musl",
+  "name": "@paddor/omq-node-linux-arm64-musl",
   "version": "0.1.0",
   "cpu": [
     "arm64"

--- a/bindings/node/npm/linux-x64-gnu/README.md
+++ b/bindings/node/npm/linux-x64-gnu/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-linux-x64-gnu`
+# `@paddor/omq-node-linux-x64-gnu`
 
-This is the **x86_64-unknown-linux-gnu** binary for `@zeromq/omq-node`
+This is the **x86_64-unknown-linux-gnu** binary for `@paddor/omq-node`

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-linux-x64-gnu",
+  "name": "@paddor/omq-node-linux-x64-gnu",
   "version": "0.1.0",
   "cpu": [
     "x64"

--- a/bindings/node/npm/linux-x64-musl/README.md
+++ b/bindings/node/npm/linux-x64-musl/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-linux-x64-musl`
+# `@paddor/omq-node-linux-x64-musl`
 
-This is the **x86_64-unknown-linux-musl** binary for `@zeromq/omq-node`
+This is the **x86_64-unknown-linux-musl** binary for `@paddor/omq-node`

--- a/bindings/node/npm/linux-x64-musl/package.json
+++ b/bindings/node/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-linux-x64-musl",
+  "name": "@paddor/omq-node-linux-x64-musl",
   "version": "0.1.0",
   "cpu": [
     "x64"

--- a/bindings/node/npm/win32-arm64-msvc/README.md
+++ b/bindings/node/npm/win32-arm64-msvc/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-win32-arm64-msvc`
+# `@paddor/omq-node-win32-arm64-msvc`
 
-This is the **aarch64-pc-windows-msvc** binary for `@zeromq/omq-node`
+This is the **aarch64-pc-windows-msvc** binary for `@paddor/omq-node`

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-win32-arm64-msvc",
+  "name": "@paddor/omq-node-win32-arm64-msvc",
   "version": "0.1.0",
   "cpu": [
     "arm64"

--- a/bindings/node/npm/win32-x64-msvc/README.md
+++ b/bindings/node/npm/win32-x64-msvc/README.md
@@ -1,3 +1,3 @@
-# `@zeromq/omq-node-win32-x64-msvc`
+# `@paddor/omq-node-win32-x64-msvc`
 
-This is the **x86_64-pc-windows-msvc** binary for `@zeromq/omq-node`
+This is the **x86_64-pc-windows-msvc** binary for `@paddor/omq-node`

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node-win32-x64-msvc",
+  "name": "@paddor/omq-node-win32-x64-msvc",
   "version": "0.1.0",
   "cpu": [
     "x64"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@zeromq/omq-node",
+  "name": "@paddor/omq-node",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@zeromq/omq-node",
+      "name": "@paddor/omq-node",
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zeromq/omq-node",
+  "name": "@paddor/omq-node",
   "version": "0.1.0",
   "description": "Native Node.js binding for OMQ.rs",
   "license": "ISC",

--- a/bindings/node/ts/index.ts
+++ b/bindings/node/ts/index.ts
@@ -915,7 +915,7 @@ function loadNative(): NativeModule {
       }
     }
     const message =
-      "Cannot load @zeromq/omq-node native addon. Run `npm run build:native` in bindings/node or install a matching prebuild.";
+      "Cannot load @paddor/omq-node native addon. Run `npm run build:native` in bindings/node or install a matching prebuild.";
     const error = new Error(message);
     (error as Error & { cause?: unknown }).cause = localError;
     throw error;
@@ -928,16 +928,16 @@ function platformPackageName(): string | undefined {
   if (platform === "linux") {
     const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } } | undefined;
     const libc = report?.header?.glibcVersionRuntime ? "gnu" : "musl";
-    if (arch === "x64") return `@zeromq/omq-node-linux-x64-${libc}`;
-    if (arch === "arm64") return `@zeromq/omq-node-linux-arm64-${libc}`;
+    if (arch === "x64") return `@paddor/omq-node-linux-x64-${libc}`;
+    if (arch === "arm64") return `@paddor/omq-node-linux-arm64-${libc}`;
   }
   if (platform === "darwin") {
-    if (arch === "x64") return "@zeromq/omq-node-darwin-x64";
-    if (arch === "arm64") return "@zeromq/omq-node-darwin-arm64";
+    if (arch === "x64") return "@paddor/omq-node-darwin-x64";
+    if (arch === "arm64") return "@paddor/omq-node-darwin-arm64";
   }
   if (platform === "win32") {
-    if (arch === "x64") return "@zeromq/omq-node-win32-x64-msvc";
-    if (arch === "arm64") return "@zeromq/omq-node-win32-arm64-msvc";
+    if (arch === "x64") return "@paddor/omq-node-win32-x64-msvc";
+    if (arch === "arm64") return "@paddor/omq-node-win32-arm64-msvc";
   }
   return undefined;
 }

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-16
+
+### Added
+
+- `Context.share_key()` and `Context.from_share_key()` expose native context
+  core sharing for Python and Rust interop.
+- Python zguide examples now cover request/reply, pub/sub, and pipeline flows.
+
+### Fixed
+
+- `Poller` now reports `POLLOUT` readiness and avoids blocking when writable
+  sockets are already ready.
+- Deadline handling now avoids overflow near very large timeout values.
+
+### Changed
+
+- `inproc://` names now rely on the native per-context-core namespace instead
+  of Python-side endpoint rewriting.
+- *(deps)* Bump bundled `omq-tokio` to 0.21.2, `omq-proto` to 0.26.0, and
+  `yring` to 0.3.14.
+
 ## [0.19.2] - 2026-08-08
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.19.2"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.19.2"
+version = "0.20.0"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- Prepare `pyomq` `0.20.0` release metadata and changelog.
- Add `OMQ.java` `0.3.1` changelog entries for receive close fixes, license metadata, and bundled backend updates.
- Document binding release steps for `pyomq`, `OMQ.java`, `OMQ.go`, and `OMQ.node`.
- Move `OMQ.node` npm package metadata and release workflow from `@zeromq` to `@paddor` scope.