### PR TITLE
Fix OMQ.node release publishing

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -280,7 +280,7 @@ jobs:
             if [[ "$package" == "$root" ]]; then
               continue
             fi
-            npm publish "$package" --access public --provenance
+            npm publish "./$package" --access public --provenance
           done
       - name: Publish root package
-        run: npm publish "dist/paddor-omq-node-${{ needs.package.outputs.version }}.tgz" --access public --provenance
+        run: npm publish "./dist/paddor-omq-node-${{ needs.package.outputs.version }}.tgz" --access public --provenance

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -429,8 +429,8 @@ platform packages first, then publishes the root package. Required repository
 secret: `NPM_TOKEN`. After the PR is merged, push a tag:
 
 ```sh
-git tag -a omq-node-v0.1.0 -m "OMQ.node 0.1.0"
-git push origin omq-node-v0.1.0
+git tag -a omq-node-v0.1.1 -m "OMQ.node 0.1.1"
+git push origin omq-node-v0.1.1
 gh run watch --repo paddor/omq.rs --exit-status
 ```
 

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "omq-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "napi",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.93"
 publish = false

--- a/bindings/node/DEVELOPMENT.md
+++ b/bindings/node/DEVELOPMENT.md
@@ -116,10 +116,10 @@ Do not run `npm publish` locally.
 Trigger CI release with a tag:
 
 ```sh
-git tag omq-node-v0.1.0
+git tag omq-node-v0.1.1
 ```
 
-Or run `.github/workflows/release-node.yml` with `version=0.1.0`.
+Or run `.github/workflows/release-node.yml` with `version=0.1.1`.
 
 Native jobs build platform addons named `omq_node.<platform>.node`.
 Package job copies them into `npm/<platform>/`, writes root
@@ -135,7 +135,7 @@ cp omq_node.linux-x64-gnu.node npm/linux-x64-gnu/
 npm pack ./npm/linux-x64-gnu --dry-run
 ```
 
-Use `npm run release:prepare -- 0.1.0 --dry-run` to validate metadata without
+Use `npm run release:prepare -- 0.1.1 --dry-run` to validate metadata without
 rewriting manifests.
 
 `npm run artifacts` expects every configured platform addon under `artifacts/`.

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-arm64-musl/package.json
+++ b/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-musl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-x64-musl/package.json
+++ b/bindings/node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-arm64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paddor/omq-node",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Native Node.js binding for OMQ.rs",
   "license": "ISC",
   "type": "commonjs",


### PR DESCRIPTION
- publish npm tarballs through explicit local paths in the release workflow
- bump OMQ.node release metadata to 0.1.1 after the failed 0.1.0 publish attempt
- update node release docs to use the next patch tag