### PR TITLE
Publish Java releases from CI

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -229,7 +229,7 @@ jobs:
           else
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           fi
-      - name: Upload for validation
+      - name: Publish to Maven Central
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
@@ -238,5 +238,5 @@ jobs:
           mvn -B -ntp -f bindings/java/pom.xml -Prelease
           -Drevision=${{ steps.version.outputs.version }}
           -DskipNative=true -DskipTests
-          -Dcentral.autoPublish=false -Dcentral.waitUntil=validated
+          -Dcentral.autoPublish=true -Dcentral.waitUntil=published
           deploy

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -398,14 +398,13 @@ or manual `workflow_dispatch` input; `pom.xml` normally stays at
 After the PR is merged, push a tag:
 
 ```sh
-git tag -a omq-java-v0.3.1 -m "OMQ.java 0.3.1"
-git push origin omq-java-v0.3.1
+git tag -a omq-java-v0.3.2 -m "OMQ.java 0.3.2"
+git push origin omq-java-v0.3.2
 gh run watch --repo paddor/omq.rs --exit-status
 ```
 
-The workflow uploads a validated Central deployment with
-`central.autoPublish=false`; publish the validated deployment in Central after
-the workflow passes.
+The workflow publishes with `central.autoPublish=true` and waits until Central
+reports the deployment as published.
 
 `OMQ.go` is a Go subdirectory module. It has no registry account or upload
 step; the Git tag is the release. After the PR is merged, push a subdirectory
@@ -426,11 +425,12 @@ Prepare a release by checking `bindings/node/package.json`,
 the tag or manual `workflow_dispatch` input, builds all platform native
 addons, packs platform packages, smoke-tests host tarballs, publishes
 platform packages first, then publishes the root package. Required repository
-secret: `NPM_TOKEN`. After the PR is merged, push a tag:
+secret: `NPM_TOKEN`; for CI publishing, use a publish-capable npm token that
+can bypass 2FA. After the PR is merged, push a tag:
 
 ```sh
-git tag -a omq-node-v0.1.1 -m "OMQ.node 0.1.1"
-git push origin omq-node-v0.1.1
+git tag -a omq-node-v0.1.2 -m "OMQ.node 0.1.2"
+git push origin omq-node-v0.1.2
 gh run watch --repo paddor/omq.rs --exit-status
 ```
 

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.3.2]
+
+- Re-run the OMQ.java release through a Maven Central workflow that publishes
+  automatically after validation.
+
 ## [0.3.1]
 
 - Use timed PUSH/PULL throughput samples for the OMQ.java performance chart

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "omq-node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "napi",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-node"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.93"
 publish = false

--- a/bindings/node/DEVELOPMENT.md
+++ b/bindings/node/DEVELOPMENT.md
@@ -116,10 +116,10 @@ Do not run `npm publish` locally.
 Trigger CI release with a tag:
 
 ```sh
-git tag omq-node-v0.1.1
+git tag omq-node-v0.1.2
 ```
 
-Or run `.github/workflows/release-node.yml` with `version=0.1.1`.
+Or run `.github/workflows/release-node.yml` with `version=0.1.2`.
 
 Native jobs build platform addons named `omq_node.<platform>.node`.
 Package job copies them into `npm/<platform>/`, writes root
@@ -135,7 +135,7 @@ cp omq_node.linux-x64-gnu.node npm/linux-x64-gnu/
 npm pack ./npm/linux-x64-gnu --dry-run
 ```
 
-Use `npm run release:prepare -- 0.1.1 --dry-run` to validate metadata without
+Use `npm run release:prepare -- 0.1.2 --dry-run` to validate metadata without
 rewriting manifests.
 
 `npm run artifacts` expects every configured platform addon under `artifacts/`.

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-arm64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-x64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-gnu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-arm64-musl/package.json
+++ b/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-musl",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-gnu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-x64-musl/package.json
+++ b/bindings/node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-musl",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-arm64-msvc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-x64-msvc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paddor/omq-node",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Native Node.js binding for OMQ.rs",
   "license": "ISC",
   "type": "commonjs",


### PR DESCRIPTION
- switch the OMQ.java release workflow to auto-publish and wait for Central published state
- add a 0.3.2 Java changelog entry for the auto-published retry
- bump the next OMQ.node release attempt to 0.1.2 after the failed 0.1.1 npm publish
- document that npm CI publishing needs a publish-capable token with 2FA bypass