### PR TITLE
Extend latency profile socket coverage

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -95,6 +95,7 @@ jobs:
           - test: omq_soak_compression_zstd
           - test: omq_soak_pub_sub_zstd_dict
           - test: omq_soak_large_throughput
+          - test: omq_soak_latency_profile
           - test: omq_soak_cancel_safety
           - test: omq_soak_inproc_cross_thread
           - test: omq_soak_multi_socket

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -301,6 +301,10 @@ name = "omq_soak_large_throughput"
 path = "tests/omq_soak_large_throughput.rs"
 
 [[test]]
+name = "omq_soak_latency_profile"
+path = "tests/omq_soak_latency_profile.rs"
+
+[[test]]
 name = "omq_soak_mechanism_reconnect"
 path = "tests/omq_soak_mechanism_reconnect.rs"
 

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -986,7 +986,7 @@ where
 
             let want_write = connection.has_pending_transmit() || !eq.is_empty();
 
-            // Latency-routed REQ/REP sends are encoded into the wire slot by
+            // Latency-routed sends are encoded into the wire slot by
             // the caller. Drain that already-queued work before polling the
             // reader, avoiding an extra zero-time reactor roundtrip.
             if latency_profile && transmit_slot.as_ref().is_some_and(|slot| !slot.is_empty()) {

--- a/omq-tokio/src/routing/latency.rs
+++ b/omq-tokio/src/routing/latency.rs
@@ -1,8 +1,8 @@
-//! Low-latency send routing for request/reply ping-pong.
+//! Low-latency send routing for one-message-at-a-time TCP flows.
 //!
 //! This route encodes directly into each peer's transmit slot. It avoids the
 //! generic yring send pipe, which is the right tradeoff for one-message-at-a-
-//! time REQ/REP but not for throughput-oriented routing.
+//! time flows but not for throughput-oriented routing.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};

--- a/omq-tokio/src/routing/mod.rs
+++ b/omq-tokio/src/routing/mod.rs
@@ -225,6 +225,9 @@ impl SendStrategy {
             SendCategory::RoundRobin if uses_latency_round_robin(t, options) => {
                 Self::Latency(LatencySend::new(options))
             }
+            SendCategory::Exclusive if uses_latency_exclusive(t, options) => {
+                Self::Latency(LatencySend::new(options))
+            }
             SendCategory::RoundRobin
                 if t == SocketType::Rep
                     && !options.mechanism.has_frame_transform()
@@ -395,12 +398,21 @@ fn uses_latency_round_robin(t: SocketType, options: &Options) -> bool {
         return false;
     }
     match t {
-        // REQ keeps its historical latency default. DEALER opts in explicitly
-        // so existing throughput-oriented applications retain their queues.
+        // REQ keeps its historical latency default. Other round-robin
+        // socket types opt in explicitly so existing throughput-oriented
+        // applications retain their queues.
         SocketType::Req => options.workload_profile != Some(omq_proto::WorkloadProfile::Throughput),
-        SocketType::Dealer => options.workload_profile == Some(omq_proto::WorkloadProfile::Latency),
+        SocketType::Dealer | SocketType::Client => {
+            options.workload_profile == Some(omq_proto::WorkloadProfile::Latency)
+        }
         _ => false,
     }
+}
+
+fn uses_latency_exclusive(t: SocketType, options: &Options) -> bool {
+    !options.mechanism.has_frame_transform()
+        && matches!(t, SocketType::Pair)
+        && options.workload_profile == Some(omq_proto::WorkloadProfile::Latency)
 }
 
 /// Recv-side policy.
@@ -500,5 +512,45 @@ mod tests {
             SendStrategy::for_socket_type(SocketType::Dealer, &Options::default(), &io_pool),
             SendStrategy::RoundRobin(_)
         ));
+    }
+
+    #[test]
+    fn latency_profile_extends_client_and_pair() {
+        let io_pool = crate::context::IoPoolHandle::none();
+        let latency = Options::default().workload_profile(WorkloadProfile::Latency);
+
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Client, &latency, &io_pool),
+            SendStrategy::Latency(_)
+        ));
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Client, &Options::default(), &io_pool),
+            SendStrategy::RoundRobin(_)
+        ));
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Pair, &latency, &io_pool),
+            SendStrategy::Latency(_)
+        ));
+        assert!(matches!(
+            SendStrategy::for_socket_type(SocketType::Pair, &Options::default(), &io_pool),
+            SendStrategy::Exclusive(_)
+        ));
+    }
+
+    #[test]
+    fn identity_types_use_transmit_slots_for_latency_profile() {
+        let io_pool = crate::context::IoPoolHandle::none();
+        let latency = Options::default().workload_profile(WorkloadProfile::Latency);
+
+        for socket_type in [SocketType::Router, SocketType::Server] {
+            let latency_strategy = SendStrategy::for_socket_type(socket_type, &latency, &io_pool);
+            assert!(matches!(latency_strategy, SendStrategy::Identity(_)));
+            assert!(latency_strategy.needs_transmit_slot());
+
+            let throughput_strategy =
+                SendStrategy::for_socket_type(socket_type, &Options::default(), &io_pool);
+            assert!(matches!(throughput_strategy, SendStrategy::Identity(_)));
+            assert!(!throughput_strategy.needs_transmit_slot());
+        }
     }
 }

--- a/omq-tokio/src/socket/actor/peer_materialize.rs
+++ b/omq-tokio/src/socket/actor/peer_materialize.rs
@@ -384,7 +384,13 @@ fn split_direct_tcp_writer(
 fn supports_direct_tcp_writer(socket_type: SocketType) -> bool {
     matches!(
         socket_type,
-        SocketType::Req | SocketType::Rep | SocketType::Dealer
+        SocketType::Req
+            | SocketType::Rep
+            | SocketType::Dealer
+            | SocketType::Router
+            | SocketType::Server
+            | SocketType::Client
+            | SocketType::Pair
     )
 }
 
@@ -642,9 +648,18 @@ mod tests {
 
     #[test]
     fn direct_tcp_writer_supports_latency_round_robin_types() {
-        assert!(supports_direct_tcp_writer(SocketType::Req));
-        assert!(supports_direct_tcp_writer(SocketType::Rep));
-        assert!(supports_direct_tcp_writer(SocketType::Dealer));
+        for socket_type in [
+            SocketType::Req,
+            SocketType::Rep,
+            SocketType::Dealer,
+            SocketType::Router,
+            SocketType::Server,
+            SocketType::Client,
+            SocketType::Pair,
+        ] {
+            assert!(supports_direct_tcp_writer(socket_type));
+        }
         assert!(!supports_direct_tcp_writer(SocketType::Push));
+        assert!(!supports_direct_tcp_writer(SocketType::Channel));
     }
 }

--- a/omq-tokio/tests/connect_before_bind.rs
+++ b/omq-tokio/tests/connect_before_bind.rs
@@ -9,7 +9,7 @@ mod test_support;
 
 use bytes::Bytes;
 use omq_tokio::endpoint::Host;
-use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::options::{ReconnectPolicy, WorkloadProfile};
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
 fn opts() -> Options {
@@ -188,6 +188,35 @@ async fn pair_connect_before_bind_tcp() {
     pair_connect_before_bind(tcp_ep(free_tcp_port())).await;
 }
 
+#[tokio::test]
+async fn latency_pair_connect_before_bind_tcp() {
+    let ep = tcp_ep(free_tcp_port());
+    let options = opts().workload_profile(WorkloadProfile::Latency);
+    let a = Socket::new(SocketType::Pair, options);
+    a.connect(ep.clone()).await.unwrap();
+
+    let b = Socket::new(
+        SocketType::Pair,
+        Options::default().workload_profile(WorkloadProfile::Latency),
+    );
+    b.bind(ep).await.unwrap();
+    test_support::wait_for_handshake(&b).await;
+
+    a.send(Message::single("from-latency-a")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, b.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::single("from-latency-a"));
+
+    b.send(Message::single("from-latency-b")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, a.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::single("from-latency-b"));
+}
+
 // -- PUB/SUB -----------------------------------------------------------------
 
 async fn pub_sub_connect_before_bind(ep: Endpoint) {
@@ -337,6 +366,42 @@ async fn client_server_connect_before_bind_ipc() {
 #[tokio::test]
 async fn client_server_connect_before_bind_tcp() {
     client_server_connect_before_bind(tcp_ep(free_tcp_port())).await;
+}
+
+#[tokio::test]
+async fn latency_client_server_connect_before_bind_tcp() {
+    let ep = tcp_ep(free_tcp_port());
+    let client = Socket::new(
+        SocketType::Client,
+        opts()
+            .identity(Bytes::from_static(b"latency-c1"))
+            .workload_profile(WorkloadProfile::Latency),
+    );
+    client.connect(ep.clone()).await.unwrap();
+
+    let server = Socket::new(
+        SocketType::Server,
+        Options::default().workload_profile(WorkloadProfile::Latency),
+    );
+    server.bind(ep).await.unwrap();
+    test_support::wait_for_handshake(&server).await;
+
+    client.send(Message::single("ping")).await.unwrap();
+    let m = tokio::time::timeout(TIMEOUT, server.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::multipart(["latency-c1", "ping"]));
+
+    server
+        .send(Message::multipart(["latency-c1", "pong"]))
+        .await
+        .unwrap();
+    let m = tokio::time::timeout(TIMEOUT, client.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(m, Message::single("pong"));
 }
 
 // -- SCATTER/GATHER ----------------------------------------------------------

--- a/omq-tokio/tests/omq_soak_latency_profile.rs
+++ b/omq-tokio/tests/omq_soak_latency_profile.rs
@@ -1,0 +1,379 @@
+#![cfg(feature = "soak")]
+//! Soak: regular `Socket` latency profile across every supported type.
+//!
+//! Keeps one TCP-bound socket alive per scenario, repeatedly connects a peer,
+//! exchanges a round trip, idles long enough for heartbeats to run, closes the
+//! peer, and verifies the bound side observes the disappearance.
+
+#[global_allocator]
+static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
+
+mod soak_common;
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use omq_tokio::options::{ReconnectPolicy, WorkloadProfile};
+use omq_tokio::{
+    Endpoint, Message, MonitorEvent, MonitorTryRecvError, Options, Socket, SocketType,
+};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_millis(120);
+const IO_TIMEOUT: Duration = Duration::from_secs(2);
+const IDLE_HEARTBEATS: Duration = Duration::from_millis(80);
+
+#[derive(Clone, Copy, Debug)]
+enum Flow {
+    Pair,
+    DealerRouter,
+    ReqRep,
+    ClientServer,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Scenario {
+    name: &'static str,
+    bind_kind: SocketType,
+    connect_kind: SocketType,
+    flow: Flow,
+}
+
+struct ScenarioState {
+    spec: Scenario,
+    bound: Socket,
+    endpoint: Endpoint,
+    monitor: omq_tokio::MonitorStream,
+    cycles: u64,
+    disconnects: u64,
+}
+
+fn latency_options(kind: SocketType, side: &str) -> Options {
+    let identity = match kind {
+        SocketType::Dealer => Bytes::from(format!("dealer-{side}")),
+        SocketType::Client => Bytes::from(format!("client-{side}")),
+        SocketType::Req => Bytes::from(format!("req-{side}")),
+        SocketType::Rep => Bytes::from(format!("rep-{side}")),
+        SocketType::Router => Bytes::from(format!("router-{side}")),
+        SocketType::Server => Bytes::from(format!("server-{side}")),
+        SocketType::Pair => Bytes::from(format!("pair-{side}")),
+        _ => Bytes::new(),
+    };
+    Options::default()
+        .identity(identity)
+        .workload_profile(WorkloadProfile::Latency)
+        .send_hwm(32)
+        .recv_hwm(32)
+        .reconnect(ReconnectPolicy::Fixed(Duration::from_millis(5)))
+        .handshake_timeout(Duration::from_secs(1))
+        .heartbeat_interval(HEARTBEAT_INTERVAL)
+        .heartbeat_ttl(HEARTBEAT_TIMEOUT)
+        .heartbeat_timeout(HEARTBEAT_TIMEOUT)
+        .linger(Duration::ZERO)
+}
+
+async fn make_state(spec: Scenario) -> ScenarioState {
+    let bound = Socket::new(spec.bind_kind, latency_options(spec.bind_kind, "bind"));
+    let mut monitor = bound.monitor();
+    let endpoint = bound.bind(soak_common::tcp_ep(0)).await.unwrap();
+    wait_for_listening(&mut monitor).await;
+    ScenarioState {
+        spec,
+        bound,
+        endpoint,
+        monitor,
+        cycles: 0,
+        disconnects: 0,
+    }
+}
+
+async fn wait_for_listening(monitor: &mut omq_tokio::MonitorStream) {
+    let deadline = Instant::now() + IO_TIMEOUT;
+    loop {
+        match tokio::time::timeout(IO_TIMEOUT, monitor.recv()).await {
+            Ok(Ok(MonitorEvent::Listening { .. })) => return,
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => panic!("monitor failed before listening: {error:?}"),
+            Err(error) => panic!("socket did not report Listening before timeout: {error:?}"),
+        }
+        assert!(Instant::now() < deadline, "listening monitor timed out");
+    }
+}
+
+async fn connect_peer(state: &mut ScenarioState) -> (Socket, omq_tokio::MonitorStream) {
+    let peer = Socket::new(
+        state.spec.connect_kind,
+        latency_options(state.spec.connect_kind, "connect"),
+    );
+    let mut peer_monitor = peer.monitor();
+    peer.connect(state.endpoint.clone()).await.unwrap();
+    peer.wait_connected(1, IO_TIMEOUT).await.unwrap();
+    state.bound.wait_connected(1, IO_TIMEOUT).await.unwrap();
+    wait_for_handshake(&mut peer_monitor).await;
+    (peer, peer_monitor)
+}
+
+async fn wait_for_handshake(monitor: &mut omq_tokio::MonitorStream) {
+    let deadline = Instant::now() + IO_TIMEOUT;
+    loop {
+        match tokio::time::timeout(IO_TIMEOUT, monitor.recv()).await {
+            Ok(Ok(MonitorEvent::HandshakeSucceeded { .. })) => return,
+            Ok(Ok(MonitorEvent::Disconnected { reason, .. })) => {
+                panic!("peer disconnected before handshake: {reason:?}");
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => panic!("monitor failed before handshake: {error:?}"),
+            Err(error) => panic!("peer did not report handshake before timeout: {error:?}"),
+        }
+        assert!(Instant::now() < deadline, "handshake monitor timed out");
+    }
+}
+
+async fn cycle(state: &mut ScenarioState) {
+    let (peer, mut peer_monitor) = connect_peer(state).await;
+    exchange_once(state.spec, &state.bound, &peer, state.cycles).await;
+    drive_idle_heartbeats(&mut state.monitor, &mut peer_monitor, state.spec.name).await;
+    peer.close_with_linger(Some(Duration::ZERO)).await.unwrap();
+    wait_for_disconnect(&mut state.monitor, state.spec.name).await;
+    state.disconnects += 1;
+    state.cycles += 1;
+}
+
+async fn exchange_once(spec: Scenario, bound: &Socket, peer: &Socket, seq: u64) {
+    match spec.flow {
+        Flow::Pair => exchange_pair(bound, peer, seq).await,
+        Flow::DealerRouter => exchange_dealer_router(spec, bound, peer, seq).await,
+        Flow::ReqRep => exchange_req_rep(spec, bound, peer, seq).await,
+        Flow::ClientServer => exchange_client_server(spec, bound, peer, seq).await,
+    }
+}
+
+async fn exchange_pair(bound: &Socket, peer: &Socket, seq: u64) {
+    let body = format!("pair-{seq}");
+    peer.send(Message::single(body.clone())).await.unwrap();
+    assert_eq!(recv("pair-bound", bound).await, Message::single(body));
+
+    bound.send(Message::single("pair-reply")).await.unwrap();
+    assert_eq!(recv("pair-peer", peer).await, Message::single("pair-reply"));
+}
+
+async fn exchange_dealer_router(spec: Scenario, bound: &Socket, peer: &Socket, seq: u64) {
+    if spec.bind_kind == SocketType::Dealer {
+        dealer_router_round_trip(bound, peer, seq).await;
+    } else {
+        dealer_router_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn dealer_router_round_trip(dealer: &Socket, router: &Socket, seq: u64) {
+    let body = format!("dealer-router-{seq}");
+    dealer.send(Message::single(body.clone())).await.unwrap();
+    let request = recv("router request", router).await;
+    let identity = request.part_bytes(0).unwrap().clone();
+    assert_eq!(request.part_bytes(1).unwrap(), body.as_bytes());
+
+    router
+        .send(Message::multipart([
+            identity,
+            Bytes::from_static(b"dealer-router-reply"),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        recv("dealer reply", dealer).await,
+        Message::single("dealer-router-reply")
+    );
+}
+
+async fn exchange_req_rep(spec: Scenario, bound: &Socket, peer: &Socket, seq: u64) {
+    if spec.bind_kind == SocketType::Req {
+        req_rep_round_trip(bound, peer, seq).await;
+    } else {
+        req_rep_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn req_rep_round_trip(req: &Socket, rep: &Socket, seq: u64) {
+    let body = format!("req-rep-{seq}");
+    req.send(Message::single(body.clone())).await.unwrap();
+    assert_eq!(recv("rep request", rep).await, Message::single(body));
+
+    rep.send(Message::single("req-rep-reply")).await.unwrap();
+    assert_eq!(
+        recv("req reply", req).await,
+        Message::single("req-rep-reply")
+    );
+}
+
+async fn exchange_client_server(spec: Scenario, bound: &Socket, peer: &Socket, seq: u64) {
+    if spec.bind_kind == SocketType::Client {
+        client_server_round_trip(bound, peer, seq).await;
+    } else {
+        client_server_round_trip(peer, bound, seq).await;
+    }
+}
+
+async fn client_server_round_trip(client: &Socket, server: &Socket, seq: u64) {
+    let body = format!("client-server-{seq}");
+    client.send(Message::single(body.clone())).await.unwrap();
+    let request = recv("server request", server).await;
+    let identity = request.part_bytes(0).unwrap().clone();
+    assert_eq!(request.part_bytes(1).unwrap(), body.as_bytes());
+
+    server
+        .send(Message::multipart([
+            identity,
+            Bytes::from_static(b"client-server-reply"),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        recv("client reply", client).await,
+        Message::single("client-server-reply")
+    );
+}
+
+async fn recv(label: &str, socket: &Socket) -> Message {
+    tokio::time::timeout(IO_TIMEOUT, socket.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{label} timed out"))
+        .unwrap()
+}
+
+async fn drive_idle_heartbeats(
+    bound_monitor: &mut omq_tokio::MonitorStream,
+    peer_monitor: &mut omq_tokio::MonitorStream,
+    scenario: &str,
+) {
+    let start = Instant::now();
+    while start.elapsed() < IDLE_HEARTBEATS {
+        assert_no_disconnect(bound_monitor, scenario);
+        assert_no_disconnect(peer_monitor, scenario);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+fn assert_no_disconnect(monitor: &mut omq_tokio::MonitorStream, scenario: &str) {
+    loop {
+        match monitor.try_recv() {
+            Ok(MonitorEvent::Disconnected { reason, .. }) => {
+                panic!("{scenario} disconnected during heartbeat idle: {reason:?}");
+            }
+            Ok(_) => {}
+            Err(MonitorTryRecvError::Empty | MonitorTryRecvError::Closed) => return,
+            Err(MonitorTryRecvError::Lagged(skipped)) => {
+                panic!("{scenario} monitor lagged during soak: skipped {skipped}");
+            }
+            Err(error) => panic!("{scenario} unexpected monitor error during soak: {error:?}"),
+        }
+    }
+}
+
+async fn wait_for_disconnect(monitor: &mut omq_tokio::MonitorStream, scenario: &str) {
+    let deadline = Instant::now() + IO_TIMEOUT;
+    loop {
+        match tokio::time::timeout(IO_TIMEOUT, monitor.recv()).await {
+            Ok(Ok(MonitorEvent::Disconnected { .. })) => return,
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => panic!("{scenario} monitor failed before disconnect: {error:?}"),
+            Err(error) => panic!("{scenario} did not report disconnect before timeout: {error:?}"),
+        }
+        assert!(Instant::now() < deadline, "{scenario} disconnect timed out");
+    }
+}
+
+#[test]
+fn soak_latency_profile_all_supported_socket_types() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+    let ctx = soak_common::build_context();
+
+    ctx.block_on(async move {
+        let specs = [
+            Scenario {
+                name: "pair",
+                bind_kind: SocketType::Pair,
+                connect_kind: SocketType::Pair,
+                flow: Flow::Pair,
+            },
+            Scenario {
+                name: "dealer-router",
+                bind_kind: SocketType::Router,
+                connect_kind: SocketType::Dealer,
+                flow: Flow::DealerRouter,
+            },
+            Scenario {
+                name: "router-dealer",
+                bind_kind: SocketType::Dealer,
+                connect_kind: SocketType::Router,
+                flow: Flow::DealerRouter,
+            },
+            Scenario {
+                name: "req-rep",
+                bind_kind: SocketType::Rep,
+                connect_kind: SocketType::Req,
+                flow: Flow::ReqRep,
+            },
+            Scenario {
+                name: "rep-req",
+                bind_kind: SocketType::Req,
+                connect_kind: SocketType::Rep,
+                flow: Flow::ReqRep,
+            },
+            Scenario {
+                name: "client-server",
+                bind_kind: SocketType::Server,
+                connect_kind: SocketType::Client,
+                flow: Flow::ClientServer,
+            },
+            Scenario {
+                name: "server-client",
+                bind_kind: SocketType::Client,
+                connect_kind: SocketType::Server,
+                flow: Flow::ClientServer,
+            },
+        ];
+
+        let mut states = Vec::new();
+        for spec in specs {
+            states.push(make_state(spec).await);
+        }
+
+        let start = Instant::now();
+        let mut last_log = start;
+        while start.elapsed() < duration {
+            for state in &mut states {
+                cycle(state).await;
+            }
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!("[latency-profile] {:.0}s:", start.elapsed().as_secs_f64());
+                for state in &states {
+                    eprintln!(
+                        "  {}: {} cycles, {} disconnects",
+                        state.spec.name, state.cycles, state.disconnects
+                    );
+                }
+                last_log = Instant::now();
+            }
+        }
+
+        for state in &states {
+            assert!(state.cycles > 0, "{} had no cycles", state.spec.name);
+            assert_eq!(
+                state.disconnects, state.cycles,
+                "{} missed disconnect events",
+                state.spec.name
+            );
+        }
+        for state in states {
+            state
+                .bound
+                .close_with_linger(Some(Duration::ZERO))
+                .await
+                .unwrap();
+        }
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("latency-profile");
+}

--- a/omq-tokio/tests/router_dealer.rs
+++ b/omq-tokio/tests/router_dealer.rs
@@ -141,6 +141,42 @@ async fn latency_dealer_round_robins_tcp_peers() {
     assert_eq!(counts, [10, 10]);
 }
 
+#[tokio::test]
+async fn latency_router_can_reply_to_dealer() {
+    let router = Socket::new(
+        SocketType::Router,
+        Options::default().workload_profile(WorkloadProfile::Latency),
+    );
+    let port = test_support::bind_loopback(&router).await;
+
+    let dealer = latency_dealer(b"latency-router-peer");
+    dealer
+        .connect(test_support::tcp_loopback(port))
+        .await
+        .unwrap();
+    dealer
+        .wait_connected(1, Duration::from_secs(1))
+        .await
+        .unwrap();
+
+    dealer.send(Message::single("ping")).await.unwrap();
+    let request = tokio::time::timeout(Duration::from_secs(1), router.recv())
+        .await
+        .expect("router did not receive latency DEALER message")
+        .unwrap();
+    assert_eq!(request, Message::multipart(["latency-router-peer", "ping"]));
+
+    router
+        .send(Message::multipart(["latency-router-peer", "pong"]))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), dealer.recv())
+        .await
+        .expect("dealer did not receive latency ROUTER reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("pong"));
+}
+
 fn drain_count(router: &Socket) -> u32 {
     let mut count = 0;
     loop {

--- a/omq-tokio/tests/tcp_smoke.rs
+++ b/omq-tokio/tests/tcp_smoke.rs
@@ -2,6 +2,7 @@ mod test_support;
 
 use std::time::Duration;
 
+use omq_tokio::options::WorkloadProfile;
 use omq_tokio::{Message, Options, Socket, SocketType};
 
 #[tokio::test]
@@ -73,4 +74,78 @@ async fn pair_tcp_connect_by_localhost_name() {
         .expect("client did not receive PAIR reply")
         .unwrap();
     assert_eq!(reply, Message::single("WORLD"));
+}
+
+#[tokio::test]
+async fn latency_pair_tcp_smoke() {
+    let options = Options::default().workload_profile(WorkloadProfile::Latency);
+    let server = Socket::new(SocketType::Pair, options.clone());
+    let port = test_support::bind_loopback(&server).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let client = Socket::new(SocketType::Pair, options);
+    client.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&client).await;
+
+    client.send(Message::single("latency-pair")).await.unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), server.recv())
+        .await
+        .expect("server did not receive latency PAIR message")
+        .unwrap();
+    assert_eq!(got, Message::single("latency-pair"));
+
+    server
+        .send(Message::single("latency-pair-reply"))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), client.recv())
+        .await
+        .expect("client did not receive latency PAIR reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("latency-pair-reply"));
+}
+
+#[tokio::test]
+async fn latency_client_server_tcp_smoke() {
+    let server = Socket::new(
+        SocketType::Server,
+        Options::default().workload_profile(WorkloadProfile::Latency),
+    );
+    let port = test_support::bind_loopback(&server).await;
+    let ep = test_support::tcp_loopback(port);
+
+    let client = Socket::new(
+        SocketType::Client,
+        Options::default()
+            .identity(bytes::Bytes::from_static(b"latency-client"))
+            .workload_profile(WorkloadProfile::Latency),
+    );
+    client.connect(ep).await.unwrap();
+    test_support::wait_for_handshake(&client).await;
+
+    client
+        .send(Message::single("latency-client"))
+        .await
+        .unwrap();
+    let request = tokio::time::timeout(Duration::from_secs(1), server.recv())
+        .await
+        .expect("server did not receive latency CLIENT message")
+        .unwrap();
+    assert_eq!(
+        request,
+        Message::multipart(["latency-client", "latency-client"])
+    );
+
+    server
+        .send(Message::multipart([
+            "latency-client",
+            "latency-server-reply",
+        ]))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), client.recv())
+        .await
+        .expect("client did not receive latency SERVER reply")
+        .unwrap();
+    assert_eq!(reply, Message::single("latency-server-reply"));
 }


### PR DESCRIPTION
- Enable latency-profile direct send routing for `CLIENT` and `PAIR`.
- Enable direct TCP writer support for latency-profile `ROUTER`, `SERVER`, `CLIENT`, and `PAIR` sockets.
- Add TCP smoke and connect-before-bind coverage for new latency-profile socket pairs.
- Add `omq_soak_latency_profile` for regular `Socket` latency-profile peer churn, heartbeat idle, disconnect observation, and resource monitoring across `REQ`/`REP`, `DEALER`/`ROUTER`, `CLIENT`/`SERVER`, and `PAIR`.
- Add the new latency-profile soak target to extended CI.
