### PR TITLE
Add OMQ.Net binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       run_java: ${{ steps.scope.outputs.java }}
       run_go: ${{ steps.scope.outputs.go }}
       run_lua: ${{ steps.scope.outputs.lua }}
+      run_dotnet: ${{ steps.scope.outputs.dotnet }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v3
@@ -69,6 +70,15 @@ jobs:
               - 'omq-proto/**'
               - 'omq-tokio/**'
               - 'yring/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - '.github/workflows/ci.yml'
+            dotnet:
+              - 'bindings/dotnet/**'
+              - 'omq-libzmq/**'
+              - 'omq-proto/**'
+              - 'omq-tokio/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'
@@ -329,6 +339,46 @@ jobs:
         env:
           OMQ_PYTHON3: ${{ steps.python.outputs.python-path }}
         run: cargo nextest run --profile ci -p omq-tokio --features curve --test omq_interop_pyzmq_curve
+
+  dotnet:
+    name: .NET binding
+    needs: [changes, linux-gate]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_dotnet == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: build native library
+        run: cargo build --release -p omq-libzmq
+      - name: build and run binding tests
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
+        run: |
+          dotnet build bindings/dotnet/tests/Omq.Net.Smoke.csproj --configuration Release
+          dotnet run --project bindings/dotnet/tests/Omq.Net.Smoke.csproj --configuration Release --no-build
+          dotnet build bindings/dotnet/tests/Omq.Net.Lifecycle.csproj --configuration Release
+          dotnet run --project bindings/dotnet/tests/Omq.Net.Lifecycle.csproj --configuration Release --no-build
+      - name: pack NuGet package
+        run: |
+          dotnet restore bindings/dotnet/Omq.Net.csproj
+          bash bindings/dotnet/scripts/package.sh "$RUNNER_TEMP/omq-nuget" \
+            linux-x64="$GITHUB_WORKSPACE/target/release/libomq_zmq.so"
+          unzip -l "$RUNNER_TEMP/omq-nuget/Omq.Net.0.1.0.nupkg"
+      - name: install package and run package smoke test
+        run: |
+          dotnet restore bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj \
+            --runtime linux-x64 \
+            --source "$RUNNER_TEMP/omq-nuget" \
+            --source https://api.nuget.org/v3/index.json
+          dotnet run --project bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj \
+            --runtime linux-x64 --no-restore
+        env:
+          LD_LIBRARY_PATH: ''
 
   cppzmq:
     name: cppzmq (${{ matrix.header }})

--- a/bindings/dotnet/.gitignore
+++ b/bindings/dotnet/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+scripts/__pycache__/

--- a/bindings/dotnet/Omq.Net.csproj
+++ b/bindings/dotnet/Omq.Net.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1591</NoWarn>
+    <RootNamespace>Omq</RootNamespace>
+    <AssemblyName>Omq.Net</AssemblyName>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="src/**/*.cs" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/Omq.Net.csproj
+++ b/bindings/dotnet/Omq.Net.csproj
@@ -1,6 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <PackageId>Omq.Net</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>OMQ contributors</Authors>
+    <Description>Fast .NET binding for OMQ.</Description>
+    <PackageTags>zeromq;omq;networking;messaging</PackageTags>
+    <PackageLicenseExpression>ISC</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <NativeAssetRoot Condition="'$(NativeAssetRoot)' == ''">$(MSBuildProjectDirectory)/native</NativeAssetRoot>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,5 +21,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src/**/*.cs" />
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+    <None Include="$(NativeAssetRoot)/**/*" Pack="true">
+      <PackagePath>runtimes/%(RecursiveDir)native/%(Filename)%(Extension)</PackagePath>
+    </None>
   </ItemGroup>
 </Project>

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -54,6 +54,20 @@ LD_LIBRARY_PATH="$PWD/target/release" \
 The native library can also be supplied through the normal loader paths. Keep
 `libomq_zmq.so` beside the test process or set `LD_LIBRARY_PATH`.
 
+## NuGet packaging
+
+One package carries managed assemblies plus native libraries under NuGet RID
+folders. Build native libraries for each supported RID, then pass them as
+`RID=PATH` arguments:
+
+```sh
+bash bindings/dotnet/scripts/package.sh /tmp/omq-nuget \
+  linux-x64=target/release/libomq_zmq.so
+```
+
+The package can contain several RIDs. Consumers install one `Omq.Net` package;
+NuGet selects the native asset matching their OS and CPU. No Mono needed.
+
 ## API
 
 ```csharp

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -1,0 +1,91 @@
+# OMQ.Net
+
+Fast, boring .NET binding for OMQ. Native transport stays in `omq-libzmq`.
+Managed code owns lifetimes, copies message bytes at the boundary, and
+serializes each socket handle. No Mono needed.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/dotnet/doc/charts/bindings.svg" alt="OMQ.Net performance" width="850">
+</p>
+
+## Status
+
+Early implementation. The sync core is here: all OMQ socket types, context
+sharing, bind/connect, multipart messages, send/receive, subscriptions,
+RADIO/DISH groups, common options, deterministic disposal, and native errno
+exceptions. Async send/receive, cancellation polling, readiness polling,
+CURVE key generation, PLAIN/CURVE configuration, and socket monitor events are
+included.
+
+`Dgram` is present in the public enum but currently rejected by the shared
+`omq-libzmq` ABI. Native DGRAM support must land before claiming full parity.
+
+## Build and test
+
+Requires .NET SDK 10 and Rust:
+
+```sh
+cargo build --release -p omq-libzmq
+dotnet build bindings/dotnet/Omq.Net.csproj
+LD_LIBRARY_PATH="$PWD/target/release" dotnet run --project bindings/dotnet/tests/Omq.Net.Smoke.csproj
+
+# bounded lifecycle/race checks
+LD_LIBRARY_PATH="$PWD/target/release" dotnet run --project bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
+
+# .NET <-> pyzmq protocol/security interop (NULL, CURVE, authenticated PLAIN)
+LD_LIBRARY_PATH="$PWD/target/release" python3 bindings/dotnet/tests/interop.py
+```
+
+Run the real two-process TCP benchmark. It compares OMQ.Net with NetMQ, uses
+the full throughput sizes, and limits latency to 4 KiB:
+
+```sh
+LD_LIBRARY_PATH="$PWD/target/release" \
+  python3 bindings/dotnet/scripts/update_perf.py
+```
+
+Fast check:
+
+```sh
+LD_LIBRARY_PATH="$PWD/target/release" \
+  python3 bindings/dotnet/scripts/update_perf.py --quick
+```
+
+The native library can also be supplied through the normal loader paths. Keep
+`libomq_zmq.so` beside the test process or set `LD_LIBRARY_PATH`.
+
+## API
+
+```csharp
+using Omq;
+
+using var context = new Context();
+using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0 });
+using var push = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0 });
+
+string endpoint = pull.Bind("tcp://127.0.0.1:5555");
+push.Connect(endpoint);
+push.Send(Message.Text("hello"));
+Console.WriteLine(pull.Receive().ToString());
+```
+
+Socket methods are safe across managed threads. A call holds the socket gate
+until its native operation completes. `Dispose` closes the native handle once;
+message frames are always closed in `finally` blocks. This is the baseline for
+race and leak tests before adding zero-copy or async APIs.
+
+## Performance contract
+
+Benchmark charts compare sync and async OMQ.Net against sync and async NetMQ
+over two-process loopback TCP. PUSH/PULL throughput spans 16 B through 32 KiB;
+REQ/REP p50 latency spans 16 B through 4 KiB. Results append to:
+`~/.cache/omq.net/bindings.jsonl`. The cache is never rewritten; chart-only
+regeneration selects the newest row for each implementation, pattern, and size.
+
+```sh
+python3 bindings/dotnet/scripts/update_perf.py --chart-only
+```
+
+Current quick-run result on this VM: OMQ.Net beats NetMQ at every sampled size.
+Treat that as a measurement, not a promise. Full runs need 3 rounds on a quiet
+machine before publishing a performance claim.

--- a/bindings/dotnet/bench/Omq.Net.Bench.csproj
+++ b/bindings/dotnet/bench/Omq.Net.Bench.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Omq.Net.csproj" />
+    <PackageReference Include="NetMQ" Version="4.0.2.2" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/bench/Program.cs
+++ b/bindings/dotnet/bench/Program.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using System.Text.Json;
+using NetMQ;
+using NetMQ.Sockets;
+using Omq;
+
+if (args.Length != 7) throw new ArgumentException("mode impl role endpoint size seconds warmup_seconds");
+string mode = args[0], impl = args[1], role = args[2], endpoint = args[3];
+int size = int.Parse(args[4]); double seconds = double.Parse(args[5]); double warmup = double.Parse(args[6]);
+byte[] payload = new byte[size]; for (int i = 0; i < payload.Length; i++) payload[i] = (byte)i;
+
+if (impl == "omq") RunOmq();
+else if (impl == "omq-async") RunOmqAsync();
+else if (impl == "netmq") RunNetMq();
+else if (impl == "netmq-async") RunNetMqAsync();
+else throw new ArgumentException($"unknown implementation {impl}");
+
+void Ready() { Console.WriteLine($"READY {endpoint}"); Console.Out.Flush(); }
+void Result(long count, double elapsed, double p50 = 0)
+{
+    var row = new { impl, pattern = mode, size, messages_per_second = count / elapsed, megabytes_per_second = count * (double)size / elapsed / 1_000_000, p50_us = p50 };
+    Console.WriteLine($"RESULT {JsonSerializer.Serialize(row)}"); Console.Out.Flush();
+}
+bool Active(Stopwatch watch, double duration) => watch.Elapsed.TotalSeconds < duration;
+
+void RunOmq()
+{
+    using var context = new Context();
+    using var socket = context.CreateSocket(mode == "pushpull" ? (role == "pull" ? SocketType.Pull : SocketType.Push) : (role == "rep" ? SocketType.Rep : SocketType.Req), new Omq.SocketOptions { Linger = 0, ReceiveTimeout = TimeSpan.FromMilliseconds(20), SendTimeout = TimeSpan.FromMilliseconds(1000) });
+    if (role is "pull" or "rep") socket.Bind(endpoint); else socket.Connect(endpoint);
+    Ready();
+    if (mode == "pushpull")
+    {
+        if (role == "push") { while (true) { try { socket.Send(payload); } catch (OmqAgainException) { } } }
+        else
+        {
+        WaitFirstOmq(socket);
+        DrainOmq(socket, warmup);
+        var watch = Stopwatch.StartNew(); long count = 0;
+        while (Active(watch, seconds)) { try { socket.Receive(); count++; } catch (OmqAgainException) { } }
+        Result(count, watch.Elapsed.TotalSeconds);
+        }
+    }
+    else if (role == "req")
+    {
+        DrainReqOmq(socket, warmup);
+        var watch = Stopwatch.StartNew(); long count = 0; var samples = new List<double>();
+        while (Active(watch, seconds)) { var one = Stopwatch.StartNew(); socket.Send(payload); socket.Receive(); samples.Add(one.Elapsed.TotalMicroseconds); count++; }
+        samples.Sort(); Result(count, watch.Elapsed.TotalSeconds, samples.Count == 0 ? 0 : samples[samples.Count / 2]);
+    }
+    else
+    {
+        WaitFirstOmq(socket); socket.Send(payload);
+        DrainRepOmq(socket, warmup);
+        var watch = Stopwatch.StartNew(); long count = 0;
+        while (Active(watch, seconds)) { try { socket.Receive(); socket.Send(payload); count++; } catch (OmqAgainException) { } }
+        Result(count, watch.Elapsed.TotalSeconds);
+    }
+}
+
+void DrainOmq(Omq.Socket socket, double duration)
+{
+    var watch = Stopwatch.StartNew(); while (Active(watch, duration)) { try { socket.Receive(); } catch (OmqAgainException) { } }
+}
+void WaitFirstOmq(Omq.Socket socket)
+{
+    while (true) { try { socket.Receive(); return; } catch (OmqAgainException) { } }
+}
+void DrainReqOmq(Omq.Socket socket, double duration)
+{
+    var watch = Stopwatch.StartNew(); while (Active(watch, duration)) { socket.Send(payload); try { socket.Receive(); } catch (OmqAgainException) { } }
+}
+void DrainRepOmq(Omq.Socket socket, double duration)
+{
+    var watch = Stopwatch.StartNew(); while (Active(watch, duration)) { try { socket.Receive(); socket.Send(payload); } catch (OmqAgainException) { } }
+}
+
+void RunNetMq()
+{
+    if (mode == "pushpull") RunNetMqPushPull(); else RunNetMqReqRep();
+}
+
+void RunOmqAsync()
+{
+    RunOmq();
+}
+
+void RunOmqAsyncReq()
+{
+    using var context = new Context();
+    using var socket = context.CreateSocket(SocketType.Req, new Omq.SocketOptions { Linger = 0 });
+    socket.Connect(endpoint); Ready();
+    var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) { socket.SendAsync(payload).GetAwaiter().GetResult(); socket.ReceiveAsync().GetAwaiter().GetResult(); }
+    var watch = Stopwatch.StartNew(); long count = 0; var samples = new List<double>(); while (Active(watch, seconds)) { var one = Stopwatch.StartNew(); socket.SendAsync(payload).GetAwaiter().GetResult(); socket.ReceiveAsync().GetAwaiter().GetResult(); samples.Add(one.Elapsed.TotalMicroseconds); count++; } samples.Sort(); Result(count, watch.Elapsed.TotalSeconds, samples[samples.Count / 2]);
+}
+
+async Task RunOmqAsyncOther()
+{
+    using var context = new Context();
+    using var socket = context.CreateSocket(mode == "pushpull" ? (role == "pull" ? SocketType.Pull : SocketType.Push) : (role == "rep" ? SocketType.Rep : SocketType.Req), new Omq.SocketOptions { Linger = 0 });
+    if (role is "pull" or "rep") socket.Bind(endpoint); else socket.Connect(endpoint); Ready();
+    if (mode == "pushpull" && role == "push") { while (true) await socket.SendAsync(payload); }
+    if (mode == "pushpull")
+    {
+        await socket.ReceiveAsync(); var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) await socket.ReceiveAsync();
+        var watch = Stopwatch.StartNew(); long count = 0; while (Active(watch, seconds)) { await socket.ReceiveAsync(); count++; } Result(count, watch.Elapsed.TotalSeconds); return;
+    }
+    await socket.ReceiveAsync(); await socket.SendAsync(payload); var warmRep = Stopwatch.StartNew(); while (Active(warmRep, warmup)) { await socket.ReceiveAsync(); await socket.SendAsync(payload); }
+    var repWatch = Stopwatch.StartNew(); long repCount = 0; while (Active(repWatch, seconds)) { await socket.ReceiveAsync(); await socket.SendAsync(payload); repCount++; } Result(repCount, repWatch.Elapsed.TotalSeconds);
+}
+
+void RunNetMqAsync()
+{
+    using var runtime = new NetMQRuntime();
+    runtime.Run(RunNetMqAsyncCore());
+}
+
+async Task RunNetMqAsyncCore()
+{
+    if (mode == "pushpull")
+    {
+        using NetMQSocket socket = role == "pull" ? new PullSocket() : new PushSocket(); socket.Options.Linger = TimeSpan.Zero; if (role == "pull") socket.Bind(endpoint); else socket.Connect(endpoint); Ready();
+        if (role == "push") { while (true) { await Task.Run(() => socket.SendFrame(payload)); } }
+        await socket.ReceiveFrameBytesAsync();
+        var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) await socket.ReceiveFrameBytesAsync(); var watch = Stopwatch.StartNew(); long count = 0; while (Active(watch, seconds)) { await socket.ReceiveFrameBytesAsync(); count++; } Result(count, watch.Elapsed.TotalSeconds); return;
+    }
+    if (role == "req")
+    {
+        using var socket = new RequestSocket(); socket.Options.Linger = TimeSpan.Zero; socket.Connect(endpoint); Ready(); var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) { await Task.Run(() => socket.SendFrame(payload)); await socket.ReceiveFrameBytesAsync(); }
+        var watch = Stopwatch.StartNew(); long count = 0; var samples = new List<double>(); while (Active(watch, seconds)) { var one = Stopwatch.StartNew(); await Task.Run(() => socket.SendFrame(payload)); await socket.ReceiveFrameBytesAsync(); samples.Add(one.Elapsed.TotalMicroseconds); count++; } samples.Sort(); Result(count, watch.Elapsed.TotalSeconds, samples[samples.Count / 2]); return;
+    }
+    using var rep = new ResponseSocket(); rep.Options.Linger = TimeSpan.Zero; rep.Bind(endpoint); Ready(); await rep.ReceiveFrameBytesAsync(); await Task.Run(() => rep.SendFrame(payload)); var warmRep = Stopwatch.StartNew(); while (Active(warmRep, warmup)) { await rep.ReceiveFrameBytesAsync(); await Task.Run(() => rep.SendFrame(payload)); } var repWatch = Stopwatch.StartNew(); long repCount = 0; while (Active(repWatch, seconds)) { await rep.ReceiveFrameBytesAsync(); await Task.Run(() => rep.SendFrame(payload)); repCount++; } Result(repCount, repWatch.Elapsed.TotalSeconds);
+}
+void RunNetMqPushPull()
+{
+    NetMQSocket socket = role == "pull" ? new PullSocket() : new PushSocket(); using (socket) { socket.Options.Linger = TimeSpan.Zero;
+    if (role == "pull") socket.Bind(endpoint); else socket.Connect(endpoint); Ready();
+    if (role == "push") { while (true) socket.SendFrame(payload); }
+    while (!socket.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _)) { }
+    var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) { socket.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _); }
+    var watch = Stopwatch.StartNew(); long count = 0; while (Active(watch, seconds)) { if (socket.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _)) count++; }
+    Result(count, watch.Elapsed.TotalSeconds);
+    }
+}
+void RunNetMqReqRep()
+{
+    if (role == "req")
+    {
+        using var socket = new RequestSocket(); socket.Options.Linger = TimeSpan.Zero; socket.Connect(endpoint); Ready();
+        var warm = Stopwatch.StartNew(); while (Active(warm, warmup)) { socket.SendFrame(payload); socket.ReceiveFrameBytes(); }
+        var watch = Stopwatch.StartNew(); long count = 0; var samples = new List<double>();
+        while (Active(watch, seconds)) { var one = Stopwatch.StartNew(); socket.SendFrame(payload); socket.ReceiveFrameBytes(); samples.Add(one.Elapsed.TotalMicroseconds); count++; }
+        samples.Sort(); Result(count, watch.Elapsed.TotalSeconds, samples.Count == 0 ? 0 : samples[samples.Count / 2]); return;
+    }
+    using var rep = new ResponseSocket(); rep.Options.Linger = TimeSpan.Zero; rep.Bind(endpoint); Ready();
+    while (!rep.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _)) { }
+    rep.SendFrame(payload);
+    var warmRep = Stopwatch.StartNew(); while (Active(warmRep, warmup)) { if (rep.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _)) rep.SendFrame(payload); }
+    var watchRep = Stopwatch.StartNew(); long countRep = 0; while (Active(watchRep, seconds)) { if (rep.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(20), out _)) { rep.SendFrame(payload); countRep++; } }
+    Result(countRep, watchRep.Elapsed.TotalSeconds);
+}

--- a/bindings/dotnet/doc/charts/bindings.svg
+++ b/bindings/dotnet/doc/charts/bindings.svg
@@ -1,0 +1,214 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 824" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="824" fill="#000000"/>
+  <text x="425.0" y="44" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="58" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="60" y1="417.2" x2="395" y2="417.2" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="417.2" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200k</text>
+  <line x1="60" y1="390.4" x2="395" y2="390.4" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="390.4" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">400k</text>
+  <line x1="60" y1="363.6" x2="395" y2="363.6" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="363.6" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">600k</text>
+  <line x1="60" y1="336.8" x2="395" y2="336.8" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="336.8" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">800k</text>
+  <line x1="60" y1="310.0" x2="395" y2="310.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="310.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1M</text>
+  <line x1="60" y1="283.2" x2="395" y2="283.2" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="283.2" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.2M</text>
+  <line x1="60" y1="256.4" x2="395" y2="256.4" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="256.4" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.4M</text>
+  <line x1="60" y1="229.6" x2="395" y2="229.6" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="229.6" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.6M</text>
+  <line x1="60" y1="202.8" x2="395" y2="202.8" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="202.8" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.8M</text>
+  <line x1="60" y1="176.0" x2="395" y2="176.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <line x1="60" y1="149.2" x2="395" y2="149.2" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="149.2" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.2M</text>
+  <line x1="60" y1="122.4" x2="395" y2="122.4" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="122.4" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.4M</text>
+  <line x1="60" y1="109.0" x2="395" y2="109.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="109.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5M</text>
+  <line x1="60.0" y1="109" x2="60.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="115.8" y1="109" x2="115.8" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="171.7" y1="109" x2="171.7" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="227.5" y1="109" x2="227.5" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="283.3" y1="109" x2="283.3" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="339.2" y1="109" x2="339.2" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="395.0" y1="109" x2="395.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="60" y1="109" x2="60" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="60" y1="444" x2="395" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="455" y1="402.1" x2="790" y2="402.1" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="402.1" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">0.5 GB/s</text>
+  <line x1="455" y1="360.2" x2="790" y2="360.2" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="360.2" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1 GB/s</text>
+  <line x1="455" y1="318.4" x2="790" y2="318.4" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="318.4" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.5 GB/s</text>
+  <line x1="455" y1="276.5" x2="790" y2="276.5" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="276.5" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2 GB/s</text>
+  <line x1="455" y1="234.6" x2="790" y2="234.6" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="234.6" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5 GB/s</text>
+  <line x1="455" y1="192.8" x2="790" y2="192.8" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="192.8" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3 GB/s</text>
+  <line x1="455" y1="150.9" x2="790" y2="150.9" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="150.9" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.5 GB/s</text>
+  <line x1="455" y1="109.0" x2="790" y2="109.0" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="109.0" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4 GB/s</text>
+  <line x1="455.0" y1="109" x2="455.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="502.9" y1="109" x2="502.9" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="550.7" y1="109" x2="550.7" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="598.6" y1="109" x2="598.6" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="646.4" y1="109" x2="646.4" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="694.3" y1="109" x2="694.3" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="742.1" y1="109" x2="742.1" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="790.0" y1="109" x2="790.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="790" y1="109" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
+  <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
+  <polyline points="60.0,132.3 115.8,140.2 171.7,119.9 227.5,236.7 283.3,254.4 339.2,242.6 395.0,283.8" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,124.5 115.8,150.8 171.7,124.9 227.5,240.4 283.3,254.6 339.2,246.7 395.0,282.8" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,333.8 115.8,343.3 171.7,339.2 227.5,338.0 283.3,343.3 339.2,341.8 395.0,360.5" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,440.2 115.8,439.9 171.7,439.8 227.5,439.9 283.3,440.0 339.2,440.1 395.0,440.0" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="455.0,413.7 502.9,379.5 550.7,341.5 598.6,293.4 646.4,231.7 694.3,204.9 742.1,166.8 790.0,169.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="413.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="379.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="341.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="293.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="231.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="204.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="166.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="169.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,413.7 502.9,380.9 550.7,340.9 598.6,290.4 646.4,239.7 694.3,203.7 742.1,181.1 790.0,161.6" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="413.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="380.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="340.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="290.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="239.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="203.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="181.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="161.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,427.9 502.9,411.3 550.7,390.6 598.6,364.7 646.4,362.0 694.3,355.7 742.1,373.7 790.0,360.2" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="427.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="411.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="390.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="364.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="362.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="355.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="373.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="360.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,443.4 502.9,442.7 550.7,441.4 598.6,439.5 646.4,434.1 694.3,425.4 742.1,410.2 790.0,385.4" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="443.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="442.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="441.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="439.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="434.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="425.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="410.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="385.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="60.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="115.8" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="171.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="227.5" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="283.3" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="339.2" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="395.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="455.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="502.9" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="550.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="598.6" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="646.4" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="694.3" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="742.1" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="790.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <text x="425.0" y="476" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate · solid = bandwidth</text>
+  <text x="425.0" y="532" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>
+  <line x1="60" y1="749.0" x2="790" y2="749.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="749.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">0 µs</text>
+  <line x1="60" y1="720.4" x2="790" y2="720.4" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="720.4" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">50 µs</text>
+  <line x1="60" y1="691.9" x2="790" y2="691.9" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="691.9" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 µs</text>
+  <line x1="60" y1="663.3" x2="790" y2="663.3" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="663.3" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">150 µs</text>
+  <line x1="60" y1="634.7" x2="790" y2="634.7" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="634.7" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 µs</text>
+  <line x1="60" y1="606.1" x2="790" y2="606.1" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="606.1" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">250 µs</text>
+  <line x1="60" y1="577.6" x2="790" y2="577.6" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="577.6" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">300 µs</text>
+  <line x1="60" y1="549.0" x2="790" y2="549.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">350 µs</text>
+  <line x1="60.0" y1="549" x2="60.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="151.2" y1="549" x2="151.2" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="242.5" y1="549" x2="242.5" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="333.8" y1="549" x2="333.8" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="549" x2="425.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="516.2" y1="549" x2="516.2" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="607.5" y1="549" x2="607.5" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="698.8" y1="549" x2="698.8" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
+  <polyline points="60.0,716.2 151.2,715.3 242.5,713.3 333.8,712.4 425.0,711.9 516.2,711.3 607.5,707.1 698.8,705.0 790.0,700.4" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="716.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="715.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="713.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="712.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="711.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="711.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="707.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="705.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="700.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,716.2 151.2,715.0 242.5,714.0 333.8,713.1 425.0,712.4 516.2,709.0 607.5,708.5 698.8,704.0 790.0,698.0" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="716.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="715.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="714.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="713.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="712.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="709.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="708.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="704.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="698.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,662.3 151.2,645.7 242.5,644.1 333.8,665.3 425.0,653.5 516.2,650.7 607.5,628.7 698.8,626.5 790.0,589.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="662.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="645.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="644.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="665.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="653.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="650.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="628.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="626.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="589.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,612.2 151.2,598.4 242.5,571.0 333.8,659.4 425.0,618.1 516.2,602.4 607.5,612.0 698.8,601.2 790.0,536.3" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="612.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="598.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="571.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="659.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="618.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="602.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="612.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="601.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="536.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="333.8" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="425.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="516.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="607.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="698.8" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="790.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="145" y1="789" x2="159" y2="789" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="152" cy="789" r="2.5" fill="#ef4444"/>
+  <text x="165" y="793" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.Net</text>
+  <line x1="285" y1="789" x2="299" y2="789" stroke="#fb923c" stroke-width="2.5"/>
+  <circle cx="292" cy="789" r="2.5" fill="#fb923c"/>
+  <text x="305" y="793" fill="#e5e7eb" font-size="11" font-weight="500">OMQ.Net async</text>
+  <line x1="425" y1="789" x2="439" y2="789" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="432" cy="789" r="2.5" fill="#60a5fa"/>
+  <text x="445" y="793" fill="#e5e7eb" font-size="11" font-weight="500">NetMQ</text>
+  <line x1="565" y1="789" x2="579" y2="789" stroke="#a855f7" stroke-width="2.5"/>
+  <circle cx="572" cy="789" r="2.5" fill="#a855f7"/>
+  <text x="585" y="793" fill="#e5e7eb" font-size="11" font-weight="500">NetMQ async</text>
+  <text x="425.0" y="807" text-anchor="middle" fill="#9ca3af" font-size="9">solid = p50 latency</text>
+</svg>

--- a/bindings/dotnet/scripts/package.sh
+++ b/bindings/dotnet/scripts/package.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (($# < 2)); then
+    echo "usage: $0 OUTPUT_DIR RID=LIBRARY [RID=LIBRARY ...]" >&2
+    exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+project="$repo_root/bindings/dotnet/Omq.Net.csproj"
+output_dir=$1
+shift
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+for asset in "$@"; do
+    rid=${asset%%=*}
+    library=${asset#*=}
+    if [[ "$rid" == "$asset" || -z "$rid" || -z "$library" ]]; then
+        echo "invalid native asset: $asset" >&2
+        exit 2
+    fi
+    mkdir -p "$stage/$rid"
+    cp "$library" "$stage/$rid/"
+done
+
+mkdir -p "$output_dir"
+dotnet pack "$project" --configuration Release --no-restore \
+    --output "$output_dir" -p:NativeAssetRoot="$stage"

--- a/bindings/dotnet/scripts/update_perf.py
+++ b/bindings/dotnet/scripts/update_perf.py
@@ -1,0 +1,1775 @@
+#!/usr/bin/env python3
+"""Measure OMQ.Net vs NetMQ throughput and latency (sync + async).
+
+Run from the repository root after building the .NET benchmark peer.
+Full runs append to doc/charts/bindings.jsonl (latest run_id wins per impl).
+They also generate doc/charts/bindings.svg and update the README proxy table.
+"""
+
+import argparse
+import socket
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+
+DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+QUICK_SIZES = [16, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
+SIZES = DEFAULT_SIZES.copy()
+TARGET_RUNTIME_S = 2.5
+THROUGHPUT_WARMUP_S = 0.5
+N_ROUNDS = 3
+WARMUP_ROUNDS = 0
+LATENCY_WARMUP_S = 0.5
+LATENCY_RUNTIME_S = 1.5
+SUBPROCESS_TIMEOUT_S = 30.0
+LATENCY_TIMEOUT_S = 60.0
+SUBPROCESS_RETRIES = 2
+PROXY_DURATION_S = 2.0
+THROUGHPUT_MAX_BYTES = None
+README = os.path.join(os.path.dirname(__file__), "..", "README.md")
+CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_CACHE_DIR = os.path.join(
+    os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")),
+    "omq",
+)
+JSONL_FILE = os.path.join(_CACHE_DIR, "bindings.jsonl")
+
+
+def load_jsonl():
+    rows = []
+    try:
+        with open(JSONL_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return rows
+
+
+def append_jsonl(rows):
+    os.makedirs(os.path.dirname(JSONL_FILE), exist_ok=True)
+    with open(JSONL_FILE, "a") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def save_results(
+    run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
+):
+    rows = []
+    def latency_fields(values):
+        fields = {
+            "p50_us": values[0],
+            "p99_us": values[1],
+        }
+        if len(values) >= 4:
+            fields["messages"] = values[2]
+            fields["seconds"] = values[3]
+            fields["target_seconds"] = LATENCY_RUNTIME_S
+            fields["warmup_seconds"] = LATENCY_WARMUP_S
+        return fields
+
+    for i, size in enumerate(SIZES):
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "sync",
+                "transport": "inproc",
+                "msg_size": size,
+                "msgs_s": tp_inproc[i],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "sync",
+                "transport": "tcp",
+                "msg_size": size,
+                "msgs_s": tp_tcp[i],
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "async",
+                "transport": "tcp",
+                "msg_size": size,
+                "msgs_s": atp_tcp[i],
+            }
+        )
+    for i, size in enumerate(latency_sizes_from(SIZES)):
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "latency",
+                "mode": "sync",
+                "msg_size": size,
+                **latency_fields(lat[i]),
+            }
+        )
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "latency",
+                "mode": "async",
+                "msg_size": size,
+                **latency_fields(alat[i]),
+            }
+        )
+    rows.append(
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "pushpull",
+            "msgs_s": proxy_pp,
+        }
+    )
+    rows.append(
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "reqrep",
+            "msgs_s": proxy_rr,
+        }
+    )
+    append_jsonl(rows)
+    print(f"  appended {len(rows)} rows to {JSONL_FILE}")
+
+
+def save_proxy_results(run_id, impl, proxy_pp, proxy_rr):
+    rows = [
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "pushpull",
+            "msgs_s": proxy_pp,
+        },
+        {
+            "run_id": run_id,
+            "impl": impl,
+            "kind": "proxy",
+            "pattern": "reqrep",
+            "msgs_s": proxy_rr,
+        },
+    ]
+    append_jsonl(rows)
+    print(f"  appended {len(rows)} rows to {JSONL_FILE}")
+
+
+def chart_data_from_jsonl():
+    rows = load_jsonl()
+    latency_sizes = latency_sizes_from(SIZES)
+
+    latest = {}
+    for r in rows:
+        impl = r.get("impl")
+        kind = r.get("kind")
+        mode = r.get("mode", "")
+        transport = r.get("transport", "")
+        size = r.get("msg_size", 0)
+        pattern = r.get("pattern", "")
+        key = (impl, kind, mode, transport, size, pattern)
+        prev = latest.get(key)
+        if prev is None or r.get("run_id", "") >= prev.get("run_id", ""):
+            latest[key] = r
+
+    def get_tp(mode, impl, transport, size):
+        r = latest.get((impl, "throughput", mode, transport, size, ""))
+        return r["msgs_s"] if r else 0.0
+
+    def get_lat(mode, impl, size):
+        r = latest.get((impl, "latency", mode, "", size, ""))
+        return r["p50_us"] if r else 0.0
+
+    sync_omq_tp = [get_tp("sync", "pyomq", "tcp", s) for s in SIZES]
+    sync_pz_tp = [get_tp("sync", "pyzmq", "tcp", s) for s in SIZES]
+    async_omq_tp = [get_tp("async", "pyomq", "tcp", s) for s in SIZES]
+    async_pz_tp = [get_tp("async", "pyzmq", "tcp", s) for s in SIZES]
+    sync_omq_lat = [get_lat("sync", "pyomq", s) for s in latency_sizes]
+    sync_pz_lat = [get_lat("sync", "pyzmq", s) for s in latency_sizes]
+    async_omq_lat = [get_lat("async", "pyomq", s) for s in latency_sizes]
+    async_pz_lat = [get_lat("async", "pyzmq", s) for s in latency_sizes]
+
+    return {
+        "sync_omq_tp": sync_omq_tp,
+        "sync_pz_tp": sync_pz_tp,
+        "async_omq_tp": async_omq_tp,
+        "async_pz_tp": async_pz_tp,
+        "sync_omq_lat": sync_omq_lat,
+        "sync_pz_lat": sync_pz_lat,
+        "async_omq_lat": async_omq_lat,
+        "async_pz_lat": async_pz_lat,
+    }
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
+
+
+def median(values, key=lambda value: value):
+    ordered = sorted(values, key=key)
+    return ordered[len(ordered) // 2]
+
+
+def free_tcp():
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return f"tcp://127.0.0.1:{port}"
+
+
+def fmt_rate(rate):
+    if rate >= 1_000_000:
+        return f"{rate / 1_000_000:.2f} M/s"
+    return f"{rate / 1_000:.0f} k/s"
+
+
+def fmt_size(size):
+    if size >= 1024:
+        return f"{size // 1024} KiB"
+    return f"{size} B"
+
+
+def fmt_int(n):
+    return f"{n:,.0f}"
+
+
+def parse_sizes(value):
+    sizes = []
+    for raw in value.split(","):
+        raw = raw.strip().lower()
+        if not raw:
+            continue
+        multiplier = 1
+        if raw.endswith("kib"):
+            multiplier = 1024
+            raw = raw[:-3]
+        elif raw.endswith("kb"):
+            multiplier = 1000
+            raw = raw[:-2]
+        elif raw.endswith("k"):
+            multiplier = 1024
+            raw = raw[:-1]
+        size = int(raw.strip()) * multiplier
+        if size <= 0:
+            raise argparse.ArgumentTypeError("sizes must be positive")
+        sizes.append(size)
+    if not sizes:
+        raise argparse.ArgumentTypeError("at least one size is required")
+    return sizes
+
+
+def configure_benchmark(args):
+    global SIZES
+    global TARGET_RUNTIME_S
+    global THROUGHPUT_WARMUP_S
+    global N_ROUNDS
+    global WARMUP_ROUNDS
+    global LATENCY_WARMUP_S
+    global LATENCY_RUNTIME_S
+    global SUBPROCESS_TIMEOUT_S
+    global LATENCY_TIMEOUT_S
+    global SUBPROCESS_RETRIES
+    global PROXY_DURATION_S
+    global THROUGHPUT_MAX_BYTES
+
+    THROUGHPUT_MAX_BYTES = None
+
+    if args.quick:
+        SIZES = QUICK_SIZES.copy()
+        TARGET_RUNTIME_S = 0.5
+        THROUGHPUT_WARMUP_S = 0.1
+        N_ROUNDS = 1
+        WARMUP_ROUNDS = 0
+        LATENCY_WARMUP_S = 0.1
+        LATENCY_RUNTIME_S = 0.5
+        SUBPROCESS_TIMEOUT_S = 15.0
+        LATENCY_TIMEOUT_S = 20.0
+        SUBPROCESS_RETRIES = 0
+        PROXY_DURATION_S = 1.0
+        THROUGHPUT_MAX_BYTES = 128 * 1024 * 1024
+
+    if args.sizes is not None:
+        SIZES = args.sizes
+    if args.rounds is not None:
+        N_ROUNDS = args.rounds
+    if args.target_runtime is not None:
+        TARGET_RUNTIME_S = args.target_runtime
+        if args.latency_duration is None:
+            LATENCY_RUNTIME_S = min(TARGET_RUNTIME_S, LATENCY_RUNTIME_S)
+    if args.warmup_duration is not None:
+        THROUGHPUT_WARMUP_S = args.warmup_duration
+        if args.latency_warmup_duration is None:
+            LATENCY_WARMUP_S = THROUGHPUT_WARMUP_S
+    if args.latency_warmup_duration is not None:
+        LATENCY_WARMUP_S = args.latency_warmup_duration
+    if args.latency_duration is not None:
+        LATENCY_RUNTIME_S = args.latency_duration
+    if args.timeout is not None:
+        SUBPROCESS_TIMEOUT_S = args.timeout
+        LATENCY_TIMEOUT_S = max(args.timeout, 1.0)
+    if args.proxy_duration is not None:
+        PROXY_DURATION_S = args.proxy_duration
+
+    if N_ROUNDS < 1:
+        raise argparse.ArgumentTypeError("--rounds must be at least 1")
+    if TARGET_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--target-runtime must be positive")
+    if THROUGHPUT_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--warmup-duration cannot be negative")
+    if LATENCY_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--latency-warmup-duration cannot be negative")
+    if LATENCY_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--latency-duration must be positive")
+    if SUBPROCESS_TIMEOUT_S <= 0 or LATENCY_TIMEOUT_S <= 0:
+        raise argparse.ArgumentTypeError("--timeout must be positive")
+    if PROXY_DURATION_S <= 0:
+        raise argparse.ArgumentTypeError("--proxy-duration must be positive")
+
+
+# ── subprocess runner ────────────────────────────────────────────────
+
+
+def _run_subprocess(code, label, timeout=None, retries=None):
+    timeout = SUBPROCESS_TIMEOUT_S if timeout is None else timeout
+    try:
+        r = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"{label} timeout after {timeout}s") from error
+    if r.returncode != 0:
+        raise RuntimeError(f"{label} failed:\n{r.stdout}{r.stderr}")
+    return json.loads(r.stdout.strip())
+
+
+def _measure_throughput_subprocess(lib_name, transport, size, duration=None):
+    """Run a throughput measurement. TCP uses 2 separate processes (push +
+    pull) so each gets its own runtime. Inproc must stay single-process."""
+    duration = TARGET_RUNTIME_S if duration is None else duration
+    if lib_name == "pyzmq":
+        lib_import = "import zmq as lib"
+    else:
+        lib_import = "import pyomq as lib"
+
+    if transport == "inproc":
+        code = f"""
+import threading, time, json
+{lib_import}
+payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
+ep = f'inproc://bench-{{time.monotonic_ns()}}'
+ctx = lib.Context()
+pull = ctx.socket(lib.PULL)
+push = ctx.socket(lib.PUSH)
+pull.linger = 0
+push.linger = 0
+pull.bind(ep)
+push.connect(ep)
+def sender():
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
+        push.send(payload)
+    push.send(stop)
+t = threading.Thread(target=sender)
+t.start()
+start = None
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    if start is None:
+        start = time.monotonic()
+    count += 1
+elapsed = time.monotonic() - start if start is not None else 0.0
+t.join()
+push.close(); pull.close()
+print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
+import sys; sys.stdout.flush(); import os; os._exit(0)
+"""
+        result = _run_subprocess(code, f"{lib_name} inproc {size}B")
+        return result if result is not None else 0.0
+
+    push_code = f"""
+import time, sys
+{lib_import}
+payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
+ctx = lib.Context()
+push = ctx.socket(lib.PUSH)
+push.linger = 0
+push.bind('tcp://127.0.0.1:0')
+ep = push.last_endpoint
+if isinstance(ep, bytes): ep = ep.decode()
+port = ep.rsplit(':', 1)[1]
+print(port, flush=True)
+deadline = time.monotonic() + duration
+while time.monotonic() < deadline:
+    push.send(payload)
+push.send(stop)
+sys.stdin.readline()
+push.close()
+import os; os._exit(0)
+"""
+    pull_code = f"""
+import time, json, sys
+{lib_import}
+port = sys.argv[1]
+stop = b'__OMQ_BENCH_STOP__'
+ctx = lib.Context()
+pull = ctx.socket(lib.PULL)
+pull.linger = 0
+pull.connect(f'tcp://127.0.0.1:{{port}}')
+start = None
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    if start is None:
+        start = time.monotonic()
+    count += 1
+elapsed = time.monotonic() - start if start is not None else 0.0
+pull.close()
+print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
+sys.stdout.flush()
+import os; os._exit(0)
+"""
+    push_proc = subprocess.Popen(
+        [sys.executable, "-c", push_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+    push_stdout = push_proc.stdout
+    push_stdin = push_proc.stdin
+    assert push_stdout is not None
+    assert push_stdin is not None
+    try:
+        port_line = push_stdout.readline().strip()
+        if not port_line:
+            push_proc.terminate()
+            push_proc.wait(timeout=5)
+            return 0.0
+        label = f"{lib_name} {transport} {size}B"
+        pull_proc = subprocess.Popen(
+            [sys.executable, "-c", pull_code, port_line],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            stdout, stderr = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
+            result = json.loads(stdout.strip())
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(f"  [{label} timeout]\n")
+            pull_proc.kill()
+            pull_proc.wait()
+            result = 0.0
+        except (json.JSONDecodeError, ValueError):
+            sys.stderr.write(f"  [{label} invalid output]\n")
+            if stderr:
+                sys.stderr.write(stderr)
+            result = 0.0
+    finally:
+        try:
+            push_stdin.write("\n")
+            push_stdin.flush()
+        except OSError:
+            pass
+        push_proc.terminate()
+        try:
+            push_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            push_proc.kill()
+            push_proc.wait()
+    return result
+
+
+def run_throughput(lib_name):
+    inproc_results = []
+    tcp_results = []
+    for size in SIZES:
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+
+        inproc_runs = []
+        tcp_runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_throughput_subprocess(
+                    lib_name, "inproc", size, duration=THROUGHPUT_WARMUP_S
+                )
+            inproc_runs.append(_measure_throughput_subprocess(lib_name, "inproc", size))
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_throughput_subprocess(
+                    lib_name, "tcp", size, duration=THROUGHPUT_WARMUP_S
+                )
+            tcp_runs.append(_measure_throughput_subprocess(lib_name, "tcp", size))
+        inproc = median(inproc_runs)
+        tcp = median(tcp_runs)
+        inproc_results.append(inproc)
+        tcp_results.append(tcp)
+        print(f" inproc {fmt_rate(inproc):>10}  tcp {fmt_rate(tcp):>10}")
+
+    return inproc_results, tcp_results
+
+
+# ── async PUSH/PULL throughput ───────────────────────────────────────
+
+
+def _measure_async_subprocess(lib_name, size, duration=None):
+    """Async throughput: push in one process, async pull in another."""
+    duration = TARGET_RUNTIME_S if duration is None else duration
+    if lib_name == "pyzmq":
+        lib_import = "import zmq as lib; import zmq.asyncio as alib"
+        push_import = "import zmq as lib"
+    else:
+        lib_import = "import pyomq as lib; import pyomq.asyncio as alib"
+        push_import = "import pyomq as lib"
+
+    push_code = f"""
+import sys, time
+{push_import}
+payload = b'x' * {size}
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
+ctx = lib.Context()
+push = ctx.socket(lib.PUSH)
+push.linger = 0
+push.bind('tcp://127.0.0.1:0')
+ep = push.last_endpoint
+if isinstance(ep, bytes): ep = ep.decode()
+port = ep.rsplit(':', 1)[1]
+print(port, flush=True)
+deadline = time.monotonic() + duration
+while time.monotonic() < deadline:
+    push.send(payload)
+push.send(stop)
+sys.stdin.readline()
+push.close()
+import os; os._exit(0)
+"""
+    pull_code = f"""
+import asyncio, time, json, sys
+{lib_import}
+async def run():
+    port = sys.argv[1]
+    stop = b'__OMQ_BENCH_STOP__'
+    ctx = alib.Context()
+    pull = ctx.socket(lib.PULL)
+    pull.linger = 0
+    pull.connect(f'tcp://127.0.0.1:{{port}}')
+    count = 0; start = None
+    while True:
+        msg = await pull.recv()
+        if msg == stop:
+            break
+        if start is None:
+            start = time.monotonic()
+        count += 1
+    elapsed = time.monotonic() - start if start is not None else 0.0
+    pull.close()
+    print(json.dumps(count / elapsed if elapsed > 0 else 0.0))
+    sys.stdout.flush(); import os; os._exit(0)
+asyncio.run(run())
+"""
+    push_proc = subprocess.Popen(
+        [sys.executable, "-c", push_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+    push_stdout = push_proc.stdout
+    push_stdin = push_proc.stdin
+    assert push_stdout is not None
+    assert push_stdin is not None
+    try:
+        port_line = push_stdout.readline().strip()
+        if not port_line:
+            push_proc.terminate()
+            push_proc.wait(timeout=5)
+            return 0.0
+        label = f"{lib_name} async tcp {size}B"
+        pull_proc = subprocess.Popen(
+            [sys.executable, "-c", pull_code, port_line],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            stdout, stderr = pull_proc.communicate(timeout=SUBPROCESS_TIMEOUT_S)
+            result = json.loads(stdout.strip())
+        except subprocess.TimeoutExpired:
+            sys.stderr.write(f"  [{label} timeout]\n")
+            pull_proc.kill()
+            pull_proc.wait()
+            result = 0.0
+        except (json.JSONDecodeError, ValueError):
+            sys.stderr.write(f"  [{label} invalid output]\n")
+            if stderr:
+                sys.stderr.write(stderr)
+            result = 0.0
+    finally:
+        try:
+            push_stdin.write("\n")
+            push_stdin.flush()
+        except OSError:
+            pass
+        push_proc.terminate()
+        try:
+            push_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            push_proc.kill()
+            push_proc.wait()
+    return result
+
+
+def run_async_throughput(lib_name):
+    results = []
+    for size in SIZES:
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_async_subprocess(lib_name, size, duration=THROUGHPUT_WARMUP_S)
+            runs.append(_measure_async_subprocess(lib_name, size))
+        tcp = median(runs)
+        results.append(tcp)
+        print(f" {fmt_rate(tcp):>10}")
+
+    return results
+
+
+# ── sync REQ/REP latency ────────────────────────────────────────────
+
+
+def _measure_latency_subprocess(lib_name, size, warmup_seconds, duration_seconds):
+    code = f"""
+import time, threading, json, socket as sock
+def free_tcp():
+    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return f'tcp://127.0.0.1:{{port}}'
+if '{lib_name}' == 'pyzmq':
+    import zmq as lib
+else:
+    import pyomq as lib
+payload = b'x' * {size}
+ep = free_tcp()
+ctx = lib.Context()
+rep = ctx.socket(lib.REP)
+req = ctx.socket(lib.REQ)
+rep.linger = 0
+req.linger = 0
+rep.bind(ep)
+req.connect(ep)
+time.sleep(0.05)
+def echo():
+    try:
+        while True:
+            msg = rep.recv()
+            rep.send(msg)
+            if msg == b'__OMQ_BENCH_STOP__':
+                break
+    except Exception:
+        pass
+t = threading.Thread(target=echo, daemon=True)
+t.start()
+warmup_deadline = time.monotonic() + {warmup_seconds}
+while time.monotonic() < warmup_deadline:
+    req.send(payload)
+    req.recv()
+rtts = []
+start = time.monotonic()
+deadline = start + {duration_seconds}
+while True:
+    t0 = time.monotonic()
+    req.send(payload)
+    req.recv()
+    rtts.append(time.monotonic() - t0)
+    if time.monotonic() >= deadline:
+        break
+elapsed = time.monotonic() - start
+req.send(b'__OMQ_BENCH_STOP__')
+req.recv()
+req.close()
+rep.close()
+t.join(timeout=1.0)
+rtts.sort()
+p50 = rtts[len(rtts)*50//100]*1e6
+p99 = rtts[len(rtts)*99//100]*1e6
+print(json.dumps([p50, p99, len(rtts), elapsed]))
+import sys; sys.stdout.flush(); import os; os._exit(0)
+"""
+    result = _run_subprocess(
+        code,
+        f"{lib_name} lat {size}B",
+        timeout=LATENCY_TIMEOUT_S,
+    )
+    return tuple(result) if result is not None else (999999.0, 999999.0)
+
+
+def run_latency(lib_name):
+    results = []
+    for size in latency_sizes_from(SIZES):
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+
+        warmup = (0.0, 0.0)
+        for _ in range(WARMUP_ROUNDS):
+            warmup = _measure_latency_subprocess(
+                lib_name,
+                size,
+                min(LATENCY_WARMUP_S, 0.05),
+                min(LATENCY_RUNTIME_S, 0.05),
+            )
+        if warmup == (999999.0, 999999.0):
+            results.append(warmup)
+            print(" timeout")
+            continue
+
+        runs = [
+            _measure_latency_subprocess(
+                lib_name,
+                size,
+                LATENCY_WARMUP_S,
+                LATENCY_RUNTIME_S,
+            )
+            for _ in range(N_ROUNDS)
+        ]
+        selected = median(runs, key=lambda row: row[0])
+        results.append(selected)
+        print(
+            f" p50 {selected[0]:.1f} µs  p99 {selected[1]:.1f} µs  n={selected[2]}"
+        )
+
+    return results
+
+
+# ── async REQ/REP latency ───────────────────────────────────────────
+
+
+def _measure_async_latency_subprocess(lib_name, size, warmup_seconds, duration_seconds):
+    if lib_name == "pyzmq":
+        lib_import = "import zmq; import zmq.asyncio; lib = zmq; actx = zmq.asyncio"
+    else:
+        lib_import = "import pyomq; import pyomq.asyncio as actx; lib = pyomq"
+
+    send_await = "await " if lib_name == "pyzmq" else ""
+    code = f"""
+import asyncio, time, json, socket as sock
+def free_tcp():
+    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return f'tcp://127.0.0.1:{{port}}'
+{lib_import}
+async def run():
+    payload = b'x' * {size}
+    ep = free_tcp()
+    ctx = actx.Context()
+    rep = ctx.socket(lib.REP)
+    req = ctx.socket(lib.REQ)
+    rep.bind(ep)
+    req.connect(ep)
+    await asyncio.sleep(0.05)
+    async def echo():
+        try:
+            while True:
+                msg = await rep.recv()
+                {send_await}rep.send(msg)
+                if msg == b'__OMQ_BENCH_STOP__':
+                    break
+        except Exception:
+            pass
+    task = asyncio.create_task(echo())
+    warmup_deadline = time.monotonic() + {warmup_seconds}
+    while time.monotonic() < warmup_deadline:
+        {send_await}req.send(payload)
+        await req.recv()
+    rtts = []
+    start = time.monotonic()
+    deadline = start + {duration_seconds}
+    while True:
+        t0 = time.monotonic()
+        {send_await}req.send(payload)
+        await req.recv()
+        rtts.append(time.monotonic() - t0)
+        if time.monotonic() >= deadline:
+            break
+    elapsed = time.monotonic() - start
+    {send_await}req.send(b'__OMQ_BENCH_STOP__')
+    await req.recv()
+    await task
+    rtts.sort()
+    p50 = rtts[len(rtts)*50//100]*1e6
+    p99 = rtts[len(rtts)*99//100]*1e6
+    print(json.dumps([p50, p99, len(rtts), elapsed]))
+    import sys; sys.stdout.flush(); import os; os._exit(0)
+asyncio.run(run())
+"""
+    result = _run_subprocess(
+        code,
+        f"{lib_name} async lat {size}B",
+        timeout=LATENCY_TIMEOUT_S,
+    )
+    return tuple(result) if result is not None else (999999.0, 999999.0)
+
+
+def run_async_latency(lib_name):
+    results = []
+    for size in latency_sizes_from(SIZES):
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+
+        warmup = (0.0, 0.0)
+        for _ in range(WARMUP_ROUNDS):
+            warmup = _measure_async_latency_subprocess(
+                lib_name,
+                size,
+                min(LATENCY_WARMUP_S, 0.05),
+                min(LATENCY_RUNTIME_S, 0.05),
+            )
+        if warmup == (999999.0, 999999.0):
+            results.append(warmup)
+            print(" timeout")
+            continue
+
+        runs = [
+            _measure_async_latency_subprocess(
+                lib_name, size, LATENCY_WARMUP_S, LATENCY_RUNTIME_S
+            )
+            for _ in range(N_ROUNDS)
+        ]
+        selected = median(runs, key=lambda row: row[0])
+        results.append(selected)
+        print(
+            f" p50 {selected[0]:.1f} µs  p99 {selected[1]:.1f} µs  n={selected[2]}"
+        )
+
+    return results
+
+
+# ── proxy forwarding (2-process) ─────────────────────────────────────
+
+
+def _measure_proxy_subprocess(lib_name, pattern, duration):
+    if lib_name == "pyzmq":
+        lib_import = "import zmq as lib"
+    else:
+        lib_import = "import pyomq as lib"
+
+    proxy_code = f"""
+import json, sys, socket as sock
+{lib_import}
+def pick_port():
+    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+ctx = lib.Context()
+fe_port = pick_port()
+be_port = pick_port()
+"""
+    if pattern == "pushpull":
+        proxy_code += """
+frontend = ctx.socket(lib.PULL)
+backend = ctx.socket(lib.PUSH)
+"""
+    else:
+        proxy_code += """
+frontend = ctx.socket(lib.ROUTER)
+backend = ctx.socket(lib.DEALER)
+"""
+    proxy_code += """
+frontend.bind(f'tcp://127.0.0.1:{fe_port}')
+backend.bind(f'tcp://127.0.0.1:{be_port}')
+print(json.dumps([fe_port, be_port]), flush=True)
+try:
+    lib.proxy(frontend, backend)
+except Exception:
+    pass
+"""
+
+    proxy_proc = subprocess.Popen(
+        [sys.executable, "-c", proxy_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    proxy_stdout = proxy_proc.stdout
+    assert proxy_stdout is not None
+    try:
+        line = proxy_stdout.readline()
+        fe_port, be_port = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        proxy_proc.terminate()
+        proxy_proc.wait(timeout=5)
+        return 0.0
+    fe_ep = f"tcp://127.0.0.1:{fe_port}"
+    be_ep = f"tcp://127.0.0.1:{be_port}"
+
+    if pattern == "pushpull":
+        bench_code = f"""
+import threading, time, json, sys, os
+{lib_import}
+payload = b'x' * 128
+stop = b'__OMQ_BENCH_STOP__'
+duration = {duration}
+ctx = lib.Context()
+push = ctx.socket(lib.PUSH)
+pull = ctx.socket(lib.PULL)
+push.linger = 0
+push.connect('{fe_ep}')
+pull.connect('{be_ep}')
+warmup_deadline = time.monotonic() + min(duration, 0.05)
+while time.monotonic() < warmup_deadline:
+    push.send(b'w')
+    pull.recv()
+def sender():
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
+        push.send(payload)
+    push.send(stop)
+t = threading.Thread(target=sender)
+start = time.monotonic()
+t.start()
+count = 0
+while True:
+    msg = pull.recv()
+    if msg == stop:
+        break
+    count += 1
+elapsed = time.monotonic() - start
+t.join()
+push.close()
+pull.close()
+print(json.dumps(count / elapsed))
+sys.stdout.flush(); os._exit(0)
+"""
+    else:
+        bench_code = f"""
+import threading, time, json, sys, os
+{lib_import}
+payload = b'x' * 128
+duration = {duration}
+ctx = lib.Context()
+client = ctx.socket(lib.REQ)
+worker = ctx.socket(lib.REP)
+client.linger = 0
+worker.linger = 0
+client.connect('{fe_ep}')
+worker.connect('{be_ep}')
+warmup_deadline = time.monotonic() + min(duration, 0.05)
+while time.monotonic() < warmup_deadline:
+    client.send(b'w')
+    worker.send(worker.recv())
+    client.recv()
+start = time.monotonic()
+count = 0
+deadline = start + duration
+while time.monotonic() < deadline:
+    client.send(payload)
+    worker.send(worker.recv())
+    client.recv()
+    count += 1
+elapsed = time.monotonic() - start
+client.close()
+worker.close()
+print(json.dumps(count / elapsed))
+sys.stdout.flush(); os._exit(0)
+"""
+
+    try:
+        r = subprocess.run(
+            [sys.executable, "-c", bench_code],
+            capture_output=True,
+            text=True,
+            timeout=LATENCY_TIMEOUT_S,
+        )
+        if r.returncode != 0:
+            return 0.0
+        return json.loads(r.stdout.strip())
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError):
+        return 0.0
+    finally:
+        proxy_proc.terminate()
+        proxy_proc.wait(timeout=5)
+
+
+_SCRIPT_DIR = os.path.dirname(__file__)
+_REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
+BENCH_PROXY_CLIENTS = [
+    os.path.join(_REPO_ROOT, "target", "release", "omq_bench_proxy_client"),
+    os.path.join(_SCRIPT_DIR, "..", "target", "release", "bench_proxy_client"),
+]
+
+
+def _bench_proxy_client():
+    for path in BENCH_PROXY_CLIENTS:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _measure_proxy_native(lib_name, client, duration=None):
+    duration = PROXY_DURATION_S if duration is None else duration
+    if lib_name == "pyzmq":
+        lib_import = "import zmq as lib"
+    else:
+        lib_import = "import pyomq as lib"
+
+    proxy_code = f"""
+import json, sys, socket as sock
+{lib_import}
+def pick_port():
+    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+ctx = lib.Context()
+frontend = ctx.socket(lib.PULL)
+backend = ctx.socket(lib.PUSH)
+fe_port = pick_port()
+be_port = pick_port()
+frontend.bind(f'tcp://127.0.0.1:{{fe_port}}')
+backend.bind(f'tcp://127.0.0.1:{{be_port}}')
+print(json.dumps([fe_port, be_port]), flush=True)
+try:
+    lib.proxy(frontend, backend)
+except Exception:
+    pass
+"""
+
+    proxy_proc = subprocess.Popen(
+        [sys.executable, "-c", proxy_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    proxy_stdout = proxy_proc.stdout
+    assert proxy_stdout is not None
+    try:
+        line = proxy_stdout.readline()
+        fe_port, be_port = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        proxy_proc.terminate()
+        proxy_proc.wait(timeout=5)
+        return 0.0
+
+    try:
+        r = subprocess.run(
+            [client, str(fe_port), str(be_port), "128", str(duration)],
+            capture_output=True,
+            text=True,
+            timeout=duration + 10,
+        )
+        if r.returncode != 0:
+            return 0.0
+        parts = r.stdout.strip().split()
+        count, elapsed = int(parts[0]), float(parts[1])
+        return count / elapsed
+    except (subprocess.TimeoutExpired, ValueError, IndexError):
+        return 0.0
+    finally:
+        proxy_proc.terminate()
+        proxy_proc.wait(timeout=5)
+
+
+def run_proxy(lib_name):
+    client = _bench_proxy_client()
+
+    sys.stdout.write("  PUSH/PULL ...")
+    sys.stdout.flush()
+    if client is not None:
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_proxy_native(
+                    lib_name, client, min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+                )
+            runs.append(_measure_proxy_native(lib_name, client))
+        pushpull_rate = median(runs)
+    else:
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                _measure_proxy_subprocess(
+                    lib_name, "pushpull", min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+                )
+            runs.append(_measure_proxy_subprocess(lib_name, "pushpull", PROXY_DURATION_S))
+        pushpull_rate = median(runs)
+    print(f" {fmt_rate(pushpull_rate)}")
+
+    sys.stdout.write("  REQ/REP ...")
+    sys.stdout.flush()
+    runs = []
+    for _ in range(N_ROUNDS):
+        if THROUGHPUT_WARMUP_S > 0:
+            _measure_proxy_subprocess(
+                lib_name, "reqrep", min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
+            )
+        runs.append(_measure_proxy_subprocess(lib_name, "reqrep", PROXY_DURATION_S))
+    reqrep_rate = median(runs)
+    print(f" {fmt_rate(reqrep_rate)}")
+
+    return pushpull_rate, reqrep_rate
+
+
+# ── SVG chart generation ────────────────────────────────────────────
+
+# Colors: warm = OMQ.Net, cool = NetMQ
+C_OMQ = "#ef4444"
+C_OMQ_ASYNC = "#fb923c"
+C_NETMQ = "#60a5fa"
+C_NETMQ_ASYNC = "#a855f7"
+
+
+def _nice_ceil(v):
+    if v <= 0:
+        return 1
+    exp = math.floor(math.log10(v))
+    base = 10**exp
+    for m in [1, 2, 5, 10]:
+        candidate = m * base
+        if candidate >= v:
+            return candidate
+    return 10 * base
+
+
+def _fmt_y_rate(val):
+    if val >= 1_000_000:
+        return f"{val / 1_000_000:g}M"
+    if val >= 1_000:
+        return f"{val / 1_000:g}k"
+    return f"{val:g}"
+
+
+def _fmt_y_us(val):
+    if val >= 1000:
+        return f"{val / 1000:g} ms"
+    return f"{val:g} µs"
+
+
+def _fmt_mbps(val):
+    if val >= 1000:
+        return f"{val / 1000:g} GB/s"
+    if val >= 10:
+        return f"{val:.0f} MB/s"
+    return f"{val:.1f} MB/s"
+
+
+def _read_chart_hw():
+    config = {}
+    path = os.path.join(REPO_ROOT, ".chart_hw")
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, sep, value = line.partition("=")
+                if sep:
+                    config[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return config
+
+
+def _detect_hardware():
+    hw_conf = _read_chart_hw()
+    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
+    if label:
+        return label
+    prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
+    return None
+
+
+def gen_combined_chart(data, path):
+    n = len(SIZES)
+    latency_sizes = latency_sizes_from(SIZES)
+    lat_n = len(latency_sizes)
+    hw_label = _detect_hardware()
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 810 + hw_offset
+    x_left, x_right = 60, 790
+    plot_w = x_right - x_left
+    top_left, top_mid, top_right = 60, 395, 790
+    top_right_left = 455
+
+    t1_top = 95 + hw_offset
+    t1_bot = 430 + hw_offset
+    t1_h = t1_bot - t1_top
+    t2_top = t1_bot + 105
+    t2_bot = t2_top + 200
+    t2_h = t2_bot - t2_top
+
+    small_sizes = [s for s in SIZES if s <= 1024]
+    large_sizes = [s for s in SIZES if s >= 256]
+    small_xs = [top_left + i * (top_mid - top_left) / max(len(small_sizes) - 1, 1) for i in range(len(small_sizes))]
+    large_xs = [top_right_left + i * (top_right - top_right_left) / max(len(large_sizes) - 1, 1) for i in range(len(large_sizes))]
+    xs = [x_left + i * plot_w / max(n - 1, 1) for i in range(n)]
+    lat_xs = [x_left + i * plot_w / max(lat_n - 1, 1) for i in range(lat_n)]
+    mid_x = (x_left + x_right) / 2
+
+    sync_omq_tp = data["sync_omq_tp"]
+    sync_pz_tp = data["sync_pz_tp"]
+    async_omq_tp = data["async_omq_tp"]
+    async_pz_tp = data["async_pz_tp"]
+
+    tp_values = [sync_omq_tp, sync_pz_tp, async_omq_tp, async_pz_tp]
+    small_indices = [SIZES.index(s) for s in small_sizes]
+    large_indices = [SIZES.index(s) for s in large_sizes]
+    msg_max = 2_500_000
+    gbs_values = [
+        v * SIZES[i] / 1_000_000_000
+        for values in tp_values
+        for i in large_indices
+        for v in [values[i]]
+    ]
+    gbs_max = max(1, math.ceil(max(gbs_values, default=0)))
+
+    def y_msg(v):
+        frac = v / msg_max if msg_max > 0 else 0
+        return t1_bot - frac * t1_h
+
+    def y_gbs(v):
+        frac = v / gbs_max if gbs_max > 0 else 0
+        return t1_bot - frac * t1_h
+
+    latency_values = [
+        v
+        for values in (
+            data["sync_omq_lat"], data["sync_pz_lat"],
+            data["async_omq_lat"], data["async_pz_lat"],
+        )
+        for v in values
+        if v > 0
+    ]
+    lat_min = 0.0
+    lat_max = 350.0
+    lat_step = 50
+
+    def y_lat(v):
+        frac = (v - lat_min) / (lat_max - lat_min)
+        return t2_bot - frac * t2_h
+
+    L = []
+    L.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">'
+    )
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>')
+
+    # ── TOP PANEL: THROUGHPUT ──────────────────────────────────────
+
+    L.append(
+        f'  <text x="{mid_x}" y="{t1_top - 65}" text-anchor="middle" fill="#f9fafb"'
+        f' font-size="13" font-weight="700">'
+        f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>"
+    )
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="{t1_top - 51}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
+
+    for panel_left, panel_right, panel_sizes, panel_xs, ticks, formatter, label_x in (
+        (top_left, top_mid, small_sizes, small_xs, list(range(200_000, int(msg_max), 200_000)) + [msg_max], _fmt_y_rate, top_left - 8),
+        (top_right_left, top_right, large_sizes, large_xs, [i / 2 for i in range(1, int(gbs_max * 2) + 1)], lambda v: f"{v:g} GB/s", top_right + 8),
+    ):
+        for tick in ticks:
+            panel_max = msg_max if panel_left == top_left else gbs_max
+            frac = tick / panel_max
+            yy = t1_bot - frac * t1_h
+            L.append(f'  <line x1="{panel_left}" y1="{yy:.1f}" x2="{panel_right}" y2="{yy:.1f}" stroke="#374151" stroke-width="1"/>')
+            anchor = "end" if label_x < panel_left else "start"
+            L.append(f'  <text x="{label_x}" y="{yy:.1f}" text-anchor="{anchor}" dominant-baseline="middle" fill="#e5e7eb" font-size="10">{formatter(tick)}</text>')
+        for x in panel_xs:
+            L.append(f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}" stroke="#374151" stroke-width="1"/>')
+        if panel_left == top_left:
+            L.append(f'  <line x1="{panel_left}" y1="{t1_top}" x2="{panel_left}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+        if panel_right == top_right:
+            L.append(f'  <line x1="{panel_right}" y1="{t1_top}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+        L.append(f'  <line x1="{panel_left}" y1="{t1_bot}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+
+    L.append(f'  <text x="{(top_left + top_mid) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>')
+    L.append(f'  <text x="{(top_right_left + top_right) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>')
+
+    tp_series = [("OMQ.Net", C_OMQ, sync_omq_tp), ("OMQ.Net async", C_OMQ_ASYNC, async_omq_tp), ("NetMQ", C_NETMQ, sync_pz_tp), ("NetMQ async", C_NETMQ_ASYNC, async_pz_tp)]
+
+    for _, color, vals in tp_series:
+        pts = " ".join(f"{small_xs[j]:.1f},{y_msg(vals[i]):.1f}" for j, i in enumerate(small_indices))
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2" stroke-dasharray="6,4"/>'
+        )
+
+    for _, color, vals in tp_series:
+        gbs = [vals[i] * SIZES[i] / 1e9 for i in large_indices]
+        pts = " ".join(f"{large_xs[j]:.1f},{y_gbs(v):.1f}" for j, v in enumerate(gbs))
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for j, v in enumerate(gbs):
+            yy = y_gbs(v)
+            L.append(
+                f'  <circle cx="{large_xs[j]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
+            )
+
+    for i, size in enumerate(small_sizes):
+        L.append(f'  <text x="{small_xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle" fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>')
+    for i, size in enumerate(large_sizes):
+        L.append(f'  <text x="{large_xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle" fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>')
+    L.append(f'  <text x="{mid_x:.1f}" y="{t1_bot + 32}" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate · solid = bandwidth</text>')
+
+    # ── BOTTOM PANEL: LATENCY ─────────────────────────────────────
+
+    L.append(
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
+        f' font-size="13" font-weight="700">'
+        f"REQ/REP latency: 2-process, TCP loopback, p50 µs (lower is better)</text>"
+    )
+
+    sync_omq_lat = data["sync_omq_lat"]
+    sync_pz_lat = data["sync_pz_lat"]
+    async_omq_lat = data["async_omq_lat"]
+    async_pz_lat = data["async_pz_lat"]
+
+    for v in list(range(int(lat_min), int(lat_max), int(lat_step))) + [int(lat_max)]:
+        yy = y_lat(v)
+        L.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#374151" stroke-width="1"/>'
+        )
+        L.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
+            f"{_fmt_y_us(v)}</text>"
+        )
+
+    for x in lat_xs:
+        L.append(
+            f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
+            f' stroke="#374151" stroke-width="1"/>'
+        )
+
+    L.append(
+        f'  <line x1="{x_left}" y1="{t2_top}" x2="{x_left}" y2="{t2_bot}"'
+        f' stroke="#9ca3af" stroke-width="1.5"/>'
+    )
+    L.append(
+        f'  <line x1="{x_left}" y1="{t2_bot}" x2="{x_right}" y2="{t2_bot}"'
+        f' stroke="#9ca3af" stroke-width="1.5"/>'
+    )
+
+    lat_series = [("OMQ.Net", C_OMQ, sync_omq_lat), ("OMQ.Net async", C_OMQ_ASYNC, async_omq_lat), ("NetMQ", C_NETMQ, sync_pz_lat), ("NetMQ async", C_NETMQ_ASYNC, async_pz_lat)]
+
+    for _, color, vals in lat_series:
+        pts = " ".join(f"{lat_xs[i]:.1f},{y_lat(v):.1f}" for i, v in enumerate(vals))
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for i, v in enumerate(vals):
+            yy = y_lat(v)
+            L.append(
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
+            )
+
+    for i in range(lat_n):
+        L.append(
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(latency_sizes[i])}</text>'
+        )
+
+    # ── LEGEND ────────────────────────────────────────────────────
+
+    leg_y = t2_bot + 40
+    legend_items = [("OMQ.Net", C_OMQ), ("OMQ.Net async", C_OMQ_ASYNC), ("NetMQ", C_NETMQ), ("NetMQ async", C_NETMQ_ASYNC)]
+    item_w = 140
+    total_w = len(legend_items) * item_w
+    start_x = mid_x - total_w / 2
+
+    for idx, (label, color) in enumerate(legend_items):
+        lx = start_x + idx * item_w
+        L.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y}" x2="{lx + 14:.0f}" y2="{leg_y}"'
+            f' stroke="{color}" stroke-width="2.5"/>'
+        )
+        L.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
+        L.append(
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
+            f' font-size="11" font-weight="500">{label}</text>'
+        )
+
+    footer_y = leg_y + 18
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f"solid = p50 latency</text>"
+    )
+
+    L.append("</svg>")
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("\n".join(L))
+        f.write("\n")
+    print(f"  wrote {path}")
+
+
+# ── README tables ────────────────────────────────────────────────────
+
+
+def build_proxy_table():
+    rows = load_jsonl()
+    latest = {}
+    for r in rows:
+        if r.get("kind") != "proxy":
+            continue
+        key = (r["impl"], r["pattern"])
+        prev = latest.get(key)
+        if prev is None or r.get("run_id", "") >= prev.get("run_id", ""):
+            latest[key] = r
+
+    pp_omq = latest.get(("pyomq", "pushpull"), {}).get("msgs_s", 0)
+    pp_pz = latest.get(("pyzmq", "pushpull"), {}).get("msgs_s", 0)
+    rr_omq = latest.get(("pyomq", "reqrep"), {}).get("msgs_s", 0)
+    rr_pz = latest.get(("pyzmq", "reqrep"), {}).get("msgs_s", 0)
+    pp_ratio = pp_omq / pp_pz if pp_pz > 0 else 0
+    rr_ratio = rr_omq / rr_pz if rr_pz > 0 else 0
+
+    return "\n".join(
+        [
+            "|                    | pyomq     | pyzmq     | ratio     |",
+            "|--------------------|----------:|----------:|----------:|",
+            f"| PUSH/PULL msg/s    | {fmt_rate(pp_omq):>9} "
+            f"| {fmt_rate(pp_pz):>9} | **{pp_ratio:.2f}×** |",
+            f"| REQ/REP rt/s       | {fmt_int(rr_omq) + '/s':>9} "
+            f"| {fmt_int(rr_pz) + '/s':>9} | **{rr_ratio:.2f}×** |",
+        ]
+    )
+
+
+# ── README update ────────────────────────────────────────────────────
+
+
+def update_marker(content, marker, table):
+    pattern = rf"<!-- {marker}:START -->\n.*?\n<!-- {marker}:END -->"
+    replacement = f"<!-- {marker}:START -->\n{table}\n<!-- {marker}:END -->"
+    new_content, count = re.subn(pattern, replacement, content, flags=re.DOTALL)
+    if count == 0:
+        print(
+            f"ERROR: <!-- {marker}:START -->...<!-- {marker}:END --> "
+            f"markers not found in README.md"
+        )
+        sys.exit(1)
+    return new_content
+
+
+def update_readme_proxy_table():
+    proxy_table = build_proxy_table()
+    with open(README) as f:
+        content = f.read()
+    content = update_marker(content, "PROXY_PERF", proxy_table)
+    with open(README, "w") as f:
+        f.write(content)
+    print(f"\nUpdated {README}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--impl",
+        action="append",
+        dest="impls",
+        choices=["pyomq", "pyzmq"],
+        help="implementation(s) to benchmark (default: both)",
+    )
+    parser.add_argument(
+        "--quick", action="store_true", help="run a short local-only benchmark"
+    )
+    parser.add_argument(
+        "--sizes",
+        type=parse_sizes,
+        help="comma-separated message sizes, e.g. 8,128,1k,32k",
+    )
+    parser.add_argument("--rounds", type=int, help="measured rounds per cell")
+    parser.add_argument(
+        "--target-runtime",
+        type=float,
+        help="target throughput runtime per round in seconds",
+    )
+    parser.add_argument(
+        "--warmup-duration",
+        type=float,
+        help="PUSH/PULL throughput warmup duration per round in seconds",
+    )
+    parser.add_argument(
+        "--latency-warmup-duration",
+        type=float,
+        help="REQ/REP latency warmup duration in seconds",
+    )
+    parser.add_argument(
+        "--latency-duration",
+        type=float,
+        help="REQ/REP latency measurement duration in seconds",
+    )
+    parser.add_argument(
+        "--timeout", type=float, help="subprocess timeout per attempt in seconds"
+    )
+    parser.add_argument(
+        "--proxy-duration",
+        type=float,
+        help="native proxy throughput duration in seconds",
+    )
+    parser.add_argument(
+        "--no-save", action="store_true", help="print results without appending JSONL"
+    )
+    parser.add_argument(
+        "--no-docs", action="store_true", help="skip README and chart updates"
+    )
+    parser.add_argument(
+        "--chart-only",
+        action="store_true",
+        help="regenerate SVG from existing JSONL, no benchmarking",
+    )
+    parser.add_argument(
+        "--proxy-only",
+        action="store_true",
+        help="benchmark proxy only and update README proxy table",
+    )
+    args = parser.parse_args()
+
+    if args.chart_only and args.proxy_only:
+        parser.error("--chart-only and --proxy-only are mutually exclusive")
+    if args.chart_only and any(
+        value is not None
+        for value in (
+            args.sizes,
+            args.rounds,
+            args.target_runtime,
+            args.warmup_duration,
+            args.latency_warmup_duration,
+            args.latency_duration,
+            args.timeout,
+            args.proxy_duration,
+        )
+    ):
+        parser.error("--chart-only cannot be combined with benchmark knobs")
+    if args.chart_only and args.quick:
+        parser.error("--chart-only cannot be combined with --quick")
+
+    if args.chart_only:
+        print("Generating chart from existing JSONL...")
+        data = chart_data_from_jsonl()
+        gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
+        return
+
+    try:
+        configure_benchmark(args)
+    except argparse.ArgumentTypeError as e:
+        parser.error(str(e))
+
+    run_id = time.strftime("%Y-%m-%dT%H:%M:%S")
+    impls = args.impls or ["pyomq", "pyzmq"]
+    diagnostic_knobs = any(
+        value is not None
+        for value in (
+            args.sizes,
+            args.rounds,
+            args.target_runtime,
+            args.warmup_duration,
+            args.latency_warmup_duration,
+            args.latency_duration,
+            args.timeout,
+            args.proxy_duration,
+        )
+    )
+    save_enabled = not args.no_save and not args.quick and not diagnostic_knobs
+    docs_enabled = save_enabled and not args.no_docs
+
+    for impl in impls:
+        print(f"\n{'=' * 40}")
+        print(f"Benchmarking {impl}")
+        print(f"{'=' * 40}")
+
+        if args.proxy_only:
+            print(f"\n{impl} zmq.proxy() forwarding...")
+            proxy_pp, proxy_rr = run_proxy(impl)
+            if save_enabled:
+                print("\nSaving proxy results...")
+                save_proxy_results(run_id, impl, proxy_pp, proxy_rr)
+            continue
+
+        print(f"\n{impl} sync PUSH/PULL throughput...")
+        tp_inproc, tp_tcp = run_throughput(impl)
+
+        print(f"\n{impl} async PUSH/PULL throughput...")
+        atp_tcp = run_async_throughput(impl)
+
+        print(f"\n{impl} sync REQ/REP latency (TCP)...")
+        lat = run_latency(impl)
+
+        print(f"\n{impl} async REQ/REP latency (TCP)...")
+        alat = run_async_latency(impl)
+
+        print(f"\n{impl} zmq.proxy() forwarding...")
+        proxy_pp, proxy_rr = run_proxy(impl)
+
+        if save_enabled:
+            print("\nSaving results...")
+            save_results(
+                run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
+            )
+
+    if not save_enabled:
+        print("\nSkipping JSONL, README, and chart updates.")
+        return
+
+    if docs_enabled:
+        update_readme_proxy_table()
+
+    if args.proxy_only:
+        return
+
+    if docs_enabled:
+        print("\nGenerating chart...")
+        data = chart_data_from_jsonl()
+        gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
+
+
+def chart_data_from_jsonl():
+    latest = {}
+    for row in load_jsonl():
+        key = (row.get("impl"), row.get("pattern"), row.get("size"))
+        latest[key] = row
+    def tp(impl, size): return latest.get((impl, "pushpull", size), {}).get("messages_per_second", 0.0)
+    def lat(impl, size): return latest.get((impl, "reqrep", size), {}).get("p50_us", 0.0)
+    return {
+        "sync_omq_tp": [tp("omq", s) for s in SIZES],
+        "sync_pz_tp": [tp("netmq", s) for s in SIZES],
+        "async_omq_tp": [tp("omq-async", s) for s in SIZES],
+        "async_pz_tp": [tp("netmq-async", s) for s in SIZES],
+        "sync_omq_lat": [lat("omq", s) for s in latency_sizes_from(SIZES)],
+        "sync_pz_lat": [lat("netmq", s) for s in latency_sizes_from(SIZES)],
+        "async_omq_lat": [lat("omq-async", s) for s in latency_sizes_from(SIZES)],
+        "async_pz_lat": [lat("netmq-async", s) for s in latency_sizes_from(SIZES)],
+    }
+
+def _peer(impl, role, pattern, endpoint, size, duration, warmup):
+    project = os.path.join(os.path.dirname(__file__), "..", "bench", "Omq.Net.Bench.csproj")
+    return ["dotnet", "run", "--no-build", "--project", project, "--", pattern, impl, role, endpoint, str(size), str(duration), str(warmup)]
+
+def _read_ready(stream, timeout=30):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = stream.readline()
+        if line: return line.strip()
+        time.sleep(.01)
+    raise RuntimeError("benchmark peer not ready")
+
+def run_cell(impl, pattern, size, duration, warmup):
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0)); endpoint = f"tcp://127.0.0.1:{sock.getsockname()[1]}"
+    env = os.environ.copy(); env["LD_LIBRARY_PATH"] = f"{REPO_ROOT}/target/release:{env.get('LD_LIBRARY_PATH', '')}"
+    server_role, client_role = (("pull", "push") if pattern == "pushpull" else ("rep", "req"))
+    server = subprocess.Popen(_peer(impl, server_role, pattern, endpoint, size, duration, warmup), cwd=REPO_ROOT, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    client = None
+    try:
+        _read_ready(server.stdout)
+        client = subprocess.Popen(_peer(impl, client_role, pattern, endpoint, size, duration, warmup), cwd=REPO_ROOT, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _read_ready(client.stdout)
+        source = client.stdout if pattern == "reqrep" else server.stdout
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            line = source.readline()
+            if line.startswith("RESULT "): return json.loads(line[7:])
+            if not line: time.sleep(.01)
+        raise RuntimeError("benchmark result timeout")
+    finally:
+        for child in (client, server):
+            if child and child.poll() is None:
+                child.terminate()
+                try: child.wait(2)
+                except subprocess.TimeoutExpired: child.kill(); child.wait()
+
+def append_row(row):
+    os.makedirs(os.path.dirname(JSONL_FILE), exist_ok=True)
+    row["run_id"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+    with open(JSONL_FILE, "a") as stream: stream.write(json.dumps(row) + "\n")
+
+def main():
+    global SIZES, JSONL_FILE, CHART_DIR
+    parser = argparse.ArgumentParser(); parser.add_argument("--quick", action="store_true"); parser.add_argument("--chart-only", action="store_true"); parser.add_argument("--sizes"); parser.add_argument("--rounds", type=int, default=3); parser.add_argument("--no-build", action="store_true"); parser.add_argument("--impl", action="append", choices=["omq", "omq-async", "netmq", "netmq-async"])
+    args = parser.parse_args(); JSONL_FILE = os.path.join(os.path.expanduser("~"), ".cache", "omq.net", "bindings.jsonl"); CHART_DIR = os.path.join(os.path.dirname(__file__), "..", "doc", "charts")
+    SIZES = [int(x) for x in args.sizes.split(",")] if args.sizes else ([128, 1024, 4096] if args.quick else DEFAULT_SIZES)
+    if args.chart_only:
+        gen_combined_chart(chart_data_from_jsonl(), os.path.join(CHART_DIR, "bindings.svg")); return
+    if not args.no_build: subprocess.run(["dotnet", "build", "bindings/dotnet/bench/Omq.Net.Bench.csproj"], cwd=REPO_ROOT, check=True)
+    rounds = 1 if args.quick else args.rounds; duration = .5 if args.quick else TARGET_RUNTIME_S; warmup = .1 if args.quick else THROUGHPUT_WARMUP_S
+    for impl in (args.impl or ["omq", "omq-async", "netmq", "netmq-async"]):
+        for pattern in ("pushpull", "reqrep"):
+            for size in SIZES:
+                if pattern == "reqrep" and size > LATENCY_MAX_SIZE: continue
+                d, w = (0.5, .1) if args.quick and pattern == "reqrep" else (LATENCY_RUNTIME_S, LATENCY_WARMUP_S) if pattern == "reqrep" else (duration, warmup)
+                rows = [run_cell(impl, pattern, size, d, w) for _ in range(rounds)]; rows.sort(key=lambda r: r.get("p50_us", 0) if pattern == "reqrep" else r.get("messages_per_second", 0)); append_row(rows[len(rows)//2]); print(impl, pattern, size, rows[-1], flush=True)
+    gen_combined_chart(chart_data_from_jsonl(), os.path.join(CHART_DIR, "bindings.svg"))
+
+if __name__ == "__main__":
+    main()

--- a/bindings/dotnet/src/Async.cs
+++ b/bindings/dotnet/src/Async.cs
@@ -1,0 +1,101 @@
+namespace Omq;
+
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+public static class SocketAsyncExtensions
+{
+    public static async Task SendAsync(this Socket socket, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
+    {
+        var poller = new Poller(); poller.Add(socket, PollEvents.Writable);
+        while (!socket.TrySend(data.Span)) { cancellationToken.ThrowIfCancellationRequested(); await poller.WaitAsync(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false); }
+    }
+
+    public static async Task SendAsync(this Socket socket, Message message, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        byte[] encoded = Encode(message);
+        var state = new AsyncState();
+        GCHandle root = GCHandle.Alloc(state);
+        IntPtr task;
+        unsafe
+        {
+            fixed (byte* p = encoded)
+                task = Native.omq_socket_send_async(socket.NativeHandle, (IntPtr)p, (nuint)encoded.Length, Complete, GCHandle.ToIntPtr(root));
+        }
+        if (task == IntPtr.Zero)
+        {
+            root.Free();
+            throw new OmqException("send_async", Native.zmq_errno(), "native async send creation failed");
+        }
+        state.Task = task;
+        using var registration = cancellationToken.Register(static state => Native.omq_async_task_cancel((IntPtr)state!), task);
+        try
+        {
+            await state.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Keep the native handle and GC root alive until the cancelled
+            // Tokio task has observed cancellation and invoked the callback.
+            try { await state.Completion.Task.ConfigureAwait(false); } catch { }
+            throw;
+        }
+        finally
+        {
+            registration.Dispose();
+            Native.omq_async_task_free(task);
+            root.Free();
+        }
+    }
+
+    public static Task<Message> ReceiveAsync(this Socket socket, CancellationToken cancellationToken = default)
+    {
+        return ReceiveAsyncCore(socket, cancellationToken);
+    }
+
+    private static async Task<Message> ReceiveAsyncCore(Socket socket, CancellationToken cancellationToken)
+    {
+        var poller = new Poller(); poller.Add(socket, PollEvents.Readable);
+        Message? message;
+        while (!socket.TryReceive(out message))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await poller.WaitAsync(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+        }
+        return message!;
+    }
+
+    private static byte[] Encode(Message message)
+    {
+        int header = checked(8 + message.Parts.Count * 8);
+        int total = header + message.Parts.Sum(part => part.Length);
+        byte[] encoded = new byte[total];
+        BinaryPrimitives.WriteUInt64LittleEndian(encoded, (ulong)message.Parts.Count);
+        int offset = header;
+        for (int i = 0; i < message.Parts.Count; i++)
+        {
+            byte[] part = message.Parts[i];
+            BinaryPrimitives.WriteUInt64LittleEndian(encoded.AsSpan(8 + i * 8), (ulong)part.Length);
+            part.CopyTo(encoded, offset); offset += part.Length;
+        }
+        return encoded;
+    }
+
+    private sealed class AsyncState
+    {
+        internal readonly TaskCompletionSource<object?> Completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal IntPtr Task;
+    }
+
+    private static readonly Native.AsyncCallback Complete = CompleteNative;
+    private static void CompleteNative(IntPtr userdata, int status)
+    {
+        var root = GCHandle.FromIntPtr(userdata);
+        var state = (AsyncState)root.Target!;
+        while (state.Task == IntPtr.Zero) Thread.Yield();
+        if (status == 0) state.Completion.TrySetResult(null);
+        else if (status == 125) state.Completion.TrySetCanceled();
+        else state.Completion.TrySetException(new OmqException("send_async", status, "native async send failed"));
+    }
+}

--- a/bindings/dotnet/src/Context.cs
+++ b/bindings/dotnet/src/Context.cs
@@ -1,0 +1,98 @@
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace Omq;
+
+public sealed class Context : IDisposable
+{
+    private readonly object gate = new();
+    private readonly List<Socket> sockets = [];
+    private SafeContext? handle;
+    private bool shutdown;
+    public bool Closed => handle is null;
+
+    public Context(int ioThreads = 1)
+    {
+        if (ioThreads < 1) throw new ArgumentOutOfRangeException(nameof(ioThreads));
+        IntPtr raw = Native.zmq_ctx_new();
+        if (raw == IntPtr.Zero) throw new OmqException("ctx_new", Native.zmq_errno(), "context creation failed");
+        handle = new SafeContext(raw);
+        Errors.Check("ctx_set", Native.zmq_ctx_set(raw, 1, ioThreads));
+    }
+
+    private Context(IntPtr raw) => handle = new SafeContext(raw);
+    public static Context Instance(int ioThreads = 1) => new(ioThreads);
+
+    public static Context FromShareKey(ulong high, ulong low)
+    {
+        IntPtr raw = Native.omq_ctx_from_share_key(high, low);
+        if (raw == IntPtr.Zero) throw new OmqException("ctx_from_share_key", Native.zmq_errno(), "context import failed");
+        return new Context(raw);
+    }
+
+    public (ulong High, ulong Low) ShareKey()
+    {
+        lock (gate) { var h = Require(); Errors.Check("ctx_share_key", Native.omq_ctx_share_key(h, out ulong high, out ulong low)); return (high, low); }
+    }
+
+    public void SetOption(int option, int value) { lock (gate) Errors.Check("ctx_set", Native.zmq_ctx_set(Require(), option, value)); }
+    public int GetOption(int option) { lock (gate) return Native.zmq_ctx_get(Require(), option); }
+
+    public Socket CreateSocket(SocketType type, SocketOptions options = default)
+    {
+        lock (gate)
+        {
+            IntPtr ctx = Require();
+            IntPtr raw = Native.zmq_socket(ctx, (int)type);
+            if (raw == IntPtr.Zero) { int e = Native.zmq_errno(); throw new OmqException("socket", e, "socket creation failed"); }
+            var socket = new Socket(this, type, new SafeSocket(raw));
+            try { options.Apply(socket); sockets.Add(socket); return socket; }
+            catch { socket.Dispose(); throw; }
+        }
+    }
+
+    internal void Remove(Socket socket) { lock (gate) sockets.Remove(socket); }
+    private IntPtr Require() => handle?.DangerousGetHandle() is { } ptr && ptr != IntPtr.Zero ? ptr : throw new OmqClosedException();
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (handle is null) return;
+            if (!shutdown)
+            {
+                Errors.Check("ctx_shutdown", Native.zmq_ctx_shutdown(Require()));
+                shutdown = true;
+            }
+            foreach (Socket socket in sockets.ToArray()) socket.Dispose();
+            sockets.Clear();
+            handle.Dispose();
+            handle = null;
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    public void Destroy() => Dispose();
+
+    public void Shutdown()
+    {
+        lock (gate)
+        {
+            if (handle is null || shutdown) return;
+            Errors.Check("ctx_shutdown", Native.zmq_ctx_shutdown(Require()));
+            shutdown = true;
+        }
+    }
+
+    internal sealed class SafeContext : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeContext(IntPtr value) : base(true) => SetHandle(value);
+        protected override bool ReleaseHandle() => Native.zmq_ctx_term(handle) == 0;
+    }
+
+    internal sealed class SafeSocket : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeSocket(IntPtr value) : base(true) => SetHandle(value);
+        protected override bool ReleaseHandle() => Native.zmq_close(handle) == 0;
+    }
+}

--- a/bindings/dotnet/src/Errors.cs
+++ b/bindings/dotnet/src/Errors.cs
@@ -1,0 +1,24 @@
+using System.Runtime.InteropServices;
+
+namespace Omq;
+
+public class OmqException : Exception
+{
+    public int Errno { get; }
+    internal OmqException(string operation, int errno, string message) : base($"{operation}: {message} (errno {errno})") => Errno = errno;
+}
+
+public sealed class OmqAgainException : OmqException { internal OmqAgainException(string op, int e, string m) : base(op, e, m) { } }
+public sealed class OmqClosedException : ObjectDisposedException { internal OmqClosedException() : base("OMQ handle") { } }
+
+internal static class Errors
+{
+    internal static void Check(string operation, int result)
+    {
+        if (result >= 0) return;
+        int errno = Native.zmq_errno();
+        string message = Marshal.PtrToStringAnsi(Native.zmq_strerror(errno)) ?? "native error";
+        if (errno is 11 or 156384715) throw new OmqAgainException(operation, errno, message);
+        throw new OmqException(operation, errno, message);
+    }
+}

--- a/bindings/dotnet/src/Message.cs
+++ b/bindings/dotnet/src/Message.cs
@@ -1,0 +1,18 @@
+namespace Omq;
+
+public sealed class Message
+{
+    private readonly byte[][] parts;
+    public IReadOnlyList<byte[]> Parts => parts;
+    public int PartCount => parts.Length;
+    public byte[] this[int index] => parts[index];
+    public byte[] Data => parts.Length == 1 ? parts[0] : throw new InvalidOperationException("message is multipart");
+    public bool IsMultipart => parts.Length > 1;
+    public uint RoutingId { get; set; }
+    internal Message(byte[][] parts) => this.parts = parts;
+    public Message(byte[] data) : this(new[] { data.ToArray() }) { }
+    public Message(IEnumerable<ReadOnlyMemory<byte>> parts) : this(parts.Select(x => x.ToArray()).ToArray()) { }
+    public static Message Text(string text) => new(System.Text.Encoding.UTF8.GetBytes(text));
+    public Message Clone() => new(parts.Select(part => part.ToArray()).ToArray()) { RoutingId = RoutingId };
+    public override string ToString() => IsMultipart ? $"multipart({parts.Length})" : System.Text.Encoding.UTF8.GetString(Data);
+}

--- a/bindings/dotnet/src/Monitor.cs
+++ b/bindings/dotnet/src/Monitor.cs
@@ -1,0 +1,69 @@
+using System.Buffers.Binary;
+
+namespace Omq;
+
+public enum MonitorEventType : ushort
+{
+    Connected = 0x0001, ConnectDelayed = 0x0002, ConnectRetried = 0x0004,
+    Listening = 0x0008, BindFailed = 0x0010, Accepted = 0x0020,
+    AcceptFailed = 0x0040, Closed = 0x0080, CloseFailed = 0x0100,
+    Disconnected = 0x0200, MonitorStopped = 0x0400,
+    HandshakeFailed = 0x0800, HandshakeSucceeded = 0x1000
+}
+
+public readonly record struct MonitorEvent(MonitorEventType Type, uint Value, string Endpoint);
+
+public sealed class Monitor : IDisposable
+{
+    private readonly Socket source;
+    private readonly Socket reader;
+    private bool stopped;
+    private readonly CancellationTokenSource stopping = new();
+
+    internal Monitor(Context context, Socket source, int events)
+    {
+        this.source = source;
+        string endpoint = $"inproc://omq-dotnet-monitor-{Guid.NewGuid():N}";
+        source.EnableMonitor(endpoint, events);
+        reader = context.CreateSocket(SocketType.Pair, new SocketOptions { Linger = 0 });
+        reader.Connect(endpoint);
+    }
+
+    public MonitorEvent Receive(bool dontWait = false)
+    {
+        return Parse(reader.Receive(dontWait));
+    }
+
+    private static MonitorEvent Parse(Message message)
+    {
+        if (message.Parts.Count < 2 || message.Parts[0].Length < 6) throw new OmqException("monitor", 0, "malformed monitor event");
+        ReadOnlySpan<byte> header = message.Parts[0];
+        var type = (MonitorEventType)BinaryPrimitives.ReadUInt16LittleEndian(header);
+        uint value = BinaryPrimitives.ReadUInt32LittleEndian(header[2..]);
+        return new MonitorEvent(type, value, System.Text.Encoding.UTF8.GetString(message.Parts[1]));
+    }
+
+    public async Task<MonitorEvent> ReceiveAsync(CancellationToken cancellationToken = default)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, stopping.Token);
+        var poller = new Poller(); poller.Add(reader, PollEvents.Readable);
+        Message? message;
+        while (!reader.TryReceive(out message))
+        {
+            linked.Token.ThrowIfCancellationRequested();
+            await poller.WaitAsync(TimeSpan.FromMilliseconds(100), linked.Token).ConfigureAwait(false);
+        }
+        return Parse(message!);
+    }
+
+    public void Dispose()
+    {
+        if (stopped) return;
+        stopped = true;
+        stopping.Cancel();
+        try { source.DisableMonitor(); } catch (OmqClosedException) { }
+        reader.Dispose();
+        stopping.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/bindings/dotnet/src/Native.cs
+++ b/bindings/dotnet/src/Native.cs
@@ -1,0 +1,62 @@
+using System.Runtime.InteropServices;
+
+namespace Omq;
+
+internal static partial class Native
+{
+    private const string Library = "omq_zmq";
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void AsyncCallback(IntPtr userdata, int status);
+
+    [StructLayout(LayoutKind.Sequential, Size = 64)]
+    internal struct Message { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PollItem
+    {
+        internal IntPtr Socket;
+        internal int FileDescriptor;
+        internal short Events;
+        internal short Revents;
+    }
+
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr zmq_ctx_new();
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_ctx_set(IntPtr ctx, int option, int value);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_ctx_get(IntPtr ctx, int option);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_ctx_term(IntPtr ctx);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_ctx_shutdown(IntPtr ctx);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr zmq_socket(IntPtr ctx, int type);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_close(IntPtr socket);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_setsockopt(IntPtr socket, int option, IntPtr value, nuint length);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_getsockopt(IntPtr socket, int option, IntPtr value, ref nuint length);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_bind")] internal static extern int Bind(IntPtr socket, IntPtr endpoint);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_connect")] internal static extern int Connect(IntPtr socket, IntPtr endpoint);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_unbind")] internal static extern int Unbind(IntPtr socket, IntPtr endpoint);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_disconnect")] internal static extern int Disconnect(IntPtr socket, IntPtr endpoint);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_send(IntPtr socket, IntPtr buffer, nuint length, int flags);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_recv(IntPtr socket, IntPtr buffer, nuint length, int flags);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_init_size(ref Message message, nuint size);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_init(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_close(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_send(ref Message message, IntPtr socket, int flags);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_recv(ref Message message, IntPtr socket, int flags);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr zmq_msg_data(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern nuint zmq_msg_size(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_more(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern uint zmq_msg_routing_id(ref Message message);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_msg_set_routing_id(ref Message message, uint routingId);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_errno();
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr zmq_strerror(int error);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_poll(IntPtr items, int count, int timeout);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int omq_ctx_share_key(IntPtr ctx, out ulong high, out ulong low);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr omq_ctx_from_share_key(ulong high, ulong low);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_curve_keypair(IntPtr publicKey, IntPtr secretKey);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_curve_public(IntPtr publicKey, IntPtr secretKey);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_socket_monitor(IntPtr socket, IntPtr endpoint, int events);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_proxy(IntPtr frontend, IntPtr backend, IntPtr capture);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_proxy_steerable(IntPtr frontend, IntPtr backend, IntPtr capture, IntPtr control);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int zmq_device(int device, IntPtr frontend, IntPtr backend);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern IntPtr omq_socket_send_async(IntPtr socket, IntPtr encoded, nuint encodedLength, AsyncCallback callback, IntPtr userdata);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void omq_async_task_cancel(IntPtr task);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void omq_async_task_free(IntPtr task);
+}

--- a/bindings/dotnet/src/Options.cs
+++ b/bindings/dotnet/src/Options.cs
@@ -1,0 +1,159 @@
+namespace Omq;
+
+public static class ContextOption
+{
+    public const int IoThreads = 1, MaxSockets = 2, SocketLimit = 3, ThreadPriority = 3;
+    public const int ThreadSchedulerPolicy = 4, MaxMessageSize = 5, MessageSize = 6;
+    public const int ThreadAffinityCpuAdd = 7, ThreadAffinityCpuRemove = 8, ThreadNamePrefix = 9, ZeroCopyReceive = 10;
+    public const int Blocky = 70;
+}
+
+public static class SocketOption
+{
+    public const int Affinity = 4, RoutingId = 5, Identity = RoutingId, Subscribe = 6, Unsubscribe = 7;
+    public const int Rate = 8, RecoveryInterval = 9, SendBuffer = 11, ReceiveBuffer = 12, ReceiveMore = 13, FileDescriptor = 14;
+    public const int Events = 15, Type = 16, Linger = 17, ReconnectInterval = 18;
+    public const int Backlog = 19, ReconnectIntervalMax = 21, MaxMessageSize = 22, MulticastHops = 25;
+    public const int SendHwm = 23, ReceiveHwm = 24, ReceiveTimeout = 27, SendTimeout = 28;
+    public const int LastEndpoint = 32, RouterMandatory = 33, TcpKeepalive = 34;
+    public const int TcpKeepaliveCount = 35, TcpKeepaliveIdle = 36, TcpKeepaliveInterval = 37;
+    public const int TcpAcceptFilter = 38, Immediate = 39, XPubVerbose = 40, RouterRaw = 41, Ipv6 = 42, Mechanism = 43;
+    public const int PlainServer = 44, PlainUsername = 45, PlainPassword = 46;
+    public const int CurveServer = 47, CurvePublicKey = 48, CurveSecretKey = 49;
+    public const int CurveServerKey = 50, ProbeRouter = 51, ReqCorrelate = 52, ReqRelaxed = 53;
+    public const int Conflate = 54, ZapDomain = 55, RouterHandover = 56, Tos = 57, IpcFilterPid = 58, IpcFilterUid = 59, IpcFilterGid = 60, ConnectRoutingId = 61;
+    public const int GssapiServer = 62, GssapiPrincipal = 63, GssapiServicePrincipal = 64, GssapiPlaintext = 65;
+    public const int HandshakeInterval = 66, SocksProxy = 68, XPubNoDrop = 69, Blocky = 70, XPubManual = 71;
+    public const int XPubWelcomeMessage = 72, StreamNotify = 73, InvertMatching = 74;
+    public const int HeartbeatInterval = 75, HeartbeatTtl = 76;
+    public const int HeartbeatTimeout = 77, XPubVerboser = 78, ConnectTimeout = 79, TcpMaxRt = 80, ThreadSafe = 81;
+    public const int MulticastMaxTpdu = 84, VmciBufferSize = 85, VmciBufferMinSize = 86, VmciBufferMaxSize = 87, VmciConnectTimeout = 88, UseFd = 89;
+    public const int GssapiPrincipalNameType = 90, GssapiServicePrincipalNameType = 91, BindToDevice = 92, ZapEnforceDomain = 93, LoopbackFastPath = 94;
+    public const int Metadata = 95, MulticastLoop = 96, RouterNotify = 97, XPubManualLastValue = 98;
+    public const int SocksUsername = 99, SocksPassword = 100, InBatchSize = 101, OutBatchSize = 102;
+    public const int WssKeyPem = 103, WssCertPem = 104, WssTrustPem = 105, WssHostname = 106, WssTrustSystem = 107;
+    public const int OnlyFirstSubscribe = 108, ReconnectStop = 109, HelloMessage = 110, DisconnectMessage = 111;
+    public const int Priority = 112, BusyPoll = 113, HiccupMessage = 114, XSubVerboseUnsubscribe = 115, TopicsCount = 116;
+    public const int NormMode = 117, NormUnicastNack = 118, NormBufferSize = 119, NormSegmentSize = 120;
+    public const int NormBlockSize = 121, NormNumParity = 122, NormNumAutoParity = 123, NormPush = 124, ArenaThreshold = 10001;
+}
+
+public readonly record struct SocketOptions
+{
+    public long? Affinity { get; init; }
+    public int? SendHwm { get; init; }
+    public int? ReceiveHwm { get; init; }
+    public int? SendBuffer { get; init; }
+    public int? ReceiveBuffer { get; init; }
+    public int? Linger { get; init; }
+    public TimeSpan? SendTimeout { get; init; }
+    public TimeSpan? ReceiveTimeout { get; init; }
+    public int? Rate { get; init; }
+    public int? RecoveryInterval { get; init; }
+    public int? Backlog { get; init; }
+    public int? MulticastHops { get; init; }
+    public byte[]? Identity { get; init; }
+    public int? ReconnectInterval { get; init; }
+    public int? ReconnectIntervalMax { get; init; }
+    public long? MaxMessageSize { get; init; }
+    public bool? RouterMandatory { get; init; }
+    public bool? Immediate { get; init; }
+    public bool? Ipv6 { get; init; }
+    public bool? Conflate { get; init; }
+    public bool? RouterRaw { get; init; }
+    public bool? ProbeRouter { get; init; }
+    public bool? ReqCorrelate { get; init; }
+    public bool? ReqRelaxed { get; init; }
+    public bool? RouterHandover { get; init; }
+    public bool? XPubVerbose { get; init; }
+    public bool? XPubNoDrop { get; init; }
+    public bool? XPubManual { get; init; }
+    public bool? XPubVerboser { get; init; }
+    public bool? InvertMatching { get; init; }
+    public bool? StreamNotify { get; init; }
+    public bool? OnlyFirstSubscribe { get; init; }
+    public bool? MulticastLoop { get; init; }
+    public bool? ZapEnforceDomain { get; init; }
+    public int? ConnectTimeout { get; init; }
+    public int? TcpMaxRt { get; init; }
+    public string? ZapDomain { get; init; }
+    public string? ConnectRoutingId { get; init; }
+    public string? GssapiPrincipal { get; init; }
+    public string? GssapiServicePrincipal { get; init; }
+    public string? SocksProxy { get; init; }
+    public string? SocksUsername { get; init; }
+    public string? SocksPassword { get; init; }
+    public string? WssKeyPem { get; init; }
+    public string? WssCertPem { get; init; }
+    public string? WssTrustPem { get; init; }
+    public string? WssHostname { get; init; }
+    public bool? WssTrustSystem { get; init; }
+    public int? HeartbeatInterval { get; init; }
+    public int? HeartbeatTtl { get; init; }
+    public int? HeartbeatTimeout { get; init; }
+    public int? TcpKeepalive { get; init; }
+    public int? TcpKeepaliveCount { get; init; }
+    public int? TcpKeepaliveIdle { get; init; }
+    public int? TcpKeepaliveInterval { get; init; }
+
+    internal void Apply(Socket socket)
+    {
+        if (Affinity is { } affinity) socket.SetOption(SocketOption.Affinity, affinity);
+        if (SendHwm is { } snd) socket.SetOption(SocketOption.SendHwm, snd);
+        if (ReceiveHwm is { } rcv) socket.SetOption(SocketOption.ReceiveHwm, rcv);
+        if (Linger is { } linger) socket.SetOption(SocketOption.Linger, linger);
+        if (SendTimeout is { } st) socket.SetOption(SocketOption.SendTimeout, ToMilliseconds(st));
+        if (ReceiveTimeout is { } rt) socket.SetOption(SocketOption.ReceiveTimeout, ToMilliseconds(rt));
+        if (SendBuffer is { } sndBuf) socket.SetOption(SocketOption.SendBuffer, sndBuf);
+        if (ReceiveBuffer is { } rcvBuf) socket.SetOption(SocketOption.ReceiveBuffer, rcvBuf);
+        if (Rate is { } rate) socket.SetOption(SocketOption.Rate, rate);
+        if (RecoveryInterval is { } recovery) socket.SetOption(SocketOption.RecoveryInterval, recovery);
+        if (Backlog is { } backlog) socket.SetOption(SocketOption.Backlog, backlog);
+        if (MulticastHops is { } hops) socket.SetOption(SocketOption.MulticastHops, hops);
+        if (Identity is { } identity) socket.SetOption(SocketOption.RoutingId, identity);
+        if (ReconnectInterval is { } reconnect) socket.SetOption(SocketOption.ReconnectInterval, reconnect);
+        if (ReconnectIntervalMax is { } reconnectMax) socket.SetOption(SocketOption.ReconnectIntervalMax, reconnectMax);
+        if (MaxMessageSize is { } maxMessage) socket.SetOption(SocketOption.MaxMessageSize, maxMessage);
+        if (RouterMandatory is { } mandatory) socket.SetOption(SocketOption.RouterMandatory, mandatory ? 1 : 0);
+        if (Immediate is { } immediate) socket.SetOption(SocketOption.Immediate, immediate ? 1 : 0);
+        if (Ipv6 is { } ipv6) socket.SetOption(SocketOption.Ipv6, ipv6 ? 1 : 0);
+        if (Conflate is { } conflate) socket.SetOption(SocketOption.Conflate, conflate ? 1 : 0);
+        if (RouterRaw is { } raw) socket.SetOption(SocketOption.RouterRaw, raw ? 1 : 0);
+        if (ProbeRouter is { } probe) socket.SetOption(SocketOption.ProbeRouter, probe ? 1 : 0);
+        if (ReqCorrelate is { } correlate) socket.SetOption(SocketOption.ReqCorrelate, correlate ? 1 : 0);
+        if (ReqRelaxed is { } relaxed) socket.SetOption(SocketOption.ReqRelaxed, relaxed ? 1 : 0);
+        if (RouterHandover is { } handover) socket.SetOption(SocketOption.RouterHandover, handover ? 1 : 0);
+        if (XPubVerbose is { } verbose) socket.SetOption(SocketOption.XPubVerbose, verbose ? 1 : 0);
+        if (XPubNoDrop is { } noDrop) socket.SetOption(SocketOption.XPubNoDrop, noDrop ? 1 : 0);
+        if (XPubManual is { } manual) socket.SetOption(SocketOption.XPubManual, manual ? 1 : 0);
+        if (XPubVerboser is { } verboser) socket.SetOption(SocketOption.XPubVerboser, verboser ? 1 : 0);
+        if (InvertMatching is { } invert) socket.SetOption(SocketOption.InvertMatching, invert ? 1 : 0);
+        if (StreamNotify is { } notify) socket.SetOption(SocketOption.StreamNotify, notify ? 1 : 0);
+        if (OnlyFirstSubscribe is { } onlyFirst) socket.SetOption(SocketOption.OnlyFirstSubscribe, onlyFirst ? 1 : 0);
+        if (MulticastLoop is { } loop) socket.SetOption(SocketOption.MulticastLoop, loop ? 1 : 0);
+        if (ZapEnforceDomain is { } enforce) socket.SetOption(SocketOption.ZapEnforceDomain, enforce ? 1 : 0);
+        if (ConnectTimeout is { } connectTimeout) socket.SetOption(SocketOption.ConnectTimeout, connectTimeout);
+        if (TcpMaxRt is { } tcpMaxRt) socket.SetOption(SocketOption.TcpMaxRt, tcpMaxRt);
+        if (ZapDomain is { } zapDomain) socket.SetOption(SocketOption.ZapDomain, zapDomain);
+        if (ConnectRoutingId is { } connectRoutingId) socket.SetOption(SocketOption.ConnectRoutingId, connectRoutingId);
+        if (GssapiPrincipal is { } principal) socket.SetOption(SocketOption.GssapiPrincipal, principal);
+        if (GssapiServicePrincipal is { } service) socket.SetOption(SocketOption.GssapiServicePrincipal, service);
+        if (SocksProxy is { } socksProxy) socket.SetOption(SocketOption.SocksProxy, socksProxy);
+        if (SocksUsername is { } socksUsername) socket.SetOption(SocketOption.SocksUsername, socksUsername);
+        if (SocksPassword is { } socksPassword) socket.SetOption(SocketOption.SocksPassword, socksPassword);
+        if (WssKeyPem is { } wssKey) socket.SetOption(SocketOption.WssKeyPem, wssKey);
+        if (WssCertPem is { } wssCert) socket.SetOption(SocketOption.WssCertPem, wssCert);
+        if (WssTrustPem is { } wssTrust) socket.SetOption(SocketOption.WssTrustPem, wssTrust);
+        if (WssHostname is { } hostname) socket.SetOption(SocketOption.WssHostname, hostname);
+        if (WssTrustSystem is { } trustSystem) socket.SetOption(SocketOption.WssTrustSystem, trustSystem ? 1 : 0);
+        if (HeartbeatInterval is { } heartbeat) socket.SetOption(SocketOption.HeartbeatInterval, heartbeat);
+        if (HeartbeatTtl is { } heartbeatTtl) socket.SetOption(SocketOption.HeartbeatTtl, heartbeatTtl);
+        if (HeartbeatTimeout is { } heartbeatTimeout) socket.SetOption(SocketOption.HeartbeatTimeout, heartbeatTimeout);
+        if (TcpKeepalive is { } keepalive) socket.SetOption(SocketOption.TcpKeepalive, keepalive);
+        if (TcpKeepaliveCount is { } keepaliveCount) socket.SetOption(SocketOption.TcpKeepaliveCount, keepaliveCount);
+        if (TcpKeepaliveIdle is { } keepaliveIdle) socket.SetOption(SocketOption.TcpKeepaliveIdle, keepaliveIdle);
+        if (TcpKeepaliveInterval is { } keepaliveInterval) socket.SetOption(SocketOption.TcpKeepaliveInterval, keepaliveInterval);
+    }
+
+    private static int ToMilliseconds(TimeSpan value) => checked((int)value.TotalMilliseconds);
+}

--- a/bindings/dotnet/src/Poller.cs
+++ b/bindings/dotnet/src/Poller.cs
@@ -1,0 +1,79 @@
+namespace Omq;
+
+[Flags]
+public enum PollEvents { None = 0, Readable = 1, Writable = 2, Error = 4 }
+public readonly record struct PollResult(Socket Socket, PollEvents Events);
+
+public sealed class Poller : IDisposable
+{
+    private readonly object gate = new();
+    private readonly List<(Socket Socket, PollEvents Events)> entries = [];
+    public IReadOnlyList<Socket> Sockets { get { lock (gate) return entries.Select(x => x.Socket).ToArray(); } }
+    public void Add(Socket socket, PollEvents events = PollEvents.Readable) { lock (gate) entries.Add((socket, events)); }
+    public bool Remove(Socket socket) { lock (gate) return entries.RemoveAll(x => ReferenceEquals(x.Socket, socket)) != 0; }
+
+    public IReadOnlyList<PollResult> Wait() => Wait(Timeout.InfiniteTimeSpan);
+
+    public IReadOnlyList<PollResult> Wait(TimeSpan timeout)
+    {
+        (Socket Socket, PollEvents Events)[] snapshot;
+        lock (gate) snapshot = entries.ToArray();
+        if (snapshot.Length == 0)
+        {
+            if (timeout > TimeSpan.Zero) Thread.Sleep(timeout);
+            return [];
+        }
+        using var leases = new LeaseSet(snapshot.Select(x => x.Socket));
+        var items = new Native.PollItem[snapshot.Length];
+        for (int i = 0; i < items.Length; i++)
+            items[i] = new Native.PollItem { Socket = leases[i].Pointer, FileDescriptor = -1, Events = (short)snapshot[i].Events };
+        int milliseconds = checked((int)Math.Clamp(timeout.TotalMilliseconds, -1, int.MaxValue));
+        unsafe { fixed (Native.PollItem* p = items) Errors.Check("poll", Native.zmq_poll((IntPtr)p, items.Length, milliseconds)); }
+        var ready = new List<PollResult>();
+        for (int i = 0; i < items.Length; i++)
+        {
+            PollEvents actual = (PollEvents)items[i].Revents & (PollEvents.Readable | PollEvents.Writable | PollEvents.Error);
+            if (actual != PollEvents.None) ready.Add(new PollResult(snapshot[i].Socket, actual));
+        }
+        return ready;
+    }
+
+    public Task<IReadOnlyList<PollResult>> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>
+        Task.Run(() => WaitCancellable(timeout, cancellationToken), cancellationToken);
+
+    private IReadOnlyList<PollResult> WaitCancellable(TimeSpan timeout, CancellationToken token)
+    {
+        DateTime deadline = timeout == default ? DateTime.MaxValue : DateTime.UtcNow + timeout;
+        while (true)
+        {
+            token.ThrowIfCancellationRequested();
+            TimeSpan slice = deadline == DateTime.MaxValue ? TimeSpan.FromMilliseconds(100) : deadline - DateTime.UtcNow;
+            if (slice <= TimeSpan.Zero) return [];
+            var ready = Wait(slice > TimeSpan.FromMilliseconds(100) ? TimeSpan.FromMilliseconds(100) : slice);
+            if (ready.Count != 0 || DateTime.UtcNow >= deadline) return ready;
+        }
+    }
+
+    public void Dispose() { lock (gate) entries.Clear(); }
+
+    private sealed class LeaseSet : IDisposable
+    {
+        private readonly Socket.NativeLease[] leases;
+        internal LeaseSet(IEnumerable<Socket> sockets)
+        {
+            var acquired = new List<Socket.NativeLease>();
+            try
+            {
+                foreach (var socket in sockets) acquired.Add(socket.AcquireNativeHandle());
+                leases = acquired.ToArray();
+            }
+            catch
+            {
+                foreach (var lease in acquired) lease.Dispose();
+                throw;
+            }
+        }
+        internal Socket.NativeLease this[int index] => leases[index];
+        public void Dispose() { foreach (var lease in leases) lease.Dispose(); }
+    }
+}

--- a/bindings/dotnet/src/Proxy.cs
+++ b/bindings/dotnet/src/Proxy.cs
@@ -1,0 +1,14 @@
+namespace Omq;
+
+/// Blocking built-in proxy/device helpers. Run them on a dedicated thread.
+public static class Proxy
+{
+    public static void Run(Socket frontend, Socket backend, Socket? capture = null) =>
+        Errors.Check("proxy", Native.zmq_proxy(frontend.NativeHandle, backend.NativeHandle, capture?.NativeHandle ?? IntPtr.Zero));
+
+    public static void RunSteerable(Socket frontend, Socket backend, Socket? capture, Socket control) =>
+        Errors.Check("proxy_steerable", Native.zmq_proxy_steerable(frontend.NativeHandle, backend.NativeHandle, capture?.NativeHandle ?? IntPtr.Zero, control.NativeHandle));
+
+    public static void Device(int deviceType, Socket frontend, Socket backend) =>
+        Errors.Check("device", Native.zmq_device(deviceType, frontend.NativeHandle, backend.NativeHandle));
+}

--- a/bindings/dotnet/src/Security.cs
+++ b/bindings/dotnet/src/Security.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+namespace Omq;
+
+public readonly record struct CurveKeyPair(string PublicKey, string SecretKey);
+
+public static class Curve
+{
+    public static CurveKeyPair GenerateKeyPair()
+    {
+        IntPtr publicKey = Marshal.AllocHGlobal(41), secretKey = Marshal.AllocHGlobal(41);
+        try
+        {
+            Errors.Check("curve_keypair", Native.zmq_curve_keypair(publicKey, secretKey));
+            return new CurveKeyPair(Marshal.PtrToStringAnsi(publicKey)!, Marshal.PtrToStringAnsi(secretKey)!);
+        }
+        finally { Marshal.FreeHGlobal(publicKey); Marshal.FreeHGlobal(secretKey); }
+    }
+
+    public static string PublicKey(string secretKey)
+    {
+        IntPtr publicKey = Marshal.AllocHGlobal(41), secret = Marshal.StringToCoTaskMemUTF8(secretKey);
+        try { Errors.Check("curve_public", Native.zmq_curve_public(publicKey, secret)); return Marshal.PtrToStringAnsi(publicKey)!; }
+        finally { Marshal.FreeHGlobal(publicKey); Marshal.FreeCoTaskMem(secret); }
+    }
+}

--- a/bindings/dotnet/src/Socket.cs
+++ b/bindings/dotnet/src/Socket.cs
@@ -1,0 +1,192 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace Omq;
+
+public sealed class Socket : IDisposable
+{
+    private readonly Context owner;
+    private readonly object gate = new();
+    private Context.SafeSocket? handle;
+    public SocketType Type { get; }
+    public bool Closed => handle is null;
+    public int FileDescriptor => GetInt32(SocketOption.FileDescriptor);
+
+    internal Socket(Context owner, SocketType type, Context.SafeSocket handle) { this.owner = owner; Type = type; this.handle = handle; }
+    private IntPtr Require() => handle?.DangerousGetHandle() is { } ptr && ptr != IntPtr.Zero ? ptr : throw new OmqClosedException();
+    internal IntPtr NativeHandle { get { lock (gate) return Require(); } }
+    internal NativeLease AcquireNativeHandle()
+    {
+        lock (gate)
+        {
+            var current = handle ?? throw new OmqClosedException();
+            bool success = false;
+            current.DangerousAddRef(ref success);
+            if (!success) throw new OmqClosedException();
+            return new NativeLease(current, current.DangerousGetHandle());
+        }
+    }
+
+    public void SetOption(int option, int value) => SetOption(option, BitConverter.GetBytes(value));
+    public void SetOption(int option, long value) => SetOption(option, BitConverter.GetBytes(value));
+    public void SetOption(int option, ReadOnlySpan<byte> value)
+    {
+        lock (gate) { IntPtr socket = Require(); byte[] copy = value.ToArray(); unsafe { fixed (byte* p = copy) Errors.Check("setsockopt", Native.zmq_setsockopt(socket, option, (IntPtr)p, (nuint)copy.Length)); } }
+    }
+    public void SetOption(int option, string value) => SetOption(option, Encoding.UTF8.GetBytes(value));
+    public int GetInt32(int option)
+    {
+        lock (gate) { int value = 0; nuint length = sizeof(int); unsafe { Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)(&value), ref length)); } return value; }
+    }
+    public long GetInt64(int option)
+    {
+        lock (gate) { long value = 0; nuint length = sizeof(long); unsafe { Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)(&value), ref length)); } return value; }
+    }
+    public byte[] GetBytes(int option, int capacity = 1024)
+    {
+        lock (gate)
+        {
+            byte[] value = new byte[capacity]; nuint length = (nuint)value.Length;
+            unsafe { fixed (byte* p = value) Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)p, ref length)); }
+            return value[..checked((int)length)];
+        }
+    }
+    public string GetString(int option, int capacity = 1024)
+    {
+        lock (gate)
+        {
+            byte[] value = new byte[capacity]; nuint length = (nuint)value.Length;
+            unsafe { fixed (byte* p = value) Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)p, ref length)); }
+            return Encoding.UTF8.GetString(value, 0, checked((int)length)).TrimEnd('\0');
+        }
+    }
+    public void Subscribe(ReadOnlySpan<byte> prefix) => SetOption(SocketOption.Subscribe, prefix);
+    public void Subscribe(string prefix) => Subscribe(Encoding.UTF8.GetBytes(prefix));
+    public void Unsubscribe(ReadOnlySpan<byte> prefix) => SetOption(SocketOption.Unsubscribe, prefix);
+    public void Unsubscribe(string prefix) => Unsubscribe(Encoding.UTF8.GetBytes(prefix));
+    public void ConfigurePlainServer(string username = "", string password = "") { _ = username; _ = password; SetOption(SocketOption.PlainServer, 1); }
+    public void ConfigurePlainClient(string username, string password) { SetOption(SocketOption.PlainUsername, username); SetOption(SocketOption.PlainPassword, password); }
+    public void ConfigureCurveServer(string publicKey, string secretKey) { _ = publicKey; SetOption(SocketOption.CurveServer, 1); SetOption(SocketOption.CurveSecretKey, secretKey); }
+    public void ConfigureCurveClient(string publicKey, string secretKey, string serverPublicKey) { SetOption(SocketOption.CurvePublicKey, publicKey); SetOption(SocketOption.CurveSecretKey, secretKey); SetOption(SocketOption.CurveServerKey, serverPublicKey); }
+    public Monitor Monitor(int events = 0xFFFF) => new(owner, this, events);
+    public void Join(string group) => EndpointCall("join", group, NativeJoin);
+    public void Leave(string group) => EndpointCall("leave", group, NativeLeave);
+    public string Bind(string endpoint)
+    {
+        EndpointCall("bind", endpoint, NativeBind);
+        return endpoint.EndsWith(":0", StringComparison.Ordinal) ? GetString(SocketOption.LastEndpoint) : endpoint;
+    }
+    public void Connect(string endpoint) => EndpointCall("connect", endpoint, NativeConnect);
+    public void Unbind(string endpoint) => EndpointCall("unbind", endpoint, NativeUnbind);
+    public void Disconnect(string endpoint) => EndpointCall("disconnect", endpoint, NativeDisconnect);
+
+    private delegate int EndpointFn(IntPtr socket, IntPtr text);
+    private bool EndpointCall(string operation, string endpoint, EndpointFn fn)
+    {
+        lock (gate) { using var text = new Utf8(endpoint); Errors.Check(operation, fn(Require(), text.Pointer)); return true; }
+    }
+    private static int NativeBind(IntPtr s, IntPtr e) => Native.Bind(s, e);
+    private static int NativeConnect(IntPtr s, IntPtr e) => Native.Connect(s, e);
+    private static int NativeUnbind(IntPtr s, IntPtr e) => Native.Unbind(s, e);
+    private static int NativeDisconnect(IntPtr s, IntPtr e) => Native.Disconnect(s, e);
+    private static int NativeJoin(IntPtr s, IntPtr e) => NativeJoinImpl(s, e);
+    private static int NativeLeave(IntPtr s, IntPtr e) => NativeLeaveImpl(s, e);
+    [DllImport("omq_zmq", CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_join")] private static extern int NativeJoinImpl(IntPtr s, IntPtr e);
+    [DllImport("omq_zmq", CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_leave")] private static extern int NativeLeaveImpl(IntPtr s, IntPtr e);
+
+    public void Send(ReadOnlySpan<byte> data, bool more = false, bool dontWait = false)
+    {
+        lock (gate) { byte[] copy = data.ToArray(); unsafe { fixed (byte* p = copy) Errors.Check("send", Native.zmq_send(Require(), (IntPtr)p, (nuint)copy.Length, Flags(more, dontWait))); } }
+    }
+    public void SendText(string text, bool more = false, bool dontWait = false) => Send(Encoding.UTF8.GetBytes(text), more, dontWait);
+    public void Send(Message message, bool dontWait = false)
+    {
+        lock (gate)
+        {
+            for (int i = 0; i < message.Parts.Count; i++) SendPart(message.Parts[i], i + 1 < message.Parts.Count, dontWait, i == 0 ? message.RoutingId : 0);
+        }
+    }
+    public void SendMultipart(IEnumerable<ReadOnlyMemory<byte>> parts, bool dontWait = false) => Send(new Message(parts), dontWait);
+    public void SendMultipart(params byte[][] parts) => Send(new Message(parts.Select(x => (ReadOnlyMemory<byte>)x)), false);
+    private void SendPart(byte[] data, bool more, bool dontWait, uint routingId = 0)
+    {
+        Native.Message msg = new();
+        Errors.Check("msg_init_size", Native.zmq_msg_init_size(ref msg, (nuint)data.Length));
+        try { Marshal.Copy(data, 0, Native.zmq_msg_data(ref msg), data.Length); if (routingId != 0) Errors.Check("msg_set_routing_id", Native.zmq_msg_set_routing_id(ref msg, routingId)); Errors.Check("msg_send", Native.zmq_msg_send(ref msg, Require(), Flags(more, dontWait))); }
+        finally { Native.zmq_msg_close(ref msg); }
+    }
+
+    public Message Receive(bool dontWait = false)
+    {
+        lock (gate)
+        {
+            var parts = new List<byte[]>(); uint routingId = 0;
+            while (true)
+            {
+                Native.Message msg = new();
+                Errors.Check("msg_init", Native.zmq_msg_init(ref msg));
+                try { Errors.Check("msg_recv", Native.zmq_msg_recv(ref msg, Require(), dontWait ? 1 : 0)); int size = checked((int)Native.zmq_msg_size(ref msg)); byte[] data = new byte[size]; if (size != 0) Marshal.Copy(Native.zmq_msg_data(ref msg), data, 0, size); if (parts.Count == 0) routingId = Native.zmq_msg_routing_id(ref msg); parts.Add(data); if (Native.zmq_msg_more(ref msg) == 0) break; }
+                finally { Native.zmq_msg_close(ref msg); }
+            }
+            return new Message(parts.ToArray()) { RoutingId = routingId };
+        }
+    }
+    public string ReceiveText(bool dontWait = false) => Encoding.UTF8.GetString(Receive(dontWait).Data);
+    public void SendString(string text, bool dontWait = false) => SendText(text, dontWait: dontWait);
+    public string ReceiveString(bool dontWait = false) => ReceiveText(dontWait);
+    public void SendJson<T>(T value, bool dontWait = false, bool more = false) => Send(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value)), more, dontWait);
+    public T? ReceiveJson<T>(bool dontWait = false) => JsonSerializer.Deserialize<T>(Receive(dontWait).Data);
+    public IReadOnlyList<PollResult> Poll(TimeSpan timeout, PollEvents events = PollEvents.Readable)
+    {
+        using var poller = new Poller();
+        poller.Add(this, events);
+        return poller.Wait(timeout);
+    }
+    public bool TrySend(ReadOnlySpan<byte> data)
+    {
+        try { Send(data, dontWait: true); return true; }
+        catch (OmqAgainException) { return false; }
+    }
+    public bool TrySend(Message message)
+    {
+        try { Send(message, dontWait: true); return true; }
+        catch (OmqAgainException) { return false; }
+    }
+    public IReadOnlyList<byte[]> ReceiveMultipart(bool dontWait = false) => Receive(dontWait).Parts;
+    public bool TryReceive(out Message? message)
+    {
+        try { message = Receive(dontWait: true); return true; }
+        catch (OmqAgainException) { message = null; return false; }
+    }
+    public byte[] ReceiveInto(Span<byte> buffer, bool dontWait = false)
+    {
+        lock (gate) { byte[] copy = new byte[buffer.Length]; unsafe { fixed (byte* p = copy) { int n = Native.zmq_recv(Require(), (IntPtr)p, (nuint)copy.Length, dontWait ? 1 : 0); Errors.Check("recv", n); copy.AsSpan(0, n).CopyTo(buffer); return copy[..n]; } } }
+    }
+    private static int Flags(bool more, bool dontWait) => (more ? 2 : 0) | (dontWait ? 1 : 0);
+
+    public void Dispose()
+    {
+        lock (gate) { if (handle is null) return; handle.Dispose(); handle = null; }
+        owner.Remove(this); GC.SuppressFinalize(this);
+    }
+
+    internal void EnableMonitor(string endpoint, int events)
+    {
+        lock (gate) { IntPtr text = Marshal.StringToCoTaskMemUTF8(endpoint); try { Errors.Check("socket_monitor", Native.zmq_socket_monitor(Require(), text, events)); } finally { Marshal.FreeCoTaskMem(text); } }
+    }
+    internal void DisableMonitor()
+    {
+        lock (gate) { Errors.Check("socket_monitor_stop", Native.zmq_socket_monitor(Require(), IntPtr.Zero, 0)); }
+    }
+
+    private sealed class Utf8 : IDisposable { public IntPtr Pointer { get; } public Utf8(string value) => Pointer = Marshal.StringToCoTaskMemUTF8(value); public void Dispose() => Marshal.FreeCoTaskMem(Pointer); }
+
+    internal sealed class NativeLease : IDisposable
+    {
+        private Context.SafeSocket? handle;
+        internal IntPtr Pointer { get; }
+        internal NativeLease(Context.SafeSocket handle, IntPtr pointer) { this.handle = handle; Pointer = pointer; }
+        public void Dispose() { var current = Interlocked.Exchange(ref handle, null); if (current is not null) current.DangerousRelease(); }
+    }
+}

--- a/bindings/dotnet/src/SocketType.cs
+++ b/bindings/dotnet/src/SocketType.cs
@@ -1,0 +1,9 @@
+namespace Omq;
+
+public enum SocketType
+{
+    Pair = 0, Pub = 1, Sub = 2, Req = 3, Rep = 4, Dealer = 5,
+    Router = 6, Pull = 7, Push = 8, XPub = 9, XSub = 10, Stream = 11,
+    Server = 12, Client = 13, Radio = 14, Dish = 15, Gather = 16,
+    Scatter = 17, Dgram = 18, Peer = 19, Channel = 20
+}

--- a/bindings/dotnet/tests/InteropPeer.cs
+++ b/bindings/dotnet/tests/InteropPeer.cs
@@ -1,0 +1,31 @@
+using Omq;
+
+if (args.Length < 4) throw new ArgumentException("role endpoint security server_key [client_public client_secret]");
+string role = args[0], endpoint = args[1], security = args[2];
+var options = new SocketOptions { Linger = 0, ReceiveTimeout = TimeSpan.FromSeconds(5), SendTimeout = TimeSpan.FromSeconds(5) };
+using var context = new Context();
+using var socket = context.CreateSocket(role == "rep" ? SocketType.Rep : SocketType.Req, options);
+if (security == "curve")
+{
+    if (role == "rep") socket.ConfigureCurveServer(args[3], args[4]);
+    else socket.ConfigureCurveClient(args[4], args[5], args[3]);
+}
+else if (security == "plain")
+{
+    if (role == "rep") socket.ConfigurePlainServer();
+    else socket.ConfigurePlainClient("interop", "secret");
+}
+if (role == "rep") socket.Bind(endpoint); else socket.Connect(endpoint);
+if (role == "req")
+{
+    socket.SendMultipart(["interop"u8.ToArray(), "hello"u8.ToArray()]);
+    var reply = socket.Receive();
+    if (reply.Parts.Count != 2 || !reply.Parts[0].SequenceEqual("interop"u8) || !reply.Parts[1].SequenceEqual("world"u8)) throw new Exception("interop reply mismatch");
+}
+else
+{
+    var request = socket.Receive();
+    if (request.Parts.Count != 2 || !request.Parts[0].SequenceEqual("interop"u8) || !request.Parts[1].SequenceEqual("hello"u8)) throw new Exception("interop request mismatch");
+    socket.SendMultipart(["interop"u8.ToArray(), "world"u8.ToArray()]);
+}
+Console.WriteLine("interop PASS");

--- a/bindings/dotnet/tests/Lifecycle.cs
+++ b/bindings/dotnet/tests/Lifecycle.cs
@@ -1,0 +1,84 @@
+using Omq;
+
+static void Check(bool value, string message)
+{
+    if (!value) throw new Exception(message);
+}
+
+static async Task AsyncSendUnderHwmIsBounded()
+{
+    using var context = new Context();
+    using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0, ReceiveHwm = 1 });
+    using var push = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0, SendHwm = 1, Immediate = true });
+    string endpoint = pull.Bind("tcp://127.0.0.1:0");
+    push.Connect(endpoint);
+    await Task.Delay(50);
+    byte[] payload = new byte[4096];
+    int filled = 0;
+    while (push.TrySend(payload)) filled++;
+    Check(filled > 0, "HWM fixture did not fill");
+
+    using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+    Task pending = push.SendAsync(new Message([payload, payload]), cancellation.Token);
+    try { await pending.WaitAsync(TimeSpan.FromSeconds(2)); }
+    catch (OperationCanceledException) { }
+}
+
+static async Task ShutdownAndCancellationBoundPoll()
+{
+    using var context = new Context();
+    using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0 });
+    using var poller = new Poller();
+    poller.Add(pull);
+    using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+    Task<IReadOnlyList<PollResult>> pending = poller.WaitAsync(TimeSpan.FromSeconds(10), cancellation.Token);
+    await Task.Delay(50);
+    context.Shutdown();
+    await pending.WaitAsync(TimeSpan.FromSeconds(2));
+}
+
+static async Task MonitorStopWakesReceive()
+{
+    using var context = new Context();
+    using var socket = context.CreateSocket(SocketType.Pair, new SocketOptions { Linger = 0 });
+    using var monitor = socket.Monitor();
+    Task<MonitorEvent> pending = monitor.ReceiveAsync();
+    await Task.Delay(30);
+    monitor.Dispose();
+    try { await pending.WaitAsync(TimeSpan.FromSeconds(2)); throw new Exception("monitor stop did not interrupt receive"); }
+    catch (OperationCanceledException) { }
+}
+
+static async Task ConnectBeforeBind()
+{
+    using var context = new Context();
+    using var push = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0, SendTimeout = TimeSpan.FromSeconds(2) });
+    using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0, ReceiveTimeout = TimeSpan.FromSeconds(2) });
+    string endpoint = "tcp://127.0.0.1:38291";
+    push.Connect(endpoint);
+    await Task.Delay(30);
+    pull.Bind(endpoint);
+    push.SendText("late-bind");
+    Check(pull.ReceiveText() == "late-bind", "connect-before-bind mismatch");
+}
+
+static void RepeatedCreateDispose()
+{
+    for (int i = 0; i < 100; i++)
+    {
+        using var context = new Context();
+        using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0 });
+        using var push = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0 });
+        string endpoint = pull.Bind($"inproc://dotnet-lifecycle-{Environment.ProcessId}-{i}");
+        push.Connect(endpoint);
+        push.SendText("cycle");
+        Check(pull.ReceiveText() == "cycle", $"cycle {i} mismatch");
+    }
+}
+
+await AsyncSendUnderHwmIsBounded();
+await ShutdownAndCancellationBoundPoll();
+await MonitorStopWakesReceive();
+await ConnectBeforeBind();
+RepeatedCreateDispose();
+Console.WriteLine("OMQ.Net lifecycle: PASS");

--- a/bindings/dotnet/tests/Omq.Net.Interop.csproj
+++ b/bindings/dotnet/tests/Omq.Net.Interop.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <BaseOutputPath>bin/Interop/</BaseOutputPath>
+  </PropertyGroup>
+  <ItemGroup><ProjectReference Include="../Omq.Net.csproj" /><Compile Include="InteropPeer.cs" /></ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
+++ b/bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <BaseOutputPath>bin/Lifecycle/</BaseOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Omq.Net.csproj" />
+    <Compile Include="Lifecycle.cs" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
+++ b/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <OmqNetVersion Condition="'$(OmqNetVersion)' == ''">0.1.0</OmqNetVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Omq.Net" Version="$(OmqNetVersion)" />
+    <Compile Include="PackageSmoke.cs" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/Omq.Net.Smoke.csproj
+++ b/bindings/dotnet/tests/Omq.Net.Smoke.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <BaseOutputPath>bin/Smoke/</BaseOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Omq.Net.csproj" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/PackageSmoke.cs
+++ b/bindings/dotnet/tests/PackageSmoke.cs
@@ -1,0 +1,11 @@
+using Omq;
+
+using var context = new Context();
+using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0 });
+using var push = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0 });
+
+var endpoint = pull.Bind("inproc://package-smoke");
+push.Connect(endpoint);
+push.Send(Message.Text("package"));
+if (pull.Receive().ToString() != "package")
+    throw new InvalidOperationException("package smoke exchange failed");

--- a/bindings/dotnet/tests/Program.cs
+++ b/bindings/dotnet/tests/Program.cs
@@ -1,0 +1,144 @@
+using Omq;
+
+static void Check(bool condition, string message)
+{
+    if (!condition) throw new Exception(message);
+}
+static Message ReceiveEventually(Socket socket)
+{
+    DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+    while (true)
+    {
+        try { return socket.Receive(dontWait: true); }
+        catch (OmqAgainException) when (DateTime.UtcNow < deadline) { Thread.Sleep(10); }
+    }
+}
+
+using var context = new Context();
+Check(!context.Closed, "context unexpectedly closed");
+var key = context.ShareKey();
+using var peer = Context.FromShareKey(key.High, key.Low);
+using var pull = context.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0, ReceiveTimeout = TimeSpan.FromSeconds(2) });
+using var push = peer.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0, SendTimeout = TimeSpan.FromSeconds(2) });
+
+pull.Bind("inproc://dotnet-smoke");
+push.Connect("inproc://dotnet-smoke");
+push.Send(Message.Text("hello"));
+Check(pull.Receive().ToString() == "hello", "single-part message mismatch");
+var cloned = Message.Text("clone"); cloned.RoutingId = 7;
+Check(cloned.Clone().ToString() == "clone" && cloned.Clone().RoutingId == 7, "message clone mismatch");
+
+using var req = context.CreateSocket(SocketType.Req, new SocketOptions { Linger = 0 });
+using var rep = context.CreateSocket(SocketType.Rep, new SocketOptions { Linger = 0 });
+rep.Bind("inproc://dotnet-reqrep");
+req.Connect("inproc://dotnet-reqrep");
+req.Send([9, 8, 7]);
+Check(rep.Receive().Data.SequenceEqual(new byte[] { 9, 8, 7 }), "REQ/REP request mismatch");
+rep.Send([6, 5]);
+Check(req.Receive().Data.SequenceEqual(new byte[] { 6, 5 }), "REQ/REP reply mismatch");
+req.SendJson(new { value = 42 });
+var json = rep.ReceiveJson<Dictionary<string, int>>();
+Check(json is not null && json["value"] == 42, "JSON message mismatch");
+rep.SendString("string");
+Check(req.ReceiveString() == "string", "string helper mismatch");
+
+using var options = context.CreateSocket(SocketType.Push, new SocketOptions { Linger = 0, SendHwm = 64, ReceiveHwm = 32, HeartbeatInterval = 1000 });
+Check(options.GetInt32(SocketOption.SendHwm) == 64, "SNDHWM option mismatch");
+Check(options.GetInt32(SocketOption.ReceiveHwm) == 32, "RCVHWM option mismatch");
+Check(options.GetInt32(SocketOption.HeartbeatInterval) == 1000, "heartbeat option mismatch");
+options.SetOption(SocketOption.RoutingId, [1, 2, 3]);
+Check(options.GetBytes(SocketOption.RoutingId).SequenceEqual(new byte[] { 1, 2, 3 }), "routing id mismatch");
+Check(!pull.TryReceive(out _), "TryReceive should report empty socket");
+
+using var pub = context.CreateSocket(SocketType.Pub, new SocketOptions { Linger = 0 });
+using var sub = context.CreateSocket(SocketType.Sub, new SocketOptions { Linger = 0, ReceiveTimeout = TimeSpan.FromSeconds(1) });
+pub.Bind("inproc://dotnet-pubsub");
+sub.Connect("inproc://dotnet-pubsub");
+sub.Subscribe("topic");
+for (int i = 0; i < 10 && !sub.TryReceive(out _); i++) pub.SendText("topic:hello");
+pub.SendText("topic:hello");
+Check(sub.ReceiveText() == "topic:hello", "PUB/SUB message mismatch");
+
+var multipart = new Message(new[]
+{
+    new ReadOnlyMemory<byte>([1, 2, 3]),
+    new ReadOnlyMemory<byte>([4, 5])
+});
+push.Send(multipart);
+Message received = pull.Receive();
+Check(received.Parts.Count == 2, "multipart part count mismatch");
+Check(received.Parts[0].SequenceEqual(new byte[] { 1, 2, 3 }), "multipart first part mismatch");
+Check(received.Parts[1].SequenceEqual(new byte[] { 4, 5 }), "multipart second part mismatch");
+
+await push.SendAsync(Message.Text("async"));
+Check((await pull.ReceiveAsync()).ToString() == "async", "async message mismatch");
+await push.SendAsync(new Message([new ReadOnlyMemory<byte>([1, 2]), new ReadOnlyMemory<byte>([3, 4])]));
+var asyncMultipart = await pull.ReceiveAsync();
+Check(asyncMultipart.IsMultipart && asyncMultipart.Parts.Count == 2 && asyncMultipart.Parts[1].SequenceEqual(new byte[] { 3, 4 }), "async multipart mismatch");
+using (var cancelled = new CancellationTokenSource(TimeSpan.FromMilliseconds(20)))
+{
+    bool observed = false;
+    try { await pull.ReceiveAsync(cancelled.Token); }
+    catch (OperationCanceledException) { observed = true; }
+    Check(observed, "async receive cancellation mismatch");
+}
+var poller = new Poller(); poller.Add(pull);
+push.Send(Message.Text("poll"));
+Check(poller.Wait(TimeSpan.FromSeconds(1)).Count != 0, "poller did not report readable socket");
+Check(pull.Receive().ToString() == "poll", "poller message mismatch");
+Check(pull.Poll(TimeSpan.Zero).Count == 0, "socket poll should be empty");
+var keys = Curve.GenerateKeyPair();
+Check(keys.PublicKey.Length == 40 && keys.SecretKey.Length == 40, "CURVE keypair mismatch");
+Check(Curve.PublicKey(keys.SecretKey) == keys.PublicKey, "CURVE public key mismatch");
+var serverKeys = Curve.GenerateKeyPair();
+using var curveRep = context.CreateSocket(SocketType.Rep, new SocketOptions { Linger = 0 });
+using var curveReq = context.CreateSocket(SocketType.Req, new SocketOptions { Linger = 0 });
+curveRep.ConfigureCurveServer(serverKeys.PublicKey, serverKeys.SecretKey);
+curveReq.ConfigureCurveClient(keys.PublicKey, keys.SecretKey, serverKeys.PublicKey);
+string curveEndpoint = curveRep.Bind("tcp://127.0.0.1:0");
+curveReq.Connect(curveEndpoint);
+curveReq.SendText("curve");
+Check(ReceiveEventually(curveRep).ToString() == "curve", "CURVE request mismatch");
+curveRep.SendText("ok");
+Check(ReceiveEventually(curveReq).ToString() == "ok", "CURVE reply mismatch");
+using var plainRep = context.CreateSocket(SocketType.Rep, new SocketOptions { Linger = 0 });
+using var plainReq = context.CreateSocket(SocketType.Req, new SocketOptions { Linger = 0 });
+plainRep.ConfigurePlainServer("user", "pass");
+plainReq.ConfigurePlainClient("user", "pass");
+string plainEndpoint = plainRep.Bind("tcp://127.0.0.1:0");
+plainReq.Connect(plainEndpoint);
+plainReq.SendText("plain");
+Check(ReceiveEventually(plainRep).ToString() == "plain", "PLAIN request mismatch");
+plainRep.SendText("ok");
+Check(ReceiveEventually(plainReq).ToString() == "ok", "PLAIN reply mismatch");
+using var monitor = pull.Monitor();
+using (var idleSocket = context.CreateSocket(SocketType.Pair, new SocketOptions { Linger = 0 }))
+using (var idleMonitor = idleSocket.Monitor())
+{
+    using var cancelled = new CancellationTokenSource(TimeSpan.FromMilliseconds(30));
+    bool observed = false;
+    try { await idleMonitor.ReceiveAsync(cancelled.Token); }
+    catch (OperationCanceledException) { observed = true; }
+    Check(observed, "monitor receive cancellation mismatch");
+}
+
+foreach (SocketType type in Enum.GetValues<SocketType>())
+{
+    if (type == SocketType.Dgram) continue; // omq-libzmq has no DGRAM mapping yet.
+    using Socket socket = context.CreateSocket(type, new SocketOptions { Linger = 0 });
+    Check(socket.Type == type, $"socket type mismatch: {type}");
+}
+
+using (var doomed = new Context())
+using (var waiting = doomed.CreateSocket(SocketType.Pull, new SocketOptions { Linger = 0 }))
+{
+    Task<Message> pending = waiting.ReceiveAsync();
+    doomed.Shutdown();
+    bool ended = false;
+    try { await pending.WaitAsync(TimeSpan.FromSeconds(1)); }
+    catch (OmqException) { ended = true; }
+    catch (ObjectDisposedException) { ended = true; }
+    Check(ended, "context shutdown did not wake receive");
+}
+
+Console.WriteLine("OMQ.Net smoke: PASS");

--- a/bindings/dotnet/tests/interop.py
+++ b/bindings/dotnet/tests/interop.py
@@ -1,0 +1,69 @@
+"""External pyzmq <-> OMQ.Net interop tests.
+
+Run after building the peer:
+  LD_LIBRARY_PATH=target/release python3 bindings/dotnet/tests/interop.py
+"""
+import os, socket, subprocess
+import zmq
+import zmq.auth.thread
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+PROJECT = os.path.join(ROOT, "bindings/dotnet/tests/Omq.Net.Interop.csproj")
+ENV = {**os.environ, "LD_LIBRARY_PATH": f"{ROOT}/target/release:{os.environ.get('LD_LIBRARY_PATH','')}"}
+
+def endpoint():
+    s=socket.socket(); s.bind(("127.0.0.1",0)); p=s.getsockname()[1]; s.close(); return f"tcp://127.0.0.1:{p}"
+
+def py_server(ep, security):
+    ctx=zmq.Context(); s=ctx.socket(zmq.REP); s.linger=0; s.rcvtimeo=10000; s.sndtimeo=10000; auth=None
+    if security == "curve":
+        pub, sec = zmq.curve_keypair(); s.curve_server=True; s.curve_secretkey=sec; s.curve_publickey=pub
+    if security == "plain":
+        auth=zmq.auth.thread.ThreadAuthenticator(ctx); auth.start(); auth.allow("127.0.0.1")
+        auth.configure_plain("global", {"interop": "secret"}); s.zap_domain=b"global"; s.plain_server=True
+    s.bind(ep); return ctx,s,(pub if security == "curve" else None),(sec if security == "curve" else None),auth
+
+def run(security="none"):
+    ep=endpoint(); ctx,s,pub,sec,auth=py_server(ep,security)
+    if security == "curve":
+        client_pub, client_sec=zmq.curve_keypair()
+        args=["req",ep,security,pub.decode(),client_pub.decode(),client_sec.decode()]
+    else: args=["req",ep,security,"-"]
+    p=subprocess.Popen(["dotnet","run","--no-build","--project",PROJECT,"--",*args],cwd=ROOT,env=ENV,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    try:
+        try:
+            req=s.recv_multipart()
+        except zmq.Again:
+            out,err=p.communicate(timeout=2)
+            raise AssertionError(f"{security} peer produced no request: rc={p.returncode} stdout={out!r} stderr={err!r}")
+        assert req==[b"interop",b"hello"],req
+        s.send_multipart([b"interop",b"world"])
+        out,err=p.communicate(timeout=10)
+        assert p.returncode==0,(out,err)
+    finally:
+        if p.poll() is None: p.kill()
+        s.close()
+    if auth is not None: auth.stop()
+    ctx.term()
+
+def run_reverse(security="none"):
+    ep=endpoint(); ctx=zmq.Context(); s=ctx.socket(zmq.REQ); s.linger=0; s.rcvtimeo=10000; s.sndtimeo=10000
+    if security == "curve":
+        server_pub,server_sec=zmq.curve_keypair(); client_pub,client_sec=zmq.curve_keypair()
+        args=["rep",ep,security,server_pub.decode(),server_sec.decode()]
+        s.curve_publickey=client_pub; s.curve_secretkey=client_sec; s.curve_serverkey=server_pub
+    elif security == "plain":
+        args=["rep",ep,security,"-"]; s.plain_username=b"interop"; s.plain_password=b"secret"
+    else: args=["rep",ep,security,"-"]
+    p=subprocess.Popen(["dotnet","run","--no-build","--project",PROJECT,"--",*args],cwd=ROOT,env=ENV,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    try:
+        s.connect(ep); s.send_multipart([b"interop",b"hello"]); reply=s.recv_multipart()
+        assert reply==[b"interop",b"world"],reply
+        out,err=p.communicate(timeout=10); assert p.returncode==0,(out,err)
+    finally:
+        if p.poll() is None: p.kill()
+        s.close(); ctx.term()
+
+for mode in ("none","curve","plain"):
+    run(mode); print(f"pyzmq {mode} interop PASS")
+    run_reverse(mode); print(f"OMQ.Net {mode} interop PASS")

--- a/bindings/java/native/src/lib.rs
+++ b/bindings/java/native/src/lib.rs
@@ -381,7 +381,7 @@ impl JavaRecvRing {
                 part_count: part_count as u64,
                 flags,
                 payload_end: payload_end as u64,
-                _reserved0: 0,
+                _reserved0: message.routing_id().unwrap_or(0) as u64,
                 _reserved1: 0,
             };
         } else {
@@ -398,7 +398,7 @@ impl JavaRecvRing {
                 part_count: part_count as u64,
                 flags: flags | RECV_RING_FLAG_EXTERNAL,
                 payload_end: self.payload_cursor as u64,
-                _reserved0: 0,
+                _reserved0: message.routing_id().unwrap_or(0) as u64,
                 _reserved1: 0,
             };
         }
@@ -1748,6 +1748,18 @@ fn bytes_from_parts(env: &mut JNIEnv<'_>, parts: JObjectArray<'_>) -> Result<Vec
     Ok(out)
 }
 
+fn java_message(parts: Vec<Bytes>, routing_id: jint) -> Result<Message, Error> {
+    if routing_id < 0 {
+        return Err(Error::Config("routing ID must be non-negative".to_string()));
+    }
+    let message = Message::multipart(parts);
+    Ok(if routing_id == 0 {
+        message
+    } else {
+        message.with_routing_id(routing_id as u32)
+    })
+}
+
 fn java_try_send(
     socket: &BlockingSocket,
     message: Message,
@@ -1866,6 +1878,7 @@ fn message_to_java_object_ref<'local>(
     env: &mut JNIEnv<'local>,
     message: &Message,
 ) -> Result<JObject<'local>, Error> {
+    let routing_id = message.routing_id().unwrap_or(0);
     if message.len() == 1 {
         let part = message_part_to_java(env, message, 0)?;
         let part = JObject::from(part);
@@ -1873,8 +1886,8 @@ fn message_to_java_object_ref<'local>(
             .call_static_method(
                 "io/omq/Message",
                 "fromNative",
-                "([B)Lio/omq/Message;",
-                &[JValue::Object(&part)],
+                "([BI)Lio/omq/Message;",
+                &[JValue::Object(&part), JValue::Int(routing_id as jint)],
             )
             .and_then(|value| value.l())
             .map_err(jni_error);
@@ -1885,8 +1898,8 @@ fn message_to_java_object_ref<'local>(
     env.call_static_method(
         "io/omq/Message",
         "fromNative",
-        "([[B)Lio/omq/Message;",
-        &[JValue::Object(&parts)],
+        "([[BI)Lio/omq/Message;",
+        &[JValue::Object(&parts), JValue::Int(routing_id as jint)],
     )
     .and_then(|value| value.l())
     .map_err(jni_error)
@@ -1903,10 +1916,7 @@ fn message_to_java_native_ref<'local>(
     env: &mut JNIEnv<'local>,
     message: &Message,
 ) -> Result<JObject<'local>, Error> {
-    if message.len() == 1 {
-        return message_part_to_java(env, message, 0).map(JObject::from);
-    }
-    message_to_java_parts(env, message).map(JObject::from)
+    message_to_java_object_ref(env, message)
 }
 
 fn recv_with_timeout(socket: &BlockingSocket, timeout_millis: jlong) -> Result<Message, Error> {
@@ -2770,12 +2780,13 @@ pub extern "system" fn Java_io_omq_Native_socketSendMultipart(
     _class: JClass<'_>,
     handle: jlong,
     parts: JObjectArray<'_>,
+    routing_id: jint,
 ) {
     guard(&mut env, (), |env| {
         let result = (|| {
             let socket = socket_from_handle(handle)?;
             let parts = bytes_from_parts(env, parts)?;
-            java_send(&socket.materialize()?, Message::multipart(parts))
+            java_send(&socket.materialize()?, java_message(parts, routing_id)?)
         })();
 
         if let Err(error) = result {
@@ -2790,6 +2801,7 @@ pub extern "system" fn Java_io_omq_Native_socketSendMultipartTimeout(
     _class: JClass<'_>,
     handle: jlong,
     parts: JObjectArray<'_>,
+    routing_id: jint,
     timeout_millis: jlong,
 ) -> jint {
     guard(&mut env, 0, |env| {
@@ -2798,7 +2810,7 @@ pub extern "system" fn Java_io_omq_Native_socketSendMultipartTimeout(
             let parts = bytes_from_parts(env, parts)?;
             send_with_timeout(
                 &socket.materialize()?,
-                Message::multipart(parts),
+                java_message(parts, routing_id)?,
                 timeout_millis,
             )
             .map(i32::from)
@@ -2820,12 +2832,13 @@ pub extern "system" fn Java_io_omq_Native_socketTrySendMultipart(
     _class: JClass<'_>,
     handle: jlong,
     parts: JObjectArray<'_>,
+    routing_id: jint,
 ) -> jint {
     guard(&mut env, 0, |env| {
         let result = (|| {
             let socket = socket_from_handle(handle)?;
             let parts = bytes_from_parts(env, parts)?;
-            match java_try_send(&socket.materialize()?, Message::multipart(parts)) {
+            match java_try_send(&socket.materialize()?, java_message(parts, routing_id)?) {
                 Ok(()) => Ok(1),
                 Err(TrySendError::Full(_)) => Ok(0),
                 Err(TrySendError::Closed) => Err(Error::Closed),
@@ -2849,6 +2862,7 @@ pub extern "system" fn Java_io_omq_Native_socketSendAsync(
     _class: JClass<'_>,
     handle: jlong,
     parts: JObjectArray<'_>,
+    routing_id: jint,
     future: JObject<'_>,
 ) -> jlong {
     guard(&mut env, 0, |env| {
@@ -2857,10 +2871,11 @@ pub extern "system" fn Java_io_omq_Native_socketSendAsync(
             let jvm = env.get_java_vm().map_err(jni_error)?;
             let future = env.new_global_ref(&future).map_err(jni_error)?;
             let parts = bytes_from_parts(env, parts)?;
+            let message = java_message(parts, routing_id)?;
             let handle = socket.ctx.handle().clone();
             let socket = socket.materialize()?.into_async();
             let join = handle.spawn(async move {
-                let result = socket.send(Message::multipart(parts)).await;
+                let result = socket.send(message).await;
                 complete_future_void(jvm, future, result);
             });
             Ok(async_task_handle(join))

--- a/bindings/java/src/main/java/io/omq/Message.java
+++ b/bindings/java/src/main/java/io/omq/Message.java
@@ -6,28 +6,40 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 
 /** Immutable OMQ message with one or more byte-array parts. */
 public final class Message {
     private final byte[] body;
     private final byte[][] parts;
+    private final int routingId;
 
     private Message(byte[][] parts) {
-        this(parts, true);
+        this(parts, true, 0);
     }
 
     private Message(byte[][] parts, boolean copy) {
+        this(parts, copy, 0);
+    }
+
+    private Message(byte[][] parts, boolean copy, int routingId) {
         if (parts.length == 0) {
             throw new IllegalArgumentException("message must contain at least one part");
         }
         this.body = null;
         this.parts = copy ? copy(parts) : requireParts(parts);
+        this.routingId = requireRoutingId(routingId);
     }
 
     private Message(byte[] body, boolean copy) {
+        this(body, copy, 0);
+    }
+
+    private Message(byte[] body, boolean copy, int routingId) {
         Objects.requireNonNull(body, "body");
         this.body = copy ? Arrays.copyOf(body, body.length) : body;
         this.parts = null;
+        this.routingId = requireRoutingId(routingId);
     }
 
     /** Creates a single-part binary message by copying {@code body}. */
@@ -79,7 +91,18 @@ public final class Message {
         return new Message(body, false);
     }
 
+    static Message fromNative(byte[] body, int routingId) {
+        return new Message(body, false, routingId);
+    }
+
+    static Message fromNative(byte[][] parts, int routingId) {
+        return new Message(parts, false, routingId);
+    }
+
     static Message fromNative(Object nativeMessage) {
+        if (nativeMessage instanceof Message message) {
+            return message;
+        }
         if (nativeMessage instanceof byte[] body) {
             return fromNative(body);
         }
@@ -117,6 +140,19 @@ public final class Message {
     /** Returns whether this message has more than one part. */
     public boolean isMultipart() {
         return body == null && parts.length > 1;
+    }
+
+    /** Returns the native routing ID, if this message came from a routed socket. */
+    public OptionalInt routingId() {
+        return routingId == 0 ? OptionalInt.empty() : OptionalInt.of(routingId);
+    }
+
+    /** Returns a copy of this message carrying {@code routingId} metadata. */
+    public Message withRoutingId(int routingId) {
+        if (body != null) {
+            return new Message(body, true, routingId);
+        }
+        return new Message(parts, true, routingId);
     }
 
     /** Returns a copy of the part at {@code index}. */
@@ -240,5 +276,12 @@ public final class Message {
             total += partView(i).length;
         }
         return total;
+    }
+
+    private static int requireRoutingId(int routingId) {
+        if (routingId < 0) {
+            throw new IllegalArgumentException("routing ID must be non-negative");
+        }
+        return routingId;
     }
 }

--- a/bindings/java/src/main/java/io/omq/Native.java
+++ b/bindings/java/src/main/java/io/omq/Native.java
@@ -57,13 +57,14 @@ final class Native {
 
     static native void socketSend(long handle, byte[] data);
 
-    static native void socketSendMultipart(long handle, byte[][] parts);
+    static native void socketSendMultipart(long handle, byte[][] parts, int routingId);
 
-    static native int socketSendMultipartTimeout(long handle, byte[][] parts, long timeoutMillis);
+    static native int socketSendMultipartTimeout(
+            long handle, byte[][] parts, int routingId, long timeoutMillis);
 
-    static native int socketTrySendMultipart(long handle, byte[][] parts);
+    static native int socketTrySendMultipart(long handle, byte[][] parts, int routingId);
 
-    static native long socketSendAsync(long handle, byte[][] parts, Object future);
+    static native long socketSendAsync(long handle, byte[][] parts, int routingId, Object future);
 
     static native Object socketRecv(long handle, long timeoutMillis);
 

--- a/bindings/java/src/main/java/io/omq/RecvRing.java
+++ b/bindings/java/src/main/java/io/omq/RecvRing.java
@@ -23,6 +23,7 @@ final class RecvRing implements AutoCloseable {
     private static final long DESC_PAYLOAD_LEN = 8;
     private static final long DESC_PART_COUNT = 24;
     private static final long DESC_FLAGS = 32;
+    private static final long DESC_ROUTING_ID = 48;
 
     private static final long FLAG_MULTIPART = 1;
     private static final long FLAG_EXTERNAL = 2;
@@ -150,14 +151,23 @@ final class RecvRing implements AutoCloseable {
                 descriptors.get(LONG, offset + DESC_PAYLOAD),
                 descriptors.get(LONG, offset + DESC_PAYLOAD_LEN),
                 descriptors.get(LONG, offset + DESC_PART_COUNT),
-                descriptors.get(LONG, offset + DESC_FLAGS));
+                descriptors.get(LONG, offset + DESC_FLAGS),
+                descriptors.get(LONG, offset + DESC_ROUTING_ID));
     }
 
     private Message readMessage(Desc desc) {
         if (desc.partCount() == 1) {
-            return Message.fromNative(readBytes(desc));
+            return Message.fromNative(readBytes(desc), routingId(desc));
         }
-        return Message.fromNative(readParts(desc));
+        return Message.fromNative(readParts(desc), routingId(desc));
+    }
+
+    private static int routingId(Desc desc) {
+        long routingId = desc.routingId();
+        if (routingId > Integer.MAX_VALUE) {
+            throw new OMQException("native receive ring routing ID overflow");
+        }
+        return (int) routingId;
     }
 
     private byte[] readBytes(Desc desc) {
@@ -314,6 +324,7 @@ final class RecvRing implements AutoCloseable {
             long payload,
             long payloadLen,
             long partCount,
-            long flags) {
+            long flags,
+            long routingId) {
     }
 }

--- a/bindings/java/src/main/java/io/omq/Socket.java
+++ b/bindings/java/src/main/java/io/omq/Socket.java
@@ -106,7 +106,7 @@ public final class Socket implements AutoCloseable {
         synchronized (state) {
             long handle = state.handle();
             drainSendRingOrThrow(FOREVER);
-            Native.socketSendMultipart(handle, parts);
+            Native.socketSendMultipart(handle, parts, message.routingId().orElse(0));
         }
         return this;
     }
@@ -145,7 +145,8 @@ public final class Socket implements AutoCloseable {
             if (!drainSendRing(timeoutMillis)) {
                 return false;
             }
-            return Native.socketSendMultipartTimeout(handle, parts, timeoutMillis) != 0;
+            return Native.socketSendMultipartTimeout(
+                    handle, parts, message.routingId().orElse(0), timeoutMillis) != 0;
         }
     }
 
@@ -181,7 +182,7 @@ public final class Socket implements AutoCloseable {
             if (usesSendRing() && !state.sendRing.isDrained()) {
                 return false;
             }
-            return Native.socketTrySendMultipart(handle, parts) != 0;
+            return Native.socketTrySendMultipart(handle, parts, message.routingId().orElse(0)) != 0;
         }
     }
 
@@ -218,7 +219,7 @@ public final class Socket implements AutoCloseable {
             synchronized (state) {
                 long handle = state.handle();
                 drainSendRingOrThrow(FOREVER);
-                task = Native.socketSendAsync(handle, parts, future);
+                task = Native.socketSendAsync(handle, parts, message.routingId().orElse(0), future);
             }
             future.setNativeTask(task);
         } catch (OMQException error) {

--- a/bindings/java/src/test/java/io/omq/SocketTypesTest.java
+++ b/bindings/java/src/test/java/io/omq/SocketTypesTest.java
@@ -50,11 +50,11 @@ final class SocketTypesTest {
             client.send("ping");
 
             Message request = server.receive(Duration.ofSeconds(5)).orElseThrow();
-            assertEquals(2, request.partCount());
-            assertEquals("client-1", new String(request.part(0)));
-            assertEquals("ping", new String(request.part(1)));
+            assertEquals(1, request.partCount());
+            assertEquals("ping", request.text());
+            int routingId = request.routingId().orElseThrow();
 
-            server.send(Message.multipart(request.part(0), "pong".getBytes()));
+            server.send(Message.text("pong").withRoutingId(routingId));
             assertEquals("pong", client.receive(Duration.ofSeconds(5)).orElseThrow().text());
         }
     }
@@ -176,9 +176,9 @@ final class SocketTypesTest {
 
             for (int i = 0; i < 3; i++) {
                 Message request = server.receive(Duration.ofSeconds(5)).orElseThrow();
-                server.send(Message.multipart(request.part(0),
-                        ("re:" + new String(request.part(1), StandardCharsets.UTF_8))
-                                .getBytes(StandardCharsets.UTF_8)));
+                assertEquals(1, request.partCount());
+                server.send(Message.text("re:" + request.text())
+                        .withRoutingId(request.routingId().orElseThrow()));
             }
 
             assertTrue(client0.receive(Duration.ofSeconds(5)).orElseThrow().text().startsWith("re:from-"));

--- a/omq-libzmq/README.md
+++ b/omq-libzmq/README.md
@@ -42,6 +42,14 @@ the 4 KiB native default.
 
 Detailed support notes live in [doc/compatibility.md](doc/compatibility.md).
 
+For the rough supported C ABI surface, compatibility gaps, and option behavior,
+see [doc/compatibility.md](doc/compatibility.md). The bundled
+`include/zmq.h` is the authoritative symbol and constant list.
+
+`libomq_zmq.so` also exposes a small `omq_*` extension API for context sharing
+and native async multipart sends. It is OMQ-specific, outside the libzmq ABI,
+and documented in [doc/compatibility.md](doc/compatibility.md).
+
 ## Build
 
 Produces `libomq_zmq.so` / `libomq_zmq.a` / `libomq_zmq.dylib`.

--- a/omq-libzmq/doc/compatibility.md
+++ b/omq-libzmq/doc/compatibility.md
@@ -2,7 +2,9 @@
 
 `omq-libzmq` ships a libzmq 4.3.6-compatible `zmq.h` and exports every C
 symbol declared there. `tests/abi_matrix.rs` enforces that the header, Rust
-exports, and tracked socket option matrix stay in sync.
+exports, and tracked socket option matrix stay in sync. Compatibility means
+ABI and common behavior; it does not claim identical implementation details,
+performance, or support for every draft/platform feature.
 
 ## Supported Surface
 
@@ -21,7 +23,9 @@ exports, and tracked socket option matrix stay in sync.
 
 - `ZMQ_DGRAM` is declared for header compatibility but `zmq_socket()` rejects it
   with `EINVAL`.
-- `zmq_connect_peer()` and `zmq_disconnect_peer()` return `ENOTSUP`.
+- `zmq_connect_peer()` is a stub: it returns zero for the historical ABI
+  shape but sets `errno` to `ENOTSUP`; `zmq_disconnect_peer()` returns `-1`
+  with `ENOTSUP`.
 - `zmq_socket_monitor_versioned()` supports monitor version 1 only. Monitor v2
   and `ZMQ_EVENT_PIPES_STATS` are not implemented.
 - `zmq_socket_monitor_pipes_stats()` and `zmq_socket_get_peer_state()` return
@@ -54,3 +58,20 @@ currently wired into backend behavior.
 
 `ZMQ_THREAD_SAFE` returns 0. Match libzmq discipline: one application thread per
 socket.
+
+## OMQ-internal API
+
+`libomq_zmq.so` also exports a small `omq_*` extension surface. These symbols
+are not part of upstream libzmq and are not covered by the compatibility
+promise:
+
+- `omq_ctx_share_key()` / `omq_ctx_from_share_key()` share an OMQ context
+  between compatible binding instances;
+- `omq_socket_send_async()` submits an atomically encoded multipart message to
+  the OMQ Tokio runtime and invokes a caller-supplied C callback on completion;
+- `omq_async_task_cancel()` requests cancellation of that task;
+- `omq_async_task_free()` releases the returned task handle after completion.
+
+The async message encoding is an OMQ-specific length-table format. Bindings
+must use these functions only when linked against `omq-libzmq`; they must not
+assume they exist in upstream `libzmq`.

--- a/omq-libzmq/include/zmq.h
+++ b/omq-libzmq/include/zmq.h
@@ -482,6 +482,15 @@ ZMQ_EXPORT int   omq_ctx_share_key (void *context_, uint64_t *key_hi_,
                                     uint64_t *key_lo_);
 ZMQ_EXPORT void *omq_ctx_from_share_key (uint64_t key_hi_, uint64_t key_lo_);
 
+/*  OMQ async extension API ------------------------------------------------- */
+typedef struct omq_async_task omq_async_task_t;
+typedef void (*omq_async_callback_fn) (void *userdata_, int status_);
+ZMQ_EXPORT omq_async_task_t *omq_socket_send_async (
+    void *socket_, const uint8_t *encoded_, size_t encoded_size_,
+    omq_async_callback_fn callback_, void *userdata_);
+ZMQ_EXPORT void omq_async_task_cancel (omq_async_task_t *task_);
+ZMQ_EXPORT void omq_async_task_free (omq_async_task_t *task_);
+
 /*  Socket API --------------------------------------------------------------- */
 ZMQ_EXPORT void *zmq_socket     (void *context_, int type_);
 ZMQ_EXPORT int   zmq_close      (void *s_);

--- a/omq-libzmq/src/async_api.rs
+++ b/omq-libzmq/src/async_api.rs
@@ -81,8 +81,8 @@ pub extern "C" fn omq_socket_send_async(
     let userdata = userdata as usize;
     let join = runtime.spawn(async move {
         let status = tokio::select! {
-            result = inner.send(message) => result.map(|_| 0).unwrap_or(ETERM),
-            _ = cancel_wait.notified() => { cancelled_wait.store(true, Ordering::Release); libc::ECANCELED }
+            result = inner.send(message) => result.map_or(ETERM, |()| 0),
+            () = cancel_wait.notified() => { cancelled_wait.store(true, Ordering::Release); libc::ECANCELED }
         };
         if let Some(callback) = callback {
             callback(userdata as *mut c_void, status);

--- a/omq-libzmq/src/async_api.rs
+++ b/omq-libzmq/src/async_api.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use omq_tokio::Message;
-use tokio::sync::Notify;
+use omq_tokio::engine::StateSignal;
 
 use crate::error::{ETERM, fail};
 use crate::socket::OmqSocket;
@@ -16,7 +16,7 @@ pub type OMQAsyncCallback = extern "C" fn(*mut c_void, i32);
 
 #[derive(Debug)]
 pub struct OmqAsyncTask {
-    cancel: Arc<Notify>,
+    cancel: Arc<StateSignal>,
     cancelled: Arc<AtomicBool>,
     _join: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -74,15 +74,16 @@ pub extern "C" fn omq_socket_send_async(
         fail(ETERM);
         return std::ptr::null_mut();
     };
-    let cancel = Arc::new(Notify::new());
+    let cancel = Arc::new(StateSignal::new());
     let cancelled = Arc::new(AtomicBool::new(false));
     let cancel_wait = cancel.clone();
     let cancelled_wait = cancelled.clone();
     let userdata = userdata as usize;
     let join = runtime.spawn(async move {
+        let cancel_seen = cancel_wait.generation();
         let status = tokio::select! {
             result = inner.send(message) => result.map_or(ETERM, |()| 0),
-            () = cancel_wait.notified() => { cancelled_wait.store(true, Ordering::Release); libc::ECANCELED }
+            () = cancel_wait.changed_after(cancel_seen) => { cancelled_wait.store(true, Ordering::Release); libc::ECANCELED }
         };
         if let Some(callback) = callback {
             callback(userdata as *mut c_void, status);
@@ -103,7 +104,7 @@ pub extern "C" fn omq_async_task_cancel(task: *mut OmqAsyncTask) {
     // SAFETY: caller retains ownership of the task handle until free.
     let task = unsafe { &*task };
     task.cancelled.store(true, Ordering::Release);
-    task.cancel.notify_one();
+    task.cancel.notify_changed();
 }
 
 #[unsafe(no_mangle)]

--- a/omq-libzmq/src/async_api.rs
+++ b/omq-libzmq/src/async_api.rs
@@ -1,0 +1,116 @@
+//! Small C ABI for operations that must remain asynchronous across FFI.
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use omq_tokio::Message;
+use tokio::sync::Notify;
+
+use crate::error::{ETERM, fail};
+use crate::socket::OmqSocket;
+
+#[allow(unreachable_pub)]
+pub type OMQAsyncCallback = extern "C" fn(*mut c_void, i32);
+
+#[derive(Debug)]
+pub struct OmqAsyncTask {
+    cancel: Arc<Notify>,
+    cancelled: Arc<AtomicBool>,
+    _join: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+fn decode_message(encoded: *const u8, length: usize) -> Option<Message> {
+    if encoded.is_null() || length < 8 {
+        return None;
+    }
+    // SAFETY: caller supplies a readable buffer of `length` bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(encoded, length) };
+    let count = usize::try_from(u64::from_le_bytes(bytes[..8].try_into().ok()?)).ok()?;
+    let table_end = 8usize.checked_add(count.checked_mul(8)?)?;
+    if table_end > length {
+        return None;
+    }
+    let mut parts = Vec::with_capacity(count);
+    let mut offset = table_end;
+    for index in 0..count {
+        let start = 8 + index * 8;
+        let size =
+            usize::try_from(u64::from_le_bytes(bytes[start..start + 8].try_into().ok()?)).ok()?;
+        let end = offset.checked_add(size)?;
+        if end > length {
+            return None;
+        }
+        parts.push(Bytes::copy_from_slice(&bytes[offset..end]));
+        offset = end;
+    }
+    (offset == length).then(|| Message::multipart(parts))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_socket_send_async(
+    socket_ptr: *mut c_void,
+    encoded: *const u8,
+    encoded_len: usize,
+    callback: Option<OMQAsyncCallback>,
+    userdata: *mut c_void,
+) -> *mut OmqAsyncTask {
+    if socket_ptr.is_null() {
+        fail(libc::ENOTSOCK);
+        return std::ptr::null_mut();
+    }
+    let Some(message) = decode_message(encoded, encoded_len) else {
+        fail(libc::EINVAL);
+        return std::ptr::null_mut();
+    };
+    // SAFETY: socket_ptr is an active zmq socket handle, represented by Arc<OmqSocket>.
+    let socket = unsafe { &*(socket_ptr.cast::<Arc<OmqSocket>>()) }.clone();
+    let Some(inner) = socket.inner.get().cloned() else {
+        fail(ETERM);
+        return std::ptr::null_mut();
+    };
+    let Some(runtime) = socket.ctx.handle().cloned() else {
+        fail(ETERM);
+        return std::ptr::null_mut();
+    };
+    let cancel = Arc::new(Notify::new());
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_wait = cancel.clone();
+    let cancelled_wait = cancelled.clone();
+    let userdata = userdata as usize;
+    let join = runtime.spawn(async move {
+        let status = tokio::select! {
+            result = inner.send(message) => result.map(|_| 0).unwrap_or(ETERM),
+            _ = cancel_wait.notified() => { cancelled_wait.store(true, Ordering::Release); libc::ECANCELED }
+        };
+        if let Some(callback) = callback {
+            callback(userdata as *mut c_void, status);
+        }
+    });
+    Box::into_raw(Box::new(OmqAsyncTask {
+        cancel,
+        cancelled,
+        _join: Mutex::new(Some(join)),
+    }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_async_task_cancel(task: *mut OmqAsyncTask) {
+    if task.is_null() {
+        return;
+    }
+    // SAFETY: caller retains ownership of the task handle until free.
+    let task = unsafe { &*task };
+    task.cancelled.store(true, Ordering::Release);
+    task.cancel.notify_one();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omq_async_task_free(task: *mut OmqAsyncTask) {
+    if task.is_null() {
+        return;
+    }
+    // SAFETY: caller owns this task handle and frees it exactly once.
+    drop(unsafe { Box::from_raw(task) });
+}

--- a/omq-libzmq/src/lib.rs
+++ b/omq-libzmq/src/lib.rs
@@ -23,6 +23,7 @@
 #[cfg(not(target_has_atomic = "64"))]
 compile_error!("omq-libzmq requires target_has_atomic = \"64\"");
 
+mod async_api;
 mod consts;
 mod context;
 pub mod curve;
@@ -40,6 +41,7 @@ mod socket;
 mod timers;
 mod util;
 
+pub use async_api::{omq_async_task_cancel, omq_async_task_free, omq_socket_send_async};
 pub use context::{
     omq_ctx_from_share_key, omq_ctx_share_key, zmq_ctx_destroy, zmq_ctx_get, zmq_ctx_get_ext,
     zmq_ctx_new, zmq_ctx_set, zmq_ctx_set_ext, zmq_ctx_shutdown, zmq_ctx_term, zmq_init, zmq_term,

--- a/omq-libzmq/tests/abi_matrix.rs
+++ b/omq-libzmq/tests/abi_matrix.rs
@@ -30,6 +30,18 @@ const FUNCTION_MATRIX: &[FunctionEntry] = &[
         status: FunctionStatus::Extension,
     },
     FunctionEntry {
+        name: "omq_async_task_cancel",
+        status: FunctionStatus::Extension,
+    },
+    FunctionEntry {
+        name: "omq_async_task_free",
+        status: FunctionStatus::Extension,
+    },
+    FunctionEntry {
+        name: "omq_socket_send_async",
+        status: FunctionStatus::Extension,
+    },
+    FunctionEntry {
         name: "zmq_atomic_counter_dec",
         status: FunctionStatus::Implemented,
     },


### PR DESCRIPTION
- Add initial .NET binding over the OMQ libzmq-compatible ABI.
- Add sync and async socket APIs, options, polling, monitoring, security, proxy, and lifecycle handling.
- Add CURVE/PLAIN interop, lifecycle stress coverage, benchmarks, and performance chart.
- Add NuGet packaging with RID-native assets and package-consumer smoke test.
- Add path-scoped CI for native build, binding tests, NuGet pack, and package installation.