### PR TITLE
perf(go): cut scalar REQ/REP latency

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -38,8 +38,10 @@ runs the Go tests with the right library path:
 - `Context` owns native IO threads and creates sockets.
 - `Context.ShareKey()` / `OpenShared(...)` explicitly share one native context
   core and `inproc://` namespace across Go handles.
-- `Socket` serializes native access through an owner goroutine, so public calls
-  are race-free across goroutines.
+- `Socket` serializes native access, so public calls are race-free across
+  goroutines. SPSC-backed socket types use the owner goroutine. `REQ` and `REP`
+  scalar data calls use thread-neutral native routes directly under a
+  per-socket mutex.
 - `Message` supports single-part and multipart payloads and copies input on
   construction.
 - `RecvInto` is the direct single-part receive path when the caller owns the

--- a/bindings/go/doc/architecture.md
+++ b/bindings/go/doc/architecture.md
@@ -33,9 +33,18 @@ Timeout helpers are convenience wrappers around context-aware loops:
 - `timeout < 0`: wait forever
 - `timeout > 0`: deadline
 
-Go cancellation is handled before entering cgo and between nonblocking
-native attempts. User goroutines do not need to close a socket from another
+Go cancellation is handled before entering cgo and between bounded native
+receive attempts. User goroutines do not need to close a socket from another
 goroutine to interrupt a blocked receive.
+
+Most socket types serialize native calls through the pinned owner goroutine.
+Their inproc and round-robin fast paths contain thread-owned SPSC producers.
+`REQ` and `REP` use thread-neutral, mutex-backed send routes. Their scalar data
+calls therefore skip the owner-channel handoff and serialize directly with a
+per-socket native-call mutex. Their scalar blocking receives wait briefly in
+native code before retrying, which avoids repeated Go scheduler round trips
+when a reply is already in flight. `TryRecv` and `TryRecvInto` remain
+nonblocking.
 
 `Socket.Run(ctx, fn)` executes `fn` on the socket owner goroutine, pinned to
 one OS thread. It is the low-latency path for tight loops. `BoundSocket`
@@ -68,9 +77,10 @@ measure owned native send buffers that Go fills before transfer to OMQ, plus
 a direct native `RecvInto` path that decodes single-part messages into the
 caller buffer when batching would not be harmed.
 
-The general scalar API remains context-aware and goroutine-safe. It pays the
-owner-channel and cgo transition costs on each operation. Use `Socket.Run`
-when a socket is on a hot path.
+The general scalar API remains context-aware and goroutine-safe. SPSC-backed
+socket types pay the owner-channel and cgo transition costs on each operation.
+`REQ` and `REP` scalar data calls pay only the cgo transition. Use `Socket.Run`
+for other tight socket loops that need to amortize these costs.
 
 ## Channels
 

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -48,48 +48,48 @@
   <line x1="760" y1="49" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="384" x2="760" y2="384" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="216" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,216)">msg/s</text>
-  <polyline points="90.0,101.3 150.9,82.4 211.8,259.2 272.7,270.4 333.6,281.7 394.5,309.9 455.5,325.3 516.4,344.5 577.3,361.2 638.2,371.5 699.1,377.2 760.0,380.3" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,330.4 150.9,332.3 211.8,333.0 272.7,338.3 333.6,342.6 394.5,351.9 455.5,362.8 516.4,374.0 577.3,379.3 638.2,380.9 699.1,382.0 760.0,382.3" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,348.0 150.9,350.5 211.8,351.3 272.7,352.5 333.6,356.0 394.5,361.3 455.5,368.4 516.4,372.8 577.3,377.5 638.2,379.9 699.1,381.7 760.0,382.8" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
-  <polyline points="90.0,375.0 150.9,364.7 211.8,368.0 272.7,354.9 333.6,331.6 394.5,308.1 455.5,263.8 516.4,222.1 577.3,197.4 638.2,179.7 699.1,160.9 760.0,139.3" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="375.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="364.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="368.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="354.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="331.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="308.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="263.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="222.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="197.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="179.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="160.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="139.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,382.3 150.9,380.7 211.8,377.5 272.7,372.3 333.6,362.8 394.5,351.1 455.5,340.6 516.4,343.0 577.3,345.7 638.2,333.7 699.1,319.8 760.0,273.7" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="90.0,120.3 150.9,136.1 211.8,258.5 272.7,271.4 333.6,277.3 394.5,298.1 455.5,326.6 516.4,343.0 577.3,360.8 638.2,370.5 699.1,376.8 760.0,380.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,332.2 150.9,331.6 211.8,333.2 272.7,340.9 333.6,344.2 394.5,352.7 455.5,365.4 516.4,372.9 577.3,378.6 638.2,380.8 699.1,381.9 760.0,382.4" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,346.4 150.9,347.8 211.8,351.6 272.7,351.9 333.6,355.3 394.5,360.4 455.5,368.0 516.4,372.3 577.3,377.1 638.2,379.8 699.1,381.6 760.0,382.8" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,4"/>
+  <polyline points="90.0,375.6 150.9,368.1 211.8,367.9 272.7,355.2 333.6,329.4 394.5,296.1 455.5,266.3 516.4,216.1 577.3,193.9 638.2,163.0 699.1,146.8 760.0,122.7" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="375.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="368.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="367.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="355.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="329.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="296.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="266.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="216.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="193.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="163.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="146.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="122.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,382.3 150.9,380.6 211.8,377.5 272.7,373.0 333.6,363.6 394.5,351.9 455.5,345.9 516.4,338.4 577.3,339.9 638.2,331.1 699.1,316.7 760.0,277.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="380.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="380.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="211.8" cy="377.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="372.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="362.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="351.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="340.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="343.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="345.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="333.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="319.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="273.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,382.8 150.9,381.9 211.8,379.8 272.7,375.9 333.6,369.7 394.5,360.8 455.5,352.1 516.4,338.3 577.3,331.0 638.2,317.1 699.1,307.2 760.0,305.2" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="272.7" cy="373.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="363.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="351.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="345.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="338.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="339.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="331.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="316.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="277.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,382.8 150.9,381.7 211.8,379.9 272.7,375.8 333.6,369.3 394.5,359.8 455.5,351.2 516.4,336.3 577.3,327.9 638.2,315.8 699.1,306.2 760.0,303.3" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="382.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="150.9" cy="381.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="211.8" cy="379.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="272.7" cy="375.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.6" cy="369.7" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="394.5" cy="360.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="455.5" cy="352.1" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.4" cy="338.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="577.3" cy="331.0" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="638.2" cy="317.1" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="699.1" cy="307.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="305.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="150.9" cy="381.7" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="211.8" cy="379.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="272.7" cy="375.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.6" cy="369.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="394.5" cy="359.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="455.5" cy="351.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.4" cy="336.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="577.3" cy="327.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="638.2" cy="315.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="699.1" cy="306.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="303.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="150.9" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="211.8" y="398" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
@@ -145,46 +145,46 @@
   <line x1="90" y1="489" x2="90" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="90" y1="609" x2="760" y2="609" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="40" y="549" text-anchor="middle" dominant-baseline="middle" fill="#e5e7eb" font-size="10" font-weight="600" transform="rotate(-90,40,549)">p50 latency (us)</text>
-  <polyline points="90.0,503.7 173.8,507.2 257.5,499.4 341.2,510.2 425.0,507.9 508.8,508.7 592.5,506.7 676.2,507.8 760.0,500.7" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="503.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="507.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="499.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="510.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="507.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="508.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="506.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="507.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="500.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,566.7 173.8,568.2 257.5,568.1 341.2,568.7 425.0,568.0 508.8,568.0 592.5,567.1 676.2,566.4 760.0,562.6" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="566.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="568.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="568.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,567.9 173.8,567.7 257.5,568.8 341.2,568.2 425.0,568.0 508.8,567.1 592.5,567.4 676.2,564.8 760.0,559.8" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="567.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="567.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="568.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="568.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="568.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="567.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="567.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="564.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="559.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,567.4 173.8,567.7 257.5,567.1 341.2,568.7 425.0,568.2 508.8,567.1 592.5,567.0 676.2,565.2 760.0,562.3" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="567.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="567.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="567.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
   <circle cx="341.2" cy="568.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="568.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="568.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="567.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="566.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="562.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,548.0 173.8,551.1 257.5,549.6 341.2,549.6 425.0,548.0 508.8,548.5 592.5,548.5 676.2,546.6 760.0,546.2" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="548.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="551.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="549.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="549.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="548.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="548.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="548.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="546.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="546.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,533.2 173.8,533.9 257.5,531.2 341.2,532.7 425.0,529.5 508.8,533.9 592.5,535.7 676.2,536.0 760.0,531.9" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="533.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="533.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="531.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="532.7" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="529.5" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="533.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="535.7" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="536.0" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="531.9" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="568.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="567.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="567.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="565.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="562.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,546.5 173.8,547.9 257.5,544.4 341.2,550.3 425.0,548.5 508.8,548.4 592.5,547.1 676.2,548.0 760.0,545.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="546.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="547.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="544.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="550.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="548.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="548.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="547.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="548.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="545.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="90.0,535.3 173.8,534.2 257.5,530.6 341.2,533.3 425.0,531.3 508.8,532.5 592.5,536.7 676.2,535.2 760.0,530.8" fill="none" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="90.0" cy="535.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="173.8" cy="534.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="257.5" cy="530.6" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="341.2" cy="533.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="531.3" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="508.8" cy="532.5" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="592.5" cy="536.7" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="676.2" cy="535.2" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
+  <circle cx="760.0" cy="530.8" r="3" fill="#f472b6" stroke="#000000" stroke-width="1"/>
   <text x="90.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="173.8" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="257.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/go/doc/charts/bindings.svg
+++ b/bindings/go/doc/charts/bindings.svg
@@ -155,16 +155,6 @@
   <circle cx="592.5" cy="567.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
   <circle cx="676.2" cy="564.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
   <circle cx="760.0" cy="559.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="90.0,567.4 173.8,567.7 257.5,567.1 341.2,568.7 425.0,568.2 508.8,567.1 592.5,567.0 676.2,565.2 760.0,562.3" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="90.0" cy="567.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="173.8" cy="567.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="257.5" cy="567.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="341.2" cy="568.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="568.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="508.8" cy="567.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="592.5" cy="567.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="676.2" cy="565.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="760.0" cy="562.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
   <polyline points="90.0,546.5 173.8,547.9 257.5,544.4 341.2,550.3 425.0,548.5 508.8,548.4 592.5,547.1 676.2,548.0 760.0,545.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="90.0" cy="546.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="173.8" cy="547.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
@@ -194,16 +184,13 @@
   <text x="592.5" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
   <text x="676.2" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
   <text x="760.0" y="623" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
-  <line x1="85" y1="649" x2="99" y2="649" stroke="#ef4444" stroke-width="2.5"/>
-  <circle cx="92" cy="649" r="2.5" fill="#ef4444"/>
-  <text x="105" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go scalar</text>
-  <line x1="255" y1="649" x2="269" y2="649" stroke="#fb923c" stroke-width="2.5"/>
-  <circle cx="262" cy="649" r="2.5" fill="#fb923c"/>
-  <text x="275" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go Socket.Run</text>
-  <line x1="425" y1="649" x2="439" y2="649" stroke="#60a5fa" stroke-width="2.5"/>
-  <circle cx="432" cy="649" r="2.5" fill="#60a5fa"/>
-  <text x="445" y="653" fill="#e5e7eb" font-size="11" font-weight="500">zmq4</text>
-  <line x1="595" y1="649" x2="609" y2="649" stroke="#f472b6" stroke-width="2.5"/>
-  <circle cx="602" cy="649" r="2.5" fill="#f472b6"/>
-  <text x="615" y="653" fill="#e5e7eb" font-size="11" font-weight="500">gRPC (grpc-go v1.75.0)</text>
+  <line x1="170" y1="649" x2="184" y2="649" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="177" cy="649" r="2.5" fill="#ef4444"/>
+  <text x="190" y="653" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.go scalar</text>
+  <line x1="340" y1="649" x2="354" y2="649" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="347" cy="649" r="2.5" fill="#60a5fa"/>
+  <text x="360" y="653" fill="#e5e7eb" font-size="11" font-weight="500">zmq4</text>
+  <line x1="510" y1="649" x2="524" y2="649" stroke="#f472b6" stroke-width="2.5"/>
+  <circle cx="517" cy="649" r="2.5" fill="#f472b6"/>
+  <text x="530" y="653" fill="#e5e7eb" font-size="11" font-weight="500">gRPC (grpc-go v1.75.0)</text>
 </svg>

--- a/bindings/go/native.go
+++ b/bindings/go/native.go
@@ -25,6 +25,10 @@ type nativeSendRing = C.OmqGoSendRing
 type nativeRecvRing = C.OmqGoRecvRing
 type nativeCancel = C.OmqGoCancel
 
+// scalarRecvParkMicros bounds the wakeable native park used by blocking
+// scalar receives. It does not affect nonblocking TryRecv calls.
+const scalarRecvParkMicros = 10
+
 type nativeStats struct {
 	contextsCreated  uint64
 	contextsFreed    uint64
@@ -384,8 +388,42 @@ func socketMessageRecvNative(socket *nativeSocket) (Message, error) {
 	return messageFromC(out), nil
 }
 
+func socketMessageRecvWaitNative(socket *nativeSocket) (Message, error) {
+	var out C.OmqGoMessage
+	err := statusErr(C.omq_go_socket_recv_wait(
+		(*C.OmqGoSocket)(socket),
+		C.uint64_t(scalarRecvParkMicros),
+		&out,
+	))
+	if err != nil {
+		return Message{}, err
+	}
+	defer C.omq_go_message_free(out)
+	return messageFromC(out), nil
+}
+
 func socketMessageRecvIntoNative(socket *nativeSocket, dst []byte) (int, error) {
 	return socketMessageRecvIntoNativeTimeout(socket, dst, 0)
+}
+
+func socketMessageRecvIntoBriefWaitNative(socket *nativeSocket, dst []byte) (int, error) {
+	var written C.size_t
+	var data *C.uint8_t
+	if len(dst) > 0 {
+		data = (*C.uint8_t)(unsafe.Pointer(&dst[0]))
+	}
+	err := statusErr(C.omq_go_socket_recv_one_into_wait(
+		(*C.OmqGoSocket)(socket),
+		C.uint64_t(scalarRecvParkMicros),
+		data,
+		C.size_t(len(dst)),
+		&written,
+	))
+	runtime.KeepAlive(dst)
+	if err != nil {
+		return 0, err
+	}
+	return int(written), nil
 }
 
 func socketMessageRecvIntoWaitNative(socket *nativeSocket, dst []byte) (int, error) {

--- a/bindings/go/native/include/omq_go.h
+++ b/bindings/go/native/include/omq_go.h
@@ -140,7 +140,9 @@ OmqGoStatus omq_go_socket_send_one(OmqGoSocket *socket, const uint8_t *data, siz
 OmqGoStatus omq_go_socket_try_send_batch(OmqGoSocket *socket, const OmqGoWireMessage *messages, size_t message_count, size_t *sent);
 OmqGoStatus omq_go_receive_any(OmqGoSocket **sockets, size_t socket_count, int64_t timeout_millis, size_t *index, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv(OmqGoSocket *socket, int64_t timeout_millis, OmqGoMessage *out);
+OmqGoStatus omq_go_socket_recv_wait(OmqGoSocket *socket, uint64_t wait_micros, OmqGoMessage *out);
 OmqGoStatus omq_go_socket_recv_one_into(OmqGoSocket *socket, int64_t timeout_millis, uint8_t *data, size_t capacity, size_t *written);
+OmqGoStatus omq_go_socket_recv_one_into_wait(OmqGoSocket *socket, uint64_t wait_micros, uint8_t *data, size_t capacity, size_t *written);
 OmqGoStatus omq_go_socket_subscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_unsubscribe(OmqGoSocket *socket, const uint8_t *data, size_t len);
 OmqGoStatus omq_go_socket_join(OmqGoSocket *socket, const uint8_t *data, size_t len);

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -1213,6 +1213,40 @@ fn recv_one(socket: &OmqGoSocket, timeout_millis: i64) -> Result<Message, Error>
         .ok_or(Error::WouldBlock)
 }
 
+fn recv_one_wait(socket: &OmqGoSocket, wait: Duration) -> Result<Message, Error> {
+    if socket.closed.load(Ordering::Acquire) {
+        return Err(Error::Closed);
+    }
+
+    if let Some(message) = socket
+        .recv_cache
+        .lock()
+        .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?
+        .pop_front()
+    {
+        return Ok(message);
+    }
+
+    let native = socket.materialize()?;
+    let mut scratch = socket
+        .recv_scratch
+        .lock()
+        .map_err(|_| Error::Config("receive scratch lock poisoned".to_string()))?;
+    scratch.clear();
+    match native.recv_many_timeout_into(RECV_BATCH, wait, &mut scratch) {
+        Ok(0) | Err(Error::Timeout | Error::WouldBlock) => return Err(Error::WouldBlock),
+        Ok(_) => {}
+        Err(error) => return Err(error),
+    }
+
+    let mut cache = socket
+        .recv_cache
+        .lock()
+        .map_err(|_| Error::Config("receive cache lock poisoned".to_string()))?;
+    cache.extend(scratch.drain(..));
+    cache.pop_front().ok_or(Error::WouldBlock)
+}
+
 struct ReceiveAnyEntry<'a> {
     index: usize,
     socket: &'a OmqGoSocket,
@@ -2049,6 +2083,30 @@ pub extern "C" fn omq_go_socket_recv(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv_wait(
+    socket: *mut OmqGoSocket,
+    wait_micros: u64,
+    out: *mut OmqGoMessage,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if out.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive output pointer");
+    }
+    let socket = unsafe { &*socket };
+    match recv_one_wait(socket, Duration::from_micros(wait_micros)) {
+        Ok(message) => {
+            unsafe {
+                *out = message_to_c(message);
+            }
+            OmqGoStatus::ok()
+        }
+        Err(error) => OmqGoStatus::from_error(error),
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn omq_go_socket_recv_one_into(
     socket: *mut OmqGoSocket,
     timeout_millis: i64,
@@ -2069,6 +2127,36 @@ pub extern "C" fn omq_go_socket_recv_one_into(
     let result = (|| {
         let destination = bytes_from_c_mut(data, capacity)?;
         let message = recv_one(socket, timeout_millis)?;
+        let copied = copy_message_into(&message, destination)?;
+        unsafe {
+            *written = copied;
+        }
+        Ok(())
+    })();
+    status_from_result(result)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_go_socket_recv_one_into_wait(
+    socket: *mut OmqGoSocket,
+    wait_micros: u64,
+    data: *mut u8,
+    capacity: usize,
+    written: *mut usize,
+) -> OmqGoStatus {
+    if socket.is_null() {
+        return OmqGoStatus::err(CLOSED, "socket closed");
+    }
+    if written.is_null() {
+        return OmqGoStatus::err(CONFIG, "null receive length pointer");
+    }
+    unsafe {
+        *written = 0;
+    }
+    let socket = unsafe { &*socket };
+    let result = (|| {
+        let destination = bytes_from_c_mut(data, capacity)?;
+        let message = recv_one_wait(socket, Duration::from_micros(wait_micros))?;
         let copied = copy_message_into(&message, destination)?;
         unsafe {
             *written = copied;

--- a/bindings/go/race_test.go
+++ b/bindings/go/race_test.go
@@ -3,10 +3,102 @@ package omq
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 )
+
+func TestReqRepScalarCallsCanMoveBetweenThreads(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	rep := newTestSocket(t, ctx, Rep)
+	defer closeSocket(t, rep)
+	req := newTestSocket(t, ctx, Req)
+	defer closeSocket(t, req)
+
+	endpoint, err := rep.Bind("inproc://go-req-rep-thread-migration")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := req.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	sent := make(chan error, 1)
+	releaseThread := make(chan struct{})
+	defer close(releaseThread)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		sent <- req.SendTimeout(String("question"), time.Second)
+		<-releaseThread
+	}()
+	if err := <-sent; err != nil {
+		t.Fatal(err)
+	}
+
+	query, err := rep.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := query.String(); got != "question" {
+		t.Fatalf("query = %q, want question", got)
+	}
+	if err := rep.SendTimeout(String("answer"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := req.RecvTimeout(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reply.String(); got != "answer" {
+		t.Fatalf("reply = %q, want answer", got)
+	}
+}
+
+func TestReqScalarReceiveCancellationAndClose(t *testing.T) {
+	ctx := openTestContext(t)
+	defer closeContext(t, ctx)
+
+	rep := newTestSocket(t, ctx, Rep)
+	defer closeSocket(t, rep)
+	req := newTestSocket(t, ctx, Req)
+	defer closeSocket(t, req)
+
+	endpoint, err := rep.Bind("inproc://go-req-recv-cancel-close")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := req.Connect(endpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := req.SendTimeout(String("question"), time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := req.RecvTimeout(5 * time.Millisecond); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("RecvTimeout err = %v, want ErrTimeout", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := req.Recv(context.Background())
+		errCh <- err
+	}()
+	time.Sleep(time.Millisecond)
+	if err := req.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("Recv err = %v, want ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("receive did not unblock after close")
+	}
+}
 
 func TestConcurrentSendReceive(t *testing.T) {
 	ctx := openTestContext(t)

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -38,7 +38,8 @@ DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
 QUICK_SIZES = [16, 128, 1024, 4096, 32768]
 LATENCY_MAX_SIZE = 4096
 DEFAULT_IMPLS = ["omq-run-into", "zmq4", "grpc"]
-DEFAULT_LATENCY_IMPLS = ["omq", "omq-run", "zmq4", "grpc"]
+DEFAULT_LATENCY_IMPLS = ["omq", "zmq4", "grpc"]
+SUPPORTED_LATENCY_IMPLS = ["omq", "omq-run", "zmq4", "grpc"]
 IMPL_LABELS = {
     "omq": "OMQ.go scalar",
     "omq-run": "OMQ.go Socket.Run",
@@ -1654,7 +1655,7 @@ def main():
         if impl not in IMPL_LABELS:
             parser.error(f"unknown throughput impl: {impl}")
     for impl in args.latency_impls:
-        if impl not in DEFAULT_LATENCY_IMPLS:
+        if impl not in SUPPORTED_LATENCY_IMPLS:
             parser.error(f"unknown latency impl: {impl}")
     latency_sizes = latency_sizes_from(sizes)
 

--- a/bindings/go/socket.go
+++ b/bindings/go/socket.go
@@ -25,6 +25,7 @@ type socketState struct {
 	handle    *nativeSocket
 	owner     *contextState
 	handleMu  sync.RWMutex
+	nativeMu  sync.Mutex
 	closed    atomic.Bool
 	ops       chan socketOp
 	ownerDone chan struct{}
@@ -47,6 +48,8 @@ const (
 	socketOpSendBatch
 	socketOpRecv
 	socketOpRecvInto
+	socketOpRecvWait
+	socketOpRecvIntoWait
 	socketOpSubscribe
 	socketOpUnsubscribe
 	socketOpJoin
@@ -125,13 +128,18 @@ func (s *socketState) ownerLoop() {
 
 	handle := s.handle
 	for op := range s.ops {
-		op.call.resp <- runSocketOp(handle, op)
+		s.nativeMu.Lock()
+		result := runSocketOp(handle, op)
+		s.nativeMu.Unlock()
+		op.call.resp <- result
 	}
 	if handle != nil {
+		s.nativeMu.Lock()
 		s.handleMu.Lock()
 		socketFreeNative(handle)
 		s.handle = nil
 		s.handleMu.Unlock()
+		s.nativeMu.Unlock()
 	}
 }
 
@@ -162,6 +170,12 @@ func runSocketOp(handle *nativeSocket, op socketOp) socketResult {
 		return socketResult{message: msg, err: err}
 	case socketOpRecvInto:
 		count, err := socketMessageRecvIntoNative(handle, op.buffer)
+		return socketResult{count: count, err: err}
+	case socketOpRecvWait:
+		msg, err := socketMessageRecvWaitNative(handle)
+		return socketResult{message: msg, err: err}
+	case socketOpRecvIntoWait:
+		count, err := socketMessageRecvIntoBriefWaitNative(handle, op.buffer)
 		return socketResult{count: count, err: err}
 	case socketOpSubscribe:
 		return socketResult{err: socketSubscribeNative(handle, op.data)}
@@ -269,6 +283,43 @@ func (s *socketState) do(ctx context.Context, allowClosed bool, op socketOp) (re
 	}
 }
 
+func (s *socketState) doDirect(ctx context.Context, op socketOp) (socketResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil {
+		return socketResult{}, ErrClosed
+	}
+	if op.ctx == nil {
+		op.ctx = ctx
+	}
+
+	s.nativeMu.Lock()
+	defer s.nativeMu.Unlock()
+	if s.closed.Load() || s.handle == nil {
+		return socketResult{}, ErrClosed
+	}
+	result := runSocketOp(s.handle, op)
+	return result, result.err
+}
+
+func (s *Socket) doData(ctx context.Context, op socketOp) (socketResult, error) {
+	state := s.stateOrNil()
+	if state == nil {
+		return socketResult{}, ErrClosed
+	}
+	if s.hasThreadNeutralDataPath() {
+		return state.doDirect(ctx, op)
+	}
+	return state.do(ctx, false, op)
+}
+
+func (s *Socket) hasThreadNeutralDataPath() bool {
+	// REQ/REP routes do not use the caller-affine ProducerOwner path. Their
+	// native calls can move between OS threads as long as they stay serialized.
+	return s != nil && (s.socketType == Req || s.socketType == Rep)
+}
+
 // Bind binds this socket to an endpoint and returns the bound endpoint.
 func (s *Socket) Bind(endpoint string) (string, error) {
 	state := s.stateOrNil()
@@ -344,11 +395,7 @@ func (s *Socket) TrySend(msg Message) error {
 }
 
 func (s *Socket) trySend(ctx context.Context, msg Message) error {
-	state := s.stateOrNil()
-	if state == nil {
-		return ErrClosed
-	}
-	_, err := state.do(ctx, false, socketOp{kind: socketOpSend, msg: msg})
+	_, err := s.doData(ctx, socketOp{kind: socketOpSend, msg: msg})
 	keepAlive(s)
 	return err
 }
@@ -388,7 +435,7 @@ func (s *Socket) Recv(ctx context.Context) (Message, error) {
 		if err := errFromContext(ctx); err != nil {
 			return Message{}, err
 		}
-		msg, err := s.tryRecv(ctx)
+		msg, err := s.recvWait(ctx)
 		if err == nil {
 			return msg, nil
 		}
@@ -410,7 +457,7 @@ func (s *Socket) RecvInto(ctx context.Context, dst []byte) (int, error) {
 		if err := errFromContext(ctx); err != nil {
 			return 0, err
 		}
-		n, err := s.tryRecvInto(ctx, dst)
+		n, err := s.recvIntoWait(ctx, dst)
 		if err == nil {
 			return n, nil
 		}
@@ -429,11 +476,20 @@ func (s *Socket) TryRecv() (Message, error) {
 }
 
 func (s *Socket) tryRecv(ctx context.Context) (Message, error) {
-	state := s.stateOrNil()
-	if state == nil {
-		return Message{}, ErrClosed
+	result, err := s.doData(ctx, socketOp{kind: socketOpRecv})
+	if err != nil {
+		return Message{}, err
 	}
-	result, err := state.do(ctx, false, socketOp{kind: socketOpRecv})
+	keepAlive(s)
+	return result.message, nil
+}
+
+func (s *Socket) recvWait(ctx context.Context) (Message, error) {
+	kind := socketOpRecv
+	if s.hasThreadNeutralDataPath() {
+		kind = socketOpRecvWait
+	}
+	result, err := s.doData(ctx, socketOp{kind: kind})
 	if err != nil {
 		return Message{}, err
 	}
@@ -447,11 +503,20 @@ func (s *Socket) TryRecvInto(dst []byte) (int, error) {
 }
 
 func (s *Socket) tryRecvInto(ctx context.Context, dst []byte) (int, error) {
-	state := s.stateOrNil()
-	if state == nil {
-		return 0, ErrClosed
+	result, err := s.doData(ctx, socketOp{kind: socketOpRecvInto, buffer: dst})
+	if err != nil {
+		return 0, err
 	}
-	result, err := state.do(ctx, false, socketOp{kind: socketOpRecvInto, buffer: dst})
+	keepAlive(s)
+	return result.count, nil
+}
+
+func (s *Socket) recvIntoWait(ctx context.Context, dst []byte) (int, error) {
+	kind := socketOpRecvInto
+	if s.hasThreadNeutralDataPath() {
+		kind = socketOpRecvIntoWait
+	}
+	result, err := s.doData(ctx, socketOp{kind: kind, buffer: dst})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- Route Go REQ/REP scalar data calls through thread-neutral native paths under the per-socket mutex.
- Use a short wakeable native receive wait to avoid scheduler round trips while preserving context cancellation and nonblocking `TryRecv`.
- Add cross-thread, cancellation, and close-unblock regression coverage; document the threading model.
- Refresh the binding benchmark chart and omit the overlapping `Socket.Run` latency series.