### PR TITLE
Fix libzmq recv wake and extend soak coverage

### DIFF
--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -290,7 +290,9 @@ fn block_recv_result<T>(
                 None => i32::MAX,
             };
             let recv_notify = sock.notify.recv_notifier();
-            let _ = recv_notify.wait_for_readable(ms);
+            if recv_notify.wait_for_readable(ms) {
+                recv_notify.drain();
+            }
             if sock.ctx.is_effectively_terminated() {
                 return Err(ETERM);
             }
@@ -304,7 +306,9 @@ fn block_recv_result<T>(
             return Err(ETERM);
         }
         let recv_notify = sock.notify.recv_notifier();
-        let _ = recv_notify.wait_for_readable(100);
+        if recv_notify.wait_for_readable(100) {
+            recv_notify.drain();
+        }
         if sock.ctx.is_effectively_terminated() {
             return Err(ETERM);
         }

--- a/omq-libzmq/tests/basic.rs
+++ b/omq-libzmq/tests/basic.rs
@@ -6,7 +6,7 @@ mod helpers;
 
 use std::ffi::{CString, c_void};
 use std::mem::size_of;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_shutdown, zmq_ctx_term, zmq_getsockopt,
@@ -52,6 +52,18 @@ fn set_sndtimeo(sock: *mut c_void, ms: i32) {
 
 fn caddr(s: &str) -> CString {
     CString::new(s).unwrap()
+}
+
+#[cfg(unix)]
+fn thread_cpu_time() -> Duration {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts points to writable memory and CLOCK_THREAD_CPUTIME_ID needs no extra invariants.
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+    assert_eq!(rc, 0, "clock_gettime(CLOCK_THREAD_CPUTIME_ID)");
+    Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }
 
 #[test]
@@ -140,6 +152,49 @@ fn push_pull_inproc() {
     let rc = zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0);
     assert_eq!(rc, msg.len() as i32);
     assert_eq!(&buf[..rc as usize], msg);
+
+    zmq_close(push);
+    zmq_close(pull);
+    zmq_ctx_term(ctx);
+}
+
+#[cfg(unix)]
+#[test]
+fn recv_timeout_after_stale_signal_does_not_spin() {
+    let ctx = zmq_ctx_new();
+    let push = zmq_socket(ctx, ZMQ_PUSH);
+    let pull = zmq_socket(ctx, ZMQ_PULL);
+    assert!(!push.is_null() && !pull.is_null());
+
+    let addr = caddr("inproc://test-basic-recv-timeout-stale-signal");
+    assert_eq!(zmq_bind(pull, addr.as_ptr()), 0);
+    assert_eq!(zmq_connect(push, addr.as_ptr()), 0);
+    std::thread::sleep(Duration::from_millis(20));
+
+    set_rcvtimeo(pull, 100);
+    set_sndtimeo(push, 1000);
+
+    let payload = b"x";
+    assert_eq!(zmq_send(push, payload.as_ptr().cast(), payload.len(), 0), 1);
+    let mut buf = [0u8; 8];
+    assert_eq!(zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0), 1);
+
+    let wall_start = Instant::now();
+    let cpu_start = thread_cpu_time();
+    let rc = zmq_recv(pull, buf.as_mut_ptr().cast(), buf.len(), 0);
+    let wall = wall_start.elapsed();
+    let cpu = thread_cpu_time().saturating_sub(cpu_start);
+
+    assert_eq!(rc, -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EAGAIN);
+    assert!(
+        wall >= Duration::from_millis(50),
+        "recv timeout returned too early: {wall:?}",
+    );
+    assert!(
+        cpu < Duration::from_millis(25),
+        "recv timeout spun on CPU: {cpu:?}",
+    );
 
     zmq_close(push);
     zmq_close(pull);

--- a/omq-libzmq/tests/basic.rs
+++ b/omq-libzmq/tests/basic.rs
@@ -6,7 +6,9 @@ mod helpers;
 
 use std::ffi::{CString, c_void};
 use std::mem::size_of;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use omq_zmq::{
     zmq_bind, zmq_close, zmq_connect, zmq_ctx_new, zmq_ctx_shutdown, zmq_ctx_term, zmq_getsockopt,

--- a/omq-libzmq/tests/draft.rs
+++ b/omq-libzmq/tests/draft.rs
@@ -186,6 +186,46 @@ fn scatter_gather_tcp() {
     zmq_ctx_term(ctx);
 }
 
+/// omq-libzmq SCATTER to native omq-tokio GATHER with a large single frame.
+#[test]
+fn scatter_to_tokio_gather_large_tcp() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let gather =
+            omq_tokio::Socket::new(omq_tokio::SocketType::Gather, omq_tokio::Options::default());
+        let endpoint = gather
+            .bind("tcp://127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+        let endpoint = CString::new(endpoint.to_string()).unwrap();
+        let payload = vec![0x5au8; 157_197];
+        let expected = payload.clone();
+
+        let sender = std::thread::spawn(move || {
+            let ctx = zmq_ctx_new();
+            let scatter = zmq_socket(ctx, ZMQ_SCATTER);
+            set_timeo(scatter, 2_000);
+            assert_eq!(zmq_connect(scatter, endpoint.as_ptr()), 0);
+            std::thread::sleep(Duration::from_millis(100));
+            let rc = zmq_send(scatter, payload.as_ptr().cast(), payload.len(), 0);
+            assert_eq!(rc, payload.len() as i32, "scatter send failed");
+            zmq_close(scatter);
+            zmq_ctx_term(ctx);
+        });
+
+        let msg = tokio::time::timeout(Duration::from_secs(2), gather.recv())
+            .await
+            .expect("GATHER receive timed out")
+            .expect("GATHER receive failed");
+        assert_eq!(msg.part_slice(0), Some(expected.as_slice()));
+        sender.join().unwrap();
+    });
+}
+
 /// RADIO/DISH with group membership.
 #[test]
 fn radio_dish_inproc() {

--- a/omq-libzmq/tests/draft.rs
+++ b/omq-libzmq/tests/draft.rs
@@ -211,8 +211,9 @@ fn scatter_to_tokio_gather_large_tcp() {
             set_timeo(scatter, 2_000);
             assert_eq!(zmq_connect(scatter, endpoint.as_ptr()), 0);
             std::thread::sleep(Duration::from_millis(100));
+            let expected_len = i32::try_from(payload.len()).unwrap();
             let rc = zmq_send(scatter, payload.as_ptr().cast(), payload.len(), 0);
-            assert_eq!(rc, payload.len() as i32, "scatter send failed");
+            assert_eq!(rc, expected_len, "scatter send failed");
             zmq_close(scatter);
             zmq_ctx_term(ctx);
         });

--- a/omq-tokio/tests/omq_soak_rate_limit.rs
+++ b/omq-tokio/tests/omq_soak_rate_limit.rs
@@ -10,11 +10,15 @@ static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::Track
 
 mod soak_common;
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use omq_tokio::{
-    DisconnectReason, Message, MonitorEvent, Options, ReconnectPolicy, Socket, SocketType,
+    DisconnectReason, Endpoint, Message, MonitorEvent, Options, ReconnectPolicy, Socket, SocketType,
 };
+
+const SERVER_ATTACK_BURST: usize = 16;
 
 fn sender_options() -> Options {
     soak_common::soak_options().reconnect(ReconnectPolicy::Disabled)
@@ -69,6 +73,92 @@ async fn drain(socket: &Socket) -> u64 {
         received += 1;
     }
     received
+}
+
+async fn exchange_claim(client: &Socket, sequence: u64) {
+    let mut body = Vec::with_capacity(9);
+    body.push(1);
+    body.extend_from_slice(&sequence.to_le_bytes());
+    client.send(Message::single(body.clone())).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(1), client.recv())
+        .await
+        .expect("claim reply timeout")
+        .unwrap();
+    assert_eq!(reply.part_slice(0), Some(body.as_slice()));
+}
+
+async fn serve_claims(server: Socket, stop: Arc<AtomicBool>, claims: Arc<AtomicU64>) {
+    loop {
+        let received = tokio::time::timeout(Duration::from_millis(100), server.recv()).await;
+        let message = match received {
+            Ok(Ok(message)) => message,
+            Ok(Err(_)) | Err(_) if stop.load(Ordering::Relaxed) => break,
+            Ok(Err(error)) => panic!("SERVER receive failed: {error}"),
+            Err(_) => continue,
+        };
+        let body = message.part_slice(0).expect("single-part CLIENT message");
+        if body.first() != Some(&1) {
+            continue;
+        }
+
+        let routing_id = message.routing_id().expect("SERVER routing id");
+        let peer = server
+            .peer_info(routing_id)
+            .await
+            .unwrap()
+            .expect("live route missing peer info");
+        assert!(
+            peer.peer_address
+                .is_some_and(|address| address.ip().is_loopback()),
+            "SERVER peer address is not loopback: {:?}",
+            peer.peer_address,
+        );
+        assert_eq!(peer.zmtp_version.0, 3);
+
+        server
+            .send(Message::single(body.to_vec()).with_routing_id(routing_id))
+            .await
+            .unwrap();
+        claims.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+async fn run_healthy_claims(healthy: Socket, stop: Arc<AtomicBool>, roundtrips: Arc<AtomicU64>) {
+    let mut sequence = 0u64;
+    while !stop.load(Ordering::Relaxed) {
+        exchange_claim(&healthy, sequence).await;
+        roundtrips.fetch_add(1, Ordering::Relaxed);
+        sequence += 1;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn run_server_attack(endpoint: &Endpoint, events: &mut omq_tokio::MonitorStream, cycle: u64) {
+    let attacker = Socket::new(
+        SocketType::Client,
+        sender_options().send_hwm((SERVER_ATTACK_BURST * 4) as u32),
+    );
+    attacker.connect(endpoint.clone()).await.unwrap();
+    wait_for_handshakes(events, 1).await;
+    exchange_claim(&attacker, cycle).await;
+
+    for sequence in 0..SERVER_ATTACK_BURST * 4 {
+        let mut body = Vec::with_capacity(9);
+        body.push(2);
+        body.extend_from_slice(&(sequence as u64).to_le_bytes());
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            attacker.send(Message::single(body)),
+        )
+        .await;
+        if !matches!(result, Ok(Ok(()))) {
+            break;
+        }
+    }
+
+    wait_for_rate_limit_disconnect(events).await;
+    attacker.close().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
 }
 
 #[test]
@@ -174,4 +264,72 @@ fn soak_per_ip_rate_limit() {
 
     let report = monitor.stop();
     report.assert_no_leak("rate_limit_ip");
+}
+
+#[test]
+fn soak_server_peer_info_with_rate_limited_attackers() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+    let ctx = soak_common::build_context();
+    ctx.block_on(async move {
+        let server = Socket::new(
+            SocketType::Server,
+            soak_common::soak_options().recv_rate_limit(200, SERVER_ATTACK_BURST as u32),
+        );
+        let mut events = server.monitor();
+        let endpoint = server.bind(soak_common::tcp_ep(0)).await.unwrap();
+
+        let healthy = Socket::new(SocketType::Client, sender_options());
+        healthy.connect(endpoint.clone()).await.unwrap();
+        wait_for_handshakes(&mut events, 1).await;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let claims = Arc::new(AtomicU64::new(0));
+        let healthy_roundtrips = Arc::new(AtomicU64::new(0));
+
+        let server_task = tokio::spawn(serve_claims(server.clone(), stop.clone(), claims.clone()));
+        let healthy_task = tokio::spawn(run_healthy_claims(
+            healthy.clone(),
+            stop.clone(),
+            healthy_roundtrips.clone(),
+        ));
+
+        let start = Instant::now();
+        let mut attack_cycles = 0u64;
+        let mut last_log = start;
+        while start.elapsed() < duration {
+            run_server_attack(&endpoint, &mut events, attack_cycles).await;
+            attack_cycles += 1;
+
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[server_rate_limit] {:.0}s, attacks {attack_cycles}, claims {}, healthy {}",
+                    start.elapsed().as_secs_f64(),
+                    claims.load(Ordering::Relaxed),
+                    healthy_roundtrips.load(Ordering::Relaxed),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        healthy_task.await.unwrap();
+        server_task.await.unwrap();
+        healthy.close().await.unwrap();
+        server.close().await.unwrap();
+
+        let claims = claims.load(Ordering::Relaxed);
+        let healthy_roundtrips = healthy_roundtrips.load(Ordering::Relaxed);
+        assert!(attack_cycles > 0, "no rate-limited attack cycles completed");
+        assert!(healthy_roundtrips > 0, "healthy CLIENT completed no claims");
+        assert!(claims >= healthy_roundtrips + attack_cycles);
+        eprintln!(
+            "[server_rate_limit] done: {attack_cycles} attacks, {claims} peer lookups, \
+             {healthy_roundtrips} healthy roundtrips in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+    });
+
+    let report = monitor.stop();
+    report.assert_no_leak("server_rate_limit");
 }

--- a/omq-tokio/tests/omq_soak_ws.rs
+++ b/omq-tokio/tests/omq_soak_ws.rs
@@ -1,12 +1,14 @@
 #![cfg(all(feature = "soak", feature = "ws"))]
-//! Soak: WebSocket sustained throughput + bind-side restart storm.
+//! Soak: WebSocket throughput, restart churn, and fragmented input.
 //!
 //! Exercises the HTTP upgrade handshake, WS framing, and reconnection
-//! over `ws://` under sustained load. Two sub-tests:
+//! over `ws://` under sustained load. Three sub-tests:
 //!
 //! 1. Sustained throughput: PUSH/PULL over WS for `soak_duration`.
 //! 2. Restart storm: bind-side closes and rebinds repeatedly while
 //!    the connect-side reconnects and resumes sending.
+//! 3. Fragmented input: masked binary messages split into continuation
+//!    frames and arbitrary byte-stream chunks, with interleaved PINGs.
 
 #[global_allocator]
 static GLOBAL: soak_common::alloc::TrackingAllocator = soak_common::alloc::TrackingAllocator;
@@ -15,8 +17,17 @@ mod soak_common;
 
 use std::time::{Duration, Instant};
 
+use bytes::{BufMut, Bytes, BytesMut};
 use omq_tokio::options::ReconnectPolicy;
+use omq_tokio::proto::connection::{Connection, ConnectionConfig, Role, WsRole};
+use omq_tokio::proto::{Command, PeerProperties, command, zws};
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
+use rand::RngExt;
+use rand::rngs::StdRng;
+
+const OP_CONTINUATION: u8 = 0x00;
+const OP_BINARY: u8 = 0x02;
+const OP_PING: u8 = 0x09;
 
 fn ws_ep(port: u16) -> Endpoint {
     format!("ws://127.0.0.1:{port}/").parse().unwrap()
@@ -45,6 +56,127 @@ async fn rebind_ws(port: u16) -> Option<Socket> {
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
     None
+}
+
+fn masked_ws_frame(fin: bool, opcode: u8, payload: &[u8], mask: [u8; 4]) -> Bytes {
+    let mut wire = BytesMut::new();
+    wire.put_u8((if fin { 0x80 } else { 0 }) | opcode);
+    if payload.len() <= 125 {
+        wire.put_u8(0x80 | u8::try_from(payload.len()).unwrap());
+    } else if payload.len() <= 65_535 {
+        wire.put_u8(0x80 | 0x7e);
+        wire.put_u16(u16::try_from(payload.len()).unwrap());
+    } else {
+        wire.put_u8(0x80 | 0x7f);
+        wire.put_u64(u64::try_from(payload.len()).unwrap());
+    }
+    wire.put_slice(&mask);
+    let payload_start = wire.len();
+    wire.put_slice(payload);
+    for (index, byte) in wire[payload_start..].iter_mut().enumerate() {
+        *byte ^= mask[index & 3];
+    }
+    wire.freeze()
+}
+
+fn random_mask(rng: &mut StdRng) -> [u8; 4] {
+    [rng.random(), rng.random(), rng.random(), rng.random()]
+}
+
+fn fragmented_ws_message(rng: &mut StdRng, payload: &[u8], sequence: u64) -> Bytes {
+    let mut zws_message = Vec::with_capacity(payload.len() + 1);
+    zws_message.push(zws::FLAG_FINAL);
+    zws_message.extend_from_slice(payload);
+
+    let fragment_count = rng.random_range(2..=4);
+    let ping_after = rng.random_range(0..fragment_count - 1);
+    let mut offset = 0;
+    let mut wire = BytesMut::new();
+    for fragment in 0..fragment_count {
+        let remaining = zws_message.len() - offset;
+        let fragments_left = fragment_count - fragment;
+        let len = if fragments_left == 1 {
+            remaining
+        } else {
+            rng.random_range(1..=remaining - (fragments_left - 1))
+        };
+        let fin = fragments_left == 1;
+        let opcode = if fragment == 0 {
+            OP_BINARY
+        } else {
+            OP_CONTINUATION
+        };
+        wire.put_slice(&masked_ws_frame(
+            fin,
+            opcode,
+            &zws_message[offset..offset + len],
+            random_mask(rng),
+        ));
+        offset += len;
+
+        if fragment == ping_after {
+            wire.put_slice(&masked_ws_frame(
+                true,
+                OP_PING,
+                &sequence.to_le_bytes(),
+                random_mask(rng),
+            ));
+        }
+    }
+    wire.freeze()
+}
+
+fn feed_random_chunks(connection: &mut Connection, wire: &Bytes, rng: &mut StdRng) {
+    let mut offset = 0;
+    while offset < wire.len() {
+        let max = (wire.len() - offset).min(4096);
+        let len = if offset < 3 {
+            1
+        } else {
+            rng.random_range(1..=max)
+        };
+        connection
+            .handle_input(wire.slice(offset..offset + len))
+            .unwrap();
+        offset += len;
+    }
+}
+
+fn discard_transmit(connection: &mut Connection) {
+    let pending = connection.pending_transmit_size();
+    connection.advance_transmit(pending);
+}
+
+fn ready_fragmented_ws_connection(rng: &mut StdRng) -> Connection {
+    let config = ConnectionConfig::new(Role::Server, SocketType::Pull).ws_role(WsRole::Server);
+    let mut connection = Connection::new(config);
+    let mut ready = BytesMut::new();
+    command::encode(
+        &Command::Ready(PeerProperties::default().with_socket_type(SocketType::Push)),
+        &mut ready,
+    );
+
+    let mut zws_ready = Vec::with_capacity(ready.len() + 1);
+    zws_ready.push(zws::FLAG_COMMAND);
+    zws_ready.extend_from_slice(&ready);
+    let split = zws_ready.len() / 2;
+    let mut wire = BytesMut::new();
+    wire.put_slice(&masked_ws_frame(
+        false,
+        OP_BINARY,
+        &zws_ready[..split],
+        random_mask(rng),
+    ));
+    wire.put_slice(&masked_ws_frame(
+        true,
+        OP_CONTINUATION,
+        &zws_ready[split..],
+        random_mask(rng),
+    ));
+    feed_random_chunks(&mut connection, &wire.freeze(), rng);
+    assert!(connection.is_ready());
+    discard_transmit(&mut connection);
+    connection
 }
 
 #[test]
@@ -179,4 +311,65 @@ fn soak_ws_reconnect_storm() {
 
     let report = monitor.stop();
     report.assert_no_leak("ws_reconnect_storm");
+}
+
+#[test]
+fn soak_ws_fragmented_binary_input() {
+    let duration = soak_common::soak_duration();
+    let monitor = soak_common::ResourceMonitor::start();
+    {
+        let mut rng = soak_common::seeded_rng("ws_fragmented_input");
+        let mut connection = ready_fragmented_ws_connection(&mut rng);
+        let start = Instant::now();
+        let mut messages = 0u64;
+        let mut bytes = 0u64;
+        let mut last_log = start;
+
+        while start.elapsed() < duration {
+            let payload_len = match messages % 16 {
+                0 => 256 * 1024,
+                1 => 126,
+                2 => 65_536,
+                _ => rng.random_range(64..=128 * 1024),
+            };
+            let mut payload = vec![0; payload_len];
+            payload[..8].copy_from_slice(&messages.to_le_bytes());
+            let pattern = messages.to_le_bytes();
+            for (index, byte) in payload[8..].iter_mut().enumerate() {
+                *byte = pattern[index & 7];
+            }
+
+            let wire = fragmented_ws_message(&mut rng, &payload, messages);
+            feed_random_chunks(&mut connection, &wire, &mut rng);
+            let received = connection
+                .poll_message()
+                .expect("fragmented message missing");
+            assert_eq!(received.part_slice(0), Some(payload.as_slice()));
+            assert!(connection.poll_message().is_none());
+            assert!(
+                connection.pending_transmit_size() > 0,
+                "interleaved PING produced no response",
+            );
+            discard_transmit(&mut connection);
+
+            messages += 1;
+            bytes += u64::try_from(payload_len).unwrap();
+            if last_log.elapsed() >= Duration::from_secs(30) {
+                eprintln!(
+                    "[ws_fragmented_input] {:.0}s, messages {messages}, bytes {bytes}",
+                    start.elapsed().as_secs_f64(),
+                );
+                last_log = Instant::now();
+            }
+        }
+
+        assert!(messages > 0, "no fragmented messages decoded");
+        eprintln!(
+            "[ws_fragmented_input] done: {messages} messages, {bytes} bytes in {:.1}s",
+            start.elapsed().as_secs_f64(),
+        );
+    }
+
+    let report = monitor.stop();
+    report.assert_no_leak("ws_fragmented_input");
 }

--- a/omq-tokio/tests/receive_rate_limit.rs
+++ b/omq-tokio/tests/receive_rate_limit.rs
@@ -58,6 +58,44 @@ fn push_options() -> Options {
     Options::default().reconnect(ReconnectPolicy::Disabled)
 }
 
+async fn server_client_roundtrip_with_options(options: Options) {
+    let server = Socket::new(SocketType::Server, options);
+    let mut monitor = server.monitor();
+    let port = bind_port(&server, &mut monitor).await;
+
+    let client = Socket::new(SocketType::Client, push_options());
+    client.connect(tcp_loopback(port)).await.unwrap();
+    wait_for_handshakes(&mut monitor, 1).await;
+
+    client.send(Message::single("ping")).await.unwrap();
+    let request = tokio::time::timeout(Duration::from_secs(2), server.recv())
+        .await
+        .expect("SERVER recv timeout")
+        .unwrap();
+    assert_eq!(request.part_bytes(0).unwrap().as_ref(), b"ping");
+    let routing_id = request.routing_id().expect("SERVER routing id");
+    server
+        .send(Message::single("pong").with_routing_id(routing_id))
+        .await
+        .unwrap();
+
+    let reply = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .expect("CLIENT recv timeout")
+        .unwrap();
+    assert_eq!(reply.part_bytes(0).unwrap().as_ref(), b"pong");
+}
+
+#[tokio::test]
+async fn server_client_roundtrip_survives_per_connection_rate_limit() {
+    server_client_roundtrip_with_options(Options::default().recv_rate_limit(50, 100)).await;
+}
+
+#[tokio::test]
+async fn server_client_roundtrip_survives_per_ip_rate_limit() {
+    server_client_roundtrip_with_options(Options::default().recv_ip_rate_limit(500, 1_000)).await;
+}
+
 #[tokio::test]
 async fn per_connection_burst_exhaustion_disconnects_peer() {
     let pull = Socket::new(SocketType::Pull, Options::default().recv_rate_limit(1, 2));

--- a/scripts/soak-all.sh
+++ b/scripts/soak-all.sh
@@ -27,11 +27,18 @@ duration_seconds=$((10#$duration_value * duration_multiplier))
 export SOAK_FEATURES="${SOAK_FEATURES:-soak plain curve lz4 zstd ws}"
 export OMQ_SOAK_DURATION_SECS="$duration_seconds"
 export RUST_BACKTRACE="${RUST_BACKTRACE:-1}"
-if [[ -z "${OMQ_RUBY:-}" ]] && ! command -v ruby >/dev/null 2>&1 && [[ -x /home/roadster/.rubies/ruby-4.0.6/bin/ruby ]]; then
-  export OMQ_RUBY=/home/roadster/.rubies/ruby-4.0.6/bin/ruby
+if [[ -z "${RUBY:-}" ]]; then
+  if [[ -n "${OMQ_RUBY:-}" ]]; then
+    export RUBY="$OMQ_RUBY"
+  elif command -v ruby >/dev/null 2>&1; then
+    export RUBY="$(command -v ruby)"
+  elif [[ -x /home/roadster/.rubies/ruby-4.0.6/bin/ruby ]]; then
+    export RUBY=/home/roadster/.rubies/ruby-4.0.6/bin/ruby
+  fi
 fi
-if [[ -n "${OMQ_RUBY:-}" && -z "${RUBY:-}" ]]; then
-  export RUBY="$OMQ_RUBY"
+if [[ -z "${RUBY:-}" ]]; then
+  printf 'error: Ruby not found; set RUBY or OMQ_RUBY\n' >&2
+  exit 2
 fi
 
 timeout_seconds="${SOAK_TIMEOUT_SECS:-$((duration_seconds + 900))}"
@@ -206,7 +213,9 @@ if [[ "${SOAK_SKIP_PREBUILD:-0}" != "1" ]]; then
   "$cargo_cmd" build --release --manifest-path bindings/ruby/ext/omq_rs_native/Cargo.toml
   (
     cd bindings/ruby
-    export PATH="$(dirname "$RUBY"):$PATH"
+    if [[ "${RUBY:-}" == */* ]]; then
+      export PATH="$(dirname "$RUBY"):$PATH"
+    fi
     "$RUBY" -S bundle check
     "$RUBY" -S bundle exec rake compile
   )


### PR DESCRIPTION
- Drain the `omq-libzmq` recv notifier after wake so receive readiness is not stranded.
- Extend `scripts/soak-all.sh` and soak tests for rate limiting and WebSocket coverage.
- Add large `SCATTER` to native `GATHER` draft socket coverage.
- Keep draft socket tests clean under pedantic clippy.