### PR TITLE
Measure pyomq latency with two TCP processes

### DIFF
--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -151,46 +151,46 @@
   <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="60.0,690.5 151.2,691.5 242.5,691.1 333.8,691.3 425.0,691.6 516.2,690.6 607.5,689.8 698.8,684.5 790.0,681.7" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="690.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="691.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="691.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="691.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="691.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="690.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="689.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="684.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="681.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,634.1 151.2,632.3 242.5,633.6 333.8,634.9 425.0,632.9 516.2,633.4 607.5,631.5 698.8,629.3 790.0,622.9" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="634.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="632.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="633.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="634.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="632.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="633.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="631.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="629.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="622.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,650.2 151.2,649.9 242.5,648.3 333.8,648.7 425.0,648.0 516.2,648.7 607.5,645.2 698.8,644.4 790.0,643.7" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="650.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="649.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="648.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="648.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="648.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="648.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="645.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="644.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="643.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,581.1 151.2,578.6 242.5,570.7 333.8,572.3 425.0,576.8 516.2,582.8 607.5,577.7 698.8,569.7 790.0,560.5" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="581.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="578.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="570.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="572.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="576.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="582.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="577.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="569.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="560.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,676.8 151.2,680.2 242.5,677.8 333.8,679.6 425.0,677.9 516.2,676.8 607.5,679.4 698.8,674.8 790.0,671.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="676.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="680.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="677.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="679.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="677.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="676.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="679.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="674.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="671.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,616.4 151.2,615.5 242.5,622.5 333.8,615.4 425.0,616.5 516.2,617.0 607.5,616.6 698.8,617.9 790.0,606.4" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="616.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="615.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="622.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="615.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="616.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="617.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="616.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="617.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="606.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,639.6 151.2,640.5 242.5,639.0 333.8,640.1 425.0,637.9 516.2,639.7 607.5,638.2 698.8,636.0 790.0,633.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="639.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="640.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="639.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="640.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="637.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="639.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="638.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="636.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="633.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,551.4 151.2,553.3 242.5,549.2 333.8,548.2 425.0,550.0 516.2,547.4 607.5,547.9 698.8,544.6 790.0,544.6" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="551.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="553.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="549.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="548.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="550.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="547.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="547.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="544.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="544.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -11,6 +11,7 @@ import json
 import math
 import os
 import re
+import selectors
 import subprocess
 import sys
 import time
@@ -118,6 +119,7 @@ def save_results(
                 "impl": impl,
                 "kind": "latency",
                 "mode": "sync",
+                "transport": "tcp",
                 "msg_size": size,
                 **latency_fields(lat[i]),
             }
@@ -128,6 +130,7 @@ def save_results(
                 "impl": impl,
                 "kind": "latency",
                 "mode": "async",
+                "transport": "tcp",
                 "msg_size": size,
                 **latency_fields(alat[i]),
             }
@@ -197,7 +200,9 @@ def chart_data_from_jsonl():
         return r["msgs_s"] if r else 0.0
 
     def get_lat(mode, impl, size):
-        r = latest.get((impl, "latency", mode, "", size, ""))
+        r = latest.get((impl, "latency", mode, "tcp", size, ""))
+        if r is None:
+            r = latest.get((impl, "latency", mode, "", size, ""))
         return r["p50_us"] if r else 0.0
 
     sync_omq_tp = [get_tp("sync", "pyomq", "tcp", s) for s in SIZES]
@@ -369,6 +374,28 @@ def _run_subprocess(code, label, timeout=None, retries=None):
     if r.returncode != 0:
         raise RuntimeError(f"{label} failed:\n{r.stdout}{r.stderr}")
     return json.loads(r.stdout.strip())
+
+
+def _read_line_timeout(pipe, timeout):
+    selector = selectors.DefaultSelector()
+    try:
+        selector.register(pipe, selectors.EVENT_READ)
+        if not selector.select(timeout):
+            return None
+        return pipe.readline()
+    finally:
+        selector.close()
+
+
+def _kill_process(proc):
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
 
 
 def _measure_throughput_subprocess(lib_name, transport, size, duration=None):
@@ -678,50 +705,53 @@ def run_async_throughput(lib_name):
     return results
 
 
-# sync REQ/REP latency
+# async REQ/REP latency
 
 
 def _measure_latency_subprocess(lib_name, size, warmup_seconds, duration_seconds):
-    code = f"""
-import time, threading, json, socket as sock
-def free_tcp():
-    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
-    s.bind(('127.0.0.1', 0))
-    port = s.getsockname()[1]
-    s.close()
-    return f'tcp://127.0.0.1:{{port}}'
-if '{lib_name}' == 'pyzmq':
-    import zmq as lib
-else:
-    import pyomq as lib
-payload = b'x' * {size}
-ep = free_tcp()
+    if lib_name == "pyzmq":
+        lib_import = "import zmq as lib"
+    else:
+        lib_import = "import pyomq as lib"
+
+    endpoint = free_tcp()
+    rep_code = f"""
+import os, sys
+{lib_import}
+endpoint = sys.argv[1]
 ctx = lib.Context()
 rep = ctx.socket(lib.REP)
-req = ctx.socket(lib.REQ)
 rep.linger = 0
+rep.bind(endpoint)
+print('READY', flush=True)
+while True:
+    msg = rep.recv()
+    rep.send(msg)
+    if msg == b'__OMQ_BENCH_STOP__':
+        break
+rep.close()
+sys.stdout.flush()
+os._exit(0)
+"""
+    req_code = f"""
+import json, os, sys, time
+{lib_import}
+endpoint = sys.argv[1]
+size = int(sys.argv[2])
+warmup_seconds = float(sys.argv[3])
+duration_seconds = float(sys.argv[4])
+payload = b'x' * size
+ctx = lib.Context()
+req = ctx.socket(lib.REQ)
 req.linger = 0
-rep.bind(ep)
-req.connect(ep)
-time.sleep(0.05)
-def echo():
-    try:
-        while True:
-            msg = rep.recv()
-            rep.send(msg)
-            if msg == b'__OMQ_BENCH_STOP__':
-                break
-    except Exception:
-        pass
-t = threading.Thread(target=echo, daemon=True)
-t.start()
-warmup_deadline = time.monotonic() + {warmup_seconds}
+req.connect(endpoint)
+warmup_deadline = time.monotonic() + warmup_seconds
 while time.monotonic() < warmup_deadline:
     req.send(payload)
     req.recv()
 rtts = []
 start = time.monotonic()
-deadline = start + {duration_seconds}
+deadline = start + duration_seconds
 while True:
     t0 = time.monotonic()
     req.send(payload)
@@ -733,20 +763,57 @@ elapsed = time.monotonic() - start
 req.send(b'__OMQ_BENCH_STOP__')
 req.recv()
 req.close()
-rep.close()
-t.join(timeout=1.0)
+if not rtts:
+    raise RuntimeError('no latency samples')
 rtts.sort()
 p50 = rtts[len(rtts)*50//100]*1e6
 p99 = rtts[len(rtts)*99//100]*1e6
 print(json.dumps([p50, p99, len(rtts), elapsed]))
-import sys; sys.stdout.flush(); import os; os._exit(0)
+sys.stdout.flush()
+os._exit(0)
 """
-    result = _run_subprocess(
-        code,
-        f"{lib_name} lat {size}B",
-        timeout=LATENCY_TIMEOUT_S,
+    label = f"{lib_name} tcp lat {size}B"
+    rep_proc = subprocess.Popen(
+        [sys.executable, "-c", rep_code, endpoint],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
-    return tuple(result) if result is not None else (999999.0, 999999.0)
+    assert rep_proc.stdout is not None
+    try:
+        ready = _read_line_timeout(rep_proc.stdout, 10.0)
+        if ready is None or not ready.startswith("READY"):
+            stderr = ""
+            if rep_proc.poll() is not None:
+                _, stderr = rep_proc.communicate(timeout=1)
+            raise RuntimeError(f"{label} rep did not become ready:\n{stderr}")
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    req_code,
+                    endpoint,
+                    str(size),
+                    str(warmup_seconds),
+                    str(duration_seconds),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=LATENCY_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"{label} req timeout after {LATENCY_TIMEOUT_S}s") from error
+        if result.returncode != 0:
+            raise RuntimeError(f"{label} req failed:\n{result.stdout}{result.stderr}")
+        try:
+            rep_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"{label} rep did not exit") from error
+        return tuple(json.loads(result.stdout.strip()))
+    finally:
+        _kill_process(rep_proc)
 
 
 def run_latency(lib_name):
@@ -795,41 +862,47 @@ def _measure_async_latency_subprocess(lib_name, size, warmup_seconds, duration_s
         lib_import = "import pyomq; import pyomq.asyncio as actx; lib = pyomq"
 
     send_await = "await " if lib_name == "pyzmq" else ""
-    code = f"""
-import asyncio, time, json, socket as sock
-def free_tcp():
-    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
-    s.bind(('127.0.0.1', 0))
-    port = s.getsockname()[1]
-    s.close()
-    return f'tcp://127.0.0.1:{{port}}'
+    endpoint = free_tcp()
+    rep_code = f"""
+import asyncio, os, sys
 {lib_import}
 async def run():
-    payload = b'x' * {size}
-    ep = free_tcp()
+    endpoint = sys.argv[1]
     ctx = actx.Context()
     rep = ctx.socket(lib.REP)
+    rep.linger = 0
+    rep.bind(endpoint)
+    print('READY', flush=True)
+    while True:
+        msg = await rep.recv()
+        {send_await}rep.send(msg)
+        if msg == b'__OMQ_BENCH_STOP__':
+            break
+    rep.close()
+    sys.stdout.flush()
+    os._exit(0)
+asyncio.run(run())
+"""
+    req_code = f"""
+import asyncio, json, os, sys, time
+{lib_import}
+async def run():
+    endpoint = sys.argv[1]
+    size = int(sys.argv[2])
+    warmup_seconds = float(sys.argv[3])
+    duration_seconds = float(sys.argv[4])
+    payload = b'x' * size
+    ctx = actx.Context()
     req = ctx.socket(lib.REQ)
-    rep.bind(ep)
-    req.connect(ep)
-    await asyncio.sleep(0.05)
-    async def echo():
-        try:
-            while True:
-                msg = await rep.recv()
-                {send_await}rep.send(msg)
-                if msg == b'__OMQ_BENCH_STOP__':
-                    break
-        except Exception:
-            pass
-    task = asyncio.create_task(echo())
-    warmup_deadline = time.monotonic() + {warmup_seconds}
+    req.linger = 0
+    req.connect(endpoint)
+    warmup_deadline = time.monotonic() + warmup_seconds
     while time.monotonic() < warmup_deadline:
         {send_await}req.send(payload)
         await req.recv()
     rtts = []
     start = time.monotonic()
-    deadline = start + {duration_seconds}
+    deadline = start + duration_seconds
     while True:
         t0 = time.monotonic()
         {send_await}req.send(payload)
@@ -840,20 +913,59 @@ async def run():
     elapsed = time.monotonic() - start
     {send_await}req.send(b'__OMQ_BENCH_STOP__')
     await req.recv()
-    await task
+    req.close()
+    if not rtts:
+        raise RuntimeError('no latency samples')
     rtts.sort()
     p50 = rtts[len(rtts)*50//100]*1e6
     p99 = rtts[len(rtts)*99//100]*1e6
     print(json.dumps([p50, p99, len(rtts), elapsed]))
-    import sys; sys.stdout.flush(); import os; os._exit(0)
+    sys.stdout.flush()
+    os._exit(0)
 asyncio.run(run())
 """
-    result = _run_subprocess(
-        code,
-        f"{lib_name} async lat {size}B",
-        timeout=LATENCY_TIMEOUT_S,
+    label = f"{lib_name} async tcp lat {size}B"
+    rep_proc = subprocess.Popen(
+        [sys.executable, "-c", rep_code, endpoint],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
-    return tuple(result) if result is not None else (999999.0, 999999.0)
+    assert rep_proc.stdout is not None
+    try:
+        ready = _read_line_timeout(rep_proc.stdout, 10.0)
+        if ready is None or not ready.startswith("READY"):
+            stderr = ""
+            if rep_proc.poll() is not None:
+                _, stderr = rep_proc.communicate(timeout=1)
+            raise RuntimeError(f"{label} rep did not become ready:\n{stderr}")
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    req_code,
+                    endpoint,
+                    str(size),
+                    str(warmup_seconds),
+                    str(duration_seconds),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=LATENCY_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"{label} req timeout after {LATENCY_TIMEOUT_S}s") from error
+        if result.returncode != 0:
+            raise RuntimeError(f"{label} req failed:\n{result.stdout}{result.stderr}")
+        try:
+            rep_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"{label} rep did not exit") from error
+        return tuple(json.loads(result.stdout.strip()))
+    finally:
+        _kill_process(rep_proc)
 
 
 def run_async_latency(lib_name):


### PR DESCRIPTION
- Run `pyomq` and `pyzmq` REQ/REP latency benchmarks with separate REQ and REP subprocesses over TCP.
- Store latency rows with `transport: "tcp"` while preserving chart fallback for older cached rows.
- Refresh `bindings/pyomq/doc/charts/bindings.svg` from new two-process latency measurements.
