### PR TITLE
perf(tokio): add direct latency path for dealer

### DIFF
--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Explicit latency-profile `DEALER` sockets now use the existing direct TCP
+  writer and latency round-robin route. The default throughput-profile
+  `DEALER` path is unchanged.
+
 ## [0.21.2] - 2026-08-16
 
 ### Added

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -222,11 +222,7 @@ impl SendStrategy {
                 Self::FanOut(FanOutSend::new(t, options, FanOutMode::Group, io_pool))
             }
             SendCategory::IdentityRouted => Self::Identity(IdentitySend::new(t, options)),
-            SendCategory::RoundRobin
-                if t == SocketType::Req
-                    && !options.mechanism.has_frame_transform()
-                    && options.workload_profile != Some(omq_proto::WorkloadProfile::Throughput) =>
-            {
+            SendCategory::RoundRobin if uses_latency_round_robin(t, options) => {
                 Self::Latency(LatencySend::new(options))
             }
             SendCategory::RoundRobin
@@ -394,6 +390,19 @@ impl SendStrategy {
     }
 }
 
+fn uses_latency_round_robin(t: SocketType, options: &Options) -> bool {
+    if options.mechanism.has_frame_transform() {
+        return false;
+    }
+    match t {
+        // REQ keeps its historical latency default. DEALER opts in explicitly
+        // so existing throughput-oriented applications retain their queues.
+        SocketType::Req => options.workload_profile != Some(omq_proto::WorkloadProfile::Throughput),
+        SocketType::Dealer => options.workload_profile == Some(omq_proto::WorkloadProfile::Latency),
+        _ => false,
+    }
+}
+
 /// Recv-side policy.
 #[derive(Debug)]
 pub(crate) enum RecvStrategy {
@@ -472,3 +481,24 @@ pub(crate) fn supports_groups(t: SocketType) -> bool {
 }
 
 pub(crate) use omq_proto::routing::supports_conflate;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omq_proto::WorkloadProfile;
+
+    #[test]
+    fn dealer_uses_latency_route_only_when_explicitly_requested() {
+        let io_pool = crate::context::IoPoolHandle::none();
+        let latency = Options::default().workload_profile(WorkloadProfile::Latency);
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Dealer, &latency, &io_pool),
+            SendStrategy::Latency(_)
+        ));
+
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Dealer, &Options::default(), &io_pool),
+            SendStrategy::RoundRobin(_)
+        ));
+    }
+}

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -360,7 +360,7 @@ fn split_direct_tcp_writer(
     (),
 > {
     if !latency_profile
-        || !matches!(socket.socket_type, SocketType::Req | SocketType::Rep)
+        || !supports_direct_tcp_writer(socket.socket_type)
         || !matches!(endpoint, Endpoint::Tcp { .. })
         || has_transforms
     {
@@ -379,6 +379,13 @@ fn split_direct_tcp_writer(
         #[cfg(feature = "ws")]
         AnyStream::Ws(ws) => Ok((AnyStream::Ws(ws), None)),
     }
+}
+
+fn supports_direct_tcp_writer(socket_type: SocketType) -> bool {
+    matches!(
+        socket_type,
+        SocketType::Req | SocketType::Rep | SocketType::Dealer
+    )
 }
 
 fn attach_transforms(
@@ -631,5 +638,13 @@ mod tests {
         assert!(can_use_yring_recv_bypass(SocketType::Req, true));
         assert!(!can_use_yring_recv_bypass(SocketType::Req, false));
         assert!(can_use_yring_recv_bypass(SocketType::Pull, false));
+    }
+
+    #[test]
+    fn direct_tcp_writer_supports_latency_round_robin_types() {
+        assert!(supports_direct_tcp_writer(SocketType::Req));
+        assert!(supports_direct_tcp_writer(SocketType::Rep));
+        assert!(supports_direct_tcp_writer(SocketType::Dealer));
+        assert!(!supports_direct_tcp_writer(SocketType::Push));
     }
 }

--- a/omq-tokio/tests/reconnect_identity.rs
+++ b/omq-tokio/tests/reconnect_identity.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
-use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::options::{ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
 fn tcp_ep(port: u16) -> Endpoint {
@@ -47,7 +47,10 @@ async fn dealer_identity_survives_reconnect() {
     let router1 = Socket::new(SocketType::Router, Options::default());
     let ep = router1.bind(tcp_ep(0)).await.unwrap();
 
-    let dealer = Socket::new(SocketType::Dealer, fast_reconnect_with_id(b"d1"));
+    let dealer = Socket::new(
+        SocketType::Dealer,
+        fast_reconnect_with_id(b"d1").workload_profile(WorkloadProfile::Latency),
+    );
     let mut dealer_mon = dealer.monitor();
     dealer.connect(ep.clone()).await.unwrap();
     test_support::wait_for_handshake_on(&mut dealer_mon).await;

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -10,6 +10,7 @@ mod test_support;
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
+use omq_tokio::options::WorkloadProfile;
 use omq_tokio::{
     DisconnectReason, Endpoint, Error, Message, MonitorEvent, Options, ReconnectPolicy, Socket,
     SocketType,
@@ -57,6 +58,101 @@ async fn recv_dealer_body_string(dealer: &Socket) -> String {
         .unwrap();
     assert_eq!(msg.len(), 1);
     String::from_utf8(msg.part_bytes(0).unwrap().to_vec()).unwrap()
+}
+
+fn latency_dealer(identity: &'static [u8]) -> Socket {
+    Socket::new(
+        SocketType::Dealer,
+        Options::default()
+            .identity(bytes::Bytes::from_static(identity))
+            .workload_profile(WorkloadProfile::Latency),
+    )
+}
+
+#[tokio::test]
+async fn latency_dealer_preserves_multipart_and_large_fallback() {
+    let router = Socket::new(SocketType::Router, Options::default());
+    let port = test_support::bind_loopback(&router).await;
+    let dealer = latency_dealer(b"latency-dealer");
+    dealer
+        .connect(test_support::tcp_loopback(port))
+        .await
+        .unwrap();
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .unwrap();
+
+    let large = bytes::Bytes::from(vec![0x5a; 1024 * 1024]);
+    dealer
+        .send(Message::multipart([
+            bytes::Bytes::from_static(b"header"),
+            large.clone(),
+        ]))
+        .await
+        .unwrap();
+    let received = tokio::time::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.len(), 3);
+    assert_eq!(received.part_bytes(0).unwrap().as_ref(), b"latency-dealer");
+    assert_eq!(received.part_bytes(1).unwrap().as_ref(), b"header");
+    assert_eq!(received.part_bytes(2).unwrap(), &large);
+}
+
+#[tokio::test]
+async fn latency_dealer_round_robins_tcp_peers() {
+    let router_a = Socket::new(SocketType::Router, Options::default());
+    let router_b = Socket::new(SocketType::Router, Options::default());
+    let port_a = test_support::bind_loopback(&router_a).await;
+    let port_b = test_support::bind_loopback(&router_b).await;
+    let dealer = latency_dealer(b"latency-rr");
+    dealer
+        .connect(test_support::tcp_loopback(port_a))
+        .await
+        .unwrap();
+    dealer
+        .connect(test_support::tcp_loopback(port_b))
+        .await
+        .unwrap();
+    dealer
+        .wait_connected(2, Duration::from_secs(1))
+        .await
+        .unwrap();
+
+    for sequence in 0_u32..20 {
+        dealer
+            .send(Message::single(sequence.to_le_bytes().to_vec()))
+            .await
+            .unwrap();
+    }
+    let mut counts = [0_u32; 2];
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while counts.iter().sum::<u32>() < 20 {
+        counts[0] += drain_count(&router_a);
+        counts[1] += drain_count(&router_b);
+        assert!(
+            Instant::now() < deadline,
+            "latency DEALER messages timed out"
+        );
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(counts, [10, 10]);
+}
+
+fn drain_count(router: &Socket) -> u32 {
+    let mut count = 0;
+    loop {
+        match router.try_recv() {
+            Ok(message) => {
+                assert_eq!(message.part_bytes(0).unwrap().as_ref(), b"latency-rr");
+                count += 1;
+            }
+            Err(Error::WouldBlock) => return count,
+            Err(error) => panic!("latency router receive failed: {error}"),
+        }
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
This change extends the existing latency-optimized send path to `DEALER` sockets when `WorkloadProfile::Latency` is explicitly selected.

The default `DEALER` behavior remains unchanged. Applications that prefer throughput continue to use the existing queued round-robin path, while latency-sensitive applications can opt into the direct TCP writer without requiring a separate socket API.

Under Wine, this reduced median round-trip latency from approximately 70–76 µs to 26–29 µs. Native Linux performance remained effectively unchanged.

The change also includes tests covering routing selection, multipart messages, multiple peers, round-robin distribution, and identity preservation after reconnects.

Initially, I explored a separate exclusive socket API to avoid actor and channel wake-up overhead. Further testing showed that the same optimization can be integrated into the regular Socket API through the explicit latency workload profile. This preserves the standard socket semantics and avoids maintaining a parallel API.