### PR TITLE
Prepare OMQ.Net 0.1.2 docs and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+tab_width = 4
+dotnet_sort_system_directives_first = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'
+              - '.editorconfig'
               - '.github/workflows/ci.yml'
             ruby:
               - 'bindings/ruby/**'
@@ -136,6 +137,20 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/bindings/go/native/target/release:${{ github.workspace }}/bindings/go/native/target/debug
         run: go vet ./...
+
+  dotnet-lint:
+    name: dotnet format
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.run_dotnet == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: verify formatting
+        run: dotnet format bindings/dotnet/Omq.Net.csproj --verify-no-changes --verbosity minimal
 
   go-test:
     name: go test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
           dotnet restore bindings/dotnet/Omq.Net.csproj
           bash bindings/dotnet/scripts/package.sh "$RUNNER_TEMP/omq-nuget" \
             linux-x64="$GITHUB_WORKSPACE/target/release/libomq_zmq.so"
-          unzip -l "$RUNNER_TEMP/omq-nuget/Omq.Net.0.1.0.nupkg"
+          unzip -l "$RUNNER_TEMP/omq-nuget/Omq.Net.0.1.2.nupkg"
       - name: install package and run package smoke test
         run: |
           dotnet restore bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj \

--- a/bindings/dotnet/CHANGELOG.md
+++ b/bindings/dotnet/CHANGELOG.md
@@ -1,0 +1,28 @@
+# OMQ.Net Changelog
+
+## [Unreleased]
+
+## [0.1.2]
+
+### Added
+
+- XML documentation for the public API, included in the NuGet package for
+  IntelliSense.
+- Contributor, test, benchmark, and packaging instructions in
+  `DEVELOPMENT.md`.
+
+### Changed
+
+- Trim the README to installation, API, and performance context.
+- Set the next package version to `0.1.2`.
+
+## [0.1.1]
+
+### Added
+
+- First NuGet release of OMQ.Net.
+- `net8.0` and `net10.0` managed assemblies with Linux, macOS, and Windows
+  x64 native assets.
+- Synchronous and cancellation-aware asynchronous socket operations.
+- All OMQ socket types, multipart messages, polling, monitors, proxies,
+  CURVE key helpers, PLAIN/CURVE configuration, and lifecycle tests.

--- a/bindings/dotnet/DEVELOPMENT.md
+++ b/bindings/dotnet/DEVELOPMENT.md
@@ -1,0 +1,58 @@
+# OMQ.Net development
+
+Requires the .NET SDK 10 and a Rust toolchain. Mono is not required.
+
+## Build and test
+
+From the repository root:
+
+```sh
+cargo build --release -p omq-libzmq
+dotnet build bindings/dotnet/Omq.Net.csproj
+
+LD_LIBRARY_PATH="$PWD/target/release" \
+  dotnet run --project bindings/dotnet/tests/Omq.Net.Smoke.csproj
+
+LD_LIBRARY_PATH="$PWD/target/release" \
+  dotnet run --project bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
+
+LD_LIBRARY_PATH="$PWD/target/release" \
+  python3 bindings/dotnet/tests/interop.py
+```
+
+The interop suite covers .NET ↔ pyzmq NULL, CURVE, and authenticated PLAIN
+TCP peers. Lifecycle tests cover cancellation, bounded HWM waits, monitor
+shutdown, connect-before-bind, and repeated disposal.
+
+CI runs the managed binding checks on Linux. The release workflow builds
+native assets for Linux x64, macOS x64, macOS arm64, and Windows x64.
+
+## Benchmarks
+
+Run the full two-process TCP comparison against NetMQ:
+
+```sh
+LD_LIBRARY_PATH="$PWD/target/release" \
+  python3 bindings/dotnet/scripts/update_perf.py
+```
+
+Use `--quick` for a short check. Throughput measures 16 B–32 KiB; latency
+measures 16 B–4 KiB. Results append to `~/.cache/omq.net/bindings.jsonl`.
+Regenerate only the chart with:
+
+```sh
+python3 bindings/dotnet/scripts/update_perf.py --chart-only
+```
+
+## NuGet packaging
+
+Build native libraries for each RID, then pass `RID=PATH` arguments:
+
+```sh
+bash bindings/dotnet/scripts/package.sh /tmp/omq-nuget \
+  linux-x64=target/release/libomq_zmq.so
+```
+
+The package contains managed assemblies, generated XML documentation, the
+README, and native assets under NuGet RID folders. Release publication uses
+`.github/workflows/release-dotnet.yml` and NuGet trusted publishing.

--- a/bindings/dotnet/Omq.Net.csproj
+++ b/bindings/dotnet/Omq.Net.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <PackageId>Omq.Net</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.2</Version>
     <Authors>OMQ contributors</Authors>
     <Description>Fast .NET binding for OMQ.</Description>
     <PackageTags>zeromq;omq;networking;messaging</PackageTags>

--- a/bindings/dotnet/Omq.Net.csproj
+++ b/bindings/dotnet/Omq.Net.csproj
@@ -12,6 +12,7 @@
     <NativeAssetRoot Condition="'$(NativeAssetRoot)' == ''">$(MSBuildProjectDirectory)/native</NativeAssetRoot>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591</NoWarn>

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -1,72 +1,25 @@
 # OMQ.Net
 
-Fast, boring .NET binding for OMQ. Native transport stays in `omq-libzmq`.
-Managed code owns lifetimes, copies message bytes at the boundary, and
-serializes each socket handle. No Mono needed.
+Fast .NET binding for OMQ, backed by the `omq-libzmq` C ABI. Managed handles
+own native lifetimes; socket calls are serialized and message bytes are copied
+at the boundary.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/dotnet/doc/charts/bindings.svg" alt="OMQ.Net performance" width="850">
 </p>
 
-## Status
+2-process loopback TCP comparison against NetMQ. Throughput covers 16 B–32 KiB;
+REQ/REP p50 latency covers 16 B–4 KiB. See [`DEVELOPMENT.md`](DEVELOPMENT.md)
+for benchmark and regeneration commands.
 
-Early implementation. The sync core is here: all OMQ socket types, context
-sharing, bind/connect, multipart messages, send/receive, subscriptions,
-RADIO/DISH groups, common options, deterministic disposal, and native errno
-exceptions. Async send/receive, cancellation polling, readiness polling,
-CURVE key generation, PLAIN/CURVE configuration, and socket monitor events are
-included.
-
-`Dgram` is present in the public enum but currently rejected by the shared
-`omq-libzmq` ABI. Native DGRAM support must land before claiming full parity.
-
-## Build and test
-
-Requires .NET SDK 10 and Rust:
+## Install
 
 ```sh
-cargo build --release -p omq-libzmq
-dotnet build bindings/dotnet/Omq.Net.csproj
-LD_LIBRARY_PATH="$PWD/target/release" dotnet run --project bindings/dotnet/tests/Omq.Net.Smoke.csproj
-
-# bounded lifecycle/race checks
-LD_LIBRARY_PATH="$PWD/target/release" dotnet run --project bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
-
-# .NET <-> pyzmq protocol/security interop (NULL, CURVE, authenticated PLAIN)
-LD_LIBRARY_PATH="$PWD/target/release" python3 bindings/dotnet/tests/interop.py
+dotnet add package Omq.Net
 ```
 
-Run the real two-process TCP benchmark. It compares OMQ.Net with NetMQ, uses
-the full throughput sizes, and limits latency to 4 KiB:
-
-```sh
-LD_LIBRARY_PATH="$PWD/target/release" \
-  python3 bindings/dotnet/scripts/update_perf.py
-```
-
-Fast check:
-
-```sh
-LD_LIBRARY_PATH="$PWD/target/release" \
-  python3 bindings/dotnet/scripts/update_perf.py --quick
-```
-
-The native library can also be supplied through the normal loader paths. Keep
-`libomq_zmq.so` beside the test process or set `LD_LIBRARY_PATH`.
-
-## NuGet packaging
-
-One package carries managed assemblies plus native libraries under NuGet RID
-folders. Build native libraries for each supported RID, then pass them as
-`RID=PATH` arguments:
-
-```sh
-bash bindings/dotnet/scripts/package.sh /tmp/omq-nuget \
-  linux-x64=target/release/libomq_zmq.so
-```
-
-The package can contain several RIDs. Consumers install one `Omq.Net` package;
-NuGet selects the native asset matching their OS and CPU. No Mono needed.
+The package targets `net8.0` and `net10.0`, and includes RID-specific native
+assets for supported platforms.
 
 ## API
 
@@ -83,23 +36,14 @@ push.Send(Message.Text("hello"));
 Console.WriteLine(pull.Receive().ToString());
 ```
 
-Socket methods are safe across managed threads. A call holds the socket gate
-until its native operation completes. `Dispose` closes the native handle once;
-message frames are always closed in `finally` blocks. This is the baseline for
-race and leak tests before adding zero-copy or async APIs.
+The public API includes all OMQ socket types, multipart messages, options,
+polling, monitors, proxies, CURVE key helpers, synchronous operations, and
+cancellation-aware async operations. Generated XML documentation provides
+IntelliSense summaries for the public API.
 
-## Performance contract
+OMQ.Net follows OMQ/libzmq socket semantics; it is not a NetMQ compatibility
+layer.
 
-Benchmark charts compare sync and async OMQ.Net against sync and async NetMQ
-over two-process loopback TCP. PUSH/PULL throughput spans 16 B through 32 KiB;
-REQ/REP p50 latency spans 16 B through 4 KiB. Results append to:
-`~/.cache/omq.net/bindings.jsonl`. The cache is never rewritten; chart-only
-regeneration selects the newest row for each implementation, pattern, and size.
+## Development
 
-```sh
-python3 bindings/dotnet/scripts/update_perf.py --chart-only
-```
-
-Current quick-run result on this VM: OMQ.Net beats NetMQ at every sampled size.
-Treat that as a measurement, not a promise. Full runs need 3 rounds on a quiet
-machine before publishing a performance claim.
+See [`DEVELOPMENT.md`](DEVELOPMENT.md).

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -46,4 +46,6 @@ layer.
 
 ## Development
 
-See [`DEVELOPMENT.md`](DEVELOPMENT.md).
+Architecture: [`doc/architecture.md`](doc/architecture.md).
+
+Build, test, benchmark, and packaging instructions: [`DEVELOPMENT.md`](DEVELOPMENT.md).

--- a/bindings/dotnet/doc/architecture.md
+++ b/bindings/dotnet/doc/architecture.md
@@ -1,0 +1,71 @@
+# OMQ.Net architecture
+
+OMQ.Net is a managed wrapper over the `omq-libzmq` C ABI.
+
+- .NET owns API shape, validation, lifetime wrappers, option conversion, and
+  exception translation.
+- `omq-libzmq` owns contexts, sockets, queues, routing, transports, ZMTP,
+  reconnect, authentication, and native I/O threads.
+- The binding does not reimplement ZMTP or transport readiness in C#.
+
+## Runtime and ownership
+
+```text
+.NET caller
+  -> Socket / Context method
+  -> serialized managed call
+  -> omq-libzmq C ABI
+  -> native context I/O threads
+  -> transport and protocol tasks
+```
+
+`Context` owns the native context and all sockets created from it. `Socket`
+owns one `SafeHandle`. Explicit `Dispose` is idempotent; SafeHandle release is
+the fallback for abandoned handles. Socket calls hold a per-socket lock until
+the native operation completes.
+
+Pollers acquire native-handle leases before calling `zmq_poll`, so closing a
+socket cannot free its handle during an in-flight poll. Context shutdown closes
+owned sockets after waking native operations.
+
+## Data path
+
+- Outbound spans, strings, and message frames are copied into temporary
+  managed/native buffers before the C call.
+- Inbound frames are copied into managed `byte[]` values before each native
+  `zmq_msg_t` is closed.
+- Multipart receive drains the complete native message while the socket lock
+  is held, preserving frame order and routing ID.
+- No managed pointer is retained by native code after the call returns.
+
+The copying boundary is deliberate: it keeps ownership simple and makes
+dispose, cancellation, and GC interactions explicit. Zero-copy APIs are not
+part of the current public contract.
+
+## Async and cancellation
+
+`SendAsync(Message)` uses the OMQ-native async task ABI. Cancellation requests
+native task cancellation and keeps the callback state rooted until completion.
+`SendAsync(ReadOnlyMemory<byte>)` and `ReceiveAsync` use nonblocking socket
+operations plus short cancellable poll slices. `Poller.WaitAsync` uses the same
+bounded-slice model.
+
+Cancellation never frees a native async task or callback state while native
+code may still reference it. Dispose and context shutdown remain the explicit
+way to interrupt native operations that have no native cancellation handle.
+
+## Monitors and proxies
+
+`Monitor` enables the native socket monitor and reads its inproc PAIR endpoint.
+Events are decoded into managed `MonitorEvent` values; disposing the monitor
+first disables the source and then closes the reader.
+
+`Proxy` delegates blocking proxy/device loops directly to the native ABI. Run
+these methods on a dedicated thread or task.
+
+## Packaging
+
+The managed assembly targets `net8.0` and `net10.0`. One NuGet package carries
+the generated XML documentation and native libraries under RID-specific
+`runtimes/<rid>/native/` paths. The .NET host resolves the matching native
+library through normal RID asset selection.

--- a/bindings/dotnet/src/Async.cs
+++ b/bindings/dotnet/src/Async.cs
@@ -3,14 +3,17 @@ namespace Omq;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
+/// Cancellation-aware asynchronous socket operations.
 public static class SocketAsyncExtensions
 {
+    /// Sends one frame, waiting for writability when the socket HWM is full.
     public static async Task SendAsync(this Socket socket, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
     {
         var poller = new Poller(); poller.Add(socket, PollEvents.Writable);
         while (!socket.TrySend(data.Span)) { cancellationToken.ThrowIfCancellationRequested(); await poller.WaitAsync(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false); }
     }
 
+    /// Sends all frames in a message and completes when the native async send finishes.
     public static async Task SendAsync(this Socket socket, Message message, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -49,6 +52,7 @@ public static class SocketAsyncExtensions
         }
     }
 
+    /// Receives the next complete message, waiting asynchronously until available.
     public static Task<Message> ReceiveAsync(this Socket socket, CancellationToken cancellationToken = default)
     {
         return ReceiveAsyncCore(socket, cancellationToken);

--- a/bindings/dotnet/src/Context.cs
+++ b/bindings/dotnet/src/Context.cs
@@ -3,14 +3,17 @@ using System.Runtime.InteropServices;
 
 namespace Omq;
 
+/// Owns native I/O threads and the sockets created from them.
 public sealed class Context : IDisposable
 {
     private readonly object gate = new();
     private readonly List<Socket> sockets = [];
     private SafeContext? handle;
     private bool shutdown;
+    /// Gets whether the context has been shut down or disposed.
     public bool Closed => handle is null;
 
+    /// Creates a context with the requested number of native I/O threads.
     public Context(int ioThreads = 1)
     {
         if (ioThreads < 1) throw new ArgumentOutOfRangeException(nameof(ioThreads));
@@ -21,8 +24,10 @@ public sealed class Context : IDisposable
     }
 
     private Context(IntPtr raw) => handle = new SafeContext(raw);
+    /// Creates a context using the default construction style.
     public static Context Instance(int ioThreads = 1) => new(ioThreads);
 
+    /// Imports a context shared through an OMQ share key.
     public static Context FromShareKey(ulong high, ulong low)
     {
         IntPtr raw = Native.omq_ctx_from_share_key(high, low);
@@ -30,14 +35,18 @@ public sealed class Context : IDisposable
         return new Context(raw);
     }
 
+    /// Exports a key that can be used to share this context with another binding.
     public (ulong High, ulong Low) ShareKey()
     {
         lock (gate) { var h = Require(); Errors.Check("ctx_share_key", Native.omq_ctx_share_key(h, out ulong high, out ulong low)); return (high, low); }
     }
 
+    /// Sets a native context option.
     public void SetOption(int option, int value) { lock (gate) Errors.Check("ctx_set", Native.zmq_ctx_set(Require(), option, value)); }
+    /// Gets a native context option.
     public int GetOption(int option) { lock (gate) return Native.zmq_ctx_get(Require(), option); }
 
+    /// Creates and configures a socket owned by this context.
     public Socket CreateSocket(SocketType type, SocketOptions options = default)
     {
         lock (gate)
@@ -54,6 +63,7 @@ public sealed class Context : IDisposable
     internal void Remove(Socket socket) { lock (gate) sockets.Remove(socket); }
     private IntPtr Require() => handle?.DangerousGetHandle() is { } ptr && ptr != IntPtr.Zero ? ptr : throw new OmqClosedException();
 
+    /// Closes sockets, wakes blocked operations, and releases the native context.
     public void Dispose()
     {
         lock (gate)
@@ -72,8 +82,10 @@ public sealed class Context : IDisposable
         GC.SuppressFinalize(this);
     }
 
+    /// Alias for <see cref="Dispose"/>.
     public void Destroy() => Dispose();
 
+    /// Shuts down context I/O while leaving the managed context object usable for disposal.
     public void Shutdown()
     {
         lock (gate)

--- a/bindings/dotnet/src/Context.cs
+++ b/bindings/dotnet/src/Context.cs
@@ -1,5 +1,5 @@
-using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace Omq;
 

--- a/bindings/dotnet/src/Errors.cs
+++ b/bindings/dotnet/src/Errors.cs
@@ -2,13 +2,17 @@ using System.Runtime.InteropServices;
 
 namespace Omq;
 
+/// Exception raised by an OMQ native operation.
 public class OmqException : Exception
 {
+    /// Gets the native errno value.
     public int Errno { get; }
     internal OmqException(string operation, int errno, string message) : base($"{operation}: {message} (errno {errno})") => Errno = errno;
 }
 
+/// Indicates that a non-blocking operation would block.
 public sealed class OmqAgainException : OmqException { internal OmqAgainException(string op, int e, string m) : base(op, e, m) { } }
+/// Indicates that an OMQ context or socket has already been closed.
 public sealed class OmqClosedException : ObjectDisposedException { internal OmqClosedException() : base("OMQ handle") { } }
 
 internal static class Errors

--- a/bindings/dotnet/src/Message.cs
+++ b/bindings/dotnet/src/Message.cs
@@ -1,18 +1,29 @@
 namespace Omq;
 
+/// Managed, owning representation of one or more OMQ message frames.
 public sealed class Message
 {
     private readonly byte[][] parts;
+    /// Gets the message frames. Frame bytes are owned by this message.
     public IReadOnlyList<byte[]> Parts => parts;
+    /// Gets the number of frames.
     public int PartCount => parts.Length;
+    /// Gets a frame by index.
     public byte[] this[int index] => parts[index];
+    /// Gets the only frame; throws for multipart messages.
     public byte[] Data => parts.Length == 1 ? parts[0] : throw new InvalidOperationException("message is multipart");
+    /// Gets whether this message contains more than one frame.
     public bool IsMultipart => parts.Length > 1;
+    /// Gets or sets the routing ID carried by the first frame.
     public uint RoutingId { get; set; }
     internal Message(byte[][] parts) => this.parts = parts;
+    /// Copies one frame into a new message.
     public Message(byte[] data) : this(new[] { data.ToArray() }) { }
+    /// Copies all supplied frames into a new message.
     public Message(IEnumerable<ReadOnlyMemory<byte>> parts) : this(parts.Select(x => x.ToArray()).ToArray()) { }
+    /// Creates a UTF-8 single-frame message.
     public static Message Text(string text) => new(System.Text.Encoding.UTF8.GetBytes(text));
+    /// Deep-copies this message, including frame bytes and routing ID.
     public Message Clone() => new(parts.Select(part => part.ToArray()).ToArray()) { RoutingId = RoutingId };
     public override string ToString() => IsMultipart ? $"multipart({parts.Length})" : System.Text.Encoding.UTF8.GetString(Data);
 }

--- a/bindings/dotnet/src/Monitor.cs
+++ b/bindings/dotnet/src/Monitor.cs
@@ -2,6 +2,7 @@ using System.Buffers.Binary;
 
 namespace Omq;
 
+/// Native socket-monitor event flags.
 public enum MonitorEventType : ushort
 {
     Connected = 0x0001, ConnectDelayed = 0x0002, ConnectRetried = 0x0004,
@@ -11,8 +12,10 @@ public enum MonitorEventType : ushort
     HandshakeFailed = 0x0800, HandshakeSucceeded = 0x1000
 }
 
+/// One decoded socket-monitor event.
 public readonly record struct MonitorEvent(MonitorEventType Type, uint Value, string Endpoint);
 
+/// Receives lifecycle and connection events for a socket.
 public sealed class Monitor : IDisposable
 {
     private readonly Socket source;
@@ -29,6 +32,7 @@ public sealed class Monitor : IDisposable
         reader.Connect(endpoint);
     }
 
+    /// Receives the next monitor event; optionally throws immediately if none is ready.
     public MonitorEvent Receive(bool dontWait = false)
     {
         return Parse(reader.Receive(dontWait));
@@ -43,6 +47,7 @@ public sealed class Monitor : IDisposable
         return new MonitorEvent(type, value, System.Text.Encoding.UTF8.GetString(message.Parts[1]));
     }
 
+    /// Receives the next monitor event with cancellation.
     public async Task<MonitorEvent> ReceiveAsync(CancellationToken cancellationToken = default)
     {
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, stopping.Token);
@@ -56,6 +61,7 @@ public sealed class Monitor : IDisposable
         return Parse(message!);
     }
 
+    /// Stops monitoring and closes the monitor reader.
     public void Dispose()
     {
         if (stopped) return;

--- a/bindings/dotnet/src/Options.cs
+++ b/bindings/dotnet/src/Options.cs
@@ -1,13 +1,19 @@
 namespace Omq;
 
+/// Numeric context-option identifiers from the OMQ C ABI.
 public static class ContextOption
 {
+    /// Number of native I/O threads.
     public const int IoThreads = 1, MaxSockets = 2, SocketLimit = 3, ThreadPriority = 3;
+    /// Context scheduler and message-size option identifiers.
     public const int ThreadSchedulerPolicy = 4, MaxMessageSize = 5, MessageSize = 6;
+    /// Context affinity, naming, zero-copy, and blocking option identifiers.
     public const int ThreadAffinityCpuAdd = 7, ThreadAffinityCpuRemove = 8, ThreadNamePrefix = 9, ZeroCopyReceive = 10;
+    /// Whether context termination may block.
     public const int Blocky = 70;
 }
 
+/// Numeric socket-option identifiers from the OMQ/libzmq C ABI.
 public static class SocketOption
 {
     public const int Affinity = 4, RoutingId = 5, Identity = RoutingId, Subscribe = 6, Unsubscribe = 7;
@@ -38,62 +44,118 @@ public static class SocketOption
     public const int NormBlockSize = 121, NormNumParity = 122, NormNumAutoParity = 123, NormPush = 124, ArenaThreshold = 10001;
 }
 
+/// Common socket settings applied immediately after socket creation.
 public readonly record struct SocketOptions
 {
+    /// I/O thread affinity mask.
     public long? Affinity { get; init; }
+    /// Outbound high-water mark.
     public int? SendHwm { get; init; }
+    /// Inbound high-water mark.
     public int? ReceiveHwm { get; init; }
+    /// Native send buffer size.
     public int? SendBuffer { get; init; }
+    /// Native receive buffer size.
     public int? ReceiveBuffer { get; init; }
+    /// Linger duration during close.
     public int? Linger { get; init; }
+    /// Maximum send wait.
     public TimeSpan? SendTimeout { get; init; }
+    /// Maximum receive wait.
     public TimeSpan? ReceiveTimeout { get; init; }
+    /// Multicast data rate.
     public int? Rate { get; init; }
+    /// Multicast recovery interval.
     public int? RecoveryInterval { get; init; }
+    /// Listen backlog.
     public int? Backlog { get; init; }
+    /// Multicast hop limit.
     public int? MulticastHops { get; init; }
+    /// Routing identity bytes.
     public byte[]? Identity { get; init; }
+    /// Initial reconnect interval.
     public int? ReconnectInterval { get; init; }
+    /// Maximum reconnect interval.
     public int? ReconnectIntervalMax { get; init; }
+    /// Maximum accepted message size.
     public long? MaxMessageSize { get; init; }
+    /// Require a route for router sends.
     public bool? RouterMandatory { get; init; }
+    /// Queue messages until connected.
     public bool? Immediate { get; init; }
+    /// Enable IPv6 transport.
     public bool? Ipv6 { get; init; }
+    /// Keep only the last message.
     public bool? Conflate { get; init; }
+    /// Use raw router mode.
     public bool? RouterRaw { get; init; }
+    /// Probe routers on connect.
     public bool? ProbeRouter { get; init; }
+    /// Enable REQ correlation.
     public bool? ReqCorrelate { get; init; }
+    /// Allow another REQ before receiving a reply.
     public bool? ReqRelaxed { get; init; }
+    /// Allow router handover.
     public bool? RouterHandover { get; init; }
+    /// Enable XPUB verbose subscriptions.
     public bool? XPubVerbose { get; init; }
+    /// Do not drop XPUB messages.
     public bool? XPubNoDrop { get; init; }
+    /// Enable manual XPUB subscriptions.
     public bool? XPubManual { get; init; }
+    /// Enable extra XPUB subscription notifications.
     public bool? XPubVerboser { get; init; }
+    /// Invert subscription matching.
     public bool? InvertMatching { get; init; }
+    /// Notify stream peers with routing information.
     public bool? StreamNotify { get; init; }
+    /// Deliver only the first matching subscription.
     public bool? OnlyFirstSubscribe { get; init; }
+    /// Enable multicast loopback.
     public bool? MulticastLoop { get; init; }
+    /// Require the configured ZAP domain.
     public bool? ZapEnforceDomain { get; init; }
+    /// Connection establishment timeout in milliseconds.
     public int? ConnectTimeout { get; init; }
+    /// TCP maximum retransmission timeout.
     public int? TcpMaxRt { get; init; }
+    /// ZAP security domain.
     public string? ZapDomain { get; init; }
+    /// Routing ID used for outgoing connections.
     public string? ConnectRoutingId { get; init; }
+    /// GSSAPI principal.
     public string? GssapiPrincipal { get; init; }
+    /// GSSAPI service principal.
     public string? GssapiServicePrincipal { get; init; }
+    /// SOCKS proxy endpoint.
     public string? SocksProxy { get; init; }
+    /// SOCKS username.
     public string? SocksUsername { get; init; }
+    /// SOCKS password.
     public string? SocksPassword { get; init; }
+    /// WSS private-key PEM.
     public string? WssKeyPem { get; init; }
+    /// WSS certificate PEM.
     public string? WssCertPem { get; init; }
+    /// WSS trust bundle PEM.
     public string? WssTrustPem { get; init; }
+    /// WSS expected hostname.
     public string? WssHostname { get; init; }
+    /// Use the system WSS trust store.
     public bool? WssTrustSystem { get; init; }
+    /// Heartbeat interval in milliseconds.
     public int? HeartbeatInterval { get; init; }
+    /// Heartbeat TTL in deciseconds.
     public int? HeartbeatTtl { get; init; }
+    /// Heartbeat timeout in milliseconds.
     public int? HeartbeatTimeout { get; init; }
+    /// Enable TCP keepalive.
     public int? TcpKeepalive { get; init; }
+    /// TCP keepalive probe count.
     public int? TcpKeepaliveCount { get; init; }
+    /// TCP keepalive idle interval.
     public int? TcpKeepaliveIdle { get; init; }
+    /// TCP keepalive probe interval.
     public int? TcpKeepaliveInterval { get; init; }
 
     internal void Apply(Socket socket)

--- a/bindings/dotnet/src/Poller.cs
+++ b/bindings/dotnet/src/Poller.cs
@@ -1,19 +1,27 @@
 namespace Omq;
 
+/// Events that a poller can report.
 [Flags]
 public enum PollEvents { None = 0, Readable = 1, Writable = 2, Error = 4 }
+/// A socket and the events currently ready on it.
 public readonly record struct PollResult(Socket Socket, PollEvents Events);
 
+/// Thread-safe collection of sockets polled through the native OMQ poller.
 public sealed class Poller : IDisposable
 {
     private readonly object gate = new();
     private readonly List<(Socket Socket, PollEvents Events)> entries = [];
+    /// Gets a snapshot of registered sockets.
     public IReadOnlyList<Socket> Sockets { get { lock (gate) return entries.Select(x => x.Socket).ToArray(); } }
+    /// Registers a socket and its interest mask.
     public void Add(Socket socket, PollEvents events = PollEvents.Readable) { lock (gate) entries.Add((socket, events)); }
+    /// Removes all registrations for a socket.
     public bool Remove(Socket socket) { lock (gate) return entries.RemoveAll(x => ReferenceEquals(x.Socket, socket)) != 0; }
 
+    /// Waits indefinitely for an event.
     public IReadOnlyList<PollResult> Wait() => Wait(Timeout.InfiniteTimeSpan);
 
+    /// Waits up to <paramref name="timeout"/> and returns ready sockets.
     public IReadOnlyList<PollResult> Wait(TimeSpan timeout)
     {
         (Socket Socket, PollEvents Events)[] snapshot;
@@ -38,6 +46,7 @@ public sealed class Poller : IDisposable
         return ready;
     }
 
+    /// Waits asynchronously and observes cancellation between native poll slices.
     public Task<IReadOnlyList<PollResult>> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>
         Task.Run(() => WaitCancellable(timeout, cancellationToken), cancellationToken);
 
@@ -54,6 +63,7 @@ public sealed class Poller : IDisposable
         }
     }
 
+    /// Removes all registrations.
     public void Dispose() { lock (gate) entries.Clear(); }
 
     private sealed class LeaseSet : IDisposable

--- a/bindings/dotnet/src/Proxy.cs
+++ b/bindings/dotnet/src/Proxy.cs
@@ -3,12 +3,15 @@ namespace Omq;
 /// Blocking built-in proxy/device helpers. Run them on a dedicated thread.
 public static class Proxy
 {
+    /// Runs a blocking proxy between frontend and backend sockets.
     public static void Run(Socket frontend, Socket backend, Socket? capture = null) =>
         Errors.Check("proxy", Native.zmq_proxy(frontend.NativeHandle, backend.NativeHandle, capture?.NativeHandle ?? IntPtr.Zero));
 
+    /// Runs a blocking steerable proxy.
     public static void RunSteerable(Socket frontend, Socket backend, Socket? capture, Socket control) =>
         Errors.Check("proxy_steerable", Native.zmq_proxy_steerable(frontend.NativeHandle, backend.NativeHandle, capture?.NativeHandle ?? IntPtr.Zero, control.NativeHandle));
 
+    /// Runs a legacy native device by numeric device type.
     public static void Device(int deviceType, Socket frontend, Socket backend) =>
         Errors.Check("device", Native.zmq_device(deviceType, frontend.NativeHandle, backend.NativeHandle));
 }

--- a/bindings/dotnet/src/Security.cs
+++ b/bindings/dotnet/src/Security.cs
@@ -2,10 +2,13 @@ using System.Runtime.InteropServices;
 
 namespace Omq;
 
+/// A Z85-encoded CURVE public/secret key pair.
 public readonly record struct CurveKeyPair(string PublicKey, string SecretKey);
 
+/// CURVE key generation helpers.
 public static class Curve
 {
+    /// Generates a new CURVE key pair.
     public static CurveKeyPair GenerateKeyPair()
     {
         IntPtr publicKey = Marshal.AllocHGlobal(41), secretKey = Marshal.AllocHGlobal(41);
@@ -17,6 +20,7 @@ public static class Curve
         finally { Marshal.FreeHGlobal(publicKey); Marshal.FreeHGlobal(secretKey); }
     }
 
+    /// Derives the Z85 public key corresponding to a secret key.
     public static string PublicKey(string secretKey)
     {
         IntPtr publicKey = Marshal.AllocHGlobal(41), secret = Marshal.StringToCoTaskMemUTF8(secretKey);

--- a/bindings/dotnet/src/Socket.cs
+++ b/bindings/dotnet/src/Socket.cs
@@ -4,13 +4,17 @@ using System.Text.Json;
 
 namespace Omq;
 
+/// Thread-safe managed wrapper around one native OMQ socket.
 public sealed class Socket : IDisposable
 {
     private readonly Context owner;
     private readonly object gate = new();
     private Context.SafeSocket? handle;
+    /// Gets the socket pattern.
     public SocketType Type { get; }
+    /// Gets whether the native socket has been closed.
     public bool Closed => handle is null;
+    /// Gets the native pollable file descriptor.
     public int FileDescriptor => GetInt32(SocketOption.FileDescriptor);
 
     internal Socket(Context owner, SocketType type, Context.SafeSocket handle) { this.owner = owner; Type = type; this.handle = handle; }
@@ -28,21 +32,28 @@ public sealed class Socket : IDisposable
         }
     }
 
+    /// Sets an integer socket option.
     public void SetOption(int option, int value) => SetOption(option, BitConverter.GetBytes(value));
+    /// Sets a 64-bit socket option.
     public void SetOption(int option, long value) => SetOption(option, BitConverter.GetBytes(value));
+    /// Sets a raw socket option value.
     public void SetOption(int option, ReadOnlySpan<byte> value)
     {
         lock (gate) { IntPtr socket = Require(); byte[] copy = value.ToArray(); unsafe { fixed (byte* p = copy) Errors.Check("setsockopt", Native.zmq_setsockopt(socket, option, (IntPtr)p, (nuint)copy.Length)); } }
     }
+    /// Sets a UTF-8 string socket option.
     public void SetOption(int option, string value) => SetOption(option, Encoding.UTF8.GetBytes(value));
+    /// Gets an integer socket option.
     public int GetInt32(int option)
     {
         lock (gate) { int value = 0; nuint length = sizeof(int); unsafe { Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)(&value), ref length)); } return value; }
     }
+    /// Gets a 64-bit socket option.
     public long GetInt64(int option)
     {
         lock (gate) { long value = 0; nuint length = sizeof(long); unsafe { Errors.Check("getsockopt", Native.zmq_getsockopt(Require(), option, (IntPtr)(&value), ref length)); } return value; }
     }
+    /// Gets a variable-length socket option as bytes.
     public byte[] GetBytes(int option, int capacity = 1024)
     {
         lock (gate)
@@ -52,6 +63,7 @@ public sealed class Socket : IDisposable
             return value[..checked((int)length)];
         }
     }
+    /// Gets a UTF-8 string socket option.
     public string GetString(int option, int capacity = 1024)
     {
         lock (gate)
@@ -61,24 +73,39 @@ public sealed class Socket : IDisposable
             return Encoding.UTF8.GetString(value, 0, checked((int)length)).TrimEnd('\0');
         }
     }
+    /// Adds a subscription prefix.
     public void Subscribe(ReadOnlySpan<byte> prefix) => SetOption(SocketOption.Subscribe, prefix);
+    /// Adds a UTF-8 subscription prefix.
     public void Subscribe(string prefix) => Subscribe(Encoding.UTF8.GetBytes(prefix));
+    /// Removes a subscription prefix.
     public void Unsubscribe(ReadOnlySpan<byte> prefix) => SetOption(SocketOption.Unsubscribe, prefix);
+    /// Removes a UTF-8 subscription prefix.
     public void Unsubscribe(string prefix) => Unsubscribe(Encoding.UTF8.GetBytes(prefix));
+    /// Enables PLAIN server mode.
     public void ConfigurePlainServer(string username = "", string password = "") { _ = username; _ = password; SetOption(SocketOption.PlainServer, 1); }
+    /// Configures PLAIN client credentials.
     public void ConfigurePlainClient(string username, string password) { SetOption(SocketOption.PlainUsername, username); SetOption(SocketOption.PlainPassword, password); }
+    /// Enables CURVE server mode with its secret key.
     public void ConfigureCurveServer(string publicKey, string secretKey) { _ = publicKey; SetOption(SocketOption.CurveServer, 1); SetOption(SocketOption.CurveSecretKey, secretKey); }
+    /// Configures CURVE client keys and the server key.
     public void ConfigureCurveClient(string publicKey, string secretKey, string serverPublicKey) { SetOption(SocketOption.CurvePublicKey, publicKey); SetOption(SocketOption.CurveSecretKey, secretKey); SetOption(SocketOption.CurveServerKey, serverPublicKey); }
+    /// Creates a monitor for this socket.
     public Monitor Monitor(int events = 0xFFFF) => new(owner, this, events);
+    /// Joins a RADIO/DISH group.
     public void Join(string group) => EndpointCall("join", group, NativeJoin);
+    /// Leaves a RADIO/DISH group.
     public void Leave(string group) => EndpointCall("leave", group, NativeLeave);
+    /// Binds and returns the effective endpoint.
     public string Bind(string endpoint)
     {
         EndpointCall("bind", endpoint, NativeBind);
         return endpoint.EndsWith(":0", StringComparison.Ordinal) ? GetString(SocketOption.LastEndpoint) : endpoint;
     }
+    /// Connects to an endpoint.
     public void Connect(string endpoint) => EndpointCall("connect", endpoint, NativeConnect);
+    /// Removes a binding.
     public void Unbind(string endpoint) => EndpointCall("unbind", endpoint, NativeUnbind);
+    /// Removes a connection.
     public void Disconnect(string endpoint) => EndpointCall("disconnect", endpoint, NativeDisconnect);
 
     private delegate int EndpointFn(IntPtr socket, IntPtr text);
@@ -95,11 +122,14 @@ public sealed class Socket : IDisposable
     [DllImport("omq_zmq", CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_join")] private static extern int NativeJoinImpl(IntPtr s, IntPtr e);
     [DllImport("omq_zmq", CallingConvention = CallingConvention.Cdecl, EntryPoint = "zmq_leave")] private static extern int NativeLeaveImpl(IntPtr s, IntPtr e);
 
+    /// Sends one frame, optionally marking it as multipart and/or non-blocking.
     public void Send(ReadOnlySpan<byte> data, bool more = false, bool dontWait = false)
     {
         lock (gate) { byte[] copy = data.ToArray(); unsafe { fixed (byte* p = copy) Errors.Check("send", Native.zmq_send(Require(), (IntPtr)p, (nuint)copy.Length, Flags(more, dontWait))); } }
     }
+    /// Sends a UTF-8 frame.
     public void SendText(string text, bool more = false, bool dontWait = false) => Send(Encoding.UTF8.GetBytes(text), more, dontWait);
+    /// Sends all frames in a message.
     public void Send(Message message, bool dontWait = false)
     {
         lock (gate)
@@ -107,7 +137,9 @@ public sealed class Socket : IDisposable
             for (int i = 0; i < message.Parts.Count; i++) SendPart(message.Parts[i], i + 1 < message.Parts.Count, dontWait, i == 0 ? message.RoutingId : 0);
         }
     }
+    /// Sends copied multipart frames.
     public void SendMultipart(IEnumerable<ReadOnlyMemory<byte>> parts, bool dontWait = false) => Send(new Message(parts), dontWait);
+    /// Sends copied multipart byte arrays.
     public void SendMultipart(params byte[][] parts) => Send(new Message(parts.Select(x => (ReadOnlyMemory<byte>)x)), false);
     private void SendPart(byte[] data, bool more, bool dontWait, uint routingId = 0)
     {
@@ -117,6 +149,7 @@ public sealed class Socket : IDisposable
         finally { Native.zmq_msg_close(ref msg); }
     }
 
+    /// Receives one complete message, including all multipart frames.
     public Message Receive(bool dontWait = false)
     {
         lock (gate)
@@ -132,39 +165,51 @@ public sealed class Socket : IDisposable
             return new Message(parts.ToArray()) { RoutingId = routingId };
         }
     }
+    /// Receives a UTF-8 single-frame message.
     public string ReceiveText(bool dontWait = false) => Encoding.UTF8.GetString(Receive(dontWait).Data);
+    /// Sends a UTF-8 string.
     public void SendString(string text, bool dontWait = false) => SendText(text, dontWait: dontWait);
+    /// Receives a UTF-8 string.
     public string ReceiveString(bool dontWait = false) => ReceiveText(dontWait);
+    /// Serializes and sends a JSON frame.
     public void SendJson<T>(T value, bool dontWait = false, bool more = false) => Send(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value)), more, dontWait);
+    /// Receives and deserializes a JSON frame.
     public T? ReceiveJson<T>(bool dontWait = false) => JsonSerializer.Deserialize<T>(Receive(dontWait).Data);
+    /// Polls this socket for readiness.
     public IReadOnlyList<PollResult> Poll(TimeSpan timeout, PollEvents events = PollEvents.Readable)
     {
         using var poller = new Poller();
         poller.Add(this, events);
         return poller.Wait(timeout);
     }
+    /// Attempts a non-blocking frame send.
     public bool TrySend(ReadOnlySpan<byte> data)
     {
         try { Send(data, dontWait: true); return true; }
         catch (OmqAgainException) { return false; }
     }
+    /// Attempts a non-blocking message send.
     public bool TrySend(Message message)
     {
         try { Send(message, dontWait: true); return true; }
         catch (OmqAgainException) { return false; }
     }
+    /// Receives all frames as byte arrays.
     public IReadOnlyList<byte[]> ReceiveMultipart(bool dontWait = false) => Receive(dontWait).Parts;
+    /// Attempts a non-blocking message receive.
     public bool TryReceive(out Message? message)
     {
         try { message = Receive(dontWait: true); return true; }
         catch (OmqAgainException) { message = null; return false; }
     }
+    /// Receives one frame into a caller-provided buffer.
     public byte[] ReceiveInto(Span<byte> buffer, bool dontWait = false)
     {
         lock (gate) { byte[] copy = new byte[buffer.Length]; unsafe { fixed (byte* p = copy) { int n = Native.zmq_recv(Require(), (IntPtr)p, (nuint)copy.Length, dontWait ? 1 : 0); Errors.Check("recv", n); copy.AsSpan(0, n).CopyTo(buffer); return copy[..n]; } } }
     }
     private static int Flags(bool more, bool dontWait) => (more ? 2 : 0) | (dontWait ? 1 : 0);
 
+    /// Closes the socket and releases its native handle.
     public void Dispose()
     {
         lock (gate) { if (handle is null) return; handle.Dispose(); handle = null; }

--- a/bindings/dotnet/src/SocketType.cs
+++ b/bindings/dotnet/src/SocketType.cs
@@ -1,5 +1,6 @@
 namespace Omq;
 
+/// OMQ socket patterns supported by the native ABI.
 public enum SocketType
 {
     Pair = 0, Pub = 1, Sub = 2, Req = 3, Rep = 4, Dealer = 5,

--- a/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
+++ b/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <OmqNetVersion Condition="'$(OmqNetVersion)' == ''">0.1.0</OmqNetVersion>
+    <OmqNetVersion Condition="'$(OmqNetVersion)' == ''">0.1.2</OmqNetVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Omq.Net" Version="$(OmqNetVersion)" />


### PR DESCRIPTION
- Add concise XML documentation for the public .NET API
- Generate and package XML docs for `net8.0` and `net10.0`
- Trim `bindings/dotnet/README.md` and move development details to `DEVELOPMENT.md`
- Add brief `bindings/dotnet/doc/architecture.md` for runtime, ownership, async, and packaging
- Add `dotnet format` as an early CI lint job for .NET binding changes
- Prepare `Omq.Net` version `0.1.2` and curate `bindings/dotnet/CHANGELOG.md`