### PR TITLE
Audit Ruby binding and chart metadata

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -237,7 +237,8 @@ Results go to `~/.cache/omq/comparisons.jsonl`. APPEND-ONLY!
 Chart subtitles come from `.chart_hw` in the repo root:
 
 ```text
-label=Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off
+prefix=Linux VM on a 2018 Mac Mini
+postfix=6 cores, performance governor, turbo off
 ```
 
 `omq-bench` and binding chart scripts read the repo-root `.chart_hw`
@@ -358,7 +359,6 @@ cargo run --release -p omq-bench -- chart compression
 
 ```sh
 cd bindings/pyomq
-export OMQ_HW_EXTRAS="performance governor, turbo off"
 maturin develop --release
 python scripts/update_perf.py --impl pyomq
 python scripts/update_perf.py --chart-only

--- a/bindings/dotnet/scripts/update_perf.py
+++ b/bindings/dotnet/scripts/update_perf.py
@@ -1221,9 +1221,6 @@ def _read_chart_hw():
 
 def _detect_hardware():
     hw_conf = _read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
     if prefix and postfix:

--- a/bindings/go/scripts/update_perf.py
+++ b/bindings/go/scripts/update_perf.py
@@ -1371,9 +1371,6 @@ def read_chart_hw():
 
 def detect_hardware():
     config = read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
     if prefix and postfix:

--- a/bindings/java/scripts/bench_pushpull_tcp.py
+++ b/bindings/java/scripts/bench_pushpull_tcp.py
@@ -445,9 +445,6 @@ def escape_svg(value):
 
 def detect_hardware():
     config = read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
     if prefix and postfix:

--- a/bindings/lua/scripts/update_perf.py
+++ b/bindings/lua/scripts/update_perf.py
@@ -572,9 +572,6 @@ def read_chart_hw():
 
 def detect_hardware():
     config = read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or config.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or config.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or config.get("postfix")
     if prefix and postfix:

--- a/bindings/node/DEVELOPMENT.md
+++ b/bindings/node/DEVELOPMENT.md
@@ -94,7 +94,8 @@ bindings/node/doc/charts/bindings.svg
 Hardware subtitle comes from the repo-root `.chart_hw`:
 
 ```text
-label=Ryzen 9 9950X, 16 cores, turbo off, performance governor
+prefix=Ryzen 9 9950X
+postfix=16 cores, turbo off, performance governor
 ```
 
 `.chart_hw` is local-only and gitignored.

--- a/bindings/node/scripts/update_perf.py
+++ b/bindings/node/scripts/update_perf.py
@@ -206,9 +206,6 @@ def _read_chart_hw():
 
 def _detect_hardware():
     hw_conf = _read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
     if prefix and postfix:

--- a/bindings/pyomq/AGENTS.md
+++ b/bindings/pyomq/AGENTS.md
@@ -30,9 +30,8 @@ workspace root lock file.
 
 ## Benchmarks
 
-Chart subtitle reads `bindings/pyomq/.chart_hw` plus detected CPU info.
-Use `OMQ_HW_PREFIX`/`OMQ_HW_POSTFIX` to override it for one run, or
-`OMQ_HW_EXTRAS` to append one-off details.
+Chart subtitle reads the repo-root `.chart_hw`. Use `OMQ_HW_PREFIX` and
+`OMQ_HW_POSTFIX` to override its `prefix` and `postfix` values for one run.
 
 Bench machine: i7-8700B, performance governor, turbo off.
 

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -64,6 +64,7 @@ def save_results(
     run_id, impl, tp_inproc, tp_tcp, atp_tcp, lat, alat, proxy_pp, proxy_rr
 ):
     rows = []
+
     def latency_fields(values):
         fields = {
             "p50_us": values[0],
@@ -779,9 +780,7 @@ def run_latency(lib_name):
         ]
         selected = median(runs, key=lambda row: row[0])
         results.append(selected)
-        print(
-            f" p50 {selected[0]:.1f} μs  p99 {selected[1]:.1f} μs  n={selected[2]}"
-        )
+        print(f" p50 {selected[0]:.1f} μs  p99 {selected[1]:.1f} μs  n={selected[2]}")
 
     return results
 
@@ -885,9 +884,7 @@ def run_async_latency(lib_name):
         ]
         selected = median(runs, key=lambda row: row[0])
         results.append(selected)
-        print(
-            f" p50 {selected[0]:.1f} μs  p99 {selected[1]:.1f} μs  n={selected[2]}"
-        )
+        print(f" p50 {selected[0]:.1f} μs  p99 {selected[1]:.1f} μs  n={selected[2]}")
 
     return results
 
@@ -1139,7 +1136,9 @@ def run_proxy(lib_name):
                 _measure_proxy_subprocess(
                     lib_name, "pushpull", min(PROXY_DURATION_S, THROUGHPUT_WARMUP_S)
                 )
-            runs.append(_measure_proxy_subprocess(lib_name, "pushpull", PROXY_DURATION_S))
+            runs.append(
+                _measure_proxy_subprocess(lib_name, "pushpull", PROXY_DURATION_S)
+            )
         pushpull_rate = median(runs)
     print(f" {fmt_rate(pushpull_rate)}")
 
@@ -1232,7 +1231,6 @@ def _detect_hardware():
 
 
 def gen_combined_chart(data, path):
-    n = len(SIZES)
     latency_sizes = latency_sizes_from(SIZES)
     lat_n = len(latency_sizes)
     hw_label = _detect_hardware()
@@ -1336,19 +1334,35 @@ def gen_combined_chart(data, path):
     ):
         for tick in ticks:
             yy = t1_bot - (tick / panel_max) * t1_h
-            L.append(f'  <line x1="{panel_left}" y1="{yy:.1f}" x2="{panel_right}" y2="{yy:.1f}" stroke="#374151" stroke-width="1"/>')
+            L.append(
+                f'  <line x1="{panel_left}" y1="{yy:.1f}" x2="{panel_right}" y2="{yy:.1f}" stroke="#374151" stroke-width="1"/>'
+            )
             anchor = "end" if label_x < panel_left else "start"
-            L.append(f'  <text x="{label_x}" y="{yy:.1f}" text-anchor="{anchor}" dominant-baseline="middle" fill="#e5e7eb" font-size="10">{formatter(tick)}</text>')
+            L.append(
+                f'  <text x="{label_x}" y="{yy:.1f}" text-anchor="{anchor}" dominant-baseline="middle" fill="#e5e7eb" font-size="10">{formatter(tick)}</text>'
+            )
         for x in panel_xs:
-            L.append(f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}" stroke="#374151" stroke-width="1"/>')
+            L.append(
+                f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}" stroke="#374151" stroke-width="1"/>'
+            )
         if panel_left == top_left:
-            L.append(f'  <line x1="{panel_left}" y1="{t1_top}" x2="{panel_left}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+            L.append(
+                f'  <line x1="{panel_left}" y1="{t1_top}" x2="{panel_left}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+            )
         if panel_right == top_right:
-            L.append(f'  <line x1="{panel_right}" y1="{t1_top}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
-        L.append(f'  <line x1="{panel_left}" y1="{t1_bot}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+            L.append(
+                f'  <line x1="{panel_right}" y1="{t1_top}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+            )
+        L.append(
+            f'  <line x1="{panel_left}" y1="{t1_bot}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+        )
 
-    L.append(f'  <text x="{(top_left + top_mid) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>')
-    L.append(f'  <text x="{(top_right_left + top_right) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>')
+    L.append(
+        f'  <text x="{(top_left + top_mid) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>'
+    )
+    L.append(
+        f'  <text x="{(top_right_left + top_right) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>'
+    )
 
     tp_series = [
         ("pyomq", C_PYOMQ, sync_omq_tp),
@@ -1358,7 +1372,10 @@ def gen_combined_chart(data, path):
     ]
 
     for _, color, vals in tp_series:
-        pts = " ".join(f"{small_xs[j]:.1f},{y_msg(vals[i]):.1f}" for j, i in enumerate(small_indices))
+        pts = " ".join(
+            f"{small_xs[j]:.1f},{y_msg(vals[i]):.1f}"
+            for j, i in enumerate(small_indices)
+        )
         L.append(
             f'  <polyline points="{pts}" fill="none" stroke="{color}"'
             f' stroke-width="2" stroke-dasharray="6,4"/>'
@@ -1388,7 +1405,9 @@ def gen_combined_chart(data, path):
             f'  <text x="{large_xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
             f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
         )
-    L.append(f'  <text x="{mid_x:.1f}" y="{t1_bot + 32}" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate · solid = bandwidth</text>')
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{t1_bot + 32}" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate · solid = bandwidth</text>'
+    )
 
     # BOTTOM PANEL: LATENCY
 

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -1220,9 +1220,6 @@ def _read_chart_hw():
 
 def _detect_hardware():
     hw_conf = _read_chart_hw()
-    label = os.environ.get("OMQ_HW_LABEL") or hw_conf.get("label")
-    if label:
-        return label
     prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
     postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
     if prefix and postfix:

--- a/bindings/ruby/DEVELOPMENT.md
+++ b/bindings/ruby/DEVELOPMENT.md
@@ -1,0 +1,154 @@
+# omq-rs development
+
+Run commands from the repository root unless a section changes directory.
+
+## Prerequisites
+
+- Ruby 3.3 or newer with Bundler.
+- Rust 1.93 or newer with Cargo, rustfmt, and Clippy.
+- Python with pyzmq for the Python interoperability tests.
+- CZMQ and libzmq development files for cztop interoperability and both
+  benchmark baselines.
+
+Install the Ruby dependencies:
+
+```sh
+cd bindings/ruby
+bundle install
+```
+
+## Build and test
+
+Run the normal binding test pass from the repository root:
+
+```sh
+./scripts/test-ruby.sh
+```
+
+Select a Ruby executable explicitly with `OMQ_RUBY`:
+
+```sh
+OMQ_RUBY=/path/to/ruby ./scripts/test-ruby.sh
+```
+
+The equivalent commands from the binding directory are:
+
+```sh
+cd bindings/ruby
+bundle exec rake
+```
+
+Compile once, then run one test file:
+
+```sh
+bundle exec rake compile
+bundle exec ruby -Ilib:test test/test_features.rb
+```
+
+The suite covers socket patterns, options, transports, CURVE, PLAIN,
+compression, monitors, Fiber schedulers, Ractors, lifecycle behavior, and
+pyzmq interoperability. pyzmq tests skip when pyzmq is unavailable. cztop
+tests skip when CZMQ or cztop is unavailable. Ractor tests require Ruby 4.
+
+`scripts/test-all.sh` includes the Ruby pass in the full repository test run.
+
+## Static checks
+
+Run the same native checks as CI:
+
+```sh
+cargo fmt --manifest-path bindings/ruby/Cargo.toml --all --check
+cargo clippy --manifest-path bindings/ruby/Cargo.toml \
+  --all-targets --all-features -- -D warnings
+```
+
+Check Ruby syntax:
+
+```sh
+find bindings/ruby/lib bindings/ruby/test bindings/ruby/scripts \
+  -name '*.rb' -print0 | xargs -0 -n1 ruby -cw
+ruby -cw bindings/ruby/Rakefile
+ruby -cw bindings/ruby/omq-rs.gemspec
+```
+
+Check public YARD coverage from `bindings/ruby` after installing YARD:
+
+```sh
+yard stats --no-save --no-cache --list-undoc --no-private \
+  'lib/**/*.rb' 'lib/*.rb'
+```
+
+## Benchmarks
+
+Run benchmarks on an otherwise idle machine. The harness starts separate Ruby
+processes over TCP. PUSH/PULL throughput covers 16 B through 32 KiB. REQ/REP
+mean latency covers 16 B through 4 KiB. The default run keeps the best of three
+rounds for each implementation, pattern, and message size.
+
+From the binding directory:
+
+```sh
+cd bindings/ruby
+bundle exec rake compile
+bundle exec ruby -Ilib scripts/update_perf.rb
+```
+
+The default run benchmarks `omq-rs`. It includes cztop when CZMQ is available
+and ffi-rzmq when libzmq is available. Missing baselines are skipped.
+
+Useful controls:
+
+```sh
+bundle exec ruby -Ilib scripts/update_perf.rb --quick
+bundle exec ruby -Ilib scripts/update_perf.rb --impl omq-rs,cztop,ffi-rzmq
+bundle exec ruby -Ilib scripts/update_perf.rb --patterns pushpull,reqrep
+bundle exec ruby -Ilib scripts/update_perf.rb --sizes 16,128,1024,4096
+bundle exec ruby -Ilib scripts/update_perf.rb --rounds 5
+bundle exec ruby -Ilib scripts/update_perf.rb --no-record
+```
+
+`--quick` runs one round at 128 B and 1 KiB without recording results or
+rewriting the chart.
+
+## Chart generation
+
+Benchmark rows append to:
+
+```text
+~/.cache/omq-rs/bindings.jsonl
+```
+
+Regenerate the SVG from the latest cached row for each implementation,
+pattern, and message size:
+
+```sh
+cd bindings/ruby
+bundle exec ruby -Ilib scripts/update_perf.rb --chart-only
+```
+
+The output is `bindings/ruby/doc/charts/bindings.svg`. Its hardware subtitle
+comes from the repository-root `.chart_hw` file:
+
+```text
+prefix=Linux VM on a 2018 Mac Mini
+postfix=6 cores, performance governor, turbo off
+```
+
+`.chart_hw` is local-only and gitignored.
+
+## Packaging and release
+
+Build the source gem from the binding directory:
+
+```sh
+cd bindings/ruby
+bundle exec rake build
+```
+
+The gem is written to `bindings/ruby/pkg/`. Publication runs only through
+`.github/workflows/release-rubygems.yml` using RubyGems trusted publishing.
+The release tag must match the gem version:
+
+```text
+ruby-v<VERSION>
+```

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -7,6 +7,26 @@ synchronous; its waits cooperate with an installed `Fiber.scheduler`.
 MRI 3.3+, MRI 4.0+, and TruffleRuby are supported. TruffleRuby 34 does not
 provide Ruby's `Fiber.scheduler` API, so waits block the calling thread there.
 
+## Performance
+
+![Ruby binding benchmark](doc/charts/bindings.svg)
+
+The binding benchmark uses separate Ruby processes over TCP and compares
+`omq-rs` with [cztop](https://github.com/paddor/cztop), which calls CZMQ and
+libzmq through FFI, and [ffi-rzmq](https://github.com/chuckremes/ffi-rzmq),
+which calls libzmq directly through FFI. Install CZMQ and libzmq to include
+both baselines.
+
+```sh
+ruby -Ilib scripts/update_perf.rb
+ruby -Ilib scripts/update_perf.rb --quick
+ruby -Ilib scripts/update_perf.rb --chart-only
+```
+
+Rows append to `~/.cache/omq-rs/bindings.jsonl`. The generated chart is
+`doc/charts/bindings.svg`. `--quick` only runs a smoke benchmark and does not
+write results or a chart.
+
 ## Install
 
 ```sh
@@ -135,26 +155,6 @@ TCP endpoints; no preparation call is required.
 bundle install
 bundle exec rake
 ```
-
-## Performance
-
-![Ruby binding benchmark](doc/charts/bindings.svg)
-
-The binding benchmark uses separate Ruby processes over TCP and compares
-`omq-rs` with [cztop](https://github.com/paddor/cztop), which calls CZMQ and
-libzmq through FFI, and [ffi-rzmq](https://github.com/chuckremes/ffi-rzmq),
-which calls libzmq directly through FFI. Install CZMQ and libzmq to include
-both baselines.
-
-```sh
-ruby -Ilib scripts/update_perf.rb
-ruby -Ilib scripts/update_perf.rb --quick
-ruby -Ilib scripts/update_perf.rb --chart-only
-```
-
-Rows append to `~/.cache/omq-rs/bindings.jsonl`. The generated chart is
-`doc/charts/bindings.svg`. `--quick` only runs a smoke benchmark and does not
-write results or a chart.
 
 ## License
 

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -14,18 +14,8 @@ provide Ruby's `Fiber.scheduler` API, so waits block the calling thread there.
 The binding benchmark uses separate Ruby processes over TCP and compares
 `omq-rs` with [cztop](https://github.com/paddor/cztop), which calls CZMQ and
 libzmq through FFI, and [ffi-rzmq](https://github.com/chuckremes/ffi-rzmq),
-which calls libzmq directly through FFI. Install CZMQ and libzmq to include
-both baselines.
-
-```sh
-ruby -Ilib scripts/update_perf.rb
-ruby -Ilib scripts/update_perf.rb --quick
-ruby -Ilib scripts/update_perf.rb --chart-only
-```
-
-Rows append to `~/.cache/omq-rs/bindings.jsonl`. The generated chart is
-`doc/charts/bindings.svg`. `--quick` only runs a smoke benchmark and does not
-write results or a chart.
+which calls libzmq directly through FFI. See [DEVELOPMENT.md](DEVELOPMENT.md)
+for methodology and regeneration commands.
 
 ## Install
 
@@ -151,10 +141,7 @@ TCP endpoints; no preparation call is required.
 
 ## Development
 
-```sh
-bundle install
-bundle exec rake
-```
+Build, test, benchmark, and release instructions: [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## License
 

--- a/bindings/ruby/ext/omq_rs_native/src/socket.rs
+++ b/bindings/ruby/ext/omq_rs_native/src/socket.rs
@@ -198,7 +198,8 @@ fn set_curve_authenticator(
     }
     drop(options_guard);
 
-    if let Some(previous) = rb_self.auth_worker.lock().unwrap().take() {
+    let previous = rb_self.auth_worker.lock().unwrap().take();
+    if let Some(previous) = previous {
         previous.stop();
     }
     *rb_self.auth_worker.lock().unwrap() = worker;
@@ -774,7 +775,8 @@ unsafe extern "C" fn rust_socket_leave(rb_self: VALUE, group: VALUE) -> VALUE {
 fn rust_socket_close_impl(rb_self: &RustSocket, wait_for_auth_worker: bool) {
     rb_self.closed.store(true, Ordering::Relaxed);
     #[cfg(feature = "curve")]
-    if let Some(worker) = rb_self.auth_worker.lock().unwrap().take() {
+    let worker = rb_self.auth_worker.lock().unwrap().take();
+    if let Some(worker) = worker {
         if wait_for_auth_worker {
             worker.stop();
         } else {

--- a/bindings/ruby/lib/omq/rs.rb
+++ b/bindings/ruby/lib/omq/rs.rb
@@ -4,6 +4,7 @@ require_relative "rs/version"
 require_relative "rs/omq_rs_native"
 require_relative "rs/socket"
 
+# Brokerless messaging APIs and language backends.
 module OMQ
   class << self
     # Returns the OMQ.rs namespace or creates an OMQ.rs-backed socket.

--- a/bindings/ruby/lib/omq/rs/socket.rb
+++ b/bindings/ruby/lib/omq/rs/socket.rb
@@ -18,6 +18,69 @@ module OMQ
     # @api private
     SINGLE_FRAME_TYPES = %i[client server scatter gather channel].freeze
 
+    # @api private
+    SOCKET_OPTIONS = %w[
+      workload_profile
+      send_hwm
+      recv_hwm
+      recv_rate_limit
+      recv_ip_rate_limit
+
+      linger
+      identity
+      router_mandatory
+      conflate
+
+      heartbeat_interval
+      heartbeat_ttl
+      heartbeat_timeout
+      handshake_timeout
+      max_pending_handshakes
+
+      max_message_size
+      sndbuf
+      rcvbuf
+      large_message_threshold
+      arena_threshold
+      transmit_slot_cap
+
+      xpub_nodrop
+      reconnect_stop_conn_refused
+      on_mute
+      reconnect_interval
+      reconnect_interval_min
+      reconnect_interval_max
+
+      compression_dict
+      compression_auto_train
+      compression_threshold
+      compression_level
+      compression_dict_capacity
+      max_recv_dict_size
+      compression_offload_threshold
+
+      mechanism_type
+      mechanism_server
+      mechanism_public_key
+      mechanism_secret_key
+      mechanism_server_key
+      mechanism_username
+      mechanism_password
+
+      curve_server
+      curve_publickey
+      curve_public_key
+      curve_secretkey
+      curve_secret_key
+      curve_serverkey
+      curve_server_key
+
+      plain_server
+      plain_username
+      plain_password
+    ].freeze
+    private_constant :ROUTED_TYPES, :SINGLE_FRAME_TYPES, :SOCKET_OPTIONS
+
     # CURVE peer metadata passed to callable authenticators.
     #
     # @!attribute [r] public_key
@@ -34,11 +97,13 @@ module OMQ
         Native.io_threads
       end
 
-      # Sets number of OMQ.rs IO threads used by subsequently created sockets.
+      # Sets number of OMQ.rs IO threads before the shared runtime starts.
       #
       # @param count [Integer] positive IO thread count
       # @return [Integer] assigned count
       # @raise [ArgumentError] if +count+ is not positive
+      # @note Set this before materializing any socket. It does not resize a
+      #   running runtime.
       def io_threads=(count)
         count = Integer(count)
         raise ArgumentError, "io_threads must be positive" unless count.positive?
@@ -139,7 +204,9 @@ module OMQ
       def each
         return enum_for(__method__) unless block_given?
 
-        loop { yield recv }
+        while (event = recv)
+          yield event
+        end
       rescue IOError
         raise unless @socket.closed?
       end
@@ -156,8 +223,53 @@ module OMQ
       # @param send_timeout [Numeric, nil] send timeout in seconds
       # @param curve_auth [Array<String>, #call, nil] CURVE allowlist or authenticator
       # @param options [Hash] native OMQ.rs socket options
+      # @option options [Symbol] :workload_profile +:throughput+ or +:latency+
+      # @option options [Integer] :send_hwm outbound message capacity
+      # @option options [Integer] :recv_hwm inbound message capacity
+      # @option options [Hash] :recv_rate_limit per-connection
+      #   +:messages_per_second+ (or +:rate+) and +:burst+
+      # @option options [Hash] :recv_ip_rate_limit per-IP
+      #   +:messages_per_second+ (or +:rate+) and +:burst+
+      # @option options [Numeric] :linger close linger in seconds; positive
+      #   infinity waits forever
+      # @option options [String] :identity ZMTP socket identity
+      # @option options [Boolean] :router_mandatory reject unroutable sends
+      # @option options [Boolean] :conflate retain only latest received message
+      # @option options [Numeric] :heartbeat_interval heartbeat period in seconds
+      # @option options [Numeric] :heartbeat_ttl remote heartbeat TTL in seconds
+      # @option options [Numeric] :heartbeat_timeout peer timeout in seconds
+      # @option options [Numeric] :handshake_timeout handshake timeout in seconds
+      # @option options [Integer] :max_pending_handshakes inbound handshake limit
+      # @option options [Integer] :max_message_size maximum received message bytes
+      # @option options [Integer] :sndbuf kernel send buffer bytes
+      # @option options [Integer] :rcvbuf kernel receive buffer bytes
+      # @option options [Integer] :large_message_threshold receive buffer threshold
+      # @option options [Integer] :arena_threshold contiguous frame arena threshold
+      # @option options [Integer] :transmit_slot_cap per-peer transmit bytes
+      # @option options [Boolean] :xpub_nodrop block instead of dropping on mute
+      # @option options [Boolean] :reconnect_stop_conn_refused stop refused reconnects
+      # @option options [Symbol] :on_mute +:block+, +:drop_newest+, or +:drop_oldest+
+      # @option options [Numeric] :reconnect_interval fixed reconnect delay in seconds
+      # @option options [Numeric] :reconnect_interval_min minimum backoff in seconds
+      # @option options [Numeric] :reconnect_interval_max maximum backoff in seconds
+      # @option options [String] :compression_dict compression dictionary bytes
+      # @option options [Boolean] :compression_auto_train train a zstd dictionary
+      # @option options [Integer] :compression_threshold minimum bytes to compress
+      # @option options [Integer] :compression_level zstd compression level
+      # @option options [Integer] :compression_dict_capacity trained dictionary bytes
+      # @option options [Integer] :max_recv_dict_size received dictionary byte limit
+      # @option options [Integer] :compression_offload_threshold offload threshold;
+      #   negative disables offloading
+      # @option options [Symbol] :mechanism_type +:null+, +:plain+, or +:curve+
+      # @option options [Boolean] :plain_server enable PLAIN server mode
+      # @option options [String] :plain_username PLAIN client username
+      # @option options [String] :plain_password PLAIN client password
+      # @option options [Boolean] :curve_server enable CURVE server mode
+      # @option options [String] :curve_publickey local raw or Z85 public key
+      # @option options [String] :curve_secretkey local raw or Z85 secret key
+      # @option options [String] :curve_serverkey CURVE server raw or Z85 public key
       # @return [Socket]
-      # @raise [ArgumentError] if an option is invalid
+      # @raise [ArgumentError] if an option is unknown or invalid
       def initialize(recv_timeout: nil, send_timeout: nil, curve_auth: nil, **options)
         socket_type = self.class.const_get(:SOCKET_TYPE, false)
         @socket_type = socket_type.to_s.downcase.to_sym
@@ -176,6 +288,8 @@ module OMQ
         @materialized = false
         @recv_io = nil
         @send_io = nil
+        @peer_connected = false
+        @subscriber_joined = false
         set_curve_auth(curve_auth) unless curve_auth.nil?
       end
 
@@ -228,7 +342,7 @@ module OMQ
         @native.peer_info(routing_id)
       end
 
-      # Configures CURVE client authentication before socket materialization.
+      # Configures CURVE client authorization on a server before materialization.
       #
       # @param authenticator [Array<String>, #call, nil] public-key allowlist,
       #   callable receiving {MechanismPeerInfo}, or +nil+ to allow valid clients
@@ -430,9 +544,16 @@ module OMQ
       # @param timeout [Numeric, nil] maximum wait in seconds
       # @return [Socket] self
       # @raise [IO::TimeoutError] if timeout expires
+      # @raise [IOError] if socket closes first
       def wait_for_peer(timeout: nil)
+        raise IOError, "socket closed" if closed?
+        return self if @peer_connected
+
         ensure_materialized
         wait_for_native_fd(@native.peer_connected_fd, timeout, "peer connection timed out")
+        raise IOError, "socket closed" if closed?
+
+        @peer_connected = true
         self
       end
 
@@ -441,9 +562,16 @@ module OMQ
       # @param timeout [Numeric, nil] maximum wait in seconds
       # @return [Socket] self
       # @raise [IO::TimeoutError] if timeout expires
+      # @raise [IOError] if socket closes first
       def wait_for_subscriber(timeout: nil)
+        raise IOError, "socket closed" if closed?
+        return self if @subscriber_joined
+
         ensure_materialized
         wait_for_native_fd(@native.subscriber_joined_fd, timeout, "subscriber timed out")
+        raise IOError, "socket closed" if closed?
+
+        @subscriber_joined = true
         self
       end
 
@@ -471,6 +599,8 @@ module OMQ
       # @return [Hash, nil]
       # @raise [IO::TimeoutError] if timeout expires
       def monitor_event(timeout: @recv_timeout)
+        return if closed?
+
         ensure_materialized
         event = @native.try_recv_monitor
         return event if event
@@ -483,6 +613,8 @@ module OMQ
       #
       # @return [Hash, nil]
       def try_monitor_event
+        return if closed?
+
         ensure_materialized
         @native.try_recv_monitor
       end
@@ -532,11 +664,17 @@ module OMQ
       end
 
       def normalize_options(options)
-        options.to_h do |key, value|
+        normalized = options.to_h do |key, value|
           value = value.to_s if value.is_a?(Symbol)
           value = value.transform_keys(&:to_s) if value.is_a?(Hash)
           [key.to_s, value]
         end
+        unknown = normalized.keys - SOCKET_OPTIONS
+        unless unknown.empty?
+          raise ArgumentError, "unknown socket option#{"s" if unknown.length > 1}: #{unknown.sort.join(", ")}"
+        end
+
+        normalized
       end
 
       def validate_send_parts!(parts)

--- a/bindings/ruby/omq-rs.gemspec
+++ b/bindings/ruby/omq-rs.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.license     = "ISC"
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/omq-rs"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.required_ruby_version = ">= 3.3"

--- a/bindings/ruby/omq-rs.gemspec
+++ b/bindings/ruby/omq-rs.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
     "ext/**/*.{rs,rb}",
     "ext/**/Cargo.toml",
     "README.md",
+    "DEVELOPMENT.md",
     "LICENSE",
     "CHANGELOG.md",
   ]

--- a/bindings/ruby/scripts/update_perf.rb
+++ b/bindings/ruby/scripts/update_perf.rb
@@ -167,9 +167,6 @@ def hardware_label
     end
   end
 
-  label = ENV["OMQ_HW_LABEL"] || config["label"]
-  return label if label
-
   prefix = ENV["OMQ_HW_PREFIX"] || config["prefix"]
   postfix = ENV["OMQ_HW_POSTFIX"] || config["postfix"]
   combined = [prefix, postfix].compact.join(", ")

--- a/bindings/ruby/test/test_api.rb
+++ b/bindings/ruby/test/test_api.rb
@@ -70,6 +70,14 @@ class ApiTest < Minitest::Test
     assert_raises(ArgumentError) { OMQ.rs(:pull, send_hwm: -1) }
     assert_raises(ArgumentError) { OMQ.rs(:pull, workload_profile: :fast) }
     assert_raises(ArgumentError) { OMQ.rs(:pull, recv_rate_limit: {rate: 10}) }
+    error = assert_raises(ArgumentError) { OMQ.rs(:pull, send_hmw: 10) }
+    assert_match(/unknown socket option: send_hmw/, error.message)
+  end
+
+  def test_gemspec_links_api_documentation
+    spec = Gem::Specification.load(File.expand_path("../omq-rs.gemspec", __dir__))
+
+    assert_equal "https://www.rubydoc.info/gems/omq-rs", spec.metadata["documentation_uri"]
   end
 
   private

--- a/bindings/ruby/test/test_features.rb
+++ b/bindings/ruby/test/test_features.rb
@@ -290,6 +290,14 @@ class FeaturesTest < Minitest::Test
     assert_instance_of Integer, handshake[:connection_id]
   end
 
+  def test_monitor_each_stops_when_socket_closes
+    pull = socket(:pull)
+    events = pull.monitor.each
+    pull.close
+
+    assert_raises(StopIteration) { events.next }
+  end
+
   def test_wake_recv_makes_wait_readable_return
     pull = socket(:pull)
     pull.bind("inproc://ruby-wake-recv")

--- a/bindings/ruby/test/test_patterns.rb
+++ b/bindings/ruby/test/test_patterns.rb
@@ -8,6 +8,7 @@ class PatternsTest < Minitest::Test
     endpoint = tcp_endpoint(pull)
     push = socket(:push)
     push.connect(endpoint).wait_for_peer(timeout: 2)
+    assert_same push, push.wait_for_peer(timeout: 0)
 
     push << "one"
     push.send("two", "three")
@@ -43,6 +44,7 @@ class PatternsTest < Minitest::Test
     sub = socket(:sub, recv_timeout: 2)
     sub.subscribe("weather.").connect(endpoint)
     pub.wait_for_subscriber(timeout: 2)
+    assert_same pub, pub.wait_for_subscriber(timeout: 0)
 
     pub.send("news.world", "ignored")
     pub.send("weather.ch", "sunny")
@@ -168,5 +170,22 @@ class PatternsTest < Minitest::Test
     pull.close
 
     assert_instance_of IOError, result.value
+  end
+
+  def test_close_interrupts_peer_wait
+    push = socket(:push)
+    push.connect("tcp://127.0.0.1:1")
+
+    waiter = Thread.new do
+      push.wait_for_peer(timeout: 2)
+    rescue StandardError => error
+      error
+    end
+    sleep 0.01 until waiter.status == "sleep"
+    push.close
+
+    error = waiter.value
+    assert_instance_of IOError, error
+    assert_equal "socket closed", error.message
   end
 end

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -170,17 +170,6 @@ pub(crate) fn msg_axis_2m(max_val: f64) -> (f64, usize) {
 pub(crate) fn detect_hardware() -> Option<String> {
     let hw_conf = read_chart_hw();
 
-    if let Ok(label) = std::env::var("OMQ_HW_LABEL")
-        && !label.is_empty()
-    {
-        return Some(label);
-    }
-    if let Some(label) = hw_conf.get("label")
-        && !label.is_empty()
-    {
-        return Some(label.clone());
-    }
-
     let postfix = std::env::var("OMQ_HW_POSTFIX")
         .ok()
         .or_else(|| hw_conf.get("postfix").cloned());


### PR DESCRIPTION
- Complete YARD coverage for the Ruby API and expose RubyDoc through gem metadata.
- Reject unknown socket options and fix monitor/readiness close behavior with regression tests.
- Avoid CURVE auth-worker shutdown deadlocks by releasing its mutex before joining.
- Move the Ruby performance chart below the intro and contributor details into a packaged DEVELOPMENT.md.
- Standardize all chart generators and docs on .chart_hw prefix/postfix metadata.