### PR TITLE
Add remaining Lua socket types

### DIFF
--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -27,8 +27,8 @@ export LUA_CPATH="$PWD/bindings/lua/native/target/debug/lib?.so;;"
 
 ## API Shape
 
-- Socket constants: `PAIR`, `PUB`, `SUB`, `REQ`, `REP`, `DEALER`, `ROUTER`,
-  `PULL`, `PUSH`, `XPUB`, `XSUB`.
+- Socket constants: all 20 ZMTP socket types, including `CLIENT`, `SERVER`,
+  `RADIO`, `DISH`, `SCATTER`, `GATHER`, `CHANNEL`, `PEER`, and `STREAM`.
 - Flags: `DONTWAIT`, `SNDMORE`.
 - Arena constants: `OMQ_ARENA_THRESHOLD`, `DEFAULT_ARENA_THRESHOLD`.
 - `omq.monotonic_seconds()` returns a monotonic timestamp for tests and
@@ -52,6 +52,8 @@ export LUA_CPATH="$PWD/bindings/lua/native/target/debug/lib?.so;;"
 - `Socket:recv_parts(max_size, flags)` receives all frames in one message.
 - `Socket:subscribe(prefix)` adds a SUB prefix.
 - `Socket:unsubscribe(prefix)` removes a SUB prefix.
+- `Socket:join(group)` and `Socket:leave(group)` manage DISH groups.
+- `Socket:send_group(group, "bytes", flags)` sends a RADIO message to a group.
 - `Socket:set_linger(ms)`, `Socket:set_send_timeout(ms)`,
   `Socket:set_recv_timeout(ms)`, `Socket:set_send_hwm(value)`,
   `Socket:set_recv_hwm(value)`, `Socket:set_arena_threshold(bytes)`, and

--- a/bindings/lua/lua/omq.lua
+++ b/bindings/lua/lua/omq.lua
@@ -41,6 +41,33 @@ M.XPUB = native.XPUB
 ---Raw subscribe socket type.
 ---@type integer
 M.XSUB = native.XSUB
+---Raw TCP socket type.
+---@type integer
+M.STREAM = native.STREAM
+---Single-frame routed server socket type.
+---@type integer
+M.SERVER = native.SERVER
+---Single-frame client socket type.
+---@type integer
+M.CLIENT = native.CLIENT
+---Group-based publish socket type.
+---@type integer
+M.RADIO = native.RADIO
+---Group-based subscribe socket type.
+---@type integer
+M.DISH = native.DISH
+---Single-frame gather socket type.
+---@type integer
+M.GATHER = native.GATHER
+---Single-frame scatter socket type.
+---@type integer
+M.SCATTER = native.SCATTER
+---Identity-routed bidirectional socket type.
+---@type integer
+M.PEER = native.PEER
+---Single-frame bidirectional socket type.
+---@type integer
+M.CHANNEL = native.CHANNEL
 ---Nonblocking send/receive flag.
 ---@type integer
 M.DONTWAIT = native.DONTWAIT
@@ -88,6 +115,15 @@ local socket_types = {
   push = M.PUSH,
   xpub = M.XPUB,
   xsub = M.XSUB,
+  stream = M.STREAM,
+  server = M.SERVER,
+  client = M.CLIENT,
+  radio = M.RADIO,
+  dish = M.DISH,
+  gather = M.GATHER,
+  scatter = M.SCATTER,
+  peer = M.PEER,
+  channel = M.CHANNEL,
 }
 
 ---@class omq.Context
@@ -106,6 +142,9 @@ Context.__index = Context
 ---@field recv_parts fun(self: omq.Socket, max_size?: integer, flags?: integer): string[] Receive all frames in one message.
 ---@field subscribe fun(self: omq.Socket, prefix: string): boolean Add SUB prefix.
 ---@field unsubscribe fun(self: omq.Socket, prefix: string): boolean Remove SUB prefix.
+---@field join fun(self: omq.Socket, group: string): boolean Join a DISH group.
+---@field leave fun(self: omq.Socket, group: string): boolean Leave a DISH group.
+---@field send_group fun(self: omq.Socket, group: string, data: string, flags?: integer): boolean Send a RADIO message to a group.
 ---@field set_linger fun(self: omq.Socket, millis: integer): boolean Set close linger in milliseconds.
 ---@field set_send_timeout fun(self: omq.Socket, millis: integer): boolean Set send timeout in milliseconds.
 ---@field set_recv_timeout fun(self: omq.Socket, millis: integer): boolean Set receive timeout in milliseconds.
@@ -183,7 +222,8 @@ end
 
 ---Create a socket owned by this context.
 ---@param socket_type string|integer socket type name (`"push"`, `"pull"`,
----`"req"`, etc.) or numeric ZMQ constant.
+---`"req"`, etc.) or numeric ZMQ constant. All 20 ZMTP socket types are
+---supported.
 ---@param options? {linger?: integer, send_timeout?: integer, recv_timeout?: integer,
 ---send_hwm?: integer, recv_hwm?: integer, arena_threshold?: integer, subscribe?: string}
 ---socket options applied before bind/connect. `arena_threshold` overrides

--- a/bindings/lua/native/src/lib.rs
+++ b/bindings/lua/native/src/lib.rs
@@ -23,6 +23,15 @@ const ZMQ_PULL: i32 = 7;
 const ZMQ_PUSH: i32 = 8;
 const ZMQ_XPUB: i32 = 9;
 const ZMQ_XSUB: i32 = 10;
+const ZMQ_STREAM: i32 = 11;
+const ZMQ_SERVER: i32 = 12;
+const ZMQ_CLIENT: i32 = 13;
+const ZMQ_RADIO: i32 = 14;
+const ZMQ_DISH: i32 = 15;
+const ZMQ_GATHER: i32 = 16;
+const ZMQ_SCATTER: i32 = 17;
+const ZMQ_PEER: i32 = 19;
+const ZMQ_CHANNEL: i32 = 20;
 const ZMQ_DONTWAIT: i32 = 1;
 const ZMQ_SNDMORE: i32 = 2;
 const ZMQ_SUBSCRIBE: i32 = 6;
@@ -478,6 +487,25 @@ impl UserData for NativeSocket {
             this.set_bytes(ZMQ_UNSUBSCRIBE, prefix.as_bytes().as_ref())?;
             Ok(true)
         });
+        methods.add_method("join", |_, this, group: LuaString| {
+            this.join(group.as_bytes().as_ref())?;
+            Ok(true)
+        });
+        methods.add_method("leave", |_, this, group: LuaString| {
+            this.leave(group.as_bytes().as_ref())?;
+            Ok(true)
+        });
+        methods.add_method(
+            "send_group",
+            |_, this, (group, payload, flags): (LuaString, LuaString, Option<i32>)| {
+                this.send_group(
+                    group.as_bytes().as_ref(),
+                    payload.as_bytes().as_ref(),
+                    flags.unwrap_or(0),
+                )?;
+                Ok(true)
+            },
+        );
     }
 }
 
@@ -689,6 +717,49 @@ impl NativeSocket {
             value.len(),
         );
         check_rc(rc)
+    }
+
+    fn join(&self, group: &[u8]) -> LuaResult<()> {
+        let group =
+            CString::new(group).map_err(|_| LuaError::external("group contains a NUL byte"))?;
+        check_rc(omq_zmq::zmq_join(self.inner.ptr()?, group.as_ptr()))
+    }
+
+    fn leave(&self, group: &[u8]) -> LuaResult<()> {
+        let group =
+            CString::new(group).map_err(|_| LuaError::external("group contains a NUL byte"))?;
+        check_rc(omq_zmq::zmq_leave(self.inner.ptr()?, group.as_ptr()))
+    }
+
+    fn send_group(&self, group: &[u8], payload: &[u8], flags: i32) -> LuaResult<()> {
+        let group =
+            CString::new(group).map_err(|_| LuaError::external("group contains a NUL byte"))?;
+        let mut msg = std::mem::MaybeUninit::<omq_zmq::OmqMsgRepr>::uninit();
+        let msg = msg.as_mut_ptr();
+        check_rc(omq_zmq::zmq_msg_init_size(msg, payload.len()))?;
+        if !payload.is_empty() {
+            let data = omq_zmq::zmq_msg_data(msg);
+            if data.is_null() {
+                let _ = omq_zmq::zmq_msg_close(msg);
+                return Err(LuaError::runtime("message data was null"));
+            }
+            // SAFETY: zmq_msg_init_size allocated exactly payload.len() bytes.
+            unsafe {
+                std::ptr::copy_nonoverlapping(payload.as_ptr(), data.cast(), payload.len());
+            }
+        }
+        if omq_zmq::zmq_msg_set_group(msg, group.as_ptr()) != 0 {
+            let err = last_error();
+            let _ = omq_zmq::zmq_msg_close(msg);
+            return Err(err);
+        }
+        let rc = omq_zmq::zmq_msg_send(msg, self.inner.ptr()?, flags);
+        if rc < 0 {
+            let err = last_error();
+            let _ = omq_zmq::zmq_msg_close(msg);
+            return Err(err);
+        }
+        Ok(())
     }
 
     fn last_endpoint(&self) -> Option<String> {
@@ -1507,6 +1578,63 @@ unsafe extern "C-unwind" fn raw_socket_unsubscribe(state: *mut ffi::lua_State) -
     raw_finish(state, raw_socket_set_bytes(state, ZMQ_UNSUBSCRIBE))
 }
 
+fn raw_socket_group_action(state: *mut ffi::lua_State, join: bool) -> Result<c_int, String> {
+    let socket = raw_socket_mut(state)?;
+    let group = lua_string_bytes(state, 2)?;
+    if group.contains(&0) {
+        return Err("group contains a NUL byte".to_owned());
+    }
+    let group = CString::new(group).map_err(|_| "group contains a NUL byte".to_owned())?;
+    let rc = if join {
+        omq_zmq::zmq_join(
+            socket
+                .socket()?
+                .inner
+                .ptr()
+                .map_err(|err| err.to_string())?,
+            group.as_ptr(),
+        )
+    } else {
+        omq_zmq::zmq_leave(
+            socket
+                .socket()?
+                .inner
+                .ptr()
+                .map_err(|err| err.to_string())?,
+            group.as_ptr(),
+        )
+    };
+    if rc != 0 {
+        return Err(last_error_message());
+    }
+    Ok(lua_bool(state, true))
+}
+
+unsafe extern "C-unwind" fn raw_socket_join(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_group_action(state, true))
+}
+
+unsafe extern "C-unwind" fn raw_socket_leave(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(state, raw_socket_group_action(state, false))
+}
+
+unsafe extern "C-unwind" fn raw_socket_send_group(state: *mut ffi::lua_State) -> c_int {
+    raw_finish(
+        state,
+        (|| -> Result<c_int, String> {
+            let socket = raw_socket_mut(state)?;
+            let group = lua_string_bytes(state, 2)?;
+            let payload = lua_string_bytes(state, 3)?;
+            let flags = lua_optional_i32(state, 4, 0)?;
+            socket
+                .socket()?
+                .send_group(group, payload, flags)
+                .map_err(|err| err.to_string())?;
+            Ok(lua_bool(state, true))
+        })(),
+    )
+}
+
 fn raw_set_cfunc(state: *mut ffi::lua_State, name: &'static [u8], func: ffi::lua_CFunction) {
     unsafe {
         ffi::lua_pushcfunction(state, func);
@@ -1545,6 +1673,9 @@ fn ensure_raw_socket_metatable(state: *mut ffi::lua_State) {
             );
             raw_set_cfunc(state, b"subscribe\0", raw_socket_subscribe);
             raw_set_cfunc(state, b"unsubscribe\0", raw_socket_unsubscribe);
+            raw_set_cfunc(state, b"join\0", raw_socket_join);
+            raw_set_cfunc(state, b"leave\0", raw_socket_leave);
+            raw_set_cfunc(state, b"send_group\0", raw_socket_send_group);
         }
     }
 }
@@ -1632,6 +1763,15 @@ fn set_constants(table: &Table) -> LuaResult<()> {
     table.set("PUSH", ZMQ_PUSH)?;
     table.set("XPUB", ZMQ_XPUB)?;
     table.set("XSUB", ZMQ_XSUB)?;
+    table.set("STREAM", ZMQ_STREAM)?;
+    table.set("SERVER", ZMQ_SERVER)?;
+    table.set("CLIENT", ZMQ_CLIENT)?;
+    table.set("RADIO", ZMQ_RADIO)?;
+    table.set("DISH", ZMQ_DISH)?;
+    table.set("GATHER", ZMQ_GATHER)?;
+    table.set("SCATTER", ZMQ_SCATTER)?;
+    table.set("PEER", ZMQ_PEER)?;
+    table.set("CHANNEL", ZMQ_CHANNEL)?;
     table.set("DONTWAIT", ZMQ_DONTWAIT)?;
     table.set("SNDMORE", ZMQ_SNDMORE)?;
     table.set("OMQ_ARENA_THRESHOLD", OMQ_ARENA_THRESHOLD)?;

--- a/bindings/lua/omq-0.2.0-1.rockspec
+++ b/bindings/lua/omq-0.2.0-1.rockspec
@@ -1,0 +1,51 @@
+rockspec_format = "3.0"
+package = "omq"
+version = "0.2.0-1"
+
+source = {
+   url = "git+https://github.com/paddor/omq.rs.git",
+   tag = "omq-lua-v0.2.0",
+}
+
+description = {
+   summary = "Lua 5.4 binding for OMQ.rs",
+   detailed = [[
+      OMQ.lua is a Lua 5.4 binding for OMQ.rs backed by the omq-libzmq
+      C ABI. It exposes the OMQ socket API through a small Lua module and
+      a Rust native module.
+   ]],
+   homepage = "https://github.com/paddor/omq.rs/tree/main/bindings/lua",
+   issues_url = "https://github.com/paddor/omq.rs/issues",
+   license = "ISC",
+   labels = { "zeromq", "omq", "messaging", "networking" },
+}
+
+dependencies = {
+   "lua >= 5.4, < 5.5",
+}
+
+external_dependencies = {
+   CARGO = {
+      program = "cargo",
+   },
+}
+
+build = {
+   type = "command",
+   build_command = "cargo build --release --manifest-path bindings/lua/native/Cargo.toml",
+   install_command = [[
+      mkdir -p "$(LUADIR)" "$(LIBDIR)" &&
+      cp bindings/lua/lua/omq.lua "$(LUADIR)/omq.lua" &&
+      if [ -f bindings/lua/native/target/release/libomq_native.so ]; then
+         cp bindings/lua/native/target/release/libomq_native.so "$(LIBDIR)/omq_native.so";
+      elif [ -f bindings/lua/native/target/release/libomq_native.dylib ]; then
+         cp bindings/lua/native/target/release/libomq_native.dylib "$(LIBDIR)/omq_native.so";
+      elif [ -f bindings/lua/native/target/release/omq_native.dll ]; then
+         cp bindings/lua/native/target/release/omq_native.dll "$(LIBDIR)/omq_native.dll";
+      else
+         echo "omq_native shared library not found" >&2;
+         exit 1;
+      fi
+   ]],
+   copy_directories = {},
+}

--- a/bindings/lua/tests/test_socket_types.lua
+++ b/bindings/lua/tests/test_socket_types.lua
@@ -1,0 +1,51 @@
+local omq = require("omq")
+
+local ctx = omq.context()
+
+local types = {
+  { "pair", omq.PAIR, 0 },
+  { "pub", omq.PUB, 1 },
+  { "sub", omq.SUB, 2 },
+  { "req", omq.REQ, 3 },
+  { "rep", omq.REP, 4 },
+  { "dealer", omq.DEALER, 5 },
+  { "router", omq.ROUTER, 6 },
+  { "pull", omq.PULL, 7 },
+  { "push", omq.PUSH, 8 },
+  { "xpub", omq.XPUB, 9 },
+  { "xsub", omq.XSUB, 10 },
+  { "stream", omq.STREAM, 11 },
+  { "server", omq.SERVER, 12 },
+  { "client", omq.CLIENT, 13 },
+  { "radio", omq.RADIO, 14 },
+  { "dish", omq.DISH, 15 },
+  { "gather", omq.GATHER, 16 },
+  { "scatter", omq.SCATTER, 17 },
+  { "peer", omq.PEER, 19 },
+  { "channel", omq.CHANNEL, 20 },
+}
+
+for _, entry in ipairs(types) do
+  local name, constant, expected = table.unpack(entry)
+  assert(constant == expected, name .. " constant mismatch")
+  local socket = ctx:socket(name, { linger = 0 })
+  socket:close()
+  local numeric_socket = ctx:socket(constant, { linger = 0 })
+  numeric_socket:close()
+end
+
+local server = ctx:socket("server", { linger = 0, recv_timeout = 1000 })
+local client = ctx:socket("client", { linger = 0, recv_timeout = 1000 })
+local endpoint = server:bind("inproc://lua-client-server")
+client:connect(endpoint)
+
+client:send("request")
+local request = server:recv_parts()
+assert(#request == 2)
+assert(request[2] == "request")
+server:send_parts({ request[1], "reply" })
+assert(client:recv() == "reply")
+
+client:close()
+server:close()
+ctx:term()

--- a/bindings/lua/tests/test_socket_types_behavior.lua
+++ b/bindings/lua/tests/test_socket_types_behavior.lua
@@ -1,0 +1,83 @@
+local omq = require("omq")
+
+local function options()
+  return { linger = 0, recv_timeout = 1000, send_timeout = 1000 }
+end
+
+local ctx = omq.context()
+
+-- CLIENT/SERVER carries the server routing id as an internal first frame.
+do
+  local server = ctx:socket("SERVER", options())
+  local client = ctx:socket("CLIENT", options())
+  local endpoint = server:bind("inproc://lua-client-server-behavior")
+  client:connect(endpoint)
+
+  for i = 1, 3 do
+    client:send("request-" .. i)
+    local request = server:recv_parts()
+    assert(#request == 2)
+    assert(request[2] == "request-" .. i)
+    server:send_parts({ request[1], "reply-" .. i })
+    assert(client:recv() == "reply-" .. i)
+  end
+
+  client:close()
+  server:close()
+end
+
+-- SCATTER/GATHER accepts single-frame messages and delivers each one.
+do
+  local gather = ctx:socket("gather", options())
+  local scatter = ctx:socket("scatter", options())
+  local endpoint = gather:bind("inproc://lua-scatter-gather-behavior")
+  scatter:connect(endpoint)
+
+  for i = 1, 3 do
+    scatter:send("scatter-" .. i)
+  end
+  for i = 1, 3 do
+    assert(gather:recv() == "scatter-" .. i)
+  end
+
+  gather:close()
+  scatter:close()
+end
+
+-- CHANNEL is bidirectional and single-frame.
+do
+  local left = ctx:socket("channel", options())
+  local right = ctx:socket("channel", options())
+  local endpoint = left:bind("inproc://lua-channel-behavior")
+  right:connect(endpoint)
+
+  left:send("left-to-right")
+  right:send("right-to-left")
+  assert(right:recv() == "left-to-right")
+  assert(left:recv() == "right-to-left")
+
+  left:close()
+  right:close()
+end
+
+-- RADIO/DISH uses explicit group membership and grouped messages.
+do
+  local radio = ctx:socket("radio", options())
+  local dish = ctx:socket("dish", options())
+  local endpoint = radio:bind("inproc://lua-radio-dish-behavior")
+  dish:join("weather")
+  dish:connect(endpoint)
+
+  os.execute("sleep 0.05")
+  radio:send_group("weather", "sunny")
+  assert(dish:recv() == "sunny")
+
+  dish:leave("weather")
+  radio:send_group("weather", "ignored")
+  assert(dish:try_recv() == nil)
+
+  dish:close()
+  radio:close()
+end
+
+ctx:term()


### PR DESCRIPTION
- Expose all 20 ZMTP socket types in the Lua binding.
- Add `join`, `leave`, and `send_group` for RADIO/DISH.
- Add Lua coverage for socket creation, CLIENT/SERVER, SCATTER/GATHER, CHANNEL, and RADIO/DISH behavior.