### PR TITLE
docs: clean up binding readmes

### DIFF
--- a/bindings/lua/DEVELOPMENT.md
+++ b/bindings/lua/DEVELOPMENT.md
@@ -24,6 +24,15 @@ LUA_PATH="$PWD/bindings/lua/lua/?.lua;;"
 LUA_CPATH="$PWD/bindings/lua/native/target/debug/lib?.so;;"
 ```
 
+Manual equivalent:
+
+```sh
+cargo build --manifest-path bindings/lua/native/Cargo.toml
+export LUA_PATH="$PWD/bindings/lua/lua/?.lua;;"
+export LUA_CPATH="$PWD/bindings/lua/native/target/debug/lib?.so;;"
+/usr/bin/lua bindings/lua/tests/test_basic.lua
+```
+
 ## Native Checks
 
 ```sh

--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -8,22 +8,12 @@ The binding is a Lua module loaded by `/usr/bin/lua`. Public Lua APIs live in
 
 Architecture notes: [`doc/architecture.md`](doc/architecture.md).
 
-## Build And Test
+## Performance
 
-Requires `/usr/bin/lua`, Python 3 for charts, and a Rust toolchain.
+![OMQ.lua performance](https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/lua/doc/charts/bindings.svg)
 
-```sh
-./scripts/test-lua.sh
-```
-
-Manual equivalent:
-
-```sh
-cargo build --manifest-path bindings/lua/native/Cargo.toml
-export LUA_PATH="$PWD/bindings/lua/lua/?.lua;;"
-export LUA_CPATH="$PWD/bindings/lua/native/target/debug/lib?.so;;"
-/usr/bin/lua bindings/lua/tests/test_basic.lua
-```
+Benchmark and build details live in
+[`DEVELOPMENT.md`](DEVELOPMENT.md).
 
 ## API Shape
 
@@ -82,31 +72,4 @@ print(pull:recv())
 push:close()
 pull:close()
 ctx:term()
-```
-
-## Performance Chart
-
-![OMQ.lua performance](https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/lua/doc/charts/bindings.svg)
-
-Generate a quick local chart:
-
-```sh
-bindings/lua/scripts/update_perf.py --quick
-```
-
-The script uses the same append-only cache and SVG chart shape as the Go and
-Python bindings. It benchmarks `omq.lua` and, when `require("lzmq")` works for
-the selected Lua binary, `lzmq`. User-local rocks are visible when `luarocks`
-is available.
-
-Limit a run to one implementation:
-
-```sh
-bindings/lua/scripts/update_perf.py --quick --impls omq.lua --latency-impls omq.lua
-```
-
-Benchmark rows append to:
-
-```text
-~/.cache/omq.lua/bindings.jsonl
 ```

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -3,6 +3,22 @@
 Python binding for [omq.rs](https://github.com/paddor/omq.rs), a Rust libzmq
 port. Drop-in pyzmq replacement on the common path.
 
+## Highlights
+
+- Sync and `asyncio` APIs with all 20 ZMTP socket types.
+- Standard sockets: PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH,
+  XPUB, XSUB, and STREAM.
+- Draft sockets: SERVER, CLIENT, RADIO, DISH, GATHER, SCATTER, PEER, and
+  CHANNEL.
+- `tcp://`, `ipc://`, `inproc://`, and `udp://` transports (RADIO/DISH only).
+- Optional `plain`, `curve`, `lz4`, and `zstd` features in the published
+  wheel.
+- Built on [`omq-tokio`](https://github.com/paddor/omq.rs/tree/main/omq-tokio);
+  runtime work runs on a dedicated background thread and Python calls release
+  the GIL across the runtime trip.
+- DISH groups use `socket.join()` / `socket.leave()` and multipart group
+  messages.
+
 ## Install
 
 ```sh
@@ -44,25 +60,6 @@ await sock.close()
 ```
 
 Zguide-style runnable examples live in [examples/zguide/](examples/zguide/).
-
-## Status
-
-Sync and `asyncio` APIs both ship in this release. All 20 ZMTP socket types are wired:
-
-- **Standard (RFC 28 + 47)**: PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH, XPUB, XSUB, STREAM.
-- **Draft**: SERVER, CLIENT (RFC 41), RADIO, DISH (RFC 48), GATHER, SCATTER (RFC 49), PEER, CHANNEL (RFC 51).
-
-Transports: `tcp://`, `ipc://`, `inproc://`, and `udp://` (RADIO/DISH only).
-Optional features built into the wheel: `plain`, `curve`, `lz4`, `zstd`.
-
-DISH groups: use `socket.join(b"group")` / `socket.leave(b"group")` to manage
-subscriptions; messages are sent as multipart `[group, body]`.
-
-## Backend
-
-pyomq is built on `omq-tokio` (multi-threaded tokio runtime). The runtime
-runs on a dedicated background thread; every Python call releases the GIL
-across the runtime trip.
 
 ## Performance
 


### PR DESCRIPTION
- Move pyomq status and backend details into a Highlights section.
- Keep the Lua README focused on its performance chart.
- Move Lua build and benchmark instructions into DEVELOPMENT.md.