### PR TITLE
Harden inproc sends and pool large receive buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- Tokio direct TCP receives reuse bounded buffers through 8 MiB without
+  zero-filling payload memory or extending pool lifetime past connection close.
+
 ### Added
 
 - Tokio byte-stream sockets can enforce hard per-connection and aggregate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 - SERVER sockets can resolve a received routing id to its live `PeerInfo`
   with `Socket::peer_info()`.
 
+### Fixed
+
+- Async inproc `PUSH` sends remain safe when a task moves between runtime
+  worker threads or cloned socket handles send concurrently.
+
 ## [pyomq 0.19.1] - 2026-08-02
 
 ### Fixed

--- a/bindings/lua/native/Cargo.lock
+++ b/bindings/lua/native/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "futures",
  "libc",
  "omq-proto",
+ "parking_lot",
  "rand",
  "rustc-hash",
  "rustls",

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +508,7 @@ dependencies = [
  "futures",
  "libc",
  "omq-proto",
+ "parking_lot",
  "rand",
  "rustc-hash",
  "smallvec",
@@ -523,6 +530,29 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "patricia_tree"
@@ -676,6 +706,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex-automata"

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -187,6 +187,16 @@ to 55 B inline, avoiding heap allocation and refcount traffic for small
 messages. Larger single-part messages use `Bytes`; multipart messages use
 `Vec<Payload>`.
 
+### Receive buffers
+
+Plain TCP/IPC frames at or above the direct-read threshold bypass the rolling
+decoder buffer. Payloads through 8 MiB read into a per-connection `BytesMut`
+pool without zero-filling spare capacity. `Bytes::from_owner` returns the
+allocation only after the last payload clone or slice drops. The pool retains
+at most 64 MiB and payload owners hold only a weak pool reference, so closing a
+connection releases idle buffers even while the application holds messages.
+Payloads above 8 MiB use a fresh `BytesMut` and are never pooled.
+
 ## Encoding
 
 `FrameBuffer` is the outbound framing buffer: an arena (16 KiB for TCP/WS,

--- a/doc/charts/main_pushpull_tcp.svg
+++ b/doc/charts/main_pushpull_tcp.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 950 498" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="950" height="498" opacity="1" fill="#000000" stroke="none"/>
+<svg viewBox="0 0 950 514" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="950" height="514" opacity="1" fill="#000000" stroke="none"/>
 <text x="475" y="17" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#F9FAFB">PUSH/PULL throughput, TCP loopback, 2-process</text>
 <text x="475" y="31" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#9CA3AF">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
 <text x="227" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
@@ -13,49 +13,44 @@ small messages (higher is better)
 <line opacity="1" stroke="#374151" stroke-width="1" x1="383" y1="311" x2="383" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="444" y1="311" x2="444" y2="56"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="311" x2="444" y2="311"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="280" x2="444" y2="280"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="248" x2="444" y2="248"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="216" x2="444" y2="216"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="184" x2="444" y2="184"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="152" x2="444" y2="152"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="120" x2="444" y2="120"/>
-<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="88" x2="444" y2="88"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="275" x2="444" y2="275"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="239" x2="444" y2="239"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="202" x2="444" y2="202"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="166" x2="444" y2="166"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="129" x2="444" y2="129"/>
+<line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="93" x2="444" y2="93"/>
 <line opacity="1" stroke="#374151" stroke-width="1" x1="80" y1="56" x2="444" y2="56"/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="79,56 79,311 "/>
 <text x="70" y="311" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 0/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,311 79,311 "/>
-<text x="70" y="280" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<text x="70" y="275" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,280 79,280 "/>
-<text x="70" y="248" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,275 79,275 "/>
+<text x="70" y="239" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,248 79,248 "/>
-<text x="70" y="216" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,239 79,239 "/>
+<text x="70" y="202" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,216 79,216 "/>
-<text x="70" y="184" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,202 79,202 "/>
+<text x="70" y="166" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,184 79,184 "/>
-<text x="70" y="152" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,166 79,166 "/>
+<text x="70" y="129" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,152 79,152 "/>
-<text x="70" y="120" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,129 79,129 "/>
+<text x="70" y="93" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12M/s
 </text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,120 79,120 "/>
-<text x="70" y="88" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14M/s
-</text>
-<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,88 79,88 "/>
+<polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,93 79,93 "/>
 <text x="70" y="56" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16M/s
+14M/s
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="74,56 79,56 "/>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="80,312 444,312 "/>
@@ -87,403 +82,458 @@ small messages (higher is better)
 1 KiB
 </text>
 <polyline fill="none" opacity="1" stroke="#9CA3AF" stroke-width="1" points="444,312 444,317 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="80,290 86,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="89,290 95,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="98,290 104,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="107,290 113,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="116,290 122,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="125,290 131,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="134,290 140,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="143,290 149,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="152,290 158,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="161,290 167,290 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="170,290 176,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="179,291 185,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="188,291 194,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="197,291 201,291 203,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="206,291 212,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="215,291 221,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="224,291 230,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="233,291 239,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="242,291 248,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="251,291 257,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="260,291 262,291 266,291 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="269,291 275,292 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="278,292 284,292 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="287,293 293,293 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="296,293 302,294 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="305,294 311,294 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="314,294 320,295 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="323,295 329,295 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="332,296 338,296 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="341,296 347,297 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="350,297 356,297 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="359,297 365,298 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="368,298 374,298 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="377,299 383,299 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="386,299 392,299 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="395,299 401,299 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="404,299 410,299 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="413,299 419,300 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="422,300 428,300 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="431,300 437,300 "/>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="440,300 444,300 "/>
-<circle cx="80" cy="290" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="290" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="291" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="291" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="295" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="299" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="300" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,259 86,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,259 95,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,258 104,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,258 113,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,258 122,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,258 131,257 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,257 140,257 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,257 149,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,258 158,258 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,258 167,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,259 176,259 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,260 185,260 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,260 194,261 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,261 201,261 203,261 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,261 212,262 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,262 221,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,263 230,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,264 239,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,264 248,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,265 257,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,266 262,266 266,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,266 275,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,266 284,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,266 293,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,267 302,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,267 311,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,267 320,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,267 329,267 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="332,266 338,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="341,266 347,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="350,265 356,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="359,265 365,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="368,264 374,264 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="377,263 382,263 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="385,263 391,265 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,265 400,266 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,267 409,268 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,269 418,270 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="421,270 427,272 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="430,272 435,273 "/>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="438,274 444,275 "/>
-<circle cx="80" cy="259" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="257" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="261" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="266" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="267" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="263" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="275" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,292 86,291 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,291 95,290 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,290 104,289 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,288 113,288 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,287 122,286 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,286 131,285 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="134,285 139,284 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="142,284 148,284 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="151,284 157,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="160,283 166,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="169,283 175,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="178,283 184,283 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="187,282 193,282 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="196,282 201,282 202,282 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="205,281 211,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,279 220,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,278 229,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,276 238,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="241,274 247,273 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="250,272 255,271 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="258,271 262,270 264,270 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="267,270 273,271 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="276,271 282,271 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="285,271 291,271 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="294,272 300,272 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="303,272 309,272 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="312,273 318,273 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="321,273 322,273 327,273 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="330,273 336,274 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="339,274 345,274 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="348,274 354,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="357,275 363,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="366,275 372,275 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="375,276 381,276 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="384,276 390,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="393,277 399,277 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="402,278 408,278 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="411,278 417,279 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="420,279 426,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="429,280 435,280 "/>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="438,281 444,281 "/>
-<circle cx="80" cy="292" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="284" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="282" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="270" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="273" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="276" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="281" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,306 86,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,306 95,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,306 104,306 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,306 113,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,307 122,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,307 131,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,307 140,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,307 149,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,307 158,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,307 167,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,307 176,307 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="80,287 86,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="89,287 95,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="98,287 104,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="107,287 113,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="116,287 122,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="125,287 131,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="134,287 140,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="143,287 149,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="152,287 158,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="161,287 167,287 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="170,287 176,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="179,288 185,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="188,288 194,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="197,288 201,288 203,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="206,288 212,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="215,288 221,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="224,288 230,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="233,288 239,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="242,288 248,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="251,288 257,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="260,288 262,288 266,288 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="269,288 275,289 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="278,289 284,289 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="287,290 293,290 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="296,290 302,291 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="305,291 311,291 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="314,291 320,292 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="323,292 329,293 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="332,293 338,293 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="341,294 347,294 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="350,294 356,295 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="359,295 365,296 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="368,296 374,296 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="377,296 383,297 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="386,297 392,297 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="395,297 401,297 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="404,297 410,297 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="413,297 419,298 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="422,298 428,298 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="431,298 437,298 "/>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="440,298 444,298 "/>
+<circle cx="80" cy="287" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="287" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="288" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="288" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="292" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="297" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="298" r="2.5" opacity="1" fill="#F472B6" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="80,252 86,252 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="89,252 95,251 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="98,251 104,251 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="107,251 113,250 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="116,250 122,250 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="125,250 131,249 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="134,249 140,249 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="143,249 149,250 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="152,250 158,250 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="161,251 167,251 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="170,251 176,252 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="179,252 185,253 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="188,253 194,253 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="197,254 201,254 203,254 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="206,254 212,255 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="215,255 221,256 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="224,256 230,256 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="233,257 239,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="242,257 248,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="251,258 257,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="260,259 262,259 266,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="269,259 275,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="278,259 284,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="287,259 293,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="296,260 302,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="305,260 311,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="314,260 320,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="323,260 328,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="331,259 337,259 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="340,259 346,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="349,258 355,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="358,258 364,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="367,257 373,257 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="376,256 382,256 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="385,257 391,258 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="394,259 400,260 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="403,261 409,262 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="412,263 417,264 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="420,265 426,266 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="429,267 435,268 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="438,269 444,270 "/>
+<circle cx="80" cy="252" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="249" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="254" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="259" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="260" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="256" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="270" r="2.5" opacity="1" fill="#10B981" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="80,289 86,288 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="89,288 95,287 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="98,286 104,285 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="107,285 113,284 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="116,284 122,283 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="125,282 130,281 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="133,281 139,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="142,280 148,280 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="151,280 157,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="160,279 166,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="169,279 175,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="178,279 184,279 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="187,278 193,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="196,278 201,278 202,278 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="205,277 211,276 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="214,275 220,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="223,273 229,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="232,271 237,270 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="240,270 246,268 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="249,268 255,266 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="258,266 262,265 264,265 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="267,265 273,265 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="276,265 282,266 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="285,266 291,266 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="294,266 300,266 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="303,266 309,267 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="312,267 318,267 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="321,267 322,267 327,267 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="330,268 336,268 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="339,268 345,268 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="348,269 354,269 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="357,269 363,270 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="366,270 372,270 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="375,270 381,271 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="384,271 390,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="393,272 399,272 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="402,273 408,273 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="411,273 417,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="420,274 426,274 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="429,275 435,275 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="438,275 444,276 "/>
+<circle cx="80" cy="289" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="280" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="278" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="265" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="267" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="271" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="276" r="2.5" opacity="1" fill="#4ADE80" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="80,305 86,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="89,305 95,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="98,305 104,305 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="107,305 113,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="116,306 122,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="125,306 131,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="134,306 140,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="143,306 149,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="152,306 158,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="161,306 167,306 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="170,306 176,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="179,307 185,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="188,307 194,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="197,307 201,307 203,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="206,307 212,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="215,307 221,307 "/>
 <polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="224,307 230,307 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,308 239,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,308 248,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,308 257,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,308 262,308 266,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,308 275,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,308 284,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,308 293,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="296,308 302,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="305,308 311,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="314,308 320,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="323,308 329,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="332,308 338,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="341,308 347,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="350,308 356,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="359,308 365,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="368,308 374,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="377,308 383,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="386,308 392,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="395,308 401,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="404,308 410,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="413,308 419,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,308 428,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="431,308 437,308 "/>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="440,308 444,308 "/>
-<circle cx="80" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="233,307 239,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="242,307 248,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="251,307 257,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="260,307 262,307 266,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="269,307 275,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="278,307 284,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="287,307 293,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="296,307 302,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="305,307 311,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="314,307 320,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="323,307 329,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="332,307 338,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="341,307 347,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="350,307 356,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="359,307 365,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="368,307 374,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="377,307 383,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="386,307 392,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="395,307 401,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="404,307 410,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="413,307 419,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="422,307 428,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="431,307 437,307 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="440,307 444,307 "/>
+<circle cx="80" cy="305" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="306" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
 <circle cx="201" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="308" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,294 86,294 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,294 95,294 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,294 104,294 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="107,294 113,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="116,295 122,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="125,295 131,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="134,295 140,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="143,295 149,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="152,295 158,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="161,295 167,295 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="170,295 176,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="179,296 185,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="188,296 194,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="197,296 201,296 203,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="206,296 212,296 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="215,296 221,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="224,297 230,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="233,297 239,297 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="242,297 248,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="251,298 257,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="260,298 262,298 266,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="269,298 275,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="278,298 284,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="287,298 293,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="296,298 302,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="305,298 311,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="314,298 320,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="323,298 329,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="332,298 338,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="341,298 347,298 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="350,298 356,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="359,299 365,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="368,299 374,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="377,299 383,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="386,299 392,299 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="395,299 401,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="404,300 410,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="413,300 419,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="422,300 428,300 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="431,301 437,301 "/>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="440,301 444,301 "/>
-<circle cx="80" cy="294" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="295" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="296" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="298" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="298" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="299" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="301" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,183 86,183 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="89,183 95,183 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="98,184 104,184 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="107,184 113,184 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="116,184 122,184 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="125,184 131,185 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="134,185 140,185 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="142,187 147,191 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="149,193 154,196 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="156,198 161,202 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="163,204 168,208 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="170,210 175,214 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="177,215 182,219 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="184,221 189,225 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="191,227 196,231 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="198,233 201,235 203,235 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="206,235 212,236 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="215,236 221,236 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="224,236 230,236 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="233,237 239,237 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="242,237 248,237 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="251,237 257,238 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="260,238 262,238 266,239 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="269,239 275,240 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="278,241 284,242 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="287,242 293,243 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="296,244 301,245 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="304,245 310,246 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="313,247 319,248 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="322,248 328,249 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="331,250 337,252 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="340,252 345,254 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="348,254 354,256 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="357,257 363,258 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="366,259 372,260 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="375,261 380,262 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="383,263 389,264 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="392,265 398,266 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="401,266 407,267 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="410,268 416,269 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="419,269 425,271 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="428,271 434,272 "/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="437,273 442,274 "/>
-<circle cx="80" cy="183" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="185" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="235" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="238" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="248" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="263" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="274" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,81 86,81 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="89,82 95,82 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="98,82 104,83 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="107,83 113,83 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="116,83 122,84 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="125,84 131,84 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="134,85 140,85 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="142,87 145,93 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="146,95 149,100 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,103 154,108 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,110 159,116 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="160,118 164,123 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="165,126 168,131 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="170,133 173,139 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="175,141 178,146 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="179,149 182,154 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="184,156 187,162 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="189,164 192,169 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="193,172 197,177 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="198,179 201,184 202,184 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="205,183 210,182 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="213,182 219,180 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="222,180 228,179 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="231,178 237,177 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="240,176 246,175 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="249,175 255,173 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="257,173 262,172 263,173 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="266,174 271,177 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="274,178 279,181 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="282,183 287,185 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="290,187 295,190 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="298,191 303,194 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="306,195 311,198 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="314,199 319,202 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="321,204 322,204 326,207 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="329,209 334,212 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="336,214 341,217 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="344,219 348,223 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="351,224 356,228 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="358,230 363,233 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="366,235 371,238 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="373,240 378,243 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="380,245 383,247 386,248 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="388,249 394,251 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="397,252 403,253 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="406,254 411,256 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="414,257 420,259 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="423,260 428,262 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="431,263 437,265 "/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="440,266 444,267 "/>
-<circle cx="80" cy="81" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="85" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="184" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="172" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="204" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="247" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="267" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,200 86,201 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,201 95,202 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,202 104,203 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,204 113,204 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,205 122,206 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="125,206 131,207 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="134,207 139,208 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,209 147,212 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="150,214 155,217 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="158,218 163,221 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="166,222 171,225 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="174,227 179,230 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="181,231 187,234 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="189,235 195,238 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="197,240 201,242 202,243 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="205,244 210,247 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="213,249 218,252 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="221,253 226,256 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="229,257 234,260 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="236,262 242,265 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="244,266 250,269 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="252,271 257,273 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="260,275 262,276 266,276 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="269,276 275,277 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="278,277 284,277 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="287,277 293,278 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="296,278 302,278 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="305,278 311,278 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="314,279 320,279 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="323,279 329,280 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="332,280 338,281 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="341,282 346,283 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="349,283 355,284 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="358,284 364,285 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="367,286 373,287 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="376,287 382,288 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="385,288 391,289 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="394,290 400,291 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="403,291 409,292 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="412,293 418,294 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="421,294 426,295 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="429,296 435,297 "/>
-<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="438,297 444,298 "/>
-<circle cx="80" cy="200" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="140" cy="208" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="201" cy="242" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="262" cy="276" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="322" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="383" cy="288" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="298" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="307" r="2.5" opacity="1" fill="#60A5FA" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="80,292 86,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="89,292 95,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="98,292 104,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="107,292 113,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="116,292 122,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="125,292 131,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="134,292 140,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="143,292 149,292 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="152,292 158,293 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="161,293 167,293 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="170,293 176,293 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="179,293 185,293 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="188,294 194,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="197,294 201,294 203,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="206,294 212,294 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="215,294 221,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="224,295 230,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="233,295 239,295 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="242,295 248,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="251,296 257,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="260,296 262,296 266,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="269,296 275,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="278,296 284,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="287,296 293,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="296,296 302,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="305,296 311,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="314,296 320,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="323,296 329,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="332,296 338,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="341,296 347,296 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="350,296 356,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="359,297 365,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="368,297 374,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="377,297 383,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="386,297 392,297 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="395,297 401,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="404,298 410,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="413,298 419,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="422,298 428,298 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="431,299 437,299 "/>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="440,299 444,299 "/>
+<circle cx="80" cy="292" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="292" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="294" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="296" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="296" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="297" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="299" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="80,108 86,107 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="89,107 95,106 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="98,106 104,105 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="107,104 113,104 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="116,103 122,102 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="125,102 131,101 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="134,101 139,100 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="142,102 145,107 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="147,109 151,114 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="153,116 157,121 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="158,123 162,128 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="164,130 168,135 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="170,137 173,142 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="175,144 179,149 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="181,151 185,156 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="187,158 190,163 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="192,165 196,170 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="198,172 201,176 202,176 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="205,176 211,176 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="214,176 220,176 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="223,176 229,176 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="232,177 238,177 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="241,177 247,177 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="250,177 256,177 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="259,177 262,177 265,178 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="267,180 273,182 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="276,183 281,186 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="284,187 289,190 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="292,191 297,193 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="300,195 306,197 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="308,199 314,201 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="316,202 322,205 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="325,206 330,208 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="333,209 339,211 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="342,212 347,214 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="350,215 356,217 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="359,218 364,220 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="367,221 373,223 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="376,223 381,225 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="384,227 389,229 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="392,231 398,233 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="400,235 406,237 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="408,239 414,242 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="416,243 422,246 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="424,247 430,250 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="432,251 438,254 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="440,255 444,257 "/>
+<circle cx="80" cy="108" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="100" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="176" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="177" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="205" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="226" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="257" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="80,164 85,167 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="88,168 94,171 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="96,172 102,174 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="104,176 110,178 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="112,180 118,182 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="121,184 126,186 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="129,187 134,190 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="137,191 140,193 142,194 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="145,195 150,198 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="153,200 158,202 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="161,204 166,206 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="169,208 174,210 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="177,212 182,214 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="185,216 190,219 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="193,220 198,223 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="201,224 201,224 207,224 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="210,224 216,224 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="219,225 225,225 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="228,225 234,225 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="237,225 243,225 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="246,225 252,226 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="255,226 261,226 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="264,226 270,227 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="273,227 279,228 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="282,228 288,229 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="291,229 297,230 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="300,230 306,231 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="309,231 315,232 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="318,232 322,233 323,233 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="326,234 332,236 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="335,237 341,238 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="344,239 349,241 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="352,241 358,243 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="361,244 367,245 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="370,246 375,248 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="378,249 383,250 384,250 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="387,251 393,252 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="396,253 402,255 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="405,255 410,257 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="413,257 419,259 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="422,260 428,261 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="431,262 437,263 "/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="439,264 444,265 "/>
+<circle cx="80" cy="164" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="193" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="224" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="226" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="233" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="250" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="265" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="80,70 86,71 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="89,71 95,72 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="98,73 104,74 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="107,74 113,75 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="116,76 121,77 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="124,77 130,78 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="133,79 139,80 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="141,82 144,87 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="146,89 149,94 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="151,97 154,102 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="156,105 159,110 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="161,112 164,117 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="165,120 169,125 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="170,127 174,132 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="175,135 178,140 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="180,142 183,147 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="185,150 188,155 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="190,158 193,163 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="195,165 198,170 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="200,173 201,175 204,174 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="207,173 213,172 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="216,171 222,170 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="224,169 230,167 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="233,167 239,165 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="242,164 248,163 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="251,162 256,160 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="259,160 262,159 265,160 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="268,162 273,165 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="276,166 281,169 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="284,170 289,173 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="292,174 297,177 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="300,178 305,181 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="307,183 313,185 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="315,187 321,189 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="323,191 328,195 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="331,196 335,200 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="338,202 343,205 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="345,207 350,211 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="352,212 357,216 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="360,218 364,221 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="367,223 372,227 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="374,228 379,232 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="381,234 383,235 387,237 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="389,238 395,240 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="398,241 403,244 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="406,245 411,247 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="414,248 420,251 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="422,252 428,254 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="431,255 436,258 "/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="439,259 444,261 "/>
+<circle cx="80" cy="70" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="80" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="175" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="159" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="190" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="235" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="261" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="80,184 86,185 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="89,185 95,186 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="98,187 104,188 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="107,188 113,189 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="116,190 121,191 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="124,191 130,192 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="133,193 139,194 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="142,195 147,198 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="149,200 155,203 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="157,205 162,208 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="165,209 170,213 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="172,214 177,217 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="180,219 185,222 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="188,224 193,227 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="195,228 200,232 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="203,233 208,236 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="211,238 216,241 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="218,243 223,246 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="226,248 231,251 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="233,253 238,256 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="241,257 246,261 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="248,262 253,266 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="256,267 261,270 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="264,271 270,272 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="273,272 279,272 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="282,272 288,273 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="291,273 297,273 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="300,274 306,274 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="309,274 315,275 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="318,275 322,275 324,275 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="327,276 333,277 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="336,277 342,278 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="344,279 350,280 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="353,280 359,281 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="362,282 368,283 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="371,283 377,284 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="380,285 383,285 386,286 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="389,286 395,287 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="398,288 404,289 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="407,289 412,290 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="415,291 421,292 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="424,292 430,294 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="433,294 439,295 "/>
+<polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="442,296 444,296 "/>
+<circle cx="80" cy="184" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="140" cy="194" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="201" cy="232" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="262" cy="271" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="322" cy="275" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="383" cy="285" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="296" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <text x="712" y="41" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E5E7EB">
 medium/large messages (higher is better)
 </text>
@@ -639,30 +689,42 @@ medium/large messages (higher is better)
 <circle cx="798" cy="111" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="837" cy="120" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
 <circle cx="877" cy="128" r="2.5" opacity="1" fill="#A855F7" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,268 524,245 563,208 602,175 641,170 681,145 720,106 759,95 798,72 837,66 877,76 "/>
-<circle cx="485" cy="268" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="524" cy="245" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="563" cy="208" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="602" cy="175" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="641" cy="170" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="681" cy="145" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="720" cy="106" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="759" cy="95" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="798" cy="72" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="837" cy="66" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="76" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
-<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,238 524,224 563,191 602,181 641,156 681,141 720,108 759,105 798,68 837,68 877,88 "/>
-<circle cx="485" cy="238" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="524" cy="224" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="485,248 524,209 563,181 602,147 641,140 681,106 720,96 759,98 798,77 837,98 877,104 "/>
+<circle cx="485" cy="248" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="209" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="181" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="147" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="140" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="106" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="96" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="98" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="77" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="98" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="104" r="2.5" opacity="1" fill="#F97316" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="485,265 524,238 563,201 602,184 641,136 681,113 720,103 759,94 798,74 837,70 877,89 "/>
+<circle cx="485" cy="265" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="238" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="201" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="184" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="136" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="113" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="720" cy="103" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="94" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="74" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="70" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="89" r="2.5" opacity="1" fill="#FB7185" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#EF4444" stroke-width="2" points="485,239 524,220 563,191 602,168 641,145 681,113 720,108 759,101 798,75 837,61 877,83 "/>
+<circle cx="485" cy="239" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="524" cy="220" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="563" cy="191" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="602" cy="181" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="641" cy="156" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="681" cy="141" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="602" cy="168" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="641" cy="145" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="681" cy="113" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <circle cx="720" cy="108" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="759" cy="105" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="798" cy="68" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="837" cy="68" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
-<circle cx="877" cy="88" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="759" cy="101" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="798" cy="75" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="837" cy="61" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
+<circle cx="877" cy="83" r="2.5" opacity="1" fill="#EF4444" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#FACC15" stroke-width="2" points="485,289 524,279 563,274 602,267 641,263 681,262 720,261 759,231 798,149 837,139 877,143 "/>
 <circle cx="485" cy="289" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
 <circle cx="524" cy="279" r="2.5" opacity="1" fill="#FACC15" stroke="none" stroke-width="1"/>
@@ -705,10 +767,10 @@ omq
 1 IO
 </text>
 <text x="360" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-128%
+123%
 </text>
 <text x="450" y="376" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-191%
+192%
 </text>
 <polyline fill="none" opacity="1" stroke="#FB7185" stroke-width="2" points="78,398 92,398 "/>
 <text x="98" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
@@ -721,71 +783,84 @@ CT
 87%
 </text>
 <text x="450" y="392" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-89%
+90%
 </text>
-<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="78,414 92,414 "/>
+<polyline fill="none" opacity="1" stroke="#F97316" stroke-width="2" points="78,414 92,414 "/>
 <text x="98" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-tmq v0.5.0
+omq
 </text>
 <text x="250" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-1 IO
-</text>
-<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-182%
-</text>
-<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-140%
-</text>
-<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,430 92,430 "/>
-<text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-zmq.rs v0.6.0
-</text>
-<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
+<text x="360" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+132%
+</text>
+<text x="450" y="408" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+123%
+</text>
+<polyline fill="none" opacity="1" stroke="#A855F7" stroke-width="2" points="78,430 92,430 "/>
+<text x="98" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+tmq v0.5.0
+</text>
+<text x="250" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+1 IO
+</text>
 <text x="360" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-92%
+182%
 </text>
 <text x="450" y="424" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-99%
+140%
 </text>
-<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,446 92,446 "/>
+<polyline fill="none" opacity="1" stroke="#60A5FA" stroke-width="2" points="78,446 92,446 "/>
 <text x="98" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq v0.5.24
+zmq.rs v0.6.0
 </text>
 <text x="250" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-102%
+92%
 </text>
 <text x="450" y="440" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-110%
+99%
 </text>
-<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,462 92,462 "/>
+<polyline fill="none" opacity="1" stroke="#4ADE80" stroke-width="2" points="78,462 92,462 "/>
 <text x="98" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-rzmq-iouring v0.5.24
+rzmq v0.5.24
 </text>
 <text x="250" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-149%
+102%
 </text>
 <text x="450" y="456" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-139%
+110%
 </text>
-<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,478 92,478 "/>
+<polyline fill="none" opacity="1" stroke="#10B981" stroke-width="2" points="78,478 92,478 "/>
 <text x="98" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-gRPC (tonic v0.12.3)
+rzmq-iouring v0.5.24
 </text>
 <text x="250" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 12 MT
 </text>
 <text x="360" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-192%
+149%
 </text>
 <text x="450" y="472" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+139%
+</text>
+<polyline fill="none" opacity="1" stroke="#F472B6" stroke-width="2" points="78,494 92,494 "/>
+<text x="98" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+gRPC (tonic v0.12.3)
+</text>
+<text x="250" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+12 MT
+</text>
+<text x="360" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+192%
+</text>
+<text x="450" y="488" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 150%
 </text>
 </svg>

--- a/omq-bench/src/bench/comparisons.rs
+++ b/omq-bench/src/bench/comparisons.rs
@@ -100,6 +100,22 @@ static IMPLS: &[ImplDef] = &[
         env: &[],
     },
     ImplDef {
+        name: "omq-tokio-mt",
+        binary_from: Some("omq-tokio-ct"),
+        prefix: "m",
+        class: Some(ImplClass::Classic),
+        main: false,
+        transports: &[Tcp],
+        inproc_tput_subcmd: "",
+        inproc_lat_subcmd: "",
+        inproc_pubsub_subcmd: "",
+        pub_needs_peer_count: true,
+        fanout_subcmd: "",
+        fanio_needs_peer_count: false,
+        supports_pubsub: false,
+        env: &[("OMQ_BENCH_MT_RUNTIME", "1")],
+    },
+    ImplDef {
         name: "omq-tokio-2t",
         binary_from: Some("omq-tokio-1t"),
         prefix: "u",
@@ -466,6 +482,7 @@ fn addr_for(
 fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMap<String, PathBuf> {
     let mut binaries: HashMap<String, PathBuf> = HashMap::new();
     let mut built: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let needs_mt_runtime = impl_names.contains(&"omq-tokio-mt");
     let sources: Vec<&str> = impl_names
         .iter()
         .map(|&name| {
@@ -487,6 +504,9 @@ fn build_peers(impl_names: &[&str], needs_ws: bool, needs_curve: bool) -> HashMa
                 }
                 if needs_curve {
                     features.push("curve");
+                }
+                if needs_mt_runtime {
+                    features.push("bench-mt-runtime");
                 }
                 let mut cmd = vec![
                     "cargo",
@@ -2319,6 +2339,15 @@ mod tests {
         assert_eq!(ct.binary_from, None);
         assert_eq!(two_thread.binary_from, Some("omq-tokio-1t"));
         assert_eq!(curve_two_thread.binary_from, Some("omq-tokio-1t"));
+    }
+
+    #[test]
+    fn mt_runtime_omq_uses_tokio_peer_and_runtime_env() {
+        let def = find_impl("omq-tokio-mt").unwrap();
+
+        assert_eq!(def.binary_from, Some("omq-tokio-ct"));
+        assert_eq!(def.env, &[("OMQ_BENCH_MT_RUNTIME", "1")]);
+        assert!(matches!(def.transports, [Tcp]));
     }
 
     #[test]

--- a/omq-bench/src/chart/common.rs
+++ b/omq-bench/src/chart/common.rs
@@ -55,6 +55,7 @@ pub(crate) const C_LIBZMQ: RGBColor = RGBColor(250, 204, 21);
 pub(crate) const C_LIBZMQ_2T: RGBColor = RGBColor(245, 158, 11);
 pub(crate) const C_OMQ_1T: RGBColor = RGBColor(239, 68, 68);
 pub(crate) const C_OMQ_CT: RGBColor = RGBColor(251, 113, 133);
+pub(crate) const C_OMQ_MT: RGBColor = RGBColor(249, 115, 22);
 pub(crate) const C_OMQ_EXCLUSIVE: RGBColor = RGBColor(45, 212, 191);
 pub(crate) const C_OMQ_2T: RGBColor = RGBColor(185, 28, 28);
 pub(crate) const C_OMQ_3T: RGBColor = RGBColor(153, 27, 27);

--- a/omq-bench/src/chart/main_tcp.rs
+++ b/omq-bench/src/chart/main_tcp.rs
@@ -1,6 +1,6 @@
 use super::common::{
     self, C_GRPC, C_LIBZMQ, C_LIBZMQ_2T, C_OMQ_1T, C_OMQ_2T, C_OMQ_3T, C_OMQ_4T, C_OMQ_CT,
-    C_OMQ_EXCLUSIVE, C_RZMQ, C_RZMQ_IOURING, C_TMQ, C_ZMQRS, Impl,
+    C_OMQ_EXCLUSIVE, C_OMQ_MT, C_RZMQ, C_RZMQ_IOURING, C_TMQ, C_ZMQRS, Impl,
     draw_latency_single_panel_with_versions,
     draw_throughput_dual_panel_fixed_2m_msgs_with_versions,
     draw_throughput_dual_panel_with_versions, load_latency, load_tput, out_dir,
@@ -30,6 +30,12 @@ const PUSHPULL_IMPLS: &[Impl] = &[
         label: "omq",
         threads: "CT",
         color: C_OMQ_CT,
+    },
+    Impl {
+        key: "omq-tokio-mt",
+        label: "omq",
+        threads: "12 MT",
+        color: C_OMQ_MT,
     },
     Impl {
         key: "tmq",

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Direct TCP receives reuse bounded buffers through 8 MiB without zero-filling
+  payload memory. Held messages keep exclusive buffer ownership, and idle pool
+  memory is released when its connection closes.
+
 ## [0.21.3] - 2026-08-17
 
 ### Added

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -38,6 +38,7 @@ arc-swap = "1.7.1"
 bytes = "1.12.0"
 concurrent-queue = "2.5.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+parking_lot = "0.12.5"
 rand = "0.10"
 rustc-hash = "2.1.0"
 smallvec = { version = "1", features = ["const_generics", "union"] }

--- a/omq-tokio/Cargo.toml
+++ b/omq-tokio/Cargo.toml
@@ -30,6 +30,8 @@ ws = ["omq-proto/ws", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-t
 # `cargo test`. Run with `cargo test --features fuzz`.
 fuzz = []
 soak = []
+# Enables the comparison peer's Tokio multi-thread runtime variant.
+bench-mt-runtime = ["tokio/rt-multi-thread"]
 
 [dependencies]
 omq-proto = { path = "../omq-proto", version = "0.26.0", default-features = false }

--- a/omq-tokio/src/bin/bench_peer_tokio.rs
+++ b/omq-tokio/src/bin/bench_peer_tokio.rs
@@ -103,6 +103,22 @@ fn main() {
             .build()
             .unwrap();
         rt.block_on(async_main(args, ctx));
+    } else if std::env::var("OMQ_BENCH_MT_RUNTIME").is_ok() {
+        #[cfg(feature = "bench-mt-runtime")]
+        {
+            let workers = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+            eprintln!("runtime: multi_thread ({workers} workers)");
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let ctx = omq_tokio::Context::current();
+                async_main(args, ctx).await;
+            });
+        }
+        #[cfg(not(feature = "bench-mt-runtime"))]
+        panic!("OMQ_BENCH_MT_RUNTIME requires the bench-mt-runtime feature");
     } else {
         eprintln!("runtime: current_thread");
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/omq-tokio/src/engine/driver.rs
+++ b/omq-tokio/src/engine/driver.rs
@@ -3,8 +3,8 @@
 use std::collections::VecDeque;
 use std::io;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -38,7 +38,7 @@ const RECV_MEDIUM_BYTES: usize = 1024 * 1024;
 const RECV_LARGE_BYTES: usize = 1024 * 1024;
 const RECV_MEDIUM_TIME: Duration = Duration::from_micros(200);
 const RECV_LARGE_TIME: Duration = Duration::from_micros(200);
-const RECV_POOL_MAX_BUFFER_BYTES: usize = 1024 * 1024;
+const RECV_POOL_MAX_BUFFER_BYTES: usize = 8 * 1024 * 1024;
 const RECV_POOL_MAX_RETAINED_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1590,7 +1590,7 @@ struct RecvBufPool {
 
 #[derive(Debug, Default)]
 struct RecvBufPoolInner {
-    buffers: Vec<Vec<u8>>,
+    buffers: Vec<BytesMut>,
     retained_bytes: usize,
 }
 
@@ -1601,7 +1601,7 @@ impl RecvBufPool {
         })
     }
 
-    fn take(&self, capacity: usize) -> Vec<u8> {
+    fn take(&self, capacity: usize) -> BytesMut {
         let mut pool = self.inner.lock().expect("recv buf pool");
         if let Some(mut buf) = pool.buffers.pop() {
             pool.retained_bytes = pool.retained_bytes.saturating_sub(buf.capacity());
@@ -1611,10 +1611,10 @@ impl RecvBufPool {
             buf.clear();
             return buf;
         }
-        Vec::with_capacity(capacity)
+        BytesMut::with_capacity(capacity)
     }
 
-    fn give(&self, mut buf: Vec<u8>) {
+    fn give(&self, mut buf: BytesMut) {
         let capacity = buf.capacity();
         if capacity > RECV_POOL_MAX_BUFFER_BYTES {
             return;
@@ -1626,11 +1626,18 @@ impl RecvBufPool {
             pool.buffers.push(buf);
         }
     }
+
+    fn wrap(self: &Arc<Self>, buf: BytesMut) -> Bytes {
+        Bytes::from_owner(PooledRecvBuf {
+            buf,
+            pool: Arc::downgrade(self),
+        })
+    }
 }
 
 struct PooledRecvBuf {
-    buf: Vec<u8>,
-    pool: Arc<RecvBufPool>,
+    buf: BytesMut,
+    pool: Weak<RecvBufPool>,
 }
 
 impl AsRef<[u8]> for PooledRecvBuf {
@@ -1642,7 +1649,9 @@ impl AsRef<[u8]> for PooledRecvBuf {
 impl Drop for PooledRecvBuf {
     fn drop(&mut self) {
         let buf = std::mem::take(&mut self.buf);
-        self.pool.give(buf);
+        if let Some(pool) = self.pool.upgrade() {
+            pool.give(buf);
+        }
     }
 }
 
@@ -1673,15 +1682,10 @@ async fn handle_large_messages<R: AsyncRead + Unpin>(
             let mut buf = recv_pool.take(plen);
             buf.extend_from_slice(prefix.as_slice());
             if buf.len() < plen {
-                let filled = buf.len();
-                buf.resize(plen, 0);
-                reader.read_exact(&mut buf[filled..plen]).await?;
+                read_exact_buf(reader, &mut buf, plen).await?;
             }
             debug_assert_eq!(buf.len(), plen);
-            Bytes::from_owner(PooledRecvBuf {
-                buf,
-                pool: Arc::clone(recv_pool),
-            })
+            recv_pool.wrap(buf)
         } else {
             let mut buf = BytesMut::with_capacity(plen);
             buf.extend_from_slice(prefix.as_slice());
@@ -2187,7 +2191,7 @@ mod tests {
     #[test]
     fn recv_buf_pool_does_not_retain_huge_buffers() {
         let pool = RecvBufPool::new();
-        pool.give(Vec::with_capacity(RECV_POOL_MAX_BUFFER_BYTES + 1));
+        pool.give(BytesMut::with_capacity(RECV_POOL_MAX_BUFFER_BYTES + 1));
         let guard = pool.inner.lock().unwrap();
         assert_eq!(guard.buffers.len(), 0);
         assert_eq!(guard.retained_bytes, 0);
@@ -2195,17 +2199,69 @@ mod tests {
 
     #[test]
     fn recv_buf_pool_caps_total_retained_bytes() {
+        const BUFFER_BYTES: usize = 1024 * 1024;
+
         let pool = RecvBufPool::new();
-        let buffer_count = (RECV_POOL_MAX_RETAINED_BYTES / RECV_POOL_MAX_BUFFER_BYTES) + 2;
+        let buffer_count = (RECV_POOL_MAX_RETAINED_BYTES / BUFFER_BYTES) + 2;
         for _ in 0..buffer_count {
-            pool.give(Vec::with_capacity(RECV_POOL_MAX_BUFFER_BYTES));
+            pool.give(BytesMut::with_capacity(BUFFER_BYTES));
         }
         let guard = pool.inner.lock().unwrap();
         assert!(guard.retained_bytes <= RECV_POOL_MAX_RETAINED_BYTES);
         assert_eq!(
             guard.buffers.len(),
-            RECV_POOL_MAX_RETAINED_BYTES / RECV_POOL_MAX_BUFFER_BYTES
+            RECV_POOL_MAX_RETAINED_BYTES / BUFFER_BYTES
         );
+    }
+
+    #[test]
+    fn recv_buf_pool_waits_for_last_bytes_clone() {
+        let pool = RecvBufPool::new();
+        let mut buf = pool.take(4 * 1024 * 1024);
+        buf.extend_from_slice(b"payload");
+        let payload = pool.wrap(buf);
+        let clone = payload.clone();
+
+        drop(payload);
+        assert_eq!(pool.inner.lock().unwrap().buffers.len(), 0);
+
+        drop(clone);
+        let guard = pool.inner.lock().unwrap();
+        assert_eq!(guard.buffers.len(), 1);
+        assert!(guard.retained_bytes >= 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn recv_buf_pool_does_not_outlive_connection_owner() {
+        let pool = RecvBufPool::new();
+        let weak = Arc::downgrade(&pool);
+        let payload = pool.wrap(pool.take(4 * 1024 * 1024));
+
+        drop(pool);
+        assert!(weak.upgrade().is_none());
+
+        drop(payload);
+    }
+
+    #[test]
+    fn recv_buf_pool_accepts_concurrent_last_owner_drops() {
+        const BUFFER_COUNT: usize = 16;
+        const BUFFER_BYTES: usize = 1024 * 1024;
+
+        let pool = RecvBufPool::new();
+        let payloads = (0..BUFFER_COUNT)
+            .map(|_| pool.wrap(pool.take(BUFFER_BYTES)))
+            .collect::<Vec<_>>();
+
+        std::thread::scope(|scope| {
+            for payload in payloads {
+                scope.spawn(move || drop(payload));
+            }
+        });
+
+        let guard = pool.inner.lock().unwrap();
+        assert_eq!(guard.buffers.len(), BUFFER_COUNT);
+        assert_eq!(guard.retained_bytes, BUFFER_COUNT * BUFFER_BYTES);
     }
 
     #[derive(Debug)]

--- a/omq-tokio/src/socket/recv.rs
+++ b/omq-tokio/src/socket/recv.rs
@@ -1261,21 +1261,23 @@ impl SpscAwareRecv {
         {
             return SpscPush::Unavailable(msg);
         }
-        if pair.producer.is_consumer_dropped() || !pair.recv_ready.load(Ordering::Acquire) {
+        let mut producer = pair.producer.lock();
+        if producer.is_consumer_dropped() || !pair.recv_ready.load(Ordering::Acquire) {
             return SpscPush::Unavailable(msg);
         }
-        if pair.producer.is_full() {
+        if producer.is_full() {
             return SpscPush::Full {
                 msg,
                 space: pair.space_notify.clone(),
             };
         }
-        if let Err(item) = pair.producer.push_flush(RecvItem::new(msg)) {
+        if let Err(item) = producer.push_and_flush(RecvItem::new(msg)) {
             return SpscPush::Full {
                 msg: item.into_message(),
                 space: pair.space_notify.clone(),
             };
         }
+        drop(producer);
         pair.recv_signal.mark();
         pair.blocking_recv_waker.wake();
         SpscPush::Sent
@@ -1293,7 +1295,7 @@ impl SpscAwareRecv {
             || pair
                 .max_message_size
                 .is_some_and(|max| msg.max_message_size_len() > max)
-            || pair.producer.is_consumer_dropped()
+            || pair.producer.lock().is_consumer_dropped()
         {
             return false;
         }
@@ -1313,11 +1315,11 @@ impl SpscAwareRecv {
             || pair
                 .max_message_size
                 .is_some_and(|max| msg.max_message_size_len() > max)
-            || pair.producer.is_consumer_dropped()
+            || pair.producer.lock().is_consumer_dropped()
         {
             return false;
         }
-        if !pair.producer.is_full() {
+        if !pair.producer.lock().is_full() {
             return true;
         }
 
@@ -1328,11 +1330,11 @@ impl SpscAwareRecv {
             || pair
                 .max_message_size
                 .is_some_and(|max| msg.max_message_size_len() > max)
-            || pair.producer.is_consumer_dropped()
+            || pair.producer.lock().is_consumer_dropped()
         {
             return false;
         }
-        if pair.producer.is_full() {
+        if pair.producer.lock().is_full() {
             changed.await;
         }
         true

--- a/omq-tokio/src/transport/inproc.rs
+++ b/omq-tokio/src/transport/inproc.rs
@@ -20,6 +20,7 @@ use std::sync::{Condvar, Mutex as StdMutex};
 use rustc_hash::FxHashMap;
 
 use futures::channel::oneshot;
+use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::mpsc;
 
 use omq_proto::error::{Error, Result};
@@ -70,7 +71,9 @@ impl BlockingSpace {
 #[allow(private_interfaces)]
 #[derive(Debug)]
 pub struct InprocTx {
-    pub producer: yring::ProducerOwner<RecvItem>,
+    // Async sockets may move between runtime worker threads. Serialize access
+    // while retaining the SPSC ring's single active producer.
+    pub(crate) producer: ParkingMutex<yring::Producer<RecvItem>>,
     pub(crate) recv_signal: Arc<DataSignal>,
     pub recv_ready: Arc<std::sync::atomic::AtomicBool>,
     pub max_message_size: Option<usize>,
@@ -81,7 +84,8 @@ pub struct InprocTx {
 
 impl InprocTx {
     pub(crate) fn wait_for_space(&self) {
-        self.blocking_space.wait_until(|| self.producer.is_full());
+        self.blocking_space
+            .wait_until(|| self.producer.lock().is_full());
     }
 }
 
@@ -344,7 +348,7 @@ impl InprocListener {
             let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let blocking_space = Arc::new(BlockingSpace::new());
             let tx = Arc::new(InprocTx {
-                producer: yring::ProducerOwner::new(p),
+                producer: ParkingMutex::new(p),
                 recv_signal: ring_recv_signal,
                 recv_ready: ready.clone(),
                 max_message_size: mms,

--- a/omq-tokio/tests/large_messages.rs
+++ b/omq-tokio/tests/large_messages.rs
@@ -234,9 +234,9 @@ async fn many_large_messages_preserve_pattern_under_hwm_backpressure() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn held_large_messages_survive_recv_bypass_ring_pressure() {
-    const COUNT: u64 = 48;
-    const HOLD_COUNT: u64 = 8;
-    const SIZE: usize = 1024 * 1024;
+    const COUNT: u64 = 16;
+    const HOLD_COUNT: u64 = 4;
+    const SIZE: usize = 4 * 1024 * 1024;
 
     let opts = Options::default()
         .send_hwm(4)

--- a/omq-tokio/tests/omq_soak_large_throughput.rs
+++ b/omq-tokio/tests/omq_soak_large_throughput.rs
@@ -5,28 +5,21 @@ static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::Track
 
 mod soak_common;
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use std::{fs, io::Write};
 
 use omq_tokio::{Message, Options, Socket, SocketType};
 
-const MSG_SIZE: usize = 1024 * 1024;
+const MIN_MSG_SIZE: usize = 128 * 1024;
+const MAX_MSG_SIZE: usize = 8 * 1024 * 1024;
+const PROBE_MSG_SIZE: usize = 128 * 1024 * 1024;
+const SIZE_STRIDE: usize = 1_000_003;
+const HEADER_SIZE: usize = 24;
 const CANARY_MAGIC: u64 = 0xDEAD_BEEF_CAFE_F00D;
 const SHIFT_SCAN: isize = 32;
 const SHIFT_WINDOW: usize = 128;
-
-fn payload_pattern() -> &'static [u8] {
-    static PATTERN: OnceLock<Vec<u8>> = OnceLock::new();
-    PATTERN.get_or_init(|| {
-        let mut pattern = vec![0u8; MSG_SIZE];
-        for (i, slot) in pattern.iter_mut().enumerate().skip(16) {
-            *slot = offset_payload_byte(i);
-        }
-        pattern
-    })
-}
 
 fn offset_payload_byte(offset: usize) -> u8 {
     let mut byte = (offset as u8).wrapping_mul(31);
@@ -39,21 +32,30 @@ fn seq_mask(seq: u64) -> u8 {
     (seq as u8).wrapping_mul(7) ^ ((seq >> 8) as u8).wrapping_mul(3)
 }
 
+fn message_size(seq: u64) -> usize {
+    if seq == 0 {
+        return PROBE_MSG_SIZE;
+    }
+    let span = MAX_MSG_SIZE - MIN_MSG_SIZE + 1;
+    MIN_MSG_SIZE + (seq as usize - 1).wrapping_mul(SIZE_STRIDE) % span
+}
+
 fn build_payload(seq: u64) -> Vec<u8> {
+    let size = message_size(seq);
     let mask = seq_mask(seq);
-    let mut buf = payload_pattern().to_vec();
+    let mut buf = vec![0; size];
     buf[..8].copy_from_slice(&CANARY_MAGIC.to_le_bytes());
     buf[8..16].copy_from_slice(&seq.to_le_bytes());
-    for slot in &mut buf[16..] {
-        *slot ^= mask;
+    buf[16..HEADER_SIZE].copy_from_slice(&(size as u64).to_le_bytes());
+    for (i, slot) in buf.iter_mut().enumerate().skip(HEADER_SIZE) {
+        *slot = offset_payload_byte(i) ^ mask;
     }
     buf
 }
 
 fn best_source_shift(data: &[u8], seq: u64, offset: usize) -> (isize, usize, usize) {
-    let pattern = payload_pattern();
     let mask = seq_mask(seq);
-    let start = offset.saturating_sub(SHIFT_WINDOW / 2).max(16);
+    let start = offset.saturating_sub(SHIFT_WINDOW / 2).max(HEADER_SIZE);
     let end = offset.saturating_add(SHIFT_WINDOW / 2).min(data.len());
     let len = end - start;
     let mut best = (0, 0, len);
@@ -69,7 +71,10 @@ fn best_source_shift(data: &[u8], seq: u64, offset: usize) -> (isize, usize, usi
             let Ok(source) = usize::try_from(source) else {
                 continue;
             };
-            if source >= 16 && source < data.len() && byte == (pattern[source] ^ mask) {
+            if source >= HEADER_SIZE
+                && source < data.len()
+                && byte == (offset_payload_byte(source) ^ mask)
+            {
                 matches += 1;
             }
         }
@@ -81,14 +86,15 @@ fn best_source_shift(data: &[u8], seq: u64, offset: usize) -> (isize, usize, usi
 }
 
 fn corruption_context(data: &[u8], seq: u64, offset: usize) -> String {
-    let pattern = payload_pattern();
     let mask = seq_mask(seq);
     let got = data[offset];
-    let expected_byte = pattern[offset] ^ mask;
+    let expected_byte = offset_payload_byte(offset) ^ mask;
     let xor = got ^ expected_byte;
-    let start = offset.saturating_sub(16).max(16);
+    let start = offset.saturating_sub(16).max(HEADER_SIZE);
     let end = offset.saturating_add(16).min(data.len());
-    let expected: Vec<u8> = (start..end).map(|pos| pattern[pos] ^ mask).collect();
+    let expected: Vec<u8> = (start..end)
+        .map(|pos| offset_payload_byte(pos) ^ mask)
+        .collect();
     let (delta, matches, window_len) = best_source_shift(data, seq, offset);
     format!(
         "xor=0x{xor:02x}, single_bit={}, best_source_delta={delta}, \
@@ -110,18 +116,18 @@ fn dump_corruption_artifact(data: &[u8], seq: u64, offset: usize) -> Option<Stri
     let expected_path = dir.join(format!("{stamp}.expected.bin"));
     let meta_path = dir.join(format!("{stamp}.meta.txt"));
 
-    let pattern = payload_pattern();
     let mask = seq_mask(seq);
-    let expected = pattern
-        .iter()
-        .enumerate()
-        .map(|(i, &byte)| {
+    let size = message_size(seq);
+    let expected = (0..size)
+        .map(|i| {
             if i < 8 {
                 CANARY_MAGIC.to_le_bytes()[i]
             } else if i < 16 {
                 seq.to_le_bytes()[i - 8]
+            } else if i < HEADER_SIZE {
+                (size as u64).to_le_bytes()[i - 16]
             } else {
-                byte ^ mask
+                offset_payload_byte(i) ^ mask
             }
         })
         .collect::<Vec<_>>();
@@ -130,7 +136,7 @@ fn dump_corruption_artifact(data: &[u8], seq: u64, offset: usize) -> Option<Stri
     fs::write(&expected_path, expected).ok()?;
     let mut meta = fs::File::create(&meta_path).ok()?;
     let got = data[offset];
-    let expected_byte = payload_pattern()[offset] ^ seq_mask(seq);
+    let expected_byte = offset_payload_byte(offset) ^ seq_mask(seq);
     let xor = got ^ expected_byte;
     writeln!(meta, "seq={seq}").ok()?;
     writeln!(meta, "offset={offset}").ok()?;
@@ -145,6 +151,7 @@ fn dump_corruption_artifact(data: &[u8], seq: u64, offset: usize) -> Option<Stri
 
 struct PayloadStats {
     max_seq: u64,
+    max_size: usize,
     count: u64,
     reorders: u64,
     max_reorder_distance: u64,
@@ -155,6 +162,7 @@ impl PayloadStats {
     fn new() -> Self {
         Self {
             max_seq: 0,
+            max_size: 0,
             count: 0,
             reorders: 0,
             max_reorder_distance: 0,
@@ -163,10 +171,12 @@ impl PayloadStats {
     }
 
     fn validate(&mut self, data: &[u8]) {
-        assert_eq!(data.len(), MSG_SIZE, "payload size mismatch");
+        assert!(data.len() >= HEADER_SIZE, "payload shorter than header");
 
         let magic = u64::from_le_bytes(data[..8].try_into().unwrap());
         let seq = u64::from_le_bytes(data[8..16].try_into().unwrap());
+        let claimed_size = u64::from_le_bytes(data[16..HEADER_SIZE].try_into().unwrap()) as usize;
+        let expected_size = message_size(seq);
 
         assert_eq!(
             magic,
@@ -175,11 +185,12 @@ impl PayloadStats {
              Receiver lost ZMTP frame sync: payload bytes parsed as frame headers.",
             &data[..32]
         );
+        assert_eq!(claimed_size, expected_size, "payload size header mismatch");
+        assert_eq!(data.len(), expected_size, "payload size mismatch");
 
-        let pattern = payload_pattern();
         let mask = seq_mask(seq);
-        for (i, &byte) in data.iter().enumerate().skip(16) {
-            let expected = pattern[i] ^ mask;
+        for (i, &byte) in data.iter().enumerate().skip(HEADER_SIZE) {
+            let expected = offset_payload_byte(i) ^ mask;
             if byte != expected {
                 let context = corruption_context(data, seq, i);
                 let artifact = dump_corruption_artifact(data, seq, i)
@@ -201,6 +212,7 @@ impl PayloadStats {
             self.max_reorder_distance = self.max_reorder_distance.max(distance);
         }
         self.max_seq = self.max_seq.max(seq);
+        self.max_size = self.max_size.max(data.len());
         self.count += 1;
     }
 
@@ -235,6 +247,8 @@ fn soak_large_message_throughput() {
 
     let sent = Arc::new(AtomicU64::new(0));
     let recvd = Arc::new(AtomicU64::new(0));
+    let sent_bytes = Arc::new(AtomicU64::new(0));
+    let recvd_bytes = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
     let report_sent = sent.clone();
     let report_stats = Arc::new(std::sync::Mutex::new(PayloadStats::new()));
@@ -251,12 +265,14 @@ fn soak_large_message_throughput() {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         let send_sent = sent.clone();
+        let send_sent_bytes = sent_bytes.clone();
         let send_stop = stop.clone();
         let push_clone = push.clone();
         let mut send_task = tokio::spawn(async move {
             let mut seq = 0u64;
             while !send_stop.load(Ordering::Relaxed) {
                 let payload = build_payload(seq);
+                let payload_len = payload.len() as u64;
                 if let Ok(Ok(())) = tokio::time::timeout(
                     Duration::from_secs(2),
                     push_clone.send(Message::single(payload)),
@@ -265,11 +281,13 @@ fn soak_large_message_throughput() {
                 {
                     seq += 1;
                     send_sent.store(seq, Ordering::Relaxed);
+                    send_sent_bytes.fetch_add(payload_len, Ordering::Relaxed);
                 }
             }
         });
 
         let recv_recvd = recvd.clone();
+        let recv_recvd_bytes = recvd_bytes.clone();
         let recv_stop = stop.clone();
         let pull_clone = pull.clone();
         let recv_stats = stats.clone();
@@ -281,6 +299,7 @@ fn soak_large_message_throughput() {
                     let data = m.part_bytes(0).unwrap();
                     recv_stats.lock().unwrap().validate(&data);
                     recv_recvd.fetch_add(1, Ordering::Relaxed);
+                    recv_recvd_bytes.fetch_add(data.len() as u64, Ordering::Relaxed);
                 }
             }
         });
@@ -327,10 +346,11 @@ fn soak_large_message_throughput() {
 
         let s = sent.load(Ordering::Relaxed);
         let r = recvd.load(Ordering::Relaxed);
+        let bytes = recvd_bytes.load(Ordering::Relaxed);
         eprintln!(
             "[large_throughput] done: sent {s}, recvd {r} in {:.1}s ({:.1} MiB/s)",
             duration.as_secs_f64(),
-            r as f64 * MSG_SIZE as f64 / duration.as_secs_f64() / 1_048_576.0,
+            bytes as f64 / duration.as_secs_f64() / 1_048_576.0,
         );
 
         push.close().await.unwrap();
@@ -344,8 +364,16 @@ fn soak_large_message_throughput() {
     let total_sent = report_sent.load(Ordering::Relaxed);
     st.finalize(total_sent);
     eprintln!(
-        "[large_throughput] reorders: {}, max distance: {}, dropped: {}/{}",
-        st.reorders, st.max_reorder_distance, st.dropped, total_sent,
+        "[large_throughput] max size: {} MiB, reorders: {}, max distance: {}, dropped: {}/{}",
+        st.max_size / 1024 / 1024,
+        st.reorders,
+        st.max_reorder_distance,
+        st.dropped,
+        total_sent,
+    );
+    assert_eq!(
+        st.max_size, PROBE_MSG_SIZE,
+        "128 MiB probe was not received"
     );
     assert!(
         st.max_reorder_distance <= 16,

--- a/omq-tokio/tests/spsc_recovery.rs
+++ b/omq-tokio/tests/spsc_recovery.rs
@@ -1,11 +1,118 @@
 //! Verify SPSC inproc fast paths recover after peer churn.
 
+use std::collections::HashSet;
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::Duration;
 
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
 fn inproc(name: &str) -> Endpoint {
     Endpoint::Inproc { name: name.into() }
+}
+
+#[test]
+fn inproc_push_survives_sender_task_migration() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let endpoint = inproc("spsc-task-migration");
+    let (pull, push) = runtime.block_on(async {
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        let push = Socket::new(SocketType::Push, Options::default());
+        pull.bind(endpoint.clone()).await.unwrap();
+        push.connect(endpoint).await.unwrap();
+        push.wait_connected(1, Duration::from_secs(2))
+            .await
+            .unwrap();
+        (pull, push)
+    });
+
+    for payload in ["first", "second"] {
+        let handle = runtime.handle().clone();
+        let push = push.clone();
+        thread::spawn(move || {
+            handle
+                .block_on(push.send(Message::single(payload)))
+                .unwrap();
+        })
+        .join()
+        .unwrap();
+    }
+
+    runtime.block_on(async {
+        for expected in ["first", "second"] {
+            let message = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(message.part_bytes(0).unwrap(), expected.as_bytes());
+        }
+        push.close().await.unwrap();
+        pull.close().await.unwrap();
+    });
+}
+
+#[test]
+fn inproc_push_serializes_concurrent_senders() {
+    const SENDERS: usize = 4;
+    const MESSAGES: usize = 128;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let endpoint = inproc("spsc-concurrent-senders");
+    let (pull, push) = runtime.block_on(async {
+        let pull = Socket::new(SocketType::Pull, Options::default());
+        let push = Socket::new(SocketType::Push, Options::default());
+        pull.bind(endpoint.clone()).await.unwrap();
+        push.connect(endpoint).await.unwrap();
+        push.wait_connected(1, Duration::from_secs(2))
+            .await
+            .unwrap();
+        (pull, push)
+    });
+
+    let barrier = Arc::new(Barrier::new(SENDERS));
+    let senders: Vec<_> = (0..SENDERS)
+        .map(|sender| {
+            let barrier = Arc::clone(&barrier);
+            let handle = runtime.handle().clone();
+            let push = push.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                handle.block_on(async {
+                    for sequence in 0..MESSAGES {
+                        push.send(Message::single(format!("{sender}:{sequence}")))
+                            .await
+                            .unwrap();
+                    }
+                });
+            })
+        })
+        .collect();
+    for sender in senders {
+        sender.join().unwrap();
+    }
+
+    runtime.block_on(async {
+        let mut received = HashSet::new();
+        for _ in 0..SENDERS * MESSAGES {
+            let message = tokio::time::timeout(Duration::from_secs(2), pull.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            let body = message.part_bytes(0).unwrap();
+            received.insert(std::str::from_utf8(&body).unwrap().to_owned());
+        }
+        assert_eq!(received.len(), SENDERS * MESSAGES);
+        push.close().await.unwrap();
+        pull.close().await.unwrap();
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Serialize inproc SPSC producer access across migrated tasks and cloned socket handles.
- Reuse direct receive buffers through 8 MiB with bounded idle capacity and connection-scoped lifetime.
- Extend large-message coverage with retained references, variable sizes, and a mandatory 128 MiB soak probe.
- Add a Tokio multi-thread runtime comparison and refresh the main TCP PUSH/PULL chart.