### PR TITLE
bench: add tuned Monocoque Tokio baseline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -197,6 +197,7 @@ when a measured cell looks bad, don't hand-wave it as noise.
 | `omq_bench_peer_blocking` | `omq-tokio/src/bin/bench_peer_blocking.rs` | omq-tokio-1t, omq-tokio-2t |
 | `libzmq_bench_peer` | `scripts/libzmq_bench_peer.c` | libzmq, libzmq-2t |
 | `tmq_bench_peer` | `scripts/tmq_bench_peer/` | tmq |
+| `monocoque_bench_peer` | `scripts/monocoque_bench_peer/` | monocoque-tokio-ct |
 | `zmqrs_bench_peer` | `scripts/zmqrs_bench_peer/` | zmq.rs |
 | `rzmq_bench_peer` | `scripts/rzmq_bench_peer/` | rzmq, rzmq-iouring |
 | `grpc_bench_peer` | `omq-bench/src/bin/grpc_bench_peer.rs` | grpc-rust |

--- a/doc/charts/CLAUDE.md
+++ b/doc/charts/CLAUDE.md
@@ -22,9 +22,9 @@ Data: `comparisons.jsonl`. External impls required.
 
 | file | impls |
 |------|-------|
-| `main_pushpull_tcp.svg` | libzmq 1IO, omq 1IO, omq CT, zmq.rs, rzmq, rzmq-iouring, gRPC Rust |
-| `main_reqrep_tcp.svg` | libzmq 1IO, omq 1IO, omq CT, zmq.rs, rzmq, rzmq-iouring, gRPC Rust |
-| `main_pubsub_tcp.svg` | libzmq 1IO, libzmq 2IO, omq 1IO, omq 2IO, zmq.rs, rzmq, rzmq-iouring |
+| `main_pushpull_tcp.svg` | libzmq 1IO, omq 1IO, omq CT, monocoque CT, zmq.rs, rzmq, rzmq-iouring, gRPC Rust |
+| `main_reqrep_tcp.svg` | libzmq 1IO, omq 1IO, omq CT, monocoque CT, zmq.rs, rzmq, rzmq-iouring, gRPC Rust |
+| `main_pubsub_tcp.svg` | libzmq 1IO, libzmq 2IO, omq 1IO, omq 2IO, monocoque CT + 1 worker, zmq.rs, rzmq, rzmq-iouring |
 
 PUSH/PULL sizes: 16B..4MiB (14 points). PUB/SUB sizes: 16B..16KiB
 (6 points, 64 peers). REQ/REP latency sizes: 16B..16KiB (6 points).
@@ -92,6 +92,18 @@ Bench: `omq-bench run pushpull-lz4` (uses `bench_peer_blocking`, 1IO).
 - `omq-tokio-ct`: `Context::current()`, no background IO thread.
   App and IO share one current-thread runtime.
 - `omq-tokio-2t`: 2 dedicated current-thread IO runtimes.
+
+## Monocoque runtime mode
+
+- `monocoque-tokio-ct`: `monocoque-rs` 0.4.0 with `runtime-tokio`.
+  `LocalRuntime` is a Tokio current-thread runtime wrapped in a `LocalSet`.
+- PUSH/PULL and REQ/REP use one OS thread per peer process. Application and
+  socket I/O share that thread. No background I/O thread.
+- PUB uses the same current-thread runtime plus exactly one `pub-worker-0`
+  background worker. SUB remains current-thread with no worker.
+- Throughput PUSH uses 16 KiB buffers and write coalescing. Throughput PULL
+  and SUB use 16 KiB buffers without coalescing. REQ/REP uses 4 KiB buffers
+  without coalescing.
 
 ## Style
 

--- a/doc/charts/CLAUDE.md
+++ b/doc/charts/CLAUDE.md
@@ -101,9 +101,11 @@ Bench: `omq-bench run pushpull-lz4` (uses `bench_peer_blocking`, 1IO).
   socket I/O share that thread. No background I/O thread.
 - PUB uses the same current-thread runtime plus exactly one `pub-worker-0`
   background worker. SUB remains current-thread with no worker.
-- Throughput PUSH uses 16 KiB buffers and write coalescing. Throughput PULL
-  and SUB use 16 KiB buffers without coalescing. REQ/REP uses 4 KiB buffers
-  without coalescing.
+- Throughput PUSH uses the 64 KiB read slab, 64 KiB write buffer, and write
+  coalescing. Throughput PULL and SUB use the 64 KiB read slab, 8 KiB write
+  buffer, no coalescing, and `recv_into()` to reuse the receive frame vector.
+  REQ/REP leaves Monocoque's default buffers in place, disables coalescing, and
+  reuses the reply vector with `recv_into()` on the request side.
 
 ## Style
 

--- a/doc/charts/main_pubsub_tcp.svg
+++ b/doc/charts/main_pubsub_tcp.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 950 530" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="950" height="530" opacity="1" fill="#000000" stroke="none"/>
+<svg viewBox="0 0 950 546" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="950" height="546" opacity="1" fill="#000000" stroke="none"/>
 <text x="475" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUB/SUB throughput (32 peers), TCP loopback, 2-process</text>
 <text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
 <text x="227" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
@@ -192,6 +192,53 @@ small messages (higher is better)
 <circle cx="201" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="322" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,145 86,146 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,146 95,147 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,147 104,148 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,148 113,149 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,149 122,150 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,151 131,151 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,152 140,152 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="143,153 148,153 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,154 157,155 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,155 166,156 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,156 175,157 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,157 184,158 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,158 193,159 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,159 201,160 202,160 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,162 210,164 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="213,165 219,167 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="221,168 227,171 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="230,172 235,174 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="238,175 244,177 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="246,178 252,181 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="255,182 260,184 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="263,185 269,187 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="272,189 277,191 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="280,192 285,194 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="288,195 294,198 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="297,199 302,201 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="305,202 310,204 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="313,205 319,208 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="322,209 322,209 327,211 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="330,212 336,214 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="338,215 344,217 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="347,218 353,220 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="355,221 361,223 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="364,224 370,226 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="372,227 378,229 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="381,230 386,232 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="389,233 395,235 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="398,236 403,238 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="406,239 412,241 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="415,242 420,244 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="423,245 429,248 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="432,249 437,251 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="440,252 444,253 "/>
+<circle cx="80" cy="145" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="160" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="209" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="253" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,297 86,297 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,297 95,297 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,297 104,297 "/>
@@ -599,6 +646,11 @@ medium/large messages (higher is better)
 <circle cx="615" cy="305" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="746" cy="289" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="250" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,270 615,216 746,216 877,216 "/>
+<circle cx="485" cy="270" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="746" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="485,306 615,291 746,274 877,277 "/>
 <circle cx="485" cy="306" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="615" cy="291" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -710,34 +762,44 @@ tmq v0.5.0
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 187%
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,478 92,478 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="78,478 92,478 "/>
 <text x="98" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs v0.6.0
+monocoque
 </text>
 <text x="250" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-12 MT
+CT + 1 worker
 </text>
 <text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-98%
+183%
 </text>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,494 92,494 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,494 92,494 "/>
 <text x="98" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq v0.5.24
+zmq.rs v0.6.0
 </text>
 <text x="250" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-436%
+98%
 </text>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,510 92,510 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,510 92,510 "/>
 <text x="98" y="504" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring v0.5.24
+rzmq v0.5.24
 </text>
 <text x="250" y="504" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="504" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+436%
+</text>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,526 92,526 "/>
+<text x="98" y="520" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+rzmq-iouring v0.5.24
+</text>
+<text x="250" y="520" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="520" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 463%
 </text>
 </svg>

--- a/doc/charts/main_pubsub_tcp.svg
+++ b/doc/charts/main_pubsub_tcp.svg
@@ -192,53 +192,56 @@ small messages (higher is better)
 <circle cx="201" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="322" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,145 86,146 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,146 95,147 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,147 104,148 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,148 113,149 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,149 122,150 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,151 131,151 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,152 140,152 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="143,153 148,153 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,154 157,155 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,155 166,156 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,156 175,157 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,157 184,158 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,158 193,159 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,159 201,160 202,160 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,162 210,164 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="213,165 219,167 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="221,168 227,171 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="230,172 235,174 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="238,175 244,177 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="246,178 252,181 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="255,182 260,184 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="263,185 269,187 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="272,189 277,191 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="280,192 285,194 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="288,195 294,198 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="297,199 302,201 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="305,202 310,204 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="313,205 319,208 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="322,209 322,209 327,211 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="330,212 336,214 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="338,215 344,217 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="347,218 353,220 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="355,221 361,223 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="364,224 370,226 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="372,227 378,229 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="381,230 386,232 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="389,233 395,235 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="398,236 403,238 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="406,239 412,241 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="415,242 420,244 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="423,245 429,248 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="432,249 437,251 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="440,252 444,253 "/>
-<circle cx="80" cy="145" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="160" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="209" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="253" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,104 86,105 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,105 95,106 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,106 104,107 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,108 113,108 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,109 122,110 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,110 131,111 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,111 139,112 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="142,112 148,113 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,113 157,114 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,115 166,115 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,116 175,117 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,117 184,118 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,118 193,119 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,119 201,120 202,120 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,121 210,123 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="213,124 219,126 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="222,128 227,130 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="230,131 236,133 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="239,134 244,136 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="247,137 253,139 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="255,140 261,142 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="264,143 270,145 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="272,146 278,148 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="281,149 286,151 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="289,152 295,154 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="298,155 303,157 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="306,158 312,160 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="315,161 320,163 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="323,165 328,169 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="330,170 335,174 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="337,176 342,180 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="344,182 349,186 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="351,187 356,191 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="358,193 363,197 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="365,199 370,203 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="372,204 377,208 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="379,210 383,214 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="386,216 390,220 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="393,221 397,225 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="400,227 404,231 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="407,233 411,237 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="414,238 418,242 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="421,244 425,248 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="428,250 432,254 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="435,255 439,259 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="442,261 444,263 "/>
+<circle cx="80" cy="104" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="120" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="164" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="263" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,297 86,297 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,297 95,297 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,297 104,297 "/>
@@ -646,11 +649,11 @@ medium/large messages (higher is better)
 <circle cx="615" cy="305" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="746" cy="289" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="250" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,270 615,216 746,216 877,216 "/>
-<circle cx="485" cy="270" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="615" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,251 615,231 746,216 877,215 "/>
+<circle cx="485" cy="251" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="615" cy="231" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <circle cx="746" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="216" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="215" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="485,306 615,291 746,274 877,277 "/>
 <circle cx="485" cy="306" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="615" cy="291" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -770,7 +773,7 @@ monocoque
 CT + 1 worker
 </text>
 <text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-183%
+195%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,494 92,494 "/>
 <text x="98" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">

--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 950 498" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="950" height="498" opacity="1" fill="#000000" stroke="none"/>
+<svg viewBox="0 0 950 514" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="950" height="514" opacity="1" fill="#000000" stroke="none"/>
 <text x="475" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUSH/PULL throughput, TCP loopback, 2-process</text>
 <text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
 <text x="227" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
@@ -279,6 +279,56 @@ small messages (higher is better)
 <circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="383" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,160 86,161 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,161 95,162 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,162 104,163 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,164 113,164 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,165 122,166 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,166 131,167 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,167 139,168 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="142,168 148,168 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,169 157,169 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,169 166,169 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,169 175,170 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,170 184,170 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,170 193,171 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,171 201,171 202,171 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,172 211,174 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="214,174 220,176 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="223,177 228,178 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="231,179 237,180 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="240,181 246,183 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="249,184 255,185 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="257,186 262,187 263,187 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="266,189 272,191 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="274,192 280,194 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="283,195 288,198 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="291,199 297,201 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="299,202 305,204 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="308,205 313,208 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="316,209 322,211 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="325,212 330,214 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="333,215 338,218 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="341,219 347,221 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="349,222 355,225 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="358,226 363,228 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="366,229 372,231 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="374,233 380,235 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="383,236 383,236 388,238 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="391,239 397,241 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="400,242 405,244 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="408,245 414,248 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="416,249 422,251 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="425,252 431,254 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="433,255 439,257 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="442,258 444,259 "/>
+<circle cx="80" cy="160" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="168" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="171" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="187" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="211" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="236" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="259" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,294 86,294 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,294 95,294 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,294 104,294 "/>
@@ -627,6 +677,18 @@ medium/large messages (higher is better)
 <circle cx="798" cy="178" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="837" cy="217" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="220" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,243 524,209 563,167 602,132 641,140 681,103 720,136 759,141 798,129 837,145 877,162 "/>
+<circle cx="485" cy="243" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="209" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="167" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="132" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="140" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="103" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="136" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="141" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="129" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="145" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="162" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="485,302 524,294 563,282 602,263 641,256 681,254 720,252 759,216 798,111 837,120 877,128 "/>
 <circle cx="485" cy="302" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="524" cy="294" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -736,56 +798,69 @@ tmq v0.5.0
 <text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 140%
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,430 92,430 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="78,430 92,430 "/>
 <text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs v0.6.0
+monocoque
 </text>
 <text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-12 MT
+CT
 </text>
 <text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-92%
+76%
 </text>
 <text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-99%
+98%
 </text>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,446 92,446 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq v0.5.24
+zmq.rs v0.6.0
 </text>
 <text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-102%
+92%
 </text>
 <text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-110%
+99%
 </text>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,462 92,462 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring v0.5.24
+rzmq v0.5.24
 </text>
 <text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-149%
+102%
 </text>
 <text x="450" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-139%
+110%
 </text>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,478 92,478 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,478 92,478 "/>
 <text x="98" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-gRPC (tonic v0.12.3)
+rzmq-iouring v0.5.24
 </text>
 <text x="250" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-192%
+149%
 </text>
 <text x="450" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+139%
+</text>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,494 92,494 "/>
+<text x="98" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+gRPC (tonic v0.12.3)
+</text>
+<text x="250" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+192%
+</text>
+<text x="450" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 150%
 </text>
 </svg>

--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -279,56 +279,57 @@ small messages (higher is better)
 <circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="383" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="444" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,160 86,161 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,161 95,162 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,162 104,163 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,164 113,164 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,165 122,166 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,166 131,167 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,167 139,168 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="142,168 148,168 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,169 157,169 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,169 166,169 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,169 175,170 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,170 184,170 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,170 193,171 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,171 201,171 202,171 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,172 211,174 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="214,174 220,176 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="223,177 228,178 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="231,179 237,180 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="240,181 246,183 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="249,184 255,185 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="257,186 262,187 263,187 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="266,189 272,191 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="274,192 280,194 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="283,195 288,198 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="291,199 297,201 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="299,202 305,204 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="308,205 313,208 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="316,209 322,211 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="325,212 330,214 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="333,215 338,218 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="341,219 347,221 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="349,222 355,225 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="358,226 363,228 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="366,229 372,231 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="374,233 380,235 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="383,236 383,236 388,238 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="391,239 397,241 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="400,242 405,244 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="408,245 414,248 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="416,249 422,251 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="425,252 431,254 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="433,255 439,257 "/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="442,258 444,259 "/>
-<circle cx="80" cy="160" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="168" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="171" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="187" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="211" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="236" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="259" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="80,138 86,139 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="89,139 95,140 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="98,140 104,141 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="107,142 113,142 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="116,143 122,144 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="125,144 131,145 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="134,145 139,146 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="142,146 148,146 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="151,146 157,147 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="160,147 166,147 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="169,147 175,147 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="178,147 184,147 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="187,148 193,148 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="196,148 201,148 202,148 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="205,149 211,150 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="214,151 220,152 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="223,153 229,154 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="232,155 237,156 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="240,157 246,158 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="249,159 255,160 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="258,161 262,162 264,163 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="266,164 272,166 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="275,168 280,170 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="283,171 288,174 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="291,175 297,178 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="299,179 305,181 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="307,182 313,185 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="316,186 321,189 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="324,190 329,192 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="332,193 338,195 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="341,196 346,199 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="349,200 355,202 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="357,203 363,205 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="366,206 371,208 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="374,210 380,212 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="383,213 383,213 388,216 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="390,218 395,221 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="398,223 403,226 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="405,228 410,231 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="412,233 417,236 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="420,238 425,241 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="427,243 432,246 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="435,248 440,251 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="442,253 444,254 "/>
+<circle cx="80" cy="138" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="146" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="148" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="162" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="189" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="213" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="254" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,294 86,294 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,294 95,294 "/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,294 104,294 "/>
@@ -677,18 +678,18 @@ medium/large messages (higher is better)
 <circle cx="798" cy="178" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="837" cy="217" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="220" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,243 524,209 563,167 602,132 641,140 681,103 720,136 759,141 798,129 837,145 877,162 "/>
-<circle cx="485" cy="243" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="524" cy="209" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="563" cy="167" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="602" cy="132" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="641" cy="140" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="681" cy="103" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="720" cy="136" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="759" cy="141" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="798" cy="129" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="837" cy="145" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="162" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="485,228 524,177 563,154 602,149 641,149 681,159 720,145 759,148 798,118 837,142 877,159 "/>
+<circle cx="485" cy="228" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="177" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="154" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="149" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="149" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="159" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="145" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="148" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="118" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="142" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="159" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="485,302 524,294 563,282 602,263 641,256 681,254 720,252 759,216 798,111 837,120 877,128 "/>
 <circle cx="485" cy="302" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="524" cy="294" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -806,10 +807,10 @@ monocoque
 CT
 </text>
 <text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-76%
+84%
 </text>
 <text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-98%
+89%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">

--- a/doc/charts/main_reqrep_tcp.svg
+++ b/doc/charts/main_reqrep_tcp.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 850 514" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="850" height="514" opacity="1" fill="#000000" stroke="none"/>
+<svg viewBox="0 0 850 530" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="850" height="530" opacity="1" fill="#000000" stroke="none"/>
 <text x="425" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">REQ/REP latency, TCP loopback, 2-process</text>
 <text x="425" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
 <text x="415" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
@@ -96,6 +96,12 @@ p50 round-trip latency (lower is better)
 <circle cx="444" cy="240" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="631" cy="239" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="819" cy="237" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="70,246 257,251 444,243 631,242 819,233 "/>
+<circle cx="70" cy="246" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="251" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="243" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="242" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="233" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="70,122 257,127 444,125 631,122 819,119 "/>
 <circle cx="70" cy="122" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="257" cy="127" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -200,50 +206,63 @@ tmq v0.5.0
 <text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 80%
 </text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,446 92,446 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs v0.6.0
+monocoque
 </text>
 <text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-12 MT
+CT
 </text>
 <text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-53%
+54%
 </text>
 <text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-63%
+60%
 </text>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,462 92,462 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq v0.5.24
+zmq.rs v0.6.0
 </text>
 <text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-61%
+53%
 </text>
 <text x="450" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-86%
+63%
 </text>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,478 92,478 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,478 92,478 "/>
 <text x="98" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring v0.5.24
+rzmq v0.5.24
 </text>
 <text x="250" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-92%
+61%
 </text>
 <text x="450" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-126%
+86%
 </text>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,494 92,494 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,494 92,494 "/>
 <text x="98" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-gRPC (tonic v0.12.3)
+rzmq-iouring v0.5.24
 </text>
 <text x="250" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+92%
+</text>
+<text x="450" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+126%
+</text>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,510 92,510 "/>
+<text x="98" y="504" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+gRPC (tonic v0.12.3)
+</text>
+<text x="250" y="504" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 </svg>

--- a/doc/charts/main_reqrep_tcp.svg
+++ b/doc/charts/main_reqrep_tcp.svg
@@ -96,12 +96,12 @@ p50 round-trip latency (lower is better)
 <circle cx="444" cy="240" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="631" cy="239" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="819" cy="237" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="70,246 257,251 444,243 631,242 819,233 "/>
+<polyline fill="none" opacity="1" stroke="#2563EB" stroke-width="2" points="70,246 257,243 444,242 631,242 819,244 "/>
 <circle cx="70" cy="246" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="257" cy="251" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="243" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="257" cy="243" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="242" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <circle cx="631" cy="242" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
-<circle cx="819" cy="233" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
+<circle cx="819" cy="244" r="2.5" opacity="1" fill="#2563EB" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="70,122 257,127 444,125 631,122 819,119 "/>
 <circle cx="70" cy="122" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="257" cy="127" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
@@ -214,10 +214,10 @@ monocoque
 CT
 </text>
 <text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-54%
+56%
 </text>
 <text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-60%
+59%
 </text>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">

--- a/omq-bench/src/bench/comparisons.rs
+++ b/omq-bench/src/bench/comparisons.rs
@@ -228,6 +228,22 @@ static IMPLS: &[ImplDef] = &[
         env: &[],
     },
     ImplDef {
+        name: "monocoque-tokio-ct",
+        binary_from: None,
+        prefix: "o",
+        class: Some(ImplClass::Classic),
+        main: true,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "",
+        inproc_lat_subcmd: "",
+        inproc_pubsub_subcmd: "",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "",
+        fanio_needs_peer_count: false,
+        supports_pubsub: true,
+        env: &[],
+    },
+    ImplDef {
         name: "zmq.rs",
         binary_from: None,
         prefix: "q",
@@ -565,6 +581,18 @@ fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMa
                 binaries.insert(
                     source.to_string(),
                     PathBuf::from("scripts/tmq_bench_peer/target/release/tmq_bench_peer"),
+                );
+            }
+            "monocoque-tokio-ct" => {
+                run_build_in_dir(
+                    &["cargo", "build", "--release", "-q"],
+                    "scripts/monocoque_bench_peer",
+                );
+                binaries.insert(
+                    source.to_string(),
+                    PathBuf::from(
+                        "scripts/monocoque_bench_peer/target/release/monocoque_bench_peer",
+                    ),
                 );
             }
             "rzmq" => {

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -64,6 +64,7 @@ pub(crate) const C_TMQ: RGBColor = RGBColor(168, 85, 247);
 pub(crate) const C_RZMQ: RGBColor = RGBColor(74, 222, 128);
 pub(crate) const C_RZMQ_IOURING: RGBColor = RGBColor(16, 185, 129);
 pub(crate) const C_GRPC: RGBColor = RGBColor(244, 114, 182);
+pub(crate) const C_MONOCOQUE: RGBColor = RGBColor(37, 99, 235);
 
 // ── formatting ─────────────────────────────────────────────────
 

--- a/omq-bench/src/chart/main_tcp.rs
+++ b/omq-bench/src/chart/main_tcp.rs
@@ -1,6 +1,6 @@
 use super::common::{
-    self, C_GRPC, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_3T, C_OMQ_4T, C_OMQ_CT,
-    C_OMQ_EXCLUSIVE, C_RZMQ, C_RZMQ_IOURING, C_TMQ, C_ZMQRS, Impl,
+    self, C_GRPC, C_LIBZMQ, C_LIBZMQ_2T, C_MONOCOQUE, C_OMQ_1T, C_OMQ_2T, C_OMQ_3T, C_OMQ_4T,
+    C_OMQ_CT, C_OMQ_EXCLUSIVE, C_RZMQ, C_RZMQ_IOURING, C_TMQ, C_ZMQRS, Impl,
     draw_latency_single_panel_with_versions,
     draw_throughput_dual_panel_fixed_2m_msgs_with_versions,
     draw_throughput_dual_panel_with_versions, load_latency, load_tput, out_dir,
@@ -36,6 +36,12 @@ const PUSHPULL_IMPLS: &[Impl] = &[
         label: "tmq",
         threads: "1 IO",
         color: C_TMQ,
+    },
+    Impl {
+        key: "monocoque-tokio-ct",
+        label: "monocoque",
+        threads: "CT",
+        color: C_MONOCOQUE,
     },
     Impl {
         key: "zmq.rs",
@@ -93,6 +99,12 @@ const REQREP_IMPLS: &[Impl] = &[
         label: "tmq",
         threads: "1 IO",
         color: C_TMQ,
+    },
+    Impl {
+        key: "monocoque-tokio-ct",
+        label: "monocoque",
+        threads: "CT",
+        color: C_MONOCOQUE,
     },
     Impl {
         key: "zmq.rs",
@@ -162,6 +174,12 @@ const PUBSUB_IMPLS: &[Impl] = &[
         label: "tmq",
         threads: "1 IO",
         color: C_TMQ,
+    },
+    Impl {
+        key: "monocoque-tokio-ct",
+        label: "monocoque",
+        threads: "CT + 1 worker",
+        color: C_MONOCOQUE,
     },
     Impl {
         key: "zmq.rs",

--- a/omq-bench/src/chart/pubsub.rs
+++ b/omq-bench/src/chart/pubsub.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
 use super::common::{
-    C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, COMPARISON_SIZES, CpuData, Impl, ValMap,
-    draw_multirow_throughput, draw_throughput_dual_panel, load_tput, merge_cpu_data, out_dir,
+    C_LIBZMQ, C_LIBZMQ_2T, C_MONOCOQUE, C_OMQ_1T, C_OMQ_2T, COMPARISON_SIZES, CpuData, Impl,
+    ValMap, draw_multirow_throughput, draw_throughput_dual_panel, load_tput, merge_cpu_data,
+    out_dir,
 };
 
 const PUBSUB_IMPLS: &[Impl] = &[
@@ -29,6 +30,12 @@ const PUBSUB_IMPLS: &[Impl] = &[
         label: "omq",
         threads: "2 IO",
         color: C_OMQ_2T,
+    },
+    Impl {
+        key: "monocoque-tokio-ct",
+        label: "monocoque",
+        threads: "CT + 1 worker",
+        color: C_MONOCOQUE,
     },
 ];
 

--- a/scripts/monocoque_bench_peer/Cargo.toml
+++ b/scripts/monocoque_bench_peer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "monocoque_bench_peer"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "monocoque_bench_peer"
+path = "src/main.rs"
+
+[workspace]
+
+[dependencies]
+bytes = "1"
+libc = "0.2"
+monocoque-rs = { version = "0.4.0", default-features = false, features = ["runtime-tokio", "zmq"] }
+tokio = { version = "1", features = ["time", "rt", "macros"] }
+zmq = "0.10"

--- a/scripts/monocoque_bench_peer/src/main.rs
+++ b/scripts/monocoque_bench_peer/src/main.rs
@@ -1,0 +1,242 @@
+use bytes::Bytes;
+use monocoque::rt::{LocalRuntime, TcpListener, TcpStream};
+use monocoque::zmq::{
+    PubSocket, PullSocket, PushSocket, RepSocket, ReqSocket, SocketOptions, SubSocket,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn cpu() -> f64 {
+    let mut r = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    // SAFETY: getrusage initializes supplied storage.
+    unsafe { libc::getrusage(libc::RUSAGE_SELF, r.as_mut_ptr()) };
+    let r = unsafe { r.assume_init() };
+    (r.ru_utime.tv_sec + r.ru_stime.tv_sec) as f64
+        + (r.ru_utime.tv_usec + r.ru_stime.tv_usec) as f64 / 1e6
+}
+
+fn report(port: u16) {
+    let Some(ep) = std::env::var_os("OMQ_BENCH_COORD") else {
+        return;
+    };
+    let ctx = zmq::Context::new();
+    let s = ctx.socket(zmq::PUSH).expect("coord socket");
+    s.connect(ep.to_str().expect("coord endpoint"))
+        .expect("coord connect");
+    s.send(format!("READY {port}").as_bytes(), 0)
+        .expect("coord send");
+    std::mem::forget(s);
+    std::mem::forget(ctx);
+}
+
+async fn barrier() {
+    let Some(raw) = std::env::var("OMQ_BENCH_START_AT")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+    else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
+    if raw > now {
+        tokio::time::sleep(Duration::from_secs_f64(raw - now)).await;
+    }
+}
+
+fn addr(s: &str) -> String {
+    s.strip_prefix("tcp://").unwrap_or(s).to_owned()
+}
+
+fn throughput_options() -> SocketOptions {
+    SocketOptions::default()
+        .with_buffer_sizes(16 * 1024, 16 * 1024)
+        .with_write_coalescing(true)
+}
+
+fn latency_options() -> SocketOptions {
+    SocketOptions::default().with_buffer_sizes(4 * 1024, 4 * 1024)
+}
+
+fn receive_options() -> SocketOptions {
+    SocketOptions::default().with_buffer_sizes(16 * 1024, 16 * 1024)
+}
+
+async fn listener(s: &str) -> (TcpListener, u16) {
+    let l = TcpListener::bind(addr(s)).await.expect("bind");
+    let p = l.local_addr().expect("local addr").port();
+    report(p);
+    (l, p)
+}
+
+async fn push(s: &str, n: usize) {
+    let (l, _) = listener(s).await;
+    let (stream, _) = l.accept().await.expect("accept");
+    let mut p = PushSocket::from_tcp_with_options(stream, throughput_options())
+        .await
+        .expect("push handshake");
+    barrier().await;
+    let msg = Bytes::from(vec![b'x'; n]);
+    loop {
+        p.send_one(msg.clone()).await.expect("push send");
+    }
+}
+
+async fn pull(s: &str, n: usize, d: f64) {
+    let mut p = PullSocket::connect_with_options(addr(s), receive_options())
+        .await
+        .expect("pull connect");
+    barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let start_cpu = cpu();
+    let start = Instant::now();
+    let mut count = 0u64;
+    while start.elapsed() < Duration::from_secs_f64(d) {
+        p.recv().await.expect("pull recv");
+        count += 1;
+    }
+    println!(
+        "{count} {:.6} {n} {:.6}",
+        start.elapsed().as_secs_f64(),
+        cpu() - start_cpu
+    );
+}
+
+async fn pub_run(s: &str, n: usize) {
+    let mut p = PubSocket::bind_with_workers(addr(s), 1)
+        .await
+        .expect("pub bind");
+    report(p.local_addr().expect("local addr").port());
+    let peers: usize = std::env::var("OMQ_BENCH_PEERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    for _ in 0..peers {
+        p.accept_subscriber().await.expect("sub accept");
+    }
+    barrier().await;
+    let msg = Bytes::from(vec![b'x'; n]);
+    loop {
+        p.send_frames(std::slice::from_ref(&msg))
+            .await
+            .expect("pub send");
+    }
+}
+
+async fn sub(s: &str, n: usize, d: f64, peers: usize) {
+    let mut sockets = Vec::with_capacity(peers);
+    for _ in 0..peers {
+        let stream = TcpStream::connect(addr(s)).await.expect("sub connect");
+        let mut x = SubSocket::from_tcp_with_options(stream, receive_options())
+            .await
+            .expect("sub connect");
+        x.subscribe(b"").await.expect("subscribe");
+        sockets.push(x);
+    }
+    barrier().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let counts = Arc::new(AtomicU64::new(0));
+    let start_cpu = cpu();
+    let start = Instant::now();
+    for mut x in sockets {
+        let c = Arc::clone(&counts);
+        tokio::task::spawn_local(async move {
+            while x.recv().await.ok().flatten().is_some() {
+                c.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+    }
+    tokio::time::sleep(Duration::from_secs_f64(d)).await;
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "{} {:.6} {n} {:.6} {peers} 0 0",
+        counts.load(Ordering::Relaxed),
+        elapsed,
+        cpu() - start_cpu
+    );
+}
+
+async fn rep(s: &str) {
+    let (l, _) = listener(s).await;
+    let (stream, _) = l.accept().await.expect("accept");
+    let mut r = RepSocket::from_tcp_with_options(stream, latency_options())
+        .await
+        .expect("rep handshake");
+    loop {
+        let Some(msg) = r.recv().await.expect("rep recv") else {
+            return;
+        };
+        r.send(msg).await.expect("rep send");
+    }
+}
+
+async fn req(s: &str, n: usize, iters: usize, warmup: usize) {
+    let mut r = ReqSocket::connect_with_options(s, latency_options())
+        .await
+        .expect("req connect");
+    let msg = vec![Bytes::from(vec![b'x'; n])];
+    for _ in 0..warmup {
+        r.send(msg.clone()).await.expect("req send");
+        r.recv().await.expect("req recv");
+    }
+    let before = cpu();
+    let started = Instant::now();
+    let mut times = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t = Instant::now();
+        r.send(msg.clone()).await.expect("req send");
+        r.recv().await.expect("req recv");
+        times.push(t.elapsed().as_nanos() as u64);
+    }
+    times.sort_unstable();
+    let q = |p: f64| times[((times.len() - 1) as f64 * p).round() as usize] as f64 / 1000.0;
+    println!(
+        "{:.3} {:.3} {:.3} {:.3} {iters} {:.6} {:.6}",
+        q(0.5),
+        q(0.99),
+        q(0.999),
+        q(1.0),
+        cpu() - before,
+        started.elapsed().as_secs_f64()
+    );
+}
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let rt = LocalRuntime::new().expect("runtime");
+    rt.block_on(async move {
+        match a.get(1).map(String::as_str) {
+            Some("push") => push(&a[2], a[3].parse().unwrap()).await,
+            Some("pull") => pull(&a[2], a[3].parse().unwrap(), a[4].parse().unwrap()).await,
+            Some("pub") => {
+                std::env::set_var(
+                    "OMQ_BENCH_PEERS",
+                    a.get(4).cloned().unwrap_or_else(|| "1".into()),
+                );
+                pub_run(&a[2], a[3].parse().unwrap()).await;
+            }
+            Some("multi-sub") => {
+                sub(
+                    &a[2],
+                    a[3].parse().unwrap(),
+                    a[4].parse().unwrap(),
+                    a[5].parse().unwrap(),
+                )
+                .await
+            }
+            Some("rep") => rep(&a[2]).await,
+            Some("req") => {
+                req(
+                    &a[2],
+                    a[3].parse().unwrap(),
+                    a[4].parse().unwrap(),
+                    a[5].parse().unwrap(),
+                )
+                .await
+            }
+            _ => panic!("usage: monocoque_bench_peer push|pull|pub|multi-sub|rep|req ..."),
+        }
+    });
+}

--- a/scripts/monocoque_bench_peer/src/main.rs
+++ b/scripts/monocoque_bench_peer/src/main.rs
@@ -50,18 +50,23 @@ fn addr(s: &str) -> String {
     s.strip_prefix("tcp://").unwrap_or(s).to_owned()
 }
 
+// Monocoque clamps the read buffer to its 64 KiB read slab, and its own default
+// is 32 KiB. A 16 KiB read buffer is therefore below the untuned default and
+// halves the read batch. Bulk transfers want the full slab.
+const READ_SLAB: usize = 64 * 1024;
+
 fn throughput_options() -> SocketOptions {
     SocketOptions::default()
-        .with_buffer_sizes(16 * 1024, 16 * 1024)
+        .with_buffer_sizes(READ_SLAB, 64 * 1024)
         .with_write_coalescing(true)
 }
 
 fn latency_options() -> SocketOptions {
-    SocketOptions::default().with_buffer_sizes(4 * 1024, 4 * 1024)
+    SocketOptions::default().with_write_coalescing(false)
 }
 
 fn receive_options() -> SocketOptions {
-    SocketOptions::default().with_buffer_sizes(16 * 1024, 16 * 1024)
+    SocketOptions::default().with_buffer_sizes(READ_SLAB, 8 * 1024)
 }
 
 async fn listener(s: &str) -> (TcpListener, u16) {
@@ -93,8 +98,9 @@ async fn pull(s: &str, n: usize, d: f64) {
     let start_cpu = cpu();
     let start = Instant::now();
     let mut count = 0u64;
+    let mut buf: Vec<Bytes> = Vec::with_capacity(4);
     while start.elapsed() < Duration::from_secs_f64(d) {
-        p.recv().await.expect("pull recv");
+        p.recv_into(&mut buf).await.expect("pull recv");
         count += 1;
     }
     println!(
@@ -105,7 +111,14 @@ async fn pull(s: &str, n: usize, d: f64) {
 }
 
 async fn pub_run(s: &str, n: usize) {
-    let mut p = PubSocket::bind_with_workers(addr(s), 1)
+    // Default to 1 so the chart is reproducible. Set MONOCOQUE_PUB_WORKERS to
+    // compare against Monocoque's default, which picks CPU count clamped to
+    // [2, 16]. Monocoque 0.4.0 exposes no SocketOptions for PUB bind.
+    let workers: usize = std::env::var("MONOCOQUE_PUB_WORKERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let mut p = PubSocket::bind_with_workers(addr(s), workers)
         .await
         .expect("pub bind");
     report(p.local_addr().expect("local addr").port());
@@ -143,7 +156,8 @@ async fn sub(s: &str, n: usize, d: f64, peers: usize) {
     for mut x in sockets {
         let c = Arc::clone(&counts);
         tokio::task::spawn_local(async move {
-            while x.recv().await.ok().flatten().is_some() {
+            let mut buf: Vec<Bytes> = Vec::with_capacity(4);
+            while x.recv_into(&mut buf).await.unwrap_or(false) {
                 c.fetch_add(1, Ordering::Relaxed);
             }
         });
@@ -177,9 +191,10 @@ async fn req(s: &str, n: usize, iters: usize, warmup: usize) {
         .await
         .expect("req connect");
     let msg = vec![Bytes::from(vec![b'x'; n])];
+    let mut reply: Vec<Bytes> = Vec::with_capacity(4);
     for _ in 0..warmup {
         r.send(msg.clone()).await.expect("req send");
-        r.recv().await.expect("req recv");
+        r.recv_into(&mut reply).await.expect("req recv");
     }
     let before = cpu();
     let started = Instant::now();
@@ -187,7 +202,7 @@ async fn req(s: &str, n: usize, iters: usize, warmup: usize) {
     for _ in 0..iters {
         let t = Instant::now();
         r.send(msg.clone()).await.expect("req send");
-        r.recv().await.expect("req recv");
+        r.recv_into(&mut reply).await.expect("req recv");
         times.push(t.elapsed().as_nanos() as u64);
     }
     times.sort_unstable();


### PR DESCRIPTION
- Add a standalone `monocoque_bench_peer` for Monocoque 0.4.0 with the `runtime-tokio` backend.
- Benchmark explicit current-thread Tokio profiles for PUSH/PULL, REQ/REP, and PUB/SUB.
- Add Monocoque to the three main TCP charts with CT and PUB worker labels.
- Document socket tuning and Monocoque runtime/thread model.
- Refresh the three generated main charts.