### PR TITLE
chore(bindings): prepare 2026-08-23 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,7 +470,9 @@ jobs:
           dotnet restore bindings/dotnet/Omq.Net.csproj
           bash bindings/dotnet/scripts/package.sh "$RUNNER_TEMP/omq-nuget" \
             linux-x64="$GITHUB_WORKSPACE/target/release/libomq_zmq.so"
-          unzip -l "$RUNNER_TEMP/omq-nuget/Omq.Net.0.1.2.nupkg"
+          package_version=$(dotnet msbuild bindings/dotnet/Omq.Net.csproj \
+            -getProperty:Version -nologo)
+          unzip -l "$RUNNER_TEMP/omq-nuget/Omq.Net.${package_version}.nupkg"
       - name: install package and run package smoke test
         run: |
           dotnet restore bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj \

--- a/bindings/dotnet/CHANGELOG.md
+++ b/bindings/dotnet/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.1.3]
+
+### Fixed
+
+- Serialize managed socket migration and native handle leases across async
+  operations and disposal.
+- Return resolved endpoints from wildcard `bind()` calls.
+- Preserve multipart messages in mixed protocol soak exchanges.
+- Bound cancellation, churn, and shutdown paths under backpressure.
+
+### Changed
+
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+- Bundle `omq-libzmq` 0.5.15.
+
 ## [0.1.2]
 
 ### Added

--- a/bindings/dotnet/DEVELOPMENT.md
+++ b/bindings/dotnet/DEVELOPMENT.md
@@ -16,6 +16,8 @@ LD_LIBRARY_PATH="$PWD/target/release" \
 LD_LIBRARY_PATH="$PWD/target/release" \
   dotnet run --project bindings/dotnet/tests/Omq.Net.Lifecycle.csproj
 
+dotnet build bindings/dotnet/tests/Omq.Net.Interop.csproj
+
 LD_LIBRARY_PATH="$PWD/target/release" \
   python3 bindings/dotnet/tests/interop.py
 ```

--- a/bindings/dotnet/Omq.Net.csproj
+++ b/bindings/dotnet/Omq.Net.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <PackageId>Omq.Net</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>OMQ contributors</Authors>
     <Description>Fast .NET binding for OMQ.</Description>
     <PackageTags>zeromq;omq;networking;messaging</PackageTags>

--- a/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
+++ b/bindings/dotnet/tests/Omq.Net.PackageSmoke.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <OmqNetVersion Condition="'$(OmqNetVersion)' == ''">0.1.2</OmqNetVersion>
+    <OmqNetVersion Condition="'$(OmqNetVersion)' == ''">0.1.3</OmqNetVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Omq.Net" Version="$(OmqNetVersion)" />

--- a/bindings/go/CHANGELOG.md
+++ b/bindings/go/CHANGELOG.md
@@ -1,0 +1,16 @@
+# OMQ.go Changelog
+
+## [Unreleased]
+
+## [0.1.1] - 2026-08-23
+
+- Block scalar receives in native code instead of polling from Go.
+- Reduce scalar request/reply latency.
+- Preserve receives that complete at the timeout boundary.
+- Preserve `SERVER` routing IDs across native receive and send calls.
+- Bound shutdown and churn operations under backpressure.
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+
+## [0.1.0] - 2026-08-16
+
+- First release of the Go binding for OMQ.rs.

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+## [0.3.3]
+
 - Unblock concurrent socket close when a PUSH or SCATTER sender is waiting for
   space in the native send ring.
+- Wake blocked receivers during close without racing native ring teardown.
+- Restore scalar receive throughput while preserving close synchronization.
+- Preserve `SERVER` routing IDs across native receive and send calls.
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+- Bundle `omq-tokio` 0.21.4 and `omq-proto` 0.26.1.
 
 ## [0.3.2]
 

--- a/bindings/java/native/Cargo.lock
+++ b/bindings/java/native/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/bindings/lua/CHANGELOG.md
+++ b/bindings/lua/CHANGELOG.md
@@ -1,0 +1,15 @@
+# OMQ.lua Changelog
+
+## [Unreleased]
+
+## [0.2.1] - 2026-08-23
+
+- Preserve `SERVER` routing IDs across native receive and send calls.
+- Allow `inproc://` sends across OMQ runtime threads.
+- Bound exchange retries and preserve soak deadlines during shutdown.
+- Handle LZ4 compressor epoch rollover without corrupting the stream.
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+
+## [0.2.0] - 2026-08-18
+
+- First LuaRocks release of OMQ.lua.

--- a/bindings/lua/native/Cargo.lock
+++ b/bindings/lua/native/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "omq-libzmq"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/bindings/lua/omq-0.2.1-1.rockspec
+++ b/bindings/lua/omq-0.2.1-1.rockspec
@@ -1,0 +1,51 @@
+rockspec_format = "3.0"
+package = "omq"
+version = "0.2.1-1"
+
+source = {
+   url = "git+https://github.com/paddor/omq.rs.git",
+   tag = "omq-lua-v0.2.1",
+}
+
+description = {
+   summary = "Lua 5.4 binding for OMQ.rs",
+   detailed = [[
+      OMQ.lua is a Lua 5.4 binding for OMQ.rs backed by the omq-libzmq
+      C ABI. It exposes the OMQ socket API through a small Lua module and
+      a Rust native module.
+   ]],
+   homepage = "https://github.com/paddor/omq.rs/tree/main/bindings/lua",
+   issues_url = "https://github.com/paddor/omq.rs/issues",
+   license = "ISC",
+   labels = { "zeromq", "omq", "messaging", "networking" },
+}
+
+dependencies = {
+   "lua >= 5.4, < 5.5",
+}
+
+external_dependencies = {
+   CARGO = {
+      program = "cargo",
+   },
+}
+
+build = {
+   type = "command",
+   build_command = "cargo build --release --manifest-path bindings/lua/native/Cargo.toml",
+   install_command = [[
+      mkdir -p "$(LUADIR)" "$(LIBDIR)" &&
+      cp bindings/lua/lua/omq.lua "$(LUADIR)/omq.lua" &&
+      if [ -f bindings/lua/native/target/release/libomq_native.so ]; then
+         cp bindings/lua/native/target/release/libomq_native.so "$(LIBDIR)/omq_native.so";
+      elif [ -f bindings/lua/native/target/release/libomq_native.dylib ]; then
+         cp bindings/lua/native/target/release/libomq_native.dylib "$(LIBDIR)/omq_native.so";
+      elif [ -f bindings/lua/native/target/release/omq_native.dll ]; then
+         cp bindings/lua/native/target/release/omq_native.dll "$(LIBDIR)/omq_native.dll";
+      else
+         echo "omq_native shared library not found" >&2;
+         exit 1;
+      fi
+   ]],
+   copy_directories = {},
+}

--- a/bindings/node/CHANGELOG.md
+++ b/bindings/node/CHANGELOG.md
@@ -1,0 +1,17 @@
+# OMQ.node Changelog
+
+## [Unreleased]
+
+## [0.1.3] - 2026-08-23
+
+- Run asynchronous socket I/O on the shared Tokio runtime without blocking
+  Node.js worker threads.
+- Restore async send and receive throughput after the runtime migration.
+- Use Linux abstract namespace endpoints for internal IPC.
+- Add `sendGroup()` for RADIO messages.
+- Bound shutdown paths under blocked sends and receives.
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+
+## [0.1.2] - 2026-08-16
+
+- Publish multi-platform npm packages with native addons.

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "omq-node"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "napi",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-node"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.93"
 publish = false

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-arm64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-x64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-arm64-musl/package.json
+++ b/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-musl",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-x64-musl/package.json
+++ b/bindings/node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-musl",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-arm64-msvc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-x64-msvc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paddor/omq-node",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Native Node.js binding for OMQ.rs",
   "license": "ISC",
   "type": "commonjs",

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-08-23
+
+### Fixed
+
+- Preserve `routing_id` metadata on messages received by `SERVER` sockets.
+- Allow `inproc://` sends across OMQ runtime threads.
+- Preserve `REP` reply state when a latency-profile peer disconnects.
+- Bound socket shutdown paths under blocked sends and receives.
+- Handle LZ4 compressor epoch rollover without corrupting the stream.
+
+### Changed
+
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+- *(deps)* Bump bundled `omq-tokio` to 0.21.4 and `omq-proto` to 0.26.1.
+
 ## [0.20.0] - 2026-08-16
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.20.0"
+version = "0.20.1"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-23
+
+- Document the full public API and publish the RubyDoc documentation link.
+- Reject unknown socket options instead of silently ignoring misspellings.
+- Make peer, subscriber, and monitor waits stop cleanly when a socket closes.
+- Release the CURVE auth-worker mutex before joining its thread during close.
+- Add mixed transport, protocol, lifecycle, and resource soak coverage.
+- Require `omq-proto` 0.26.1 and `omq-tokio` 0.21.4.
+
+## [0.1.0] - 2026-08-20
+
 - Add standalone `omq-rs` Ruby binding with all 20 OMQ socket types.
 - Add PLAIN and CURVE sockets, Z85 key generation, CURVE client authentication,
   and pyzmq CURVE interoperability.

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "omq_rs_native"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omq-rs (0.1.0)
+    omq-rs (0.1.1)
       rb_sys (~> 0.9)
 
 GEM
@@ -71,7 +71,7 @@ CHECKSUMS
   io-event (1.19.5) sha256=b168a9b7c5a0e894f2047f82f4bf831f59edd067843005e930a62f375738bad2
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  omq-rs (0.1.0)
+  omq-rs (0.1.1)
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/bindings/ruby/ext/omq_rs_native/Cargo.toml
+++ b/bindings/ruby/ext/omq_rs_native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq_rs_native"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"
@@ -20,8 +20,8 @@ zstd = ["omq-tokio/zstd"]
 ws = ["omq-tokio/ws"]
 
 [dependencies]
-omq-proto = { version = ">=0.26.0, <0.28.0", default-features = false }
-omq-tokio = { version = ">=0.21.3, <0.23.0", default-features = false }
+omq-proto = { version = ">=0.26.1, <0.28.0", default-features = false }
+omq-tokio = { version = ">=0.21.4, <0.23.0", default-features = false }
 yring = { version = "=0.3.14", features = ["async"] }
 
 bytes = "1.12.0"

--- a/bindings/ruby/lib/omq/rs/version.rb
+++ b/bindings/ruby/lib/omq/rs/version.rb
@@ -5,6 +5,6 @@ module OMQ
   module Rust
     # Ruby binding version.
     # @return [String]
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
- Prepare `pyomq` 0.20.1 and `omq-rs` 0.1.1 with released `omq-proto` 0.26.1 and `omq-tokio` 0.21.4 dependencies.
- Prepare OMQ.java 0.3.3, OMQ.go 0.1.1, OMQ.node 0.1.3, OMQ.Net 0.1.3, and OMQ.lua 0.2.1.
- Add release notes for routing metadata, lifecycle, shutdown, async I/O, and soak fixes.
- Update tracked native lockfiles, package manifests, and the LuaRocks rockspec.
- Document the required OMQ.Net interop peer build step.