### PR TITLE
Use dotnet release tag prefix

### DIFF
--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -3,7 +3,7 @@ name: Release OMQ.Net
 on:
   push:
     tags:
-      - 'omq-net-v*'
+      - 'omq-dotnet-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -85,7 +85,7 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            version="${GITHUB_REF_NAME#omq-net-v}"
+            version="${GITHUB_REF_NAME#omq-dotnet-v}"
           else
             version="$INPUT_VERSION"
           fi


### PR DESCRIPTION
- Change OMQ.Net release trigger from `omq-net-v*` to `omq-dotnet-v*`
- Parse package version from `omq-dotnet-v*` tags
- Keep NuGet package ID as `Omq.Net`