### PR TITLE
Update binding README coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ not depend on libzmq, libsodium, or a C compiler.
 - Native bindings and compatibility APIs:
   - [C/C++](omq-libzmq/)
   - [Crystal](https://github.com/paddor/omq-binding.cr) and pure Crystal [OMQ.cr](https://github.com/paddor/omq.cr)
+  - [BEAM: Erlang, Elixir, and Gleam](bindings/beam/)
   - [Go](bindings/go/)
   - [Java](bindings/java/)
   - [Lua](bindings/lua/)
@@ -155,6 +156,7 @@ Five Cargo workspace crates plus language bindings.
 | [`OMQ.go`](bindings/go/) | Go 1.25 binding (cgo over omq-tokio, goroutine-safe API) | cgo/native ABI boundary |
 | [`OMQ.node`](bindings/node/) | Node.js 24.11 binding (NAPI over omq-tokio, native addon) | NAPI/native addon boundary |
 | [`OMQ.lua`](bindings/lua/) | Lua 5.4 binding (mlua native module over omq-libzmq) | mlua/native ABI boundary |
+| [`OMQ.beam`](bindings/beam/) | Erlang binding plus Elixir and Gleam wrappers (Rustler NIF over omq-tokio) | BEAM NIF boundary |
 
 ## Testing
 

--- a/bindings/beam/README.md
+++ b/bindings/beam/README.md
@@ -13,45 +13,19 @@ Benchmarks compare the three OMQ wrappers against `erlzmq` and `chumak`.
 
 ## API Shape
 
-- `omq:context/0,1` owns native IO threads. `context_instance/0,1` and
-  `instance/0,1` return a process-wide singleton.
-- `term/1` and `destroy/1` close contexts. `backend_name/0`, `version/0`,
-  `omq_version/0`, `omq_version_info/0`, `zmq_version/0`,
-  `zmq_version_info/0`, and `strerror/1` expose metadata and compatibility
-  helpers.
-- `share_key/1` and `from_share_key/1` import an existing native context for
-  cross-wrapper inproc use.
-- `omq:socket/2` creates Erlang socket resources for all 20 ZMQ socket types.
-- `bind`, `bind_to_random_port`, `connect`, `unbind`, and `disconnect` use
-  normal endpoint strings.
-- `send`, `send_string`, `send_json`, `send_term`, `try_send`, `recv`,
-  `recv_string`, `recv_json`, `recv_term`, `recv_frame`, `try_recv`,
-  `send_multipart`, and `recv_multipart` cover blocking and nonblocking
-  message calls.
-- `poll/2` and `select/4` provide libzmq-style readiness helpers.
-- `monitor`, `connections`, and `connection_info` expose backend lifecycle
-  state.
-- `proxy/2,3`, `proxy_steerable/4`, and `device/3` forward between sockets,
-  with optional capture and PAUSE/RESUME/TERMINATE control.
-- `setsockopt/3` and `getsockopt/2` cover core libzmq-compatible options and
-  OMQ transport options, plus `set/get`, `set_hwm/get_hwm`, string option
-  aliases, device constants, mechanism constants, and poll constants.
-- `curve_keypair/0`, `curve_public/1`, and `has/1` expose optional feature
-  state.
-- `socket_id/1`, `closed/1`, and `context_closed/1` expose wrapper state.
-- `subscribe`, `unsubscribe`, `join`, `leave`, and `send_group` expose
-  pub/sub and RADIO/DISH controls.
-
-## Ownership
-
-Treat each socket as owned by one BEAM process. This matches normal BEAM
-actor style and keeps libzmq-style socket sequencing explicit. The native
-socket is safe to hold as a resource, but wrapper frame state for `SNDMORE`,
-`RCVMORE`, `recv_frame`, and `send(..., [sndmore])` is stored in the calling
-process. Sharing one socket across processes is only appropriate for direct
-whole-message calls where racing callers are acceptable. Single-part socket
-types avoid multipart frame state, but an owner process is still the intended
-shape.
+- `omq:context(...)` owns native IO threads and creates sockets.
+- Erlang is the base API. Elixir and Gleam wrappers keep the same native
+  context and `inproc://` namespace through explicit share keys.
+- Socket resources cover all 20 ZMQ socket types and use normal endpoint
+  strings for bind/connect.
+- Message calls support binaries, strings, Erlang terms, JSON, multipart, and
+  nonblocking variants.
+- Pub/sub controls, RADIO/DISH groups, polling, monitoring, proxies, and core
+  libzmq-compatible options are exposed through the Erlang module.
+- Treat each socket as owned by one BEAM process. This matches actor-style
+  sequencing and keeps multipart frame state local to the caller.
+- Create more sockets for more concurrent flows; share contexts when wrappers
+  need the same `inproc://` namespace.
 
 Example:
 

--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -17,43 +17,18 @@ Benchmark and build details live in
 
 ## API Shape
 
-- Socket constants: all 20 ZMTP socket types, including `CLIENT`, `SERVER`,
-  `RADIO`, `DISH`, `SCATTER`, `GATHER`, `CHANNEL`, `PEER`, and `STREAM`.
-- Flags: `DONTWAIT`, `SNDMORE`.
-- Arena constants: `OMQ_ARENA_THRESHOLD`, `DEFAULT_ARENA_THRESHOLD`.
-- `omq.monotonic_seconds()` returns a monotonic timestamp for tests and
-  benchmarks.
-- `omq.context({ io_threads = 1 })` creates a context.
-- `Context:socket("push", opts)` creates a socket by name or numeric constant.
-- `Context:term()` closes the context. It errors while sockets or helper peers
-  are still live.
-- `Context:close()` aliases `Context:term()`.
-- `Socket:bind(endpoint)` binds and returns the resolved endpoint, including
-  wildcard TCP ports when available.
-- `Socket:connect(endpoint)` connects an endpoint.
-- `Socket:close()` closes the socket. It is idempotent.
-- `Socket:send("bytes", flags)` sends one frame.
-- `Socket:send({ "part1", "part2" }, flags)` sends multipart.
-- `Socket:send_parts(parts, flags)` sends multipart.
-- `Socket:recv(max_size, flags)` receives one frame. If `max_size` is set and
-  the frame is larger, the call errors after consuming that frame.
-- `Socket:try_recv(max_size)` is nonblocking and returns `nil` when no frame is
-  ready.
-- `Socket:recv_parts(max_size, flags)` receives all frames in one message.
-- `Socket:subscribe(prefix)` adds a SUB prefix.
-- `Socket:unsubscribe(prefix)` removes a SUB prefix.
-- `Socket:join(group)` and `Socket:leave(group)` manage DISH groups.
-- `Socket:send_group(group, "bytes", flags)` sends a RADIO message to a group.
-- `Socket:set_linger(ms)`, `Socket:set_send_timeout(ms)`,
-  `Socket:set_recv_timeout(ms)`, `Socket:set_send_hwm(value)`,
-  `Socket:set_recv_hwm(value)`, `Socket:set_arena_threshold(bytes)`, and
-  `Socket:get_arena_threshold()` expose supported socket options.
-- Socket option tables support `linger`, `send_timeout`, `recv_timeout`,
-  `send_hwm`, `recv_hwm`, `arena_threshold`, and `subscribe`.
-- `arena_threshold` uses `4 KiB` by default. `0` means gather-write for all
-  payloads. `-1` restores the native default.
-- `omq.testing.*` helpers are test-only Rust backend peers. Their join handles
-  expose `endpoint()`, `join()`, and `received()`.
+- `Context` owns the native OMQ context and IO threads.
+- `Context:socket(...)` creates sockets by name or numeric ZMQ constant.
+- Socket calls follow the normal libzmq shape: bind/connect, send/receive,
+  multipart, pub/sub controls, RADIO/DISH groups, and close.
+- Lua strings are message payloads. Lua tables are multipart messages.
+- Nonblocking calls use libzmq-style flags and `try_*` helpers.
+- Socket options are supplied at creation or through setter methods for HWM,
+  linger, timeouts, subscription, and arena threshold tuning.
+- Treat each socket as owned by one Lua coroutine/thread at a time. Create
+  more sockets for more concurrent flows.
+- `omq.testing.*` helpers are test-only Rust backend peers, not application
+  APIs.
 
 Example:
 


### PR DESCRIPTION
- Add BEAM bindings to root README binding list.
- Replace Lua API inventory with concise API shape notes.
- Replace BEAM API inventory with concise API shape notes.